### PR TITLE
[SPARK-52709][SQL] Fix parsing of STRUCT<>

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -1495,7 +1495,7 @@ primitiveType
 dataType
     : complex=ARRAY (LT dataType GT)?                           #complexDataType
     | complex=MAP (LT dataType COMMA dataType GT)?              #complexDataType
-    | complex=STRUCT ((LT complexColTypeList? GT) | NEQ)?       #complexDataType
+    | complex=STRUCT ((LT complexColTypeList? GT) | NEQ {((SqlBaseLexer) getTokenStream().getTokenSource()).decComplexTypeLevelCounter();})?       #complexDataType
     | primitiveType                                             #primitiveDataType
     ;
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -1164,4 +1164,27 @@ class SparkSqlParserSuite extends AnalysisTest with SharedSparkSession {
       }
     }
   }
+
+  test("SPARK-52709: STRUCT<> should not corrupt complex_type_level_counter") {
+    // STRUCT<> is tokenized as STRUCT + NEQ by the lexer. The parser must decrement
+    // the complex_type_level_counter so that subsequent >> is recognized as shift-right.
+    // Without the fix, this throws a parse error because >> is not recognized.
+    parser.parsePlan("SELECT CAST(null AS STRUCT<>), 2 >> 1")
+
+    // Multiple empty structs should not corrupt the counter
+    parser.parsePlan("SELECT CAST(null AS STRUCT<>), CAST(null AS STRUCT<>), 4 >> 2")
+
+    // Empty struct with unsigned shift right
+    parser.parsePlan("SELECT CAST(null AS STRUCT<>), 8 >>> 2")
+
+    // ARRAY with <> as not-equal operator should still work
+    parser.parsePlan("SELECT ARRAY(1 <> 2)")
+
+    // Nested complex types with >> should still work
+    parser.parsePlan("SELECT CAST(null AS MAP<STRING, ARRAY<INT>>)")
+
+    // Mix of empty struct and nested complex types
+    parser.parsePlan(
+      "SELECT CAST(null AS STRUCT<>), CAST(null AS MAP<STRING, ARRAY<INT>>), 2 >> 1")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the `STRUCT<>` parsing bug by adding a parser-level action to decrement `complex_type_level_counter` when `STRUCT NEQ` is matched in the `dataType` rule.

**Root cause:** When the lexer sees `STRUCT<>`, it tokenizes it as `STRUCT` + `NEQ` (because `NEQ` is defined before `LT`). This increments the counter for `STRUCT` but never decrements it (no `GT` token), corrupting the counter. Subsequent `>>` then fails to be recognized as shift-right.

**Previous attempt:** PR #51480 was merged then reverted because it modified the `NEQ` lexer rule, which broke `ARRAY(col1 <> col2)` where `<>` is the not-equal operator.

**This fix:** Follows @cloud-fan's suggestion to handle it at the parser level. When the parser matches `STRUCT NEQ` in the `dataType` rule, we know `NEQ` is being used as empty angle brackets (not as a comparison), so we decrement the counter via an inline action.

### Why are the changes needed?

`SELECT CAST(null AS STRUCT<>), 2 >> 1` fails with a syntax error because the corrupted counter prevents `>>` from being recognized as shift-right.

### Does this PR introduce _any_ user-facing change?

No. This is a correctness fix for SQL parsing.

### How was this patch tested?

Added test in `SparkSqlParserSuite` covering 6 cases:

1. `STRUCT<>` followed by `>>` (the original bug)
2. Multiple `STRUCT<>` followed by `>>`
3. `STRUCT<>` followed by `>>>` (unsigned shift right)
4. `ARRAY(1 <> 2)` still works (the regression case from the reverted PR)
5. Nested complex types `MAP<STRING, ARRAY<INT>>` still work
6. Mix of empty struct + nested types + shift right

**Test results:**
- `SparkSqlParserSuite`: 46/46 passed
- `DataTypeParserSuite`: 59/59 passed
- `PlanParserSuite`: 80/80 passed

### Was this patch authored or co-authored using generative AI tooling?

Yes
