### PR TITLE
[SPARK-56438][SQL][CORE] Optimize `VectorizedPlainValuesReader.readBinary` for direct ByteBuffer by eliminating intermediate byte[] copy

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -43,6 +43,10 @@ public final class Platform {
 
   public static final int DOUBLE_ARRAY_OFFSET;
 
+  // Field offset for java.nio.Buffer.address — used to read the native memory address
+  // of a DirectByteBuffer without going through sun.nio.ch.DirectBuffer.
+  private static final long DIRECT_BUFFER_ADDRESS_OFFSET;
+
   private static final boolean unaligned;
 
   // Split java.version on non-digit chars:
@@ -230,6 +234,14 @@ public final class Platform {
     throw new IllegalStateException("unreachable");
   }
 
+  /**
+   * Returns the native memory address of a direct {@link ByteBuffer}.
+   * The buffer must be direct; passing a heap buffer produces an undefined result.
+   */
+  public static long getDirectBufferAddress(ByteBuffer buffer) {
+    return _UNSAFE.getLong(buffer, DIRECT_BUFFER_ADDRESS_OFFSET);
+  }
+
   public static void setMemory(Object object, long offset, long size, byte value) {
     _UNSAFE.setMemory(object, offset, size, value);
   }
@@ -296,6 +308,12 @@ public final class Platform {
       LONG_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(long[].class);
       FLOAT_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(float[].class);
       DOUBLE_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(double[].class);
+      try {
+        DIRECT_BUFFER_ADDRESS_OFFSET =
+            _UNSAFE.objectFieldOffset(java.nio.Buffer.class.getDeclaredField("address"));
+      } catch (NoSuchFieldException e) {
+        throw new IllegalStateException(e);
+      }
     } else {
       BOOLEAN_ARRAY_OFFSET = 0;
       BYTE_ARRAY_OFFSET = 0;
@@ -304,6 +322,7 @@ public final class Platform {
       LONG_ARRAY_OFFSET = 0;
       FLOAT_ARRAY_OFFSET = 0;
       DOUBLE_ARRAY_OFFSET = 0;
+      DIRECT_BUFFER_ADDRESS_OFFSET = 0;
     }
   }
 

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -310,7 +310,7 @@ public final class Platform {
       DOUBLE_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(double[].class);
       try {
         DIRECT_BUFFER_ADDRESS_OFFSET =
-            _UNSAFE.objectFieldOffset(java.nio.Buffer.class.getDeclaredField("address"));
+          _UNSAFE.objectFieldOffset(java.nio.Buffer.class.getDeclaredField("address"));
       } catch (NoSuchFieldException e) {
         throw new IllegalStateException(e);
       }

--- a/core/benchmarks/PlatformBenchmark-jdk21-results.txt
+++ b/core/benchmarks/PlatformBenchmark-jdk21-results.txt
@@ -2,112 +2,124 @@
 Platform Byte Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Byte Access:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putByte: On-heap                                     65             65           1       1540.3           0.6       1.0X
-putByte: Off-heap                                    76             76           0       1314.8           0.8       0.9X
-getByte: On-heap                                     53             53           0       1885.8           0.5       1.2X
-getByte: Off-heap                                    46             46           0       2170.2           0.5       1.4X
+putByte: On-heap                                     65             65           0       1543.7           0.6       1.0X
+putByte: Off-heap                                    76             76           0       1312.9           0.8       0.9X
+getByte: On-heap                                     53             53           1       1886.1           0.5       1.2X
+getByte: Off-heap                                    43             46           1       2307.0           0.4       1.5X
 
 
 ================================================================================================
 Platform Short Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Short Access:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putShort: On-heap                                    63             63           0       1581.9           0.6       1.0X
-putShort: Off-heap                                   71             71           0       1408.9           0.7       0.9X
-getShort: On-heap                                    43             43           0       2343.8           0.4       1.5X
-getShort: Off-heap                                   50             50           0       1998.5           0.5       1.3X
+putShort: On-heap                                    63             64           0       1579.8           0.6       1.0X
+putShort: Off-heap                                   71             71           0       1404.6           0.7       0.9X
+getShort: On-heap                                    43             43           0       2342.2           0.4       1.5X
+getShort: Off-heap                                   50             50           0       1994.1           0.5       1.3X
 
 
 ================================================================================================
 Platform Int Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Int Access:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putInt: On-heap                                      56             56           0       1781.2           0.6       1.0X
-putInt: Off-heap                                     53             53           0       1892.8           0.5       1.1X
-getInt: On-heap                                      35             35           0       2848.5           0.4       1.6X
-getInt: Off-heap                                     37             38           0       2678.7           0.4       1.5X
+putInt: On-heap                                      56             56           0       1780.9           0.6       1.0X
+putInt: Off-heap                                     52             52           0       1919.4           0.5       1.1X
+getInt: On-heap                                      35             35           0       2869.3           0.3       1.6X
+getInt: Off-heap                                     37             38           0       2676.8           0.4       1.5X
 
 
 ================================================================================================
 Platform Long Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Long Access:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putLong: On-heap                                     69             69           0       1445.7           0.7       1.0X
-putLong: Off-heap                                    52             53           1       1907.6           0.5       1.3X
-getLong: On-heap                                     41             42           1       2434.5           0.4       1.7X
-getLong: Off-heap                                    45             46           1       2242.5           0.4       1.6X
+putLong: On-heap                                     69             69           0       1451.6           0.7       1.0X
+putLong: Off-heap                                    52             52           0       1929.6           0.5       1.3X
+getLong: On-heap                                     41             42           0       2437.7           0.4       1.7X
+getLong: Off-heap                                    44             44           0       2291.5           0.4       1.6X
 
 
 ================================================================================================
 Platform Float Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Float Access:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putFloat: On-heap                                    44             44           0       2274.8           0.4       1.0X
-putFloat: Off-heap                                   48             48           0       2105.0           0.5       0.9X
-getFloat: On-heap                                    94             94           0       1068.3           0.9       0.5X
-getFloat: Off-heap                                   94             94           0       1068.1           0.9       0.5X
+putFloat: On-heap                                    44             44           0       2276.4           0.4       1.0X
+putFloat: Off-heap                                   48             48           0       2091.5           0.5       0.9X
+getFloat: On-heap                                    94             94           0       1067.0           0.9       0.5X
+getFloat: Off-heap                                   94             94           0       1065.9           0.9       0.5X
 
 
 ================================================================================================
 Platform Double Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Double Access:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putDouble: On-heap                                   46             47           0       2154.5           0.5       1.0X
-putDouble: Off-heap                                  50             50           0       2014.0           0.5       0.9X
-getDouble: On-heap                                   94             95           0       1058.6           0.9       0.5X
-getDouble: Off-heap                                  95             95           0       1053.9           0.9       0.5X
+putDouble: On-heap                                   47             47           0       2127.4           0.5       1.0X
+putDouble: Off-heap                                  49             50           0       2025.5           0.5       1.0X
+getDouble: On-heap                                   94             95           0       1058.9           0.9       0.5X
+getDouble: Off-heap                                  95             95           0       1053.3           0.9       0.5X
 
 
 ================================================================================================
 Platform Boolean Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Boolean Access:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putBoolean: On-heap                                  66             66           0       1509.1           0.7       1.0X
-putBoolean: Off-heap                                 78             80           7       1289.7           0.8       0.9X
-getBoolean: On-heap                                  62             62           0       1606.0           0.6       1.1X
-getBoolean: Off-heap                                 62             62           0       1605.6           0.6       1.1X
+putBoolean: On-heap                                  66             67           3       1511.5           0.7       1.0X
+putBoolean: Off-heap                                 78             78           1       1287.1           0.8       0.9X
+getBoolean: On-heap                                  62             63           0       1604.2           0.6       1.1X
+getBoolean: Off-heap                                 62             62           0       1603.7           0.6       1.1X
+
+
+================================================================================================
+Platform DirectBuffer Address Access
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+DirectBuffer Address Access:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+getLong (baseline)                                  161            164           2        619.3           1.6       1.0X
+getDirectBufferAddress                              359            362           6        278.8           3.6       0.5X
 
 
 ================================================================================================
 Platform Bulk Operations 4k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Bulk Operations 4k Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          5.4         186.4       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          4.1         241.4       0.8X
-copyMemory: Off-heap -> Heap                          0              0           0          4.4         225.5       0.8X
-copyMemory: Heap -> Heap                              0              0           0          4.3         231.4       0.8X
+copyMemory: Off-heap -> Off-heap                      0              0           0          5.4         186.3       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          5.5         181.3       1.0X
+copyMemory: Off-heap -> Heap                          0              0           0          4.3         233.4       0.8X
+copyMemory: Heap -> Heap                              0              0           0          4.2         238.4       0.8X
 manual: Heap -> Heap                                  0              0           0          0.9        1062.9       0.2X
 manual: Off-heap -> Heap                              0              0           0          1.0         960.7       0.2X
 setMemory: Off-heap                                   0              0           0          3.0         336.6       0.6X
@@ -117,97 +129,97 @@ setMemory: Off-heap                                   0              0          
 Platform Bulk Operations 16k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Bulk Operations 16k Ints:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          0.7        1526.9       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          0.7        1336.5       1.1X
-copyMemory: Off-heap -> Heap                          0              0           0          0.7        1425.6       1.1X
-copyMemory: Heap -> Heap                              0              0           0          0.7        1358.6       1.1X
-manual: Heap -> Heap                                  0              0           0          0.2        5434.1       0.3X
-manual: Off-heap -> Heap                              0              0           0          0.3        3906.2       0.4X
-setMemory: Off-heap                                   0              0           0          0.8        1293.3       1.2X
+copyMemory: Off-heap -> Off-heap                      0              0           0          0.7        1333.5       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          0.8        1302.4       1.0X
+copyMemory: Off-heap -> Heap                          0              0           0          0.8        1295.4       1.0X
+copyMemory: Heap -> Heap                              0              0           0          0.8        1314.4       1.0X
+manual: Heap -> Heap                                  0              0           0          0.2        5434.1       0.2X
+manual: Off-heap -> Heap                              0              0           0          0.3        3880.2       0.3X
+setMemory: Off-heap                                   0              0           0          0.8        1295.4       1.0X
 
 
 ================================================================================================
 Platform Bulk Operations 256k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Bulk Operations 256k Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          0.0       26855.1       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          0.0       26615.6       1.0X
-copyMemory: Off-heap -> Heap                          0              0           0          0.0       25575.7       1.1X
-copyMemory: Heap -> Heap                              0              0           0          0.0       25511.5       1.1X
-manual: Heap -> Heap                                  1              1           0          0.0       87430.0       0.3X
-manual: Off-heap -> Heap                              1              1           0          0.0       62307.2       0.4X
-setMemory: Off-heap                                   0              0           0          0.0       20416.1       1.3X
+copyMemory: Off-heap -> Off-heap                      0              0           0          0.0       28443.0       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          0.0       26028.5       1.1X
+copyMemory: Off-heap -> Heap                          0              0           0          0.0       25912.2       1.1X
+copyMemory: Heap -> Heap                              0              0           0          0.0       33938.2       0.8X
+manual: Heap -> Heap                                  1              1           0          0.0       88003.9       0.3X
+manual: Off-heap -> Heap                              1              1           0          0.0       62405.3       0.5X
+setMemory: Off-heap                                   0              0           0          0.0       20392.0       1.4X
 
 
 ================================================================================================
 Platform Bulk Operations 1m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Bulk Operations 1m Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      1              1           0          0.0      144063.6       1.0X
-copyMemory: Heap -> Off-heap                          1              1           0          0.0      136948.4       1.1X
-copyMemory: Off-heap -> Heap                          1              1           0          0.0      136958.4       1.1X
-copyMemory: Heap -> Heap                              1              1           0          0.0      137138.7       1.1X
-manual: Heap -> Heap                                  3              3           0          0.0      274832.5       0.5X
-manual: Off-heap -> Heap                              3              3           0          0.0      250522.1       0.6X
-setMemory: Off-heap                                   1              1           0          0.0       81296.7       1.8X
+copyMemory: Off-heap -> Off-heap                      1              1           0          0.0      110005.9       1.0X
+copyMemory: Heap -> Off-heap                          1              1           0          0.0      137549.3       0.8X
+copyMemory: Off-heap -> Heap                          1              1           0          0.0      113903.2       1.0X
+copyMemory: Heap -> Heap                              1              1           0          0.0      104773.2       1.0X
+manual: Heap -> Heap                                  3              3           0          0.0      275027.4       0.4X
+manual: Off-heap -> Heap                              3              3           0          0.0      250247.1       0.4X
+setMemory: Off-heap                                   1              1           0          0.0       81375.6       1.4X
 
 
 ================================================================================================
 Platform Bulk Operations 8m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Bulk Operations 8m Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                     14             14           0          0.0     1382687.3       1.0X
-copyMemory: Heap -> Off-heap                         17             18           0          0.0     1729538.1       0.8X
-copyMemory: Off-heap -> Heap                         17             17           0          0.0     1677423.9       0.8X
-copyMemory: Heap -> Heap                             17             17           0          0.0     1666798.1       0.8X
-manual: Heap -> Heap                                 25             26           0          0.0     2509961.4       0.6X
-manual: Off-heap -> Heap                             25             26           0          0.0     2499264.5       0.6X
-setMemory: Off-heap                                   8             10           1          0.0      796434.1       1.7X
+copyMemory: Off-heap -> Off-heap                     21             22           1          0.0     2148373.2       1.0X
+copyMemory: Heap -> Off-heap                         20             21           1          0.0     2007105.2       1.1X
+copyMemory: Off-heap -> Heap                         18             19           0          0.0     1806725.4       1.2X
+copyMemory: Heap -> Heap                             17             18           0          0.0     1693027.6       1.3X
+manual: Heap -> Heap                                 25             25           0          0.0     2494245.2       0.9X
+manual: Off-heap -> Heap                             28             29           0          0.0     2782226.8       0.8X
+setMemory: Off-heap                                  10             11           1          0.0     1025418.5       2.1X
 
 
 ================================================================================================
 Platform Bulk Operations 32m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Bulk Operations 32m Ints:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                     78             79           1          0.0     7763257.0       1.0X
-copyMemory: Heap -> Off-heap                         84             85           1          0.0     8381141.4       0.9X
-copyMemory: Off-heap -> Heap                         83             85           1          0.0     8338717.4       0.9X
-copyMemory: Heap -> Heap                             84             85           2          0.0     8357496.5       0.9X
-manual: Heap -> Heap                                104            107           7          0.0    10358296.5       0.7X
-manual: Off-heap -> Heap                            108            110           1          0.0    10802113.1       0.7X
-setMemory: Off-heap                                  55             57           1          0.0     5479064.0       1.4X
+copyMemory: Off-heap -> Off-heap                     77             78           1          0.0     7699847.8       1.0X
+copyMemory: Heap -> Off-heap                         83             84           1          0.0     8263815.4       0.9X
+copyMemory: Off-heap -> Heap                         83             86           2          0.0     8267087.5       0.9X
+copyMemory: Heap -> Heap                             82             84           3          0.0     8189359.5       0.9X
+manual: Heap -> Heap                                103            107           6          0.0    10332070.6       0.7X
+manual: Off-heap -> Heap                            108            110           1          0.0    10783091.0       0.7X
+setMemory: Off-heap                                  54             56           1          0.0     5444755.2       1.4X
 
 
 ================================================================================================
 Platform Memory Allocation 4k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Memory Allocation 4k Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      50000.0           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.0X
+allocateMemory                                        0              0           0      40000.0           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       1.3X
 reallocateMemory: double in size                      0              0           0       7662.8           0.1       0.2X
 
 
@@ -215,64 +227,64 @@ reallocateMemory: double in size                      0              0          
 Platform Memory Allocation 16k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Memory Allocation 16k Ints:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      50000.0           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.0X
-reallocateMemory: double in size                      0              0           0        864.3           1.2       0.0X
+allocateMemory                                        0              0           0      40816.3           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       1.2X
+reallocateMemory: double in size                      0              0           0       1447.2           0.7       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 256k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Memory Allocation 256k Ints:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      50000.0           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.0X
-reallocateMemory: double in size                      0              0           0         46.2          21.7       0.0X
+allocateMemory                                        0              0           0      25000.0           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       2.0X
+reallocateMemory: double in size                      0              0           0         57.4          17.4       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 1m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Memory Allocation 1m Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      50000.0           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.0X
-reallocateMemory: double in size                      0              0           0         14.1          71.0       0.0X
+allocateMemory                                        0              0           0      25000.0           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       2.0X
+reallocateMemory: double in size                      0              0           0         14.8          67.6       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 8m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Memory Allocation 8m Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0        468.6           2.1       1.0X
-freeMemory                                            0              0           0        333.8           3.0       0.7X
-reallocateMemory: double in size                      2              2           0          0.9        1097.5       0.0X
+allocateMemory                                        0              0           0      22471.9           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       2.2X
+reallocateMemory: double in size                      3              3           0          0.7        1437.6       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 32m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Memory Allocation 32m Ints:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0        475.3           2.1       1.0X
-freeMemory                                            0              0           0        289.3           3.5       0.6X
-reallocateMemory: double in size                     11             11           0          0.2        5503.5       0.0X
+allocateMemory                                        0              0           0        506.7           2.0       1.0X
+freeMemory                                            0              0           0        300.2           3.3       0.6X
+reallocateMemory: double in size                     10             10           0          0.2        4957.9       0.0X
 
 

--- a/core/benchmarks/PlatformBenchmark-jdk25-results.txt
+++ b/core/benchmarks/PlatformBenchmark-jdk25-results.txt
@@ -3,13 +3,13 @@ Platform Byte Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Byte Access:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putByte: On-heap                                     59             59           0       1688.7           0.6       1.0X
-putByte: Off-heap                                    72             72           0       1394.1           0.7       0.8X
-getByte: On-heap                                     46             46           0       2172.7           0.5       1.3X
-getByte: Off-heap                                    38             39           0       2602.7           0.4       1.5X
+putByte: On-heap                                     61             61           0       1641.9           0.6       1.0X
+putByte: Off-heap                                    78             78           0       1278.6           0.8       0.8X
+getByte: On-heap                                     52             52           0       1909.5           0.5       1.2X
+getByte: Off-heap                                    52             52           0       1909.5           0.5       1.2X
 
 
 ================================================================================================
@@ -17,13 +17,13 @@ Platform Short Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Short Access:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putShort: On-heap                                    59             60           1       1688.3           0.6       1.0X
-putShort: Off-heap                                   73             73           0       1374.9           0.7       0.8X
-getShort: On-heap                                    36             36           0       2758.8           0.4       1.6X
-getShort: Off-heap                                   40             40           0       2501.5           0.4       1.5X
+putShort: On-heap                                    62             62           0       1613.9           0.6       1.0X
+putShort: Off-heap                                   77             77           0       1302.9           0.8       0.8X
+getShort: On-heap                                    41             41           0       2415.0           0.4       1.5X
+getShort: Off-heap                                   50             51           0       1984.2           0.5       1.2X
 
 
 ================================================================================================
@@ -31,13 +31,13 @@ Platform Int Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Int Access:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putInt: On-heap                                      51             51           0       1970.3           0.5       1.0X
-putInt: Off-heap                                     51             51           0       1973.3           0.5       1.0X
-getInt: On-heap                                      33             33           0       3050.3           0.3       1.5X
-getInt: Off-heap                                     41             41           0       2433.8           0.4       1.2X
+putInt: On-heap                                      44             45           0       2252.3           0.4       1.0X
+putInt: Off-heap                                     56             56           0       1793.7           0.6       0.8X
+getInt: On-heap                                      34             34           0       2951.0           0.3       1.3X
+getInt: Off-heap                                     40             40           0       2498.8           0.4       1.1X
 
 
 ================================================================================================
@@ -45,13 +45,13 @@ Platform Long Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Long Access:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putLong: On-heap                                     94             95           1       1062.3           0.9       1.0X
-putLong: Off-heap                                    73             75           1       1369.1           0.7       1.3X
-getLong: On-heap                                     49             50           0       2034.4           0.5       1.9X
-getLong: Off-heap                                    55             56           1       1829.9           0.5       1.7X
+putLong: On-heap                                     68             68           0       1468.5           0.7       1.0X
+putLong: Off-heap                                    54             54           1       1863.7           0.5       1.3X
+getLong: On-heap                                     40             41           1       2522.4           0.4       1.7X
+getLong: Off-heap                                    44             45           1       2288.5           0.4       1.6X
 
 
 ================================================================================================
@@ -59,13 +59,13 @@ Platform Float Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Float Access:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putFloat: On-heap                                    58             58           0       1733.6           0.6       1.0X
-putFloat: Off-heap                                   58             58           1       1724.8           0.6       1.0X
-getFloat: On-heap                                   115            115           0        867.1           1.2       0.5X
-getFloat: Off-heap                                  115            116           0        866.9           1.2       0.5X
+putFloat: On-heap                                    44             44           0       2282.3           0.4       1.0X
+putFloat: Off-heap                                   50             50           0       2019.5           0.5       0.9X
+getFloat: On-heap                                    94             94           0       1068.3           0.9       0.5X
+getFloat: Off-heap                                   94             94           0       1067.4           0.9       0.5X
 
 
 ================================================================================================
@@ -73,13 +73,13 @@ Platform Double Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Double Access:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putDouble: On-heap                                   66             66           1       1522.4           0.7       1.0X
-putDouble: Off-heap                                  66             67           1       1517.5           0.7       1.0X
-getDouble: On-heap                                  122            122           0        818.1           1.2       0.5X
-getDouble: Off-heap                                 121            122           0        823.3           1.2       0.5X
+putDouble: On-heap                                   46             47           1       2159.7           0.5       1.0X
+putDouble: Off-heap                                  52             52           1       1931.1           0.5       0.9X
+getDouble: On-heap                                   94             94           0       1061.3           0.9       0.5X
+getDouble: Off-heap                                  94             95           0       1059.0           0.9       0.5X
 
 
 ================================================================================================
@@ -87,13 +87,13 @@ Platform Boolean Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Boolean Access:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putBoolean: On-heap                                  56             56           0       1796.8           0.6       1.0X
-putBoolean: Off-heap                                 55             55           0       1831.8           0.5       1.0X
-getBoolean: On-heap                                  58             58           0       1733.8           0.6       1.0X
-getBoolean: Off-heap                                 58             58           0       1722.6           0.6       1.0X
+putBoolean: On-heap                                  68             68           0       1468.3           0.7       1.0X
+putBoolean: Off-heap                                 52             52           0       1928.6           0.5       1.3X
+getBoolean: On-heap                                  62             62           0       1603.6           0.6       1.1X
+getBoolean: Off-heap                                 62             63           0       1602.4           0.6       1.1X
 
 
 ================================================================================================
@@ -101,11 +101,11 @@ Platform DirectBuffer Address Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 DirectBuffer Address Access:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-getLong (baseline)                                  275            276           1        363.5           2.8       1.0X
-getDirectBufferAddress                              558            559           1        179.3           5.6       0.5X
+getLong (baseline)                                  154            159           4        648.9           1.5       1.0X
+getDirectBufferAddress                              329            335           4        303.8           3.3       0.5X
 
 
 ================================================================================================
@@ -113,16 +113,16 @@ Platform Bulk Operations 4k Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Bulk Operations 4k Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          6.3         157.5       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          4.6         217.3       0.7X
-copyMemory: Off-heap -> Heap                          0              0           0          7.0         143.4       1.1X
-copyMemory: Heap -> Heap                              0              0           0          4.8         207.6       0.8X
-manual: Heap -> Heap                                  0              0           0          0.8        1184.2       0.1X
-manual: Off-heap -> Heap                              0              0           0          1.4         733.5       0.2X
-setMemory: Off-heap                                   0              0           0          3.3         302.1       0.5X
+copyMemory: Off-heap -> Off-heap                      0              0           0          5.4         186.3       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          4.3         230.4       0.8X
+copyMemory: Off-heap -> Heap                          0              0           0          5.6         177.3       1.1X
+copyMemory: Heap -> Heap                              0              0           0          5.4         185.4       1.0X
+manual: Heap -> Heap                                  0              0           0          0.9        1115.0       0.2X
+manual: Off-heap -> Heap                              0              0           0          1.0         958.7       0.2X
+setMemory: Off-heap                                   0              0           0          3.1         322.6       0.6X
 
 
 ================================================================================================
@@ -130,16 +130,16 @@ Platform Bulk Operations 16k Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Bulk Operations 16k Ints:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          0.6        1816.0       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          0.6        1812.8       1.0X
-copyMemory: Off-heap -> Heap                          0              0           0          0.6        1816.5       1.0X
-copyMemory: Heap -> Heap                              0              0           0          0.5        1851.4       1.0X
-manual: Heap -> Heap                                  0              0           0          0.2        5030.9       0.4X
-manual: Off-heap -> Heap                              0              0           0          0.3        3694.6       0.5X
-setMemory: Off-heap                                   0              0           0          0.7        1481.0       1.2X
+copyMemory: Off-heap -> Off-heap                      0              0           0          0.8        1294.4       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          0.7        1366.6       0.9X
+copyMemory: Off-heap -> Heap                          0              0           0          0.7        1381.6       0.9X
+copyMemory: Heap -> Heap                              0              0           0          0.7        1385.7       0.9X
+manual: Heap -> Heap                                  0              0           0          0.2        5502.3       0.2X
+manual: Off-heap -> Heap                              0              0           0          0.3        3946.4       0.3X
+setMemory: Off-heap                                   0              0           0          0.8        1286.4       1.0X
 
 
 ================================================================================================
@@ -147,16 +147,16 @@ Platform Bulk Operations 256k Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Bulk Operations 256k Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      1              1           0          0.0       63452.0       1.0X
-copyMemory: Heap -> Off-heap                          1              1           0          0.0       63366.4       1.0X
-copyMemory: Off-heap -> Heap                          1              1           0          0.0       63369.9       1.0X
-copyMemory: Heap -> Heap                              1              1           0          0.0       63552.5       1.0X
-manual: Heap -> Heap                                  1              1           0          0.0       75496.0       0.8X
-manual: Off-heap -> Heap                              1              1           0          0.0       71931.1       0.9X
-setMemory: Off-heap                                   0              0           0          0.0       24792.2       2.6X
+copyMemory: Off-heap -> Off-heap                      0              0           0          0.0       29367.2       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          0.0       26129.1       1.1X
+copyMemory: Off-heap -> Heap                          0              0           0          0.0       25692.3       1.1X
+copyMemory: Heap -> Heap                              0              0           0          0.0       25556.1       1.1X
+manual: Heap -> Heap                                  1              1           0          0.0       71480.4       0.4X
+manual: Off-heap -> Heap                              1              1           0          0.0       62589.7       0.5X
+setMemory: Off-heap                                   0              0           0          0.0       20488.5       1.4X
 
 
 ================================================================================================
@@ -164,16 +164,16 @@ Platform Bulk Operations 1m Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Bulk Operations 1m Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      3              3           0          0.0      254879.5       1.0X
-copyMemory: Heap -> Off-heap                          3              3           0          0.0      258716.7       1.0X
-copyMemory: Off-heap -> Heap                          3              3           0          0.0      258582.1       1.0X
-copyMemory: Heap -> Heap                              3              3           0          0.0      256088.4       1.0X
-manual: Heap -> Heap                                  3              3           0          0.0      313177.5       0.8X
-manual: Off-heap -> Heap                              3              3           0          0.0      276017.1       0.9X
-setMemory: Off-heap                                   1              1           0          0.0      141193.8       1.8X
+copyMemory: Off-heap -> Off-heap                      1              1           0          0.0      103428.5       1.0X
+copyMemory: Heap -> Off-heap                          1              1           0          0.0      104011.6       1.0X
+copyMemory: Off-heap -> Heap                          1              1           0          0.0      103916.4       1.0X
+copyMemory: Heap -> Heap                              1              1           0          0.0      104673.9       1.0X
+manual: Heap -> Heap                                  3              3           0          0.0      287721.0       0.4X
+manual: Off-heap -> Heap                              3              3           0          0.0      252355.6       0.4X
+setMemory: Off-heap                                   1              1           0          0.0       82176.6       1.3X
 
 
 ================================================================================================
@@ -181,16 +181,16 @@ Platform Bulk Operations 8m Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Bulk Operations 8m Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                     34             34           1          0.0     3355812.5       1.0X
-copyMemory: Heap -> Off-heap                         34             35           1          0.0     3381002.6       1.0X
-copyMemory: Off-heap -> Heap                         34             35           1          0.0     3443423.3       1.0X
-copyMemory: Heap -> Heap                             35             36           1          0.0     3521640.3       1.0X
-manual: Heap -> Heap                                 40             41           1          0.0     3961712.4       0.8X
-manual: Off-heap -> Heap                             40             41           1          0.0     3977464.5       0.8X
-setMemory: Off-heap                                  13             13           0          0.0     1317968.4       2.5X
+copyMemory: Off-heap -> Off-heap                     20             22           1          0.0     2037981.7       1.0X
+copyMemory: Heap -> Off-heap                         20             20           0          0.0     1986022.1       1.0X
+copyMemory: Off-heap -> Heap                         17             18           1          0.0     1705983.5       1.2X
+copyMemory: Heap -> Heap                             16             17           1          0.0     1610255.5       1.3X
+manual: Heap -> Heap                                 25             25           0          0.0     2484988.6       0.8X
+manual: Off-heap -> Heap                             27             28           0          0.0     2707546.2       0.8X
+setMemory: Off-heap                                  12             14           1          0.0     1197866.2       1.7X
 
 
 ================================================================================================
@@ -198,16 +198,16 @@ Platform Bulk Operations 32m Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Bulk Operations 32m Ints:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                    161            163           2          0.0    16110688.1       1.0X
-copyMemory: Heap -> Off-heap                        179            180           1          0.0    17873886.6       0.9X
-copyMemory: Off-heap -> Heap                        179            180           1          0.0    17918651.9       0.9X
-copyMemory: Heap -> Heap                            179            180           1          0.0    17907395.2       0.9X
-manual: Heap -> Heap                                183            183           1          0.0    18277542.2       0.9X
-manual: Off-heap -> Heap                            186            187           1          0.0    18568680.3       0.9X
-setMemory: Off-heap                                 107            108           1          0.0    10724669.7       1.5X
+copyMemory: Off-heap -> Off-heap                     77             79           1          0.0     7748515.9       1.0X
+copyMemory: Heap -> Off-heap                         82             84           2          0.0     8163292.9       0.9X
+copyMemory: Off-heap -> Heap                         80             83           2          0.0     7979049.4       1.0X
+copyMemory: Heap -> Heap                             78             80           1          0.0     7840213.0       1.0X
+manual: Heap -> Heap                                101            103           3          0.0    10077287.6       0.8X
+manual: Off-heap -> Heap                            102            106           2          0.0    10208030.5       0.8X
+setMemory: Off-heap                                  59             60           1          0.0     5877037.2       1.3X
 
 
 ================================================================================================
@@ -215,12 +215,12 @@ Platform Memory Allocation 4k Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Memory Allocation 4k Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      37735.8           0.0       1.0X
-freeMemory                                            0              0           0      42553.2           0.0       1.1X
-reallocateMemory: double in size                      0              0           0       5128.2           0.2       0.1X
+allocateMemory                                        0              0           0      68965.5           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       0.7X
+reallocateMemory: double in size                      0              0           0       6250.0           0.2       0.1X
 
 
 ================================================================================================
@@ -228,12 +228,12 @@ Platform Memory Allocation 16k Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Memory Allocation 16k Ints:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      35714.3           0.0       1.0X
-freeMemory                                            0              0           0      42553.2           0.0       1.2X
-reallocateMemory: double in size                      0              0           0       1358.7           0.7       0.0X
+allocateMemory                                        0              0           0      40816.3           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       1.2X
+reallocateMemory: double in size                      0              0           0       1435.8           0.7       0.0X
 
 
 ================================================================================================
@@ -241,12 +241,12 @@ Platform Memory Allocation 256k Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Memory Allocation 256k Ints:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      24390.2           0.0       1.0X
-freeMemory                                            0              0           0      42553.2           0.0       1.7X
-reallocateMemory: double in size                      0              0           0         32.0          31.3       0.0X
+allocateMemory                                        0              0           0      25000.0           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       2.0X
+reallocateMemory: double in size                      0              0           0         66.5          15.0       0.0X
 
 
 ================================================================================================
@@ -254,12 +254,12 @@ Platform Memory Allocation 1m Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Memory Allocation 1m Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      26315.8           0.0       1.0X
-freeMemory                                            0              0           0      42553.2           0.0       1.6X
-reallocateMemory: double in size                      0              0           0          7.9         126.5       0.0X
+allocateMemory                                        0              0           0      28985.5           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       1.7X
+reallocateMemory: double in size                      0              0           0         19.4          51.5       0.0X
 
 
 ================================================================================================
@@ -267,12 +267,12 @@ Platform Memory Allocation 8m Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Memory Allocation 8m Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      25316.5           0.0       1.0X
-freeMemory                                            0              0           0      42553.2           0.0       1.7X
-reallocateMemory: double in size                      5              5           0          0.4        2470.6       0.0X
+allocateMemory                                        0              0           0      25000.0           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       2.0X
+reallocateMemory: double in size                      3              3           0          0.7        1350.9       0.0X
 
 
 ================================================================================================
@@ -280,11 +280,11 @@ Platform Memory Allocation 32m Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 Memory Allocation 32m Ints:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0        993.5           1.0       1.0X
-freeMemory                                            0              0           0        630.5           1.6       0.6X
-reallocateMemory: double in size                     22             22           0          0.1       10992.5       0.0X
+allocateMemory                                        0              0           0        539.5           1.9       1.0X
+freeMemory                                            0              0           0        311.4           3.2       0.6X
+reallocateMemory: double in size                     11             12           2          0.2        5376.3       0.0X
 
 

--- a/core/benchmarks/PlatformBenchmark-jdk25-results.txt
+++ b/core/benchmarks/PlatformBenchmark-jdk25-results.txt
@@ -3,13 +3,13 @@ Platform Byte Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Byte Access:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putByte: On-heap                                     64             65           0       1552.4           0.6       1.0X
-putByte: Off-heap                                    81             81           0       1233.4           0.8       0.8X
-getByte: On-heap                                     59             59           1       1703.4           0.6       1.1X
-getByte: Off-heap                                    59             59           0       1688.3           0.6       1.1X
+putByte: On-heap                                     59             59           0       1688.7           0.6       1.0X
+putByte: Off-heap                                    72             72           0       1394.1           0.7       0.8X
+getByte: On-heap                                     46             46           0       2172.7           0.5       1.3X
+getByte: Off-heap                                    38             39           0       2602.7           0.4       1.5X
 
 
 ================================================================================================
@@ -17,13 +17,13 @@ Platform Short Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Short Access:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putShort: On-heap                                    64             65           3       1554.3           0.6       1.0X
-putShort: Off-heap                                   80             80           0       1250.9           0.8       0.8X
-getShort: On-heap                                    46             47           0       2151.7           0.5       1.4X
-getShort: Off-heap                                   57             57           0       1766.3           0.6       1.1X
+putShort: On-heap                                    59             60           1       1688.3           0.6       1.0X
+putShort: Off-heap                                   73             73           0       1374.9           0.7       0.8X
+getShort: On-heap                                    36             36           0       2758.8           0.4       1.6X
+getShort: Off-heap                                   40             40           0       2501.5           0.4       1.5X
 
 
 ================================================================================================
@@ -31,13 +31,13 @@ Platform Int Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Int Access:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putInt: On-heap                                     107            108           0        932.8           1.1       1.0X
-putInt: Off-heap                                    116            117           0        860.4           1.2       0.9X
-getInt: On-heap                                      37             37           0       2676.6           0.4       2.9X
-getInt: Off-heap                                     44             44           0       2260.0           0.4       2.4X
+putInt: On-heap                                      51             51           0       1970.3           0.5       1.0X
+putInt: Off-heap                                     51             51           0       1973.3           0.5       1.0X
+getInt: On-heap                                      33             33           0       3050.3           0.3       1.5X
+getInt: Off-heap                                     41             41           0       2433.8           0.4       1.2X
 
 
 ================================================================================================
@@ -45,13 +45,13 @@ Platform Long Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Long Access:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putLong: On-heap                                     68             68           0       1477.4           0.7       1.0X
-putLong: Off-heap                                   116            116           0        865.4           1.2       0.6X
-getLong: On-heap                                     39             39           0       2584.0           0.4       1.7X
-getLong: Off-heap                                    45             46           1       2201.3           0.5       1.5X
+putLong: On-heap                                     94             95           1       1062.3           0.9       1.0X
+putLong: Off-heap                                    73             75           1       1369.1           0.7       1.3X
+getLong: On-heap                                     49             50           0       2034.4           0.5       1.9X
+getLong: Off-heap                                    55             56           1       1829.9           0.5       1.7X
 
 
 ================================================================================================
@@ -59,13 +59,13 @@ Platform Float Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Float Access:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putFloat: On-heap                                    53             53           0       1901.2           0.5       1.0X
-putFloat: Off-heap                                   53             53           0       1879.0           0.5       1.0X
-getFloat: On-heap                                   106            106           0        946.0           1.1       0.5X
-getFloat: Off-heap                                  106            106           0        946.0           1.1       0.5X
+putFloat: On-heap                                    58             58           0       1733.6           0.6       1.0X
+putFloat: Off-heap                                   58             58           1       1724.8           0.6       1.0X
+getFloat: On-heap                                   115            115           0        867.1           1.2       0.5X
+getFloat: Off-heap                                  115            116           0        866.9           1.2       0.5X
 
 
 ================================================================================================
@@ -73,13 +73,13 @@ Platform Double Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Double Access:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putDouble: On-heap                                   54             54           0       1860.6           0.5       1.0X
-putDouble: Off-heap                                  54             57          13       1843.9           0.5       1.0X
-getDouble: On-heap                                  106            106           0        945.3           1.1       0.5X
-getDouble: Off-heap                                 106            106           0        944.6           1.1       0.5X
+putDouble: On-heap                                   66             66           1       1522.4           0.7       1.0X
+putDouble: Off-heap                                  66             67           1       1517.5           0.7       1.0X
+getDouble: On-heap                                  122            122           0        818.1           1.2       0.5X
+getDouble: Off-heap                                 121            122           0        823.3           1.2       0.5X
 
 
 ================================================================================================
@@ -87,13 +87,13 @@ Platform Boolean Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Boolean Access:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putBoolean: On-heap                                 122            123           0        820.9           1.2       1.0X
-putBoolean: Off-heap                                 88             90           1       1131.0           0.9       1.4X
-getBoolean: On-heap                                  70             71           0       1419.6           0.7       1.7X
-getBoolean: Off-heap                                 70             71           2       1418.6           0.7       1.7X
+putBoolean: On-heap                                  56             56           0       1796.8           0.6       1.0X
+putBoolean: Off-heap                                 55             55           0       1831.8           0.5       1.0X
+getBoolean: On-heap                                  58             58           0       1733.8           0.6       1.0X
+getBoolean: Off-heap                                 58             58           0       1722.6           0.6       1.0X
 
 
 ================================================================================================
@@ -101,11 +101,11 @@ Platform DirectBuffer Address Access
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 DirectBuffer Address Access:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-getLong (baseline)                                  130            134           8        768.7           1.3       1.0X
-getDirectBufferAddress                              393            401           5        254.3           3.9       0.3X
+getLong (baseline)                                  275            276           1        363.5           2.8       1.0X
+getDirectBufferAddress                              558            559           1        179.3           5.6       0.5X
 
 
 ================================================================================================
@@ -113,16 +113,16 @@ Platform Bulk Operations 4k Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Bulk Operations 4k Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          4.8         207.3       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          4.1         246.4       0.8X
-copyMemory: Off-heap -> Heap                          0              0           0          3.7         272.4       0.8X
-copyMemory: Heap -> Heap                              0              0           0          3.3         299.4       0.7X
-manual: Heap -> Heap                                  0              0           0          0.8        1261.8       0.2X
-manual: Off-heap -> Heap                              0              0           0          1.0        1015.5       0.2X
-setMemory: Off-heap                                   0              0           0          2.8         360.5       0.6X
+copyMemory: Off-heap -> Off-heap                      0              0           0          6.3         157.5       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          4.6         217.3       0.7X
+copyMemory: Off-heap -> Heap                          0              0           0          7.0         143.4       1.1X
+copyMemory: Heap -> Heap                              0              0           0          4.8         207.6       0.8X
+manual: Heap -> Heap                                  0              0           0          0.8        1184.2       0.1X
+manual: Off-heap -> Heap                              0              0           0          1.4         733.5       0.2X
+setMemory: Off-heap                                   0              0           0          3.3         302.1       0.5X
 
 
 ================================================================================================
@@ -130,16 +130,16 @@ Platform Bulk Operations 16k Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Bulk Operations 16k Ints:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          0.7        1508.2       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          0.6        1539.3       1.0X
-copyMemory: Off-heap -> Heap                          0              0           0          0.7        1508.2       1.0X
-copyMemory: Heap -> Heap                              0              0           0          0.7        1526.3       1.0X
-manual: Heap -> Heap                                  0              0           0          0.2        5766.7       0.3X
-manual: Off-heap -> Heap                              0              0           0          0.2        4494.7       0.3X
-setMemory: Off-heap                                   0              0           0          0.7        1448.1       1.0X
+copyMemory: Off-heap -> Off-heap                      0              0           0          0.6        1816.0       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          0.6        1812.8       1.0X
+copyMemory: Off-heap -> Heap                          0              0           0          0.6        1816.5       1.0X
+copyMemory: Heap -> Heap                              0              0           0          0.5        1851.4       1.0X
+manual: Heap -> Heap                                  0              0           0          0.2        5030.9       0.4X
+manual: Off-heap -> Heap                              0              0           0          0.3        3694.6       0.5X
+setMemory: Off-heap                                   0              0           0          0.7        1481.0       1.2X
 
 
 ================================================================================================
@@ -147,16 +147,16 @@ Platform Bulk Operations 256k Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Bulk Operations 256k Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          0.0       27706.6       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          0.0       34242.4       0.8X
-copyMemory: Off-heap -> Heap                          0              0           0          0.0       29100.7       1.0X
-copyMemory: Heap -> Heap                              0              0           0          0.0       31155.8       0.9X
-manual: Heap -> Heap                                  1              1           0          0.0       80579.0       0.3X
-manual: Off-heap -> Heap                              1              1           0          0.0       70706.2       0.4X
-setMemory: Off-heap                                   0              0           0          0.0       23773.7       1.2X
+copyMemory: Off-heap -> Off-heap                      1              1           0          0.0       63452.0       1.0X
+copyMemory: Heap -> Off-heap                          1              1           0          0.0       63366.4       1.0X
+copyMemory: Off-heap -> Heap                          1              1           0          0.0       63369.9       1.0X
+copyMemory: Heap -> Heap                              1              1           0          0.0       63552.5       1.0X
+manual: Heap -> Heap                                  1              1           0          0.0       75496.0       0.8X
+manual: Off-heap -> Heap                              1              1           0          0.0       71931.1       0.9X
+setMemory: Off-heap                                   0              0           0          0.0       24792.2       2.6X
 
 
 ================================================================================================
@@ -164,16 +164,16 @@ Platform Bulk Operations 1m Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Bulk Operations 1m Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      1              1           0          0.0      119678.8       1.0X
-copyMemory: Heap -> Off-heap                          1              1           0          0.0      127046.9       0.9X
-copyMemory: Off-heap -> Heap                          1              1           0          0.0      126821.5       0.9X
-copyMemory: Heap -> Heap                              1              1           0          0.0      126894.7       0.9X
-manual: Heap -> Heap                                  3              3           0          0.0      325086.2       0.4X
-manual: Off-heap -> Heap                              3              3           0          0.0      297113.3       0.4X
-setMemory: Off-heap                                   1              1           0          0.0       91608.6       1.3X
+copyMemory: Off-heap -> Off-heap                      3              3           0          0.0      254879.5       1.0X
+copyMemory: Heap -> Off-heap                          3              3           0          0.0      258716.7       1.0X
+copyMemory: Off-heap -> Heap                          3              3           0          0.0      258582.1       1.0X
+copyMemory: Heap -> Heap                              3              3           0          0.0      256088.4       1.0X
+manual: Heap -> Heap                                  3              3           0          0.0      313177.5       0.8X
+manual: Off-heap -> Heap                              3              3           0          0.0      276017.1       0.9X
+setMemory: Off-heap                                   1              1           0          0.0      141193.8       1.8X
 
 
 ================================================================================================
@@ -181,16 +181,16 @@ Platform Bulk Operations 8m Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Bulk Operations 8m Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                     15             16           1          0.0     1532636.0       1.0X
-copyMemory: Heap -> Off-heap                         16             17           1          0.0     1579805.0       1.0X
-copyMemory: Off-heap -> Heap                         15             16           0          0.0     1503746.8       1.0X
-copyMemory: Heap -> Heap                             16             16           1          0.0     1550167.9       1.0X
-manual: Heap -> Heap                                 26             26           0          0.0     2621474.4       0.6X
-manual: Off-heap -> Heap                             24             25           0          0.0     2441700.8       0.6X
-setMemory: Off-heap                                   8              9           1          0.0      847346.8       1.8X
+copyMemory: Off-heap -> Off-heap                     34             34           1          0.0     3355812.5       1.0X
+copyMemory: Heap -> Off-heap                         34             35           1          0.0     3381002.6       1.0X
+copyMemory: Off-heap -> Heap                         34             35           1          0.0     3443423.3       1.0X
+copyMemory: Heap -> Heap                             35             36           1          0.0     3521640.3       1.0X
+manual: Heap -> Heap                                 40             41           1          0.0     3961712.4       0.8X
+manual: Off-heap -> Heap                             40             41           1          0.0     3977464.5       0.8X
+setMemory: Off-heap                                  13             13           0          0.0     1317968.4       2.5X
 
 
 ================================================================================================
@@ -198,16 +198,16 @@ Platform Bulk Operations 32m Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Bulk Operations 32m Ints:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                     71             73           5          0.0     7078254.4       1.0X
-copyMemory: Heap -> Off-heap                         78             79           2          0.0     7777528.8       0.9X
-copyMemory: Off-heap -> Heap                         77             79           1          0.0     7693510.6       0.9X
-copyMemory: Heap -> Heap                             76             78           2          0.0     7608350.7       0.9X
-manual: Heap -> Heap                                105            107           4          0.0    10501889.2       0.7X
-manual: Off-heap -> Heap                             97            100           6          0.0     9749678.6       0.7X
-setMemory: Off-heap                                  39             42           1          0.0     3946801.7       1.8X
+copyMemory: Off-heap -> Off-heap                    161            163           2          0.0    16110688.1       1.0X
+copyMemory: Heap -> Off-heap                        179            180           1          0.0    17873886.6       0.9X
+copyMemory: Off-heap -> Heap                        179            180           1          0.0    17918651.9       0.9X
+copyMemory: Heap -> Heap                            179            180           1          0.0    17907395.2       0.9X
+manual: Heap -> Heap                                183            183           1          0.0    18277542.2       0.9X
+manual: Off-heap -> Heap                            186            187           1          0.0    18568680.3       0.9X
+setMemory: Off-heap                                 107            108           1          0.0    10724669.7       1.5X
 
 
 ================================================================================================
@@ -215,12 +215,12 @@ Platform Memory Allocation 4k Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Memory Allocation 4k Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      40000.0           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.3X
-reallocateMemory: double in size                      0              0           0       5714.3           0.2       0.1X
+allocateMemory                                        0              0           0      37735.8           0.0       1.0X
+freeMemory                                            0              0           0      42553.2           0.0       1.1X
+reallocateMemory: double in size                      0              0           0       5128.2           0.2       0.1X
 
 
 ================================================================================================
@@ -228,12 +228,12 @@ Platform Memory Allocation 16k Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Memory Allocation 16k Ints:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      33333.3           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.5X
-reallocateMemory: double in size                      0              0           0       1322.8           0.8       0.0X
+allocateMemory                                        0              0           0      35714.3           0.0       1.0X
+freeMemory                                            0              0           0      42553.2           0.0       1.2X
+reallocateMemory: double in size                      0              0           0       1358.7           0.7       0.0X
 
 
 ================================================================================================
@@ -241,12 +241,12 @@ Platform Memory Allocation 256k Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Memory Allocation 256k Ints:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      22222.2           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       2.3X
-reallocateMemory: double in size                      0              0           0         64.3          15.6       0.0X
+allocateMemory                                        0              0           0      24390.2           0.0       1.0X
+freeMemory                                            0              0           0      42553.2           0.0       1.7X
+reallocateMemory: double in size                      0              0           0         32.0          31.3       0.0X
 
 
 ================================================================================================
@@ -254,12 +254,12 @@ Platform Memory Allocation 1m Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Memory Allocation 1m Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      22222.2           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       2.3X
-reallocateMemory: double in size                      0              0           0         16.5          60.7       0.0X
+allocateMemory                                        0              0           0      26315.8           0.0       1.0X
+freeMemory                                            0              0           0      42553.2           0.0       1.6X
+reallocateMemory: double in size                      0              0           0          7.9         126.5       0.0X
 
 
 ================================================================================================
@@ -267,12 +267,12 @@ Platform Memory Allocation 8m Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Memory Allocation 8m Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      22222.2           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       2.3X
-reallocateMemory: double in size                      2              3           0          0.8        1194.7       0.0X
+allocateMemory                                        0              0           0      25316.5           0.0       1.0X
+freeMemory                                            0              0           0      42553.2           0.0       1.7X
+reallocateMemory: double in size                      5              5           0          0.4        2470.6       0.0X
 
 
 ================================================================================================
@@ -280,11 +280,11 @@ Platform Memory Allocation 32m Ints
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Memory Allocation 32m Ints:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0        463.4           2.2       1.0X
-freeMemory                                            0              0           0        295.0           3.4       0.6X
-reallocateMemory: double in size                      9              9           0          0.2        4470.0       0.0X
+allocateMemory                                        0              0           0        993.5           1.0       1.0X
+freeMemory                                            0              0           0        630.5           1.6       0.6X
+reallocateMemory: double in size                     22             22           0          0.1       10992.5       0.0X
 
 

--- a/core/benchmarks/PlatformBenchmark-jdk25-results.txt
+++ b/core/benchmarks/PlatformBenchmark-jdk25-results.txt
@@ -2,277 +2,289 @@
 Platform Byte Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Byte Access:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putByte: On-heap                                     61             61           0       1645.1           0.6       1.0X
-putByte: Off-heap                                    78             78           0       1281.6           0.8       0.8X
-getByte: On-heap                                     52             52           0       1912.1           0.5       1.2X
-getByte: Off-heap                                    52             52           0       1909.8           0.5       1.2X
+putByte: On-heap                                     64             65           0       1552.4           0.6       1.0X
+putByte: Off-heap                                    81             81           0       1233.4           0.8       0.8X
+getByte: On-heap                                     59             59           1       1703.4           0.6       1.1X
+getByte: Off-heap                                    59             59           0       1688.3           0.6       1.1X
 
 
 ================================================================================================
 Platform Short Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Short Access:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putShort: On-heap                                    61             62           0       1627.3           0.6       1.0X
-putShort: Off-heap                                   76             76           0       1317.8           0.8       0.8X
-getShort: On-heap                                    41             41           0       2420.1           0.4       1.5X
-getShort: Off-heap                                   50             50           0       1992.3           0.5       1.2X
+putShort: On-heap                                    64             65           3       1554.3           0.6       1.0X
+putShort: Off-heap                                   80             80           0       1250.9           0.8       0.8X
+getShort: On-heap                                    46             47           0       2151.7           0.5       1.4X
+getShort: Off-heap                                   57             57           0       1766.3           0.6       1.1X
 
 
 ================================================================================================
 Platform Int Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Int Access:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putInt: On-heap                                      44             44           0       2260.5           0.4       1.0X
-putInt: Off-heap                                     56             56           0       1795.5           0.6       0.8X
-getInt: On-heap                                      34             34           0       2972.8           0.3       1.3X
-getInt: Off-heap                                     40             40           0       2502.6           0.4       1.1X
+putInt: On-heap                                     107            108           0        932.8           1.1       1.0X
+putInt: Off-heap                                    116            117           0        860.4           1.2       0.9X
+getInt: On-heap                                      37             37           0       2676.6           0.4       2.9X
+getInt: Off-heap                                     44             44           0       2260.0           0.4       2.4X
 
 
 ================================================================================================
 Platform Long Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Long Access:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putLong: On-heap                                     68             68           1       1478.1           0.7       1.0X
-putLong: Off-heap                                    54             54           0       1858.3           0.5       1.3X
-getLong: On-heap                                     40             41           1       2514.0           0.4       1.7X
-getLong: Off-heap                                    43             45           1       2308.7           0.4       1.6X
+putLong: On-heap                                     68             68           0       1477.4           0.7       1.0X
+putLong: Off-heap                                   116            116           0        865.4           1.2       0.6X
+getLong: On-heap                                     39             39           0       2584.0           0.4       1.7X
+getLong: Off-heap                                    45             46           1       2201.3           0.5       1.5X
 
 
 ================================================================================================
 Platform Float Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Float Access:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putFloat: On-heap                                    44             44           0       2262.0           0.4       1.0X
-putFloat: Off-heap                                   50             50           0       2019.5           0.5       0.9X
-getFloat: On-heap                                    94             94           0       1068.9           0.9       0.5X
-getFloat: Off-heap                                   94             94           0       1068.1           0.9       0.5X
+putFloat: On-heap                                    53             53           0       1901.2           0.5       1.0X
+putFloat: Off-heap                                   53             53           0       1879.0           0.5       1.0X
+getFloat: On-heap                                   106            106           0        946.0           1.1       0.5X
+getFloat: Off-heap                                  106            106           0        946.0           1.1       0.5X
 
 
 ================================================================================================
 Platform Double Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Double Access:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putDouble: On-heap                                   46             47           0       2168.0           0.5       1.0X
-putDouble: Off-heap                                  52             52           0       1931.2           0.5       0.9X
-getDouble: On-heap                                   94             94           0       1061.9           0.9       0.5X
-getDouble: Off-heap                                  95             95           0       1058.1           0.9       0.5X
+putDouble: On-heap                                   54             54           0       1860.6           0.5       1.0X
+putDouble: Off-heap                                  54             57          13       1843.9           0.5       1.0X
+getDouble: On-heap                                  106            106           0        945.3           1.1       0.5X
+getDouble: Off-heap                                 106            106           0        944.6           1.1       0.5X
 
 
 ================================================================================================
 Platform Boolean Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Boolean Access:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putBoolean: On-heap                                  68             70           5       1469.9           0.7       1.0X
-putBoolean: Off-heap                                 52             52           0       1929.7           0.5       1.3X
-getBoolean: On-heap                                  62             62           0       1605.4           0.6       1.1X
-getBoolean: Off-heap                                 62             62           0       1603.2           0.6       1.1X
+putBoolean: On-heap                                 122            123           0        820.9           1.2       1.0X
+putBoolean: Off-heap                                 88             90           1       1131.0           0.9       1.4X
+getBoolean: On-heap                                  70             71           0       1419.6           0.7       1.7X
+getBoolean: Off-heap                                 70             71           2       1418.6           0.7       1.7X
+
+
+================================================================================================
+Platform DirectBuffer Address Access
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
+DirectBuffer Address Access:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+getLong (baseline)                                  130            134           8        768.7           1.3       1.0X
+getDirectBufferAddress                              393            401           5        254.3           3.9       0.3X
 
 
 ================================================================================================
 Platform Bulk Operations 4k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Bulk Operations 4k Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          5.4         186.3       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          4.6         216.4       0.9X
-copyMemory: Off-heap -> Heap                          0              0           0          4.0         250.4       0.7X
-copyMemory: Heap -> Heap                              0              0           0          4.6         218.4       0.9X
-manual: Heap -> Heap                                  0              0           0          0.9        1115.0       0.2X
-manual: Off-heap -> Heap                              0              0           0          1.0         958.7       0.2X
-setMemory: Off-heap                                   0              0           0          3.1         321.6       0.6X
+copyMemory: Off-heap -> Off-heap                      0              0           0          4.8         207.3       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          4.1         246.4       0.8X
+copyMemory: Off-heap -> Heap                          0              0           0          3.7         272.4       0.8X
+copyMemory: Heap -> Heap                              0              0           0          3.3         299.4       0.7X
+manual: Heap -> Heap                                  0              0           0          0.8        1261.8       0.2X
+manual: Off-heap -> Heap                              0              0           0          1.0        1015.5       0.2X
+setMemory: Off-heap                                   0              0           0          2.8         360.5       0.6X
 
 
 ================================================================================================
 Platform Bulk Operations 16k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Bulk Operations 16k Ints:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          0.8        1297.4       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          0.7        1374.5       0.9X
-copyMemory: Off-heap -> Heap                          0              0           0          0.8        1307.4       1.0X
-copyMemory: Heap -> Heap                              0              0           0          0.8        1308.4       1.0X
-manual: Heap -> Heap                                  0              0           0          0.2        5481.2       0.2X
-manual: Off-heap -> Heap                              0              0           0          0.3        3927.3       0.3X
-setMemory: Off-heap                                   0              0           0          0.8        1286.3       1.0X
+copyMemory: Off-heap -> Off-heap                      0              0           0          0.7        1508.2       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          0.6        1539.3       1.0X
+copyMemory: Off-heap -> Heap                          0              0           0          0.7        1508.2       1.0X
+copyMemory: Heap -> Heap                              0              0           0          0.7        1526.3       1.0X
+manual: Heap -> Heap                                  0              0           0          0.2        5766.7       0.3X
+manual: Off-heap -> Heap                              0              0           0          0.2        4494.7       0.3X
+setMemory: Off-heap                                   0              0           0          0.7        1448.1       1.0X
 
 
 ================================================================================================
 Platform Bulk Operations 256k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Bulk Operations 256k Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          0.0       28214.6       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          0.0       25715.9       1.1X
-copyMemory: Off-heap -> Heap                          0              0           0          0.0       26025.5       1.1X
-copyMemory: Heap -> Heap                              0              0           0          0.0       25499.4       1.1X
-manual: Heap -> Heap                                  1              1           0          0.0       89010.7       0.3X
-manual: Off-heap -> Heap                              1              1           0          0.0       64418.9       0.4X
-setMemory: Off-heap                                   0              0           0          0.0       20724.7       1.4X
+copyMemory: Off-heap -> Off-heap                      0              0           0          0.0       27706.6       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          0.0       34242.4       0.8X
+copyMemory: Off-heap -> Heap                          0              0           0          0.0       29100.7       1.0X
+copyMemory: Heap -> Heap                              0              0           0          0.0       31155.8       0.9X
+manual: Heap -> Heap                                  1              1           0          0.0       80579.0       0.3X
+manual: Off-heap -> Heap                              1              1           0          0.0       70706.2       0.4X
+setMemory: Off-heap                                   0              0           0          0.0       23773.7       1.2X
 
 
 ================================================================================================
 Platform Bulk Operations 1m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Bulk Operations 1m Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      1              1           0          0.0      106262.8       1.0X
-copyMemory: Heap -> Off-heap                          1              1           0          0.0      104618.6       1.0X
-copyMemory: Off-heap -> Heap                          1              1           0          0.0      104421.3       1.0X
-copyMemory: Heap -> Heap                              1              1           0          0.0      103696.0       1.0X
-manual: Heap -> Heap                                  3              3           0          0.0      287286.8       0.4X
-manual: Off-heap -> Heap                              3              3           0          0.0      254099.0       0.4X
-setMemory: Off-heap                                   1              1           0          0.0       81383.4       1.3X
+copyMemory: Off-heap -> Off-heap                      1              1           0          0.0      119678.8       1.0X
+copyMemory: Heap -> Off-heap                          1              1           0          0.0      127046.9       0.9X
+copyMemory: Off-heap -> Heap                          1              1           0          0.0      126821.5       0.9X
+copyMemory: Heap -> Heap                              1              1           0          0.0      126894.7       0.9X
+manual: Heap -> Heap                                  3              3           0          0.0      325086.2       0.4X
+manual: Off-heap -> Heap                              3              3           0          0.0      297113.3       0.4X
+setMemory: Off-heap                                   1              1           0          0.0       91608.6       1.3X
 
 
 ================================================================================================
 Platform Bulk Operations 8m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Bulk Operations 8m Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                     14             16           1          0.0     1408711.6       1.0X
-copyMemory: Heap -> Off-heap                         16             17           1          0.0     1592233.3       0.9X
-copyMemory: Off-heap -> Heap                         16             17           0          0.0     1580333.7       0.9X
-copyMemory: Heap -> Heap                             16             17           1          0.0     1594253.6       0.9X
-manual: Heap -> Heap                                 25             25           0          0.0     2473883.8       0.6X
-manual: Off-heap -> Heap                             25             26           1          0.0     2500358.3       0.6X
-setMemory: Off-heap                                   8             13           1          0.0      849445.6       1.7X
+copyMemory: Off-heap -> Off-heap                     15             16           1          0.0     1532636.0       1.0X
+copyMemory: Heap -> Off-heap                         16             17           1          0.0     1579805.0       1.0X
+copyMemory: Off-heap -> Heap                         15             16           0          0.0     1503746.8       1.0X
+copyMemory: Heap -> Heap                             16             16           1          0.0     1550167.9       1.0X
+manual: Heap -> Heap                                 26             26           0          0.0     2621474.4       0.6X
+manual: Off-heap -> Heap                             24             25           0          0.0     2441700.8       0.6X
+setMemory: Off-heap                                   8              9           1          0.0      847346.8       1.8X
 
 
 ================================================================================================
 Platform Bulk Operations 32m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Bulk Operations 32m Ints:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                     75             77           1          0.0     7519485.5       1.0X
-copyMemory: Heap -> Off-heap                         83             86           2          0.0     8296719.9       0.9X
-copyMemory: Off-heap -> Heap                         79             82           2          0.0     7949268.1       0.9X
-copyMemory: Heap -> Heap                             78             81           2          0.0     7825109.7       1.0X
-manual: Heap -> Heap                                100            101           1          0.0    10000320.7       0.8X
-manual: Off-heap -> Heap                            101            105           2          0.0    10118767.2       0.7X
-setMemory: Off-heap                                  58             62           2          0.0     5778583.5       1.3X
+copyMemory: Off-heap -> Off-heap                     71             73           5          0.0     7078254.4       1.0X
+copyMemory: Heap -> Off-heap                         78             79           2          0.0     7777528.8       0.9X
+copyMemory: Off-heap -> Heap                         77             79           1          0.0     7693510.6       0.9X
+copyMemory: Heap -> Heap                             76             78           2          0.0     7608350.7       0.9X
+manual: Heap -> Heap                                105            107           4          0.0    10501889.2       0.7X
+manual: Off-heap -> Heap                             97            100           6          0.0     9749678.6       0.7X
+setMemory: Off-heap                                  39             42           1          0.0     3946801.7       1.8X
 
 
 ================================================================================================
 Platform Memory Allocation 4k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Memory Allocation 4k Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      50000.0           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.0X
-reallocateMemory: double in size                      0              0           0       6666.7           0.2       0.1X
+allocateMemory                                        0              0           0      40000.0           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       1.3X
+reallocateMemory: double in size                      0              0           0       5714.3           0.2       0.1X
 
 
 ================================================================================================
 Platform Memory Allocation 16k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Memory Allocation 16k Ints:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      40816.3           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.2X
-reallocateMemory: double in size                      0              0           0        713.0           1.4       0.0X
+allocateMemory                                        0              0           0      33333.3           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       1.5X
+reallocateMemory: double in size                      0              0           0       1322.8           0.8       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 256k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Memory Allocation 256k Ints:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      40816.3           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.2X
-reallocateMemory: double in size                      0              0           0         40.9          24.4       0.0X
+allocateMemory                                        0              0           0      22222.2           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       2.3X
+reallocateMemory: double in size                      0              0           0         64.3          15.6       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 1m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Memory Allocation 1m Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      40816.3           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.2X
-reallocateMemory: double in size                      0              0           0         19.5          51.4       0.0X
+allocateMemory                                        0              0           0      22222.2           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       2.3X
+reallocateMemory: double in size                      0              0           0         16.5          60.7       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 8m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Memory Allocation 8m Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0        464.1           2.2       1.0X
-freeMemory                                            0              0           0        329.4           3.0       0.7X
-reallocateMemory: double in size                      2              2           0          0.9        1109.9       0.0X
+allocateMemory                                        0              0           0      22222.2           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       2.3X
+reallocateMemory: double in size                      2              3           0          0.8        1194.7       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 32m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Memory Allocation 32m Ints:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0        463.3           2.2       1.0X
-freeMemory                                            0              0           0        284.4           3.5       0.6X
-reallocateMemory: double in size                     10             10           0          0.2        4779.0       0.0X
+allocateMemory                                        0              0           0        463.4           2.2       1.0X
+freeMemory                                            0              0           0        295.0           3.4       0.6X
+reallocateMemory: double in size                      9              9           0          0.2        4470.0       0.0X
 
 

--- a/core/benchmarks/PlatformBenchmark-results.txt
+++ b/core/benchmarks/PlatformBenchmark-results.txt
@@ -2,113 +2,125 @@
 Platform Byte Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Byte Access:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putByte: On-heap                                     63             63           0       1590.5           0.6       1.0X
-putByte: Off-heap                                    80             80           0       1245.7           0.8       0.8X
-getByte: On-heap                                     59             59           0       1685.7           0.6       1.1X
-getByte: Off-heap                                    47             48           1       2112.6           0.5       1.3X
+putByte: On-heap                                     63             63           0       1592.6           0.6       1.0X
+putByte: Off-heap                                    78             78           0       1282.3           0.8       0.8X
+getByte: On-heap                                     59             60           0       1684.2           0.6       1.1X
+getByte: Off-heap                                    47             47           0       2110.6           0.5       1.3X
 
 
 ================================================================================================
 Platform Short Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Short Access:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putShort: On-heap                                    63             63           1       1586.2           0.6       1.0X
-putShort: Off-heap                                  119            119           0        839.2           1.2       0.5X
-getShort: On-heap                                    44             44           0       2256.6           0.4       1.4X
-getShort: Off-heap                                   57             57           0       1761.1           0.6       1.1X
+putShort: On-heap                                    63             63           0       1581.9           0.6       1.0X
+putShort: Off-heap                                  119            119           0        838.3           1.2       0.5X
+getShort: On-heap                                    44             44           0       2256.3           0.4       1.4X
+getShort: Off-heap                                   57             57           1       1760.7           0.6       1.1X
 
 
 ================================================================================================
 Platform Int Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Int Access:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putInt: On-heap                                      42             42           0       2369.5           0.4       1.0X
-putInt: Off-heap                                     50             50           0       2000.7           0.5       0.8X
-getInt: On-heap                                      34             34           0       2941.2           0.3       1.2X
-getInt: Off-heap                                     49             49           0       2034.2           0.5       0.9X
+putInt: On-heap                                      42             42           0       2386.5           0.4       1.0X
+putInt: Off-heap                                     50             50           0       2009.2           0.5       0.8X
+getInt: On-heap                                      33             34           4       2988.7           0.3       1.3X
+getInt: Off-heap                                     49             49           0       2053.4           0.5       0.9X
 
 
 ================================================================================================
 Platform Long Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Long Access:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putLong: On-heap                                     65             65           0       1546.6           0.6       1.0X
-putLong: Off-heap                                    48             48           0       2084.7           0.5       1.3X
-getLong: On-heap                                     40             42           1       2493.5           0.4       1.6X
-getLong: Off-heap                                    52             52           0       1941.1           0.5       1.3X
+putLong: On-heap                                     65             66           0       1534.8           0.7       1.0X
+putLong: Off-heap                                    48             50           4       2071.2           0.5       1.3X
+getLong: On-heap                                     42             43           1       2393.8           0.4       1.6X
+getLong: Off-heap                                    51             52           1       1945.4           0.5       1.3X
 
 
 ================================================================================================
 Platform Float Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Float Access:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putFloat: On-heap                                    47             47           0       2115.7           0.5       1.0X
-putFloat: Off-heap                                   63             63           0       1596.2           0.6       0.8X
-getFloat: On-heap                                    94             94           0       1068.3           0.9       0.5X
-getFloat: Off-heap                                   94             94           0       1067.6           0.9       0.5X
+putFloat: On-heap                                    47             47           0       2119.8           0.5       1.0X
+putFloat: Off-heap                                   63             63           0       1597.1           0.6       0.8X
+getFloat: On-heap                                    94             94           0       1068.2           0.9       0.5X
+getFloat: Off-heap                                   94             94           0       1067.9           0.9       0.5X
 
 
 ================================================================================================
 Platform Double Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Double Access:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putDouble: On-heap                                   49             49           0       2043.5           0.5       1.0X
-putDouble: Off-heap                                  64             64           0       1562.3           0.6       0.8X
-getDouble: On-heap                                   94             94           0       1061.5           0.9       0.5X
-getDouble: Off-heap                                  95             95           0       1057.1           0.9       0.5X
+putDouble: On-heap                                   49             49           0       2048.2           0.5       1.0X
+putDouble: Off-heap                                  64             64           0       1558.9           0.6       0.8X
+getDouble: On-heap                                   95             95           0       1058.0           0.9       0.5X
+getDouble: Off-heap                                  95             95           0       1055.4           0.9       0.5X
 
 
 ================================================================================================
 Platform Boolean Access
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Boolean Access:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-putBoolean: On-heap                                  78             78           0       1279.0           0.8       1.0X
-putBoolean: Off-heap                                 76             76           1       1314.5           0.8       1.0X
-getBoolean: On-heap                                  62             62           0       1604.5           0.6       1.3X
+putBoolean: On-heap                                  78             78           0       1279.4           0.8       1.0X
+putBoolean: Off-heap                                 78             80           6       1286.9           0.8       1.0X
+getBoolean: On-heap                                  62             62           0       1603.5           0.6       1.3X
 getBoolean: Off-heap                                 62             63           0       1601.0           0.6       1.3X
+
+
+================================================================================================
+Platform DirectBuffer Address Access
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+DirectBuffer Address Access:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+getLong (baseline)                                  156            159           2        640.4           1.6       1.0X
+getDirectBufferAddress                              325            327           2        308.1           3.2       0.5X
 
 
 ================================================================================================
 Platform Bulk Operations 4k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Bulk Operations 4k Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          5.4         184.3       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          1.6         608.2       0.3X
-copyMemory: Off-heap -> Heap                          0              0           0          4.9         202.3       0.9X
-copyMemory: Heap -> Heap                              0              0           0          4.7         211.3       0.9X
-manual: Heap -> Heap                                  0              0           0          0.9        1063.0       0.2X
+copyMemory: Off-heap -> Off-heap                      0              0           0          5.4         186.3       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          4.4         228.4       0.8X
+copyMemory: Off-heap -> Heap                          0              0           0          5.0         199.3       0.9X
+copyMemory: Heap -> Heap                              0              0           0          4.8         206.4       0.9X
+manual: Heap -> Heap                                  0              0           0          0.9        1116.0       0.2X
 manual: Off-heap -> Heap                              0              0           0          1.0         960.7       0.2X
 setMemory: Off-heap                                   0              0           0          1.5         649.2       0.3X
 
@@ -117,162 +129,162 @@ setMemory: Off-heap                                   0              0          
 Platform Bulk Operations 16k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Bulk Operations 16k Ints:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          0.8        1294.4       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          0.7        1414.7       0.9X
-copyMemory: Off-heap -> Heap                          0              0           0          0.8        1287.4       1.0X
-copyMemory: Heap -> Heap                              0              0           0          0.8        1286.4       1.0X
-manual: Heap -> Heap                                  0              0           0          0.2        5439.1       0.2X
-manual: Off-heap -> Heap                              0              0           0          0.3        3849.2       0.3X
-setMemory: Off-heap                                   0              0           0          0.4        2552.7       0.5X
+copyMemory: Off-heap -> Off-heap                      0              0           0          0.8        1305.5       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          0.8        1289.4       1.0X
+copyMemory: Off-heap -> Heap                          0              0           0          0.8        1322.4       1.0X
+copyMemory: Heap -> Heap                              0              0           0          0.7        1401.6       0.9X
+manual: Heap -> Heap                                  0              0           0          0.2        5420.2       0.2X
+manual: Off-heap -> Heap                              0              0           0          0.3        3946.4       0.3X
+setMemory: Off-heap                                   0              0           0          0.4        2548.7       0.5X
 
 
 ================================================================================================
 Platform Bulk Operations 256k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Bulk Operations 256k Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      0              0           0          0.0       27951.4       1.0X
-copyMemory: Heap -> Off-heap                          0              0           0          0.0       27292.1       1.0X
-copyMemory: Off-heap -> Heap                          0              0           0          0.0       25880.5       1.1X
-copyMemory: Heap -> Heap                              0              0           0          0.0       25672.1       1.1X
-manual: Heap -> Heap                                  1              1           0          0.0       88010.9       0.3X
-manual: Off-heap -> Heap                              1              1           0          0.0       62301.7       0.4X
-setMemory: Off-heap                                   0              0           0          0.0       40585.0       0.7X
+copyMemory: Off-heap -> Off-heap                      0              0           0          0.0       25903.4       1.0X
+copyMemory: Heap -> Off-heap                          0              0           0          0.0       25576.8       1.0X
+copyMemory: Off-heap -> Heap                          0              0           0          0.0       25723.1       1.0X
+copyMemory: Heap -> Heap                              0              0           0          0.0       25510.7       1.0X
+manual: Heap -> Heap                                  1              1           0          0.0       71333.3       0.4X
+manual: Off-heap -> Heap                              1              1           0          0.0       62080.1       0.4X
+setMemory: Off-heap                                   0              0           0          0.0       40571.8       0.6X
 
 
 ================================================================================================
 Platform Bulk Operations 1m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Bulk Operations 1m Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                      1              2           0          0.0      138711.9       1.0X
-copyMemory: Heap -> Off-heap                          1              1           0          0.0      104891.6       1.3X
-copyMemory: Off-heap -> Heap                          1              1           0          0.0      104430.8       1.3X
-copyMemory: Heap -> Heap                              1              1           0          0.0      103958.9       1.3X
-manual: Heap -> Heap                                  3              3           0          0.0      274934.2       0.5X
-manual: Off-heap -> Heap                              3              3           1          0.0      252551.2       0.5X
-setMemory: Off-heap                                   2              2           0          0.0      162971.4       0.9X
+copyMemory: Off-heap -> Off-heap                      1              1           0          0.0      132795.2       1.0X
+copyMemory: Heap -> Off-heap                          2              2           0          0.0      195968.4       0.7X
+copyMemory: Off-heap -> Heap                          1              1           0          0.0      104412.2       1.3X
+copyMemory: Heap -> Heap                              1              1           0          0.0      103728.0       1.3X
+manual: Heap -> Heap                                  3              3           0          0.0      287306.2       0.5X
+manual: Off-heap -> Heap                              3              3           0          0.0      252722.5       0.5X
+setMemory: Off-heap                                   2              2           0          0.0      163130.2       0.8X
 
 
 ================================================================================================
 Platform Bulk Operations 8m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Bulk Operations 8m Ints:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                     15             16           0          0.0     1494501.6       1.0X
-copyMemory: Heap -> Off-heap                         17             18           0          0.0     1696782.5       0.9X
-copyMemory: Off-heap -> Heap                         17             17           0          0.0     1674377.6       0.9X
-copyMemory: Heap -> Heap                             17             17           0          0.0     1665476.9       0.9X
-manual: Heap -> Heap                                 25             25           0          0.0     2459913.6       0.6X
-manual: Off-heap -> Heap                             25             25           0          0.0     2455565.3       0.6X
-setMemory: Off-heap                                  14             15           0          0.0     1409985.1       1.1X
+copyMemory: Off-heap -> Off-heap                     19             20           0          0.0     1896040.1       1.0X
+copyMemory: Heap -> Off-heap                         20             22           1          0.0     2046607.6       0.9X
+copyMemory: Off-heap -> Heap                         19             20           0          0.0     1879749.7       1.0X
+copyMemory: Heap -> Heap                             17             18           0          0.0     1717599.3       1.1X
+manual: Heap -> Heap                                 25             25           1          0.0     2461400.1       0.8X
+manual: Off-heap -> Heap                             27             27           0          0.0     2675801.9       0.7X
+setMemory: Off-heap                                  15             15           0          0.0     1476851.3       1.3X
 
 
 ================================================================================================
 Platform Bulk Operations 32m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Bulk Operations 32m Ints:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-copyMemory: Off-heap -> Off-heap                     77             77           1          0.0     7664570.1       1.0X
-copyMemory: Heap -> Off-heap                         84             86           1          0.0     8400167.3       0.9X
-copyMemory: Off-heap -> Heap                         81             85           1          0.0     8115112.6       0.9X
-copyMemory: Heap -> Heap                             82             84           1          0.0     8232211.9       0.9X
-manual: Heap -> Heap                                 99            100           1          0.0     9924878.4       0.8X
-manual: Off-heap -> Heap                            101            103           1          0.0    10107944.3       0.8X
-setMemory: Off-heap                                  59             60           1          0.0     5916000.3       1.3X
+copyMemory: Off-heap -> Off-heap                     76             77           1          0.0     7571838.0       1.0X
+copyMemory: Heap -> Off-heap                         87             90           2          0.0     8706587.6       0.9X
+copyMemory: Off-heap -> Heap                         80             83           3          0.0     7977628.2       0.9X
+copyMemory: Heap -> Heap                             82             83           0          0.0     8188052.7       0.9X
+manual: Heap -> Heap                                 99            103           8          0.0     9910843.4       0.8X
+manual: Off-heap -> Heap                             99            101           2          0.0     9905358.2       0.8X
+setMemory: Off-heap                                  59             61           1          0.0     5866641.1       1.3X
 
 
 ================================================================================================
 Platform Memory Allocation 4k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Memory Allocation 4k Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
 allocateMemory                                        0              0           0      40816.3           0.0       1.0X
 freeMemory                                            0              0           0      50000.0           0.0       1.2X
-reallocateMemory: double in size                      0              0           0       5882.4           0.2       0.1X
+reallocateMemory: double in size                      0              0           0       7662.8           0.1       0.2X
 
 
 ================================================================================================
 Platform Memory Allocation 16k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Memory Allocation 16k Ints:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
 allocateMemory                                        0              0           0      40816.3           0.0       1.0X
 freeMemory                                            0              0           0      50000.0           0.0       1.2X
-reallocateMemory: double in size                      0              0           0       1296.2           0.8       0.0X
+reallocateMemory: double in size                      0              0           0       1457.7           0.7       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 256k Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Memory Allocation 256k Ints:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      50000.0           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.0X
-reallocateMemory: double in size                      0              0           0         45.6          21.9       0.0X
+allocateMemory                                        0              0           0      22471.9           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       2.2X
+reallocateMemory: double in size                      0              0           0         77.3          12.9       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 1m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Memory Allocation 1m Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0      50000.0           0.0       1.0X
-freeMemory                                            0              0           0      50000.0           0.0       1.0X
-reallocateMemory: double in size                      0              0           0         13.5          73.9       0.0X
+allocateMemory                                        0              0           0      20000.0           0.1       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       2.5X
+reallocateMemory: double in size                      0              0           0         11.3          88.8       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 8m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Memory Allocation 8m Ints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0        400.9           2.5       1.0X
-freeMemory                                            0              0           0        386.8           2.6       1.0X
-reallocateMemory: double in size                      3              3           0          0.7        1384.4       0.0X
+allocateMemory                                        0              0           0      22471.9           0.0       1.0X
+freeMemory                                            0              0           0      50000.0           0.0       2.2X
+reallocateMemory: double in size                      3              3           0          0.7        1379.0       0.0X
 
 
 ================================================================================================
 Platform Memory Allocation 32m Ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Memory Allocation 32m Ints:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-allocateMemory                                        0              0           0        476.5           2.1       1.0X
-freeMemory                                            0              0           0        294.9           3.4       0.6X
-reallocateMemory: double in size                     11             11           0          0.2        5518.7       0.0X
+allocateMemory                                        0              0           0        532.3           1.9       1.0X
+freeMemory                                            0              0           0        304.3           3.3       0.6X
+reallocateMemory: double in size                     10             10           0          0.2        4796.7       0.0X
 
 

--- a/core/src/test/scala/org/apache/spark/unsafe/PlatformBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/unsafe/PlatformBenchmark.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.unsafe
 
+import java.nio.ByteBuffer
+
 import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
 
 /**
@@ -55,6 +57,7 @@ object PlatformBenchmark extends BenchmarkBase {
     runFloatAccess(count8m, iterations)
     runDoubleAccess(count8m, iterations)
     runBooleanAccess(count8m, iterations)
+    runDirectBufferAddressAccess(count8m, iterations)
 
     val counts = Seq((count4k, str4k), (count16k, str16k), (count256k, str256k),
       (count1m, str1m), (count8m, str8m), (count32m, str32m))
@@ -438,6 +441,52 @@ object PlatformBenchmark extends BenchmarkBase {
       }
     } finally {
       Platform.freeMemory(address)
+    }
+  }
+
+  private def runDirectBufferAddressAccess(count: Long, iterations: Long): Unit = {
+    val addresses = new Array[Long](count.toInt)
+    var j = 0
+    while (j < count) {
+      addresses(j) = Platform.allocateMemory(8)
+      j += 1
+    }
+    val buffers = new Array[ByteBuffer](count.toInt)
+    j = 0
+    while (j < count) {
+      buffers(j) = ByteBuffer.allocateDirect(1)
+      j += 1
+    }
+    val mask = count - 1
+    try {
+      runBenchmark("Platform DirectBuffer Address Access") {
+        val benchmark = new Benchmark("DirectBuffer Address Access", iterations, output = output)
+
+        benchmark.addCase("getLong (baseline)") { _ =>
+          var i = 0L
+          var sum = 0L
+          while (i < iterations) {
+            sum += Platform.getLong(null, addresses((i & mask).toInt))
+            i += 1
+          }
+        }
+
+        benchmark.addCase("getDirectBufferAddress") { _ =>
+          var i = 0L
+          var sum = 0L
+          while (i < iterations) {
+            sum += Platform.getDirectBufferAddress(buffers((i & mask).toInt))
+            i += 1
+          }
+        }
+        benchmark.run()
+      }
+    } finally {
+      j = 0
+      while (j < count) {
+        Platform.freeMemory(addresses(j))
+        j += 1
+      }
     }
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -475,9 +475,9 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
       if (buffer.hasArray()) {
         v.putByteArray(rowId + i, buffer.array(), buffer.arrayOffset() + buffer.position(), len);
       } else {
-        byte[] bytes = new byte[len];
-        buffer.get(bytes);
-        v.putByteArray(rowId + i, bytes);
+        // Copy directly from the ByteBuffer into the column vector's backing storage,
+        // bypassing any intermediate byte[] allocation.
+        v.putByteArray(rowId + i, buffer, buffer.position(), len);
       }
     }
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -206,15 +206,9 @@ public final class OffHeapColumnVector extends WritableColumnVector {
   @Override
   public void putBytes(int rowId, int count, ByteBuffer src, int srcIndex) {
     if (src.hasArray()) {
-      Platform.copyMemory(
-          src.array(),
-          Platform.BYTE_ARRAY_OFFSET + src.arrayOffset() + srcIndex,
-          null,
-          data + rowId,
-          count);
+      Platform.copyMemory(src.array(), Platform.BYTE_ARRAY_OFFSET + src.arrayOffset() + srcIndex,
+        null, data + rowId, count);
     } else {
-      // Direct buffer: native-to-native copy, single Unsafe call, no temp array.
-      assert src.isDirect() : "Expected a direct ByteBuffer";
       long srcAddr = Platform.getDirectBufferAddress(src) + srcIndex;
       Platform.copyMemory(null, srcAddr, null, data + rowId, count);
     }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -204,6 +204,23 @@ public final class OffHeapColumnVector extends WritableColumnVector {
   }
 
   @Override
+  public void putBytes(int rowId, int count, ByteBuffer src, int srcIndex) {
+    if (src.hasArray()) {
+      Platform.copyMemory(
+          src.array(),
+          Platform.BYTE_ARRAY_OFFSET + src.arrayOffset() + srcIndex,
+          null,
+          data + rowId,
+          count);
+    } else {
+      // Direct buffer: native-to-native copy, single Unsafe call, no temp array.
+      assert src.isDirect() : "Expected a direct ByteBuffer";
+      long srcAddr = Platform.getDirectBufferAddress(src) + srcIndex;
+      Platform.copyMemory(null, srcAddr, null, data + rowId, count);
+    }
+  }
+
+  @Override
   public byte getByte(int rowId) {
     if (dictionary == null) {
       return Platform.getByte(null, data + rowId);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -208,9 +208,14 @@ public final class OffHeapColumnVector extends WritableColumnVector {
     if (src.hasArray()) {
       Platform.copyMemory(src.array(), Platform.BYTE_ARRAY_OFFSET + src.arrayOffset() + srcIndex,
         null, data + rowId, count);
-    } else {
+    } else if (src.isDirect()) {
       long srcAddr = Platform.getDirectBufferAddress(src) + srcIndex;
       Platform.copyMemory(null, srcAddr, null, data + rowId, count);
+    } else {
+      // Fallback for non-heap, non-direct buffers (e.g., read-only wrappers).
+      byte[] tmp = new byte[count];
+      src.get(srcIndex, tmp, 0, count);
+      Platform.copyMemory(tmp, Platform.BYTE_ARRAY_OFFSET, null, data + rowId, count);
     }
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -202,6 +202,12 @@ public final class OnHeapColumnVector extends WritableColumnVector {
   }
 
   @Override
+  public void putBytes(int rowId, int count, ByteBuffer src, int srcIndex) {
+    // Absolute bulk get: single copy, does not modify src's position.
+    src.get(srcIndex, byteData, rowId, count);
+  }
+
+  @Override
   public byte getByte(int rowId) {
     if (dictionary == null) {
       return byteData[rowId];

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -287,6 +287,12 @@ public abstract class WritableColumnVector extends ColumnVector {
   public abstract void putBytes(int rowId, int count, byte[] src, int srcIndex);
 
   /**
+   * Copies {@code count} bytes from a {@link ByteBuffer} starting at absolute position
+   * {@code srcIndex} into this column at {@code rowId}. Does not modify the buffer's position.
+   */
+  public abstract void putBytes(int rowId, int count, ByteBuffer src, int srcIndex);
+
+  /**
    * Sets `value` to the value at rowId.
    */
   public abstract void putShort(int rowId, short value);
@@ -433,6 +439,25 @@ public abstract class WritableColumnVector extends ColumnVector {
   public abstract int putByteArray(int rowId, byte[] value, int offset, int count);
   public final int putByteArray(int rowId, byte[] value) {
     return putByteArray(rowId, value, 0, value.length);
+  }
+
+  /**
+   * Stores bytes from a {@link ByteBuffer} as a variable-length byte array at {@code rowId}.
+   * Copies {@code length} bytes starting at absolute position {@code srcPosition} in the buffer.
+   * Does not modify the buffer's position.
+   */
+  public final int putByteArray(int rowId, ByteBuffer src, int srcPosition, int length) {
+    int result = arrayData().appendBytes(length, src, srcPosition);
+    putArray(rowId, result, length);
+    return result;
+  }
+
+  final int appendBytes(int length, ByteBuffer src, int srcPosition) {
+    reserve(elementsAppended + length);
+    int result = elementsAppended;
+    putBytes(elementsAppended, length, src, srcPosition);
+    elementsAppended += length;
+    return result;
   }
 
   @Override

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnVectorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnVectorSuite.scala
@@ -298,6 +298,37 @@ class ColumnVectorSuite extends SparkFunSuite with SQLHelper {
     verifyPutByteArray(testVector)
   }
 
+  testVectors("putBytes from ByteBuffer", 16, ByteType) { testVector =>
+    val data = Array[Byte](10, 20, 30, 40, 50, 60, 70, 80)
+
+    // Heap ByteBuffer
+    testVector.putBytes(0, data.length, ByteBuffer.wrap(data), 0)
+    (0 until data.length).foreach { i =>
+      assert(testVector.getByte(i) === data(i))
+    }
+
+    // Direct ByteBuffer
+    val directBuf = ByteBuffer.allocateDirect(data.length)
+    directBuf.put(data)
+    testVector.putBytes(0, data.length, directBuf, 0)
+    (0 until data.length).foreach { i =>
+      assert(testVector.getByte(i) === data(i))
+    }
+
+    // Read-only ByteBuffer (hasArray=false, isDirect=false)
+    val readOnlyBuf = ByteBuffer.wrap(data).asReadOnlyBuffer()
+    testVector.putBytes(0, data.length, readOnlyBuf, 0)
+    (0 until data.length).foreach { i =>
+      assert(testVector.getByte(i) === data(i))
+    }
+
+    // With srcIndex offset
+    testVector.putBytes(0, 4, ByteBuffer.wrap(data), 4)
+    (0 until 4).foreach { i =>
+      assert(testVector.getByte(i) === data(i + 4))
+    }
+  }
+
   DataTypeTestUtils.yearMonthIntervalTypes.foreach {
     dt =>
       testVectors(dt.typeName,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnVectorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnVectorSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.vectorized
 
+import java.nio.ByteBuffer
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.YearUDT
 import org.apache.spark.sql.catalyst.expressions.SpecificInternalRow
@@ -260,6 +262,40 @@ class ColumnVectorSuite extends SparkFunSuite with SQLHelper {
       assert(array.get(i, BinaryType) === utf8)
       assert(arrayCopy.get(i, BinaryType) === utf8)
     }
+  }
+
+  testVectors("putByteArray from ByteBuffer", 10, BinaryType) { testVector =>
+    def verifyPutByteArray(testVector: WritableColumnVector): Unit = {
+      (0 until 10).foreach { i =>
+        assert(testVector.getBinary(i) === s"str$i".getBytes("utf8"))
+      }
+    }
+
+    // Heap ByteBuffer
+    (0 until 10).foreach { i =>
+      val bytes = s"str$i".getBytes("utf8")
+      testVector.putByteArray(i, ByteBuffer.wrap(bytes), 0, bytes.length)
+    }
+    verifyPutByteArray(testVector)
+
+    // Direct ByteBuffer
+    testVector.reset()
+    (0 until 10).foreach { i =>
+      val bytes = s"str$i".getBytes("utf8")
+      val buf = ByteBuffer.allocateDirect(bytes.length)
+      buf.put(bytes)
+      testVector.putByteArray(i, buf, 0, bytes.length)
+    }
+    verifyPutByteArray(testVector)
+
+    // Read-only ByteBuffer (hasArray=false, isDirect=false)
+    testVector.reset()
+    (0 until 10).foreach { i =>
+      val bytes = s"str$i".getBytes("utf8")
+      val buf = ByteBuffer.wrap(bytes).asReadOnlyBuffer()
+      testVector.putByteArray(i, buf, 0, bytes.length)
+    }
+    verifyPutByteArray(testVector)
   }
 
   DataTypeTestUtils.yearMonthIntervalTypes.foreach {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR optimizes `VectorizedPlainValuesReader.readBinary` for the direct (non-heap) `ByteBuffer` path by eliminating an intermediate `byte[]` copy.

Previously, when reading binary/string values from a direct `ByteBuffer`, each value required:
1. Allocating a new `byte[len]`
2. Copying from the `ByteBuffer` into the temp array
3. Copying from the temp array into the column vector's backing storage

This PR adds `ByteBuffer`-aware `putBytes`/`putByteArray` overloads to `WritableColumnVector`, enabling a **single-copy** path:

- **`OnHeapColumnVector`**: uses `ByteBuffer.get(index, byte[], offset, length)` (absolute bulk get) to copy directly into the backing `byte[]` — one native-to-heap copy.
- **`OffHeapColumnVector`**: uses `Platform.copyMemory` with the direct buffer's native address — one native-to-native copy.

A `Platform.getDirectBufferAddress(ByteBuffer)` helper is added to read a `DirectByteBuffer`'s native address via the `Buffer.address` field offset, consistent with `Platform`'s existing `Unsafe`-based accessor pattern.


### Why are the changes needed?
In Spark's vectorized Parquet reader, binary/string columns from memory-mapped (direct) `ByteBuffer` sources incur two full `memcpy` operations per value. The intermediate `byte[]` allocation also adds GC pressure.

Eliminating one copy per value yields a **10–22% improvement** on the default `DIRECT`/`ON_HEAP` path across JDK 17, 21, and 25.



### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
- Pass Github Actions
- A micro-benchmark that simulates changes with JMH to verify the performance improvement.

<details>
<summary><b>Benchmark Code (click to expand)</b></summary>

```java
package org.apache.spark.sql.execution.datasources.parquet;

import java.io.IOException;
import java.nio.ByteBuffer;
import java.nio.ByteOrder;
import java.util.Random;
import java.util.concurrent.TimeUnit;

import org.apache.parquet.bytes.ByteBufferInputStream;
import org.openjdk.jmh.annotations.*;
import org.openjdk.jmh.runner.Runner;
import org.openjdk.jmh.runner.options.CommandLineOptions;
import org.openjdk.jmh.runner.options.Options;
import org.openjdk.jmh.runner.options.OptionsBuilder;

import org.apache.spark.sql.execution.vectorized.OffHeapColumnVector;
import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector;
import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
import org.apache.spark.sql.types.DataTypes;

@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Warmup(iterations = 20, time = 1)
@Measurement(iterations = 50, time = 1)
@Fork(1)
@State(Scope.Benchmark)
public class VectorizedPlainValuesReaderBenchmark {

  @Param({"1024", "4096", "8192"})
  private int totalValues;

  @Param({"16", "64", "256"})
  private int valueLength;

  @Param({"HEAP", "DIRECT"})
  private String bufferType;

  @Param({"ON_HEAP", "OFF_HEAP"})
  private String columnVectorType;

  /** Plain-encoded binary payload: repeated [int length][bytes]. */
  private byte[] rawData;

  private VectorizedPlainValuesReader newReader;
  private OldVectorizedPlainValuesReader oldReader;
  private WritableColumnVector columnVector;

  @Setup(Level.Trial)
  public void setupTrial() {
    Random rng = new Random(42);
    rawData = new byte[totalValues * (4 + valueLength)];
    ByteBuffer tmp = ByteBuffer.wrap(rawData).order(ByteOrder.LITTLE_ENDIAN);
    byte[] payload = new byte[valueLength];
    for (int i = 0; i < totalValues; i++) {
      tmp.putInt(valueLength);
      rng.nextBytes(payload);
      tmp.put(payload);
    }

    newReader = new VectorizedPlainValuesReader();
    oldReader = new OldVectorizedPlainValuesReader();
  }

  @Setup(Level.Invocation)
  public void setupInvocation() throws IOException {
    // Recreate the column vector and reinitialize readers before each invocation
    // so that readBinary always starts from the beginning of the buffer.
    if (columnVector != null) {
      columnVector.close();
    }

    if ("ON_HEAP".equals(columnVectorType)) {
      columnVector = new OnHeapColumnVector(totalValues, DataTypes.BinaryType);
    } else {
      columnVector = new OffHeapColumnVector(totalValues, DataTypes.BinaryType);
    }

    newReader.initFromPage(totalValues, ByteBufferInputStream.wrap(makeBuffer()));
    oldReader.initFromPage(totalValues, ByteBufferInputStream.wrap(makeBuffer()));
  }

  private ByteBuffer makeBuffer() {
    if ("HEAP".equals(bufferType)) {
      // Heap buffer: hasArray() returns true
      return ByteBuffer.wrap(rawData.clone());
    }
    // Direct buffer: hasArray() returns false
    ByteBuffer buffer = ByteBuffer.allocateDirect(rawData.length);
    buffer.put(rawData);
    buffer.flip();
    return buffer;
  }

  @TearDown(Level.Trial)
  public void tearDown() {
    if (columnVector != null) {
      columnVector.close();
      columnVector = null;
    }
  }

  @Benchmark
  public void newReadBinary() {
    newReader.readBinary(totalValues, columnVector, 0);
  }

  @Benchmark
  public void oldReadBinary() {
    oldReader.readBinary(totalValues, columnVector, 0);
  }

  public static void main(String[] args) throws Exception {
    // Forward CLI args (e.g. -p, -wi, -i, -f) so callers can override the
    // defaults specified by class-level annotations.
    Options opt = new OptionsBuilder()
        .parent(new CommandLineOptions(args))
        .include(VectorizedPlainValuesReaderBenchmark.class.getSimpleName())
        .build();
    new Runner(opt).run();
  }
}


```
</details>

Perform `build/sbt "sql/Test/runMain org.apache.spark.sql.execution.datasources.parquet.VectorizedPlainValuesReaderBenchmark"` to conduct the test


<details>
<summary><b>Benchmark results(click to expand)</b></summary>

- Java  17

```
Benchmark                                           (bufferType)  (columnVectorType)  (totalValues)  (valueLength)  Mode  Cnt        Score        Error  Units
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           1024             16  avgt   50    21133.686 ±    103.769  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           1024             64  avgt   50    40714.762 ±    327.320  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           1024            256  avgt   50   127898.922 ±   1814.317  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           4096             16  avgt   50    83794.427 ±    423.578  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           4096             64  avgt   50   148011.789 ±   1657.605  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           4096            256  avgt   50   466875.025 ±   6739.475  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           8192             16  avgt   50   166724.800 ±    966.615  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           8192             64  avgt   50   310514.587 ±   3240.505  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           8192            256  avgt   50   982629.498 ±  11190.783  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           1024             16  avgt   50    18746.843 ±     51.526  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           1024             64  avgt   50    24426.161 ±     85.028  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           1024            256  avgt   50    58474.238 ±    237.509  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           4096             16  avgt   50    91843.587 ±    410.836  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           4096             64  avgt   50   121805.218 ±    122.957  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           4096            256  avgt   50  1413572.197 ±   4883.098  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           8192             16  avgt   50   154660.449 ±    895.345  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           8192             64  avgt   50   250413.950 ±    984.141  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           8192            256  avgt   50  1553024.626 ±   9369.443  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           1024             16  avgt   50    22171.027 ±     63.213  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           1024             64  avgt   50    39802.235 ±    300.151  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           1024            256  avgt   50   118034.848 ±    933.948  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           4096             16  avgt   50    87004.832 ±    330.969  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           4096             64  avgt   50   154505.438 ±   1108.452  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           4096            256  avgt   50   481165.804 ±   4692.772  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           8192             16  avgt   50   175463.325 ±    620.053  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           8192             64  avgt   50   317021.089 ±   1836.755  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           8192            256  avgt   50   962231.599 ±   9226.917  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           1024             16  avgt   50    22266.132 ±    181.957  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           1024             64  avgt   50    42590.654 ±    204.662  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           1024            256  avgt   50    76168.938 ±   1020.339  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           4096             16  avgt   50    91004.256 ±   2420.553  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           4096             64  avgt   50   363483.527 ±   9405.034  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           4096            256  avgt   50   530389.201 ± 358392.769  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           8192             16  avgt   50   192375.671 ±   9134.541  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           8192             64  avgt   50   775415.608 ±   7968.378  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           8192            256  avgt   50   948844.125 ± 184802.997  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           1024             16  avgt   50    20143.714 ±    127.970  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           1024             64  avgt   50    37213.528 ±    294.623  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           1024            256  avgt   50   115370.388 ±   1277.143  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           4096             16  avgt   50    81896.442 ±    319.206  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           4096             64  avgt   50   149584.303 ±   1966.657  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           4096            256  avgt   50   478158.897 ±   4064.925  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           8192             16  avgt   50   164793.858 ±   1039.258  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           8192             64  avgt   50   299629.657 ±   1684.947  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           8192            256  avgt   50   960621.319 ±   9025.326  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           1024             16  avgt   50    19042.590 ±     33.934  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           1024             64  avgt   50    24329.773 ±     86.621  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           1024            256  avgt   50    58411.323 ±    217.244  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           4096             16  avgt   50    92017.040 ±    376.556  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           4096             64  avgt   50   126487.647 ±    604.634  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           4096            256  avgt   50   230289.460 ±   2777.458  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           8192             16  avgt   50   149320.253 ±    595.932  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           8192             64  avgt   50   248600.054 ±   1645.170  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           8192            256  avgt   50   768789.899 ±   7270.904  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           1024             16  avgt   50    28069.933 ±     94.204  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           1024             64  avgt   50    48188.101 ±    289.352  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           1024            256  avgt   50   128637.878 ±   2340.360  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           4096             16  avgt   50   112014.092 ±    777.772  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           4096             64  avgt   50   192862.134 ±    847.013  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           4096            256  avgt   50   566865.312 ±   7235.458  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           8192             16  avgt   50   223146.102 ±   1132.153  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           8192             64  avgt   50   393649.960 ±   3152.221  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           8192            256  avgt   50  1091348.875 ±   9892.825  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           1024             16  avgt   50    27603.142 ±     81.746  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           1024             64  avgt   50    41045.293 ±    243.418  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           1024            256  avgt   50    96053.138 ±   2003.381  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           4096             16  avgt   50   105388.181 ±    599.746  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           4096             64  avgt   50   167514.849 ±    645.858  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           4096            256  avgt   50   362335.778 ±   2938.215  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           8192             16  avgt   50   223378.419 ±   2566.009  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           8192             64  avgt   50   379184.204 ±   6134.777  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           8192            256  avgt   50  2243461.086 ± 322551.647  ns/op
```

- Java 21

```
Benchmark                                           (bufferType)  (columnVectorType)  (totalValues)  (valueLength)  Mode  Cnt        Score        Error  Units
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           1024             16  avgt   50    20792.936 ±     11.228  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           1024             64  avgt   50    32154.816 ±    328.300  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           1024            256  avgt   50    78592.323 ±    299.584  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           4096             16  avgt   50    82743.923 ±     79.815  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           4096             64  avgt   50   123702.471 ±    344.559  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           4096            256  avgt   50   326172.070 ±   2779.330  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           8192             16  avgt   50   165555.669 ±    318.138  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           8192             64  avgt   50   246627.341 ±    881.138  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           8192            256  avgt   50   646678.788 ±   2935.725  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           1024             16  avgt   50    21927.422 ±     24.128  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           1024             64  avgt   50    26163.304 ±     30.701  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           1024            256  avgt   50    50298.061 ±    123.971  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           4096             16  avgt   50    77656.063 ±    175.033  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           4096             64  avgt   50   103280.982 ±    221.227  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           4096            256  avgt   50   189700.428 ±    551.328  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           8192             16  avgt   50   154309.639 ±    291.313  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           8192             64  avgt   50   205462.097 ±    400.891  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           8192            256  avgt   50  1552902.350 ±  14219.023  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           1024             16  avgt   50    22033.101 ±    117.469  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           1024             64  avgt   50    32175.461 ±    177.490  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           1024            256  avgt   50    81801.706 ±    875.499  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           4096             16  avgt   50    87343.132 ±    105.192  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           4096             64  avgt   50   126698.538 ±    342.324  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           4096            256  avgt   50   318603.784 ±   1587.226  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           8192             16  avgt   50   173906.502 ±    173.984  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           8192             64  avgt   50   251866.225 ±    277.314  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           8192            256  avgt   50   641804.331 ±   2665.650  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           1024             16  avgt   50    24193.047 ±     77.459  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           1024             64  avgt   50    31668.278 ±    844.566  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           1024            256  avgt   50   335385.137 ±   4701.693  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           4096             16  avgt   50    95884.649 ±    663.374  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           4096             64  avgt   50   147133.621 ±  19982.708  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           4096            256  avgt   50  1518057.520 ±  16671.100  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           8192             16  avgt   50   211044.238 ±  12543.959  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           8192             64  avgt   50   349151.424 ±  37775.452  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           8192            256  avgt   50   998617.960 ± 268723.495  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           1024             16  avgt   50    23289.402 ±     61.648  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           1024             64  avgt   50    31459.997 ±    146.714  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           1024            256  avgt   50    77385.110 ±    288.525  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           4096             16  avgt   50    82537.027 ±     54.329  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           4096             64  avgt   50   122728.156 ±    428.668  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           4096            256  avgt   50   314828.587 ±    430.744  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           8192             16  avgt   50   164735.844 ±   1007.932  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           8192             64  avgt   50   245329.614 ±   1094.253  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           8192            256  avgt   50   621594.576 ±    890.237  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           1024             16  avgt   50    21882.702 ±     18.040  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           1024             64  avgt   50    26182.730 ±      9.474  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           1024            256  avgt   50    49825.929 ±     70.440  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           4096             16  avgt   50    86606.432 ±     92.960  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           4096             64  avgt   50   103397.329 ±    247.826  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           4096            256  avgt   50   188128.946 ±    216.008  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           8192             16  avgt   50   154325.782 ±     92.420  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           8192             64  avgt   50   205757.658 ±    427.901  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           8192            256  avgt   50  1571651.603 ±   5295.372  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           1024             16  avgt   50    27107.719 ±     27.489  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           1024             64  avgt   50    41349.661 ±     45.008  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           1024            256  avgt   50    94134.921 ±    659.365  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           4096             16  avgt   50   107704.612 ±     93.806  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           4096             64  avgt   50   159254.420 ±    598.247  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           4096            256  avgt   50   363235.908 ±    787.751  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           8192             16  avgt   50   220019.108 ±    252.893  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           8192             64  avgt   50   323097.051 ±    288.586  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           8192            256  avgt   50   745273.951 ±   1250.609  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           1024             16  avgt   50    26419.773 ±     76.761  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           1024             64  avgt   50    39714.193 ±    480.726  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           1024            256  avgt   50    88174.807 ±   3618.109  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           4096             16  avgt   50   102708.357 ±    173.331  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           4096             64  avgt   50   308566.639 ±   3679.216  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           4096            256  avgt   50   278667.492 ±   1505.321  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           8192             16  avgt   50   231747.397 ±   3885.522  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           8192             64  avgt   50   382719.924 ±  12336.323  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           8192            256  avgt   50   847664.028 ±  23769.709  ns/op
```

- Java 25

```
Benchmark                                           (bufferType)  (columnVectorType)  (totalValues)  (valueLength)  Mode  Cnt        Score        Error  Units
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           1024             16  avgt   50    19454.336 ±     51.571  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           1024             64  avgt   50    35224.107 ±     93.873  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           1024            256  avgt   50   106094.049 ±    607.124  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           4096             16  avgt   50    76377.758 ±    170.304  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           4096             64  avgt   50   136363.493 ±    420.498  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           4096            256  avgt   50   401909.415 ±   1978.047  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           8192             16  avgt   50   153405.787 ±    329.935  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           8192             64  avgt   50   277290.682 ±    638.883  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP             ON_HEAP           8192            256  avgt   50   830389.462 ±   4434.923  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           1024             16  avgt   50    19447.941 ±     42.082  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           1024             64  avgt   50    24238.319 ±     84.138  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           1024            256  avgt   50    46731.494 ±    190.227  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           4096             16  avgt   50    74605.605 ±     50.031  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           4096             64  avgt   50    99683.575 ±    131.143  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           4096            256  avgt   50   184584.818 ±   2159.308  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           8192             16  avgt   50   150929.836 ±    237.595  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           8192             64  avgt   50   200577.256 ±    812.859  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary          HEAP            OFF_HEAP           8192            256  avgt   50   369071.136 ±   3405.637  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           1024             16  avgt   50    21421.781 ±     60.139  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           1024             64  avgt   50    34617.991 ±     65.177  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           1024            256  avgt   50    98082.743 ±    333.873  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           4096             16  avgt   50    83154.102 ±    138.081  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           4096             64  avgt   50   137378.799 ±    475.677  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           4096            256  avgt   50   397669.586 ±   1724.217  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           8192             16  avgt   50   165375.588 ±    308.414  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           8192             64  avgt   50   281011.423 ±    515.650  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT             ON_HEAP           8192            256  avgt   50   799352.042 ±   3406.062  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           1024             16  avgt   50    23396.644 ±    203.316  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           1024             64  avgt   50    30945.248 ±    172.520  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           1024            256  avgt   50    67093.924 ±    305.839  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           4096             16  avgt   50    95412.589 ±   1732.252  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           4096             64  avgt   50   321344.149 ±   9031.271  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           4096            256  avgt   50  1329057.617 ±  28490.214  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           8192             16  avgt   50   196217.213 ±   8448.670  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           8192             64  avgt   50   817464.101 ±  16282.918  ns/op
VectorizedPlainValuesReaderBenchmark.newReadBinary        DIRECT            OFF_HEAP           8192            256  avgt   50   796312.740 ± 147155.047  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           1024             16  avgt   50    19174.985 ±     91.202  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           1024             64  avgt   50    33204.299 ±     76.652  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           1024            256  avgt   50    94013.579 ±    327.183  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           4096             16  avgt   50    76527.485 ±    344.190  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           4096             64  avgt   50   131084.445 ±    303.759  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           4096            256  avgt   50   388912.079 ±   1287.693  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           8192             16  avgt   50   153907.585 ±    272.593  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           8192             64  avgt   50   269241.711 ±   1199.887  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP             ON_HEAP           8192            256  avgt   50   793134.485 ±   3236.322  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           1024             16  avgt   50    19431.150 ±     21.515  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           1024             64  avgt   50    24472.057 ±     25.534  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           1024            256  avgt   50    47889.963 ±    213.726  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           4096             16  avgt   50    75002.105 ±     70.072  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           4096             64  avgt   50    99832.226 ±    153.149  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           4096            256  avgt   50   188772.060 ±   1725.794  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           8192             16  avgt   50   150155.171 ±    104.622  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           8192             64  avgt   50   200136.556 ±    684.288  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary          HEAP            OFF_HEAP           8192            256  avgt   50   367258.001 ±   4519.780  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           1024             16  avgt   50    25810.554 ±     59.352  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           1024             64  avgt   50    43051.872 ±    112.457  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           1024            256  avgt   50   109254.476 ±    477.191  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           4096             16  avgt   50   104029.132 ±    298.893  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           4096             64  avgt   50   166544.608 ±    371.249  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           4096            256  avgt   50   449783.642 ±   2843.943  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           8192             16  avgt   50   207660.121 ±    246.678  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           8192             64  avgt   50   342410.957 ±    896.064  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT             ON_HEAP           8192            256  avgt   50   886503.174 ±   5756.155  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           1024             16  avgt   50    27903.709 ±    116.360  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           1024             64  avgt   50    38895.079 ±    112.427  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           1024            256  avgt   50    86762.539 ±   3300.275  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           4096             16  avgt   50   104535.716 ±    299.104  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           4096             64  avgt   50   248648.137 ±   2828.450  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           4096            256  avgt   50  1087469.272 ±   7033.347  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           8192             16  avgt   50   215132.226 ±   2714.048  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           8192             64  avgt   50   346034.950 ±  11971.660  ns/op
VectorizedPlainValuesReaderBenchmark.oldReadBinary        DIRECT            OFF_HEAP           8192            256  avgt   50   744647.868 ±  11141.025  ns/op
```
</details>

Across JDK 17, 21 and 25, the default `DIRECT/ON_HEAP` path achieves a **performance improvement of 10%–22%** and `HEAP` path results are unchanged as expected (code path not affected).


### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code