### PR TITLE
[SPARK-56253][PYTHON][CONNECT][FOLLOW-UP] Reject multi-column DataFrame input in spark.read.json

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1451,6 +1451,18 @@
     ],
     "sqlState" : "42887"
   },
+  "DATAFRAME_INPUT_NOT_SINGLE_COLUMN" : {
+    "message" : [
+      "Input DataFrame must have exactly one column, but got <numColumns>."
+    ],
+    "sqlState" : "42K09"
+  },
+  "DATAFRAME_INPUT_NOT_STRING_TYPE" : {
+    "message" : [
+      "Input DataFrame column must be StringType, but got <dataType>."
+    ],
+    "sqlState" : "42K09"
+  },
   "DATAFLOW_GRAPH_NOT_FOUND" : {
     "message" : [
       "Dataflow graph with id <graphId> could not be found"
@@ -5651,12 +5663,6 @@
       "Syntax error, unexpected empty statement."
     ],
     "sqlState" : "42617"
-  },
-  "PARSE_INPUT_NOT_STRING_TYPE" : {
-    "message" : [
-      "Input DataFrame column must be StringType, but got <dataType>."
-    ],
-    "sqlState" : "42K09"
   },
   "PARSE_MODE_UNSUPPORTED" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1451,6 +1451,12 @@
     ],
     "sqlState" : "42887"
   },
+  "DATAFLOW_GRAPH_NOT_FOUND" : {
+    "message" : [
+      "Dataflow graph with id <graphId> could not be found"
+    ],
+    "sqlState" : "KD011"
+  },
   "DATAFRAME_INPUT_NOT_SINGLE_COLUMN" : {
     "message" : [
       "Input DataFrame must have exactly one column, but got <numColumns>."
@@ -1462,12 +1468,6 @@
       "Input DataFrame column must be StringType, but got <dataType>."
     ],
     "sqlState" : "42K09"
-  },
-  "DATAFLOW_GRAPH_NOT_FOUND" : {
-    "message" : [
-      "Dataflow graph with id <graphId> could not be found"
-    ],
-    "sqlState" : "KD011"
   },
   "DATATYPE_CANNOT_ORDER" : {
     "message" : [

--- a/python/pyspark/sql/tests/connect/test_connect_readwriter.py
+++ b/python/pyspark/sql/tests/connect/test_connect_readwriter.py
@@ -197,7 +197,7 @@ class SparkConnectReadWriterTests(SparkConnectSQLTestCase):
 
     def test_json_with_dataframe_input_non_string_column(self):
         int_df = self.connect.createDataFrame([(1,), (2,)], schema="value INT")
-        with self.assertRaisesRegex(Exception, "PARSE_INPUT_NOT_STRING_TYPE"):
+        with self.assertRaisesRegex(Exception, "DATAFRAME_INPUT_NOT_STRING_TYPE"):
             self.connect.read.json(int_df).collect()
 
     def test_json_with_dataframe_input_multiple_columns(self):
@@ -205,13 +205,12 @@ class SparkConnectReadWriterTests(SparkConnectSQLTestCase):
             [('{"name": "Alice"}', "extra"), ('{"name": "Bob"}', "extra")],
             schema="value STRING, other STRING",
         )
-        result = self.connect.read.json(multi_df)
-        expected = [Row(name="Alice"), Row(name="Bob")]
-        self.assertEqual(sorted(result.collect(), key=lambda r: r.name), expected)
+        with self.assertRaisesRegex(Exception, "DATAFRAME_INPUT_NOT_SINGLE_COLUMN"):
+            self.connect.read.json(multi_df).collect()
 
     def test_json_with_dataframe_input_zero_columns(self):
         empty_schema_df = self.connect.range(1).select()
-        with self.assertRaisesRegex(Exception, "PARSE_INPUT_NOT_STRING_TYPE"):
+        with self.assertRaisesRegex(Exception, "DATAFRAME_INPUT_NOT_SINGLE_COLUMN"):
             self.connect.read.json(empty_schema_df).collect()
 
     def test_multi_paths(self):

--- a/python/pyspark/sql/tests/test_datasources.py
+++ b/python/pyspark/sql/tests/test_datasources.py
@@ -113,7 +113,7 @@ class DataSourcesTestsMixin:
 
     def test_json_with_dataframe_input_non_string_column(self):
         int_df = self.spark.createDataFrame([(1,), (2,)], schema="value INT")
-        with self.assertRaisesRegex(Exception, "PARSE_INPUT_NOT_STRING_TYPE"):
+        with self.assertRaisesRegex(Exception, "DATAFRAME_INPUT_NOT_STRING_TYPE"):
             self.spark.read.json(int_df).collect()
 
     def test_json_with_dataframe_input_multiple_columns(self):
@@ -121,13 +121,12 @@ class DataSourcesTestsMixin:
             [('{"name": "Alice"}', "extra"), ('{"name": "Bob"}', "extra")],
             schema="value STRING, other STRING",
         )
-        result = self.spark.read.json(multi_df)
-        expected = [Row(name="Alice"), Row(name="Bob")]
-        self.assertEqual(sorted(result.collect(), key=lambda r: r.name), expected)
+        with self.assertRaisesRegex(Exception, "DATAFRAME_INPUT_NOT_SINGLE_COLUMN"):
+            self.spark.read.json(multi_df).collect()
 
     def test_json_with_dataframe_input_zero_columns(self):
         empty_schema_df = self.spark.range(1).select()
-        with self.assertRaisesRegex(Exception, "PARSE_INPUT_NOT_STRING_TYPE"):
+        with self.assertRaisesRegex(Exception, "DATAFRAME_INPUT_NOT_SINGLE_COLUMN"):
             self.spark.read.json(empty_schema_df).collect()
 
     def test_multiline_csv(self):

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3496,9 +3496,15 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     )
   }
 
-  def parseInputNotStringTypeError(dataType: DataType): Throwable = {
+  def dataframeInputNotSingleColumnError(numColumns: Int): Throwable = {
     new AnalysisException(
-      errorClass = "PARSE_INPUT_NOT_STRING_TYPE",
+      errorClass = "DATAFRAME_INPUT_NOT_SINGLE_COLUMN",
+      messageParameters = Map("numColumns" -> numColumns.toString))
+  }
+
+  def dataframeInputNotStringTypeError(dataType: DataType): Throwable = {
+    new AnalysisException(
+      errorClass = "DATAFRAME_INPUT_NOT_STRING_TYPE",
       messageParameters = Map("dataType" -> toSQLType(dataType)))
   }
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1762,14 +1762,13 @@ class SparkConnectPlanner(
       val input = transformRelation(rel.getInput)
       val df = Dataset.ofRows(session, input)
       val fields = df.schema.fields
-      if (fields.isEmpty) {
-        throw QueryCompilationErrors.parseInputNotStringTypeError(
-          org.apache.spark.sql.types.NullType)
+      if (fields.length != 1) {
+        throw QueryCompilationErrors.dataframeInputNotSingleColumnError(fields.length)
       }
       if (fields.head.dataType != org.apache.spark.sql.types.StringType) {
-        throw QueryCompilationErrors.parseInputNotStringTypeError(fields.head.dataType)
+        throw QueryCompilationErrors.dataframeInputNotStringTypeError(fields.head.dataType)
       }
-      df.select(df.columns.head).as(Encoders.STRING)
+      df.as(Encoders.STRING)
     }
 
     rel.getFormat match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -205,14 +205,13 @@ private[sql] object PythonSQLUtils extends Logging {
       df: DataFrame): DataFrame = {
     val classicReader = reader.asInstanceOf[ClassicDataFrameReader]
     val fields = df.schema.fields
-    if (fields.isEmpty) {
-      throw QueryCompilationErrors.parseInputNotStringTypeError(
-        org.apache.spark.sql.types.NullType)
+    if (fields.length != 1) {
+      throw QueryCompilationErrors.dataframeInputNotSingleColumnError(fields.length)
     }
     if (fields.head.dataType != org.apache.spark.sql.types.StringType) {
-      throw QueryCompilationErrors.parseInputNotStringTypeError(fields.head.dataType)
+      throw QueryCompilationErrors.dataframeInputNotStringTypeError(fields.head.dataType)
     }
-    classicReader.json(df.select(df.columns.head).as(Encoders.STRING))
+    classicReader.json(df.as(Encoders.STRING))
   }
 
   def cleanupPythonWorkerLogs(sessionUUID: String, sparkContext: SparkContext): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to #55097. Reject multi-column DataFrame input in `spark.read.json()` explicitly instead of silently using the first column and dropping the rest.

Also renames error conditions and methods from `PARSE_INPUT_*` to `DATAFRAME_INPUT_*` since these are query compilation errors, not parse errors.

### Why are the changes needed?

Per review feedback on #55097 from cloud-fan and zhengruifeng: silently dropping columns is an anti-pattern. Multi-column DataFrame input should fail explicitly.

### Does this PR introduce _any_ user-facing change?

Yes. `spark.read.json(df)` now raises `DATAFRAME_INPUT_NOT_SINGLE_COLUMN` when the input DataFrame has more than one column (previously it silently used only the first column). Zero-column input now also raises `DATAFRAME_INPUT_NOT_SINGLE_COLUMN` instead of `PARSE_INPUT_NOT_STRING_TYPE`.

### How was this patch tested?

Updated existing tests in `test_datasources.py` (classic) and `test_connect_readwriter.py` (Connect) to verify that multi-column and zero-column input raises the expected error.

### Was this patch authored or co-authored using generative AI tooling?

No