### PR TITLE
[SPARK-56449][INFRA] Skip pre-flight checks for code questions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Before the first code edit or running test in a session, ensure a clean working 
 2. If the latest commit on `<upstream>/master` is more than a day old (check with `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.
 3. If there are uncommitted changes (check with `git status`), ask the user to stash them before proceeding.
 4. Switch to the appropriate branch:
-   - **Existing PR**: resolve the PR branch name via `gh api repos/databricks-eng/runtime/pulls/<number> --jq '.head.ref'`, then look for a local branch matching that name. If found, switch to it and inform the user. If not found, ask whether to fetch it or if there is a local branch under a different name.
+   - **Existing PR**: resolve the PR branch name via `gh api repos/apache/spark/pulls/<number> --jq '.head.ref'`, then look for a local branch matching that name. If found, switch to it and inform the user. If not found, ask whether to fetch it or if there is a local branch under a different name.
    - **New edits**: ask the user to choose: create a new git worktree from `<upstream>/master` and work from there (recommended), or create and switch to a new branch from `<upstream>/master`.
    - **Running tests**: use `<upstream>/master`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,9 @@
 
 ## Pre-flight Checks
 
-Before the first code read, edit, or test in a session, ensure a clean working environment. DO NOT skip these checks:
+These checks apply to all tasks **except** answering questions about the code or its behavior. For those, skip these checks and work directly on whatever branch is currently checked out.
+
+Before the first edit or test in a session, ensure a clean working environment. DO NOT skip these checks:
 
 1. Run `git remote -v` to identify the personal fork and upstream (`apache/spark`). If unclear, ask the user to configure their remotes following the standard convention (`origin` for the fork, `upstream` for `apache/spark`).
 2. If the latest commit on `<upstream>/master` is more than a day old (check with `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.
@@ -10,7 +12,7 @@ Before the first code read, edit, or test in a session, ensure a clean working e
 4. Switch to the appropriate branch:
    - **Existing PR**: resolve the PR branch name via `gh api repos/databricks-eng/runtime/pulls/<number> --jq '.head.ref'`, then look for a local branch matching that name. If found, switch to it and inform the user. If not found, ask whether to fetch it or if there is a local branch under a different name.
    - **New edits**: ask the user to choose: create a new git worktree from `<upstream>/master` and work from there (recommended), or create and switch to a new branch from `<upstream>/master`.
-   - **Reading code or running tests**: use `<upstream>/master`.
+   - **Running tests**: use `<upstream>/master`.
 
 ## Development Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,7 @@
 
 ## Pre-flight Checks
 
-These checks apply to all tasks **except** answering questions about the code or its behavior. For those, skip these checks and work directly on whatever branch is currently checked out.
-
-Before the first edit or test in a session, ensure a clean working environment. DO NOT skip these checks:
+Before the first code edit or running test in a session, ensure a clean working environment. DO NOT skip these checks:
 
 1. Run `git remote -v` to identify the personal fork and upstream (`apache/spark`). If unclear, ask the user to configure their remotes following the standard convention (`origin` for the fork, `upstream` for `apache/spark`).
 2. If the latest commit on `<upstream>/master` is more than a day old (check with `git log -1 --format="%ci" <upstream>/master`), run `git fetch <upstream> master`.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Updated AGENTS.md to skip the pre-flight checks when the user is only asking questions about the code or its behavior.

### Why are the changes needed?

For every new AI agent session (cursor, claude code), a new questions like "what does function X do?" previously triggered `git remote -v`, a staleness check, a potential `git fetch`, `git status`, and a branch switch.

It's somewhat of a regression from the previous, more lightweight experience before AGENTS.md.  It happens whenever open a tabs to start a different question session about the code.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual verification — this is a documentation-only change to AI agent instructions.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor (Claude Opus 4)