### PR TITLE
[SPARK-56374][BUILD] Align SBT assembly shade rules with Maven

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -828,6 +828,9 @@ object SparkConnect {
       ShadeRule.rename("io.perfmark.**" -> "org.sparkproject.connect.io_perfmark.@1").inAll,
       ShadeRule.rename("org.codehaus.mojo.animal_sniffer.**" -> "org.sparkproject.connect.animal_sniffer.@1").inAll,
       ShadeRule.rename("com.google.gson.**" -> "org.sparkproject.connect.gson.@1").inAll,
+      // Keep Guava relocation consistent with other modules (e.g., spark-network-common).
+      ShadeRule.rename("com.google.common.**" -> "org.sparkproject.guava.@1").inAll,
+      ShadeRule.rename("com.google.thirdparty.**" -> "org.sparkproject.guava.thirdparty.@1").inAll,
       ShadeRule.rename("com.google.api.**" -> "org.sparkproject.connect.google_protos.api.@1").inAll,
       ShadeRule.rename("com.google.apps.**" -> "org.sparkproject.connect.google_protos.apps.@1").inAll,
       ShadeRule.rename("com.google.cloud.**" -> "org.sparkproject.connect.google_protos.cloud.@1").inAll,
@@ -926,6 +929,7 @@ object SparkConnectJdbc {
       ShadeRule.rename("io.netty.**" -> "org.sparkproject.connect.client.io.netty.@1").inAll,
       ShadeRule.rename("io.perfmark.**" -> "org.sparkproject.connect.client.io.perfmark.@1").inAll,
       ShadeRule.rename("org.codehaus.**" -> "org.sparkproject.connect.client.org.codehaus.@1").inAll,
+      ShadeRule.rename("org.apache.arrow.**" -> "org.sparkproject.connect.client.org.apache.arrow.@1").inAll,
       ShadeRule.rename("android.annotation.**" -> "org.sparkproject.connect.client.android.annotation.@1").inAll
     ),
 
@@ -1007,6 +1011,7 @@ object SparkConnectClient {
       ShadeRule.rename("io.netty.**" -> "org.sparkproject.connect.client.io.netty.@1").inAll,
       ShadeRule.rename("io.perfmark.**" -> "org.sparkproject.connect.client.io.perfmark.@1").inAll,
       ShadeRule.rename("org.codehaus.**" -> "org.sparkproject.connect.client.org.codehaus.@1").inAll,
+      ShadeRule.rename("org.apache.arrow.**" -> "org.sparkproject.connect.client.org.apache.arrow.@1").inAll,
       ShadeRule.rename("android.annotation.**" -> "org.sparkproject.connect.client.android.annotation.@1").inAll
     ),
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add missing shade rules to `project/SparkBuild.scala` to align SBT assembly output with Maven for three connect modules:

1. **SparkConnect (server)**: Add `com.google.common` → `org.sparkproject.guava` and `com.google.thirdparty` → `org.sparkproject.guava.thirdparty` relocations. Maven's `sql/connect/server/pom.xml` has these but SBT was missing them.

2. **SparkConnectClient (jvm)**: Add `org.apache.arrow` → `org.sparkproject.connect.client.org.apache.arrow` relocation. Maven's `connector/connect/client/jvm/pom.xml` has this but SBT was missing it.

3. **SparkConnectJdbc**: Add `org.apache.arrow` relocation for consistency with Maven's `sql/connect/client/jdbc/pom.xml`.

### Why are the changes needed?

SBT assembly shade rules were out of sync with Maven, causing differences in the assembled JARs:

- **Server**: Without the guava relocation, grpc classes in the server assembly reference unshaded `com.google.common.*`. At runtime these fail to resolve because Guava is shaded to `org.sparkproject.guava` in `spark-network-common`. Verified by inspecting `ManagedChannelImpl.class` — after the fix, references correctly point to `org/sparkproject/guava/base/MoreObjects` instead of `com/google/common/base/MoreObjects`.

- **Client JVM**: Arrow classes were not being shaded. After the fix, they appear under `org/sparkproject/connect/client/org/apache/arrow/`.

Other Maven modules with shade rules (`core`, `sql/core`, `network-yarn`, root `pom.xml`) were verified to be intentionally different in SBT — those modules don't produce separate assembly JARs in SBT, and their shading is handled at a different level in the SBT build architecture.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Built all three affected SBT assemblies and verified the output JARs:

```
build/sbt connect/assembly              # ✅ success
build/sbt connect-client-jvm/assembly   # ✅ success
build/sbt connect-client-jdbc/assembly  # ✅ success
```

Verified shading in the output JARs:
- Server assembly: `strings ManagedChannelImpl.class` shows `org/sparkproject/guava/base/MoreObjects` (was `com/google/common/base/MoreObjects` before fix)
- Client JVM assembly: `jar tf` shows arrow classes under `org/sparkproject/connect/client/org/apache/arrow/` with zero unshaded `org/apache/arrow` entries

### Was this patch authored or co-authored using generative AI tooling?

Yes
