### PR TITLE
[SPARK-56374][BUILD] Align SBT assembly shade rules with Maven

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -926,6 +926,7 @@ object SparkConnectJdbc {
       ShadeRule.rename("io.netty.**" -> "org.sparkproject.connect.client.io.netty.@1").inAll,
       ShadeRule.rename("io.perfmark.**" -> "org.sparkproject.connect.client.io.perfmark.@1").inAll,
       ShadeRule.rename("org.codehaus.**" -> "org.sparkproject.connect.client.org.codehaus.@1").inAll,
+      ShadeRule.rename("org.apache.arrow.**" -> "org.sparkproject.connect.client.org.apache.arrow.@1").inAll,
       ShadeRule.rename("android.annotation.**" -> "org.sparkproject.connect.client.android.annotation.@1").inAll
     ),
 
@@ -1007,6 +1008,7 @@ object SparkConnectClient {
       ShadeRule.rename("io.netty.**" -> "org.sparkproject.connect.client.io.netty.@1").inAll,
       ShadeRule.rename("io.perfmark.**" -> "org.sparkproject.connect.client.io.perfmark.@1").inAll,
       ShadeRule.rename("org.codehaus.**" -> "org.sparkproject.connect.client.org.codehaus.@1").inAll,
+      ShadeRule.rename("org.apache.arrow.**" -> "org.sparkproject.connect.client.org.apache.arrow.@1").inAll,
       ShadeRule.rename("android.annotation.**" -> "org.sparkproject.connect.client.android.annotation.@1").inAll
     ),
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the missing `org.apache.arrow` shade rule to `SparkConnectClient` (jvm) and `SparkConnectJdbc` assembly settings in `project/SparkBuild.scala`.

This is a small incremental step toward full SBT/Maven assembly parity (SPARK-56374).

### Why are the changes needed?

Maven's `sql/connect/client/jvm/pom.xml` relocates Arrow classes to `org/sparkproject/org/apache/arrow/` inside the client assembly JAR. SBT was missing this rule, leaving 998 Arrow classes unshaded at `org/apache/arrow/` inside the assembly JAR.

Since Arrow classes are **bundled inside** the client assembly JAR (not on the external classpath), they should be shaded like the other bundled dependencies (grpc, netty, protobuf, etc.) to avoid classpath conflicts when the client JAR is used alongside other libraries that depend on a different Arrow version.

**Comparison of Connect client JVM assembly JARs (before this fix):**

| Dependency | Maven | SBT |
|-----------|-------|-----|
| grpc | `org/sparkproject/io/grpc/` | `org/sparkproject/connect/client/io/grpc/` ✅ |
| netty | `org/sparkproject/io/netty/` | `org/sparkproject/connect/client/io/netty/` ✅ |
| guava | `org/sparkproject/connect/guava/` | `org/sparkproject/connect/client/com/google/common/` ✅ |
| **arrow** | `org/sparkproject/org/apache/arrow/` (998 classes) | **`org/apache/arrow/` — NOT SHADED** ❌ |

After this fix, Arrow is shaded to `org/sparkproject/connect/client/org/apache/arrow/`.

**Note:** The Connect **server** assembly already matches Maven (identical class count of 5739 and identical shaded namespaces). No server changes are needed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

**Build verification:**
```
build/sbt connect-client-jvm/assembly   # ✅ success
build/sbt connect-client-jdbc/assembly  # ✅ success
```

**JAR content verification:**
- `jar tf` confirms Arrow classes now appear under `org/sparkproject/connect/client/org/apache/arrow/` with zero unshaded `org/apache/arrow/` entries

**Runtime tests:**
- `connect-client-jvm/testOnly org.apache.spark.sql.connect.client.arrow.*` — **113/113 passed** (Arrow serialization/deserialization)
- `connect-client-jvm/testOnly org.apache.spark.sql.connect.client.SparkConnectClientSuite` — **58/58 passed**
- Full `connect-client-jvm/test` — **1141/1166 passed** (1 pre-existing failure in `JavaEncoderSuite` confirmed on master, 24 E2E suites require running server)

### Was this patch authored or co-authored using generative AI tooling?

Yes