### PR TITLE
[SPARK-56452][PYTHON] Fix pip install failure for prerelease versions

### DIFF
--- a/python/pyspark/install.py
+++ b/python/pyspark/install.py
@@ -106,7 +106,9 @@ def convert_old_hadoop_version(spark_version: str, hadoop_version: str) -> str:
         "without": "without",
         "without-hadoop": "without-hadoop",
     }
-    spark_version_parts = re.search("^spark-([0-9]+)\\.([0-9]+)\\.[0-9]+(?:\\.dev[0-9]+)?$", spark_version)
+    spark_version_parts = re.search(
+        "^spark-([0-9]+)\\.([0-9]+)\\.[0-9]+(?:\\.dev[0-9]+)?$", spark_version
+    )
     assert spark_version_parts is not None
     spark_major_version = int(spark_version_parts.group(1))
     spark_minor_version = int(spark_version_parts.group(2))

--- a/python/pyspark/install.py
+++ b/python/pyspark/install.py
@@ -68,7 +68,7 @@ def checked_versions(
         fully-qualified versions of Spark, Hadoop and Hive in a tuple.
         For example, spark-3.2.0, hadoop3 and hive2.3.
     """
-    if re.match("^[0-9]+\\.[0-9]+\\.[0-9]+$", spark_version):
+    if re.match("^[0-9]+\\.[0-9]+\\.[0-9]+(?:\\.dev[0-9]+)?$", spark_version):
         spark_version = "spark-%s" % spark_version
     if not spark_version.startswith("spark-"):
         raise RuntimeError(
@@ -106,7 +106,7 @@ def convert_old_hadoop_version(spark_version: str, hadoop_version: str) -> str:
         "without": "without",
         "without-hadoop": "without-hadoop",
     }
-    spark_version_parts = re.search("^spark-([0-9]+)\\.([0-9]+)\\.[0-9]+$", spark_version)
+    spark_version_parts = re.search("^spark-([0-9]+)\\.([0-9]+)\\.[0-9]+(?:\\.dev[0-9]+)?$", spark_version)
     assert spark_version_parts is not None
     spark_major_version = int(spark_version_parts.group(1))
     spark_minor_version = int(spark_version_parts.group(2))

--- a/python/pyspark/tests/test_install_spark.py
+++ b/python/pyspark/tests/test_install_spark.py
@@ -106,6 +106,17 @@ class SparkInstallationTestCase(unittest.TestCase):
             checked_versions("spark-3.3.0", "hadoop3", "hive2.3"),
         )
 
+        # Prerelease version (e.g. pip dev builds)
+        self.assertEqual(
+            ("spark-4.2.0.dev4", "hadoop3", "hive2.3"),
+            checked_versions("4.2.0.dev4", "3", "2.3"),
+        )
+
+        self.assertEqual(
+            ("spark-4.2.0.dev4", "hadoop3", "hive2.3"),
+            checked_versions("spark-4.2.0.dev4", "hadoop3", "hive2.3"),
+        )
+
         # Negative test cases
         for hadoop_version, hive_version in UNSUPPORTED_COMBINATIONS:
             with self.assertRaisesRegex(RuntimeError, "Hive.*should.*Hadoop"):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Updated the version validation regexes in `python/pyspark/install.py` to accept prerelease version strings (e.g. `4.2.0.dev4`).

Two regexes were updated:
- `checked_versions()` (line 71): the regex that detects bare version strings and prepends `spark-`
- `convert_old_hadoop_version()` (line 109): the regex that extracts major/minor version parts

Both now include an optional `(?:\.dev[0-9]+)?` suffix.

### Why are the changes needed?

When installing a PySpark prerelease via pip (e.g. `pip install pyspark==4.2.0.dev4`), the version string `4.2.0.dev4` does not match the existing regex `^[0-9]+\.[0-9]+\.[0-9]+$`. This causes the `spark-` prefix to not be added, which then triggers a `RuntimeError`:

```
RuntimeError: Spark version should start with 'spark-' prefix; however, got 4.2.0.dev4
```

GitHub issue: https://github.com/apache/spark/issues/55289

### Does this PR introduce _any_ user-facing change?

Yes. Previously, `pip install pyspark==4.2.0.dev4` would fail with a `RuntimeError`. After this fix, prerelease versions install correctly.

### How was this patch tested?

Added two test cases in `test_checked_versions` for prerelease versions:
- `checked_versions("4.2.0.dev4", "3", "2.3")` — bare version with dev suffix
- `checked_versions("spark-4.2.0.dev4", "hadoop3", "hive2.3")` — already prefixed version with dev suffix

### Was this patch authored or co-authored using generative AI tooling?

No.