### PR TITLE
[SPARK-56424][PYTHON][TESTS] Add ASV benchmark for SQL_SCALAR_PANDAS_UDF

### DIFF
--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -1098,6 +1098,76 @@ class ScalarArrowIterUDFPeakmemBench(_ScalarArrowIterBenchMixin, _PeakmemBenchBa
     pass
 
 
+# -- SQL_SCALAR_PANDAS_UDF --------------------------------------------------
+# UDF receives ``pandas.Series`` columns, returns ``pandas.Series``.
+# Measures the full Arrow-to-Pandas-to-Arrow round-trip.
+
+
+class _ScalarPandasBenchMixin:
+    """Mixin for SQL_SCALAR_PANDAS_UDF benchmarks."""
+
+    def _scalar_pandas_sort(s):
+        return s.sort_values().reset_index(drop=True)
+
+    def _scalar_pandas_nullcheck(s):
+        return s.notna()
+
+    _scenario_configs = {
+        "sm_batch_few_col": ("mixed", 500_000, 5, 1_000),
+        "sm_batch_many_col": ("mixed", 50_000, 50, 1_000),
+        "lg_batch_few_col": ("mixed", 5_000_000, 5, 10_000),
+        "lg_batch_many_col": ("mixed", 500_000, 50, 10_000),
+        "pure_ints": ("pure_ints", 1_000_000, 10, 5_000),
+        "pure_floats": ("pure_floats", 1_000_000, 10, 5_000),
+        "pure_strings": ("pure_strings", 1_000_000, 10, 5_000),
+        "pure_ts": ("pure_ts", 1_000_000, 10, 5_000),
+        "mixed_types": ("mixed", 1_000_000, 10, 5_000),
+    }
+
+    @staticmethod
+    def _build_scenario(name):
+        """Build a single scenario by name."""
+        np.random.seed(42)
+        type_key, num_rows, num_cols, batch_size = _ScalarPandasBenchMixin._scenario_configs[name]
+        pool = MockDataFactory.NAMED_TYPE_POOLS[type_key]
+        return MockDataFactory.make_batches(
+            num_rows=num_rows,
+            num_cols=num_cols,
+            spark_type_pool=pool,
+            batch_size=batch_size,
+        )
+
+    _eval_type = PythonEvalType.SQL_SCALAR_PANDAS_UDF
+    # ret_type=None means "use schema.fields[0].dataType from the scenario"
+    _udfs = {
+        "identity_udf": (lambda s: s, None, [0]),
+        "sort_udf": (_scalar_pandas_sort, None, [0]),
+        "nullcheck_udf": (_scalar_pandas_nullcheck, BooleanType(), [0]),
+    }
+    params = [list(_scenario_configs), list(_udfs)]
+    param_names = ["scenario", "udf"]
+
+    def _write_scenario(self, scenario, udf_name, buf):
+        batches, schema = self._build_scenario(scenario)
+        udf_func, ret_type, arg_offsets = self._udfs[udf_name]
+        if ret_type is None:
+            ret_type = schema.fields[0].dataType
+        MockProtocolWriter.write_worker_input(
+            self._eval_type,
+            lambda b: MockProtocolWriter.write_udf_payload(udf_func, ret_type, arg_offsets, b),
+            lambda b: MockProtocolWriter.write_data_payload(iter(batches), b),
+            buf,
+        )
+
+
+class ScalarPandasUDFTimeBench(_ScalarPandasBenchMixin, _TimeBenchBase):
+    pass
+
+
+class ScalarPandasUDFPeakmemBench(_ScalarPandasBenchMixin, _PeakmemBenchBase):
+    pass
+
+
 # -- SQL_WINDOW_AGG_ARROW_UDF ------------------------------------------------
 # UDF receives ``pa.Array`` columns for the entire window partition, returns scalar.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add ASV microbenchmarks for `SQL_SCALAR_PANDAS_UDF` eval type in `bench_eval_type.py`.

The new `_ScalarPandasBenchMixin` follows the same pattern as the existing `_ScalarArrowBenchMixin` but uses Pandas Series operations. It measures the full Arrow-to-Pandas-to-Arrow round-trip that occurs in scalar Pandas UDFs.

**Scenarios** (9): `sm_batch_few_col`, `sm_batch_many_col`, `lg_batch_few_col`, `lg_batch_many_col`, `pure_ints`, `pure_floats`, `pure_strings`, `pure_ts`, `mixed_types`

**UDFs** (3): `identity_udf` (passthrough), `sort_udf` (Series.sort_values), `nullcheck_udf` (Series.notna)

**Benchmark classes** (2): `ScalarPandasUDFTimeBench`, `ScalarPandasUDFPeakmemBench`

### Why are the changes needed?

This is part of the PySpark Serializer & EvalType Refactor effort (SPARK-55724). We need baseline benchmarks for every eval type before refactoring the serialization path, so we can detect performance regressions. `SQL_SCALAR_PANDAS_UDF` is one of the most commonly used eval types and its Arrow-to-Pandas-to-Arrow conversion cost is a key metric for the refactor.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran all 54 benchmarks (27 time + 27 peakmem) locally with `python/asv run --python=same --quick`:

```
time_worker results (27/27 passed):
  sm_batch_few_col   identity_udf: 269ms, sort_udf: 385ms, nullcheck_udf: 300ms
  lg_batch_few_col   identity_udf: 836ms, sort_udf: 1.06s, nullcheck_udf: 834ms
  pure_ints          identity_udf: 165ms, sort_udf: 236ms, nullcheck_udf: 170ms
  pure_strings       identity_udf: 819ms, sort_udf: 1.17s, nullcheck_udf: 818ms
  mixed_types        identity_udf: 504ms, sort_udf: 551ms, nullcheck_udf: 510ms
  (+ 12 more scenarios all passing)

peakmem_worker results (27/27 passed):
  Range: 479M - 628M across all scenario/udf combinations
```

### Was this patch authored or co-authored using generative AI tooling?

No.