### PR TITLE
[SPARK-56456] Improve checkError() diagnostics

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkTestSuite.scala
@@ -22,7 +22,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{Files, Path}
 import java.util.{Locale, TimeZone}
 
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.jdk.CollectionConverters._
 
 import org.apache.logging.log4j._
@@ -301,59 +301,117 @@ trait SparkTestSuite
       parameters: Map[String, String] = Map.empty,
       matchPVals: Boolean = false,
       queryContext: Array[ExpectedContext] = Array.empty): Unit = {
-    assert(exception.getCondition === condition)
-    sqlState.foreach(state => assert(exception.getSqlState === state))
+    val mismatches = new ListBuffer[String]
+
+    if (exception.getCondition != condition) {
+      mismatches += s"condition: expected '$condition' but got '${exception.getCondition}'"
+    }
+    sqlState.foreach { state =>
+      if (exception.getSqlState != state) {
+        mismatches += s"sqlState: expected '$state' but got '${exception.getSqlState}'"
+      }
+    }
+
     val actualParameters = exception.getMessageParameters.asScala
     val ignorable = checkErrorIgnorableParameters.getOrElse(condition, Set.empty[String])
     val actualParametersToCompare = actualParameters.filter { case (k, _) =>
       !ignorable.contains(k) || parameters.contains(k)
     }
     if (matchPVals) {
-      assert(actualParametersToCompare.size === parameters.size)
-      actualParametersToCompare.foreach(
-        exp => {
-          val parm = parameters.getOrElse(exp._1,
-            throw new IllegalArgumentException("Missing parameter" + exp._1))
-          if (!exp._2.matches(parm)) {
-            throw new IllegalArgumentException("For parameter '" + exp._1 + "' value '" + exp._2 +
-              "' does not match: " + parm)
-          }
-        }
-      )
-    } else {
-      assert(actualParametersToCompare === parameters)
-    }
-    val actualQueryContext = exception.getQueryContext()
-    assert(actualQueryContext.length === queryContext.length, "Invalid length of the query context")
-    actualQueryContext.zip(queryContext).foreach { case (actual, expected) =>
-      assert(actual.contextType() === expected.contextType,
-        "Invalid contextType of a query context Actual:" + actual.toString)
-      if (actual.contextType() == QueryContextType.SQL) {
-        assert(actual.objectType() === expected.objectType,
-          "Invalid objectType of a query context Actual:" + actual.toString)
-        assert(actual.objectName() === expected.objectName,
-          "Invalid objectName of a query context. Actual:" + actual.toString)
-        // If startIndex and stopIndex are -1, it means we simply want to check the
-        // fragment of the query context. This should be the case when the fragment is
-        // distinguished within the query text.
-        if (expected.startIndex != -1) {
-          assert(actual.startIndex() === expected.startIndex,
-            "Invalid startIndex of a query context. Actual:" + actual.toString)
-        }
-        if (expected.stopIndex != -1) {
-          assert(actual.stopIndex() === expected.stopIndex,
-            "Invalid stopIndex of a query context. Actual:" + actual.toString)
-        }
-        assert(actual.fragment() === expected.fragment,
-          "Invalid fragment of a query context. Actual:" + actual.toString)
-      } else if (actual.contextType() == QueryContextType.DataFrame) {
-        assert(actual.fragment() === expected.fragment,
-          "Invalid code fragment of a query context. Actual:" + actual.toString)
-        if (expected.callSitePattern.nonEmpty) {
-          assert(actual.callSite().matches(expected.callSitePattern),
-            "Invalid callSite of a query context. Actual:" + actual.toString)
+      if (actualParametersToCompare.size != parameters.size) {
+        mismatches += s"parameters size: expected ${parameters.size} but got" +
+          s" ${actualParametersToCompare.size}"
+      }
+      actualParametersToCompare.foreach { case (key, actualVal) =>
+        parameters.get(key) match {
+          case None =>
+            mismatches += s"parameters: unexpected key '$key' with value '$actualVal'"
+          case Some(pattern) if !actualVal.matches(pattern) =>
+            mismatches += s"parameters['$key']: value '$actualVal' does not match pattern" +
+              s" '$pattern'"
+          case _ =>
         }
       }
+      parameters.keys.filterNot(actualParametersToCompare.contains).foreach { key =>
+        mismatches += s"parameters: missing expected key '$key'"
+      }
+    } else if (actualParametersToCompare != parameters) {
+      mismatches += s"parameters: expected $parameters but got $actualParametersToCompare"
+    }
+
+    val actualQueryContext = exception.getQueryContext()
+    if (actualQueryContext.length != queryContext.length) {
+      mismatches += s"queryContext.length: expected ${queryContext.length}" +
+        s" but got ${actualQueryContext.length}"
+    }
+    actualQueryContext.zip(queryContext).zipWithIndex.foreach {
+      case ((actual, expected), idx) =>
+        if (actual.contextType() != expected.contextType) {
+          mismatches += s"queryContext[$idx].contextType: expected ${expected.contextType}" +
+            s" but got ${actual.contextType()}"
+        }
+        if (actual.contextType() == QueryContextType.SQL) {
+          if (actual.objectType() != expected.objectType) {
+            mismatches += s"queryContext[$idx].objectType: expected '${expected.objectType}'" +
+              s" but got '${actual.objectType()}'"
+          }
+          if (actual.objectName() != expected.objectName) {
+            mismatches += s"queryContext[$idx].objectName: expected '${expected.objectName}'" +
+              s" but got '${actual.objectName()}'"
+          }
+          if (expected.startIndex != -1 && actual.startIndex() != expected.startIndex) {
+            mismatches += s"queryContext[$idx].startIndex: expected ${expected.startIndex}" +
+              s" but got ${actual.startIndex()}"
+          }
+          if (expected.stopIndex != -1 && actual.stopIndex() != expected.stopIndex) {
+            mismatches += s"queryContext[$idx].stopIndex: expected ${expected.stopIndex}" +
+              s" but got ${actual.stopIndex()}"
+          }
+          if (actual.fragment() != expected.fragment) {
+            mismatches += s"queryContext[$idx].fragment: expected '${expected.fragment}'" +
+              s" but got '${actual.fragment()}'"
+          }
+        } else if (actual.contextType() == QueryContextType.DataFrame) {
+          if (actual.fragment() != expected.fragment) {
+            mismatches += s"queryContext[$idx].fragment: expected '${expected.fragment}'" +
+              s" but got '${actual.fragment()}'"
+          }
+          if (expected.callSitePattern.nonEmpty &&
+              !actual.callSite().matches(expected.callSitePattern)) {
+            mismatches += s"queryContext[$idx].callSite: '${actual.callSite()}'" +
+              s" does not match pattern '${expected.callSitePattern}'"
+          }
+        }
+    }
+
+    if (mismatches.nonEmpty) {
+      val sb = new StringBuilder
+      sb.append(s"checkError found ${mismatches.size} mismatch(es).\n\n")
+      sb.append("=== Actual Exception State ===\n")
+      sb.append(s"  condition: ${exception.getCondition}\n")
+      sb.append(s"  sqlState:  ${exception.getSqlState}\n")
+      sb.append(s"  parameters:\n")
+      if (actualParameters.isEmpty) {
+        sb.append("    (empty)\n")
+      } else {
+        actualParameters.foreach { case (k, v) => sb.append(s"    $k -> $v\n") }
+      }
+      actualQueryContext.zipWithIndex.foreach { case (ctx, idx) =>
+        sb.append(s"  queryContext[$idx] (${ctx.contextType()}):\n")
+        if (ctx.contextType() == QueryContextType.SQL) {
+          sb.append(s"    objectType: ${ctx.objectType()}\n")
+          sb.append(s"    objectName: ${ctx.objectName()}\n")
+          sb.append(s"    startIndex: ${ctx.startIndex()}\n")
+          sb.append(s"    stopIndex:  ${ctx.stopIndex()}\n")
+          sb.append(s"    fragment:   ${ctx.fragment()}\n")
+        } else if (ctx.contextType() == QueryContextType.DataFrame) {
+          sb.append(s"    fragment:   ${ctx.fragment()}\n")
+          sb.append(s"    callSite:   ${ctx.callSite()}\n")
+        }
+      }
+      sb.append("\n=== Mismatches ===\n")
+      mismatches.foreach(m => sb.append(s"  $m\n"))
+      fail(sb.toString())
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/SparkTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkTestSuite.scala
@@ -359,6 +359,9 @@ trait SparkTestSuite
             mismatches += s"queryContext[$idx].objectName: expected '${expected.objectName}'" +
               s" but got '${actual.objectName()}'"
           }
+          // If startIndex and stopIndex are -1, it means we simply want to check the
+          // fragment of the query context. This should be the case when the fragment is
+          // distinguished within the query text.
           if (expected.startIndex != -1 && actual.startIndex() != expected.startIndex) {
             mismatches += s"queryContext[$idx].startIndex: expected ${expected.startIndex}" +
               s" but got ${actual.startIndex()}"

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.core.util.{DefaultIndenter, DefaultPrettyPrinter}
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.scalatest.exceptions.TestFailedException
 
 import org.apache.spark.SparkThrowableHelper._
 import org.apache.spark.util.Utils
@@ -799,5 +800,63 @@ class SparkThrowableSuite extends SparkFunSuite {
 
     assert(errorWithNull.getSqlState == "22018",
       "Should fall back to error class reader SQL state when custom is null")
+  }
+
+  test("checkError reports all mismatches in a single failure message") {
+    class TestQueryContext extends QueryContext {
+      override val contextType = QueryContextType.SQL
+      override val objectName = "v1"
+      override val objectType = "VIEW"
+      override val startIndex = 2
+      override val stopIndex = 10
+      override val fragment = "1 / 0"
+      override val callSite = ""
+      override val summary = ""
+    }
+
+    val exception = new SparkArithmeticException(
+      errorClass = "DIVIDE_BY_ZERO",
+      messageParameters = Map("config" -> "CONFIG"),
+      context = Array(new TestQueryContext),
+      summary = "")
+
+    val error = intercept[TestFailedException] {
+      checkError(
+        exception = exception,
+        condition = "WRONG_CONDITION",
+        sqlState = Some("99999"),
+        parameters = Map("config" -> "WRONG_VALUE"),
+        queryContext = Array(ExpectedContext(
+          objectType = "TABLE",
+          objectName = "t1",
+          startIndex = 0,
+          stopIndex = 5,
+          fragment = "wrong fragment")))
+    }
+    val msg = error.getMessage
+    assert(msg.contains("=== Actual Exception State ==="), "Should contain actual state header")
+    assert(msg.contains("=== Mismatches ==="), "Should contain mismatches header")
+    assert(msg.contains("condition:"), "Should report condition mismatch")
+    assert(msg.contains("sqlState:"), "Should report sqlState mismatch")
+    assert(msg.contains("parameters:"), "Should report parameters mismatch")
+    assert(msg.contains("queryContext[0].objectType:"), "Should report objectType mismatch")
+    assert(msg.contains("queryContext[0].objectName:"), "Should report objectName mismatch")
+    assert(msg.contains("queryContext[0].startIndex:"), "Should report startIndex mismatch")
+    assert(msg.contains("queryContext[0].stopIndex:"), "Should report stopIndex mismatch")
+    assert(msg.contains("queryContext[0].fragment:"), "Should report fragment mismatch")
+  }
+
+  test("checkError succeeds when all fields match") {
+    val exception = new SparkArithmeticException(
+      errorClass = "DIVIDE_BY_ZERO",
+      messageParameters = Map("config" -> "CONFIG"),
+      context = Array.empty,
+      summary = "")
+
+    checkError(
+      exception = exception,
+      condition = "DIVIDE_BY_ZERO",
+      sqlState = Some("22012"),
+      parameters = Map("config" -> "CONFIG"))
   }
 }

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/QueryTest.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/QueryTest.scala
@@ -152,47 +152,46 @@ abstract class QueryTest extends ConnectFunSuite with SQLHelper {
       mismatches += s"queryContext.length: expected ${queryContext.length}" +
         s" but got ${actualQueryContext.length}"
     }
-    actualQueryContext.zip(queryContext).zipWithIndex.foreach {
-      case ((actual, expected), idx) =>
-        if (actual.contextType() != expected.contextType) {
-          mismatches += s"queryContext[$idx].contextType: expected ${expected.contextType}" +
-            s" but got ${actual.contextType()}"
+    actualQueryContext.zip(queryContext).zipWithIndex.foreach { case ((actual, expected), idx) =>
+      if (actual.contextType() != expected.contextType) {
+        mismatches += s"queryContext[$idx].contextType: expected ${expected.contextType}" +
+          s" but got ${actual.contextType()}"
+      }
+      if (actual.contextType() == QueryContextType.SQL) {
+        if (actual.objectType() != expected.objectType) {
+          mismatches += s"queryContext[$idx].objectType: expected '${expected.objectType}'" +
+            s" but got '${actual.objectType()}'"
         }
-        if (actual.contextType() == QueryContextType.SQL) {
-          if (actual.objectType() != expected.objectType) {
-            mismatches += s"queryContext[$idx].objectType: expected '${expected.objectType}'" +
-              s" but got '${actual.objectType()}'"
-          }
-          if (actual.objectName() != expected.objectName) {
-            mismatches += s"queryContext[$idx].objectName: expected '${expected.objectName}'" +
-              s" but got '${actual.objectName()}'"
-          }
-          // If startIndex and stopIndex are -1, it means we simply want to check the
-          // fragment of the query context. This should be the case when the fragment is
-          // distinguished within the query text.
-          if (expected.startIndex != -1 && actual.startIndex() != expected.startIndex) {
-            mismatches += s"queryContext[$idx].startIndex: expected ${expected.startIndex}" +
-              s" but got ${actual.startIndex()}"
-          }
-          if (expected.stopIndex != -1 && actual.stopIndex() != expected.stopIndex) {
-            mismatches += s"queryContext[$idx].stopIndex: expected ${expected.stopIndex}" +
-              s" but got ${actual.stopIndex()}"
-          }
-          if (actual.fragment() != expected.fragment) {
-            mismatches += s"queryContext[$idx].fragment: expected '${expected.fragment}'" +
-              s" but got '${actual.fragment()}'"
-          }
-        } else if (actual.contextType() == QueryContextType.DataFrame) {
-          if (actual.fragment() != expected.fragment) {
-            mismatches += s"queryContext[$idx].fragment: expected '${expected.fragment}'" +
-              s" but got '${actual.fragment()}'"
-          }
-          if (expected.callSitePattern.nonEmpty &&
-              !actual.callSite().matches(expected.callSitePattern)) {
-            mismatches += s"queryContext[$idx].callSite: '${actual.callSite()}'" +
-              s" does not match pattern '${expected.callSitePattern}'"
-          }
+        if (actual.objectName() != expected.objectName) {
+          mismatches += s"queryContext[$idx].objectName: expected '${expected.objectName}'" +
+            s" but got '${actual.objectName()}'"
         }
+        // If startIndex and stopIndex are -1, it means we simply want to check the
+        // fragment of the query context. This should be the case when the fragment is
+        // distinguished within the query text.
+        if (expected.startIndex != -1 && actual.startIndex() != expected.startIndex) {
+          mismatches += s"queryContext[$idx].startIndex: expected ${expected.startIndex}" +
+            s" but got ${actual.startIndex()}"
+        }
+        if (expected.stopIndex != -1 && actual.stopIndex() != expected.stopIndex) {
+          mismatches += s"queryContext[$idx].stopIndex: expected ${expected.stopIndex}" +
+            s" but got ${actual.stopIndex()}"
+        }
+        if (actual.fragment() != expected.fragment) {
+          mismatches += s"queryContext[$idx].fragment: expected '${expected.fragment}'" +
+            s" but got '${actual.fragment()}'"
+        }
+      } else if (actual.contextType() == QueryContextType.DataFrame) {
+        if (actual.fragment() != expected.fragment) {
+          mismatches += s"queryContext[$idx].fragment: expected '${expected.fragment}'" +
+            s" but got '${actual.fragment()}'"
+        }
+        if (expected.callSitePattern.nonEmpty &&
+          !actual.callSite().matches(expected.callSitePattern)) {
+          mismatches += s"queryContext[$idx].callSite: '${actual.callSite()}'" +
+            s" does not match pattern '${expected.callSitePattern}'"
+        }
+      }
     }
 
     if (mismatches.nonEmpty) {

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/QueryTest.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/QueryTest.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.connect.test
 
 import java.util.TimeZone
 
+import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
 
 import org.scalatest.Assertions
@@ -112,58 +113,113 @@ abstract class QueryTest extends ConnectFunSuite with SQLHelper {
       parameters: Map[String, String] = Map.empty,
       matchPVals: Boolean = false,
       queryContext: Array[ExpectedContext] = Array.empty): Unit = {
-    assert(exception.getCondition === condition)
-    sqlState.foreach(state => assert(exception.getSqlState === state))
-    val expectedParameters = exception.getMessageParameters.asScala
-    if (matchPVals) {
-      assert(expectedParameters.size === parameters.size)
-      expectedParameters.foreach(exp => {
-        val parm = parameters.getOrElse(
-          exp._1,
-          throw new IllegalArgumentException("Missing parameter" + exp._1))
-        if (!exp._2.matches(parm)) {
-          throw new IllegalArgumentException(
-            "For parameter '" + exp._1 + "' value '" + exp._2 +
-              "' does not match: " + parm)
-        }
-      })
-    } else {
-      assert(expectedParameters === parameters)
+    val mismatches = new ListBuffer[String]
+
+    if (exception.getCondition != condition) {
+      mismatches += s"condition: expected '$condition' but got '${exception.getCondition}'"
     }
-    val actualQueryContext = exception.getQueryContext()
-    assert(
-      actualQueryContext.length === queryContext.length,
-      "Invalid length of the query context")
-    actualQueryContext.zip(queryContext).foreach { case (actual, expected) =>
-      assert(
-        actual.contextType() === expected.contextType,
-        "Invalid contextType of a query context Actual:" + actual.toString)
-      if (actual.contextType() == QueryContextType.SQL) {
-        assert(
-          actual.objectType() === expected.objectType,
-          "Invalid objectType of a query context Actual:" + actual.toString)
-        assert(
-          actual.objectName() === expected.objectName,
-          "Invalid objectName of a query context. Actual:" + actual.toString)
-        assert(
-          actual.startIndex() === expected.startIndex,
-          "Invalid startIndex of a query context. Actual:" + actual.toString)
-        assert(
-          actual.stopIndex() === expected.stopIndex,
-          "Invalid stopIndex of a query context. Actual:" + actual.toString)
-        assert(
-          actual.fragment() === expected.fragment,
-          "Invalid fragment of a query context. Actual:" + actual.toString)
-      } else if (actual.contextType() == QueryContextType.DataFrame) {
-        assert(
-          actual.fragment() === expected.fragment,
-          "Invalid code fragment of a query context. Actual:" + actual.toString)
-        if (expected.callSitePattern.nonEmpty) {
-          assert(
-            actual.callSite().matches(expected.callSitePattern),
-            "Invalid callSite of a query context. Actual:" + actual.toString)
+    sqlState.foreach { state =>
+      if (exception.getSqlState != state) {
+        mismatches += s"sqlState: expected '$state' but got '${exception.getSqlState}'"
+      }
+    }
+
+    val actualParameters = exception.getMessageParameters.asScala
+    if (matchPVals) {
+      if (actualParameters.size != parameters.size) {
+        mismatches += s"parameters size: expected ${parameters.size} but got" +
+          s" ${actualParameters.size}"
+      }
+      actualParameters.foreach { case (key, actualVal) =>
+        parameters.get(key) match {
+          case None =>
+            mismatches += s"parameters: unexpected key '$key' with value '$actualVal'"
+          case Some(pattern) if !actualVal.matches(pattern) =>
+            mismatches += s"parameters['$key']: value '$actualVal' does not match pattern" +
+              s" '$pattern'"
+          case _ =>
         }
       }
+      parameters.keys.filterNot(actualParameters.contains).foreach { key =>
+        mismatches += s"parameters: missing expected key '$key'"
+      }
+    } else if (actualParameters != parameters) {
+      mismatches += s"parameters: expected $parameters but got $actualParameters"
+    }
+
+    val actualQueryContext = exception.getQueryContext()
+    if (actualQueryContext.length != queryContext.length) {
+      mismatches += s"queryContext.length: expected ${queryContext.length}" +
+        s" but got ${actualQueryContext.length}"
+    }
+    actualQueryContext.zip(queryContext).zipWithIndex.foreach {
+      case ((actual, expected), idx) =>
+        if (actual.contextType() != expected.contextType) {
+          mismatches += s"queryContext[$idx].contextType: expected ${expected.contextType}" +
+            s" but got ${actual.contextType()}"
+        }
+        if (actual.contextType() == QueryContextType.SQL) {
+          if (actual.objectType() != expected.objectType) {
+            mismatches += s"queryContext[$idx].objectType: expected '${expected.objectType}'" +
+              s" but got '${actual.objectType()}'"
+          }
+          if (actual.objectName() != expected.objectName) {
+            mismatches += s"queryContext[$idx].objectName: expected '${expected.objectName}'" +
+              s" but got '${actual.objectName()}'"
+          }
+          if (actual.startIndex() != expected.startIndex) {
+            mismatches += s"queryContext[$idx].startIndex: expected ${expected.startIndex}" +
+              s" but got ${actual.startIndex()}"
+          }
+          if (actual.stopIndex() != expected.stopIndex) {
+            mismatches += s"queryContext[$idx].stopIndex: expected ${expected.stopIndex}" +
+              s" but got ${actual.stopIndex()}"
+          }
+          if (actual.fragment() != expected.fragment) {
+            mismatches += s"queryContext[$idx].fragment: expected '${expected.fragment}'" +
+              s" but got '${actual.fragment()}'"
+          }
+        } else if (actual.contextType() == QueryContextType.DataFrame) {
+          if (actual.fragment() != expected.fragment) {
+            mismatches += s"queryContext[$idx].fragment: expected '${expected.fragment}'" +
+              s" but got '${actual.fragment()}'"
+          }
+          if (expected.callSitePattern.nonEmpty &&
+              !actual.callSite().matches(expected.callSitePattern)) {
+            mismatches += s"queryContext[$idx].callSite: '${actual.callSite()}'" +
+              s" does not match pattern '${expected.callSitePattern}'"
+          }
+        }
+    }
+
+    if (mismatches.nonEmpty) {
+      val sb = new StringBuilder
+      sb.append(s"checkError found ${mismatches.size} mismatch(es).\n\n")
+      sb.append("=== Actual Exception State ===\n")
+      sb.append(s"  condition: ${exception.getCondition}\n")
+      sb.append(s"  sqlState:  ${exception.getSqlState}\n")
+      sb.append(s"  parameters:\n")
+      if (actualParameters.isEmpty) {
+        sb.append("    (empty)\n")
+      } else {
+        actualParameters.foreach { case (k, v) => sb.append(s"    $k -> $v\n") }
+      }
+      actualQueryContext.zipWithIndex.foreach { case (ctx, idx) =>
+        sb.append(s"  queryContext[$idx] (${ctx.contextType()}):\n")
+        if (ctx.contextType() == QueryContextType.SQL) {
+          sb.append(s"    objectType: ${ctx.objectType()}\n")
+          sb.append(s"    objectName: ${ctx.objectName()}\n")
+          sb.append(s"    startIndex: ${ctx.startIndex()}\n")
+          sb.append(s"    stopIndex:  ${ctx.stopIndex()}\n")
+          sb.append(s"    fragment:   ${ctx.fragment()}\n")
+        } else if (ctx.contextType() == QueryContextType.DataFrame) {
+          sb.append(s"    fragment:   ${ctx.fragment()}\n")
+          sb.append(s"    callSite:   ${ctx.callSite()}\n")
+        }
+      }
+      sb.append("\n=== Mismatches ===\n")
+      mismatches.foreach(m => sb.append(s"  $m\n"))
+      fail(sb.toString())
     }
   }
 

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/QueryTest.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/test/QueryTest.scala
@@ -167,11 +167,14 @@ abstract class QueryTest extends ConnectFunSuite with SQLHelper {
             mismatches += s"queryContext[$idx].objectName: expected '${expected.objectName}'" +
               s" but got '${actual.objectName()}'"
           }
-          if (actual.startIndex() != expected.startIndex) {
+          // If startIndex and stopIndex are -1, it means we simply want to check the
+          // fragment of the query context. This should be the case when the fragment is
+          // distinguished within the query text.
+          if (expected.startIndex != -1 && actual.startIndex() != expected.startIndex) {
             mismatches += s"queryContext[$idx].startIndex: expected ${expected.startIndex}" +
               s" but got ${actual.startIndex()}"
           }
-          if (actual.stopIndex() != expected.stopIndex) {
+          if (expected.stopIndex != -1 && actual.stopIndex() != expected.stopIndex) {
             mismatches += s"queryContext[$idx].stopIndex: expected ${expected.stopIndex}" +
               s" but got ${actual.stopIndex()}"
           }


### PR DESCRIPTION
Replace the sequential assert chain in checkError() with a collect-all-then-fail pattern so that all mismatches plus the complete actual exception state are reported in a single failure message, eliminating iterative guess-and-rerun cycles.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
We're improving checkError() to provide a detailed report on the context diff, instead off failing on the first assert.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This increases turn around time to fix test cases when they are newly written or logic changes.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added two tests in SparkThrowableSuite verifying the collect-all-then-fail behavior and the happy path.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Claude Opus 4.6
