### PR TITLE
[SPARK 55879] [Web UI] copy sql to clipboard

### DIFF
--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/allexecutionspage.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/allexecutionspage.js
@@ -92,12 +92,18 @@ function descriptionHtml(exec) {
   var desc = exec.description || "";
   var basePath = uiRoot + appBasePath;
   var url = basePath + "/SQL/execution/?id=" + exec.id;
+  var link;
   if (desc.length > 100) {
     var short = escapeHtml(desc.substring(0, 100)) + "...";
-    return '<a href="' + url + '" title="' + escapeHtml(desc) + '">' +
+    link = '<a href="' + url + '" title="' + escapeHtml(desc) + '">' +
       short + '</a>';
+  } else {
+    link = '<a href="' + url + '">' + (escapeHtml(desc) || exec.id) + '</a>';
   }
-  return '<a href="' + url + '">' + (escapeHtml(desc) || exec.id) + '</a>';
+  var copyBtn = '<button class="btn btn-sm btn-outline-secondary ms-1 copy-sql-btn" ' +
+    'type="button" title="Copy SQL to clipboard" ' +
+    'data-sql="' + escapeHtml(desc) + '">&#x1f4cb;</button>';
+  return link + copyBtn;
 }
 
 // Remove client-side filter — status filtering is now server-side
@@ -225,6 +231,15 @@ $(document).ready(function () {
 
     $("#status-filter").on("change", function () {
       table.draw();
+    });
+
+    // Copy SQL to clipboard via delegated handler on the DataTable
+    $("#sql-table").on("click", ".copy-sql-btn", function (e) {
+      e.stopPropagation();
+      var sql = $(this).attr("data-sql");
+      if (sql) {
+        navigator.clipboard.writeText(sql);
+      }
     });
 
   } // end init

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -700,6 +700,20 @@ document.addEventListener("DOMContentLoaded", function () {
     renderPlanViz();
   }
 
+  // Copy SQL description to clipboard
+  var copySqlBtn = document.getElementById("copy-sql-btn");
+  if (copySqlBtn) {
+    copySqlBtn.addEventListener("click", function () {
+      var sqlEl = document.getElementById("sql-description");
+      var text = sqlEl ? sqlEl.textContent : "";
+      navigator.clipboard.writeText(text.trim()).then(function () {
+        if (typeof showToast === "function") {
+          showToast("SQL copied to clipboard", "success");
+        }
+      });
+    });
+  }
+
   // Copy physical plan text to clipboard
   var copyPlanBtn = document.getElementById("copy-plan-btn");
   if (copyPlanBtn) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -102,7 +102,10 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
             <label for="plan-viz-format-select">
               <a id="plan-viz-download-btn" class="downloadbutton">Download</a>
             </label>
-            <button id="copy-plan-btn" class="btn btn-sm btn-outline-secondary ms-2"
+            <button id="copy-sql-btn" class="btn btn-sm btn-outline-secondary ms-2"
+                    type="button" title="Copy SQL to clipboard">
+              &#x1f4cb; Copy SQL</button>
+            <button id="copy-plan-btn" class="btn btn-sm btn-outline-secondary ms-1"
                     type="button" title="Copy physical plan to clipboard">
               &#x1f4cb; Copy Plan</button>
             <button id="copy-link-btn" class="btn btn-sm btn-outline-secondary ms-1"
@@ -111,11 +114,17 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
           </div>
         </div>
 
+      val sqlDescription =
+        <div id="sql-description" style="display:none">
+          {executionUIData.description}
+        </div>
+
       val metrics = sqlStore.executionMetrics(executionId)
       val graph = sqlStore.planGraph(executionId)
       val configs = Option(executionUIData.modifiedConfigs).getOrElse(Map.empty)
 
       summary ++
+        sqlDescription ++
         planVisualization(request, metrics, graph) ++
         physicalPlanDescription(executionUIData.physicalPlanDescription) ++
         jobsTable(request, executionUIData) ++


### PR DESCRIPTION
Ref https://issues.apache.org/jira/browse/SPARK-55879

### What changes were proposed in this pull request?

descriptionHtml() now appends a clipboard icon button (copy-sql-btn) next to each SQL description


### Why are the changes needed?

 Added copy-sql-btn button next to existing Copy Plan / Copy Link buttons. Added hidden <div id="sql-description"> containing the full SQL text.


### Does this PR introduce _any_ user-facing change?

clipboard icon button added 

### How was this patch tested?
Unit testing

### Was this patch authored or co-authored using generative AI tooling?
Yes