### PR TITLE
[SPARK-56457][SQL] Fix Avro V2 formatName to match V1 FileFormat.toString

### DIFF
--- a/connector/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroTable.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroTable.scala
@@ -51,5 +51,5 @@ case class AvroTable(
 
   override def supportsDataType(dataType: DataType): Boolean = AvroUtils.supportsDataType(dataType)
 
-  override def formatName: String = "AVRO"
+  override def formatName: String = "Avro"
 }

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -22,7 +22,7 @@ import java.net.URI
 import java.nio.file.{Files, Paths, StandardCopyOption}
 import java.sql.{Date, Timestamp}
 import java.time.{LocalDate, LocalDateTime}
-import java.util.UUID
+import java.util.{Collections => JCollections, UUID}
 
 import scala.jdk.CollectionConverters._
 
@@ -44,7 +44,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeTestUtils
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, LA, UTC}
 import org.apache.spark.sql.execution.{FormattedMode, SparkPlan}
 import org.apache.spark.sql.execution.datasources.{CommonFileDataSourceSuite, DataSource, FilePartition}
-import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, FileDataSourceV2, FileTable}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.LegacyBehaviorPolicy
 import org.apache.spark.sql.internal.LegacyBehaviorPolicy._
@@ -3481,6 +3481,18 @@ class AvroV2Suite extends AvroSuite with ExplainSuiteHelper {
       // Verify data integrity
       checkAnswer(readDf, df)
     }
+  }
+
+  test("SPARK-56457: Avro V2 formatName matches V1 FileFormat.toString") {
+    val v2Provider = DataSource.lookupDataSourceV2("avro", spark.sessionState.conf)
+    assert(v2Provider.isDefined)
+    val dsV2 = v2Provider.get.asInstanceOf[FileDataSourceV2]
+    val v1Format = dsV2.fallbackFileFormat.getDeclaredConstructor().newInstance()
+    val emptyProps = JCollections.emptyMap[String, String]()
+    val v2Table = dsV2.getTable(
+      new StructType(), Array.empty, emptyProps).asInstanceOf[FileTable]
+    assert(v2Table.formatName == v1Format.toString,
+      s"V2 formatName '${v2Table.formatName}' != V1 toString '${v1Format.toString}'")
   }
 
   test("Geospatial types are not supported in Avro") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/FileTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/FileTableSuite.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
+import java.util.{Collections => JCollections}
+
 import scala.jdk.CollectionConverters._
 
 import org.apache.hadoop.fs.FileStatus
@@ -92,6 +94,23 @@ class FileTableSuite extends QueryTest with SharedSparkSession {
       val table =
         new DummyFileTable(spark, options, Seq(pathName), expectedDataSchema, userSpecifiedSchema)
       assert(table.dataSchema == expectedDataSchema)
+    }
+  }
+
+  test("SPARK-56457: V2 FileTable.formatName matches V1 FileFormat.toString") {
+    withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
+      allFileBasedDataSources.foreach { format =>
+        val v2Provider = DataSource.lookupDataSourceV2(format, spark.sessionState.conf)
+        assert(v2Provider.isDefined, s"Expected V2 provider for $format")
+        val dsV2 = v2Provider.get.asInstanceOf[FileDataSourceV2]
+        val v1Format = dsV2.fallbackFileFormat.getDeclaredConstructor().newInstance()
+        val emptyProps = JCollections.emptyMap[String, String]()
+        val v2Table = dsV2.getTable(
+          new StructType(), Array.empty, emptyProps).asInstanceOf[FileTable]
+        assert(v2Table.formatName == v1Format.toString,
+          s"V2 formatName '${v2Table.formatName}' != " +
+            s"V1 toString '${v1Format.toString}' for format '$format'")
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix `AvroTable.formatName` from `"AVRO"` to `"Avro"` to match the V1  `AvroFileFormat.toString` value. Add regression tests verifying V1/V2 format name consistency for all built-in file formats.

All other built-in file formats already have consistent naming between V1 `FileFormat.toString` and V2 `FileTable.formatName`:

  | Format  | V1 `toString` | V2 `formatName` | Match |
  |---------|---------------|-----------------|-------|
  | Parquet | Parquet       | Parquet         | Yes   |
  | ORC     | ORC           | ORC             | Yes   |
  | JSON    | JSON          | JSON            | Yes   |
  | CSV     | CSV           | CSV             | Yes   |
  | Text    | Text          | Text            | Yes   |
  | Avro    | Avro          | **AVRO**        | **No** |

  "Avro" is not an acronym (unlike ORC/JSON/CSV); the Apache Avro project uses title case everywhere (https://avro.apache.org/).

### Why are the changes needed?
Follow the existing format precedent for consistency.


### Does this PR introduce _any_ user-facing change?
Yes (minor). The `formatName` for `AvroTable` was originally displayed as `AVRO` and is now shown as `Avro`.


### How was this patch tested?
- New test in `FileTableSuite`: verifies `FileTable.formatName` matches `FileFormat.toString` for all built-in formats (parquet, orc, json, csv, text).
- New test in `AvroV2Suite`: same check for avro.


### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code
