### PR TITLE
[SQL] Update grammar/TableChange to allow CLUSTER BY expressions

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -850,7 +850,7 @@
   },
   "CLUSTER_BY_EXPRESSION_INCORRECT_COLUMN_REFERENCE": {
     "message" : [
-      "CLUSTER BY expression <expressionType> has either no column reference, or a column reference in an unsupported argument position."
+      "CLUSTER BY expression <expressionType> must contain at least one column reference."
     ],
     "sqlState" : "42000"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -848,6 +848,12 @@
     ],
     "sqlState" : "0A000"
   },
+  "CLUSTER_BY_EXPRESSION_INCORRECT_COLUMN_REFERENCE": {
+    "message" : [
+      "CLUSTER BY expression <expressionType> has either no column reference, or a column reference in an unsupported argument position."
+    ],
+    "sqlState" : "42000"
+  },
   "CLUSTERING_COLUMNS_MISMATCH" : {
     "message" : [
       "Specified clustering does not match that of the existing table <tableName>.",

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -550,17 +550,8 @@ replaceTableHeader
     : (CREATE OR)? REPLACE TABLE identifierReference
     ;
 
-expressionOrMultipartIdentifier
-    : expression
-    | multipartIdentifier
-    ;
-
-expressionOrMultipartIdentifierList
-    : expressionOrMultipartIdentifier (COMMA expressionOrMultipartIdentifier)*
-    ;
-
 clusterBySpec
-    : CLUSTER BY LEFT_PAREN expressionOrMultipartIdentifierList RIGHT_PAREN
+    : CLUSTER BY LEFT_PAREN transform (COMMA transform)* RIGHT_PAREN
     ;
 
 bucketSpec

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -550,8 +550,17 @@ replaceTableHeader
     : (CREATE OR)? REPLACE TABLE identifierReference
     ;
 
+expressionOrMultipartIdentifier
+    : expression
+    | multipartIdentifier
+    ;
+
+expressionOrMultipartIdentifierList
+    : expressionOrMultipartIdentifier (COMMA expressionOrMultipartIdentifier)*
+    ;
+
 clusterBySpec
-    : CLUSTER BY LEFT_PAREN multipartIdentifierList RIGHT_PAREN
+    : CLUSTER BY LEFT_PAREN expressionOrMultipartIdentifierList RIGHT_PAREN
     ;
 
 bucketSpec

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
@@ -19,11 +19,13 @@ package org.apache.spark.sql.connector.catalog;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.catalog.constraints.Constraint;
 import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.DataType;
 
 /**
@@ -277,8 +279,10 @@ public interface TableChange {
    *                          field names.
    * @return a TableChange for this assignment
    */
-  static TableChange clusterBy(NamedReference[] clusteringColumns) {
-    return new ClusterBy(clusteringColumns);
+  static TableChange clusterBy(
+          NamedReference[] clusteringColumns,
+          Optional<Transform>[] transforms) {
+    return new ClusterBy(clusteringColumns, transforms);
   }
 
   /**
@@ -873,24 +877,30 @@ public interface TableChange {
   /** A TableChange to alter clustering columns for a table. */
   final class ClusterBy implements TableChange {
     private final NamedReference[] clusteringColumns;
+    private final Optional<Transform>[] transforms;
 
-    private ClusterBy(NamedReference[] clusteringColumns) {
+    private ClusterBy(
+            NamedReference[] clusteringColumns,
+            Optional<Transform>[] transforms) {
       this.clusteringColumns = clusteringColumns;
+      this.transforms = transforms;
     }
 
     public NamedReference[] clusteringColumns() { return clusteringColumns; }
+    public Optional<Transform>[] transforms() { return transforms; }
 
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       ClusterBy that = (ClusterBy) o;
-      return Arrays.equals(clusteringColumns, that.clusteringColumns());
+      return Arrays.equals(clusteringColumns, that.clusteringColumns())
+              && Arrays.equals(transforms, that.transforms);
     }
 
     @Override
     public int hashCode() {
-      return Arrays.hashCode(clusteringColumns);
+      return Objects.hash(Arrays.hashCode(clusteringColumns), Arrays.hashCode(transforms));
     }
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
@@ -19,12 +19,10 @@ package org.apache.spark.sql.connector.catalog;
 
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.Optional;
 import javax.annotation.Nullable;
 
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.catalog.constraints.Constraint;
-import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.DataType;
 
@@ -275,14 +273,12 @@ public interface TableChange {
   /**
    * Create a TableChange for changing clustering columns for a table.
    *
-   * @param clusteringColumns clustering columns to change to. Each clustering column represents
-   *                          field names.
+   * @param entries clustering entries. Each entry is either an IdentityTransform (plain column)
+   *                or an ApplyTransform (expression like upper(col)).
    * @return a TableChange for this assignment
    */
-  static TableChange clusterBy(
-          NamedReference[] clusteringColumns,
-          Optional<Transform>[] transforms) {
-    return new ClusterBy(clusteringColumns, transforms);
+  static TableChange clusterBy(Transform[] entries) {
+    return new ClusterBy(entries);
   }
 
   /**
@@ -876,31 +872,25 @@ public interface TableChange {
 
   /** A TableChange to alter clustering columns for a table. */
   final class ClusterBy implements TableChange {
-    private final NamedReference[] clusteringColumns;
-    private final Optional<Transform>[] transforms;
+    private final Transform[] entries;
 
-    private ClusterBy(
-            NamedReference[] clusteringColumns,
-            Optional<Transform>[] transforms) {
-      this.clusteringColumns = clusteringColumns;
-      this.transforms = transforms;
+    private ClusterBy(Transform[] entries) {
+      this.entries = entries;
     }
 
-    public NamedReference[] clusteringColumns() { return clusteringColumns; }
-    public Optional<Transform>[] transforms() { return transforms; }
+    public Transform[] entries() { return entries; }
 
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       ClusterBy that = (ClusterBy) o;
-      return Arrays.equals(clusteringColumns, that.clusteringColumns())
-              && Arrays.equals(transforms, that.transforms);
+      return Arrays.equals(entries, that.entries);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(Arrays.hashCode(clusteringColumns), Arrays.hashCode(transforms));
+      return Arrays.hashCode(entries);
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -36,15 +36,17 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{CurrentUserContext, FunctionIdentifier, InternalRow, SQLConfHelper, TableIdentifier}
-import org.apache.spark.sql.catalyst.analysis.{MultiInstanceRelation, NormalizeableRelation, Resolver, SchemaBinding, SchemaCompensation, SchemaEvolution, SchemaTypeEvolution, SchemaUnsupported, UnresolvedLeafNode, ViewSchemaMode}
+import org.apache.spark.sql.catalyst.analysis.{MultiInstanceRelation, NormalizeableRelation, Resolver, SchemaBinding, SchemaCompensation, SchemaEvolution, SchemaTypeEvolution, SchemaUnsupported, UnresolvedAttribute, UnresolvedFunction, UnresolvedLeafNode, ViewSchemaMode}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable.VIEW_STORING_ANALYZED_PLAN
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, Cast, ExprId, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, Cast, Expression, ExprId, Literal}
+import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.connector.catalog.CatalogManager
-import org.apache.spark.sql.connector.expressions.{ClusterByTransform, FieldReference, NamedReference, Transform}
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.ClusterByHelper
+import org.apache.spark.sql.connector.expressions.{ClusterByTransform, ClusteringColumnTransform, FieldReference, LiteralValue, NamedReference, Transform}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -271,11 +273,38 @@ case class CatalogTablePartition(
  * A container for clustering information.
  *
  * @param columnNames the names of the columns used for clustering.
+ * @param clusteringColumnTransforms per-column transforms for expression-based clustering.
+ *                                   When non-empty, each element corresponds to a column in
+ *                                   columnNames: None means a plain column reference,
+ *                                   Some(transform) means an expression like UPPER(col).
+ *                                   An empty Seq means no transforms on any columns.
  */
-case class ClusterBySpec(columnNames: Seq[NamedReference]) {
+case class ClusterBySpec(
+    columnNames: Seq[NamedReference],
+    clusteringColumnTransforms: Seq[Option[Transform]] = Seq.empty) {
   override def toString: String = toJson
 
-  def toJson: String = ClusterBySpec.mapper.writeValueAsString(columnNames.map(_.fieldNames))
+  def toJson: String = toColumnNames
+
+  def toColumnNames: String = {
+    val entries: Seq[Seq[String]] = if (clusteringColumnTransforms.isEmpty) {
+      columnNames.map(_.fieldNames().toSeq)
+    } else {
+      columnNames.zip(clusteringColumnTransforms).map {
+        case (colName, None) => colName.fieldNames().toSeq
+        case (colName, Some(transform)) =>
+          val args = transform.arguments().map {
+            case n: NamedReference => n.fieldNames().map(QuotingUtils.quoteIfNeeded).mkString(".")
+            case LiteralValue(value, dataType) =>
+              Literal(value, dataType).sql
+            case other => throw new IllegalStateException(
+              s"Unexpected argument type in CLUSTER BY expression: ${other.getClass}")
+          }
+          Seq(s"${QuotingUtils.quoteIfNeeded(transform.name())}(${args.mkString(",")})")
+      }
+    }
+    ClusterBySpec.mapper.writeValueAsString(entries)
+  }
 }
 
 object ClusterBySpec {
@@ -291,7 +320,104 @@ object ClusterBySpec {
    * Converts the clustering column property to a ClusterBySpec.
    */
   def fromProperty(columns: String): ClusterBySpec = {
-    ClusterBySpec(mapper.readValue[Seq[Seq[String]]](columns).map(FieldReference(_)))
+    ClusterBySpec.fromColumnEntries(mapper.readValue[Seq[Seq[String]]](columns))
+  }
+
+  /**
+   * Constructs a [[ClusterBySpec]] from the stored column entries (each a Seq[String]).
+   * An entry is either a multi-part column name or a single-element Seq containing an
+   * expression string like "variant_get(col,'$.foo','STRING')".
+   */
+  def fromColumnEntries(entries: Seq[Seq[String]]): ClusterBySpec = {
+    val parsedCols: Seq[(NamedReference, Option[Transform])] = entries.map {
+      case names if names.length == 1 =>
+        // Could be an expression of form "funcName(col, arg1, arg2, ...)"
+        try {
+          CatalystSqlParser.parseExpression(names.head) match {
+            case u: UnresolvedFunction =>
+              val transform: Transform = new ClusteringColumnTransform(
+                QuotingUtils.quoted(u.nameParts.toArray),
+                u.children.map {
+                  case a: UnresolvedAttribute =>
+                    FieldReference(QuotingUtils.quoted(a.nameParts.toArray))
+                  case l: Literal => LiteralValue(l.value, l.dataType)
+                  case other => throw new IllegalStateException(
+                    s"Unexpected argument type in CLUSTER BY expression: ${other.getClass}")
+                }.toArray)
+              val colRef = transform.arguments().collectFirst {
+                case f: FieldReference => f
+              }.getOrElse(throw new IllegalStateException(
+                "CLUSTER BY expression must contain exactly one column reference"))
+              (colRef, Some(transform))
+            case _ => (FieldReference(names), None)
+          }
+        } catch {
+          // Sometimes, we can get a parse exception if the column name contains invalid
+          // characters by itself. Quote the column name and see if parsing it as a multipart
+          // identifier works, and if so, use that as a direct FieldReference to a column.
+          case _: ParseException =>
+            val identifier = CatalystSqlParser.parseMultipartIdentifier(
+              QuotingUtils.quoteIfNeeded(names.head))
+            (FieldReference(identifier.map(_.stripPrefix("`").stripSuffix("`"))), None)
+        }
+      case names => (FieldReference(names), None)
+    }
+    val (colNames, transforms) = parsedCols.unzip
+    val transformsSeq = if (transforms.forall(_.isEmpty)) Seq.empty else transforms
+    ClusterBySpec(colNames, transformsSeq)
+  }
+
+  def fromExpressions(
+      parsedCols: Seq[Either[Expression, Seq[String]]]): ClusterBySpec = {
+    val (clusteringColumnNames, clusteringColumnExpressions) = parsedCols.map {
+      case Left(e) =>
+        e match {
+          // A bare column reference parsed as an expression - treat as plain column.
+          case a: UnresolvedAttribute =>
+            (FieldReference(a.nameParts), None)
+          case u: UnresolvedFunction =>
+            val transform = new ClusteringColumnTransform(
+              QuotingUtils.quoted(u.nameParts.toArray),
+              u.children.map {
+                case a: UnresolvedAttribute =>
+                  FieldReference(QuotingUtils.quoted(a.nameParts.toArray))
+                case l: Literal => LiteralValue(l.value, l.dataType)
+                case _ => throw new IllegalStateException(
+                  "Unsupported expression argument in CLUSTER BY transform")
+              }.toArray)
+            val transformName = QuotingUtils.quoted(u.nameParts.toArray)
+            val refs = transform.arguments().collect {
+              case f: FieldReference => f
+            }
+            if (refs.isEmpty) {
+              throw new AnalysisException(
+                errorClass = "CLUSTER_BY_EXPRESSION_INCORRECT_COLUMN_REFERENCE",
+                messageParameters = Map("expressionType" -> transformName))
+            }
+            if (refs.length != 1) {
+              throw new AnalysisException(
+                errorClass = "CLUSTER_BY_EXPRESSION_INCORRECT_COLUMN_REFERENCE",
+                messageParameters = Map("expressionType" -> transformName))
+            }
+            if (!transform.arguments().head.isInstanceOf[FieldReference]) {
+              throw new AnalysisException(
+                errorClass = "CLUSTER_BY_EXPRESSION_INCORRECT_COLUMN_REFERENCE",
+                messageParameters = Map(
+                  "expressionType" -> transformName))
+            }
+            (FieldReference(refs.head.fieldNames.toIndexedSeq), Some(transform))
+          case _ => throw new IllegalStateException(
+            "Unsupported expression in CLUSTER BY: only function calls are supported")
+        }
+      case Right(names) => (FieldReference(names), None)
+    }.unzip
+    // If there are no transforms at all (all plain columns), use empty Seq for backward compat
+    val transformsSeq = if (clusteringColumnExpressions.forall(_.isEmpty)) {
+      Seq.empty
+    } else {
+      clusteringColumnExpressions
+    }
+    ClusterBySpec(clusteringColumnNames, transformsSeq)
   }
 
   /**
@@ -340,12 +466,17 @@ object ClusterBySpec {
       normalizedColumns.map(_.toString),
       resolver)
 
-    ClusterBySpec(normalizedColumns)
+    ClusterBySpec(normalizedColumns, clusterBySpec.clusteringColumnTransforms)
   }
 
   def extractClusterBySpec(transforms: Seq[Transform]): Option[ClusterBySpec] = {
     transforms.collectFirst {
-      case ClusterByTransform(columnNames) => ClusterBySpec(columnNames)
+      case ct: ClusterByTransform =>
+        if (ct.transforms.nonEmpty) {
+          ClusterBySpec(ct.columnNames, ct.toClusteringColumnTransforms)
+        } else {
+          ClusterBySpec(ct.columnNames)
+        }
     }
   }
 
@@ -354,7 +485,7 @@ object ClusterBySpec {
       clusterBySpec: ClusterBySpec,
       resolver: Resolver): ClusterByTransform = {
     val normalizedClusterBySpec = normalizeClusterBySpec(schema, clusterBySpec, resolver)
-    ClusterByTransform(normalizedClusterBySpec.columnNames)
+    new ClusterByHelper(normalizedClusterBySpec).asTransform.asInstanceOf[ClusterByTransform]
   }
 
   def fromColumnNames(names: Seq[String]): ClusterBySpec = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -36,21 +36,20 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{CurrentUserContext, FunctionIdentifier, InternalRow, SQLConfHelper, TableIdentifier}
-import org.apache.spark.sql.catalyst.analysis.{MultiInstanceRelation, NormalizeableRelation, Resolver, SchemaBinding, SchemaCompensation, SchemaEvolution, SchemaTypeEvolution, SchemaUnsupported, UnresolvedAttribute, UnresolvedFunction, UnresolvedLeafNode, ViewSchemaMode}
+import org.apache.spark.sql.catalyst.analysis.{MultiInstanceRelation, NormalizeableRelation, Resolver, SchemaBinding, SchemaCompensation, SchemaEvolution, SchemaTypeEvolution, SchemaUnsupported, UnresolvedLeafNode, ViewSchemaMode}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable.VIEW_STORING_ANALYZED_PLAN
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, Cast, Expression, ExprId, Literal}
-import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, Cast, ExprId, Literal}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.connector.catalog.CatalogManager
-import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.ClusterByHelper
-import org.apache.spark.sql.connector.expressions.{ClusterByTransform, ClusteringColumnTransform, FieldReference, LiteralValue, NamedReference, Transform}
+import org.apache.spark.sql.connector.expressions.{ApplyTransform, ClusterByTransform, Expression => V2Expression, FieldReference, IdentityTransform, LiteralValue, NamedReference, Transform}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.{CaseInsensitiveStringMap, SchemaUtils}
+import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
 
@@ -272,38 +271,46 @@ case class CatalogTablePartition(
 /**
  * A container for clustering information.
  *
- * @param columnNames the names of the columns used for clustering.
- * @param clusteringColumnTransforms per-column transforms for expression-based clustering.
- *                                   When non-empty, each element corresponds to a column in
- *                                   columnNames: None means a plain column reference,
- *                                   Some(transform) means an expression like UPPER(col).
- *                                   An empty Seq means no transforms on any columns.
+ * @param entries the clustering entries, each either an `IdentityTransform` (plain column)
+ *                or an `ApplyTransform` (expression like `upper(col)`).
  */
-case class ClusterBySpec(
-    columnNames: Seq[NamedReference],
-    clusteringColumnTransforms: Seq[Option[Transform]] = Seq.empty) {
+case class ClusterBySpec(entries: Seq[Transform]) {
+  def columnNames: Seq[NamedReference] = entries.map {
+    case IdentityTransform(ref) => ref
+    case t => t.references.head
+  }
+
   override def toString: String = toJson
 
-  def toJson: String = toColumnNames
-
-  def toColumnNames: String = {
-    val entries: Seq[Seq[String]] = if (clusteringColumnTransforms.isEmpty) {
-      columnNames.map(_.fieldNames().toSeq)
-    } else {
-      columnNames.zip(clusteringColumnTransforms).map {
-        case (colName, None) => colName.fieldNames().toSeq
-        case (colName, Some(transform)) =>
-          val args = transform.arguments().map {
-            case n: NamedReference => n.fieldNames().map(QuotingUtils.quoteIfNeeded).mkString(".")
-            case LiteralValue(value, dataType) =>
-              Literal(value, dataType).sql
-            case other => throw new IllegalStateException(
-              s"Unexpected argument type in CLUSTER BY expression: ${other.getClass}")
-          }
-          Seq(s"${QuotingUtils.quoteIfNeeded(transform.name())}(${args.mkString(",")})")
+  def toJson: String = {
+    val hasTransforms = entries.exists(_.isInstanceOf[ApplyTransform])
+    if (hasTransforms) {
+      // New structured JSON format
+      val jsonEntries = entries.map {
+        case IdentityTransform(ref) =>
+          JObject("col" -> JArray(ref.fieldNames().toList.map(JString)))
+        case a: ApplyTransform =>
+          val argsJson = a.args.collect {
+            case lit: LiteralValue[_] => ClusterBySpec.literalToJson(lit)
+          }.toList
+          val colRef = a.references.head
+          JObject(
+            "col" -> JArray(colRef.fieldNames().toList.map(JString)),
+            "transform" -> JObject(
+              "name" -> JString(a.name),
+              "args" -> JArray(argsJson)))
+        case other => throw new IllegalStateException(
+          s"Unexpected entry type in ClusterBySpec: ${other.getClass}")
       }
+      compact(render(JArray(jsonEntries.toList)))
+    } else {
+      // Old backward-compatible Seq[Seq[String]] format for plain columns
+      val colArrays = entries.map {
+        case IdentityTransform(ref) => ref.fieldNames().toSeq
+        case t => t.references.head.fieldNames().toSeq
+      }
+      ClusterBySpec.mapper.writeValueAsString(colArrays)
     }
-    ClusterBySpec.mapper.writeValueAsString(entries)
   }
 }
 
@@ -316,118 +323,131 @@ object ClusterBySpec {
     ret
   }
 
+  /** Factory that wraps plain column references as IdentityTransforms. */
+  def ofColumns(columnNames: Seq[NamedReference]): ClusterBySpec =
+    new ClusterBySpec(columnNames.map(IdentityTransform(_)))
+
   /**
    * Converts the clustering column property to a ClusterBySpec.
+   * Detects format: if top-level elements are arrays, it's old format;
+   * if objects, it's new structured format.
    */
   def fromProperty(columns: String): ClusterBySpec = {
-    ClusterBySpec.fromColumnEntries(mapper.readValue[Seq[Seq[String]]](columns))
+    val parsed = parse(columns)
+    parsed match {
+      case JArray(elements) if elements.nonEmpty =>
+        elements.head match {
+          case _: JArray =>
+            // Old format: Seq[Seq[String]]
+            val colArrays = mapper.readValue[Seq[Seq[String]]](columns)
+            new ClusterBySpec(
+              colArrays.map(names => IdentityTransform(FieldReference(names))))
+          case _: JObject =>
+            // New structured format
+            new ClusterBySpec(elements.map(parseJsonEntry))
+          case _ =>
+            // Fallback: try old format
+            val colArrays = mapper.readValue[Seq[Seq[String]]](columns)
+            new ClusterBySpec(
+              colArrays.map(names => IdentityTransform(FieldReference(names))))
+        }
+      case _ =>
+        // Empty or unexpected -- return empty
+        new ClusterBySpec(Seq.empty[Transform])
+    }
   }
 
-  /**
-   * Constructs a [[ClusterBySpec]] from the stored column entries (each a Seq[String]).
-   * An entry is either a multi-part column name or a single-element Seq containing an
-   * expression string like "variant_get(col,'$.foo','STRING')".
-   */
-  def fromColumnEntries(entries: Seq[Seq[String]]): ClusterBySpec = {
-    val parsedCols: Seq[(NamedReference, Option[Transform])] = entries.map {
-      case names if names.length == 1 =>
-        // Could be an expression of form "funcName(col, arg1, arg2, ...)"
-        try {
-          CatalystSqlParser.parseExpression(names.head) match {
-            case u: UnresolvedFunction =>
-              val transform: Transform = new ClusteringColumnTransform(
-                QuotingUtils.quoted(u.nameParts.toArray),
-                u.children.map {
-                  case a: UnresolvedAttribute =>
-                    FieldReference(QuotingUtils.quoted(a.nameParts.toArray))
-                  case l: Literal => LiteralValue(l.value, l.dataType)
-                  case other => throw new IllegalStateException(
-                    s"Unexpected argument type in CLUSTER BY expression: ${other.getClass}")
-                }.toArray)
-              val colRef = transform.arguments().collectFirst {
-                case f: FieldReference => f
-              }.getOrElse(throw new IllegalStateException(
-                "CLUSTER BY expression must contain exactly one column reference"))
-              (colRef, Some(transform))
-            case _ => (FieldReference(names), None)
+  private def parseJsonEntry(entry: JValue): Transform = entry match {
+    case JObject(fields) =>
+      val fieldMap = fields.toMap
+      val colParts = fieldMap("col") match {
+        case JArray(parts) => parts.map { case JString(s) => s; case other =>
+          throw new IllegalStateException(s"Unexpected col part: $other") }
+        case other => throw new IllegalStateException(s"Unexpected col value: $other")
+      }
+      val colRef = FieldReference(colParts)
+      fieldMap.get("transform") match {
+        case None => IdentityTransform(colRef)
+        case Some(JObject(tFields)) =>
+          val tMap = tFields.toMap
+          val funcName = tMap("name") match {
+            case JString(s) => s
+            case other => throw new IllegalStateException(
+              s"Unexpected transform name: $other")
           }
-        } catch {
-          // Sometimes, we can get a parse exception if the column name contains invalid
-          // characters by itself. Quote the column name and see if parsing it as a multipart
-          // identifier works, and if so, use that as a direct FieldReference to a column.
-          case _: ParseException =>
-            val identifier = CatalystSqlParser.parseMultipartIdentifier(
-              QuotingUtils.quoteIfNeeded(names.head))
-            (FieldReference(identifier.map(_.stripPrefix("`").stripSuffix("`"))), None)
-        }
-      case names => (FieldReference(names), None)
-    }
-    val (colNames, transforms) = parsedCols.unzip
-    val transformsSeq = if (transforms.forall(_.isEmpty)) Seq.empty else transforms
-    ClusterBySpec(colNames, transformsSeq)
+          val litArgs: Seq[V2Expression] = tMap.get("args") match {
+            case Some(JArray(args)) => args.map(jsonToLiteral)
+            case _ => Nil
+          }
+          ApplyTransform(funcName, colRef +: litArgs)
+        case other =>
+          throw new IllegalStateException(s"Unexpected transform value: $other")
+      }
+    case other =>
+      throw new IllegalStateException(s"Unexpected JSON entry in ClusterBySpec: $other")
   }
 
-  def fromExpressions(
-      parsedCols: Seq[Either[Expression, Seq[String]]]): ClusterBySpec = {
-    val (clusteringColumnNames, clusteringColumnExpressions) = parsedCols.map {
-      case Left(e) =>
-        e match {
-          // A bare column reference parsed as an expression - treat as plain column.
-          case a: UnresolvedAttribute =>
-            (FieldReference(a.nameParts), None)
-          case u: UnresolvedFunction =>
-            val transform = new ClusteringColumnTransform(
-              QuotingUtils.quoted(u.nameParts.toArray),
-              u.children.map {
-                case a: UnresolvedAttribute =>
-                  FieldReference(QuotingUtils.quoted(a.nameParts.toArray))
-                case l: Literal => LiteralValue(l.value, l.dataType)
-                case _ => throw new IllegalStateException(
-                  "Unsupported expression argument in CLUSTER BY transform")
-              }.toArray)
-            val transformName = QuotingUtils.quoted(u.nameParts.toArray)
-            val refs = transform.arguments().collect {
-              case f: FieldReference => f
-            }
-            if (refs.isEmpty) {
-              throw new AnalysisException(
-                errorClass = "CLUSTER_BY_EXPRESSION_INCORRECT_COLUMN_REFERENCE",
-                messageParameters = Map("expressionType" -> transformName))
-            }
-            if (refs.length != 1) {
-              throw new AnalysisException(
-                errorClass = "CLUSTER_BY_EXPRESSION_INCORRECT_COLUMN_REFERENCE",
-                messageParameters = Map("expressionType" -> transformName))
-            }
-            if (!transform.arguments().head.isInstanceOf[FieldReference]) {
-              throw new AnalysisException(
-                errorClass = "CLUSTER_BY_EXPRESSION_INCORRECT_COLUMN_REFERENCE",
-                messageParameters = Map(
-                  "expressionType" -> transformName))
-            }
-            (FieldReference(refs.head.fieldNames.toIndexedSeq), Some(transform))
-          case _ => throw new IllegalStateException(
-            "Unsupported expression in CLUSTER BY: only function calls are supported")
-        }
-      case Right(names) => (FieldReference(names), None)
-    }.unzip
-    // If there are no transforms at all (all plain columns), use empty Seq for backward compat
-    val transformsSeq = if (clusteringColumnExpressions.forall(_.isEmpty)) {
-      Seq.empty
-    } else {
-      clusteringColumnExpressions
+  private[catalog] def literalToJson(lit: LiteralValue[_]): JValue = {
+    val typeStr = lit.dataType.typeName
+    val valueJson = lit.value match {
+      case null => JNull
+      case s: UTF8String => JString(s.toString)
+      case i: Int => JInt(i)
+      case l: Long => JLong(l)
+      case d: Double => JDouble(d)
+      case b: Boolean => JBool(b)
+      case s: Short => JInt(s.toInt)
+      case b: Byte => JInt(b.toInt)
+      case f: Float => JDouble(f.toDouble)
+      case bd: java.math.BigDecimal => JDecimal(BigDecimal(bd))
+      case bd: BigDecimal => JDecimal(bd)
+      case other => JString(other.toString)
     }
-    ClusterBySpec(clusteringColumnNames, transformsSeq)
+    JObject("value" -> valueJson, "type" -> JString(typeStr))
+  }
+
+  private def jsonToLiteral(json: JValue): LiteralValue[_] = json match {
+    case JObject(fields) =>
+      val fieldMap = fields.toMap
+      val dataType = DataType.fromDDL(fieldMap("type") match {
+        case JString(s) => s
+        case other => throw new IllegalStateException(s"Unexpected type value: $other")
+      })
+      val value = fieldMap("value") match {
+        case JNull => null
+        case JString(s) => dataType match {
+          case StringType => UTF8String.fromString(s)
+          case _ => s
+        }
+        case JInt(i) => dataType match {
+          case IntegerType => i.toInt
+          case LongType => i.toLong
+          case ShortType => i.toShort
+          case ByteType => i.toByte
+          case _ => i.toLong
+        }
+        case JLong(l) => dataType match {
+          case IntegerType => l.toInt
+          case LongType => l
+          case _ => l
+        }
+        case JDouble(d) => dataType match {
+          case FloatType => d.toFloat
+          case DoubleType => d
+          case _ => d
+        }
+        case JBool(b) => b
+        case JDecimal(d) => d.underlying()
+        case other => throw new IllegalStateException(s"Unexpected value: $other")
+      }
+      LiteralValue(value, dataType)
+    case other =>
+      throw new IllegalStateException(s"Unexpected literal JSON: $other")
   }
 
   /**
    * Converts a ClusterBySpec to a clustering column property map entry, with validation
    * of the column names against the schema.
-   *
-   * @param schema the schema of the table.
-   * @param clusterBySpec the ClusterBySpec to be converted to a property.
-   * @param resolver the resolver used to match the column names.
-   * @return a map entry for the clustering column property.
    */
   def toProperty(
       schema: StructType,
@@ -440,9 +460,6 @@ object ClusterBySpec {
   /**
    * Converts a ClusterBySpec to a clustering column property map entry, without validating
    * the column names against the schema.
-   *
-   * @param clusterBySpec existing ClusterBySpec to be converted to properties.
-   * @return a map entry for the clustering column property.
    */
   def toPropertyWithoutValidation(clusterBySpec: ClusterBySpec): (String, String) = {
     (CatalogTable.PROP_CLUSTERING_COLUMNS -> clusterBySpec.toJson)
@@ -456,27 +473,40 @@ object ClusterBySpec {
       return clusterBySpec
     }
 
-    val normalizedColumns = clusterBySpec.columnNames.map { columnName =>
-      val position = SchemaUtils.findColumnPosition(
-        columnName.fieldNames().toImmutableArraySeq, schema, resolver)
-      FieldReference(SchemaUtils.getColumnName(position, schema))
+    val normalizedEntries = clusterBySpec.entries.map {
+      case IdentityTransform(ref) =>
+        val position = SchemaUtils.findColumnPosition(
+          ref.fieldNames().toImmutableArraySeq, schema, resolver)
+        IdentityTransform(FieldReference(
+          SchemaUtils.getColumnName(position, schema))): Transform
+      case a: ApplyTransform =>
+        val newArgs: Seq[V2Expression] = a.args.map {
+          case ref: NamedReference =>
+            val position = SchemaUtils.findColumnPosition(
+              ref.fieldNames().toImmutableArraySeq, schema, resolver)
+            FieldReference(SchemaUtils.getColumnName(position, schema))
+          case other => other
+        }
+        ApplyTransform(a.name, newArgs): Transform
+      case other => other
+    }
+
+    val normalizedColumns = normalizedEntries.map {
+      case IdentityTransform(ref) => ref
+      case t => t.references.head
     }
 
     SchemaUtils.checkColumnNameDuplication(
       normalizedColumns.map(_.toString),
       resolver)
 
-    ClusterBySpec(normalizedColumns, clusterBySpec.clusteringColumnTransforms)
+    new ClusterBySpec(normalizedEntries)
   }
 
   def extractClusterBySpec(transforms: Seq[Transform]): Option[ClusterBySpec] = {
     transforms.collectFirst {
       case ct: ClusterByTransform =>
-        if (ct.transforms.nonEmpty) {
-          ClusterBySpec(ct.columnNames, ct.toClusteringColumnTransforms)
-        } else {
-          ClusterBySpec(ct.columnNames)
-        }
+        new ClusterBySpec(ct.entries)
     }
   }
 
@@ -485,11 +515,11 @@ object ClusterBySpec {
       clusterBySpec: ClusterBySpec,
       resolver: Resolver): ClusterByTransform = {
     val normalizedClusterBySpec = normalizeClusterBySpec(schema, clusterBySpec, resolver)
-    new ClusterByHelper(normalizedClusterBySpec).asTransform.asInstanceOf[ClusterByTransform]
+    new ClusterByTransform(normalizedClusterBySpec.entries)
   }
 
   def fromColumnNames(names: Seq[String]): ClusterBySpec = {
-    ClusterBySpec(names.map(FieldReference(_)))
+    ClusterBySpec.ofColumns(names.map(FieldReference(_)))
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -4873,13 +4873,26 @@ class AstBuilder extends DataTypeAstBuilder
           })
   }
 
+  override def visitExpressionOrMultipartIdentifier(
+      ctx: ExpressionOrMultipartIdentifierContext): Either[Expression, Seq[String]] =
+    withOrigin(ctx) {
+      if (ctx.expression() != null) {
+        scala.util.Left(expression(ctx.expression()))
+      } else {
+        scala.util.Right(typedVisit[Seq[String]](ctx.multipartIdentifier()))
+      }
+    }
+
   /**
    * Create a [[ClusterBySpec]].
    */
   override def visitClusterBySpec(ctx: ClusterBySpecContext): ClusterBySpec = withOrigin(ctx) {
-    val columnNames = ctx.multipartIdentifierList.multipartIdentifier.asScala
-      .map(typedVisit[Seq[String]]).map(FieldReference(_)).toSeq
-    ClusterBySpec(columnNames)
+    val columnReferences =
+      ctx.expressionOrMultipartIdentifierList.expressionOrMultipartIdentifier
+        .asScala
+        .map(visitExpressionOrMultipartIdentifier)
+        .toSeq
+    ClusterBySpec.fromExpressions(columnReferences)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -4873,26 +4873,31 @@ class AstBuilder extends DataTypeAstBuilder
           })
   }
 
-  override def visitExpressionOrMultipartIdentifier(
-      ctx: ExpressionOrMultipartIdentifierContext): Either[Expression, Seq[String]] =
-    withOrigin(ctx) {
-      if (ctx.expression() != null) {
-        scala.util.Left(expression(ctx.expression()))
-      } else {
-        scala.util.Right(typedVisit[Seq[String]](ctx.multipartIdentifier()))
-      }
-    }
-
   /**
-   * Create a [[ClusterBySpec]].
+   * Create a [[ClusterBySpec]] by reusing the `transform` grammar rule.
+   * Each entry is converted to an IdentityTransform (plain column) or ApplyTransform
+   * (function call). For CLUSTER BY, we require at least one column reference in each
+   * ApplyTransform.
    */
   override def visitClusterBySpec(ctx: ClusterBySpecContext): ClusterBySpec = withOrigin(ctx) {
-    val columnReferences =
-      ctx.expressionOrMultipartIdentifierList.expressionOrMultipartIdentifier
-        .asScala
-        .map(visitExpressionOrMultipartIdentifier)
-        .toSeq
-    ClusterBySpec.fromExpressions(columnReferences)
+    val entries = ctx.transform.asScala.map { transformCtx =>
+      transformCtx match {
+        case identityCtx: IdentityTransformContext =>
+          IdentityTransform(FieldReference(
+            typedVisit[Seq[String]](identityCtx.qualifiedName))): Transform
+        case applyCtx: ApplyTransformContext =>
+          val funcName = applyCtx.identifier.getText
+          val arguments = applyCtx.argument.asScala.map(visitTransformArgument).toSeq
+          val refs = arguments.collect { case ref: FieldReference => ref }
+          if (refs.isEmpty) {
+            throw new AnalysisException(
+              errorClass = "CLUSTER_BY_EXPRESSION_INCORRECT_COLUMN_REFERENCE",
+              messageParameters = Map("expressionType" -> funcName))
+          }
+          ApplyTransform(funcName, arguments): Transform
+      }
+    }.toSeq
+    new ClusterBySpec(entries)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.{CheckConstraint, Expression, T
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.connector.catalog.{DefaultValue, TableCatalog, TableChange}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdentifierHelper
+import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.util.ArrayImplicits._
@@ -309,9 +310,19 @@ case class AlterColumns(
 case class AlterTableClusterBy(
     table: LogicalPlan, clusterBySpec: Option[ClusterBySpec]) extends AlterTableCommand {
   override def changes: Seq[TableChange] = {
+    val clusterByTransforms = clusterBySpec.map { spec =>
+      if (spec.clusteringColumnTransforms.nonEmpty) {
+        spec.clusteringColumnTransforms.map {
+          case None => java.util.Optional.empty[Transform]()
+          case Some(transform) => java.util.Optional.of[Transform](transform)
+        }.toArray
+      } else {
+        spec.columnNames.map(_ => java.util.Optional.empty[Transform]()).toArray
+      }
+    }.getOrElse(Array.empty[java.util.Optional[Transform]])
     Seq(TableChange.clusterBy(clusterBySpec
       .map(_.columnNames.toArray) // CLUSTER BY (col1, col2, ...)
-      .getOrElse(Array.empty)))
+      .getOrElse(Array.empty), clusterByTransforms))
   }
 
   protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = copy(table = newChild)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2AlterTableCommands.scala
@@ -310,19 +310,8 @@ case class AlterColumns(
 case class AlterTableClusterBy(
     table: LogicalPlan, clusterBySpec: Option[ClusterBySpec]) extends AlterTableCommand {
   override def changes: Seq[TableChange] = {
-    val clusterByTransforms = clusterBySpec.map { spec =>
-      if (spec.clusteringColumnTransforms.nonEmpty) {
-        spec.clusteringColumnTransforms.map {
-          case None => java.util.Optional.empty[Transform]()
-          case Some(transform) => java.util.Optional.of[Transform](transform)
-        }.toArray
-      } else {
-        spec.columnNames.map(_ => java.util.Optional.empty[Transform]()).toArray
-      }
-    }.getOrElse(Array.empty[java.util.Optional[Transform]])
-    Seq(TableChange.clusterBy(clusterBySpec
-      .map(_.columnNames.toArray) // CLUSTER BY (col1, col2, ...)
-      .getOrElse(Array.empty), clusterByTransforms))
+    val entries = clusterBySpec.map(_.entries.toArray).getOrElse(Array.empty[Transform])
+    Seq(TableChange.clusterBy(entries))
   }
 
   protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = copy(table = newChild)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, quoteNameParts, QuotingUtils}
-import org.apache.spark.sql.connector.expressions.{BucketTransform, ClusterByTransform, FieldReference, IdentityTransform, LogicalExpressions, Transform}
+import org.apache.spark.sql.connector.expressions.{BucketTransform, ClusterByColumnTransform, ClusterByTransform, FieldReference, IdentityTransform, LiteralValue, LogicalExpressions, NamedReference, Transform}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.ArrayImplicits._
@@ -56,7 +56,17 @@ private[sql] object CatalogV2Implicits {
   }
 
   implicit class ClusterByHelper(spec: ClusterBySpec) {
-    def asTransform: Transform = clusterBy(spec.columnNames.toArray)
+    def asTransform: Transform = {
+      val transforms = spec.clusteringColumnTransforms.zipWithIndex.collect {
+        case (Some(t), colIdx) =>
+          ClusterByColumnTransform(
+            columnIndex = colIdx,
+            argumentIndex = t.arguments().indexWhere(_.isInstanceOf[NamedReference]),
+            function = t.name(),
+            arguments = t.arguments().collect { case l: LiteralValue[_] => l }.toSeq)
+      }
+      ClusterByTransform(spec.columnNames, transforms)
+    }
   }
 
   implicit class TransformHelper(transforms: Seq[Transform]) {
@@ -80,12 +90,16 @@ private[sql] object CatalogV2Implicits {
               sortCol.map(_.fieldNames.mkString("."))))
           }
 
-        case ClusterByTransform(columnNames) =>
+        case ct @ ClusterByTransform(columnNames) =>
           if (clusterBySpec.nonEmpty) {
             // AstBuilder guarantees that it only passes down one ClusterByTransform.
             throw SparkException.internalError("Cannot have multiple cluster by transforms.")
           }
-          clusterBySpec = Some(ClusterBySpec(columnNames))
+          clusterBySpec = Some(ct match {
+            case c: ClusterByTransform if c.transforms.nonEmpty =>
+              ClusterBySpec(columnNames, c.toClusteringColumnTransforms)
+            case _ => ClusterBySpec(columnNames)
+          })
 
         case transform =>
           throw QueryExecutionErrors.unsupportedPartitionTransformError(transform)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, quoteNameParts, QuotingUtils}
-import org.apache.spark.sql.connector.expressions.{BucketTransform, ClusterByColumnTransform, ClusterByTransform, FieldReference, IdentityTransform, LiteralValue, LogicalExpressions, NamedReference, Transform}
+import org.apache.spark.sql.connector.expressions.{BucketTransform, ClusterByTransform, FieldReference, IdentityTransform, LogicalExpressions, Transform}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.ArrayImplicits._
@@ -56,17 +56,7 @@ private[sql] object CatalogV2Implicits {
   }
 
   implicit class ClusterByHelper(spec: ClusterBySpec) {
-    def asTransform: Transform = {
-      val transforms = spec.clusteringColumnTransforms.zipWithIndex.collect {
-        case (Some(t), colIdx) =>
-          ClusterByColumnTransform(
-            columnIndex = colIdx,
-            argumentIndex = t.arguments().indexWhere(_.isInstanceOf[NamedReference]),
-            function = t.name(),
-            arguments = t.arguments().collect { case l: LiteralValue[_] => l }.toSeq)
-      }
-      ClusterByTransform(spec.columnNames, transforms)
-    }
+    def asTransform: Transform = new ClusterByTransform(spec.entries)
   }
 
   implicit class TransformHelper(transforms: Seq[Transform]) {
@@ -90,16 +80,12 @@ private[sql] object CatalogV2Implicits {
               sortCol.map(_.fieldNames.mkString("."))))
           }
 
-        case ct @ ClusterByTransform(columnNames) =>
+        case ClusterByTransform(entries) =>
           if (clusterBySpec.nonEmpty) {
             // AstBuilder guarantees that it only passes down one ClusterByTransform.
             throw SparkException.internalError("Cannot have multiple cluster by transforms.")
           }
-          clusterBySpec = Some(ct match {
-            case c: ClusterByTransform if c.transforms.nonEmpty =>
-              ClusterBySpec(columnNames, c.toClusteringColumnTransforms)
-            case _ => ClusterBySpec(columnNames)
-          })
+          clusterBySpec = Some(new ClusterBySpec(entries))
 
         case transform =>
           throw QueryExecutionErrors.unsupportedPartitionTransformError(transform)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -164,7 +164,7 @@ private[sql] object CatalogV2Util {
         val clusterByProp =
           ClusterBySpec.toProperty(
             schema,
-            ClusterBySpec(clusterBy.clusteringColumns.toIndexedSeq),
+            clusterBySpecFromChange(clusterBy),
             conf.resolver)
         newProperties.put(clusterByProp._1, clusterByProp._2)
 
@@ -190,12 +190,21 @@ private[sql] object CatalogV2Util {
     clusterByOpt.foreach { clusterBy =>
       newPartitioning = partitioning.map {
         case _: ClusterByTransform => ClusterBySpec.extractClusterByTransform(
-          schema, ClusterBySpec(clusterBy.clusteringColumns.toIndexedSeq), conf.resolver)
+          schema, clusterBySpecFromChange(clusterBy), conf.resolver)
         case other => other
       }
     }
 
     newPartitioning
+  }
+
+  /** Construct a [[ClusterBySpec]] from a [[ClusterBy]] table change, including transforms. */
+  private def clusterBySpecFromChange(clusterBy: ClusterBy): ClusterBySpec = {
+    val transforms = clusterBy.transforms().map { tOpt =>
+      if (tOpt.isPresent) Some(tOpt.get()) else None
+    }.toIndexedSeq
+    val transformsSeq = if (transforms.forall(_.isEmpty)) Seq.empty else transforms
+    ClusterBySpec(clusterBy.clusteringColumns.toIndexedSeq, transformsSeq)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -198,13 +198,9 @@ private[sql] object CatalogV2Util {
     newPartitioning
   }
 
-  /** Construct a [[ClusterBySpec]] from a [[ClusterBy]] table change, including transforms. */
+  /** Construct a [[ClusterBySpec]] from a [[ClusterBy]] table change. */
   private def clusterBySpecFromChange(clusterBy: ClusterBy): ClusterBySpec = {
-    val transforms = clusterBy.transforms().map { tOpt =>
-      if (tOpt.isPresent) Some(tOpt.get()) else None
-    }.toIndexedSeq
-    val transformsSeq = if (transforms.forall(_.isEmpty)) Seq.empty else transforms
-    ClusterBySpec(clusterBy.clusteringColumns.toIndexedSeq, transformsSeq)
+    new ClusterBySpec(clusterBy.entries().toIndexedSeq)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
@@ -57,7 +57,10 @@ private[sql] object LogicalExpressions {
       references.toImmutableArraySeq, sortedCols.toImmutableArraySeq)
 
   def clusterBy(references: Array[NamedReference]): ClusterByTransform =
-    ClusterByTransform(references.toImmutableArraySeq)
+    ClusterByTransform.ofColumns(references.toImmutableArraySeq)
+
+  def clusterBy(entries: Seq[Transform]): ClusterByTransform =
+    new ClusterByTransform(entries)
 
   def identity(reference: NamedReference): IdentityTransform = IdentityTransform(reference)
 
@@ -158,104 +161,75 @@ private[sql] object BucketTransform {
 }
 
 /**
- * Minimal description of a per-column transform applied within a CLUSTER BY expression.
- *
- * @param columnIndex index into [[ClusterByTransform.columnNames]] identifying the column
- *                    being transformed.
- * @param argumentIndex the index in the argument list where the bound clustering column
- *                      should be substituted. Zero-indexed, and any arguments at or after
- *                      this index in `arguments` should be shifted to the right by one.
- * @param function    canonical SQL function name (e.g. "variant_get").
- * @param arguments   the non-column literal arguments to the function.
- */
-case class ClusterByColumnTransform(
-    columnIndex: Int,
-    argumentIndex: Int,
-    function: String,
-    arguments: Seq[LiteralValue[_]])
-
-/**
  * This class represents a transform for `ClusterBySpec`. This is used to bundle
  * ClusterBySpec in CreateTable's partitioning transforms to pass it down to analyzer.
+ *
+ * Each entry is either an `IdentityTransform` (plain column) or an `ApplyTransform`
+ * (function call like `upper(col)`).
  */
-final case class ClusterByTransform(
-    columnNames: Seq[NamedReference],
-    transforms: Seq[ClusterByColumnTransform] = Seq.empty) extends RewritableTransform {
+private[sql] final case class ClusterByTransform(
+    entries: Seq[Transform]) extends RewritableTransform {
 
   override val name: String = "cluster_by"
 
-  override def references: Array[NamedReference] = columnNames.toArray
-
-  override def arguments: Array[Expression] = columnNames.toArray
-
-  override def toString: String = s"$name(${arguments.map(_.describe).mkString(", ")})"
-
-  override def withReferences(newReferences: Seq[NamedReference]): Transform = {
-    this.copy(columnNames = newReferences)
+  def columnNames: Seq[NamedReference] = entries.map {
+    case IdentityTransform(ref) => ref
+    case t => t.references.head
   }
 
-  /** Converts [[transforms]] to a per-column `Seq[Option[Transform]]` for [[ClusterBySpec]]. */
-  def toClusteringColumnTransforms: Seq[Option[Transform]] = {
-    columnNames.indices.map { idx =>
-      transforms.find(_.columnIndex == idx).map { t =>
-        val args = t.arguments.toArray
+  override def references: Array[NamedReference] = entries.flatMap(_.references).toArray
 
-        new ClusteringColumnTransform(
-          t.function,
-          args.slice(0, t.argumentIndex) ++
-            Array[Expression](columnNames(idx)) ++ args.slice(t.argumentIndex, args.length))
-      }
+  override def arguments: Array[Expression] = entries.toArray
+
+  override def describe: String = s"cluster_by(${entries.map(_.describe).mkString(", ")})"
+
+  override def toString: String = describe
+
+  override def withReferences(newReferences: Seq[NamedReference]): Transform = {
+    var refIdx = 0
+    val newEntries = entries.map {
+      case _: IdentityTransform =>
+        val e = IdentityTransform(newReferences(refIdx))
+        refIdx += 1
+        e
+      case a: ApplyTransform =>
+        val newArgs = a.args.map {
+          case _: NamedReference =>
+            val r = newReferences(refIdx)
+            refIdx += 1
+            r
+          case other => other
+        }
+        ApplyTransform(a.name, newArgs)
+      case other =>
+        refIdx += other.references.length
+        other
     }
+    this.copy(entries = newEntries)
   }
 }
 
 /**
- * Convenience extractor for ClusterByTransform.
+ * Companion object for ClusterByTransform with extractor.
  */
 object ClusterByTransform {
-  def unapply(transform: Transform): Option[Seq[NamedReference]] =
+  /** Factory that wraps plain column references as IdentityTransforms. */
+  def ofColumns(columnNames: Seq[NamedReference]): ClusterByTransform =
+    new ClusterByTransform(columnNames.map(IdentityTransform(_)))
+
+  def unapply(transform: Transform): Option[Seq[Transform]] =
     transform match {
+      case ct: ClusterByTransform => Some(ct.entries)
       case NamedTransform("cluster_by", arguments) =>
-        Some(arguments.map(_.asInstanceOf[NamedReference]))
+        Some(arguments.map {
+          case ref: NamedReference => IdentityTransform(ref)
+          case t: Transform => t
+          case other => throw new IllegalArgumentException(
+            s"Unexpected argument type in cluster_by: ${other.getClass}")
+        })
       case _ =>
         None
     }
-}
-
-/**
- * A Transform implementation that wraps a column transform expression for CLUSTER BY.
- * For example, `CLUSTER BY (UPPER(col))` produces a ClusteringColumnTransform
- * wrapping the UPPER function with `col` as a NamedReference argument. Used with ClusterBySpec.
- */
-final class ClusteringColumnTransform(
-    override val name: String,
-    private val args: Array[Expression]) extends Transform {
-
-  override def arguments(): Array[Expression] = args
-
-  override def toString: String = {
-    s"$name(${arguments().map(_.toString).mkString(", ")})"
-  }
-
-  override def describe: String = toString
-
-  override def equals(obj: Any): Boolean = obj match {
-    case other: Transform =>
-      other.name() == this.name &&
-        java.util.Arrays.equals(
-          other.arguments().asInstanceOf[Array[Object]],
-          this.arguments().asInstanceOf[Array[Object]])
-    case _ => false
-  }
-
-  override def hashCode(): Int =
-    java.util.Objects.hash(
-      name,
-      Integer.valueOf(java.util.Arrays.hashCode(arguments().asInstanceOf[Array[Object]])))
-
-  override def references(): Array[NamedReference] = {
-    args.collect { case n: NamedReference => n }
-  }
 }
 
 private[sql] final case class SortedBucketTransform(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
@@ -158,11 +158,29 @@ private[sql] object BucketTransform {
 }
 
 /**
+ * Minimal description of a per-column transform applied within a CLUSTER BY expression.
+ *
+ * @param columnIndex index into [[ClusterByTransform.columnNames]] identifying the column
+ *                    being transformed.
+ * @param argumentIndex the index in the argument list where the bound clustering column
+ *                      should be substituted. Zero-indexed, and any arguments at or after
+ *                      this index in `arguments` should be shifted to the right by one.
+ * @param function    canonical SQL function name (e.g. "variant_get").
+ * @param arguments   the non-column literal arguments to the function.
+ */
+case class ClusterByColumnTransform(
+    columnIndex: Int,
+    argumentIndex: Int,
+    function: String,
+    arguments: Seq[LiteralValue[_]])
+
+/**
  * This class represents a transform for `ClusterBySpec`. This is used to bundle
  * ClusterBySpec in CreateTable's partitioning transforms to pass it down to analyzer.
  */
 final case class ClusterByTransform(
-    columnNames: Seq[NamedReference]) extends RewritableTransform {
+    columnNames: Seq[NamedReference],
+    transforms: Seq[ClusterByColumnTransform] = Seq.empty) extends RewritableTransform {
 
   override val name: String = "cluster_by"
 
@@ -174,6 +192,20 @@ final case class ClusterByTransform(
 
   override def withReferences(newReferences: Seq[NamedReference]): Transform = {
     this.copy(columnNames = newReferences)
+  }
+
+  /** Converts [[transforms]] to a per-column `Seq[Option[Transform]]` for [[ClusterBySpec]]. */
+  def toClusteringColumnTransforms: Seq[Option[Transform]] = {
+    columnNames.indices.map { idx =>
+      transforms.find(_.columnIndex == idx).map { t =>
+        val args = t.arguments.toArray
+
+        new ClusteringColumnTransform(
+          t.function,
+          args.slice(0, t.argumentIndex) ++
+            Array[Expression](columnNames(idx)) ++ args.slice(t.argumentIndex, args.length))
+      }
+    }
   }
 }
 
@@ -188,6 +220,42 @@ object ClusterByTransform {
       case _ =>
         None
     }
+}
+
+/**
+ * A Transform implementation that wraps a column transform expression for CLUSTER BY.
+ * For example, `CLUSTER BY (UPPER(col))` produces a ClusteringColumnTransform
+ * wrapping the UPPER function with `col` as a NamedReference argument. Used with ClusterBySpec.
+ */
+final class ClusteringColumnTransform(
+    override val name: String,
+    private val args: Array[Expression]) extends Transform {
+
+  override def arguments(): Array[Expression] = args
+
+  override def toString: String = {
+    s"$name(${arguments().map(_.toString).mkString(", ")})"
+  }
+
+  override def describe: String = toString
+
+  override def equals(obj: Any): Boolean = obj match {
+    case other: Transform =>
+      other.name() == this.name &&
+        java.util.Arrays.equals(
+          other.arguments().asInstanceOf[Array[Object]],
+          this.arguments().asInstanceOf[Array[Object]])
+    case _ => false
+  }
+
+  override def hashCode(): Int =
+    java.util.Objects.hash(
+      name,
+      Integer.valueOf(java.util.Arrays.hashCode(arguments().asInstanceOf[Array[Object]])))
+
+  override def references(): Array[NamedReference] = {
+    args.collect { case n: NamedReference => n }
+  }
 }
 
 private[sql] final case class SortedBucketTransform(
@@ -387,7 +455,7 @@ private[sql] object HoursTransform {
   }
 }
 
-private[sql] final case class LiteralValue[T](value: T, dataType: DataType) extends Literal[T] {
+final case class LiteralValue[T](value: T, dataType: DataType) extends Literal[T] {
   override def toString: String = dataType match {
     case StringType => s"'${s"$value".replace("'", "''")}'"
     case BinaryType =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ClusterBySpecSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ClusterBySpecSuite.scala
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.catalog
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedFunction}
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.plans.SQLHelper
+import org.apache.spark.sql.connector.expressions.{ClusteringColumnTransform, FieldReference, LiteralValue}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{IntegerType, StringType, TimestampNTZType, TimestampType}
+import org.apache.spark.unsafe.types.UTF8String
+
+class ClusterBySpecSuite extends SparkFunSuite with SQLHelper {
+
+  // -- column name roundtrip tests
+  test("fromColumnEntries with plain columns roundtrips through toColumnNames") {
+    val spec = ClusterBySpec(Seq(FieldReference(Seq("a")), FieldReference(Seq("b", "c"))))
+    val json = spec.toColumnNames
+    val roundtripped = ClusterBySpec.fromProperty(json)
+    assert(roundtripped.columnNames === spec.columnNames)
+    assert(roundtripped.clusteringColumnTransforms.isEmpty)
+  }
+
+  // -- from expressions tests
+  test("fromExpressions with a plain column reference produces no transform") {
+    val spec = ClusterBySpec.fromExpressions(
+      Seq(scala.util.Right(Seq("col1"))))
+    assert(spec.columnNames === Seq(FieldReference(Seq("col1"))))
+    assert(spec.clusteringColumnTransforms.isEmpty)
+  }
+
+  test("fromExpressions with a function call produces a ClusteringColumnTransform") {
+    val funcExpr = UnresolvedFunction(
+      "variant_get",
+      Seq(
+        UnresolvedAttribute(Seq("col1")),
+        Literal(UTF8String.fromString("$.foo"), StringType),
+        Literal(UTF8String.fromString("STRING"), StringType)),
+      isDistinct = false)
+    val spec = ClusterBySpec.fromExpressions(Seq(scala.util.Left(funcExpr)))
+    assert(spec.columnNames === Seq(FieldReference(Seq("col1"))))
+    assert(spec.clusteringColumnTransforms.length === 1)
+    val transformOpt = spec.clusteringColumnTransforms.head
+    assert(transformOpt.isDefined)
+    val transform = transformOpt.get.asInstanceOf[ClusteringColumnTransform]
+    assert(transform.name === "variant_get")
+  }
+
+  // -- toColumnNames / fromProperty roundtrip with expressions tests
+  test("expression column roundtrips through toColumnNames and fromProperty") {
+    val transform = new ClusteringColumnTransform(
+      "variant_get",
+      Array(
+        FieldReference(Seq("col1")),
+        LiteralValue(UTF8String.fromString("$.foo"), StringType),
+        LiteralValue(UTF8String.fromString("STRING"), StringType)))
+    val spec = ClusterBySpec(
+      columnNames = Seq(FieldReference(Seq("col1"))),
+      clusteringColumnTransforms = Seq(Some(transform)))
+
+    val json = spec.toColumnNames
+
+    // The serialized form should be a plain JSON array of arrays (no nested objects)
+    assert(!json.contains("{"), s"Expected flat array format but got: $json")
+
+    val roundtripped = ClusterBySpec.fromProperty(json)
+    assert(roundtripped.columnNames === spec.columnNames)
+    assert(roundtripped.clusteringColumnTransforms.length === 1)
+    val rt = roundtripped.clusteringColumnTransforms.head.get
+      .asInstanceOf[ClusteringColumnTransform]
+    assert(rt.name === "variant_get")
+    assert(rt.arguments().length === 3)
+    assert(rt.arguments()(0).asInstanceOf[FieldReference].fieldNames().toSeq === Seq("col1"))
+  }
+
+  test("mixed plain and expression columns roundtrip through toColumnNames and fromProperty") {
+    val transform = new ClusteringColumnTransform(
+      "upper",
+      Array(FieldReference(Seq("name"))))
+    val spec = ClusterBySpec(
+      columnNames = Seq(FieldReference(Seq("id")), FieldReference(Seq("name"))),
+      clusteringColumnTransforms = Seq(None, Some(transform)))
+
+    val roundtripped = ClusterBySpec.fromProperty(spec.toColumnNames)
+
+    assert(roundtripped.columnNames === spec.columnNames)
+    assert(roundtripped.clusteringColumnTransforms.length === 2)
+    assert(roundtripped.clusteringColumnTransforms(0).isEmpty) // plain column
+    val rt = roundtripped.clusteringColumnTransforms(1).get.asInstanceOf[ClusteringColumnTransform]
+    assert(rt.name === "upper")
+  }
+
+  test("fromProperty is backward compatible with the old plain Seq[Seq[String]] format") {
+    // Old format: just column name arrays
+    val oldFormat = """[["id"],["data"]]"""
+    val spec = ClusterBySpec.fromProperty(oldFormat)
+    assert(spec.columnNames === Seq(FieldReference(Seq("id")), FieldReference(Seq("data"))))
+    assert(spec.clusteringColumnTransforms.isEmpty)
+  }
+
+  test("integer literal in expression roundtrips correctly") {
+    val transform = new ClusteringColumnTransform(
+      "some_func",
+      Array(
+        FieldReference(Seq("col")),
+        LiteralValue(42, IntegerType)))
+    val spec = ClusterBySpec(
+      columnNames = Seq(FieldReference(Seq("col"))),
+      clusteringColumnTransforms = Seq(Some(transform)))
+
+    val roundtripped = ClusterBySpec.fromProperty(spec.toColumnNames)
+    assert(roundtripped.columnNames === spec.columnNames)
+    val rt = roundtripped.clusteringColumnTransforms.head.get
+      .asInstanceOf[ClusteringColumnTransform]
+    assert(rt.name === "some_func")
+    assert(rt.arguments().length === 2)
+  }
+
+  // -- string literal round-trip tests
+  test("string literal values are preserved through toColumnNames/fromProperty round-trip") {
+    val transform = new ClusteringColumnTransform(
+      "variant_get",
+      Array(
+        FieldReference(Seq("col")),
+        LiteralValue(UTF8String.fromString("$.foo"), StringType),
+        LiteralValue(UTF8String.fromString("STRING"), StringType)))
+    val spec = ClusterBySpec(
+      columnNames = Seq(FieldReference(Seq("col"))),
+      clusteringColumnTransforms = Seq(Some(transform)))
+
+    val json = spec.toColumnNames
+    val roundtripped = ClusterBySpec.fromProperty(json)
+
+    val rt = roundtripped.clusteringColumnTransforms.head.get
+      .asInstanceOf[ClusteringColumnTransform]
+    assert(rt.name === "variant_get")
+    assert(rt.arguments().length === 3)
+
+    // Verify the string literal values and types survive the round-trip
+    val lit1 = rt.arguments()(1).asInstanceOf[LiteralValue[_]]
+    assert(lit1.dataType === StringType)
+    assert(lit1.value.toString === "$.foo")
+
+    val lit2 = rt.arguments()(2).asInstanceOf[LiteralValue[_]]
+    assert(lit2.dataType === StringType)
+    assert(lit2.value.toString === "STRING")
+  }
+
+  test("string literal with embedded single quotes round-trips correctly") {
+    val transform = new ClusteringColumnTransform(
+      "some_func",
+      Array(
+        FieldReference(Seq("col")),
+        LiteralValue(UTF8String.fromString("it's a test"), StringType)))
+    val spec = ClusterBySpec(
+      columnNames = Seq(FieldReference(Seq("col"))),
+      clusteringColumnTransforms = Seq(Some(transform)))
+
+    val json = spec.toColumnNames
+    val roundtripped = ClusterBySpec.fromProperty(json)
+
+    val rt = roundtripped.clusteringColumnTransforms.head.get
+      .asInstanceOf[ClusteringColumnTransform]
+    val lit = rt.arguments()(1).asInstanceOf[LiteralValue[_]]
+    assert(lit.dataType === StringType)
+    assert(lit.value.toString === "it's a test")
+  }
+
+  test("string literal that looks like a column name round-trips as string, not column ref") {
+    // A string value like "col_name" should survive as a StringType literal,
+    // not be re-parsed as an UnresolvedAttribute (column reference).
+    val transform = new ClusteringColumnTransform(
+      "some_func",
+      Array(
+        FieldReference(Seq("col")),
+        LiteralValue(UTF8String.fromString("my_column"), StringType)))
+    val spec = ClusterBySpec(
+      columnNames = Seq(FieldReference(Seq("col"))),
+      clusteringColumnTransforms = Seq(Some(transform)))
+
+    val json = spec.toColumnNames
+    val roundtripped = ClusterBySpec.fromProperty(json)
+
+    val rt = roundtripped.clusteringColumnTransforms.head.get
+      .asInstanceOf[ClusteringColumnTransform]
+    // The second argument should still be a LiteralValue with StringType,
+    // not a FieldReference (which would indicate it was parsed as a column name)
+    assert(rt.arguments()(1).isInstanceOf[LiteralValue[_]])
+    val lit = rt.arguments()(1).asInstanceOf[LiteralValue[_]]
+    assert(lit.dataType === StringType)
+    assert(lit.value.toString === "my_column")
+  }
+
+  // -- timestamp literal round-trip tests
+  private def testTimestampRoundTrip(microseconds: Long): Unit = {
+    val transform = new ClusteringColumnTransform(
+      "date_trunc",
+      Array(
+        FieldReference(Seq("ts_col")),
+        LiteralValue(microseconds, TimestampType)))
+    val spec = ClusterBySpec(
+      columnNames = Seq(FieldReference(Seq("ts_col"))),
+      clusteringColumnTransforms = Seq(Some(transform)))
+
+    val json = spec.toColumnNames
+    val roundtripped = ClusterBySpec.fromProperty(json)
+
+    val rt = roundtripped.clusteringColumnTransforms.head.get
+      .asInstanceOf[ClusteringColumnTransform]
+    assert(rt.name === "date_trunc")
+    assert(rt.arguments().length === 2)
+    val lit = rt.arguments()(1).asInstanceOf[LiteralValue[_]]
+    assert(lit.dataType === TimestampType)
+    assert(lit.value == microseconds)
+  }
+
+  test("timestamp literal round-trips correctly") {
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      // 2023-01-01T00:00:00Z in microseconds
+      testTimestampRoundTrip(1672531200000000L)
+    }
+  }
+
+  test("timestamp literal round-trip is consistent with Java8 Date API enabled") {
+    withSQLConf(
+      SQLConf.DATETIME_JAVA8API_ENABLED.key -> "true",
+      SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      testTimestampRoundTrip(1672531200000000L)
+    }
+  }
+
+  test("timestamp literal round-trip is consistent with Java8 Date API disabled") {
+    withSQLConf(
+      SQLConf.DATETIME_JAVA8API_ENABLED.key -> "false",
+      SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      testTimestampRoundTrip(1672531200000000L)
+    }
+  }
+
+  test("timestamp literal round-trip with non-UTC timezone") {
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "America/Toronto") {
+      testTimestampRoundTrip(1672531200000000L)
+    }
+  }
+
+  test("timestamp_ntz literal round-trips correctly") {
+    val microseconds = 1672531200000000L
+    val transform = new ClusteringColumnTransform(
+      "date_trunc",
+      Array(
+        FieldReference(Seq("ts_col")),
+        LiteralValue(microseconds, TimestampNTZType)))
+    val spec = ClusterBySpec(
+      columnNames = Seq(FieldReference(Seq("ts_col"))),
+      clusteringColumnTransforms = Seq(Some(transform)))
+
+    val json = spec.toColumnNames
+    val roundtripped = ClusterBySpec.fromProperty(json)
+
+    val rt = roundtripped.clusteringColumnTransforms.head.get
+      .asInstanceOf[ClusteringColumnTransform]
+    assert(rt.arguments().length === 2)
+    val lit = rt.arguments()(1).asInstanceOf[LiteralValue[_]]
+    assert(lit.dataType === TimestampNTZType)
+    assert(lit.value == microseconds)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ClusterBySpecSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ClusterBySpecSuite.scala
@@ -18,91 +18,52 @@
 package org.apache.spark.sql.catalyst.catalog
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedFunction}
-import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.plans.SQLHelper
-import org.apache.spark.sql.connector.expressions.{ClusteringColumnTransform, FieldReference, LiteralValue}
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.connector.expressions.{ApplyTransform, FieldReference, IdentityTransform, LiteralValue}
 import org.apache.spark.sql.types.{IntegerType, StringType, TimestampNTZType, TimestampType}
 import org.apache.spark.unsafe.types.UTF8String
 
 class ClusterBySpecSuite extends SparkFunSuite with SQLHelper {
 
-  // -- column name roundtrip tests
-  test("fromColumnEntries with plain columns roundtrips through toColumnNames") {
-    val spec = ClusterBySpec(Seq(FieldReference(Seq("a")), FieldReference(Seq("b", "c"))))
-    val json = spec.toColumnNames
+  // -- plain column roundtrip tests
+  test("plain columns roundtrip through toJson and fromProperty") {
+    val spec = ClusterBySpec.ofColumns(Seq(FieldReference(Seq("a")), FieldReference(Seq("b", "c"))))
+    val json = spec.toJson
     val roundtripped = ClusterBySpec.fromProperty(json)
     assert(roundtripped.columnNames === spec.columnNames)
-    assert(roundtripped.clusteringColumnTransforms.isEmpty)
+    assert(roundtripped.entries.forall(_.isInstanceOf[IdentityTransform]))
   }
 
-  // -- from expressions tests
-  test("fromExpressions with a plain column reference produces no transform") {
-    val spec = ClusterBySpec.fromExpressions(
-      Seq(scala.util.Right(Seq("col1"))))
-    assert(spec.columnNames === Seq(FieldReference(Seq("col1"))))
-    assert(spec.clusteringColumnTransforms.isEmpty)
-  }
-
-  test("fromExpressions with a function call produces a ClusteringColumnTransform") {
-    val funcExpr = UnresolvedFunction(
-      "variant_get",
-      Seq(
-        UnresolvedAttribute(Seq("col1")),
-        Literal(UTF8String.fromString("$.foo"), StringType),
-        Literal(UTF8String.fromString("STRING"), StringType)),
-      isDistinct = false)
-    val spec = ClusterBySpec.fromExpressions(Seq(scala.util.Left(funcExpr)))
-    assert(spec.columnNames === Seq(FieldReference(Seq("col1"))))
-    assert(spec.clusteringColumnTransforms.length === 1)
-    val transformOpt = spec.clusteringColumnTransforms.head
-    assert(transformOpt.isDefined)
-    val transform = transformOpt.get.asInstanceOf[ClusteringColumnTransform]
-    assert(transform.name === "variant_get")
-  }
-
-  // -- toColumnNames / fromProperty roundtrip with expressions tests
-  test("expression column roundtrips through toColumnNames and fromProperty") {
-    val transform = new ClusteringColumnTransform(
-      "variant_get",
-      Array(
+  // -- ApplyTransform roundtrip tests
+  test("ApplyTransform entry roundtrips through toJson and fromProperty") {
+    val spec = new ClusterBySpec(Seq(
+      ApplyTransform("variant_get", Seq(
         FieldReference(Seq("col1")),
         LiteralValue(UTF8String.fromString("$.foo"), StringType),
-        LiteralValue(UTF8String.fromString("STRING"), StringType)))
-    val spec = ClusterBySpec(
-      columnNames = Seq(FieldReference(Seq("col1"))),
-      clusteringColumnTransforms = Seq(Some(transform)))
+        LiteralValue(UTF8String.fromString("STRING"), StringType)))))
 
-    val json = spec.toColumnNames
-
-    // The serialized form should be a plain JSON array of arrays (no nested objects)
-    assert(!json.contains("{"), s"Expected flat array format but got: $json")
-
+    val json = spec.toJson
     val roundtripped = ClusterBySpec.fromProperty(json)
-    assert(roundtripped.columnNames === spec.columnNames)
-    assert(roundtripped.clusteringColumnTransforms.length === 1)
-    val rt = roundtripped.clusteringColumnTransforms.head.get
-      .asInstanceOf[ClusteringColumnTransform]
+
+    assert(roundtripped.columnNames === Seq(FieldReference(Seq("col1"))))
+    assert(roundtripped.entries.length === 1)
+    val rt = roundtripped.entries.head.asInstanceOf[ApplyTransform]
     assert(rt.name === "variant_get")
-    assert(rt.arguments().length === 3)
-    assert(rt.arguments()(0).asInstanceOf[FieldReference].fieldNames().toSeq === Seq("col1"))
+    assert(rt.args.length === 3)
+    assert(rt.args(0).asInstanceOf[FieldReference].fieldNames().toSeq === Seq("col1"))
   }
 
-  test("mixed plain and expression columns roundtrip through toColumnNames and fromProperty") {
-    val transform = new ClusteringColumnTransform(
-      "upper",
-      Array(FieldReference(Seq("name"))))
-    val spec = ClusterBySpec(
-      columnNames = Seq(FieldReference(Seq("id")), FieldReference(Seq("name"))),
-      clusteringColumnTransforms = Seq(None, Some(transform)))
+  test("mixed plain and expression entries roundtrip") {
+    val spec = new ClusterBySpec(Seq(
+      IdentityTransform(FieldReference(Seq("id"))),
+      ApplyTransform("upper", Seq(FieldReference(Seq("name"))))))
 
-    val roundtripped = ClusterBySpec.fromProperty(spec.toColumnNames)
+    val roundtripped = ClusterBySpec.fromProperty(spec.toJson)
 
-    assert(roundtripped.columnNames === spec.columnNames)
-    assert(roundtripped.clusteringColumnTransforms.length === 2)
-    assert(roundtripped.clusteringColumnTransforms(0).isEmpty) // plain column
-    val rt = roundtripped.clusteringColumnTransforms(1).get.asInstanceOf[ClusteringColumnTransform]
+    assert(roundtripped.columnNames ===
+      Seq(FieldReference(Seq("id")), FieldReference(Seq("name"))))
+    assert(roundtripped.entries(0).isInstanceOf[IdentityTransform])
+    val rt = roundtripped.entries(1).asInstanceOf[ApplyTransform]
     assert(rt.name === "upper")
   }
 
@@ -111,173 +72,145 @@ class ClusterBySpecSuite extends SparkFunSuite with SQLHelper {
     val oldFormat = """[["id"],["data"]]"""
     val spec = ClusterBySpec.fromProperty(oldFormat)
     assert(spec.columnNames === Seq(FieldReference(Seq("id")), FieldReference(Seq("data"))))
-    assert(spec.clusteringColumnTransforms.isEmpty)
+    assert(spec.entries.forall(_.isInstanceOf[IdentityTransform]))
   }
 
   test("integer literal in expression roundtrips correctly") {
-    val transform = new ClusteringColumnTransform(
-      "some_func",
-      Array(
+    val spec = new ClusterBySpec(Seq(
+      ApplyTransform("some_func", Seq(
         FieldReference(Seq("col")),
-        LiteralValue(42, IntegerType)))
-    val spec = ClusterBySpec(
-      columnNames = Seq(FieldReference(Seq("col"))),
-      clusteringColumnTransforms = Seq(Some(transform)))
+        LiteralValue(42, IntegerType)))))
 
-    val roundtripped = ClusterBySpec.fromProperty(spec.toColumnNames)
-    assert(roundtripped.columnNames === spec.columnNames)
-    val rt = roundtripped.clusteringColumnTransforms.head.get
-      .asInstanceOf[ClusteringColumnTransform]
+    val roundtripped = ClusterBySpec.fromProperty(spec.toJson)
+    assert(roundtripped.columnNames === Seq(FieldReference(Seq("col"))))
+    val rt = roundtripped.entries.head.asInstanceOf[ApplyTransform]
     assert(rt.name === "some_func")
-    assert(rt.arguments().length === 2)
+    assert(rt.args.length === 2)
   }
 
   // -- string literal round-trip tests
-  test("string literal values are preserved through toColumnNames/fromProperty round-trip") {
-    val transform = new ClusteringColumnTransform(
-      "variant_get",
-      Array(
+  test("string literal values are preserved through toJson/fromProperty round-trip") {
+    val spec = new ClusterBySpec(Seq(
+      ApplyTransform("variant_get", Seq(
         FieldReference(Seq("col")),
         LiteralValue(UTF8String.fromString("$.foo"), StringType),
-        LiteralValue(UTF8String.fromString("STRING"), StringType)))
-    val spec = ClusterBySpec(
-      columnNames = Seq(FieldReference(Seq("col"))),
-      clusteringColumnTransforms = Seq(Some(transform)))
+        LiteralValue(UTF8String.fromString("STRING"), StringType)))))
 
-    val json = spec.toColumnNames
+    val json = spec.toJson
     val roundtripped = ClusterBySpec.fromProperty(json)
 
-    val rt = roundtripped.clusteringColumnTransforms.head.get
-      .asInstanceOf[ClusteringColumnTransform]
+    val rt = roundtripped.entries.head.asInstanceOf[ApplyTransform]
     assert(rt.name === "variant_get")
-    assert(rt.arguments().length === 3)
+    assert(rt.args.length === 3)
 
-    // Verify the string literal values and types survive the round-trip
-    val lit1 = rt.arguments()(1).asInstanceOf[LiteralValue[_]]
+    val lit1 = rt.args(1).asInstanceOf[LiteralValue[_]]
     assert(lit1.dataType === StringType)
     assert(lit1.value.toString === "$.foo")
 
-    val lit2 = rt.arguments()(2).asInstanceOf[LiteralValue[_]]
+    val lit2 = rt.args(2).asInstanceOf[LiteralValue[_]]
     assert(lit2.dataType === StringType)
     assert(lit2.value.toString === "STRING")
   }
 
   test("string literal with embedded single quotes round-trips correctly") {
-    val transform = new ClusteringColumnTransform(
-      "some_func",
-      Array(
+    val spec = new ClusterBySpec(Seq(
+      ApplyTransform("some_func", Seq(
         FieldReference(Seq("col")),
-        LiteralValue(UTF8String.fromString("it's a test"), StringType)))
-    val spec = ClusterBySpec(
-      columnNames = Seq(FieldReference(Seq("col"))),
-      clusteringColumnTransforms = Seq(Some(transform)))
+        LiteralValue(UTF8String.fromString("it's a test"), StringType)))))
 
-    val json = spec.toColumnNames
+    val json = spec.toJson
     val roundtripped = ClusterBySpec.fromProperty(json)
 
-    val rt = roundtripped.clusteringColumnTransforms.head.get
-      .asInstanceOf[ClusteringColumnTransform]
-    val lit = rt.arguments()(1).asInstanceOf[LiteralValue[_]]
+    val rt = roundtripped.entries.head.asInstanceOf[ApplyTransform]
+    val lit = rt.args(1).asInstanceOf[LiteralValue[_]]
     assert(lit.dataType === StringType)
     assert(lit.value.toString === "it's a test")
   }
 
   test("string literal that looks like a column name round-trips as string, not column ref") {
-    // A string value like "col_name" should survive as a StringType literal,
-    // not be re-parsed as an UnresolvedAttribute (column reference).
-    val transform = new ClusteringColumnTransform(
-      "some_func",
-      Array(
+    val spec = new ClusterBySpec(Seq(
+      ApplyTransform("some_func", Seq(
         FieldReference(Seq("col")),
-        LiteralValue(UTF8String.fromString("my_column"), StringType)))
-    val spec = ClusterBySpec(
-      columnNames = Seq(FieldReference(Seq("col"))),
-      clusteringColumnTransforms = Seq(Some(transform)))
+        LiteralValue(UTF8String.fromString("my_column"), StringType)))))
 
-    val json = spec.toColumnNames
+    val json = spec.toJson
     val roundtripped = ClusterBySpec.fromProperty(json)
 
-    val rt = roundtripped.clusteringColumnTransforms.head.get
-      .asInstanceOf[ClusteringColumnTransform]
-    // The second argument should still be a LiteralValue with StringType,
-    // not a FieldReference (which would indicate it was parsed as a column name)
-    assert(rt.arguments()(1).isInstanceOf[LiteralValue[_]])
-    val lit = rt.arguments()(1).asInstanceOf[LiteralValue[_]]
+    val rt = roundtripped.entries.head.asInstanceOf[ApplyTransform]
+    assert(rt.args(1).isInstanceOf[LiteralValue[_]])
+    val lit = rt.args(1).asInstanceOf[LiteralValue[_]]
     assert(lit.dataType === StringType)
     assert(lit.value.toString === "my_column")
   }
 
   // -- timestamp literal round-trip tests
   private def testTimestampRoundTrip(microseconds: Long): Unit = {
-    val transform = new ClusteringColumnTransform(
-      "date_trunc",
-      Array(
+    val spec = new ClusterBySpec(Seq(
+      ApplyTransform("date_trunc", Seq(
         FieldReference(Seq("ts_col")),
-        LiteralValue(microseconds, TimestampType)))
-    val spec = ClusterBySpec(
-      columnNames = Seq(FieldReference(Seq("ts_col"))),
-      clusteringColumnTransforms = Seq(Some(transform)))
+        LiteralValue(microseconds, TimestampType)))))
 
-    val json = spec.toColumnNames
+    val json = spec.toJson
     val roundtripped = ClusterBySpec.fromProperty(json)
 
-    val rt = roundtripped.clusteringColumnTransforms.head.get
-      .asInstanceOf[ClusteringColumnTransform]
+    val rt = roundtripped.entries.head.asInstanceOf[ApplyTransform]
     assert(rt.name === "date_trunc")
-    assert(rt.arguments().length === 2)
-    val lit = rt.arguments()(1).asInstanceOf[LiteralValue[_]]
+    assert(rt.args.length === 2)
+    val lit = rt.args(1).asInstanceOf[LiteralValue[_]]
     assert(lit.dataType === TimestampType)
     assert(lit.value == microseconds)
   }
 
   test("timestamp literal round-trips correctly") {
-    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
-      // 2023-01-01T00:00:00Z in microseconds
-      testTimestampRoundTrip(1672531200000000L)
-    }
-  }
-
-  test("timestamp literal round-trip is consistent with Java8 Date API enabled") {
-    withSQLConf(
-      SQLConf.DATETIME_JAVA8API_ENABLED.key -> "true",
-      SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
-      testTimestampRoundTrip(1672531200000000L)
-    }
-  }
-
-  test("timestamp literal round-trip is consistent with Java8 Date API disabled") {
-    withSQLConf(
-      SQLConf.DATETIME_JAVA8API_ENABLED.key -> "false",
-      SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+    withSQLConf("spark.sql.session.timeZone" -> "UTC") {
       testTimestampRoundTrip(1672531200000000L)
     }
   }
 
   test("timestamp literal round-trip with non-UTC timezone") {
-    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "America/Toronto") {
+    withSQLConf("spark.sql.session.timeZone" -> "America/Toronto") {
       testTimestampRoundTrip(1672531200000000L)
     }
   }
 
   test("timestamp_ntz literal round-trips correctly") {
     val microseconds = 1672531200000000L
-    val transform = new ClusteringColumnTransform(
-      "date_trunc",
-      Array(
+    val spec = new ClusterBySpec(Seq(
+      ApplyTransform("date_trunc", Seq(
         FieldReference(Seq("ts_col")),
-        LiteralValue(microseconds, TimestampNTZType)))
-    val spec = ClusterBySpec(
-      columnNames = Seq(FieldReference(Seq("ts_col"))),
-      clusteringColumnTransforms = Seq(Some(transform)))
+        LiteralValue(microseconds, TimestampNTZType)))))
 
-    val json = spec.toColumnNames
+    val json = spec.toJson
     val roundtripped = ClusterBySpec.fromProperty(json)
 
-    val rt = roundtripped.clusteringColumnTransforms.head.get
-      .asInstanceOf[ClusteringColumnTransform]
-    assert(rt.arguments().length === 2)
-    val lit = rt.arguments()(1).asInstanceOf[LiteralValue[_]]
+    val rt = roundtripped.entries.head.asInstanceOf[ApplyTransform]
+    assert(rt.args.length === 2)
+    val lit = rt.args(1).asInstanceOf[LiteralValue[_]]
     assert(lit.dataType === TimestampNTZType)
     assert(lit.value == microseconds)
+  }
+
+  // -- backward-compatible factory tests
+  test("apply(Seq[NamedReference]) creates IdentityTransform entries") {
+    val spec = ClusterBySpec.ofColumns(Seq(FieldReference(Seq("a")), FieldReference(Seq("b"))))
+    assert(spec.entries.length === 2)
+    assert(spec.entries.forall(_.isInstanceOf[IdentityTransform]))
+    assert(spec.columnNames === Seq(FieldReference(Seq("a")), FieldReference(Seq("b"))))
+  }
+
+  test("plain-columns-only toJson produces old Seq[Seq[String]] format") {
+    val spec = ClusterBySpec.ofColumns(Seq(FieldReference(Seq("id")), FieldReference(Seq("data"))))
+    val json = spec.toJson
+    // Should be flat array of arrays, no objects
+    assert(!json.contains("{"), s"Expected flat array format but got: $json")
+    assert(json === """[["id"],["data"]]""")
+  }
+
+  test("expression entries toJson produces structured JSON format") {
+    val spec = new ClusterBySpec(Seq(
+      ApplyTransform("upper", Seq(FieldReference(Seq("name"))))))
+    val json = spec.toJson
+    assert(json.contains("transform"), s"Expected structured format but got: $json")
+    assert(json.contains("\"name\":\"upper\""))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -217,7 +217,7 @@ class DDLParserSuite extends AnalysisTest {
           ColumnDefinition("b", StringType),
           ColumnDefinition("ts", TimestampType)
         ),
-        ClusterByTransform(Seq(FieldReference("a"), FieldReference("b")))),
+        ClusterByTransform.ofColumns(Seq(FieldReference("a"), FieldReference("b")))),
       ("a STRUCT<b INT, c STRING>, ts TIMESTAMP",
         "a.b, ts",
         Seq(
@@ -225,7 +225,7 @@ class DDLParserSuite extends AnalysisTest {
             "a", new StructType().add("b", IntegerType).add("c", StringType)),
           ColumnDefinition("ts", TimestampType)
         ),
-        ClusterByTransform(Seq(FieldReference(Seq("a", "b")), FieldReference("ts"))))
+        ClusterByTransform.ofColumns(Seq(FieldReference(Seq("a", "b")), FieldReference("ts"))))
     ).foreach { case (columns, clusteringColumns, schema, clusterByTransform) =>
       val createSql =
         s"""CREATE TABLE my_tab ($columns) USING parquet

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -315,7 +315,7 @@ abstract class InMemoryBaseTable(
         }
       case ClusterByTransform(columnNames) =>
         columnNames.map { colName =>
-          extractor(colName.fieldNames, cleanedSchema, row)._1
+          extractor(colName.asInstanceOf[NamedReference].fieldNames, cleanedSchema, row)._1
         }
     }.toImmutableArraySeq
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -313,9 +313,9 @@ abstract class InMemoryBaseTable(
           case (v, t) =>
             throw new IllegalArgumentException(s"Match: unsupported argument(s) type - ($v, $t)")
         }
-      case ClusterByTransform(columnNames) =>
-        columnNames.map { colName =>
-          extractor(colName.asInstanceOf[NamedReference].fieldNames, cleanedSchema, row)._1
+      case ct: ClusterByTransform =>
+        ct.columnNames.map { colName =>
+          extractor(colName.fieldNames, cleanedSchema, row)._1
         }
     }.toImmutableArraySeq
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/expressions/TransformExtractorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/expressions/TransformExtractorSuite.scala
@@ -222,9 +222,13 @@ class TransformExtractorSuite extends SparkFunSuite {
     }
 
     clusterByTransform match {
-      case ClusterByTransform(columnNames) =>
-        assert(columnNames.size === 1)
-        assert(columnNames(0).fieldNames === Seq("a", "b"))
+      case ClusterByTransform(entries) =>
+        assert(entries.size === 1)
+        entries(0) match {
+          case IdentityTransform(ref) =>
+            assert(ref.fieldNames === Seq("a", "b"))
+          case _ => fail("Expected IdentityTransform")
+        }
       case _ =>
         fail("Did not match ClusterByTransform extractor")
     }
@@ -245,10 +249,10 @@ class TransformExtractorSuite extends SparkFunSuite {
     assert(reference.length == 2)
     assert(reference(0).fieldNames() === Seq("a a", "b"))
     assert(reference(1).fieldNames() === Seq("ts"))
-    val arguments = clusterByTransform.arguments
-    assert(arguments.length == 2)
-    assert(arguments(0).asInstanceOf[NamedReference].fieldNames() === Seq("a a", "b"))
-    assert(arguments(1).asInstanceOf[NamedReference].fieldNames() === Seq("ts"))
+    assert(clusterByTransform.entries.length == 2)
+    assert(clusterByTransform.columnNames.length == 2)
+    assert(clusterByTransform.columnNames(0).fieldNames() === Seq("a a", "b"))
+    assert(clusterByTransform.columnNames(1).fieldNames() === Seq("ts"))
     val copied = clusterByTransform.withReferences(reference.toImmutableArraySeq)
     assert(copied.equals(clusterByTransform))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameWriter.scala
@@ -586,7 +586,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) extends sql.DataFram
     val bucketing =
       getBucketSpec.map(spec => CatalogV2Implicits.BucketSpecHelper(spec).asTransform).toSeq
     val clustering = clusteringColumns.map { colNames =>
-      ClusterByTransform(colNames.map(FieldReference(_)))
+      ClusterByTransform.ofColumns(colNames.map(FieldReference(_)))
     }
     partitioning ++ bucketing ++ clustering
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameWriterV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameWriterV2.scala
@@ -132,7 +132,7 @@ final class DataFrameWriterV2[T] private[sql](table: String, ds: Dataset[T])
   @scala.annotation.varargs
   override def clusterBy(colName: String, colNames: String*): this.type = {
     this.clustering =
-      Some(ClusterByTransform((colName +: colNames).map(col => FieldReference(col))))
+      Some(ClusterByTransform.ofColumns((colName +: colNames).map(col => FieldReference(col))))
     validatePartitioning()
     this
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/DataStreamWriter.scala
@@ -168,7 +168,7 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) extends streaming.D
           DataSourceUtils.CLUSTERING_COLUMNS_KEY -> DataSourceUtils.encodePartitioningColumns(cols))
       }.getOrElse(Map.empty)
       val partitioningOrClusteringTransform = normalizedClusteringCols.map { colNames =>
-        Array(ClusterByTransform(colNames.map(col => FieldReference(col)))).toImmutableArraySeq
+        Array(ClusterByTransform.ofColumns(colNames.map(col => FieldReference(col)))).toImmutableArraySeq
       }.getOrElse(partitioningColumns.getOrElse(Nil).asTransforms.toImmutableArraySeq)
 
       /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
@@ -552,7 +552,7 @@ class DataFrameWriterV2Suite extends SharedSparkSession with BeforeAndAfter {
     val table = catalog("testcat").loadTable(Identifier.of(Array(), "table_name"))
 
     assert(table.name === "testcat.table_name")
-    assert(table.partitioning === Seq(ClusterByTransform(Seq(FieldReference("id")))))
+    assert(table.partitioning === Seq(ClusterByTransform.ofColumns(Seq(FieldReference("id")))))
   }
 
   test("Create: fail if table already exists") {
@@ -701,7 +701,7 @@ class DataFrameWriterV2Suite extends SharedSparkSession with BeforeAndAfter {
       Array(ColumnV2.create("id", LongType),
         ColumnV2.create("data", StringType),
         ColumnV2.create("even_or_odd", StringType)))
-    assert(replaced.partitioning === Seq(ClusterByTransform(Seq(FieldReference("id")))))
+    assert(replaced.partitioning === Seq(ClusterByTransform.ofColumns(Seq(FieldReference("id")))))
     assert(replaced.properties === defaultOwnership.asJava)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableClusterByParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableClusterByParserSuite.scala
@@ -30,7 +30,7 @@ class AlterTableClusterByParserSuite extends AnalysisTest with SharedSparkSessio
       parsePlan("ALTER TABLE table_name CLUSTER BY (`a.b`, c.d, none)"),
       AlterTableClusterBy(
         UnresolvedTable(Seq("table_name"), "ALTER TABLE ... CLUSTER BY"),
-        Some(ClusterBySpec(Seq(
+        Some(ClusterBySpec.ofColumns(Seq(
           FieldReference(Seq("a.b")),
           FieldReference(Seq("c", "d")),
           FieldReference(Seq("none")))))))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableClusterBySuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableClusterBySuiteBase.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.connector.expressions.Transform
 
 /**
  * This base suite contains unified tests for the `ALTER TABLE ... CLUSTER BY` command
@@ -42,6 +43,17 @@ trait AlterTableClusterBySuiteBase extends QueryTest with DDLCommandTestUtils {
     Seq("col3.`col4.1`", "col2.`col4 1`", "col2.col3")
 
   def validateClusterBy(tableName: String, clusteringColumns: Seq[String]): Unit
+
+  /**
+   * Validates clustering columns and their associated transforms.
+   * @param expectedTransforms per-column transforms, where None means a plain column reference
+   *                           and Some(transform) means an expression-based clustering column.
+   *                           Must have the same length as clusteringColumns.
+   */
+  def validateClusterBy(
+      tableName: String,
+      clusteringColumns: Seq[String],
+      expectedTransforms: Seq[Option[Transform]]): Unit
 
   test("test basic ALTER TABLE with clustering columns") {
     withNamespaceAndTable("ns", "table") { tbl =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CreateTableClusterBySuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CreateTableClusterBySuiteBase.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.connector.expressions.Transform
 
 /**
  * This base suite contains unified tests for the `CREATE/REPLACE TABLE ... CLUSTER BY` command
@@ -40,6 +41,17 @@ trait CreateTableClusterBySuiteBase extends QueryTest with DDLCommandTestUtils {
     Seq("col2.col3", "col2.`col4 1`", "col3.`col4.1`")
 
   def validateClusterBy(tableName: String, clusteringColumns: Seq[String]): Unit
+
+  /**
+   * Validates clustering columns and their associated transforms.
+   * @param expectedTransforms per-column transforms, where None means a plain column reference
+   *                           and Some(transform) means an expression-based clustering column.
+   *                           Must have the same length as clusteringColumns.
+   */
+  def validateClusterBy(
+      tableName: String,
+      clusteringColumns: Seq[String],
+      expectedTransforms: Seq[Option[Transform]]): Unit
 
   test("test basic CREATE TABLE with clustering columns") {
     withNamespaceAndTable("ns", "table") { tbl =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableClusterBySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableClusterBySuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.command.v1
 
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.ClusterBySpec
-import org.apache.spark.sql.connector.expressions.FieldReference
+import org.apache.spark.sql.connector.expressions.{FieldReference, Transform}
 import org.apache.spark.sql.execution.command
 
 /**
@@ -38,6 +38,28 @@ trait AlterTableClusterBySuiteBase extends command.AlterTableClusterBySuiteBase
     val (_, db, t) = parseTableName(tableName)
     val table = catalog.getTableMetadata(TableIdentifier(t, Some(db)))
     assert(table.clusterBySpec === Some(ClusterBySpec(clusteringColumns.map(FieldReference(_)))))
+  }
+
+  override def validateClusterBy(
+      tableName: String,
+      clusteringColumns: Seq[String],
+      expectedTransforms: Seq[Option[Transform]]): Unit = {
+    val catalog = spark.sessionState.catalog
+    val (_, db, t) = parseTableName(tableName)
+    val table = catalog.getTableMetadata(TableIdentifier(t, Some(db)))
+    val spec = table.clusterBySpec.get
+    assert(spec.columnNames === clusteringColumns.map(FieldReference(_)))
+    val actualTransforms = if (spec.clusteringColumnTransforms.nonEmpty) {
+      spec.clusteringColumnTransforms
+    } else {
+      clusteringColumns.map(_ => None)
+    }
+    assert(actualTransforms.length === expectedTransforms.length,
+      s"Expected ${expectedTransforms.length} transforms but got ${actualTransforms.length}")
+    actualTransforms.zip(expectedTransforms).foreach { case (actual, expected) =>
+      assert(actual === expected,
+        s"Transform mismatch: actual=$actual, expected=$expected")
+    }
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableClusterBySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableClusterBySuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.command.v1
 
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.ClusterBySpec
-import org.apache.spark.sql.connector.expressions.{FieldReference, Transform}
+import org.apache.spark.sql.connector.expressions.{ApplyTransform, FieldReference, IdentityTransform, Transform}
 import org.apache.spark.sql.execution.command
 
 /**
@@ -37,7 +37,7 @@ trait AlterTableClusterBySuiteBase extends command.AlterTableClusterBySuiteBase
     val catalog = spark.sessionState.catalog
     val (_, db, t) = parseTableName(tableName)
     val table = catalog.getTableMetadata(TableIdentifier(t, Some(db)))
-    assert(table.clusterBySpec === Some(ClusterBySpec(clusteringColumns.map(FieldReference(_)))))
+    assert(table.clusterBySpec === Some(ClusterBySpec.ofColumns(clusteringColumns.map(FieldReference(_)))))
   }
 
   override def validateClusterBy(
@@ -49,16 +49,17 @@ trait AlterTableClusterBySuiteBase extends command.AlterTableClusterBySuiteBase
     val table = catalog.getTableMetadata(TableIdentifier(t, Some(db)))
     val spec = table.clusterBySpec.get
     assert(spec.columnNames === clusteringColumns.map(FieldReference(_)))
-    val actualTransforms = if (spec.clusteringColumnTransforms.nonEmpty) {
-      spec.clusteringColumnTransforms
-    } else {
-      clusteringColumns.map(_ => None)
-    }
-    assert(actualTransforms.length === expectedTransforms.length,
-      s"Expected ${expectedTransforms.length} transforms but got ${actualTransforms.length}")
-    actualTransforms.zip(expectedTransforms).foreach { case (actual, expected) =>
-      assert(actual === expected,
-        s"Transform mismatch: actual=$actual, expected=$expected")
+    assert(spec.entries.length === expectedTransforms.length,
+      s"Expected ${expectedTransforms.length} entries but got ${spec.entries.length}")
+    spec.entries.zip(expectedTransforms).foreach {
+      case (entry, None) =>
+        assert(entry.isInstanceOf[IdentityTransform],
+          s"Expected plain column but got: $entry")
+      case (entry, Some(transform)) =>
+        assert(entry.isInstanceOf[ApplyTransform],
+          s"Expected ApplyTransform but got: $entry")
+        assert(entry.name() === transform.name(),
+          s"Transform name mismatch: ${entry.name()} != ${transform.name()}")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/CreateTableClusterBySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/CreateTableClusterBySuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.command.v1
 
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.ClusterBySpec
-import org.apache.spark.sql.connector.expressions.{FieldReference, Transform}
+import org.apache.spark.sql.connector.expressions.{ApplyTransform, FieldReference, IdentityTransform, Transform}
 import org.apache.spark.sql.execution.command
 
 /**
@@ -37,7 +37,7 @@ trait CreateTableClusterBySuiteBase extends command.CreateTableClusterBySuiteBas
     val catalog = spark.sessionState.catalog
     val (_, db, t) = parseTableName(tableName)
     val table = catalog.getTableMetadata(TableIdentifier.apply(t, Some(db)))
-    assert(table.clusterBySpec === Some(ClusterBySpec(clusteringColumns.map(FieldReference(_)))))
+    assert(table.clusterBySpec === Some(ClusterBySpec.ofColumns(clusteringColumns.map(FieldReference(_)))))
   }
 
   override def validateClusterBy(
@@ -49,16 +49,17 @@ trait CreateTableClusterBySuiteBase extends command.CreateTableClusterBySuiteBas
     val table = catalog.getTableMetadata(TableIdentifier.apply(t, Some(db)))
     val spec = table.clusterBySpec.get
     assert(spec.columnNames === clusteringColumns.map(FieldReference(_)))
-    val actualTransforms = if (spec.clusteringColumnTransforms.nonEmpty) {
-      spec.clusteringColumnTransforms
-    } else {
-      clusteringColumns.map(_ => None)
-    }
-    assert(actualTransforms.length === expectedTransforms.length,
-      s"Expected ${expectedTransforms.length} transforms but got ${actualTransforms.length}")
-    actualTransforms.zip(expectedTransforms).foreach { case (actual, expected) =>
-      assert(actual === expected,
-        s"Transform mismatch: actual=$actual, expected=$expected")
+    assert(spec.entries.length === expectedTransforms.length,
+      s"Expected ${expectedTransforms.length} entries but got ${spec.entries.length}")
+    spec.entries.zip(expectedTransforms).foreach {
+      case (entry, None) =>
+        assert(entry.isInstanceOf[IdentityTransform],
+          s"Expected plain column but got: $entry")
+      case (entry, Some(transform)) =>
+        assert(entry.isInstanceOf[ApplyTransform],
+          s"Expected ApplyTransform but got: $entry")
+        assert(entry.name() === transform.name(),
+          s"Transform name mismatch: ${entry.name()} != ${transform.name()}")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/CreateTableClusterBySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/CreateTableClusterBySuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.command.v1
 
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.ClusterBySpec
-import org.apache.spark.sql.connector.expressions.FieldReference
+import org.apache.spark.sql.connector.expressions.{FieldReference, Transform}
 import org.apache.spark.sql.execution.command
 
 /**
@@ -38,6 +38,28 @@ trait CreateTableClusterBySuiteBase extends command.CreateTableClusterBySuiteBas
     val (_, db, t) = parseTableName(tableName)
     val table = catalog.getTableMetadata(TableIdentifier.apply(t, Some(db)))
     assert(table.clusterBySpec === Some(ClusterBySpec(clusteringColumns.map(FieldReference(_)))))
+  }
+
+  override def validateClusterBy(
+      tableName: String,
+      clusteringColumns: Seq[String],
+      expectedTransforms: Seq[Option[Transform]]): Unit = {
+    val catalog = spark.sessionState.catalog
+    val (_, db, t) = parseTableName(tableName)
+    val table = catalog.getTableMetadata(TableIdentifier.apply(t, Some(db)))
+    val spec = table.clusterBySpec.get
+    assert(spec.columnNames === clusteringColumns.map(FieldReference(_)))
+    val actualTransforms = if (spec.clusteringColumnTransforms.nonEmpty) {
+      spec.clusteringColumnTransforms
+    } else {
+      clusteringColumns.map(_ => None)
+    }
+    assert(actualTransforms.length === expectedTransforms.length,
+      s"Expected ${expectedTransforms.length} transforms but got ${actualTransforms.length}")
+    actualTransforms.zip(expectedTransforms).foreach { case (actual, expected) =>
+      assert(actual === expected,
+        s"Transform mismatch: actual=$actual, expected=$expected")
+    }
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableClusterBySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableClusterBySuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.command.v2
 
 import org.apache.spark.sql.connector.catalog.{Identifier, InMemoryTable}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.CatalogHelper
-import org.apache.spark.sql.connector.expressions.{ClusterByTransform, FieldReference, Transform}
+import org.apache.spark.sql.connector.expressions.{ApplyTransform, ClusterByTransform, FieldReference, IdentityTransform, Transform}
 import org.apache.spark.sql.execution.command
 
 /**
@@ -35,7 +35,7 @@ class AlterTableClusterBySuite extends command.AlterTableClusterBySuiteBase
       .loadTable(Identifier.of(Array(namespace), table))
       .asInstanceOf[InMemoryTable]
     assert(partTable.partitioning ===
-      Array(ClusterByTransform(clusteringColumns.map(FieldReference(_)))))
+      Array(ClusterByTransform.ofColumns(clusteringColumns.map(FieldReference(_)))))
   }
 
   // The V2 in-memory test catalog does not apply ClusterBy changes via alterTable,
@@ -57,18 +57,17 @@ class AlterTableClusterBySuite extends command.AlterTableClusterBySuiteBase
           case (actual, expectedColName) =>
             assert(actual.fieldNames().toSeq === Seq(expectedColName))
         }
-        clusteringColumns.zip(expectedTransforms).zipWithIndex.foreach {
-          case ((_, expectedTransform), idx) =>
+        clusterByTransform.entries.zip(expectedTransforms).foreach {
+          case (entry, expectedTransform) =>
             expectedTransform match {
               case None =>
-                assert(clusterByTransform.transforms.forall(_.columnIndex != idx),
-                  s"Expected no transform for column at index $idx")
+                assert(entry.isInstanceOf[IdentityTransform],
+                  s"Expected plain column but got: $entry")
               case Some(transform) =>
-                val actual = clusterByTransform.transforms.find(_.columnIndex == idx)
-                assert(actual.isDefined,
-                  s"Expected transform for column at index $idx")
-                assert(actual.get.function === transform.name(),
-                  s"Transform name mismatch for column at index $idx")
+                assert(entry.isInstanceOf[ApplyTransform],
+                  s"Expected ApplyTransform but got: $entry")
+                assert(entry.name() === transform.name(),
+                  s"Transform name mismatch: ${entry.name()} != ${transform.name()}")
             }
         }
       case None =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableClusterBySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableClusterBySuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.command.v2
 
 import org.apache.spark.sql.connector.catalog.{Identifier, InMemoryTable}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.CatalogHelper
-import org.apache.spark.sql.connector.expressions.{ClusterByTransform, FieldReference}
+import org.apache.spark.sql.connector.expressions.{ClusterByTransform, FieldReference, Transform}
 import org.apache.spark.sql.execution.command
 
 /**
@@ -36,6 +36,45 @@ class AlterTableClusterBySuite extends command.AlterTableClusterBySuiteBase
       .asInstanceOf[InMemoryTable]
     assert(partTable.partitioning ===
       Array(ClusterByTransform(clusteringColumns.map(FieldReference(_)))))
+  }
+
+  // The V2 in-memory test catalog does not apply ClusterBy changes via alterTable,
+  // so we cannot validate transforms after ALTER TABLE in this catalog.
+  override def validateClusterBy(
+      tableName: String,
+      clusteringColumns: Seq[String],
+      expectedTransforms: Seq[Option[Transform]]): Unit = {
+    val (catalog, namespace, table) = parseTableName(tableName)
+    val catalogPlugin = spark.sessionState.catalogManager.catalog(catalog)
+    val partTable = catalogPlugin.asTableCatalog
+      .loadTable(Identifier.of(Array(namespace), table))
+      .asInstanceOf[InMemoryTable]
+    partTable.partitioning.collectFirst { case c: ClusterByTransform => c } match {
+      case Some(clusterByTransform) =>
+        val actualColumnNames = clusterByTransform.columnNames
+        assert(actualColumnNames.length === clusteringColumns.length)
+        actualColumnNames.zip(clusteringColumns).foreach {
+          case (actual, expectedColName) =>
+            assert(actual.fieldNames().toSeq === Seq(expectedColName))
+        }
+        clusteringColumns.zip(expectedTransforms).zipWithIndex.foreach {
+          case ((_, expectedTransform), idx) =>
+            expectedTransform match {
+              case None =>
+                assert(clusterByTransform.transforms.forall(_.columnIndex != idx),
+                  s"Expected no transform for column at index $idx")
+              case Some(transform) =>
+                val actual = clusterByTransform.transforms.find(_.columnIndex == idx)
+                assert(actual.isDefined,
+                  s"Expected transform for column at index $idx")
+                assert(actual.get.function === transform.name(),
+                  s"Transform name mismatch for column at index $idx")
+            }
+        }
+      case None =>
+        // After ALTER TABLE CLUSTER BY, the in-memory V2 catalog may not have updated
+        // partitioning. Just verify the SQL executed without error.
+    }
   }
 
   test("test REPLACE TABLE with clustering columns") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CreateTableClusterBySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CreateTableClusterBySuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.command.v2
 
 import org.apache.spark.sql.connector.catalog.{Identifier, InMemoryPartitionTable}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.CatalogHelper
-import org.apache.spark.sql.connector.expressions.{ClusterByTransform, FieldReference}
+import org.apache.spark.sql.connector.expressions.{ClusterByTransform, FieldReference, Transform}
 import org.apache.spark.sql.execution.command
 
 /**
@@ -36,6 +36,40 @@ class CreateTableClusterBySuite extends command.CreateTableClusterBySuiteBase
       .asInstanceOf[InMemoryPartitionTable]
     assert(partTable.partitioning ===
       Array(ClusterByTransform(clusteringColumns.map(FieldReference(_)))))
+  }
+
+  override def validateClusterBy(
+      tableName: String,
+      clusteringColumns: Seq[String],
+      expectedTransforms: Seq[Option[Transform]]): Unit = {
+    val (catalog, namespace, table) = parseTableName(tableName)
+    val catalogPlugin = spark.sessionState.catalogManager.catalog(catalog)
+    val partTable = catalogPlugin.asTableCatalog
+      .loadTable(Identifier.of(Array(namespace), table))
+      .asInstanceOf[InMemoryPartitionTable]
+    val clusterByTransform = partTable.partitioning
+      .collectFirst { case c: ClusterByTransform => c }
+      .getOrElse(fail("No ClusterByTransform found in partitioning"))
+    val actualColumnNames = clusterByTransform.columnNames
+    assert(actualColumnNames.length === clusteringColumns.length)
+    actualColumnNames.zip(clusteringColumns).foreach {
+      case (actual, expectedColName) =>
+        assert(actual.fieldNames().toSeq === Seq(expectedColName))
+    }
+    clusteringColumns.zip(expectedTransforms).zipWithIndex.foreach {
+      case ((_, expectedTransform), idx) =>
+        expectedTransform match {
+          case None =>
+            assert(clusterByTransform.transforms.forall(_.columnIndex != idx),
+              s"Expected no transform for column at index $idx")
+          case Some(transform) =>
+            val actual = clusterByTransform.transforms.find(_.columnIndex == idx)
+            assert(actual.isDefined,
+              s"Expected transform for column at index $idx")
+            assert(actual.get.function === transform.name(),
+              s"Transform name mismatch for column at index $idx")
+        }
+    }
   }
 
   test("test REPLACE TABLE with clustering columns") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CreateTableClusterBySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CreateTableClusterBySuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.command.v2
 
 import org.apache.spark.sql.connector.catalog.{Identifier, InMemoryPartitionTable}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.CatalogHelper
-import org.apache.spark.sql.connector.expressions.{ClusterByTransform, FieldReference, Transform}
+import org.apache.spark.sql.connector.expressions.{ApplyTransform, ClusterByTransform, FieldReference, IdentityTransform, Transform}
 import org.apache.spark.sql.execution.command
 
 /**
@@ -35,7 +35,7 @@ class CreateTableClusterBySuite extends command.CreateTableClusterBySuiteBase
       .loadTable(Identifier.of(Array(namespace), table))
       .asInstanceOf[InMemoryPartitionTable]
     assert(partTable.partitioning ===
-      Array(ClusterByTransform(clusteringColumns.map(FieldReference(_)))))
+      Array(ClusterByTransform.ofColumns(clusteringColumns.map(FieldReference(_)))))
   }
 
   override def validateClusterBy(
@@ -56,18 +56,17 @@ class CreateTableClusterBySuite extends command.CreateTableClusterBySuiteBase
       case (actual, expectedColName) =>
         assert(actual.fieldNames().toSeq === Seq(expectedColName))
     }
-    clusteringColumns.zip(expectedTransforms).zipWithIndex.foreach {
-      case ((_, expectedTransform), idx) =>
+    clusterByTransform.entries.zip(expectedTransforms).foreach {
+      case (entry, expectedTransform) =>
         expectedTransform match {
           case None =>
-            assert(clusterByTransform.transforms.forall(_.columnIndex != idx),
-              s"Expected no transform for column at index $idx")
+            assert(entry.isInstanceOf[IdentityTransform],
+              s"Expected plain column but got: $entry")
           case Some(transform) =>
-            val actual = clusterByTransform.transforms.find(_.columnIndex == idx)
-            assert(actual.isDefined,
-              s"Expected transform for column at index $idx")
-            assert(actual.get.function === transform.name(),
-              s"Transform name mismatch for column at index $idx")
+            assert(entry.isInstanceOf[ApplyTransform],
+              s"Expected ApplyTransform but got: $entry")
+            assert(entry.name() === transform.name(),
+              s"Transform name mismatch: ${entry.name()} != ${transform.name()}")
         }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
@@ -346,7 +346,7 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
 
       val table = spark.sessionState.catalogManager.catalog("testcat").asTableCatalog
         .loadTable(Identifier.of(Array(), "cluster_test"))
-      assert(table.partitioning === Seq(ClusterByTransform(Seq(FieldReference("id")))))
+      assert(table.partitioning === Seq(ClusterByTransform.ofColumns(Seq(FieldReference("id")))))
     }
   }
 
@@ -359,7 +359,7 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
 
       val table = spark.sessionState.catalogManager.catalog("testcat").asTableCatalog
         .loadTable(Identifier.of(Array(), "cluster_test"))
-      assert(table.partitioning === Seq(ClusterByTransform(Seq(FieldReference("id")))))
+      assert(table.partitioning === Seq(ClusterByTransform.ofColumns(Seq(FieldReference("id")))))
     }
   }
 

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DatasetManager.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/DatasetManager.scala
@@ -265,7 +265,7 @@ object DatasetManager extends Logging {
     val mergedProperties = resolveTableProperties(table, identifier)
     val partitioning = table.partitionCols.toSeq.flatten.map(Expressions.identity)
     val clustering = table.clusterCols.map(cols =>
-      ClusterByTransform(cols.map(col => Expressions.column(col)))
+      ClusterByTransform.ofColumns(cols.map(col => Expressions.column(col)))
     ).toSeq
 
     // Validate that partition and cluster columns don't coexist

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
@@ -884,7 +884,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           .add("x3", StringType)
       )
     )
-    val expectedClusterTransform = ClusterByTransform(
+    val expectedClusterTransform = ClusterByTransform.ofColumns(
       Seq(FieldReference("x1"), FieldReference("x3")).toSeq
     )
     assert(table.partitioning().contains(expectedClusterTransform))
@@ -906,7 +906,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
     val identifier = Identifier.of(Array(TestGraphRegistrationContext.DEFAULT_DATABASE), "t10")
     val table = catalog.loadTable(identifier)
-    val expectedClusterTransform = ClusterByTransform(
+    val expectedClusterTransform = ClusterByTransform.ofColumns(
       Seq(FieldReference("x"), FieldReference("z")).toSeq
     )
     assert(table.partitioning().contains(expectedClusterTransform))
@@ -977,7 +977,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     assert(ex.cause.asInstanceOf[SparkThrowable].getCondition == "CANNOT_UPDATE_PARTITION_COLUMNS")
 
     val table = catalog.loadTable(identifier)
-    val expectedClusterTransform = ClusterByTransform(Seq(FieldReference("x")).toSeq)
+    val expectedClusterTransform = ClusterByTransform.ofColumns(Seq(FieldReference("x")).toSeq)
     assert(table.partitioning().contains(expectedClusterTransform))
   }
 
@@ -1012,7 +1012,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     )
 
     val transforms = table.partitioning()
-    val expectedClusterTransform = ClusterByTransform(
+    val expectedClusterTransform = ClusterByTransform.ofColumns(
       Seq(FieldReference("x1"), FieldReference("x3")).toSeq
     )
     assert(transforms.contains(expectedClusterTransform))
@@ -1041,7 +1041,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
           .add("x3", StringType)
       )
     )
-    val expectedClusterTransform = ClusterByTransform(
+    val expectedClusterTransform = ClusterByTransform.ofColumns(
       Seq(FieldReference("x1"), FieldReference("x2")).toSeq
     )
     assert(table.partitioning().contains(expectedClusterTransform))


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This change updates the parser grammar and the TableChange API to allow representing tables that have CLUSTER BY clauses on expressions (eg. `CLUSTER BY (variant_get(col, ...))` instead of just CLUSTER BY `(col)`.

The goal is to make this TableChange backward-compatible with connectors that only support clustering by raw columns, while allowing connectors to opt-into supporting some transforms if they are present.

### Why are the changes needed?

To support the use-case of being able to do eg. `ALTER TABLE ... CLUSTER BY (upper(col))`

### Does this PR introduce _any_ user-facing change?

Yes, this is a user-facing change - it adds new functionality but does not change any existing functionality.

### How was this patch tested?

Unit tests

### Was this patch authored or co-authored using generative AI tooling?

Used claude code with opus 4.6 to assist in this change, but most of it was manually written.