### PR TITLE
[SPARK-56415][INFRA][FOLLOWUP] Fix `ruff format` violations in `dev/` JIRA scripts

### DIFF
--- a/dev/create_jira_and_branch.py
+++ b/dev/create_jira_and_branch.py
@@ -95,9 +95,14 @@ def main():
     if not args.component:
         args.component = choose_components(asf_jira)
 
-    jira_id = create_jira_issue(asf_jira, args.title, args.component,
-                                parent=args.parent, issue_type=args.type,
-                                version=args.version)
+    jira_id = create_jira_issue(
+        asf_jira,
+        args.title,
+        args.component,
+        parent=args.parent,
+        issue_type=args.type,
+        version=args.version,
+    )
     print("Created JIRA issue: %s" % jira_id)
 
     create_and_checkout_branch(jira_id)

--- a/dev/create_spark_jira.py
+++ b/dev/create_spark_jira.py
@@ -61,8 +61,9 @@ def main():
         parser.error("-t/--type is required when not creating a subtask")
 
     asf_jira = get_jira_client()
-    jira_id = create_jira_issue(asf_jira, args.title, args.component,
-                                parent=args.parent, issue_type=args.type)
+    jira_id = create_jira_issue(
+        asf_jira, args.title, args.component, parent=args.parent, issue_type=args.type
+    )
     print(jira_id)
 
 

--- a/dev/spark_jira_utils.py
+++ b/dev/spark_jira_utils.py
@@ -44,9 +44,10 @@ def get_jira_client():
     if not JIRA_ACCESS_TOKEN:
         errors.append("JIRA_ACCESS_TOKEN env-var not set")
     if errors:
-        fail("Cannot create JIRA ticket automatically (%s). "
-             "Please create the ticket manually at %s"
-             % ("; ".join(errors), JIRA_API_BASE))
+        fail(
+            "Cannot create JIRA ticket automatically (%s). "
+            "Please create the ticket manually at %s" % ("; ".join(errors), JIRA_API_BASE)
+        )
     return jira.client.JIRA(
         {"server": JIRA_API_BASE}, token_auth=JIRA_ACCESS_TOKEN, timeout=(3.05, 30)
     )
@@ -58,14 +59,14 @@ def detect_affected_version(asf_jira):
     versions = [
         x
         for x in versions
-        if not x.raw["released"]
-        and not x.raw["archived"]
-        and re.match(r"\d+\.\d+\.\d+", x.name)
+        if not x.raw["released"] and not x.raw["archived"] and re.match(r"\d+\.\d+\.\d+", x.name)
     ]
     versions = sorted(versions, key=lambda x: x.name, reverse=True)
     if not versions:
-        fail("Cannot detect affected version. "
-             "Please create the ticket manually at %s" % JIRA_API_BASE)
+        fail(
+            "Cannot detect affected version. "
+            "Please create the ticket manually at %s" % JIRA_API_BASE
+        )
     return versions[0].name
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix `ruff format` violations in the following files:
- `dev/create_jira_and_branch.py`
- `dev/create_spark_jira.py`
- `dev/spark_jira_utils.py

### Why are the changes needed?
CI is failing due to `ruff format` check failures. These files have formatting that does not conform to the ruff formatter rules.
https://github.com/apache/spark/actions/runs/24378746909/job/71197744866

```
ruff format checks failed:
--- dev/create_jira_and_branch.py
+++ dev/create_jira_and_branch.py
@@ -95,9 +95,14 @@
     if not args.component:
         args.component = choose_components(asf_jira)
 
-    jira_id = create_jira_issue(asf_jira, args.title, args.component,
-                                parent=args.parent, issue_type=args.type,
-                                version=args.version)
+    jira_id = create_jira_issue(
+        asf_jira,
+        args.title,
+        args.component,
+        parent=args.parent,
+        issue_type=args.type,
+        version=args.version,
+    )
     print("Created JIRA issue: %s" % jira_id)
 
     create_and_checkout_branch(jira_id)

--- dev/create_spark_jira.py
+++ dev/create_spark_jira.py
@@ -61,8 +61,9 @@
         parser.error("-t/--type is required when not creating a subtask")
 
     asf_jira = get_jira_client()
-    jira_id = create_jira_issue(asf_jira, args.title, args.component,
-                                parent=args.parent, issue_type=args.type)
+    jira_id = create_jira_issue(
+        asf_jira, args.title, args.component, parent=args.parent, issue_type=args.type
+    )
     print(jira_id)
 
 

--- dev/spark_jira_utils.py
+++ dev/spark_jira_utils.py
@@ -44,9 +44,10 @@
     if not JIRA_ACCESS_TOKEN:
         errors.append("JIRA_ACCESS_TOKEN env-var not set")
     if errors:
-        fail("Cannot create JIRA ticket automatically (%s). "
-             "Please create the ticket manually at %s"
-             % ("; ".join(errors), JIRA_API_BASE))
+        fail(
+            "Cannot create JIRA ticket automatically (%s). "
+            "Please create the ticket manually at %s" % ("; ".join(errors), JIRA_API_BASE)
+        )
     return jira.client.JIRA(
         {"server": JIRA_API_BASE}, token_auth=JIRA_ACCESS_TOKEN, timeout=(3.05, 30)
     )
@@ -58,14 +59,14 @@
     versions = [
         x
         for x in versions
-        if not x.raw["released"]
-        and not x.raw["archived"]
-        and re.match(r"\d+\.\d+\.\d+", x.name)
+        if not x.raw["released"] and not x.raw["archived"] and re.match(r"\d+\.\d+\.\d+", x.name)
     ]
     versions = sorted(versions, key=lambda x: x.name, reverse=True)
     if not versions:
-        fail("Cannot detect affected version. "
-             "Please create the ticket manually at %s" % JIRA_API_BASE)
+        fail(
+            "Cannot detect affected version. "
+            "Please create the ticket manually at %s" % JIRA_API_BASE
+        )
     return versions[0].name
```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Opus 4.6
