### PR TITLE
[SPARK-56153][SQL][TESTS][FOLLOWUP] Remove unnecessary asInstanceOf[classic.Dataset] casts in QueryTest

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -205,7 +205,7 @@ trait QueryTestBase extends PlanTestBase with SparkSessionProvider { self: Suite
    */
   def assertCached(query: Dataset[_], numCachedTables: Int = 1): Unit = {
     val planWithCaching =
-      query.asInstanceOf[classic.Dataset[_]].queryExecution.withCachedData
+      query.queryExecution.withCachedData
     val cachedData = planWithCaching collect {
       case cached: InMemoryRelation => cached
     }
@@ -222,7 +222,7 @@ trait QueryTestBase extends PlanTestBase with SparkSessionProvider { self: Suite
    */
   def assertCached(query: Dataset[_], cachedName: String, storageLevel: StorageLevel): Unit = {
     val planWithCaching =
-      query.asInstanceOf[classic.Dataset[_]].queryExecution.withCachedData
+      query.queryExecution.withCachedData
     val matched = planWithCaching.exists {
       case cached: InMemoryRelation =>
         val cacheBuilder = cached.cacheBuilder
@@ -242,7 +242,7 @@ trait QueryTestBase extends PlanTestBase with SparkSessionProvider { self: Suite
    * Asserts that a given [[Dataset]] does not have missing inputs in all the analyzed plans.
    */
   def assertEmptyMissingInput(query: Dataset[_]): Unit = {
-    val qe = query.asInstanceOf[classic.Dataset[_]].queryExecution
+    val qe = query.queryExecution
     assert(qe.analyzed.missingInput.isEmpty,
       s"The analyzed logical plan has missing inputs:\n${qe.analyzed}")
     assert(qe.optimizedPlan.missingInput.isEmpty,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove three unnecessary `asInstanceOf[classic.Dataset[_]]` casts in `QueryTest.scala` (`assertCached` and `assertEmptyMissingInput` methods). The api-level `Dataset` already declares `queryExecution` (with `@ClassicOnly` annotation, which is purely documentation), so the casts are redundant.

### Why are the changes needed?

The casts are unnecessary because:
1. The api-level `Dataset` already declares `def queryExecution: QueryExecution` — calling it directly works without casting to `classic.Dataset`.
2. The same file already calls `ds.queryExecution` directly without a cast on line 126 (`getResult` method), confirming this is safe.
3. The `@ClassicOnly` annotation is a runtime documentation annotation with no compile-time effect.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests (unable to compile locally due to missing `lz4-java:1.11.0` dependency in environment).

### Was this patch authored or co-authored using generative AI tooling?

Co-authored-by: Claude code (Opus 4.6)