### PR TITLE
[SPARK-56472][SQL] Fix MERGE schema evolution with WHEN MATCHED THEN DELETE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1061,6 +1061,7 @@ case class MergeIntoTable(
     actions.forall {
       case a: UpdateAction => MergeIntoTable.areSchemaEvolutionReady(a.assignments, sourceTable)
       case a: InsertAction => MergeIntoTable.areSchemaEvolutionReady(a.assignments, sourceTable)
+      case _: DeleteAction => true
       case _ => false
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoSchemaEvolutionBasicTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoSchemaEvolutionBasicTests.scala
@@ -1245,4 +1245,16 @@ trait MergeIntoSchemaEvolutionBasicTests extends MergeIntoSchemaEvolutionSuiteBa
     expectErrorWithoutEvolutionContains = "A column, variable, or function parameter with name " +
       "`bonus` cannot be resolved"
   )
+
+  testEvolution("source has extra column with delete action")(
+    targetData = Seq((1, "hr"), (2, "software")).toDF("pk", "dep"),
+    sourceData = Seq((2, "dummy", 200), (3, "dummy", 300)).toDF("pk", "dep", "salary"),
+    clauses = Seq(delete(), insertAll()),
+    expected = Seq[(Int, String, java.lang.Integer)](
+      (1, "hr", null),
+      (3, "dummy", 300)).toDF("pk", "dep", "salary"),
+    expectedWithoutEvolution = Seq(
+      (1, "hr"),
+      (3, "dummy")).toDF("pk", "dep")
+  )
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoSchemaEvolutionBasicTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoSchemaEvolutionBasicTests.scala
@@ -1257,4 +1257,12 @@ trait MergeIntoSchemaEvolutionBasicTests extends MergeIntoSchemaEvolutionSuiteBa
       (1, "hr"),
       (3, "dummy")).toDF("pk", "dep")
   )
+
+  testEvolution("delete-only action does not trigger schema evolution")(
+    targetData = Seq((1, "hr"), (2, "software")).toDF("pk", "dep"),
+    sourceData = Seq((2, "dummy", 200)).toDF("pk", "dep", "salary"),
+    clauses = Seq(delete()),
+    expected = Seq((1, "hr")).toDF("pk", "dep"),
+    expectedWithoutEvolution = Seq((1, "hr")).toDF("pk", "dep")
+  )
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fixes a bug in MERGE INTO schema evolution so that MERGE statements that contain a DELETE clause correctly trigger schema evolution:
```
MERGE INTO target
USING source
ON target.id = source.id
WHEN MATCHED THEN DELETE
WHEN NOT MATCHED THEN INSERT SET *; 
```

Currently, `schemaEvolutionReady` always return `false` when there is a DELETE clause.

### How was this patch tested?
Added a test, confirmed that the test fails without this fix.