### PR TITLE
[SPARK-56476][SS] Fix invalid stamp error when upgrading read store to write store

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -97,6 +97,13 @@ private[sql] class RocksDBStateStoreProvider
       (RELEASED, METRICS) -> RELEASED
     )
 
+    /**
+     * Returns the [[RocksDBStateStoreProvider]] that created this store instance.
+     * Keeping private within state and shouldn't be exposed outside.
+     */
+    private[state] def creatingProvider: RocksDBStateStoreProvider =
+      RocksDBStateStoreProvider.this
+
     override def id: StateStoreId = RocksDBStateStoreProvider.this.stateStoreId
 
     override def version: Long = lastVersion
@@ -938,10 +945,27 @@ private[sql] class RocksDBStateStoreProvider
       " the same stateStoreId")
     assert(readStore.isInstanceOf[RocksDBStateStore], "Can only upgrade state store if it is a " +
       "RocksDBStateStore")
+
+    val rocksDBReadStore = readStore.asInstanceOf[RocksDBStateStore]
+    // SPARK-56476: If the provider that created the read store is a different object than this
+    // provider, another thread removed the original provider from loadedProviders between the
+    // read and write phases (e.g. maintenance or task unload). This provider's state machine
+    // never issued the read store's stamp, so calling loadStateStore here would fail with
+    // StateStoreInvalidStamp. Delegate to the original provider instead.
+    // It is safe to call the original provider because we still have a read stamp on it.
+    if (rocksDBReadStore.creatingProvider ne this) {
+      logWarning(log"Provider " +
+        log"id=${MDC(LogKeys.STATE_STORE_PROVIDER_ID, this.stateStoreProviderId)} " +
+        log"was replaced between read and write phases. Delegating upgradeReadStoreToWriteStore " +
+        log"to the original provider to avoid StateStoreInvalidStamp error.")
+      return rocksDBReadStore.creatingProvider.upgradeReadStoreToWriteStore(
+        readStore, version, uniqueId, forceSnapshotOnCommit)
+    }
+
     loadStateStore(version,
       uniqueId,
       readOnly = false,
-      existingStore = Some(readStore.asInstanceOf[RocksDBStateStore]),
+      existingStore = Some(rocksDBReadStore),
       forceSnapshotOnCommit = forceSnapshotOnCommit)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -2474,6 +2474,62 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     }
   }
 
+  test("SPARK-56476: RocksDBStateStore.creatingProvider tracks the originating provider") {
+    // Verify that a RocksDBStateStore correctly tracks which provider created it.
+    val storeId = StateStoreId(newDir(), 0L, 1)
+
+    tryWithProviderResource(newStoreProvider(storeId)) { provider1 =>
+      val store = provider1.getStore(0)
+      put(store, "a", 0, 1)
+      store.commit()
+
+      val readStore = provider1.getReadStore(1)
+        .asInstanceOf[provider1.RocksDBStateStore]
+      assert(readStore.creatingProvider eq provider1,
+        "creatingProvider should be the provider that created the store")
+
+      tryWithProviderResource(newStoreProvider(storeId)) { provider2 =>
+        assert(readStore.creatingProvider ne provider2,
+          "creatingProvider should NOT match a different provider instance")
+      }
+      readStore.abort()
+    }
+  }
+
+  test("SPARK-56476: upgradeReadStoreToWriteStore delegates to original provider " +
+    "when called on a different provider") {
+    // This test verifies the fix: when upgradeReadStoreToWriteStore detects that the read
+    // store was created by a different provider, it delegates to that provider so the
+    // upgrade succeeds instead of failing with StateStoreInvalidStamp.
+    val storeId = StateStoreId(newDir(), 0L, 1)
+
+    tryWithProviderResource(newStoreProvider(storeId)) { provider1 =>
+      // Write version 0
+      val store = provider1.getStore(0)
+      put(store, "a", 0, 1)
+      store.commit()
+
+      // Get a read store from provider1
+      val readStore = provider1.getReadStore(1)
+
+      // Create a brand-new provider (simulating eviction from loadedProviders)
+      tryWithProviderResource(newStoreProvider(storeId)) { provider2 =>
+        // Without the fix, this would fail with StateStoreInvalidStamp because provider2's
+        // state machine never issued provider1's read store stamp. With the fix, provider2
+        // detects the mismatch and delegates to provider1.
+        val writeStore = provider2.upgradeReadStoreToWriteStore(readStore, 1, None)
+        assert(get(writeStore, "a", 0) === Some(1))
+        put(writeStore, "a", 0, 2)
+        writeStore.commit()
+
+        // Verify the committed data via provider2
+        val verifyStore = provider2.getStore(2)
+        assert(get(verifyStore, "a", 0) === Some(2))
+        verifyStore.abort()
+      }
+    }
+  }
+
   test("verify operation validation before and after commit") {
     tryWithProviderResource(newStoreProvider(useColumnFamilies = false)) { provider =>
       val store = provider.getStore(0)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When a task does two separate provider lookups from loadedProviders. The read phase gets provider P1 and acquires a stamp. The write phase looks up the provider again. Between the two lookups, another thread can remove P1 from loadedProviders.

This happens when maintenance detects P1 as inactive via verifyIfStoreInstanceActive, or when another task's getStateStoreProvider receives providerIdsToUnload from the coordinator. The write phase then creates a new provider P2 via getOrElseUpdate. P2's state machine never issued P1's stamp, so upgradeReadStoreToWriteStore fails with StateStoreInvalidStamp.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix running into StateStoreInvalidStamp error in some situations for streaming aggregation queries

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Claude-4.5-opus