### PR TITLE
[SPARK-56478][INFRA] Remove hamcrest-core-1.3 in the Maven local as a workaround

### DIFF
--- a/dev/create-release/do-release.sh
+++ b/dev/create-release/do-release.sh
@@ -39,6 +39,10 @@ if [ "$RUNNING_IN_DOCKER" = "1" ]; then
     # JAVA_HOME for the openjdk package.
     export JAVA_HOME=/usr
   fi
+
+  # If ~/.m2 has metadata for hamcrest-core:1.3 but no JAR, Coursier can fail with
+  # "file:.../hamcrest-core-1.3.jar: not found". Drop that tree so artifacts re-resolve.
+  rm -rf "${HOME}/.m2/repository/org/hamcrest/hamcrest-core/1.3"
 else
   # Outside docker, need to ask for information about the release.
   get_release_info


### PR DESCRIPTION
### What changes were proposed in this pull request?

```
2026-04-14T08:46:53.3531932Z [error] lmcoursier.internal.shaded.coursier.error.FetchError$DownloadingArtifacts: Error fetching artifacts:
2026-04-14T08:46:53.3534209Z [error] file:/home/spark-rm/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar: not found: /home/spark-rm/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
2026-04-14T08:46:53.3535596Z [error] 
2026-04-14T08:46:53.3536344Z [error] 	at lmcoursier.internal.shaded.coursier.Artifacts$.$anonfun$fetchArtifacts$9(Artifacts.scala:365)
2026-04-14T08:46:53.3537596Z [error] 	at lmcoursier.internal.shaded.coursier.util.Task$.$anonfun$flatMap$extension$1(Task.scala:14)
2026-04-14T08:46:53.3538273Z [error] 	at lmcoursier.internal.shaded.coursier.util.Task$.$anonfun$flatMap$extension$1$adapted(Task.scala:14)
2026-04-14T08:46:53.3538879Z [error] 	at lmcoursier.internal.shaded.coursier.util.Task$.wrap(Task.scala:82)
2026-04-14T08:46:53.3539410Z [error] 	at lmcoursier.internal.shaded.coursier.util.Task$.$anonfun$flatMap$2(Task.scala:14)
2026-04-14T08:46:53.3540004Z [error] 	at scala.concurrent.Future.$anonfun$flatMap$1(Future.scala:307)
2026-04-14T08:46:53.3540473Z [error] 	at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:51)
2026-04-14T08:46:53.3540953Z [error] 	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:74)
2026-04-14T08:46:53.3541703Z [error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
2026-04-14T08:46:53.3542437Z [error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
2026-04-14T08:46:53.3542940Z [error] 	at java.base/java.lang.Thread.run(Thread.java:840)
2026-04-14T08:46:53.3543700Z [error] Caused by: lmcoursier.internal.shaded.coursier.cache.ArtifactError$NotFound: not found: /home/spark-rm/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
2026-04-14T08:46:53.3544671Z [error] 	at lmcoursier.internal.shaded.coursier.cache.internal.Downloader.$anonfun$checkFileExists$1(Downloader.scala:603)
2026-04-14T08:46:53.3545283Z [error] 	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:659)
2026-04-14T08:46:53.3545696Z [error] 	at scala.util.Success.$anonfun$map$1(Try.scala:255)
2026-04-14T08:46:53.3546032Z [error] 	at scala.util.Success.map(Try.scala:213)
2026-04-14T08:46:53.3546392Z [error] 	at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
2026-04-14T08:46:53.3546823Z [error] 	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:42)
2026-04-14T08:46:53.3547466Z [error] 	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:74)
2026-04-14T08:46:53.3548012Z [error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
2026-04-14T08:46:53.3548651Z [error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
2026-04-14T08:46:53.3549144Z [error] 	at java.base/java.lang.Thread.run(Thread.java:840)
2026-04-14T08:46:53.3567138Z [error] (sql / update) lmcoursier.internal.shaded.coursier.error.FetchError$DownloadingArtifacts: Error fetching artifacts:
2026-04-14T08:46:53.3568445Z [error] file:/home/spark-rm/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar: not found: /home/spark-rm/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
2026-04-14T08:46:53.3590365Z [error] Total time: 256 s (0:04:16.0), completed Apr 14, 2026, 8:46:53 AM
```

To workaround this issue.

See https://github.com/apache/spark/actions/runs/24387081622/job/71223408545.

### Why are the changes needed?

To recover the release build.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Will monitor the build.

### Was this patch authored or co-authored using generative AI tooling?

No.