### PR TITLE
[MINOR][INFRA] Fix bash newline strip for precondition output in build_and_test workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -165,7 +165,7 @@ jobs:
             }"
           echo $precondition # For debugging
           # Remove `\n` to avoid "Invalid format" error
-          precondition="${precondition//$'\n'/}}"
+          precondition="${precondition//$'\n'/}"
           echo "required=$precondition" >> $GITHUB_OUTPUT
         else
           # This is usually set by scheduled jobs.


### PR DESCRIPTION
What changes were proposed in this pull request?
Correct the precondition step in `.github/workflows/build_and_test.yml` so newline stripping uses `${precondition//$'\n'/}` (same as the inputs.jobs branch), instead of an extra `}` that could corrupt the JSON written to `GITHUB_OUTPUT`.

Why are the changes needed?
So the required output stays valid JSON for fromJson(...) when jobs are inferred from repo changes (empty inputs.jobs).

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.