### PR TITLE
[SPARK-56483][SQL][TESTS] Use abstract SparkSession/DataFrame in SQLTestUtilsBase

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2321,7 +2321,7 @@ abstract class Dataset[T] extends Serializable {
   def withColumnsRenamed(colsMap: util.Map[String, String]): DataFrame =
     withColumnsRenamed(colsMap.asScala.toMap)
 
-  protected[sql] def withColumnsRenamed(colNames: Seq[String], newColNames: Seq[String]): DataFrame
+  protected[spark] def withColumnsRenamed(colNames: Seq[String], newColNames: Seq[String]): DataFrame
 
   /**
    * Returns a new Dataset by updating an existing column with metadata.

--- a/sql/api/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2321,7 +2321,7 @@ abstract class Dataset[T] extends Serializable {
   def withColumnsRenamed(colsMap: util.Map[String, String]): DataFrame =
     withColumnsRenamed(colsMap.asScala.toMap)
 
-  protected def withColumnsRenamed(colNames: Seq[String], newColNames: Seq[String]): DataFrame
+  protected[sql] def withColumnsRenamed(colNames: Seq[String], newColNames: Seq[String]): DataFrame
 
   /**
    * Returns a new Dataset by updating an existing column with metadata.

--- a/sql/api/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2322,7 +2322,8 @@ abstract class Dataset[T] extends Serializable {
     withColumnsRenamed(colsMap.asScala.toMap)
 
   protected[spark] def withColumnsRenamed(
-      colNames: Seq[String], newColNames: Seq[String]): DataFrame
+      colNames: Seq[String],
+      newColNames: Seq[String]): DataFrame
 
   /**
    * Returns a new Dataset by updating an existing column with metadata.

--- a/sql/api/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2321,7 +2321,8 @@ abstract class Dataset[T] extends Serializable {
   def withColumnsRenamed(colsMap: util.Map[String, String]): DataFrame =
     withColumnsRenamed(colsMap.asScala.toMap)
 
-  protected[spark] def withColumnsRenamed(colNames: Seq[String], newColNames: Seq[String]): DataFrame
+  protected[spark] def withColumnsRenamed(
+      colNames: Seq[String], newColNames: Seq[String]): DataFrame
 
   /**
    * Returns a new Dataset by updating an existing column with metadata.

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/Dataset.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/Dataset.scala
@@ -778,7 +778,7 @@ class Dataset[T] private[sql] (
     }
   }
 
-  override protected[sql] def withColumnsRenamed(
+  override protected[spark] def withColumnsRenamed(
       colNames: Seq[String],
       newColNames: Seq[String]): DataFrame = {
     require(

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/Dataset.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/Dataset.scala
@@ -778,7 +778,7 @@ class Dataset[T] private[sql] (
     }
   }
 
-  override protected def withColumnsRenamed(
+  override protected[sql] def withColumnsRenamed(
       colNames: Seq[String],
       newColNames: Seq[String]): DataFrame = {
     require(

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
@@ -1306,7 +1306,7 @@ class Dataset[T] private[sql](
     }
   }
 
-  protected[spark] def withColumnsRenamed(
+  override protected[spark] def withColumnsRenamed(
       colNames: Seq[String],
       newColNames: Seq[String]): DataFrame = {
     require(colNames.size == newColNames.size,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -466,7 +466,7 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
   /**
    * Optionally returns cached data for the given [[Dataset]]
    */
-  def lookupCachedData(query: org.apache.spark.sql.Dataset[_]): Option[CachedData] = {
+  def lookupCachedData(query: Dataset[_]): Option[CachedData] = {
     lookupCachedDataInternal(query.queryExecution.normalized)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -466,7 +466,7 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
   /**
    * Optionally returns cached data for the given [[Dataset]]
    */
-  def lookupCachedData(query: Dataset[_]): Option[CachedData] = {
+  def lookupCachedData(query: org.apache.spark.sql.Dataset[_]): Option[CachedData] = {
     lookupCachedDataInternal(query.queryExecution.normalized)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -106,7 +106,7 @@ class CachedTableSuite extends QueryTest
     maybeBlock.nonEmpty && isExpectLevel
   }
 
-  private def getNumInMemoryRelations(ds: classic.Dataset[_]): Int = {
+  private def getNumInMemoryRelations(ds: Dataset[_]): Int = {
     val plan = ds.queryExecution.withCachedData
     var sum = plan.collect { case _: InMemoryRelation => 1 }.sum
     plan.transformAllExpressions {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsDataframeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsDataframeSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 class ReplaceIntegerLiteralsWithOrdinalsDataframeSuite extends QueryTest with SharedSparkSession {
+  import testImplicits._
 
   test("Group by ordinal - Dataframe") {
     val query = "SELECT * FROM VALUES(1,2),(1,3),(2,4)"

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationExpressionWalkerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationExpressionWalkerSuite.scala
@@ -35,6 +35,7 @@ import org.apache.spark.util.Utils
  *  collations
  */
 class CollationExpressionWalkerSuite extends SparkFunSuite with SharedSparkSession {
+  import testImplicits._
 
   // Trait to distinguish different cases for generation
   sealed trait CollationType

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
@@ -32,6 +32,7 @@ import org.apache.spark.storage.StorageLevel
  *       `org.apache.spark.sql.hive.execution.command.AlterTableRenameSuite`
  */
 trait AlterTableRenameSuiteBase extends QueryTest with DDLCommandTestUtils {
+  import testImplicits._
   override val command = "ALTER TABLE .. RENAME"
 
   test("rename a table in a database/namespace") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2234,7 +2234,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
     // TODO(SPARK-50244): ADD JAR is inside `sql()` thus isolated. This will break an existing Hive
     //  use case (one session adds JARs and another session uses them). After we sort out the Hive
     //  isolation issue we will decide if the next assert should be wrapped inside `withResources`.
-    spark.artifactManager.withResources {
+    spark.sessionState.artifactManager.withResources {
       assert(new File(SparkFiles.get(s"${directoryToAdd.getName}/${testFile.getName}")).exists())
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DropTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DropTableSuiteBase.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
  *     - V1 Hive External catalog: `org.apache.spark.sql.hive.execution.command.DropTableSuite`
  */
 trait DropTableSuiteBase extends QueryTest with DDLCommandTestUtils {
+  import testImplicits._
   override val command = "DROP TABLE"
 
   protected def createTable(tableName: String): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -22,7 +22,7 @@ import java.io.File
 import org.scalactic.Equality
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{classic, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.SchemaPruningTest
 import org.apache.spark.sql.catalyst.expressions.Concat
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
@@ -601,7 +601,7 @@ abstract class SchemaPruningSuite
           Concat(Seq($"name.last", $"name.first")))
       ),
       Seq($"a".string, $"b".string),
-      sql("select * from contacts").asInstanceOf[org.apache.spark.sql.classic.DataFrame].logicalPlan
+      sql("select * from contacts").asInstanceOf[classic.DataFrame].logicalPlan
     ).toDF()
     checkScan(query1, "struct<name:struct<first:string,last:string>>")
     checkAnswer(query1,
@@ -618,7 +618,7 @@ abstract class SchemaPruningSuite
     val query2 = Expand(
       Seq(Seq($"name", $"name.last")),
       Seq($"a".struct(name), $"b".string),
-      sql("select * from contacts").asInstanceOf[org.apache.spark.sql.classic.DataFrame].logicalPlan
+      sql("select * from contacts").asInstanceOf[classic.DataFrame].logicalPlan
     ).toDF()
     checkScan(query2, "struct<name:struct<first:string,middle:string,last:string>>")
     checkAnswer(query2,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -601,7 +601,7 @@ abstract class SchemaPruningSuite
           Concat(Seq($"name.last", $"name.first")))
       ),
       Seq($"a".string, $"b".string),
-      sql("select * from contacts").queryExecution.logical
+      sql("select * from contacts").asInstanceOf[org.apache.spark.sql.classic.DataFrame].logicalPlan
     ).toDF()
     checkScan(query1, "struct<name:struct<first:string,last:string>>")
     checkAnswer(query1,
@@ -618,7 +618,7 @@ abstract class SchemaPruningSuite
     val query2 = Expand(
       Seq(Seq($"name", $"name.last")),
       Seq($"a".struct(name), $"b".string),
-      sql("select * from contacts").queryExecution.logical
+      sql("select * from contacts").asInstanceOf[org.apache.spark.sql.classic.DataFrame].logicalPlan
     ).toDF()
     checkScan(query2, "struct<name:struct<first:string,middle:string,last:string>>")
     checkAnswer(query2,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -22,7 +22,7 @@ import java.io.File
 import org.scalactic.Equality
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{classic, DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.SchemaPruningTest
 import org.apache.spark.sql.catalyst.expressions.Concat
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
@@ -593,6 +593,7 @@ abstract class SchemaPruningSuite
 
   testSchemaPruning("select nested field in Expand") {
     import org.apache.spark.sql.catalyst.dsl.expressions._
+    import testImplicits.castToImpl
 
     val query1 = Expand(
       Seq(
@@ -601,7 +602,7 @@ abstract class SchemaPruningSuite
           Concat(Seq($"name.last", $"name.first")))
       ),
       Seq($"a".string, $"b".string),
-      sql("select * from contacts").asInstanceOf[classic.DataFrame].logicalPlan
+      sql("select * from contacts").logicalPlan
     ).toDF()
     checkScan(query1, "struct<name:struct<first:string,last:string>>")
     checkAnswer(query1,
@@ -618,7 +619,7 @@ abstract class SchemaPruningSuite
     val query2 = Expand(
       Seq(Seq($"name", $"name.last")),
       Seq($"a".struct(name), $"b".string),
-      sql("select * from contacts").asInstanceOf[classic.DataFrame].logicalPlan
+      sql("select * from contacts").logicalPlan
     ).toDF()
     checkScan(query2, "struct<name:struct<first:string,middle:string,last:string>>")
     checkAnswer(query2,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -601,7 +601,7 @@ abstract class SchemaPruningSuite
           Concat(Seq($"name.last", $"name.first")))
       ),
       Seq($"a".string, $"b".string),
-      sql("select * from contacts").logicalPlan
+      sql("select * from contacts").queryExecution.logical
     ).toDF()
     checkScan(query1, "struct<name:struct<first:string,last:string>>")
     checkAnswer(query1,
@@ -618,7 +618,7 @@ abstract class SchemaPruningSuite
     val query2 = Expand(
       Seq(Seq($"name", $"name.last")),
       Seq($"a".struct(name), $"b".string),
-      sql("select * from contacts").logicalPlan
+      sql("select * from contacts").queryExecution.logical
     ).toDF()
     checkScan(query2, "struct<name:struct<first:string,middle:string,last:string>>")
     checkAnswer(query2,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -43,7 +43,6 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.optimizer.InferFiltersFromConstraints
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
-import org.apache.spark.sql.classic.ClassicConversions._
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.parseColumnPath
 import org.apache.spark.sql.execution.ExplainMode
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, HadoopFsRelation, LogicalRelationWithTable, PushableColumnAndNestedColumn}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/OuterJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/OuterJoinSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.test.{SharedSparkSession, SQLTestData}
 import org.apache.spark.sql.types.{DoubleType, IntegerType, StructType}
 
 class OuterJoinSuite extends SparkPlanTest with SharedSparkSession with SQLTestData {
-  import testImplicits.toRichColumn
+  import testImplicits._
   setupTestData()
 
   private val EnsureRequirements = new EnsureRequirements()

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -449,13 +449,13 @@ private[sql] trait SQLTestUtilsBase
    * Strip Spark-side filtering in order to check if a datasource filters rows correctly.
    */
   protected def stripSparkFilter(df: DataFrame): DataFrame = {
-    val classicSpark = spark.asInstanceOf[classic.SparkSession]
     val schema = df.schema
     val withoutFilters = df.queryExecution.executedPlan.transform {
       case FilterExec(_, child) => child
     }
 
-    classicSpark.internalCreateDataFrame(withoutFilters.execute(), schema)
+    spark.asInstanceOf[classic.SparkSession]
+      .internalCreateDataFrame(withoutFilters.execute(), schema)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -33,7 +33,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite, Tag}
 import org.scalatest.concurrent.Eventually
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.{classic, AnalysisException, Row}
+import org.apache.spark.sql.{classic, AnalysisException, DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog.DEFAULT_DATABASE
@@ -41,7 +41,6 @@ import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.PlanTestBase
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util._
-import org.apache.spark.sql.classic.{ClassicConversions, ColumnConversions, ColumnNodeToExpressionConverter, DataFrame, Dataset, SparkSession, SQLImplicits}
 import org.apache.spark.sql.execution.FilterExec
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecution
 import org.apache.spark.sql.execution.datasources.DataSourceUtils
@@ -228,8 +227,6 @@ private[sql] trait SQLTestUtilsBase
   with SQLTestData
   with PlanTestBase { self: Suite =>
 
-  override protected def spark: classic.SparkSession
-
   protected def sparkContext = spark.sparkContext
 
   // Shorthand for running a query using our SparkSession
@@ -243,11 +240,13 @@ private[sql] trait SQLTestUtilsBase
    * but the implicits import is needed in the constructor.
    */
   protected object testImplicits
-    extends SQLImplicits
-      with ClassicConversions
-      with ColumnConversions {
-    override protected def session: SparkSession = self.spark
-    override protected def converter: ColumnNodeToExpressionConverter = self.spark.converter
+    extends classic.SQLImplicits
+      with classic.ClassicConversions
+      with classic.ColumnConversions {
+    override protected def session: classic.SparkSession =
+      self.spark.asInstanceOf[classic.SparkSession]
+    override protected def converter: classic.ColumnNodeToExpressionConverter =
+      self.spark.asInstanceOf[classic.SparkSession].converter
   }
 
   protected override def withSQLConf[T](pairs: (String, String)*)(f: => T): T = {
@@ -346,7 +345,7 @@ private[sql] trait SQLTestUtilsBase
     val tableIdent = spark.sessionState.sqlParser.parseTableIdentifier(tableName)
     val cascade = !spark.sessionState.catalog.isTempView(tableIdent)
     spark.sharedState.cacheManager.uncacheQuery(
-      spark.table(tableName),
+      spark.table(tableName).asInstanceOf[classic.Dataset[_]],
       cascade = cascade,
       blocking = true)
   }
@@ -450,20 +449,21 @@ private[sql] trait SQLTestUtilsBase
    * Strip Spark-side filtering in order to check if a datasource filters rows correctly.
    */
   protected def stripSparkFilter(df: DataFrame): DataFrame = {
+    val classicSpark = spark.asInstanceOf[classic.SparkSession]
     val schema = df.schema
     val withoutFilters = df.queryExecution.executedPlan.transform {
       case FilterExec(_, child) => child
     }
 
-    spark.internalCreateDataFrame(withoutFilters.execute(), schema)
+    classicSpark.internalCreateDataFrame(withoutFilters.execute(), schema)
   }
 
   /**
    * Turn a logical plan into a `DataFrame`. This should be removed once we have an easier
    * way to construct `DataFrame` directly out of local data without relying on implicits.
    */
-  protected implicit def logicalPlanToSparkQuery(plan: LogicalPlan): DataFrame = {
-    Dataset.ofRows(spark, plan)
+  protected implicit def logicalPlanToSparkQuery(plan: LogicalPlan): classic.DataFrame = {
+    classic.Dataset.ofRows(spark.asInstanceOf[classic.SparkSession], plan)
   }
 
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -48,7 +48,7 @@ case class TestData(a: Int, b: String)
  */
 @SlowHiveTest
 class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAndAfter {
-  import org.apache.spark.sql.hive.test.TestHive.sparkSession.implicits._
+  import testImplicits._
 
   private val originalCrossJoinEnabled = TestHive.conf.crossJoinEnabled
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -62,7 +62,6 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
   import testImplicits.castToImpl
 
   import spark.udf
-  import spark.implicits._
 
   test("spark sql udf test that returns a struct") {
     udf.register("getStruct", (_: Int) => Fields(1, 2, 3, 4, 5))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -58,6 +58,8 @@ case class ListStringCaseClass(l: Seq[String])
  */
 @SlowHiveTest
 class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
+  import spark.implicits._
+  import testImplicits.castToImpl
 
   import spark.udf
   import spark.implicits._

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
@@ -588,7 +588,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
       s"Complete tables should not evolve schema - isFullRefresh = $isFullRefresh"
     ) {
       val session = spark
-  
 
       val rawGraph =
         new TestGraphRegistrationContext(spark) {
@@ -647,7 +646,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     ) {
       val session = spark
       implicit val sqlCtx: SQLContext = spark.sqlContext
-  
 
       val streamInts = MemoryStream[Int]
       streamInts.addData(1 until 5: _*)

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
@@ -40,8 +40,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   import testImplicits._
 
   test("basic") {
-    val session = spark
-
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -125,8 +123,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("multiple") {
-    val session = spark
-
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -163,8 +159,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("temporary views don't get materialized") {
-    val session = spark
-
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -240,8 +234,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("schema matches existing table schema") {
-    val session = spark
-
 
     sql(s"CREATE TABLE ${TestGraphRegistrationContext.DEFAULT_DATABASE}.t2(x INT)")
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
@@ -269,9 +261,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("invalid schema merge") {
-    val session = spark
     implicit val sqlCtx: SQLContext = spark.sqlContext
-
 
     val streamInts = MemoryStream[Int]
     streamInts.addData(1, 2)
@@ -300,8 +290,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("table materialized with specified schema, even if different from inferred") {
-    val session = spark
-
 
     sql(s"CREATE TABLE ${TestGraphRegistrationContext.DEFAULT_DATABASE}.t4(x INT)")
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
@@ -339,8 +327,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("specified schema incompatible with existing table") {
-    val session = spark
-
 
     sql(s"CREATE TABLE ${TestGraphRegistrationContext.DEFAULT_DATABASE}.t6(x BOOLEAN)")
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
@@ -385,8 +371,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("partition columns with user schema") {
-    val session = spark
-
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -415,8 +399,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("specifying partition column with existing partitioned table") {
-    val session = spark
-
 
     sql(
       s"CREATE TABLE ${TestGraphRegistrationContext.DEFAULT_DATABASE}.t7(x BOOLEAN, y INT) " +
@@ -482,8 +464,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("specifying partition column different from existing partitioned table") {
-    val session = spark
-
 
     sql(
       s"CREATE TABLE ${TestGraphRegistrationContext.DEFAULT_DATABASE}.t8(x BOOLEAN, y INT) " +
@@ -547,8 +527,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("Invalid table properties error during table materialization") {
-    val session = spark
-
 
     // Invalid pipelines property
     val graph1 =
@@ -587,8 +565,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     test(
       s"Complete tables should not evolve schema - isFullRefresh = $isFullRefresh"
     ) {
-      val session = spark
-
       val rawGraph =
         new TestGraphRegistrationContext(spark) {
           registerView("a", query = dfFlowFunc(Seq((1, 2), (2, 3)).toDF("x", "y")))
@@ -644,7 +620,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     test(
       s"Streaming tables should evolve schema only if not full refresh = $isFullRefresh"
     ) {
-      val session = spark
       implicit val sqlCtx: SQLContext = spark.sqlContext
 
       val streamInts = MemoryStream[Int]
@@ -712,8 +687,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   test(
     "materialize only selected tables"
   ) {
-    val session = spark
-
 
     val graph = new TestGraphRegistrationContext(spark) {
       registerTable("a", query = Option(dfFlowFunc(Seq((1, 2), (2, 3)).toDF("x", "y"))))
@@ -759,8 +732,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("tables with arrays and maps") {
-    val session = spark
-
 
     val rawGraph =
       new TestGraphRegistrationContext(spark) {
@@ -855,8 +826,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("materializing no tables doesn't throw") {
-    val session = spark
-
 
     val graph1 =
       new DataflowGraph(flows = Seq.empty, tables = Seq.empty, views = Seq.empty, sinks = Seq.empty)
@@ -886,8 +855,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("cluster columns with user schema") {
-    val session = spark
-
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -923,8 +890,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("specifying cluster column with existing clustered table") {
-    val session = spark
-
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -979,8 +944,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("specifying cluster column different from existing clustered table") {
-    val session = spark
-
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -1018,8 +981,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("cluster columns only (no partitioning)") {
-    val session = spark
-
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -1057,8 +1018,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("materialized view with cluster columns") {
-    val session = spark
-
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -1088,8 +1047,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("partition and cluster columns together should fail") {
-    val session = spark
-
 
     val ex = intercept[TableMaterializationException] {
       materializeGraph(
@@ -1110,8 +1067,6 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   }
 
   test("cluster column that doesn't exist in table schema should fail") {
-    val session = spark
-
 
     val ex = intercept[TableMaterializationException] {
       materializeGraph(

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
@@ -37,9 +37,11 @@ class DefaultMaterializeTablesSuite extends MaterializeTablesSuite with SharedSp
  * tables are written with the appropriate schemas.
  */
 abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
+  import testImplicits._
+
   test("basic") {
     val session = spark
-    import session.implicits._
+
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -124,7 +126,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("multiple") {
     val session = spark
-    import session.implicits._
+
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -162,7 +164,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("temporary views don't get materialized") {
     val session = spark
-    import session.implicits._
+
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -239,7 +241,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("schema matches existing table schema") {
     val session = spark
-    import session.implicits._
+
 
     sql(s"CREATE TABLE ${TestGraphRegistrationContext.DEFAULT_DATABASE}.t2(x INT)")
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
@@ -269,7 +271,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
   test("invalid schema merge") {
     val session = spark
     implicit val sqlCtx: SQLContext = spark.sqlContext
-    import session.implicits._
+
 
     val streamInts = MemoryStream[Int]
     streamInts.addData(1, 2)
@@ -299,7 +301,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("table materialized with specified schema, even if different from inferred") {
     val session = spark
-    import session.implicits._
+
 
     sql(s"CREATE TABLE ${TestGraphRegistrationContext.DEFAULT_DATABASE}.t4(x INT)")
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
@@ -338,7 +340,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("specified schema incompatible with existing table") {
     val session = spark
-    import session.implicits._
+
 
     sql(s"CREATE TABLE ${TestGraphRegistrationContext.DEFAULT_DATABASE}.t6(x BOOLEAN)")
     val catalog = spark.sessionState.catalogManager.currentCatalog.asInstanceOf[TableCatalog]
@@ -384,7 +386,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("partition columns with user schema") {
     val session = spark
-    import session.implicits._
+
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -414,7 +416,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("specifying partition column with existing partitioned table") {
     val session = spark
-    import session.implicits._
+
 
     sql(
       s"CREATE TABLE ${TestGraphRegistrationContext.DEFAULT_DATABASE}.t7(x BOOLEAN, y INT) " +
@@ -481,7 +483,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("specifying partition column different from existing partitioned table") {
     val session = spark
-    import session.implicits._
+
 
     sql(
       s"CREATE TABLE ${TestGraphRegistrationContext.DEFAULT_DATABASE}.t8(x BOOLEAN, y INT) " +
@@ -546,7 +548,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("Invalid table properties error during table materialization") {
     val session = spark
-    import session.implicits._
+
 
     // Invalid pipelines property
     val graph1 =
@@ -586,7 +588,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
       s"Complete tables should not evolve schema - isFullRefresh = $isFullRefresh"
     ) {
       val session = spark
-      import session.implicits._
+  
 
       val rawGraph =
         new TestGraphRegistrationContext(spark) {
@@ -645,7 +647,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     ) {
       val session = spark
       implicit val sqlCtx: SQLContext = spark.sqlContext
-      import session.implicits._
+  
 
       val streamInts = MemoryStream[Int]
       streamInts.addData(1 until 5: _*)
@@ -713,7 +715,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
     "materialize only selected tables"
   ) {
     val session = spark
-    import session.implicits._
+
 
     val graph = new TestGraphRegistrationContext(spark) {
       registerTable("a", query = Option(dfFlowFunc(Seq((1, 2), (2, 3)).toDF("x", "y"))))
@@ -760,7 +762,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("tables with arrays and maps") {
     val session = spark
-    import session.implicits._
+
 
     val rawGraph =
       new TestGraphRegistrationContext(spark) {
@@ -856,7 +858,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("materializing no tables doesn't throw") {
     val session = spark
-    import session.implicits._
+
 
     val graph1 =
       new DataflowGraph(flows = Seq.empty, tables = Seq.empty, views = Seq.empty, sinks = Seq.empty)
@@ -887,7 +889,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("cluster columns with user schema") {
     val session = spark
-    import session.implicits._
+
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -924,7 +926,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("specifying cluster column with existing clustered table") {
     val session = spark
-    import session.implicits._
+
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -980,7 +982,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("specifying cluster column different from existing clustered table") {
     val session = spark
-    import session.implicits._
+
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -1019,7 +1021,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("cluster columns only (no partitioning)") {
     val session = spark
-    import session.implicits._
+
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -1058,7 +1060,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("materialized view with cluster columns") {
     val session = spark
-    import session.implicits._
+
 
     materializeGraph(
       new TestGraphRegistrationContext(spark) {
@@ -1089,7 +1091,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("partition and cluster columns together should fail") {
     val session = spark
-    import session.implicits._
+
 
     val ex = intercept[TableMaterializationException] {
       materializeGraph(
@@ -1111,7 +1113,7 @@ abstract class MaterializeTablesSuite extends BaseCoreExecutionTest {
 
   test("cluster column that doesn't exist in table schema should fail") {
     val session = spark
-    import session.implicits._
+
 
     val ex = intercept[TableMaterializationException] {
       materializeGraph(

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/BaseCoreExecutionTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/BaseCoreExecutionTest.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.pipelines.utils
 import org.apache.spark.sql.pipelines.graph.{DataflowGraph, DatasetManager, PipelineUpdateContext}
 
 trait BaseCoreExecutionTest extends ExecutionTest {
+  import testImplicits._
 
   /**
    * Materializes the given graph using the provided context.

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
@@ -44,6 +44,7 @@ abstract class PipelineTest
   with TargetCatalogAndDatabaseMixin
   with Logging
   with Eventually {
+  import testImplicits._
 
   protected def startPipelineAndWaitForCompletion(
        unresolvedDataflowGraph: DataflowGraph): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Decouple `SQLTestUtilsBase` from classic `SparkSession` and `DataFrame` types, switching to the abstract SQL API types instead. This is a preparatory step toward merging `SQLTestUtilsBase`/`SQLTestUtils` with `QueryTestBase`/`QueryTest`.

**Core change in `SQLTestUtils.scala`:**
- Remove `override protected def spark: classic.SparkSession` from `SQLTestUtilsBase`, letting it inherit the abstract `SparkSession` from `SparkSessionProvider`
- Move `DataFrame` and `SparkSession` imports from `o.a.s.sql.classic` to `o.a.s.sql` (abstract API)
- Cast to `classic.SparkSession` locally in methods that require classic-only APIs (`testImplicits`, `stripSparkFilter`, `logicalPlanToSparkQuery`, `uncacheTable`)
- `logicalPlanToSparkQuery` returns `classic.DataFrame` (not abstract) since it satisfies both classic and abstract targets via subtyping, avoiding the need for implicit chaining

**API visibility fix:**
- Widen `Dataset.withColumnsRenamed(Seq, Seq)` from `protected` to `protected[spark]` in the abstract API, with `override` in classic and connect — unifying the visibility across all three

**Downstream test fixes (using `import testImplicits._` to provide `ClassicConversions`):**
- `ReplaceIntegerLiteralsWithOrdinalsDataframeSuite` — added `import testImplicits._`
- `CollationExpressionWalkerSuite` — added `import testImplicits._`
- `AlterTableRenameSuiteBase` — added `import testImplicits._`
- `DropTableSuiteBase` — added `import testImplicits._`
- `OuterJoinSuite` — widened `import testImplicits.toRichColumn` to `import testImplicits._`
- `SchemaPruningSuite` — added `import testImplicits.castToImpl` (class-level `testImplicits._` conflicts with catalyst DSL `$"col"`)
- `HiveQuerySuite` — replaced `import TestHive.sparkSession.implicits._` with `import testImplicits._`
- `HiveUDFSuite` — added `import testImplicits.castToImpl`
- `MaterializeTablesSuite` — added class-level `import testImplicits._`, removed per-test `import session.implicits._` and unused `val session = spark`
- `PipelineTest`, `BaseCoreExecutionTest` — added `import testImplicits._`

**Other fixes:**
- `DDLSuite` — `spark.artifactManager` → `spark.sessionState.artifactManager`
- `CachedTableSuite` — `getNumInMemoryRelations` accepts abstract `Dataset[_]`
- `ParquetFilterSuite` — removed pre-existing unused `ClassicConversions._` import

### Why are the changes needed?

`SQLTestUtilsBase` currently requires a `classic.SparkSession`, which tightly couples it to the classic implementation. This makes it difficult to merge `SQLTestUtilsBase` with `QueryTestBase` (which uses the abstract `SparkSession` via `SparkSessionProvider`). Decoupling the base types is a necessary first step toward consolidating the test utility class hierarchy.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Compilation verified for `sql/Test/compile`, `hive/Test/compile`, `connect-common/compile`, `pipelines/Test/compile`, `avro/Test/compile`, and `kafka-0-10-sql/Test/compile`.
- Affected test suites run locally and all passed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)