### PR TITLE
[SPARK-56484][SQL] Filter's sizeInBytes estimation should not inflate over child's sizeInBytes when CBO is on

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
@@ -47,17 +47,27 @@ case class FilterEstimation(plan: Filter) extends Logging {
 
     // Estimate selectivity of this filter predicate, and update column stats if needed.
     // For not-supported condition, set filter selectivity to a conservative estimate 100%
-    val filterSelectivity = calculateFilterSelectivity(plan.condition).getOrElse(1.0)
+    val filterSelectivity =
+      calculateFilterSelectivity(plan.condition).map(boundProbability).getOrElse(1.0)
 
-    val filteredRowCount: BigInt = ceil(BigDecimal(childStats.rowCount.get) * filterSelectivity)
+    val childRowCount = childStats.rowCount.get
+    val filteredRowCount: BigInt =
+      ceil(BigDecimal(childRowCount) * filterSelectivity).min(childRowCount)
     val newColStats = if (filteredRowCount == 0) {
       // The output is empty, we don't need to keep column stats.
       AttributeMap[ColumnStat](Nil)
     } else {
-      colStatsMap.outputColumnStats(rowsBeforeFilter = childStats.rowCount.get,
+      colStatsMap.outputColumnStats(rowsBeforeFilter = childRowCount,
         rowsAfterFilter = filteredRowCount)
     }
-    val filteredSizeInBytes: BigInt = getOutputSize(plan.output, filteredRowCount, newColStats)
+    val sizeByOutputAttrs = getOutputSize(plan.output, filteredRowCount, newColStats)
+    val sizeByChildScaling = if (childRowCount > 0 && filteredRowCount > 0) {
+      ceil(BigDecimal(childStats.sizeInBytes) * BigDecimal(filteredRowCount) / BigDecimal(childRowCount))
+        .max(BigInt(1))
+    } else {
+      BigInt(1)
+    }
+    val filteredSizeInBytes: BigInt = sizeByOutputAttrs.min(sizeByChildScaling)
 
     Some(childStats.copy(sizeInBytes = filteredSizeInBytes, rowCount = Some(filteredRowCount),
       attributeStats = newColStats))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
@@ -62,7 +62,9 @@ case class FilterEstimation(plan: Filter) extends Logging {
     }
     val sizeByOutputAttrs = getOutputSize(plan.output, filteredRowCount, newColStats)
     val sizeByChildScaling = if (childRowCount > 0 && filteredRowCount > 0) {
-      ceil(BigDecimal(childStats.sizeInBytes) * BigDecimal(filteredRowCount) / BigDecimal(childRowCount))
+      ceil(
+        BigDecimal(childStats.sizeInBytes) * BigDecimal(filteredRowCount) /
+          BigDecimal(childRowCount))
         .max(BigInt(1))
     } else {
       BigInt(1)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -306,6 +306,19 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
     assert(filterStats.sizeInBytes == 1000)
   }
 
+  test("Range filter should scale sizeInBytes based on child size") {
+    val childPlan = StatsTestPlan(
+      outputList = Seq(attrInt),
+      rowCount = 10L,
+      attributeStats = AttributeMap(Seq(attrInt -> colStatInt)),
+      size = Some(100)
+    )
+    val filter = Filter(GreaterThan(attrInt, Literal(6)), childPlan)
+    val filterStats = filter.stats
+    assert(filterStats.rowCount.contains(5))
+    assert(filterStats.sizeInBytes == 50)
+  }
+
   test("cint IS NOT NULL && null") {
     // 'cint < null' will be optimized to 'cint IS NOT NULL && null'.
     // More similar cases can be found in the Optimizer NullPropagation.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -290,6 +290,22 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       expectedRowCount = 10)
   }
 
+  test("IS NOT NULL should not increase sizeInBytes over child") {
+    val attrStringLarge = AttributeReference("cstring_large", StringType)()
+    val colStatStringLarge = ColumnStat(distinctCount = Some(10), min = None, max = None,
+      nullCount = Some(0), avgLen = Some(1000), maxLen = Some(1000))
+    val childPlan = StatsTestPlan(
+      outputList = Seq(attrStringLarge),
+      rowCount = 1000,
+      attributeStats = AttributeMap(Seq(attrStringLarge -> colStatStringLarge)),
+      size = Some(1000)
+    )
+    val filter = Filter(IsNotNull(attrStringLarge), childPlan)
+    val filterStats = filter.stats
+    assert(filterStats.rowCount.contains(1000))
+    assert(filterStats.sizeInBytes == 1000)
+  }
+
   test("cint IS NOT NULL && null") {
     // 'cint < null' will be optimized to 'cint IS NOT NULL && null'.
     // More similar cases can be found in the Optimizer NullPropagation.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

We observed a significant discrepancy in the logical plan's statistics estimation at the Filter node when running Q23a and Q23b in 10TB TPC-DS . For the customer table, the RelationV2 scan correctly identifies a sizeInBytes of 248.0 MiB based on actual metadata. However, after applying the Filter isnotnull(c_customer_sk) operator, the CBO inflates the estimated size to 743.9 MiB. Even though the rowCount remains unchanged , the heuristic recalculation of sizeInBytes triples the value. This "data inflation" after a filter causes the planner to exceed the 250 MiB threshold, incorrectly disabling the Broadcast Hash Join.

```
Filter isnotnull(c_customer_sk#8913), Statistics(sizeInBytes=743.9 MiB, rowCount=6.50E+7)

+- RelationV2[c_customer_sk#8913] spark_catalog.tpcds_sf10000_parquet_zstd_iceberg_part_perfteam2.customer, Statistics(sizeInBytes=248.0 MiB, rowCount=6.50E+7)
```

The Filter node should maintain its existing logic for estimating rowCount and updating attributeStats. However, for sizeInBytes, we should adopt a more conservative approach by selecting the minimum of two estimates:

**Legacy Logic:** getOutputSize(outputAttrs, filteredRowCount, newColStats). This often results in a value larger than the actual sizeInBytes from the Scan node due to heuristic row-width defaults.

**New Scaling Logic:** child.sizeInBytes * (filteredRowCount / childRowCount). This is more reasonable as a Filter does not change the row width; it only reduces the number of rows.

**Final Decision:** min(sizeByOutputAttrs, sizeByChildScaling)

This ensures the estimated size never exceeds the actual size of the child node. (e.g., preventing the original 260MB from being inflated to 780MB).


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Missing BHJ optimization when setting 250MB bhj threshold.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
Added new unit tests
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
