### PR TITLE
[SPARK-56490][K8S] Add Java-friendly `KubernetesConf.createDriverConf`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -285,6 +285,20 @@ private[spark] object KubernetesConf {
       proxyUser)
   }
 
+  /**
+   * Java-friendly version of [[createDriverConf]] that accepts a nullable String
+   * for proxyUser instead of Option[String].
+   */
+  def createDriverConf(
+      sparkConf: SparkConf,
+      appId: String,
+      mainAppResource: MainAppResource,
+      mainClass: String,
+      appArgs: Array[String],
+      proxyUser: String): KubernetesDriverConf = {
+    createDriverConf(sparkConf, appId, mainAppResource, mainClass, appArgs, Option(proxyUser))
+  }
+
   def createExecutorConf(
       sparkConf: SparkConf,
       executorId: String,

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -109,6 +109,27 @@ class KubernetesConfSuite extends SparkFunSuite {
     assert(conf.sparkConf.get(MEMORY_OVERHEAD_FACTOR) === 0.3)
   }
 
+  test("SPARK-56490: Java-friendly createDriverConf with nullable proxyUser") {
+    val sparkConf = new SparkConf(false)
+    val conf = KubernetesConf.createDriverConf(
+      sparkConf,
+      KubernetesTestConf.APP_ID,
+      JavaMainAppResource(None),
+      KubernetesTestConf.MAIN_CLASS,
+      APP_ARGS,
+      null: String)
+    assert(conf.proxyUser === None)
+
+    val confWithProxy = KubernetesConf.createDriverConf(
+      sparkConf,
+      KubernetesTestConf.APP_ID,
+      JavaMainAppResource(None),
+      KubernetesTestConf.MAIN_CLASS,
+      APP_ARGS,
+      "proxy")
+    assert(confWithProxy.proxyUser === Some("proxy"))
+  }
+
   test("Basic executor translated fields.") {
     val conf = KubernetesConf.createExecutorConf(
       new SparkConf(false),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a Java-friendly overload of `KubernetesConf.createDriverConf` that accepts a nullable `String` for `proxyUser` instead of Scala's `Option[String]`.

### Why are the changes needed?

The existing `createDriverConf` method uses `Option[String]` for the `proxyUser` parameter, which is inconvenient to call from Java code. Java callers must explicitly construct `scala.Option` instances (e.g., `scala.Option.empty()` or `scala.Some`). The new overload allows Java callers to simply pass a nullable `String`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.6)