### PR TITLE
[SPARK-56491][CORE] Add `ReadOnlySparkConf.getAllAsJavaMap`

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -196,6 +196,9 @@ trait ReadOnlySparkConf {
   /** Get all parameters as a list of pairs */
   def getAll: Array[(String, String)]
 
+  /** Get all parameters as a Java-friendly map */
+  def getAllAsJavaMap: JMap[String, String] = getAll.toMap.asJava
+
   /**
    * Get a parameter as an integer, falling back to a default if not set
    *

--- a/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
@@ -112,6 +112,18 @@ class SparkConfSuite extends SparkFunSuite with LocalSparkContext with ResetSyst
     assert(conf.getOption("k4") === None)
   }
 
+  test("getAllAsJavaMap") {
+    val conf = new SparkConf(false)
+    assert(conf.getAllAsJavaMap.isEmpty)
+    conf.set("k1", "v1")
+    conf.setAll(Seq(("k2", "v2"), ("k3", "v3")))
+    val javaMap = conf.getAllAsJavaMap
+    assert(javaMap.size() === 3)
+    assert(javaMap.get("k1") === "v1")
+    assert(javaMap.get("k2") === "v2")
+    assert(javaMap.get("k3") === "v3")
+  }
+
   test("basic getAllWithPrefix") {
     val prefix = "spark.prefix."
     val conf = new SparkConf(false)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a `getAllAsJavaMap` method to the `SparkConf` trait that returns `java.util.Map[String, String]`.

### Why are the changes needed?

The existing `getAll` method returns `Array[(String, String)]` (Scala tuples), which is awkward to use from Java code. Java callers must deal with `scala.Tuple2` directly. The new `getAllAsJavaMap` method provides a natural Java-friendly alternative using `java.util.Map`.

### Does this PR introduce _any_ user-facing change?

Yes. A new public method `getAllAsJavaMap` is available on `SparkConf`.

### How was this patch tested?

A new unit test `getAllAsJavaMap` was added in `SparkConfSuite`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code