### PR TITLE
[SPARK-56505][SQL][TESTS] SharedSparkSession provides sql.SparkSession, add SharedClassicSparkSession, ClassicQueryTest

### DIFF
--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.{DataFrameReader, QueryTest}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.util.Utils
 
 abstract class KafkaRelationSuiteBase

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
@@ -27,14 +27,17 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 
 import org.apache.spark.{SparkConf, TestUtils}
-import org.apache.spark.sql.DataFrameReader
+import org.apache.spark.sql.{DataFrameReader, QueryTest}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.util.Utils
 
-abstract class KafkaRelationSuiteBase extends SharedSparkSession with KafkaTest {
+abstract class KafkaRelationSuiteBase
+  extends QueryTest
+    with SharedClassicSparkSession
+    with KafkaTest {
 
   import testImplicits._
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/DatasetHolder.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/DatasetHolder.scala
@@ -31,15 +31,15 @@ import org.apache.spark.annotation.Stable
  * @since 1.6.0
  */
 @Stable
-abstract class DatasetHolder[T] {
+class DatasetHolder[T](ds: Dataset[T]) {
 
   // This is declared with parentheses to prevent the Scala compiler from treating
   // `rdd.toDS("1")` as invoking this toDS and then apply on the returned Dataset.
-  def toDS(): Dataset[T]
+  def toDS(): Dataset[T] = ds
 
   // This is declared with parentheses to prevent the Scala compiler from treating
   // `rdd.toDF("1")` as invoking this toDF and then apply on the returned DataFrame.
-  def toDF(): DataFrame
+  def toDF(): DataFrame = ds.toDF()
 
-  def toDF(colNames: String*): DataFrame
+  def toDF(colNames: String*): DataFrame = ds.toDF(colNames: _*)
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -51,14 +51,16 @@ abstract class SQLImplicits extends EncoderImplicits with Serializable {
    * Creates a [[Dataset]] from a local Seq.
    * @since 1.6.0
    */
-  implicit def localSeqToDatasetHolder[T: Encoder](s: Seq[T]): DatasetHolder[T]
+  implicit def localSeqToDatasetHolder[T: Encoder](s: Seq[T]): DatasetHolder[T] =
+    new DatasetHolder[T](session.createDataset(s))
 
   /**
    * Creates a [[Dataset]] from an RDD.
    *
    * @since 1.6.0
    */
-  implicit def rddToDatasetHolder[T: Encoder](rdd: RDD[T]): DatasetHolder[T]
+  implicit def rddToDatasetHolder[T: Encoder](rdd: RDD[T]): DatasetHolder[T] =
+    new DatasetHolder[T](session.createDataset(rdd))
 
   /**
    * An implicit conversion that turns a Scala `Symbol` into a [[org.apache.spark.sql.Column]].

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SQLImplicits.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/SQLImplicits.scala
@@ -33,7 +33,7 @@ abstract class SQLImplicits private[sql] (override val session: SparkSession)
     new DatasetHolder[T](session.createDataset(rdd))
 }
 
-class DatasetHolder[U](ds: Dataset[U]) extends sql.DatasetHolder[U] {
+class DatasetHolder[U](ds: Dataset[U]) extends sql.DatasetHolder[U](ds) {
   override def toDS(): Dataset[U] = ds
   override def toDF(): DataFrame = ds.toDF()
   override def toDF(colNames: String*): DataFrame = ds.toDF(colNames: _*)

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/QueryTestWithConnectSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/QueryTestWithConnectSuite.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.test.connect.{QueryTest => ConnectQueryTest, SharedSparkSession => ConnectSharedSparkSession}
+
+/**
+ * Demonstrator: runs [[QueryTestSuite]] tests through a Connect session.
+ *
+ * This suite validates that the lifted [[QueryTestBase]] infrastructure works end-to-end with a
+ * Connect-providing session trait.
+ */
+class QueryTestWithConnectSuite
+  extends ConnectQueryTest
+    with ConnectSharedSparkSession {
+
+  test("SPARK-16940: checkAnswer should raise TestFailedException for wrong results") {
+    intercept[org.scalatest.exceptions.TestFailedException] {
+      checkAnswer(sql("SELECT 1"), Row(2) :: Nil)
+    }
+  }
+
+  test("SPARK-51349: null string and true null are distinguished") {
+    checkAnswer(sql("select case when id == 0 then struct('null') else struct(null) end s " +
+      "from range(2)"),
+      Seq(Row(Row(null)), Row(Row("null"))))
+  }
+}

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/QueryTestWithConnectSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/QueryTestWithConnectSuite.scala
@@ -17,27 +17,15 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.sql.test.connect.{QueryTest => ConnectQueryTest, SharedSparkSession => ConnectSharedSparkSession}
+import org.apache.spark.sql.test.connect.{SharedSparkSession => ConnectSharedSparkSession}
 
 /**
  * Demonstrator: runs [[QueryTestSuite]] tests through a Connect session.
  *
- * This suite validates that the lifted [[QueryTestBase]] infrastructure works end-to-end with a
- * Connect-providing session trait.
+ * This validates the `FooSuite with connect.SharedSparkSession` pattern: the existing
+ * [[QueryTestSuite]] tests are inherited unchanged, but execute against a Connect
+ * [[org.apache.spark.sql.connect.SparkSession]] instead of a classic one.
  */
 class QueryTestWithConnectSuite
-  extends ConnectQueryTest
-    with ConnectSharedSparkSession {
-
-  test("SPARK-16940: checkAnswer should raise TestFailedException for wrong results") {
-    intercept[org.scalatest.exceptions.TestFailedException] {
-      checkAnswer(sql("SELECT 1"), Row(2) :: Nil)
-    }
-  }
-
-  test("SPARK-51349: null string and true null are distinguished") {
-    checkAnswer(sql("select case when id == 0 then struct('null') else struct(null) end s " +
-      "from range(2)"),
-      Seq(Row(Row(null)), Row(Row("null"))))
-  }
-}
+  extends QueryTestSuite
+    with ConnectSharedSparkSession

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.connect.planner.SparkConnectPlanner
 import org.apache.spark.sql.connector.catalog.{CatalogManager, Column, Identifier, InMemoryChangelogCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.LongType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.Utils

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.connect.planner.SparkConnectPlanner
 import org.apache.spark.sql.connector.catalog.{CatalogManager, Column, Identifier, InMemoryChangelogCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.LongType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.Utils
@@ -70,7 +70,8 @@ import org.apache.spark.util.Utils
  * compatibility.
  */
 // scalastyle:on
-class ProtoToParsedPlanTestSuite extends SharedSparkSession with ResourceHelper {
+class ProtoToParsedPlanTestSuite
+    extends SharedClassicSparkSession with ResourceHelper {
 
   private val cleanOrphanedGoldenFiles: Boolean =
     System.getenv("SPARK_CLEAN_ORPHANED_GOLDEN_FILES") == "1"

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectServerTest.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectServerTest.scala
@@ -37,14 +37,14 @@ import org.apache.spark.sql.connect.config.Connect
 import org.apache.spark.sql.connect.dsl.MockRemoteSession
 import org.apache.spark.sql.connect.dsl.plans._
 import org.apache.spark.sql.connect.service.{ExecuteHolder, SessionKey, SparkConnectService}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.util.CloseableIterator
 
 /**
  * Base class and utilities for a test suite that starts and tests the real SparkConnectService
  * with a real SparkConnectClient, communicating over RPC, but both in-process.
  */
-trait SparkConnectServerTest extends SharedSparkSession {
+trait SparkConnectServerTest extends SharedClassicSparkSession {
 
   // Server port
   val serverPort: Int =

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectServerTest.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectServerTest.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.connect.config.Connect
 import org.apache.spark.sql.connect.dsl.MockRemoteSession
 import org.apache.spark.sql.connect.dsl.plans._
 import org.apache.spark.sql.connect.service.{ExecuteHolder, SessionKey, SparkConnectService}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.util.CloseableIterator
 
 /**

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.connect.SparkConnectTestUtils
 import org.apache.spark.sql.connect.common.InvalidPlanInput
 import org.apache.spark.sql.connect.common.LiteralValueProtoConverter.toLiteralProto
 import org.apache.spark.sql.execution.arrow.ArrowConverters
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType, TimeType}
 import org.apache.spark.unsafe.types.UTF8String
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.connect.SparkConnectTestUtils
 import org.apache.spark.sql.connect.common.InvalidPlanInput
 import org.apache.spark.sql.connect.common.LiteralValueProtoConverter.toLiteralProto
 import org.apache.spark.sql.execution.arrow.ArrowConverters
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType, TimeType}
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -45,7 +45,7 @@ import org.apache.spark.unsafe.types.UTF8String
  * Testing trait for SparkConnect tests with some helper methods to make it easier to create new
  * test cases.
  */
-trait SparkConnectPlanTest extends SharedSparkSession {
+trait SparkConnectPlanTest extends SharedClassicSparkSession {
   def transform(rel: proto.Relation): logical.LogicalPlan = {
     SparkConnectPlannerTestUtils.transform(spark, rel)
   }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -52,7 +52,7 @@ import org.apache.spark.sql.connect.plugin.SparkConnectPluginRegistry
 import org.apache.spark.sql.connect.service.{ExecuteHolder, ExecuteKey, ExecuteStatus, SessionStatus, SparkConnectAnalyzeHandler, SparkConnectService, SparkListenerConnectOperationStarted}
 import org.apache.spark.sql.connector.catalog.InMemoryPartitionTableCatalog
 import org.apache.spark.sql.streaming.StreamingQuery
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.Utils

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -52,7 +52,7 @@ import org.apache.spark.sql.connect.plugin.SparkConnectPluginRegistry
 import org.apache.spark.sql.connect.service.{ExecuteHolder, ExecuteKey, ExecuteStatus, SessionStatus, SparkConnectAnalyzeHandler, SparkConnectService, SparkListenerConnectOperationStarted}
 import org.apache.spark.sql.connector.catalog.InMemoryPartitionTableCatalog
 import org.apache.spark.sql.streaming.StreamingQuery
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.Utils
@@ -61,7 +61,7 @@ import org.apache.spark.util.Utils
  * Testing Connect Service implementation.
  */
 class SparkConnectServiceSuite
-    extends SharedSparkSession
+    extends SharedClassicSparkSession
     with MockitoSugar
     with Logging
     with SparkConnectPlanTest {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelperSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelperSuite.scala
@@ -26,9 +26,9 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.apache.spark.sql.connect.SparkConnectTestUtils
 import org.apache.spark.sql.streaming.StreamingQuery
 import org.apache.spark.sql.streaming.StreamingQueryListener
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
-class StreamingForeachBatchHelperSuite extends SharedSparkSession with MockitoSugar {
+class StreamingForeachBatchHelperSuite extends SharedClassicSparkSession with MockitoSugar {
 
   private def mockQuery(): StreamingQuery = {
     val query = mock[StreamingQuery]

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelperSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelperSuite.scala
@@ -26,7 +26,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.apache.spark.sql.connect.SparkConnectTestUtils
 import org.apache.spark.sql.streaming.StreamingQuery
 import org.apache.spark.sql.streaming.StreamingQueryListener
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 class StreamingForeachBatchHelperSuite extends SharedClassicSparkSession with MockitoSugar {
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.connect.common.InvalidPlanInput
 import org.apache.spark.sql.connect.config.Connect
 import org.apache.spark.sql.connect.planner.{SparkConnectPlanner, SparkConnectPlanTest}
 import org.apache.spark.sql.connect.service.SessionHolder
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
 class DummyPlugin extends RelationPlugin {
   override def transform(
@@ -119,7 +119,7 @@ class ExampleCommandPlugin extends CommandPlugin {
   }
 }
 
-class SparkConnectPluginRegistrySuite extends SharedSparkSession with SparkConnectPlanTest {
+class SparkConnectPluginRegistrySuite extends SharedClassicSparkSession with SparkConnectPlanTest {
 
   override def beforeEach(): Unit = {
     if (SparkEnv.get.conf.contains(Connect.CONNECT_EXTENSIONS_EXPRESSION_CLASSES)) {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.connect.common.InvalidPlanInput
 import org.apache.spark.sql.connect.config.Connect
 import org.apache.spark.sql.connect.planner.{SparkConnectPlanner, SparkConnectPlanTest}
 import org.apache.spark.sql.connect.service.SessionHolder
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 class DummyPlugin extends RelationPlugin {
   override def transform(

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
@@ -38,10 +38,10 @@ import org.apache.spark.SparkRuntimeException
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{AddArtifactsRequest, AddArtifactsResponse}
 import org.apache.spark.sql.connect.ResourceHelper
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.util.{ThreadUtils, Utils}
 
-class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
+class AddArtifactsHandlerSuite extends SharedClassicSparkSession with ResourceHelper {
 
   private val CHUNK_SIZE: Int = 32 * 1024
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
@@ -38,7 +38,7 @@ import org.apache.spark.SparkRuntimeException
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{AddArtifactsRequest, AddArtifactsResponse}
 import org.apache.spark.sql.connect.ResourceHelper
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.util.{ThreadUtils, Utils}
 
 class AddArtifactsHandlerSuite extends SharedClassicSparkSession with ResourceHelper {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ArtifactStatusesHandlerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ArtifactStatusesHandlerSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.ArtifactStatusesResponse
 import org.apache.spark.network.util.JavaUtils.sha256Hex
 import org.apache.spark.sql.connect.ResourceHelper
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.util.ThreadUtils
 
 private class DummyStreamObserver(p: Promise[ArtifactStatusesResponse])

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ArtifactStatusesHandlerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ArtifactStatusesHandlerSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.ArtifactStatusesResponse
 import org.apache.spark.network.util.JavaUtils.sha256Hex
 import org.apache.spark.sql.connect.ResourceHelper
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.util.ThreadUtils
 
 private class DummyStreamObserver(p: Promise[ArtifactStatusesResponse])
@@ -38,7 +38,7 @@ private class DummyStreamObserver(p: Promise[ArtifactStatusesResponse])
   override def onCompleted(): Unit = {}
 }
 
-class ArtifactStatusesHandlerSuite extends SharedSparkSession with ResourceHelper {
+class ArtifactStatusesHandlerSuite extends SharedClassicSparkSession with ResourceHelper {
 
   val sessionId = UUID.randomUUID().toString
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.GetStatusResponse
 import org.apache.spark.sql.connect.SparkConnectTestUtils
 import org.apache.spark.sql.connect.plugin.{GetStatusPlugin, SparkConnectPluginRegistry}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.util.ThreadUtils
 
 /**

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/GetStatusHandlerSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.GetStatusResponse
 import org.apache.spark.sql.connect.SparkConnectTestUtils
 import org.apache.spark.sql.connect.plugin.{GetStatusPlugin, SparkConnectPluginRegistry}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.util.ThreadUtils
 
 /**
@@ -104,7 +104,7 @@ class FailingGetStatusPlugin extends GetStatusPlugin {
     throw new RuntimeException("operation plugin failure")
 }
 
-class GetStatusHandlerSuite extends SharedSparkSession {
+class GetStatusHandlerSuite extends SharedClassicSparkSession {
 
   // Default userId matching SparkConnectTestUtils.createDummySessionHolder default
   private val defaultUserId = "testUser"

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectCloneSessionSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectCloneSessionSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.connect.service
 import java.util.UUID
 
 import org.apache.spark.SparkSQLException
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 class SparkConnectCloneSessionSuite extends SharedClassicSparkSession {
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectCloneSessionSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectCloneSessionSuite.scala
@@ -20,9 +20,9 @@ package org.apache.spark.sql.connect.service
 import java.util.UUID
 
 import org.apache.spark.SparkSQLException
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
-class SparkConnectCloneSessionSuite extends SharedSparkSession {
+class SparkConnectCloneSessionSuite extends SharedClassicSparkSession {
 
   override def beforeEach(): Unit = {
     super.beforeEach()

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManagerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManagerSuite.scala
@@ -18,12 +18,12 @@ package org.apache.spark.sql.connect.service
 
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.connect.SparkConnectTestUtils
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
 /**
  * Test suite for SparkConnectExecutionManager.
  */
-class SparkConnectExecutionManagerSuite extends SharedSparkSession {
+class SparkConnectExecutionManagerSuite extends SharedClassicSparkSession {
 
   protected override def afterEach(): Unit = {
     super.afterEach()

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManagerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManagerSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.connect.service
 
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.connect.SparkConnectTestUtils
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 /**
  * Test suite for SparkConnectExecutionManager.

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListenerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListenerSuite.scala
@@ -29,15 +29,19 @@ import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.scalatestplus.mockito.MockitoSugar
 
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.connect.proto.{Command, ExecutePlanResponse}
 import org.apache.spark.sql.connect.SparkConnectTestUtils
 import org.apache.spark.sql.connect.execution.ExecuteResponseObserver
 import org.apache.spark.sql.connect.planner.SparkConnectStreamingQueryListenerHandler
 import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryListener}
 import org.apache.spark.sql.streaming.Trigger.ProcessingTime
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
-class SparkConnectListenerBusListenerSuite extends SharedSparkSession with MockitoSugar {
+class SparkConnectListenerBusListenerSuite
+    extends SparkFunSuite
+    with SharedClassicSparkSession
+    with MockitoSugar {
 
   override def afterEach(): Unit = {
     try {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListenerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListenerSuite.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.connect.execution.ExecuteResponseObserver
 import org.apache.spark.sql.connect.planner.SparkConnectStreamingQueryListenerHandler
 import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryListener}
 import org.apache.spark.sql.streaming.Trigger.ProcessingTime
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 class SparkConnectListenerBusListenerSuite
     extends SparkFunSuite

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHolderSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHolderSuite.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.pipelines.graph.{DataflowGraph, PipelineUpdateContextImpl}
 import org.apache.spark.sql.pipelines.logging.PipelineEvent
 import org.apache.spark.sql.streaming.StreamingQueryListener
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.util.ArrayImplicits._
 
 class SparkConnectSessionHolderSuite extends SharedClassicSparkSession {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHolderSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHolderSuite.scala
@@ -43,10 +43,10 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.pipelines.graph.{DataflowGraph, PipelineUpdateContextImpl}
 import org.apache.spark.sql.pipelines.logging.PipelineEvent
 import org.apache.spark.sql.streaming.StreamingQueryListener
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.util.ArrayImplicits._
 
-class SparkConnectSessionHolderSuite extends SharedSparkSession {
+class SparkConnectSessionHolderSuite extends SharedClassicSparkSession {
 
   test("DataFrame cache: Successful put and get") {
     val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionManagerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionManagerSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.SparkSQLException
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.pipelines.graph.{DataflowGraph, PipelineUpdateContextImpl}
 import org.apache.spark.sql.pipelines.logging.PipelineEvent
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 class SparkConnectSessionManagerSuite extends SharedClassicSparkSession {
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionManagerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionManagerSuite.scala
@@ -25,9 +25,9 @@ import org.apache.spark.SparkSQLException
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.pipelines.graph.{DataflowGraph, PipelineUpdateContextImpl}
 import org.apache.spark.sql.pipelines.logging.PipelineEvent
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
-class SparkConnectSessionManagerSuite extends SharedSparkSession {
+class SparkConnectSessionManagerSuite extends SharedClassicSparkSession {
 
   override def beforeEach(): Unit = {
     super.beforeEach()

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/test/connect/QueryTest.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/test/connect/QueryTest.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.test.connect
+
+import org.apache.spark.sql.{DataFrame, QueryTest => BaseQueryTest, Row}
+
+/**
+ * Extends [[BaseQueryTest]] for use with Connect sessions.
+ *
+ * Overrides [[checkAnswer]] to avoid classic-only code paths (e.g. `queryExecution`,
+ * `logicalPlan`, `materializedRdd`) that are not available on Connect DataFrames.
+ */
+trait QueryTest extends BaseQueryTest with SparkSessionProvider {
+
+  override protected def checkAnswer(df: => DataFrame, expectedAnswer: Seq[Row]): Unit = {
+    val sparkAnswer = df.collect().toSeq
+    BaseQueryTest.sameRows(expectedAnswer, sparkAnswer) match {
+      case Some(errorMessage) => fail(errorMessage)
+      case None =>
+    }
+  }
+}

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/test/connect/SharedSparkSession.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/test/connect/SharedSparkSession.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.test.connect
+
+import java.util.UUID
+
+import org.apache.spark.sql.{classic => classicApi, connect => connectApi}
+import org.apache.spark.sql.connect.client.SparkConnectClient
+import org.apache.spark.sql.connect.common.config.ConnectCommon
+import org.apache.spark.sql.connect.config.Connect
+import org.apache.spark.sql.connect.service.SparkConnectService
+import org.apache.spark.sql.test.{SharedSparkSession => BaseSharedSparkSession}
+
+/**
+ * A test trait that provides a Connect
+ * [[connectApi.SparkSession SparkSession]] backed by an in-process gRPC server. Extends the
+ * base [[BaseSharedSparkSession]] (which creates a classic
+ * [[classicApi.SparkSession SparkSession]] and SparkContext), then layers a Connect client
+ * session on top by starting the gRPC service in-process.
+ *
+ * Use this trait to exercise tests through the Connect path.
+ */
+trait SharedSparkSession
+  extends BaseSharedSparkSession
+    with SparkSessionProvider {
+
+  private val serverPort: Int =
+    ConnectCommon.CONNECT_GRPC_BINDING_PORT + util.Random.nextInt(1000)
+
+  @volatile private var _connectSpark: connectApi.SparkSession = _
+
+  protected override def spark: connectApi.SparkSession = _connectSpark
+
+  /** The underlying classic session used by the in-process server. */
+  protected def classicSpark: classicApi.SparkSession =
+    super.spark.asInstanceOf[classicApi.SparkSession]
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    withSparkEnvConfs((Connect.CONNECT_GRPC_BINDING_PORT.key, serverPort.toString)) {
+      SparkConnectService.start(classicSpark.sparkContext)
+    }
+    val client = SparkConnectClient
+      .builder()
+      .port(serverPort)
+      .sessionId(UUID.randomUUID().toString)
+      .userId("test")
+      .build()
+    _connectSpark = connectApi.SparkSession
+      .builder()
+      .client(client)
+      .create()
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      if (_connectSpark != null) {
+        _connectSpark.close()
+        _connectSpark = null
+      }
+      SparkConnectService.stop()
+    } finally {
+      super.afterAll()
+    }
+  }
+}

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/test/connect/SharedSparkSession.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/test/connect/SharedSparkSession.scala
@@ -19,6 +19,11 @@ package org.apache.spark.sql.test.connect
 
 import java.util.UUID
 
+import scala.concurrent.duration._
+
+import org.scalatest.concurrent.Eventually
+
+import org.apache.spark.DebugFilesystem
 import org.apache.spark.sql.{classic => classicApi, connect => connectApi}
 import org.apache.spark.sql.connect.client.SparkConnectClient
 import org.apache.spark.sql.connect.common.config.ConnectCommon
@@ -33,11 +38,14 @@ import org.apache.spark.sql.test.{SharedSparkSession => BaseSharedSparkSession}
  * [[classicApi.SparkSession SparkSession]] and SparkContext), then layers a Connect client
  * session on top by starting the gRPC service in-process.
  *
- * Use this trait to exercise tests through the Connect path.
+ * Mix in this trait to exercise existing sql/core test suites through the Connect path:
+ * {{{
+ *   class FooWithConnectSuite extends FooSuite with connect.SharedSparkSession
+ * }}}
  */
 trait SharedSparkSession
   extends BaseSharedSparkSession
-    with SparkSessionProvider {
+    with QueryTest {
 
   private val serverPort: Int =
     ConnectCommon.CONNECT_GRPC_BINDING_PORT + util.Random.nextInt(1000)
@@ -76,6 +84,16 @@ trait SharedSparkSession
       SparkConnectService.stop()
     } finally {
       super.afterAll()
+    }
+  }
+
+  // The base SharedSparkSessionBase.afterEach calls spark.sharedState which is not supported
+  // on Connect. Override to use the classic session for cleanup.
+  protected override def afterEach(): Unit = {
+    // super.afterEach() from BeforeAndAfterEach (skipping SharedSparkSessionBase)
+    classicSpark.sharedState.cacheManager.clearCache()
+    Eventually.eventually(Eventually.timeout(10.seconds), Eventually.interval(2.seconds)) {
+      DebugFilesystem.assertNoOpenStreams()
     }
   }
 }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/test/connect/SparkSessionProvider.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/test/connect/SparkSessionProvider.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.test.connect
+
+import org.apache.spark.sql.{connect => connectApi, SparkSessionProvider => BaseSparkSessionProvider}
+
+/**
+ * A common trait for test suites that require a Connect
+ * [[connectApi.SparkSession]].
+ */
+trait SparkSessionProvider extends BaseSparkSessionProvider {
+  protected override def spark: connectApi.SparkSession
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/SQLImplicits.scala
@@ -35,7 +35,7 @@ abstract class SQLImplicits extends sql.SQLImplicits {
     new DatasetHolder[T](session.createDataset(rdd))
 }
 
-class DatasetHolder[U](ds: Dataset[U]) extends sql.DatasetHolder[U] {
+class DatasetHolder[U](ds: Dataset[U]) extends sql.DatasetHolder[U](ds) {
   override def toDS(): Dataset[U] = ds
   override def toDF(): DataFrame = ds.toDF()
   override def toDF(colNames: String*): DataFrame = ds.toDF(colNames: _*)

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -53,7 +53,7 @@ import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.execution.ui.SparkListenerSQLAdaptiveExecutionUpdate
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.storage.{RDDBlockId, StorageLevel}
 import org.apache.spark.storage.StorageLevel.{MEMORY_AND_DISK_2, MEMORY_ONLY}

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -53,7 +53,7 @@ import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.execution.ui.SparkListenerSQLAdaptiveExecutionUpdate
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.storage.{RDDBlockId, StorageLevel}
 import org.apache.spark.storage.StorageLevel.{MEMORY_AND_DISK_2, MEMORY_ONLY}
@@ -64,9 +64,10 @@ import org.apache.spark.util.{AccumulatorContext, Utils}
 private case class BigData(s: String)
 
 @SlowSQLTest
-class CachedTableSuite extends SharedSparkSession
+class CachedTableSuite extends QueryTest
+  with SharedClassicSparkSession
   with AdaptiveSparkPlanHelper {
-  import testImplicits._
+  import classicTestImplicits._
 
   override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.testcat", classOf[InMemoryCatalog].getName)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAsOfJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAsOfJoinSuite.scala
@@ -22,7 +22,7 @@ import scala.jdk.CollectionConverters._
 import org.apache.spark.sql.catalyst.plans.AsOfJoinDirection
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.SlowSQLTest
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAsOfJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAsOfJoinSuite.scala
@@ -22,12 +22,13 @@ import scala.jdk.CollectionConverters._
 import org.apache.spark.sql.catalyst.plans.AsOfJoinDirection
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.SlowSQLTest
 
 @SlowSQLTest
-class DataFrameAsOfJoinSuite extends SharedSparkSession
+class DataFrameAsOfJoinSuite extends QueryTest
+  with SharedClassicSparkSession
   with AdaptiveSparkPlanHelper {
 
   def prepareForAsOfJoin(): (classic.DataFrame, classic.DataFrame) = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, UTC}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, UTC}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 
@@ -41,8 +41,8 @@ import org.apache.spark.tags.ExtendedSQLTest
  * Test suite for functions in [[org.apache.spark.sql.functions]].
  */
 @ExtendedSQLTest
-class DataFrameFunctionsSuite extends SharedSparkSession {
-  import testImplicits._
+class DataFrameFunctionsSuite extends QueryTest with SharedClassicSparkSession {
+  import classicTestImplicits._
 
   test("DataFrame function and SQL function parity") {
     // This test compares the available list of DataFrame functions in

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNearestByJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNearestByJoinSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.plans.{NearestByDirection, NearestByJoinMod
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.tags.SlowSQLTest
 
 @SlowSQLTest

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNearestByJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNearestByJoinSuite.scala
@@ -21,11 +21,11 @@ import org.apache.spark.sql.catalyst.plans.{NearestByDirection, NearestByJoinMod
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.tags.SlowSQLTest
 
 @SlowSQLTest
-class DataFrameNearestByJoinSuite extends QueryTest with SharedSparkSession {
+class DataFrameNearestByJoinSuite extends QueryTest with SharedClassicSparkSession {
 
   private def prepareForNearestByJoin(): (classic.DataFrame, classic.DataFrame) = {
     val users = spark.createDataFrame(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSelfJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSelfJoinSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.classic.{Dataset => DatasetImpl}
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions.{col, count, explode, sum, year}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.test.SQLTestData.TestData
 import org.apache.spark.sql.types.{IntegerType, LongType, StructField, StructType}
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSelfJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSelfJoinSuite.scala
@@ -24,12 +24,12 @@ import org.apache.spark.sql.classic.{Dataset => DatasetImpl}
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions.{col, count, explode, sum, year}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.test.SQLTestData.TestData
 import org.apache.spark.sql.types.{IntegerType, LongType, StructField, StructType}
 
-class DataFrameSelfJoinSuite extends SharedSparkSession {
-  import testImplicits._
+class DataFrameSelfJoinSuite extends QueryTest with SharedClassicSparkSession {
+  import classicTestImplicits._
 
   test("join - join using self join") {
     val df = Seq(1, 2, 3).map(i => (i, i.toString)).toDF("int", "str")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.stat.StatFunctions
 import org.apache.spark.sql.functions.{col, lit, struct, when}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{ArrayType, DoubleType, StringType, StructField, StructType}
 
 class DataFrameStatSuite extends QueryTest with SharedClassicSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -26,10 +26,10 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.stat.StatFunctions
 import org.apache.spark.sql.functions.{col, lit, struct, when}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{ArrayType, DoubleType, StringType, StructField, StructType}
 
-class DataFrameStatSuite extends SharedSparkSession {
+class DataFrameStatSuite extends QueryTest with SharedClassicSparkSession {
   import testImplicits._
 
   private def toLetter(i: Int): String = (i + 97).toChar.toString
@@ -608,7 +608,7 @@ class DataFrameStatSuite extends SharedSparkSession {
 }
 
 
-class DataFrameStatPerfSuite extends SharedSparkSession with Logging {
+class DataFrameStatPerfSuite extends QueryTest with SharedClassicSparkSession with Logging {
 
   // Turn on this test if you want to test the performance of approximate quantiles.
   ignore("computing quantiles should not take much longer than describe()") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -51,7 +51,7 @@ import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.{SharedClassicSparkSession, SharedSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.ArrayImplicits._
@@ -71,9 +71,10 @@ object TestForTypeAlias {
   def aliasedArrayInTuple: (Int, IntArray) = (1, Array(1))
 }
 
-class DatasetSuite extends SharedSparkSession
+class DatasetSuite extends QueryTest
+  with SharedClassicSparkSession
   with AdaptiveSparkPlanHelper {
-  import testImplicits._
+  import classicTestImplicits._
 
   private implicit val ordering: Ordering[ClassData] = Ordering.by((c: ClassData) => c.a -> c.b)
 
@@ -3073,7 +3074,8 @@ object CustomPathEncoder {
   )
 }
 
-class DatasetLargeResultCollectingSuite extends SharedSparkSession {
+class DatasetLargeResultCollectingSuite extends QueryTest
+  with SharedSparkSession {
 
   override protected def sparkConf: SparkConf = super.sparkConf.set(MAX_RESULT_SIZE.key, "4g")
   // SPARK-41193: Ignore this suite because it cannot run successfully with Spark

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -52,7 +52,7 @@ import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.test.classic.SharedSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => ClassicSharedSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.ArrayImplicits._
@@ -73,7 +73,7 @@ object TestForTypeAlias {
 }
 
 class DatasetSuite extends QueryTest
-  with classic.SharedSparkSession
+  with ClassicSharedSparkSession
   with AdaptiveSparkPlanHelper {
   import classicTestImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -51,7 +51,8 @@ import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{SharedClassicSparkSession, SharedSparkSession}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.classic.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.ArrayImplicits._
@@ -72,7 +73,7 @@ object TestForTypeAlias {
 }
 
 class DatasetSuite extends QueryTest
-  with SharedClassicSparkSession
+  with classic.SharedSparkSession
   with AdaptiveSparkPlanHelper {
   import classicTestImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -251,6 +251,7 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
     checkKeywordsExistsInExplain(df,
       "Project [id#xL AS ifnull(id, 1)#xL, if ((id#xL = 1)) null " +
         "else id#xL AS nullif(id, 1)#xL, id#xL AS nvl(id, 1)#xL, 1 AS nvl2(id, 1, 2)#x]")
+    checkKeywordsNotExistsInExplain(df, ExtendedMode, "typednullliteral")
   }
 
   test("SPARK-26659: explain of DataWritingCommandExec should not contain duplicate cmd.nodeName") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -27,10 +27,10 @@ import org.apache.spark.sql.execution.joins.SortMergeJoinExec
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.TestOptionsSource
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
-trait ExplainSuiteHelper extends SharedSparkSession {
+trait ExplainSuiteHelper extends QueryTest with SharedClassicSparkSession {
 
   protected def getNormalizedExplain(df: DataFrame, mode: ExplainMode): String = {
     val output = new java.io.ByteArrayOutputStream()
@@ -90,7 +90,7 @@ trait ExplainSuiteHelper extends SharedSparkSession {
 }
 
 class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite {
-  import testImplicits._
+  import classicTestImplicits._
 
   test("SPARK-23034 show rdd names in RDD scan nodes (Dataset)") {
     val rddWithName = spark.sparkContext.parallelize(Row(1, "abc") :: Nil).setName("testRdd")
@@ -251,7 +251,6 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
     checkKeywordsExistsInExplain(df,
       "Project [id#xL AS ifnull(id, 1)#xL, if ((id#xL = 1)) null " +
         "else id#xL AS nullif(id, 1)#xL, id#xL AS nvl(id, 1)#xL, 1 AS nvl2(id, 1, 2)#x]")
-    checkKeywordsNotExistsInExplain(df, ExtendedMode, "typednullliteral")
   }
 
   test("SPARK-26659: explain of DataWritingCommandExec should not contain duplicate cmd.nodeName") {
@@ -550,7 +549,7 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
 }
 
 class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuite {
-  import testImplicits._
+  import classicTestImplicits._
 
   test("SPARK-35884: Explain Formatted") {
     val df1 = Seq((1, 2), (2, 3)).toDF("k", "v1")

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.execution.joins.SortMergeJoinExec
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.TestOptionsSource
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 trait ExplainSuiteHelper extends QueryTest with SharedClassicSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -35,7 +35,8 @@ import org.apache.spark.sql.execution.exchange.{ShuffleExchangeExec, ShuffleExch
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.python.BatchEvalPythonExec
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{SharedClassicSparkSession, TestSparkSession}
+import org.apache.spark.sql.test.TestSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.tags.SlowSQLTest
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -35,12 +35,12 @@ import org.apache.spark.sql.execution.exchange.{ShuffleExchangeExec, ShuffleExch
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.python.BatchEvalPythonExec
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{SharedSparkSession, TestSparkSession}
+import org.apache.spark.sql.test.{SharedClassicSparkSession, TestSparkSession}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.tags.SlowSQLTest
 
 @SlowSQLTest
-class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
+class JoinSuite extends QueryTest with SharedClassicSparkSession with AdaptiveSparkPlanHelper
   with JoinSelectionHelper {
   import testImplicits._
 
@@ -1830,7 +1830,7 @@ class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
 }
 
 class ThreadLeakInSortMergeJoinSuite
-  extends SharedSparkSession
+  extends SharedClassicSparkSession
     with AdaptiveSparkPlanHelper {
 
   setupTestData()

--- a/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
@@ -29,10 +29,10 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.PARAMETER
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.functions.{array, call_function, lit, map, map_from_arrays, map_from_entries, str_to_map, struct}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{CharType, DataType, DecimalType, StructField, VarcharType}
 
-class ParametersSuite extends SharedSparkSession {
+class ParametersSuite extends QueryTest with SharedClassicSparkSession {
 
   // Helper function to check CHAR/VARCHAR types (similar to CharVarcharTestSuite)
   private def checkColType(f: StructField, dt: DataType): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.PARAMETER
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.functions.{array, call_function, lit, map, map_from_arrays, map_from_entries, str_to_map, struct}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{CharType, DataType, DecimalType, StructField, VarcharType}
 
 class ParametersSuite extends QueryTest with SharedClassicSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -502,9 +502,9 @@ trait QueryTestBase
    * `f` returns.
    */
   protected def activateDatabase(db: String)(f: => Unit): Unit = {
-    spark.sessionState.catalogManager.setCurrentNamespace(Array(db))
+    spark.catalog.setCurrentDatabase(db)
     Utils.tryWithSafeFinally(f)(
-      spark.sessionState.catalogManager.setCurrentNamespace(Array("default")))
+      spark.catalog.setCurrentDatabase("default"))
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -285,11 +285,10 @@ trait QueryTestBase
    * but the implicits import is needed in the constructor.
    */
   protected object testImplicits
-    extends classic.SQLImplicits
+    extends SQLImplicits
       with classic.ClassicConversions
       with classic.ColumnConversions {
-    override protected def session: classic.SparkSession =
-      self.spark.asInstanceOf[classic.SparkSession]
+    override protected def session: SparkSession = self.spark
     override protected def converter: classic.ColumnNodeToExpressionConverter =
       self.spark.asInstanceOf[classic.SparkSession].converter
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -534,7 +534,8 @@ trait QueryTestBase
    */
   def makeQualifiedPath(path: String): URI = {
     val hadoopPath = new Path(path)
-    val fs = hadoopPath.getFileSystem(spark.sessionState.newHadoopConf())
+    val fs = hadoopPath.getFileSystem(
+      spark.asInstanceOf[classic.SparkSession].sessionState.newHadoopConf())
     fs.makeQualified(hadoopPath).toUri
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -38,10 +38,10 @@ import org.apache.spark.sql.catalyst.ExtendedAnalysisException
 import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog.DEFAULT_DATABASE
 import org.apache.spark.sql.catalyst.plans._
-import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.classic.ClassicConversions._
-import org.apache.spark.sql.execution.{FilterExec, QueryExecution, SparkPlan, SQLExecution}
+import org.apache.spark.sql.execution.{QueryExecution, SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecution
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.execution.datasources.DataSourceUtils
@@ -510,27 +510,6 @@ trait QueryTestBase
     spark.catalog.setCurrentDatabase(db)
     Utils.tryWithSafeFinally(f)(
       spark.catalog.setCurrentDatabase("default"))
-  }
-
-  /**
-   * Strip Spark-side filtering in order to check if a datasource filters rows correctly.
-   */
-  protected def stripSparkFilter(df: DataFrame): DataFrame = {
-    val schema = df.schema
-    val withoutFilters = df.queryExecution.executedPlan.transform {
-      case FilterExec(_, child) => child
-    }
-
-    spark.asInstanceOf[classic.SparkSession]
-      .internalCreateDataFrame(withoutFilters.execute(), schema)
-  }
-
-  /**
-   * Turn a logical plan into a `DataFrame`. This should be removed once we have an easier
-   * way to construct `DataFrame` directly out of local data without relying on implicits.
-   */
-  protected implicit def logicalPlanToSparkQuery(plan: LogicalPlan): classic.DataFrame = {
-    classic.Dataset.ofRows(spark.asInstanceOf[classic.SparkSession], plan)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -403,12 +403,18 @@ trait QueryTestBase
 
   // Blocking uncache table for tests
   protected def uncacheTable(tableName: String): Unit = {
-    val tableIdent = spark.sessionState.sqlParser.parseTableIdentifier(tableName)
-    val cascade = !spark.sessionState.catalog.isTempView(tableIdent)
-    spark.sharedState.cacheManager.uncacheQuery(
-      spark.table(tableName).asInstanceOf[classic.Dataset[_]],
-      cascade = cascade,
-      blocking = true)
+    spark match {
+      case spark: classic.SparkSession =>
+        val tableIdent = spark.sessionState.sqlParser.parseTableIdentifier(tableName)
+        val cascade = !spark.sessionState.catalog.isTempView(tableIdent)
+        spark.sharedState.cacheManager.uncacheQuery(
+          spark.table(tableName),
+          cascade = cascade,
+          blocking = true)
+      case spark =>
+        // TODO i guess this doesn't block?!
+        spark.sql(s"UNCACHE TABLE $tableName")
+    }
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -667,9 +667,12 @@ trait QueryTestBase
    * Waits for all tasks on all executors to be finished.
    */
   protected def waitForTasksToFinish(): Unit = {
-    eventually(timeout(10.seconds)) {
-      assert(spark.sparkContext.statusTracker
-        .getExecutorInfos.map(_.numRunningTasks()).sum == 0)
+    spark match {
+      case spark: classic.SparkSession =>
+        eventually(timeout(10.seconds)) {
+          assert(spark.sparkContext.statusTracker
+            .getExecutorInfos.map(_.numRunningTasks()).sum == 0)
+        }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -409,9 +409,9 @@ trait QueryTestBase
           spark.table(tableName),
           cascade = cascade,
           blocking = true)
-      case spark =>
-        // TODO i guess this doesn't block?!
-        spark.sql(s"UNCACHE TABLE $tableName")
+      case _ =>
+        throw new UnsupportedOperationException(
+          "uncacheTable with blocking semantics is not supported on Connect")
     }
   }
 
@@ -516,10 +516,15 @@ trait QueryTestBase
    * FileSystem is changed.
    */
   def makeQualifiedPath(path: String): URI = {
-    val hadoopPath = new Path(path)
-    val fs = hadoopPath.getFileSystem(
-      spark.asInstanceOf[classic.SparkSession].sessionState.newHadoopConf())
-    fs.makeQualified(hadoopPath).toUri
+    spark match {
+      case spark: classic.SparkSession =>
+        val hadoopPath = new Path(path)
+        val fs = hadoopPath.getFileSystem(spark.sessionState.newHadoopConf())
+        fs.makeQualified(hadoopPath).toUri
+      case _ =>
+        throw new UnsupportedOperationException(
+          "makeQualifiedPath is not supported on Connect")
+    }
   }
 
   /**
@@ -657,6 +662,9 @@ trait QueryTestBase
           assert(spark.sparkContext.statusTracker
             .getExecutorInfos.map(_.numRunningTasks()).sum == 0)
         }
+      case _ =>
+        throw new UnsupportedOperationException(
+          "waitForTasksToFinish is not supported on Connect")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -282,6 +282,11 @@ trait QueryTestBase
    * Note that the alternative of importing `spark.implicits._` is not possible here.
    * This is because we create the `SparkSession` immediately before the first test is run,
    * but the implicits import is needed in the constructor.
+   *
+   * IMPORTANT: This is a classic-only escape hatch retained for compatibility with ~434
+   * existing callers. The `converter` accesses classic-only internals and will throw
+   * `UnsupportedOperationException` if triggered from a Connect session. Classic-only test
+   * suites should prefer `classicTestImplicits` (defined in `classic.QueryTest`).
    */
   protected object testImplicits
     extends SQLImplicits
@@ -289,7 +294,13 @@ trait QueryTestBase
       with classic.ColumnConversions {
     override protected def session: SparkSession = self.spark
     override protected def converter: classic.ColumnNodeToExpressionConverter =
-      self.spark.asInstanceOf[classic.SparkSession].converter
+      self.spark match {
+        case spark: classic.SparkSession => spark.converter
+        case _ =>
+          throw new UnsupportedOperationException(
+            "testImplicits.converter is not supported on Connect. " +
+            "Use classicTestImplicits in classic.QueryTest instead.")
+      }
   }
 
   protected override def withSQLConf[T](pairs: (String, String)*)(f: => T): T = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -35,7 +35,6 @@ import org.scalatest.concurrent.Eventually
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.ExtendedAnalysisException
-import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog.DEFAULT_DATABASE
 import org.apache.spark.sql.catalyst.plans._
@@ -335,7 +334,7 @@ trait QueryTestBase
         val withTemporary = if (isTemporary) "TEMPORARY" else ""
         spark.sql(s"DROP $withTemporary FUNCTION IF EXISTS $functionName")
         assert(
-          !spark.sessionState.catalog.functionExists(FunctionIdentifier(functionName)),
+          !spark.catalog.functionExists(functionName),
           s"Function $functionName should have been dropped. But, it still exists.")
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -25,7 +25,6 @@ import java.util.regex.Pattern
 
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
-import scala.language.implicitConversions
 import scala.util.control.NonFatal
 
 import org.apache.hadoop.fs.Path

--- a/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsDataframeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsDataframeSuite.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.test.SharedClassicSparkSession
 class ReplaceIntegerLiteralsWithOrdinalsDataframeSuite
   extends QueryTest
     with SharedClassicSparkSession {
-  import classicTestImplicits._
 
   test("Group by ordinal - Dataframe") {
     val query = "SELECT * FROM VALUES(1,2),(1,3),(2,4)"

--- a/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsDataframeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsDataframeSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedOrdinal
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 class ReplaceIntegerLiteralsWithOrdinalsDataframeSuite
   extends QueryTest

--- a/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsDataframeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsDataframeSuite.scala
@@ -21,10 +21,12 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedOrdinal
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
-class ReplaceIntegerLiteralsWithOrdinalsDataframeSuite extends SharedSparkSession {
-  import testImplicits._
+class ReplaceIntegerLiteralsWithOrdinalsDataframeSuite
+  extends QueryTest
+    with SharedClassicSparkSession {
+  import classicTestImplicits._
 
   test("Group by ordinal - Dataframe") {
     val query = "SELECT * FROM VALUES(1,2),(1,3),(2,4)"

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -25,6 +25,7 @@ import java.util.Locale
 import org.apache.spark.{SparkConf, TestUtils}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator
 import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.NANOS_PER_SECOND
@@ -32,7 +33,7 @@ import org.apache.spark.sql.catalyst.util.stringToFile
 import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.TimestampTypes
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
@@ -152,7 +153,7 @@ import org.apache.spark.util.Utils
  */
 // scalastyle:on line.size.limit
 @ExtendedSQLTest
-class SQLQueryTestSuite extends SharedSparkSession
+class SQLQueryTestSuite extends QueryTest with SharedClassicSparkSession with SQLHelper
     with SQLQueryTestHelper with TPCDSSchema {
 
   import IntegratedUDFTestUtils._

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.util.stringToFile
 import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.TimestampTypes
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException
 import org.apache.spark.sql.connector.catalog.InMemoryCatalog
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{IntegerType, LongType}
 
 /**
@@ -33,7 +33,7 @@ import org.apache.spark.sql.types.{IntegerType, LongType}
  * Resolution-level tests (tables/functions resolving via stored frozen path)
  * are covered in SQLViewSuite and SQLFunctionSuite (SPARK-56639).
  */
-class SetPathSuite extends SharedSparkSession {
+class SetPathSuite extends QueryTest with SharedClassicSparkSession {
 
   private def withPathEnabled(f: => Unit): Unit = {
     withSQLConf(SQLConf.PATH_ENABLED.key -> "true")(f)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException
 import org.apache.spark.sql.connector.catalog.InMemoryCatalog
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{IntegerType, LongType}
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/MetadataResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/MetadataResolverSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.analysis.resolver._
 import org.apache.spark.sql.catalyst.catalog.UnresolvedCatalogRelation
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SubqueryAlias, View}
 import org.apache.spark.sql.execution.datasources.{FileResolver, HadoopFsRelation, LogicalRelation}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/MetadataResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/MetadataResolverSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.analysis.resolver
 
 import scala.collection.mutable
 
+import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.{AliasIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{
   AnalysisContext,
@@ -28,11 +29,13 @@ import org.apache.spark.sql.catalyst.analysis.resolver._
 import org.apache.spark.sql.catalyst.catalog.UnresolvedCatalogRelation
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SubqueryAlias, View}
 import org.apache.spark.sql.execution.datasources.{FileResolver, HadoopFsRelation, LogicalRelation}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-class MetadataResolverSuite extends SharedSparkSession {
+class MetadataResolverSuite
+    extends QueryTest
+    with SharedClassicSparkSession {
   private val catalogName = "spark_catalog"
 
   private val keyValueTableSchema = StructType(

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ResolverGuardSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ResolverGuardSuite.scala
@@ -381,7 +381,7 @@ class ResolverGuardSuite extends ResolverGuardSuiteBase {
 
   test("Star target with columns renames") {
     val df = sql("SELECT * FROM VALUES(1,2)")
-    val newDf = df.withColumnsRenamed(Seq("col2"), Seq("newCol2"))
+    val newDf = df.withColumnsRenamed(Map("col2" -> "newCol2"))
     checkResolverGuard(plan = newDf.queryExecution.logical, None)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.Artifact
 import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.storage.CacheId
 import org.apache.spark.util.{SparkTestUtils, Utils}

--- a/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
@@ -26,12 +26,12 @@ import org.apache.spark.sql.Artifact
 import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.storage.CacheId
 import org.apache.spark.util.{SparkTestUtils, Utils}
 
-class ArtifactManagerSuite extends SharedSparkSession {
+class ArtifactManagerSuite extends SharedClassicSparkSession {
 
   override protected def sparkConf: SparkConf = {
     val conf = super.sparkConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/classic/SparkSessionProvider.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/classic/SparkSessionProvider.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.classic
+
+import org.apache.spark.sql
+
+/**
+ * A common trait for test suites that require a classic [[SparkSession]].
+ */
+trait SparkSessionProvider {
+  protected def spark: SparkSession
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/classic/SparkSessionProvider.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/classic/SparkSessionProvider.scala
@@ -22,6 +22,6 @@ import org.apache.spark.sql
 /**
  * A common trait for test suites that require a classic [[SparkSession]].
  */
-trait SparkSessionProvider {
-  protected def spark: SparkSession
+trait SparkSessionProvider extends sql.SparkSessionProvider {
+  override protected def spark: SparkSession
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationExpressionWalkerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationExpressionWalkerSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.variant.ParseJson
 import org.apache.spark.sql.classic
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.types._
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationExpressionWalkerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationExpressionWalkerSuite.scala
@@ -19,13 +19,14 @@ package org.apache.spark.sql.collation
 
 import java.sql.Timestamp
 
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.analysis.ExpressionBuilder
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.variant.ParseJson
 import org.apache.spark.sql.classic
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.types._
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
@@ -33,8 +34,8 @@ import org.apache.spark.util.Utils
  *  This suite is introduced in order to test a bulk of expressions and functionalities related to
  *  collations
  */
-class CollationExpressionWalkerSuite extends SharedSparkSession {
-  import testImplicits._
+class CollationExpressionWalkerSuite extends SparkFunSuite with SharedClassicSparkSession {
+  import classicTestImplicits._
 
   // Trait to distinguish different cases for generation
   sealed trait CollationType

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationExpressionWalkerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationExpressionWalkerSuite.scala
@@ -35,7 +35,6 @@ import org.apache.spark.util.Utils
  *  collations
  */
 class CollationExpressionWalkerSuite extends SparkFunSuite with SharedClassicSparkSession {
-  import classicTestImplicits._
 
   // Trait to distinguish different cases for generation
   sealed trait CollationType

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
@@ -38,9 +38,11 @@ import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, Metadata, MetadataBuilder, StringType, StructField, StructType}
 
-class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
+class CollationSuite
+  extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper with SharedClassicSparkSession {
   protected val v2Source = classOf[FakeV2ProviderWithCustomSchema].getName
 
   private val collationPreservingSources = Seq("parquet")

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSuite.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, Metadata, MetadataBuilder, StringType, StructField, StructType}
 
 class CollationSuite

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.Changelog.{
   CHANGE_TYPE_DELETE, CHANGE_TYPE_INSERT, CHANGE_TYPE_UPDATE_POSTIMAGE, CHANGE_TYPE_UPDATE_PREIMAGE}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{LongType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.connector
 import java.sql.Timestamp
 import java.util
 
-import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.NamedStreamingRelation
 import org.apache.spark.sql.catalyst.streaming.UserProvided
@@ -28,7 +28,7 @@ import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.Changelog.{
   CHANGE_TYPE_DELETE, CHANGE_TYPE_INSERT, CHANGE_TYPE_UPDATE_POSTIMAGE, CHANGE_TYPE_UPDATE_PREIMAGE}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{LongType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -36,7 +36,7 @@ import org.apache.spark.unsafe.types.UTF8String
  * End-to-end tests for Change Data Capture (CDC) queries using
  * [[InMemoryChangelogCatalog]].
  */
-class ChangelogEndToEndSuite extends SharedSparkSession {
+class ChangelogEndToEndSuite extends QueryTest with SharedClassicSparkSession {
 
   private val catalogName = "cdc_e2e"
   private val testTableName = "test_table"

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DatasourceV2SQLBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DatasourceV2SQLBase.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.connector.catalog.{CatalogPlugin, InMemoryCatalog, InMemoryPartitionTableCatalog, InMemoryTableWithV2FilterCatalog, StagingInMemoryTableCatalog}
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 trait DatasourceV2SQLBase
   extends QueryTest with SharedClassicSparkSession with BeforeAndAfter {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DatasourceV2SQLBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DatasourceV2SQLBase.scala
@@ -19,12 +19,14 @@ package org.apache.spark.sql.connector
 
 import org.scalatest.BeforeAndAfter
 
+import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.connector.catalog.{CatalogPlugin, InMemoryCatalog, InMemoryPartitionTableCatalog, InMemoryTableWithV2FilterCatalog, StagingInMemoryTableCatalog}
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
-trait DatasourceV2SQLBase extends SharedSparkSession with BeforeAndAfter {
+trait DatasourceV2SQLBase
+  extends QueryTest with SharedClassicSparkSession with BeforeAndAfter {
 
   protected def registerCatalog[T <: CatalogPlugin](name: String, clazz: Class[T]): Unit = {
     spark.conf.set(s"spark.sql.catalog.$name", clazz.getName)

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
@@ -19,17 +19,19 @@ package org.apache.spark.sql.errors
 import org.apache.spark._
 import org.apache.spark.SparkBuildInfo
 import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskStart}
+import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.expressions.{CaseWhen, Cast, CheckOverflowInTableInsert, ExpressionProxy, Literal, SubExprEvaluationRuntime}
 import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation
 import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{SharedSparkSession, TestSparkSession}
+import org.apache.spark.sql.test.{SharedClassicSparkSession, TestSparkSession}
 import org.apache.spark.sql.types.ByteType
 
 // Test suite for all the execution errors that requires enable ANSI SQL mode.
-class QueryExecutionAnsiErrorsSuite extends SharedSparkSession {
-  import testImplicits._
+class QueryExecutionAnsiErrorsSuite extends QueryTest
+  with SharedClassicSparkSession {
+  import classicTestImplicits._
 
   override def sparkConf: SparkConf = super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "true")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
@@ -25,12 +25,13 @@ import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation
 import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{SharedClassicSparkSession, TestSparkSession}
+import org.apache.spark.sql.test.TestSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => ClassicSharedSparkSession}
 import org.apache.spark.sql.types.ByteType
 
 // Test suite for all the execution errors that requires enable ANSI SQL mode.
 class QueryExecutionAnsiErrorsSuite extends QueryTest
-  with SharedClassicSparkSession {
+  with ClassicSharedSparkSession {
   import classicTestImplicits._
 
   override def sparkConf: SparkConf = super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "true")

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -53,7 +53,7 @@ import org.apache.spark.sql.internal.LegacyBehaviorPolicy.EXCEPTION
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects}
 import org.apache.spark.sql.streaming.StreamingQueryException
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{ArrayType, BooleanType, DataType, DecimalType, IntegerType, LongType, MetadataBuilder, StructField, StructType}
 import org.apache.spark.sql.vectorized.ColumnarArray
 import org.apache.spark.unsafe.array.ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -53,7 +53,7 @@ import org.apache.spark.sql.internal.LegacyBehaviorPolicy.EXCEPTION
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects}
 import org.apache.spark.sql.streaming.StreamingQueryException
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{ArrayType, BooleanType, DataType, DecimalType, IntegerType, LongType, MetadataBuilder, StructField, StructType}
 import org.apache.spark.sql.vectorized.ColumnarArray
 import org.apache.spark.unsafe.array.ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH
@@ -64,7 +64,7 @@ import org.apache.spark.util.Utils
 class QueryExecutionErrorsSuite
   extends ParquetTest
   with OrcTest
-  with SharedSparkSession
+  with SharedClassicSparkSession
   with DataTypeErrorsBase {
 
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference,
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.ClassicQueryTest
+import org.apache.spark.sql.test.classic.{QueryTest => ClassicQueryTest}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.ArrayImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
@@ -28,18 +28,19 @@ import org.scalatest.exceptions.TestFailedException
 
 import org.apache.spark.{SparkException, TaskContext, TestUtils}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, GenericInternalRow}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.ClassicSQLTestUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.ArrayImplicits._
 
-abstract class BaseScriptTransformationSuite extends QueryTest {
-  import testImplicits._
+abstract class BaseScriptTransformationSuite extends SparkPlanTest with ClassicSQLTestUtils {
+  import classicTestImplicits._
   import ScriptTransformationIOSchema._
 
   protected def defaultSerDe(): String
@@ -202,7 +203,7 @@ abstract class BaseScriptTransformationSuite extends QueryTest {
           output = Seq(AttributeReference("a", StringType)()),
           child = rowsDf.queryExecution.sparkPlan,
           ioschema = defaultIOSchema)
-      QueryTest.executePlan(plan, spark.sqlContext)
+      SparkPlanTest.executePlan(plan, spark.sqlContext)
     }
     assert(e.getMessage.contains("Subprocess exited with status"))
     assert(uncaughtExceptionHandler.exception.isEmpty)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
@@ -34,12 +34,12 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference,
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.ClassicSQLTestUtils
+import org.apache.spark.sql.test.ClassicQueryTest
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.ArrayImplicits._
 
-abstract class BaseScriptTransformationSuite extends SparkPlanTest with ClassicSQLTestUtils {
+abstract class BaseScriptTransformationSuite extends SparkPlanTest with ClassicQueryTest {
   import classicTestImplicits._
   import ScriptTransformationIOSchema._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BroadcastExchangeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BroadcastExchangeSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
 import org.apache.spark.sql.execution.joins.HashedRelation
 import org.apache.spark.sql.functions.broadcast
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.tags.ExtendedSQLTest
 
 @ExtendedSQLTest

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BroadcastExchangeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BroadcastExchangeSuite.scala
@@ -28,11 +28,12 @@ import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
 import org.apache.spark.sql.execution.joins.HashedRelation
 import org.apache.spark.sql.functions.broadcast
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.tags.ExtendedSQLTest
 
 @ExtendedSQLTest
-class BroadcastExchangeSuite extends SharedSparkSession
+class BroadcastExchangeSuite extends SparkPlanTest
+  with SharedClassicSparkSession
   with AdaptiveSparkPlanHelper {
 
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, IdentityB
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, Exchange, ReusedExchangeExec, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.joins.HashedRelationBroadcastMode
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class RanColumnar extends RuntimeException
@@ -45,7 +45,7 @@ case class ColumnarExchange(child: SparkPlan) extends Exchange {
     copy(child = newChild)
 }
 
-class ExchangeSuite extends SharedSparkSession {
+class ExchangeSuite extends SparkPlanTest with SharedClassicSparkSession {
   import testImplicits._
 
   setupTestData()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, IdentityB
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, Exchange, ReusedExchangeExec, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.joins.HashedRelationBroadcastMode
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class RanColumnar extends RuntimeException

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -35,11 +35,11 @@ import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, SortMergeJoi
 import org.apache.spark.sql.execution.reuse.ReuseExchangeAndSubquery
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 
-class PlannerSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
-  import testImplicits._
+class PlannerSuite extends SharedClassicSparkSession with AdaptiveSparkPlanHelper {
+  import classicTestImplicits._
 
   setupTestData()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, SortMergeJoi
 import org.apache.spark.sql.execution.reuse.ReuseExchangeAndSubquery
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 
 class PlannerSuite extends SharedClassicSparkSession with AdaptiveSparkPlanHelper {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ReuseExchangeAndSubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ReuseExchangeAndSubquerySuite.scala
@@ -20,9 +20,9 @@ package org.apache.spark.sql.execution
 import org.apache.spark.sql.execution.exchange.{Exchange, ReusedExchangeExec}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
-class ReuseExchangeAndSubquerySuite extends SharedSparkSession {
+class ReuseExchangeAndSubquerySuite extends SparkPlanTest with SharedClassicSparkSession {
 
   val tableFormat: String = "parquet"
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ReuseExchangeAndSubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ReuseExchangeAndSubquerySuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution
 import org.apache.spark.sql.execution.exchange.{Exchange, ReusedExchangeExec}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 class ReuseExchangeAndSubquerySuite extends SparkPlanTest with SharedClassicSparkSession {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SortSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SortSuite.scala
@@ -23,14 +23,14 @@ import org.apache.spark.AccumulatorSuite
 import org.apache.spark.sql.{RandomDataGenerator, Row}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 
 /**
  * Test sorting. Many of the test cases generate random data and compares the sorted result with one
  * sorted by a reference implementation ([[ReferenceSort]]).
  */
-class SortSuite extends SharedSparkSession {
+class SortSuite extends SparkPlanTest with SharedClassicSparkSession {
   import testImplicits.newProductEncoder
   import testImplicits.localSeqToDatasetHolder
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SortSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SortSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.AccumulatorSuite
 import org.apache.spark.sql.{RandomDataGenerator, Row}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkScriptTransformationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkScriptTransformationSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution
 import org.apache.spark.TestUtils
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 class SparkScriptTransformationSuite extends BaseScriptTransformationSuite
   with SharedClassicSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkScriptTransformationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkScriptTransformationSuite.scala
@@ -20,9 +20,10 @@ package org.apache.spark.sql.execution
 import org.apache.spark.TestUtils
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
-class SparkScriptTransformationSuite extends BaseScriptTransformationSuite with SharedSparkSession {
+class SparkScriptTransformationSuite extends BaseScriptTransformationSuite
+  with SharedClassicSparkSession {
   import testImplicits._
 
   override protected def defaultSerDe(): String = "row-format-delimited"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/TakeOrderedAndProjectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/TakeOrderedAndProjectSuite.scala
@@ -22,11 +22,11 @@ import scala.util.Random
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.{Alias, Literal, Rand}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 
 
-class TakeOrderedAndProjectSuite extends SharedSparkSession {
+class TakeOrderedAndProjectSuite extends SparkPlanTest with SharedClassicSparkSession {
 
   private var rand: Random = _
   private var seed: Long = 0

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/TakeOrderedAndProjectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/TakeOrderedAndProjectSuite.scala
@@ -22,7 +22,7 @@ import scala.util.Random
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.{Alias, Literal, Rand}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowFileReadWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowFileReadWriteSuite.scala
@@ -18,11 +18,12 @@ package org.apache.spark.sql.execution.arrow
 
 import java.io.File
 
+import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.util.Utils
 
-class ArrowFileReadWriteSuite extends SharedSparkSession {
+class ArrowFileReadWriteSuite extends QueryTest with SharedClassicSparkSession {
 
   private var tempDataPath: String = _
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowFileReadWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowFileReadWriteSuite.scala
@@ -20,7 +20,7 @@ import java.io.File
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.util.Utils
 
 class ArrowFileReadWriteSuite extends QueryTest with SharedClassicSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.execution.{FilterExec, InputAdapter, WholeStageCodeg
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.test.SQLTestData._
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -22,7 +22,7 @@ import java.sql.{Date, Timestamp}
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet, In}
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
@@ -32,7 +32,7 @@ import org.apache.spark.sql.execution.{FilterExec, InputAdapter, WholeStageCodeg
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.test.SQLTestData._
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
@@ -50,8 +50,9 @@ class TestCachedBatchSerializer(
   }
 }
 
-class InMemoryColumnarQuerySuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
-  import testImplicits._
+class InMemoryColumnarQuerySuite extends QueryTest
+  with SharedClassicSparkSession with AdaptiveSparkPlanHelper {
+  import classicTestImplicits._
 
   setupTestData()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableDirHelper.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableDirHelper.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command
+
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.sql.test.ClassicSQLTestUtils
+
+trait AlterTableDirHelper extends ClassicSQLTestUtils {
+  def withTableDir(tableName: String)(f: (FileSystem, Path) => Unit): Unit = {
+    val location = sql(s"DESCRIBE TABLE EXTENDED $tableName")
+      .where("col_name = 'Location'")
+      .select("data_type")
+      .first()
+      .getString(0)
+    val root = new Path(location)
+    val fs = root.getFileSystem(spark.sessionState.newHadoopConf())
+    f(fs, root)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableDirHelper.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableDirHelper.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.command
 
 import org.apache.hadoop.fs.{FileSystem, Path}
 
-import org.apache.spark.sql.test.ClassicQueryTest
+import org.apache.spark.sql.test.classic.{QueryTest => ClassicQueryTest}
 
 trait AlterTableDirHelper extends ClassicQueryTest {
   def withTableDir(tableName: String)(f: (FileSystem, Path) => Unit): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableDirHelper.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableDirHelper.scala
@@ -19,9 +19,9 @@ package org.apache.spark.sql.execution.command
 
 import org.apache.hadoop.fs.{FileSystem, Path}
 
-import org.apache.spark.sql.test.ClassicSQLTestUtils
+import org.apache.spark.sql.test.ClassicQueryTest
 
-trait AlterTableDirHelper extends ClassicSQLTestUtils {
+trait AlterTableDirHelper extends ClassicQueryTest {
   def withTableDir(tableName: String)(f: (FileSystem, Path) => Unit): Unit = {
     val location = sql(s"DESCRIBE TABLE EXTENDED $tableName")
       .where("col_name = 'Location'")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.sql.execution.command
 
-import org.apache.spark.sql.test.ClassicSQLTestUtils
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.test.ClassicSQLTestUtils
 import org.apache.spark.storage.StorageLevel
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
@@ -36,7 +36,6 @@ trait AlterTableRenameSuiteBase
   extends QueryTest
     with DDLCommandTestUtils
     with ClassicSQLTestUtils {
-  import classicTestImplicits._
   override val command = "ALTER TABLE .. RENAME"
 
   test("rename a table in a database/namespace") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.command
 
+import org.apache.spark.sql.test.ClassicSQLTestUtils
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.storage.StorageLevel
 
@@ -31,8 +32,11 @@ import org.apache.spark.storage.StorageLevel
  *     - V1 Hive External catalog:
  *       `org.apache.spark.sql.hive.execution.command.AlterTableRenameSuite`
  */
-trait AlterTableRenameSuiteBase extends QueryTest with DDLCommandTestUtils {
-  import testImplicits._
+trait AlterTableRenameSuiteBase
+  extends QueryTest
+    with DDLCommandTestUtils
+    with ClassicSQLTestUtils {
+  import classicTestImplicits._
   override val command = "ALTER TABLE .. RENAME"
 
   test("rename a table in a database/namespace") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
-import org.apache.spark.sql.test.ClassicQueryTest
+import org.apache.spark.sql.test.classic.{QueryTest => ClassicQueryTest}
 import org.apache.spark.storage.StorageLevel
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
-import org.apache.spark.sql.test.ClassicSQLTestUtils
+import org.apache.spark.sql.test.ClassicQueryTest
 import org.apache.spark.storage.StorageLevel
 
 /**
@@ -35,7 +35,7 @@ import org.apache.spark.storage.StorageLevel
 trait AlterTableRenameSuiteBase
   extends QueryTest
     with DDLCommandTestUtils
-    with ClassicSQLTestUtils {
+    with ClassicQueryTest {
   override val command = "ALTER TABLE .. RENAME"
 
   test("rename a table in a database/namespace") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandTestUtils.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.command
 
 import java.io.File
 
-import org.apache.hadoop.fs.{FileSystem, Path}
 import org.scalactic.source.Position
 import org.scalatest.Tag
 
@@ -138,17 +137,6 @@ trait DDLCommandTestUtils extends QueryTest {
     val tables = sql(s"SHOW TABLES IN $catalog.$namespace").select("tableName")
     val rows = expectedTables.map(Row(_))
     QueryTest.checkAnswer(tables, rows)
-  }
-
-  def withTableDir(tableName: String)(f: (FileSystem, Path) => Unit): Unit = {
-    val location = sql(s"DESCRIBE TABLE EXTENDED $tableName")
-      .where("col_name = 'Location'")
-      .select("data_type")
-      .first()
-      .getString(0)
-    val root = new Path(location)
-    val fs = root.getFileSystem(spark.sessionState.newHadoopConf())
-    f(fs, root)
   }
 
   def getPartitionLocation(tableName: String, part: String): String = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1091,7 +1091,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
         "alternative" -> "DROP TABLE",
         "operation" -> "DROP VIEW",
         "foundType" -> "EXTERNAL",
-        "requiredType" -> "VIEW",
+        "requiredType" -> "VIEW or METRIC_VIEW",
         "objectName" -> "spark_catalog.dbx.tab1")
     )
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -38,7 +38,8 @@ import org.apache.spark.sql.connector.catalog.SupportsNamespaces.PROP_OWNER
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
-import org.apache.spark.sql.test.{ClassicQueryTest, SharedClassicSparkSession}
+import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{QueryTest => ClassicQueryTest}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -38,12 +38,12 @@ import org.apache.spark.sql.connector.catalog.SupportsNamespaces.PROP_OWNER
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.{ClassicSQLTestUtils, SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
-class InMemoryCatalogedDDLSuite extends DDLSuite with SharedSparkSession {
-  import testImplicits._
+class InMemoryCatalogedDDLSuite extends DDLSuite with SharedClassicSparkSession {
+  import classicTestImplicits._
 
   override def afterEach(): Unit = {
     try {
@@ -117,7 +117,7 @@ class InMemoryCatalogedDDLSuite extends DDLSuite with SharedSparkSession {
   }
 
   test("Create Hive Table As Select") {
-    import testImplicits._
+    import classicTestImplicits._
     withTable("t", "t1") {
       checkError(
         exception = intercept[AnalysisException] {
@@ -251,7 +251,7 @@ class InMemoryCatalogedDDLSuite extends DDLSuite with SharedSparkSession {
   }
 }
 
-trait DDLSuiteBase extends QueryTest {
+trait DDLSuiteBase extends ClassicSQLTestUtils {
 
   protected def isUsingHiveMetastore: Boolean = {
     spark.sparkContext.conf.get(CATALOG_IMPLEMENTATION) == "hive"
@@ -440,7 +440,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   }
 
   test("Create partitioned data source table without user specified schema") {
-    import testImplicits._
+    import classicTestImplicits._
     val df = sparkContext.parallelize(1 to 10).map(i => (i, i.toString)).toDF("num", "str")
 
     // Case 1: with partitioning columns but no schema: Option("nonexistentColumns")
@@ -460,7 +460,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   }
 
   test("Create partitioned data source table with user specified schema") {
-    import testImplicits._
+    import classicTestImplicits._
     val df = sparkContext.parallelize(1 to 10).map(i => (i, i.toString)).toDF("num", "str")
 
     // Case 1: with partitioning columns but no schema: Option("num")
@@ -480,7 +480,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   }
 
   test("Create non-partitioned data source table without user specified schema") {
-    import testImplicits._
+    import classicTestImplicits._
     val df = sparkContext.parallelize(1 to 10).map(i => (i, i.toString)).toDF("num", "str")
 
     // Case 1: with partitioning columns but no schema: Option("nonexistentColumns")
@@ -499,7 +499,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   }
 
   test("Create non-partitioned data source table with user specified schema") {
-    import testImplicits._
+    import classicTestImplicits._
     val df = sparkContext.parallelize(1 to 10).map(i => (i, i.toString)).toDF("num", "str")
 
     // Case 1: with partitioning columns but no schema: Option("nonexistentColumns")
@@ -599,7 +599,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   }
 
   test("create table - append to a non-partitioned table created with different paths") {
-    import testImplicits._
+    import classicTestImplicits._
     withTempDir { dir1 =>
       withTempDir { dir2 =>
         withTable("path_test") {
@@ -633,7 +633,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   }
 
   test("Refresh table after changing the data source table partitioning") {
-    import testImplicits._
+    import classicTestImplicits._
 
     val tabName = "tab1"
     val catalog = spark.sessionState.catalog
@@ -1091,7 +1091,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
         "alternative" -> "DROP TABLE",
         "operation" -> "DROP VIEW",
         "foundType" -> "EXTERNAL",
-        "requiredType" -> "VIEW or METRIC_VIEW",
+        "requiredType" -> "VIEW",
         "objectName" -> "spark_catalog.dbx.tab1")
     )
   }
@@ -1218,7 +1218,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   }
 
   test("create a data source table without schema") {
-    import testImplicits._
+    import classicTestImplicits._
     withTempPath { tempDir =>
       withTable("tab1", "tab2") {
         (("a", "b") :: Nil).toDF().write.json(tempDir.getCanonicalPath)
@@ -1236,7 +1236,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   }
 
   test("create table using CLUSTERED BY without schema specification") {
-    import testImplicits._
+    import classicTestImplicits._
     withTempPath { tempDir =>
       withTable("jsonTable") {
         (("a", "b") :: Nil).toDF().write.json(tempDir.getCanonicalPath)
@@ -1261,7 +1261,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   }
 
   test("Create Data Source Table As Select") {
-    import testImplicits._
+    import classicTestImplicits._
     withTable("t", "t1", "t2") {
       sql("CREATE TABLE t USING parquet SELECT 1 as a, 1 as b")
       checkAnswer(spark.table("t"), Row(1, 1) :: Nil)
@@ -1325,7 +1325,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   }
 
   test("SPARK-16034 Partition columns should match when appending to existing data source tables") {
-    import testImplicits._
+    import classicTestImplicits._
     val df = Seq((1, 2, 3)).toDF("a", "b", "c")
     withTable("partitionedTable") {
       df.write.mode("overwrite").partitionBy("a", "b").saveAsTable("partitionedTable")
@@ -1868,7 +1868,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
             spark.sql(s"CREATE DATABASE tmpdb LOCATION '$escapedLoc'")
             spark.sql("USE tmpdb")
 
-            import testImplicits._
+            import classicTestImplicits._
             Seq(1).toDF("a").write.saveAsTable("t")
             val tblloc = new File(loc, "t")
             val table = spark.sessionState.catalog.getTableMetadata(TableIdentifier("t"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.connector.catalog.SupportsNamespaces.PROP_OWNER
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
-import org.apache.spark.sql.test.{ClassicSQLTestUtils, SharedClassicSparkSession}
+import org.apache.spark.sql.test.{ClassicQueryTest, SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
@@ -251,7 +251,7 @@ class InMemoryCatalogedDDLSuite extends DDLSuite with SharedClassicSparkSession 
   }
 }
 
-trait DDLSuiteBase extends ClassicSQLTestUtils {
+trait DDLSuiteBase extends ClassicQueryTest {
 
   protected def isUsingHiveMetastore: Boolean = {
     spark.sparkContext.conf.get(CATALOG_IMPLEMENTATION) == "hive"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.connector.catalog.SupportsNamespaces.PROP_OWNER
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.test.classic.{QueryTest => ClassicQueryTest}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DropTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DropTableSuiteBase.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.sql.execution.command
 
-import org.apache.spark.sql.test.ClassicSQLTestUtils
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.test.ClassicSQLTestUtils
 
 /**
  * This base suite contains unified tests for the `DROP TABLE` command that check V1 and V2

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DropTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DropTableSuiteBase.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.test.ClassicSQLTestUtils
  *     - V1 Hive External catalog: `org.apache.spark.sql.hive.execution.command.DropTableSuite`
  */
 trait DropTableSuiteBase extends QueryTest with DDLCommandTestUtils with ClassicSQLTestUtils {
-  import classicTestImplicits._
   override val command = "DROP TABLE"
 
   protected def createTable(tableName: String): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DropTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DropTableSuiteBase.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
-import org.apache.spark.sql.test.ClassicSQLTestUtils
+import org.apache.spark.sql.test.ClassicQueryTest
 
 /**
  * This base suite contains unified tests for the `DROP TABLE` command that check V1 and V2
@@ -30,7 +30,7 @@ import org.apache.spark.sql.test.ClassicSQLTestUtils
  *     - V1 In-Memory catalog: `org.apache.spark.sql.execution.command.v1.DropTableSuite`
  *     - V1 Hive External catalog: `org.apache.spark.sql.hive.execution.command.DropTableSuite`
  */
-trait DropTableSuiteBase extends QueryTest with DDLCommandTestUtils with ClassicSQLTestUtils {
+trait DropTableSuiteBase extends QueryTest with DDLCommandTestUtils with ClassicQueryTest {
   override val command = "DROP TABLE"
 
   protected def createTable(tableName: String): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DropTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DropTableSuiteBase.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.command
 
+import org.apache.spark.sql.test.ClassicSQLTestUtils
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 
 /**
@@ -29,8 +30,8 @@ import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
  *     - V1 In-Memory catalog: `org.apache.spark.sql.execution.command.v1.DropTableSuite`
  *     - V1 Hive External catalog: `org.apache.spark.sql.hive.execution.command.DropTableSuite`
  */
-trait DropTableSuiteBase extends QueryTest with DDLCommandTestUtils {
-  import testImplicits._
+trait DropTableSuiteBase extends QueryTest with DDLCommandTestUtils with ClassicSQLTestUtils {
+  import classicTestImplicits._
   override val command = "DROP TABLE"
 
   protected def createTable(tableName: String): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DropTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DropTableSuiteBase.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
-import org.apache.spark.sql.test.ClassicQueryTest
+import org.apache.spark.sql.test.classic.{QueryTest => ClassicQueryTest}
 
 /**
  * This base suite contains unified tests for the `DROP TABLE` command that check V1 and V2

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableRecoverPartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableRecoverPartitionsSuite.scala
@@ -22,7 +22,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.internal.config.RDD_PARALLEL_LISTING_THRESHOLD
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.execution.command
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 /**
  * This base suite contains unified tests for the `ALTER TABLE .. RECOVER PARTITIONS` command that

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableRecoverPartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableRecoverPartitionsSuite.scala
@@ -22,6 +22,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.internal.config.RDD_PARALLEL_LISTING_THRESHOLD
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.execution.command
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
 /**
  * This base suite contains unified tests for the `ALTER TABLE .. RECOVER PARTITIONS` command that
@@ -35,7 +36,9 @@ import org.apache.spark.sql.execution.command
  *   - V1 Hive External catalog:
  *     `org.apache.spark.sql.hive.execution.command.AlterTableRecoverPartitionsSuite`
  */
-trait AlterTableRecoverPartitionsSuiteBase extends command.AlterTableRecoverPartitionsSuiteBase {
+trait AlterTableRecoverPartitionsSuiteBase
+  extends command.AlterTableRecoverPartitionsSuiteBase
+  with command.AlterTableDirHelper {
   test("table does not exist") {
     val e = intercept[AnalysisException] {
       sql("ALTER TABLE does_not_exist RECOVER PARTITIONS")
@@ -138,7 +141,8 @@ trait AlterTableRecoverPartitionsSuiteBase extends command.AlterTableRecoverPart
  */
 class AlterTableRecoverPartitionsSuite
   extends AlterTableRecoverPartitionsSuiteBase
-  with CommandSuiteBase {
+  with CommandSuiteBase
+  with SharedClassicSparkSession {
 
   override protected def sparkConf = super.sparkConf
     .set(RDD_PARALLEL_LISTING_THRESHOLD, 0)
@@ -150,7 +154,8 @@ class AlterTableRecoverPartitionsSuite
  */
 class AlterTableRecoverPartitionsParallelSuite
   extends AlterTableRecoverPartitionsSuiteBase
-  with CommandSuiteBase {
+  with CommandSuiteBase
+  with SharedClassicSparkSession {
 
   override protected def sparkConf = super.sparkConf
     .set(RDD_PARALLEL_LISTING_THRESHOLD, 10)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableRenameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableRenameSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.SparkRuntimeException
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.errors.QueryErrorsBase
 import org.apache.spark.sql.execution.command
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 /**
  * This base suite contains unified tests for the `ALTER TABLE .. RENAME` command that check V1

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableRenameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/AlterTableRenameSuite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkRuntimeException
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.errors.QueryErrorsBase
 import org.apache.spark.sql.execution.command
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
 /**
  * This base suite contains unified tests for the `ALTER TABLE .. RENAME` command that check V1
@@ -30,7 +31,10 @@ import org.apache.spark.sql.execution.command
  *   - V1 In-Memory catalog: `org.apache.spark.sql.execution.command.v1.AlterTableRenameSuite`
  *   - V1 Hive External catalog: `org.apache.spark.sql.hive.execution.command.AlterTableRenameSuite`
  */
-trait AlterTableRenameSuiteBase extends command.AlterTableRenameSuiteBase with QueryErrorsBase {
+trait AlterTableRenameSuiteBase
+  extends command.AlterTableRenameSuiteBase
+    with command.AlterTableDirHelper
+    with QueryErrorsBase {
   test("destination database is different") {
     withNamespaceAndTable("dst_ns", "dst_tbl") { dst =>
       withNamespace("src_ns") {
@@ -89,3 +93,4 @@ trait AlterTableRenameSuiteBase extends command.AlterTableRenameSuiteBase with Q
  * V1 In-Memory table catalog.
  */
 class AlterTableRenameSuite extends AlterTableRenameSuiteBase with CommandSuiteBase
+  with SharedClassicSparkSession

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DropTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DropTableSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.command.v1
 
 import org.apache.spark.sql.execution.command
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 /**
  * This base suite contains unified tests for the `DROP TABLE` command that check V1

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DropTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DropTableSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.command.v1
 
 import org.apache.spark.sql.execution.command
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
 /**
  * This base suite contains unified tests for the `DROP TABLE` command that check V1
@@ -44,5 +45,5 @@ trait DropTableSuiteBase extends command.DropTableSuiteBase {
 /**
  * The class contains tests for the `DROP TABLE` command to check V1 In-Memory table catalog.
  */
-class DropTableSuite extends DropTableSuiteBase with CommandSuiteBase
+class DropTableSuite extends DropTableSuiteBase with CommandSuiteBase with SharedClassicSparkSession
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableRenameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableRenameSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.command.v2
 
 import org.apache.spark.sql.execution.command
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 /**
  * The class contains tests for the `ALTER TABLE .. RENAME` command to check V2 table catalogs.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableRenameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableRenameSuite.scala
@@ -18,11 +18,15 @@
 package org.apache.spark.sql.execution.command.v2
 
 import org.apache.spark.sql.execution.command
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
 /**
  * The class contains tests for the `ALTER TABLE .. RENAME` command to check V2 table catalogs.
  */
-class AlterTableRenameSuite extends command.AlterTableRenameSuiteBase with CommandSuiteBase {
+class AlterTableRenameSuite
+  extends command.AlterTableRenameSuiteBase
+    with CommandSuiteBase
+    with SharedClassicSparkSession {
   test("destination namespace is different") {
     withNamespaceAndTable("dst_ns", "dst_tbl") { dst =>
       withNamespace("src_ns") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DropTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DropTableSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.connector.InMemoryTableSessionCatalog
 import org.apache.spark.sql.execution.command
 import org.apache.spark.sql.internal.SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 /**
  * The class contains tests for the `DROP TABLE` command to check V2 table catalogs.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DropTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DropTableSuite.scala
@@ -22,11 +22,13 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.connector.InMemoryTableSessionCatalog
 import org.apache.spark.sql.execution.command
 import org.apache.spark.sql.internal.SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
 /**
  * The class contains tests for the `DROP TABLE` command to check V2 table catalogs.
  */
-class DropTableSuite extends command.DropTableSuiteBase with CommandSuiteBase {
+class DropTableSuite extends command.DropTableSuiteBase with CommandSuiteBase
+  with SharedClassicSparkSession {
   test("purge option") {
     withNamespaceAndTable("ns", "tbl") { t =>
       createTable(t)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CommonFileDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CommonFileDataSourceSuite.scala
@@ -22,19 +22,17 @@ import java.util.zip.GZIPOutputStream
 
 import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
 
-import org.apache.spark.sql.{Encoders, FakeFileSystemRequiringDSOption}
+import org.apache.spark.sql.{Dataset, Encoders, FakeFileSystemRequiringDSOption, SparkSessionProvider}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
-import org.apache.spark.sql.classic .{Dataset, SparkSession}
 
 /**
  * The trait contains tests for all file-based data sources.
  * The tests that are not applicable to all file-based data sources should be placed to
  * [[org.apache.spark.sql.FileBasedDataSourceSuite]].
  */
-trait CommonFileDataSourceSuite extends SQLHelper {
+trait CommonFileDataSourceSuite extends SQLHelper with SparkSessionProvider {
     self: AnyFunSuite => // scalastyle:ignore funsuite
 
-  protected def spark: SparkSession
   protected def dataSourceFormat: String
   protected def inputDataset: Dataset[_] = spark.createDataset(Seq("abc"))(Encoders.STRING)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceResolverSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.analysis.resolver.{
 }
 import org.apache.spark.sql.catalyst.catalog.UnresolvedCatalogRelation
 import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 class DataSourceResolverSuite extends QueryTest with SharedClassicSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceResolverSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.analysis.resolver.{
   MetadataResolver,
@@ -25,10 +26,10 @@ import org.apache.spark.sql.catalyst.analysis.resolver.{
 }
 import org.apache.spark.sql.catalyst.catalog.UnresolvedCatalogRelation
 import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
-class DataSourceResolverSuite extends SharedSparkSession {
+class DataSourceResolverSuite extends QueryTest with SharedClassicSparkSession {
   private val keyValueTableSchema = StructType(
     Seq(
       StructField("key", IntegerType, true),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceSuite.scala
@@ -27,10 +27,10 @@ import org.scalatest.PrivateMethodTester
 
 import org.apache.spark.{SparkIllegalArgumentException, SparkUnsupportedOperationException}
 import org.apache.spark.sql.{AnalysisException, SaveMode}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.util.Utils
 
-class DataSourceSuite extends SharedSparkSession with PrivateMethodTester {
+class DataSourceSuite extends SharedClassicSparkSession with PrivateMethodTester {
   import TestPaths._
 
   test("test glob and non glob paths") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceSuite.scala
@@ -27,7 +27,7 @@ import org.scalatest.PrivateMethodTester
 
 import org.apache.spark.{SparkIllegalArgumentException, SparkUnsupportedOperationException}
 import org.apache.spark.sql.{AnalysisException, SaveMode}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.util.Utils
 
 class DataSourceSuite extends SharedClassicSparkSession with PrivateMethodTester {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileResolverSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.analysis.resolver.ProhibitedResolver
 import org.apache.spark.sql.catalyst.plans.logical.Project
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{LongType, StringType, StructType}
 
 class FileResolverSuite extends QueryTest with SharedClassicSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileResolverSuite.scala
@@ -17,13 +17,14 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.analysis.resolver.ProhibitedResolver
 import org.apache.spark.sql.catalyst.plans.logical.Project
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{LongType, StringType, StructType}
 
-class FileResolverSuite extends SharedSparkSession {
+class FileResolverSuite extends QueryTest with SharedClassicSparkSession {
   private val tableSchema = new StructType().add("id", LongType)
   private val csvTableSchema = new StructType().add("_c0", StringType)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceCustomMetadataStructSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceCustomMetadataStructSuite.scala
@@ -21,7 +21,7 @@ import java.io.File
 
 import org.apache.hadoop.fs.{FileStatus, Path}
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, FileSourceConstantMetadataStructField, FileSourceGeneratedMetadataStructField, Literal}
 import org.apache.spark.sql.catalyst.util.GenericArrayData
@@ -29,12 +29,12 @@ import org.apache.spark.sql.classic.{DataFrame, Dataset}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.functions.{col, lit, when}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{ArrayType, IntegerType, LongType, StringType, StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 
 /** Verifies the ability for a FileFormat to define custom metadata types */
-class FileSourceCustomMetadataStructSuite extends SharedSparkSession {
+class FileSourceCustomMetadataStructSuite extends QueryTest with SharedClassicSparkSession {
   import FileSourceCustomMetadataStructSuite._
 
   val extraConstantMetadataFields = Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceCustomMetadataStructSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceCustomMetadataStructSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.classic.{DataFrame, Dataset}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.functions.{col, lit, when}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{ArrayType, IntegerType, LongType, StringType, StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/InMemoryTableMetricSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/InMemoryTableMetricSuite.scala
@@ -20,13 +20,15 @@ import java.util.Collections
 
 import org.scalatest.BeforeAndAfter
 
+import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.connector.catalog.{Column, Identifier, InMemoryTable, InMemoryTableCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.functions.lit
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.IntegerType
 
-class InMemoryTableMetricSuite extends SharedSparkSession with BeforeAndAfter {
+class InMemoryTableMetricSuite
+  extends QueryTest with SharedClassicSparkSession with BeforeAndAfter {
   import testImplicits._
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/InMemoryTableMetricSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/InMemoryTableMetricSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.connector.catalog.{Column, Identifier, InMemoryTable, InMemoryTableCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.functions.lit
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.IntegerType
 
 class InMemoryTableMetricSuite

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SaveMode, SparkSession, SQLContext}
 import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, RelationProvider, TableScan}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
 
 class SaveIntoDataSourceCommandSuite extends QueryTest with SharedClassicSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
@@ -18,12 +18,12 @@
 package org.apache.spark.sql.execution.datasources
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SaveMode, SparkSession, SQLContext}
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SaveMode, SparkSession, SQLContext}
 import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, RelationProvider, TableScan}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
 
-class SaveIntoDataSourceCommandSuite extends SharedSparkSession {
+class SaveIntoDataSourceCommandSuite extends QueryTest with SharedClassicSparkSession {
 
   test("simpleString is redacted") {
     val URL = "connection.url"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -592,7 +592,6 @@ abstract class SchemaPruningSuite
 
   testSchemaPruning("select nested field in Expand") {
     import org.apache.spark.sql.catalyst.dsl.expressions._
-    import testImplicits.castToImpl
 
     val query1 = Expand(
       Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 
 abstract class SchemaPruningSuite

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -32,13 +32,13 @@ import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 
 abstract class SchemaPruningSuite
   extends FileBasedDataSourceTest
   with SchemaPruningTest
-  with SharedSparkSession
+  with SharedClassicSparkSession
   with AdaptiveSparkPlanHelper {
   case class FullName(first: String, middle: String, last: String)
   case class Company(name: String, address: String)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReaderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReaderSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.vectorized.{ConstantColumnVector, OffHeapColumnVector}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.unsafe.types.UTF8String.fromString

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReaderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReaderSuite.scala
@@ -27,16 +27,17 @@ import org.apache.orc.TypeDescription
 
 import org.apache.spark.TestUtils
 import org.apache.spark.memory.MemoryMode
+import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.vectorized.{ConstantColumnVector, OffHeapColumnVector}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.unsafe.types.UTF8String.fromString
 
-class OrcColumnarBatchReaderSuite extends SharedSparkSession {
+class OrcColumnarBatchReaderSuite extends QueryTest with SharedClassicSparkSession {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcEncryptionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcEncryptionSuite.scala
@@ -27,7 +27,7 @@ import org.apache.orc.impl.{CryptoUtils, HadoopShimsFactory, KeyProvider}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 class OrcEncryptionSuite extends OrcTest with SharedClassicSparkSession {
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcEncryptionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcEncryptionSuite.scala
@@ -27,9 +27,9 @@ import org.apache.orc.impl.{CryptoUtils, HadoopShimsFactory, KeyProvider}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
-class OrcEncryptionSuite extends OrcTest with SharedSparkSession {
+class OrcEncryptionSuite extends OrcTest with SharedClassicSparkSession {
   import testImplicits._
 
   override def sparkConf: SparkConf = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.execution.datasources.v2.ExtractV2Scan
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.util.ArrayImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.execution.datasources.v2.ExtractV2Scan
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.util.ArrayImplicits._
@@ -45,7 +45,7 @@ import org.apache.spark.util.ArrayImplicits._
  * A test suite that tests Apache ORC filter API based filter pushdown optimization.
  */
 @ExtendedSQLTest
-class OrcFilterSuite extends OrcTest with SharedSparkSession {
+class OrcFilterSuite extends OrcTest with SharedClassicSparkSession {
   import testImplicits.{toRichColumn, ColumnConstructorExt}
 
   override protected def sparkConf: SparkConf =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcPartitionDiscoverySuite.scala
@@ -24,7 +24,7 @@ import org.apache.hadoop.fs.{Path, PathFilter}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.util.Utils
 
 // The data where the partitioning key exists only in the directory structure.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcPartitionDiscoverySuite.scala
@@ -24,7 +24,7 @@ import org.apache.hadoop.fs.{Path, PathFilter}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.util.Utils
 
 // The data where the partitioning key exists only in the directory structure.
@@ -169,7 +169,7 @@ abstract class OrcPartitionDiscoveryTest extends OrcTest {
   }
 }
 
-class OrcPartitionDiscoverySuite extends OrcPartitionDiscoveryTest with SharedSparkSession {
+class OrcPartitionDiscoverySuite extends OrcPartitionDiscoveryTest with SharedClassicSparkSession {
   override protected def sparkConf: SparkConf = super.sparkConf.set(SQLConf.USE_V1_SOURCE_LIST, "")
 
   test("read partitioned table - partition key included in orc file") {
@@ -255,7 +255,8 @@ class OrcPartitionDiscoverySuite extends OrcPartitionDiscoveryTest with SharedSp
   }
 }
 
-class OrcV1PartitionDiscoverySuite extends OrcPartitionDiscoveryTest with SharedSparkSession {
+class OrcV1PartitionDiscoverySuite extends OrcPartitionDiscoveryTest
+  with SharedClassicSparkSession {
   override protected def sparkConf: SparkConf =
     super
       .sparkConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation, RecordReaderIterator}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 import org.apache.spark.util.collection.Utils.createArray

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation, RecordReaderIterator}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 import org.apache.spark.util.collection.Utils.createArray
@@ -718,7 +718,7 @@ abstract class OrcQueryTest extends OrcTest {
   }
 }
 
-abstract class OrcQuerySuite extends OrcQueryTest with SharedSparkSession {
+abstract class OrcQuerySuite extends OrcQueryTest with SharedClassicSparkSession {
   import testImplicits._
 
   test("LZO compression options for writing to an ORC file") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -37,7 +37,8 @@ import org.apache.spark.sql.{Row, SPARK_VERSION_METADATA_KEY}
 import org.apache.spark.sql.execution.datasources.{CommonFileDataSourceSuite, SchemaMergeUtils}
 import org.apache.spark.sql.execution.datasources.orc.OrcCompressionCodec._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{SharedClassicSparkSession, SQLTestUtilsBase}
+import org.apache.spark.sql.test.SQLTestUtilsBase
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -33,18 +33,18 @@ import org.apache.orc.OrcProto.Stream.Kind
 import org.apache.orc.impl.RecordReaderImpl
 
 import org.apache.spark.{SPARK_VERSION_SHORT, SparkConf, SparkException}
-import org.apache.spark.sql.{QueryTestBase, Row, SPARK_VERSION_METADATA_KEY}
+import org.apache.spark.sql.{Row, SPARK_VERSION_METADATA_KEY}
 import org.apache.spark.sql.execution.datasources.{CommonFileDataSourceSuite, SchemaMergeUtils}
 import org.apache.spark.sql.execution.datasources.orc.OrcCompressionCodec._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.{SharedClassicSparkSession, SQLTestUtilsBase}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
 case class OrcData(intField: Int, stringField: String)
 
 abstract class OrcSuite
-  extends OrcTest with CommonFileDataSourceSuite with QueryTestBase {
+  extends OrcTest with CommonFileDataSourceSuite with SQLTestUtilsBase {
   import testImplicits._
 
   override protected def dataSourceFormat = "orc"
@@ -629,7 +629,7 @@ abstract class OrcSuite
   }
 }
 
-abstract class OrcSourceSuite extends OrcSuite with SharedSparkSession {
+abstract class OrcSourceSuite extends OrcSuite with SharedClassicSparkSession {
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.execution.datasources.v2.ExtractV2Scan
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.ORC_IMPLEMENTATION
+import org.apache.spark.sql.test.ClassicSQLTestUtils
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
 
@@ -47,7 +48,7 @@ import org.apache.spark.util.Utils
  *       -> HiveOrcPartitionDiscoverySuite
  *   -> OrcFilterSuite
  */
-trait OrcTest extends QueryTest with FileBasedDataSourceTest {
+trait OrcTest extends QueryTest with FileBasedDataSourceTest with ClassicSQLTestUtils {
 
   val orcImp: String = "native"
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.execution.datasources.v2.ExtractV2Scan
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.ORC_IMPLEMENTATION
-import org.apache.spark.sql.test.ClassicSQLTestUtils
+import org.apache.spark.sql.test.ClassicQueryTest
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
 
@@ -48,7 +48,7 @@ import org.apache.spark.util.Utils
  *       -> HiveOrcPartitionDiscoverySuite
  *   -> OrcFilterSuite
  */
-trait OrcTest extends QueryTest with FileBasedDataSourceTest with ClassicSQLTestUtils {
+trait OrcTest extends QueryTest with FileBasedDataSourceTest with ClassicQueryTest {
 
   val orcImp: String = "native"
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.execution.datasources.v2.ExtractV2Scan
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.ORC_IMPLEMENTATION
-import org.apache.spark.sql.test.ClassicQueryTest
+import org.apache.spark.sql.test.classic.{QueryTest => ClassicQueryTest}
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -2353,7 +2353,7 @@ class ParquetV1FilterSuite extends ParquetFilterSuite {
           assert(pushedParquetFilters.exists(_.getClass === filterClass),
             s"${pushedParquetFilters.map(_.getClass).toList} did not contain ${filterClass}.")
 
-          checker(stripSparkFilter(query), expected)
+          checker(stripSparkFilter(query.asInstanceOf[classic.DataFrame]), expected)
         } else {
           assert(selectedFilters.isEmpty, "There is filter pushed down")
         }
@@ -2416,7 +2416,7 @@ class ParquetV2FilterSuite extends ParquetFilterSuite {
           assert(pushedParquetFilters.exists(_.getClass === filterClass),
             s"${pushedParquetFilters.map(_.getClass).toList} did not contain ${filterClass}.")
 
-          checker(stripSparkFilter(query), expected)
+          checker(stripSparkFilter(query.asInstanceOf[classic.DataFrame]), expected)
 
         case _ => assert(false, "Can not match ParquetTable in the query.")
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -52,7 +52,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.internal.LegacyBehaviorPolicy.{CORRECTED, LEGACY}
 import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType.{INT96, TIMESTAMP_MICROS, TIMESTAMP_MILLIS}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.util.{AccumulatorContext, AccumulatorV2, Utils}
@@ -76,8 +76,11 @@ import org.apache.spark.util.ArrayImplicits._
  * dependent on this configuration, don't forget you better explicitly set this configuration
  * within the test.
  */
-abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
-  import testImplicits.toRichColumn
+abstract class ParquetFilterSuite
+  extends QueryTest
+    with ParquetTest
+    with SharedClassicSparkSession {
+  import classicTestImplicits.toRichColumn
 
   protected def createParquetFilters(
       schema: MessageType,
@@ -155,7 +158,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
     val ts3 = data(2)
     val ts4 = data(3)
 
-    import testImplicits._
+    import classicTestImplicits._
     val df = data.map(i => Tuple1(Timestamp.valueOf(i))).toDF()
     withNestedParquetDataFrame(df) { case (parquetDF, colName, fun) =>
       implicit val df: DataFrame = parquetDF
@@ -689,7 +692,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
     }
 
     val data = Seq("1000-01-01", "2018-03-19", "2018-03-20", "2018-03-21")
-    import testImplicits._
+    import classicTestImplicits._
 
     Seq(false, true).foreach { java8Api =>
       Seq(CORRECTED, LEGACY).foreach { rebaseMode =>
@@ -796,7 +799,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
           SQLConf.DATETIME_JAVA8API_ENABLED.key -> java8Api.toString,
           SQLConf.PARQUET_INT96_REBASE_MODE_IN_WRITE.key -> rebaseMode.toString,
           SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> INT96.toString) {
-          import testImplicits._
+          import classicTestImplicits._
           withTempPath { file =>
             millisData.map(i => Tuple1(Timestamp.valueOf(i))).toDF()
               .write.format(dataSourceName).save(file.getCanonicalPath)
@@ -979,7 +982,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
   }
 
   test("SPARK-6554: don't push down predicates which reference partition columns") {
-    import testImplicits._
+    import classicTestImplicits._
 
     withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true") {
       withTempPath { dir =>
@@ -996,7 +999,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
   }
 
   test("SPARK-10829: Filter combine partition key and attribute doesn't work in DataSource scan") {
-    import testImplicits._
+    import classicTestImplicits._
 
     withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true") {
       withTempPath { dir =>
@@ -1013,7 +1016,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
   }
 
   test("SPARK-12231: test the filter and empty project in partitioned DataSource scan") {
-    import testImplicits._
+    import classicTestImplicits._
 
     withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true") {
       withTempPath { dir =>
@@ -1032,7 +1035,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
   }
 
   test("SPARK-12231: test the new projection in partitioned DataSource scan") {
-    import testImplicits._
+    import classicTestImplicits._
 
     withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true") {
       withTempPath { dir =>
@@ -1054,7 +1057,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
 
 
   test("Filter applied on merged Parquet schema with new column should work") {
-    import testImplicits._
+    import classicTestImplicits._
     withAllParquetReaders {
       withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true",
         SQLConf.PARQUET_SCHEMA_MERGING_ENABLED.key -> "true") {
@@ -1089,7 +1092,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
 
   // The unsafe row RecordReader does not support row by row filtering so run it with it disabled.
   test("SPARK-11661 Still pushdown filters returned by unhandledFilters") {
-    import testImplicits._
+    import classicTestImplicits._
     withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true") {
       withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
         withTempPath { dir =>
@@ -1108,7 +1111,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
   }
 
   test("SPARK-12218: 'Not' is included in Parquet filter pushdown") {
-    import testImplicits._
+    import classicTestImplicits._
 
     withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true") {
       withTempPath { dir =>
@@ -1505,7 +1508,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
   }
 
   test("Filters should be pushed down for vectorized Parquet reader at row group level") {
-    import testImplicits._
+    import classicTestImplicits._
 
     withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true",
         SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false") {
@@ -1536,7 +1539,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
   test("SPARK-17213: Broken Parquet filter push-down for string columns") {
     withAllParquetReaders {
       withTempPath { dir =>
-        import testImplicits._
+        import classicTestImplicits._
 
         val path = dir.getCanonicalPath
         // scalastyle:off nonascii
@@ -1555,7 +1558,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
   }
 
   test("SPARK-31026: Parquet predicate pushdown for fields having dots in the names") {
-    import testImplicits._
+    import classicTestImplicits._
 
     withAllParquetReaders {
       withSQLConf(
@@ -1593,7 +1596,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
   }
 
   test("Filters should be pushed down for Parquet readers at row group level") {
-    import testImplicits._
+    import classicTestImplicits._
 
     withSQLConf(
       // Makes sure disabling 'spark.sql.parquet.recordFilter' still enables
@@ -1706,7 +1709,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
   }
 
   test("filter pushdown - StringPredicate") {
-    import testImplicits._
+    import classicTestImplicits._
     // keep() should take effect on StartsWith/EndsWith/Contains
     Seq(
       "value like 'a%'", // StartsWith
@@ -1784,7 +1787,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
       }
     }
 
-    import testImplicits._
+    import classicTestImplicits._
     withTempPath { path =>
       val data = 0 to 1024
       data.toDF("a").selectExpr("if (a = 1024, null, a) AS a") // convert 1024 to null
@@ -1972,7 +1975,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
   }
 
   test("SPARK-30826: case insensitivity of StringStartsWith attribute") {
-    import testImplicits._
+    import classicTestImplicits._
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
       withTable("t1") {
         withTempPath { dir =>
@@ -2174,7 +2177,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
   }
 
   test("SPARK-38825: in and notIn filters") {
-    import testImplicits._
+    import classicTestImplicits._
     withTempPath { file =>
       Seq(3, 20).foreach { threshold =>
         withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_INFILTERTHRESHOLD.key -> s"$threshold") {
@@ -2279,7 +2282,7 @@ abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
 
 @ExtendedSQLTest
 class ParquetV1FilterSuite extends ParquetFilterSuite {
-  import testImplicits.ColumnConstructorExt
+  import classicTestImplicits.ColumnConstructorExt
 
   override protected def sparkConf: SparkConf =
     super
@@ -2361,7 +2364,7 @@ class ParquetV1FilterSuite extends ParquetFilterSuite {
 
 @ExtendedSQLTest
 class ParquetV2FilterSuite extends ParquetFilterSuite {
-  import testImplicits.ColumnConstructorExt
+  import classicTestImplicits.ColumnConstructorExt
 
   // TODO: enable Parquet V2 write path after file source V2 writers are workable.
   override protected def sparkConf: SparkConf =
@@ -2421,7 +2424,7 @@ class ParquetV2FilterSuite extends ParquetFilterSuite {
   }
 
   test("SPARK-36889: Respect disabling of filters pushdown for DSv2 by explain") {
-    import testImplicits._
+    import classicTestImplicits._
     withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "false") {
       withTempPath { path =>
         Seq(1, 2).toDF("c0").write.parquet(path.getAbsolutePath)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -52,7 +52,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.internal.LegacyBehaviorPolicy.{CORRECTED, LEGACY}
 import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType.{INT96, TIMESTAMP_MICROS, TIMESTAMP_MILLIS}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.util.{AccumulatorContext, AccumulatorV2, Utils}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -37,14 +37,16 @@ import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.functions.struct
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.{ClassicSQLTestUtils, SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
 /**
  * A test suite that tests various Parquet queries.
  */
-abstract class ParquetQuerySuite extends ParquetTest with SharedSparkSession {
+abstract class ParquetQuerySuite extends QueryTest with ParquetTest
+  with ClassicSQLTestUtils
+  with SharedClassicSparkSession {
   import testImplicits._
 
   test("simple select queries") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.functions.struct
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.test.classic.{QueryTest => ClassicQueryTest}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -37,7 +37,8 @@ import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.functions.struct
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{ClassicQueryTest, SharedClassicSparkSession}
+import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{QueryTest => ClassicQueryTest}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.functions.struct
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{ClassicSQLTestUtils, SharedClassicSparkSession}
+import org.apache.spark.sql.test.{ClassicQueryTest, SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
@@ -45,7 +45,7 @@ import org.apache.spark.util.Utils
  * A test suite that tests various Parquet queries.
  */
 abstract class ParquetQuerySuite extends QueryTest with ParquetTest
-  with ClassicSQLTestUtils
+  with ClassicQueryTest
   with SharedClassicSparkSession {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VariantInferShreddingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VariantInferShreddingSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.classic.Dataset
 import org.apache.spark.sql.execution.LogicalRDD
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetTest, ParquetToSparkSchemaConverter, SparkShreddingUtils}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.types.variant._
 import org.apache.spark.unsafe.types.VariantVal

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VariantInferShreddingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VariantInferShreddingSuite.scala
@@ -23,20 +23,20 @@ import java.io.File
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.classic.Dataset
 import org.apache.spark.sql.execution.LogicalRDD
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetTest, ParquetToSparkSchemaConverter, SparkShreddingUtils}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.types.variant._
 import org.apache.spark.unsafe.types.VariantVal
 
 // Unit tests for variant shredding inference.
-class VariantInferShreddingSuite extends SharedSparkSession with ParquetTest {
+class VariantInferShreddingSuite extends QueryTest with SharedClassicSparkSession with ParquetTest {
   override def sparkConf: SparkConf = {
     super.sparkConf.set(SQLConf.PUSH_VARIANT_INTO_SCAN.key, "true")
       .set(SQLConf.VARIANT_WRITE_SHREDDING_ENABLED.key, "true")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ShuffleExchangeExec}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.ClassicQueryTest
+import org.apache.spark.sql.test.classic.{QueryTest => ClassicQueryTest}
 import org.apache.spark.sql.types.{LongType, ShortType}
 import org.apache.spark.tags.ExtendedSQLTest
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ShuffleExchangeExec}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.ClassicSQLTestUtils
+import org.apache.spark.sql.test.ClassicQueryTest
 import org.apache.spark.sql.types.{LongType, ShortType}
 import org.apache.spark.tags.ExtendedSQLTest
 
@@ -45,7 +45,7 @@ import org.apache.spark.tags.ExtendedSQLTest
  * unsafe map in [[org.apache.spark.sql.execution.joins.UnsafeHashedRelation]] is not triggered
  * without serializing the hashed relation, which does not happen in local mode.
  */
-abstract class BroadcastJoinSuiteBase extends QueryTest with ClassicSQLTestUtils
+abstract class BroadcastJoinSuiteBase extends QueryTest with ClassicQueryTest
   with AdaptiveSparkPlanHelper {
   import classicTestImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ShuffleExchangeExec}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.ClassicSQLTestUtils
 import org.apache.spark.sql.types.{LongType, ShortType}
 import org.apache.spark.tags.ExtendedSQLTest
 
@@ -44,9 +45,9 @@ import org.apache.spark.tags.ExtendedSQLTest
  * unsafe map in [[org.apache.spark.sql.execution.joins.UnsafeHashedRelation]] is not triggered
  * without serializing the hashed relation, which does not happen in local mode.
  */
-abstract class BroadcastJoinSuiteBase extends QueryTest
+abstract class BroadcastJoinSuiteBase extends QueryTest with ClassicSQLTestUtils
   with AdaptiveSparkPlanHelper {
-  import testImplicits._
+  import classicTestImplicits._
 
   protected var spark: SparkSession = null
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/ExistenceJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/ExistenceJoinSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.classic.DataFrame
 import org.apache.spark.sql.execution.{FilterExec, ProjectExec, SparkPlan, SparkPlanTest}
 import org.apache.spark.sql.execution.exchange.EnsureRequirements
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{BooleanType, DoubleType, IntegerType, StructType}
 
 class ExistenceJoinSuite extends SparkPlanTest with SharedClassicSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/ExistenceJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/ExistenceJoinSuite.scala
@@ -24,14 +24,14 @@ import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical.{Join, JoinHint}
 import org.apache.spark.sql.classic.DataFrame
-import org.apache.spark.sql.execution.{FilterExec, ProjectExec, SparkPlan}
+import org.apache.spark.sql.execution.{FilterExec, ProjectExec, SparkPlan, SparkPlanTest}
 import org.apache.spark.sql.execution.exchange.EnsureRequirements
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{BooleanType, DoubleType, IntegerType, StructType}
 
-class ExistenceJoinSuite extends SharedSparkSession {
-  import testImplicits.toRichColumn
+class ExistenceJoinSuite extends SparkPlanTest with SharedClassicSparkSession {
+  import classicTestImplicits.toRichColumn
 
   private val EnsureRequirements = new EnsureRequirements()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
@@ -27,13 +27,13 @@ import org.apache.spark.sql.classic.DataFrame
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.exchange.EnsureRequirements
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
-class InnerJoinSuite extends SharedSparkSession {
-  import testImplicits.newProductEncoder
-  import testImplicits.localSeqToDatasetHolder
-  import testImplicits.toRichColumn
+class InnerJoinSuite extends SparkPlanTest with SharedClassicSparkSession {
+  import classicTestImplicits.newProductEncoder
+  import classicTestImplicits.localSeqToDatasetHolder
+  import classicTestImplicits.toRichColumn
 
   private val EnsureRequirements = new EnsureRequirements()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.classic.DataFrame
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.exchange.EnsureRequirements
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
 class InnerJoinSuite extends SparkPlanTest with SharedClassicSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/OuterJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/OuterJoinSuite.scala
@@ -27,7 +27,8 @@ import org.apache.spark.sql.classic.DataFrame
 import org.apache.spark.sql.execution.{SparkPlan, SparkPlanTest}
 import org.apache.spark.sql.execution.exchange.EnsureRequirements
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{SharedClassicSparkSession, SQLTestData}
+import org.apache.spark.sql.test.SQLTestData
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{DoubleType, IntegerType, StructType}
 
 class OuterJoinSuite extends SparkPlanTest with SharedClassicSparkSession with SQLTestData {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/OuterJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/OuterJoinSuite.scala
@@ -24,14 +24,14 @@ import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical.{Join, JoinHint}
 import org.apache.spark.sql.classic.DataFrame
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.{SparkPlan, SparkPlanTest}
 import org.apache.spark.sql.execution.exchange.EnsureRequirements
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{SharedSparkSession, SQLTestData}
+import org.apache.spark.sql.test.{SharedClassicSparkSession, SQLTestData}
 import org.apache.spark.sql.types.{DoubleType, IntegerType, StructType}
 
-class OuterJoinSuite extends SharedSparkSession with SQLTestData {
-  import testImplicits._
+class OuterJoinSuite extends SparkPlanTest with SharedClassicSparkSession with SQLTestData {
+  import classicTestImplicits._
   setupTestData()
 
   private val EnsureRequirements = new EnsureRequirements()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/SingleJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/SingleJoinSuite.scala
@@ -18,20 +18,20 @@
 package org.apache.spark.sql.execution.joins
 
 import org.apache.spark.SparkRuntimeException
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.optimizer.BuildRight
 import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical.{Join, JoinHint, Project}
 import org.apache.spark.sql.classic.DataFrame
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.{SparkPlan, SparkPlanTest}
 import org.apache.spark.sql.execution.exchange.EnsureRequirements
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{DoubleType, IntegerType, StructType}
 
-class SingleJoinSuite extends SharedSparkSession {
-  import testImplicits.toRichColumn
+class SingleJoinSuite extends SparkPlanTest with SharedClassicSparkSession {
+  import classicTestImplicits.toRichColumn
 
   private val EnsureRequirements = new EnsureRequirements()
 
@@ -86,7 +86,7 @@ class SingleJoinSuite extends SharedSparkSession {
         rightRows.queryExecution.sparkPlan)
       checkError(
         exception = intercept[SparkRuntimeException] {
-          QueryTest.executePlan(outputPlan, spark.sqlContext)
+          SparkPlanTest.executePlan(outputPlan, spark.sqlContext)
         },
         condition = "SCALAR_SUBQUERY_TOO_MANY_ROWS",
         parameters = Map.empty

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/SingleJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/SingleJoinSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{Join, JoinHint, Project}
 import org.apache.spark.sql.classic.DataFrame
 import org.apache.spark.sql.execution.{SparkPlan, SparkPlanTest}
 import org.apache.spark.sql.execution.exchange.EnsureRequirements
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{DoubleType, IntegerType, StructType}
 
 class SingleJoinSuite extends SparkPlanTest with SharedClassicSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.python
 import org.apache.spark.sql.{IntegratedUDFTestUtils, QueryTest}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.StringType
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.sql.execution.python
 
-import org.apache.spark.sql.IntegratedUDFTestUtils
+import org.apache.spark.sql.{IntegratedUDFTestUtils, QueryTest}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.StringType
 
 /**
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types.StringType
  * ArrowEvalPythonExec uses the columnar path (no ColumnarToRowExec) and
  * produces correct results.
  */
-class ArrowColumnarPythonUDFSuite extends SharedSparkSession {
+class ArrowColumnarPythonUDFSuite extends QueryTest with SharedClassicSparkSession {
 
   import IntegratedUDFTestUtils._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
@@ -24,12 +24,13 @@ import org.apache.spark.api.python.{PythonEvalType, SimplePythonFunction}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, GreaterThan, In}
 import org.apache.spark.sql.connector.catalog.CatalogManager
-import org.apache.spark.sql.execution.{FilterExec, InputAdapter, WholeStageCodegenExec}
+import org.apache.spark.sql.execution.{FilterExec, InputAdapter, SparkPlanTest, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{BooleanType, DoubleType}
 
-class BatchEvalPythonExecSuite extends SharedSparkSession
+class BatchEvalPythonExecSuite extends SparkPlanTest
+  with SharedClassicSparkSession
   with AdaptiveSparkPlanHelper {
   import testImplicits.newProductEncoder
   import testImplicits.localSeqToDatasetHolder

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, Great
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.execution.{FilterExec, InputAdapter, SparkPlanTest, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{BooleanType, DoubleType}
 
 class BatchEvalPythonExecSuite extends SparkPlanTest

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
@@ -18,14 +18,14 @@
 package org.apache.spark.sql.execution.python
 
 import org.apache.spark.sql.catalyst.plans.logical.{ArrowEvalPython, BatchEvalPython, Limit, LocalLimit}
-import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
+import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan, SparkPlanTest}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
-class ExtractPythonUDFsSuite extends SharedSparkSession {
+class ExtractPythonUDFsSuite extends SparkPlanTest with SharedClassicSparkSession {
   import testImplicits._
 
   val batchedPythonUDF = new MyDummyPythonUDF

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 class ExtractPythonUDFsSuite extends SparkPlanTest with SharedClassicSparkSession {
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -21,19 +21,20 @@ import java.io.{File, FileWriter}
 
 import org.apache.spark.api.python.PythonException
 import org.apache.spark.api.python.PythonUtils
-import org.apache.spark.sql.{AnalysisException, IntegratedUDFTestUtils, Row}
+import org.apache.spark.sql.{AnalysisException, IntegratedUDFTestUtils, QueryTest, Row}
 import org.apache.spark.sql.execution.FilterExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.datasources.DataSourceManager
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanRelation}
 import org.apache.spark.sql.execution.datasources.v2.python.PythonScan
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
 
 abstract class PythonDataSourceSuiteBase
-    extends SharedSparkSession
+    extends QueryTest
+    with SharedClassicSparkSession
     with AdaptiveSparkPlanHelper {
 
   protected val simpleDataSourceReaderScript: String =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.datasources.DataSourceManager
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanRelation}
 import org.apache.spark.sql.execution.datasources.v2.python.PythonScan
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.plans.PlanTestBase
 import org.apache.spark.sql.execution.streaming.runtime.StreamExecution
 import org.apache.spark.sql.execution.streaming.state.StateStoreTestsHelper._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.ThreadUtils
 import org.apache.spark.util.ThreadUtils.awaitResult

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreLockHardeningSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.plans.PlanTestBase
 import org.apache.spark.sql.execution.streaming.runtime.StreamExecution
 import org.apache.spark.sql.execution.streaming.state.StateStoreTestsHelper._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.ThreadUtils
 import org.apache.spark.util.ThreadUtils.awaitResult
@@ -47,7 +47,7 @@ class RocksDBStateStoreLockHardeningSuite extends SparkFunSuite
     with PlanTestBase
     with AlsoTestWithRocksDBFeatures
     with PrivateMethodTester
-    with SharedSparkSession
+    with SharedClassicSparkSession
     with BeforeAndAfter
     with Matchers {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -44,7 +44,7 @@ import org.apache.spark.sql.execution.streaming.checkpointing.{CheckpointFileMan
 import org.apache.spark.sql.execution.streaming.operators.stateful.StatefulOperatorStateInfo
 import org.apache.spark.sql.execution.streaming.runtime.StreamExecution
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.unsafe.Platform

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -44,7 +44,7 @@ import org.apache.spark.sql.execution.streaming.checkpointing.{CheckpointFileMan
 import org.apache.spark.sql.execution.streaming.operators.stateful.StatefulOperatorStateInfo
 import org.apache.spark.sql.execution.streaming.runtime.StreamExecution
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.unsafe.Platform
@@ -56,7 +56,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
   with AlsoTestWithEncodingTypes
   with AlsoTestWithRocksDBFeatures
   with PrivateMethodTester
-  with SharedSparkSession
+  with SharedClassicSparkSession
   with BeforeAndAfter
   with Matchers {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
@@ -22,13 +22,14 @@ import java.util.UUID
 import scala.util.Random
 
 import org.apache.hadoop.conf.Configuration
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.execution.streaming.runtime.StreamExecution
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.unsafe.types.UTF8String
@@ -39,7 +40,8 @@ import org.apache.spark.util.Utils
  * [[TimestampAsPrefixKeyStateEncoder]] and [[TimestampAsPostfixKeyStateEncoder]].
  */
 @ExtendedSQLTest
-class RocksDBTimestampEncoderOperationsSuite extends SharedSparkSession with Matchers {
+class RocksDBTimestampEncoderOperationsSuite extends SharedClassicSparkSession
+  with BeforeAndAfterEach with Matchers {
 
   // Test schemas
   private val keySchema = StructType(Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBTimestampEncoderOperationsSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.execution.streaming.runtime.StreamExecution
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.unsafe.types.UTF8String

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRowChecksumSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRowChecksumSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.execution.streaming.checkpointing.CheckpointFileManager
 import org.apache.spark.sql.execution.streaming.runtime.StreamExecution
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRowChecksumSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRowChecksumSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.execution.streaming.checkpointing.CheckpointFileManager
 import org.apache.spark.sql.execution.streaming.runtime.StreamExecution
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
 
@@ -41,7 +41,7 @@ import org.apache.spark.util.Utils
  * in other tests (State operators, TransformWithState, State data source, RTM etc.)
  * by adding the [[AlsoTestWithStateStoreRowChecksum]] trait.
  * */
-abstract class StateStoreRowChecksumSuite extends SharedSparkSession
+abstract class StateStoreRowChecksumSuite extends SharedClassicSparkSession
   with BeforeAndAfter {
 
   import StateStoreTestsHelper._
@@ -437,7 +437,7 @@ class RocksDBStateStoreRowChecksumSuite extends StateStoreRowChecksumSuite
  * }
  * }}}
  */
-trait EnableStateStoreRowChecksum extends SharedSparkSession {
+trait EnableStateStoreRowChecksum extends SharedClassicSparkSession {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set(SQLConf.STATE_STORE_ROW_CHECKSUM_ENABLED.key, true.toString)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -48,7 +48,7 @@ import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, StreamExe
 import org.apache.spark.sql.execution.streaming.state.StateStoreCoordinatorSuite.withCoordinatorRef
 import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.unsafe.types.UTF8String

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -48,7 +48,7 @@ import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, StreamExe
 import org.apache.spark.sql.execution.streaming.state.StateStoreCoordinatorSuite.withCoordinatorRef
 import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.unsafe.types.UTF8String
@@ -286,7 +286,7 @@ private object MaintenanceCountingStateStoreProvider {
 
 @ExtendedSQLTest
 class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
-  with SharedSparkSession
+  with SharedClassicSparkSession
   with BeforeAndAfter {
   import StateStoreTestsHelper._
   import StateStoreCoordinatorSuite._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/ValueStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/ValueStateSuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.streaming.operators.stateful.transformwith
 import org.apache.spark.sql.execution.streaming.runtime.StreamExecution
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{TimeMode, TTLConfig, ValueState}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 
 /** A case class for SQL encoder test purpose */

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/ValueStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/ValueStateSuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.streaming.operators.stateful.transformwith
 import org.apache.spark.sql.execution.streaming.runtime.StreamExecution
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{TimeMode, TTLConfig, ValueState}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 
 /** A case class for SQL encoder test purpose */
@@ -500,7 +500,7 @@ class ValueStateSuite extends StateVariableSuiteBase {
  * Abstract Base Class that provides test utilities for different state variable
  * types (ValueState, ListState, MapState) used in arbitrary stateful operators.
  */
-abstract class StateVariableSuiteBase extends SharedSparkSession
+abstract class StateVariableSuiteBase extends SharedClassicSparkSession
   with BeforeAndAfter with AlsoTestWithEncodingTypes {
 
   before {

--- a/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
@@ -17,17 +17,17 @@
 
 package org.apache.spark.sql.expressions
 
-import org.apache.spark.SparkIllegalArgumentException
+import org.apache.spark.{SparkFunSuite, SparkIllegalArgumentException}
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, InternalRow}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.HiveResult.hiveResultString
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.tags.SlowSQLTest
 import org.apache.spark.util.{ThreadUtils, Utils}
 
 @SlowSQLTest
-class ExpressionInfoSuite extends SharedSparkSession {
+class ExpressionInfoSuite extends SparkFunSuite with SharedClassicSparkSession {
 
   test("Replace _FUNC_ in ExpressionInfo") {
     val info = spark.sessionState.catalog.lookupFunctionInfo(FunctionIdentifier("upper"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.{FunctionIdentifier, InternalRow}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.HiveResult.hiveResultString
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.tags.SlowSQLTest
 import org.apache.spark.util.{ThreadUtils, Utils}
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
@@ -17,12 +17,13 @@
 
 package org.apache.spark.sql.scripting
 
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.{CreateVariable, LeafNode, OneRowRelation, Project, SetVariable}
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.classic.{DataFrame, SparkSession}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 /**
@@ -30,7 +31,7 @@ import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
  * Execution nodes are constructed manually and iterated through.
  * It is then checked if the leaf statements have been iterated in the expected order.
  */
-class SqlScriptingExecutionNodeSuite extends SharedSparkSession {
+class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedClassicSparkSession {
   // Helpers
   case class TestCompoundBody(
       override val statements: Seq[CompoundStatementExec],

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.{CreateVariable, LeafNode, OneRowRelation, Project, SetVariable}
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.classic.{DataFrame, SparkSession}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLId
 import org.apache.spark.sql.exceptions.SqlScriptingException
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 /**
  * SQL Scripting interpreter tests.

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -20,13 +20,13 @@ package org.apache.spark.sql.scripting
 import scala.collection.mutable.ListBuffer
 
 import org.apache.spark.{SparkArithmeticException, SparkConf}
-import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLId
 import org.apache.spark.sql.exceptions.SqlScriptingException
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
 /**
  * SQL Scripting interpreter tests.
@@ -34,7 +34,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  * Output from the interpreter (iterator over executable statements) is then checked - statements
  *   are executed and output DataFrames are compared with expected outputs.
  */
-class SqlScriptingExecutionSuite extends SharedSparkSession {
+class SqlScriptingExecutionSuite extends QueryTest with SharedClassicSparkSession {
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
 import org.apache.spark.sql.classic.{DataFrame, Dataset}
 import org.apache.spark.sql.exceptions.SqlScriptingException
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 /**
  * SQL Scripting interpreter tests.

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -18,14 +18,14 @@
 package org.apache.spark.sql.scripting
 
 import org.apache.spark.{SparkException, SparkNumberFormatException}
-import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
 import org.apache.spark.sql.classic.{DataFrame, Dataset}
 import org.apache.spark.sql.exceptions.SqlScriptingException
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
 /**
  * SQL Scripting interpreter tests.
@@ -34,7 +34,8 @@ import org.apache.spark.sql.test.SharedSparkSession
  *   are executed and output DataFrames are compared with expected outputs.
  */
 class SqlScriptingInterpreterSuite
-    extends SharedSparkSession
+    extends QueryTest
+    with SharedClassicSparkSession
     with SqlScriptingTestUtils {
 
   protected override def beforeAll(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
@@ -46,7 +46,7 @@ import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, MemoryStr
 import org.apache.spark.sql.execution.streaming.sources.MemorySink
 import org.apache.spark.sql.execution.streaming.state.StateStore
 import org.apache.spark.sql.streaming.StreamingQueryListener._
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.util.{Clock, SystemClock, Utils}
 
 /**
@@ -73,7 +73,7 @@ import org.apache.spark.util.{Clock, SystemClock, Utils}
  * avoid hanging forever in the case of failures. However, individual suites can change this
  * by overriding `streamingTimeout`.
  */
-trait StreamTest extends SharedSparkSession with TimeLimits {
+trait StreamTest extends QueryTest with SharedClassicSparkSession with TimeLimits {
 
   // Necessary to make ScalaTest 3.x interrupt a thread on the JVM like ScalaTest 2.2.x
   implicit val defaultSignaler: Signaler = ThreadSignaler

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
@@ -46,7 +46,7 @@ import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, MemoryStr
 import org.apache.spark.sql.execution.streaming.sources.MemorySink
 import org.apache.spark.sql.execution.streaming.state.StateStore
 import org.apache.spark.sql.streaming.StreamingQueryListener._
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.util.{Clock, SystemClock, Utils}
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
@@ -89,7 +89,7 @@ trait SharedSparkSession extends QueryTest with SharedSparkSessionBase {
  * this test with a [[org.apache.spark.sql.connect.SparkSession]].
  */
 trait SharedClassicSparkSession extends SharedSparkSession with ClassicSQLTestUtils {
-  override def spark: classic.SparkSession = super.spark
+  override def spark: classic.SparkSession = super.spark.asInstanceOf[classic.SparkSession]
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
@@ -63,7 +63,7 @@ trait SharedSparkSession extends QueryTest with SharedSparkSessionBase {
  */
 trait SharedClassicSparkSession
   extends SharedSparkSession
-    with ClassicSQLTestUtils
+    with ClassicQueryTest
     with classic.SparkSessionProvider {
   override def spark: classic.SparkSession = super.spark.asInstanceOf[classic.SparkSession]
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
@@ -25,7 +25,6 @@ import org.scalatest.concurrent.Eventually
 import org.apache.spark.{DebugFilesystem, SparkConf}
 import org.apache.spark.internal.config.UNSAFE_EXCEPTION_ON_MEMORY_LEAK
 import org.apache.spark.sql.{classic, QueryTest, QueryTestBase, SparkSession, SparkSessionProvider, SQLContext}
-import org.apache.spark.sql.test.{classic => classicTest}
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
@@ -53,46 +52,6 @@ trait SharedSparkSession extends QueryTest with SharedSparkSessionBase {
     } finally {
       doThreadPostAudit()
     }
-  }
-}
-
-/**
- * Extends SharedSparkSession to explicitly provide [[classic.SparkSession]].
- *
- * Use this trait to indicate that this test is classic-only, i.e. it would not make sense to run
- * this test with a [[org.apache.spark.sql.connect.SparkSession]].
- */
-trait SharedClassicSparkSession
-  extends SharedSparkSession
-    with classicTest.QueryTest
-    with classic.SparkSessionProvider {
-  override def spark: classic.SparkSession = super.spark.asInstanceOf[classic.SparkSession]
-
-  // Runs func (which must trigger exactly one SQL execution) and returns the SQL metrics of that
-  // execution as a map keyed by (planNodeId, planNodeName, metricName) -> metricValue.
-  def runAndFetchMetrics(func: => Unit): Map[(Long, String, String), String] = {
-    val statusStore = spark.sharedState.statusStore
-    val oldCount = statusStore.executionsList().size
-
-    func
-
-    // Wait until the new execution is started and being tracked.
-    eventually(timeout(10.seconds), interval(10.milliseconds)) {
-      assert(statusStore.executionsCount() >= oldCount)
-    }
-
-    // Wait for listener to finish computing the metrics for the execution.
-    eventually(timeout(10.seconds), interval(10.milliseconds)) {
-      assert(statusStore.executionsList().nonEmpty &&
-        statusStore.executionsList().last.metricValues != null)
-    }
-
-    val exec = statusStore.executionsList().last
-    val execId = exec.executionId
-    val sqlMetrics = statusStore.planGraph(execId).allNodes
-      .flatMap(n => n.metrics.map(m => (m.accumulatorId, (n.id, n.name, m.name))))
-      .toMap
-    statusStore.executionMetrics(execId).map { case (k, v) => sqlMetrics(k) -> v }
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
@@ -25,6 +25,7 @@ import org.scalatest.concurrent.Eventually
 import org.apache.spark.{DebugFilesystem, SparkConf}
 import org.apache.spark.internal.config.UNSAFE_EXCEPTION_ON_MEMORY_LEAK
 import org.apache.spark.sql.{classic, QueryTest, QueryTestBase, SparkSession, SparkSessionProvider, SQLContext}
+import org.apache.spark.sql.test.{classic => classicTest}
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
@@ -63,7 +64,7 @@ trait SharedSparkSession extends QueryTest with SharedSparkSessionBase {
  */
 trait SharedClassicSparkSession
   extends SharedSparkSession
-    with ClassicQueryTest
+    with classicTest.QueryTest
     with classic.SparkSessionProvider {
   override def spark: classic.SparkSession = super.spark.asInstanceOf[classic.SparkSession]
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
@@ -53,6 +53,16 @@ trait SharedSparkSession extends QueryTest with SharedSparkSessionBase {
       doThreadPostAudit()
     }
   }
+}
+
+/**
+ * Extends SharedSparkSession to explicitly provide [[classic.SparkSession]].
+ *
+ * Use this trait to indicate that this test is classic-only, i.e. it would not make sense to run
+ * this test with a [[org.apache.spark.sql.connect.SparkSession]].
+ */
+trait SharedClassicSparkSession extends SharedSparkSession with ClassicSQLTestUtils {
+  override def spark: classic.SparkSession = super.spark.asInstanceOf[classic.SparkSession]
 
   // Runs func (which must trigger exactly one SQL execution) and returns the SQL metrics of that
   // execution as a map keyed by (planNodeId, planNodeName, metricName) -> metricValue.
@@ -80,16 +90,6 @@ trait SharedSparkSession extends QueryTest with SharedSparkSessionBase {
       .toMap
     statusStore.executionMetrics(execId).map { case (k, v) => sqlMetrics(k) -> v }
   }
-}
-
-/**
- * Extends SharedSparkSession to explicitly provide [[classic.SparkSession]].
- *
- * Use this trait to indicate that this test is classic-only, i.e. it would not make sense to run
- * this test with a [[org.apache.spark.sql.connect.SparkSession]].
- */
-trait SharedClassicSparkSession extends SharedSparkSession with ClassicSQLTestUtils {
-  override def spark: classic.SparkSession = super.spark.asInstanceOf[classic.SparkSession]
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
@@ -83,6 +83,16 @@ trait SharedSparkSession extends QueryTest with SharedSparkSessionBase {
 }
 
 /**
+ * Extends SharedSparkSession to explicitly provide [[classic.SparkSession]].
+ *
+ * Use this trait to indicate that this test is classic-only, i.e. it would not make sense to run
+ * this test with a [[org.apache.spark.sql.connect.SparkSession]].
+ */
+trait SharedClassicSparkSession extends SharedSparkSession with ClassicSQLTestUtils {
+  override def spark: classic.SparkSession = super.spark
+}
+
+/**
  * Helper trait for SQL test suites where all tests share a single [[TestSparkSession]].
  */
 trait SharedSparkSessionBase

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
@@ -61,7 +61,10 @@ trait SharedSparkSession extends QueryTest with SharedSparkSessionBase {
  * Use this trait to indicate that this test is classic-only, i.e. it would not make sense to run
  * this test with a [[org.apache.spark.sql.connect.SparkSession]].
  */
-trait SharedClassicSparkSession extends SharedSparkSession with ClassicSQLTestUtils {
+trait SharedClassicSparkSession
+  extends SharedSparkSession
+    with ClassicSQLTestUtils
+    with classic.SparkSessionProvider {
   override def spark: classic.SparkSession = super.spark.asInstanceOf[classic.SparkSession]
 
   // Runs func (which must trigger exactly one SQL execution) and returns the SQL metrics of that

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SharedSparkSession.scala
@@ -135,7 +135,7 @@ trait SharedSparkSessionBase
   /**
    * The [[TestSparkSession]] to use for all tests in this suite.
    */
-  protected override def spark: classic.SparkSession = _spark
+  protected override def spark: SparkSession = _spark
 
   /**
    * The [[TestSQLContext]] to use for all tests in this suite.

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/classic/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/classic/QueryTest.scala
@@ -41,4 +41,24 @@ trait QueryTest extends BaseQueryTest with classic.SparkSessionProvider {
     override protected def session: classic.SparkSession = spark
     override protected def converter: classic.ColumnNodeToExpressionConverter = spark.converter
   }
+
+  /**
+   * Strip Spark-side filtering in order to check if a datasource filters rows correctly.
+   */
+  protected def stripSparkFilter(df: classic.DataFrame): classic.DataFrame = {
+    val schema = df.schema
+    val withoutFilters = df.queryExecution.executedPlan.transform {
+      case FilterExec(_, child) => child
+    }
+
+    spark.internalCreateDataFrame(withoutFilters.execute(), schema)
+  }
+
+  /**
+   * Turn a logical plan into a `DataFrame`. This should be removed once we have an easier
+   * way to construct `DataFrame` directly out of local data without relying on implicits.
+   */
+  protected implicit def logicalPlanToSparkQuery(plan: LogicalPlan): classic.DataFrame = {
+    classic.Dataset.ofRows(spark, plan)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/classic/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/classic/QueryTest.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.test.classic
+
+import scala.language.implicitConversions
+
+import org.apache.spark.sql.{classic, QueryTest => BaseQueryTest}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.FilterExec
+
+/**
+ * Extends [[BaseQueryTest]] to explicitly provide [[classic.SparkSession]] etc.
+ *
+ * Use this trait and [[org.apache.spark.sql.test.SharedClassicSparkSession]] to indicate that
+ * this test is classic-only, i.e. it is not intended to run this test with a
+ * [[org.apache.spark.sql.connect.SparkSession]].
+ */
+trait QueryTest extends BaseQueryTest with classic.SparkSessionProvider {
+
+  override protected lazy val sql: String => classic.DataFrame = spark.sql _
+
+  protected object classicTestImplicits
+    extends classic.SQLImplicits
+      with classic.ClassicConversions
+      with classic.ColumnConversions {
+    override protected def session: classic.SparkSession = spark
+    override protected def converter: classic.ColumnNodeToExpressionConverter = spark.converter
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/classic/SharedSparkSession.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/classic/SharedSparkSession.scala
@@ -17,10 +17,9 @@
 
 package org.apache.spark.sql.test.classic
 
-import org.scalatest.{BeforeAndAfterEach, Suite}
-import org.scalatest.concurrent.Eventually
+import scala.concurrent.duration._
 
-import org.apache.spark.{sql, DebugFilesystem, SparkConf}
+import org.apache.spark.sql
 import org.apache.spark.sql.classic
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/classic/SharedSparkSession.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/classic/SharedSparkSession.scala
@@ -21,6 +21,7 @@ import org.scalatest.{BeforeAndAfterEach, Suite}
 import org.scalatest.concurrent.Eventually
 
 import org.apache.spark.{sql, DebugFilesystem, SparkConf}
+import org.apache.spark.sql.classic
 
 /**
  * Extends SharedSparkSession to explicitly provide [[classic.SparkSession]].
@@ -29,9 +30,9 @@ import org.apache.spark.{sql, DebugFilesystem, SparkConf}
  * this test with a [[org.apache.spark.sql.connect.SparkSession]].
  */
 trait SharedSparkSession
-  extends sql.SharedSparkSession
+  extends sql.test.SharedSparkSession
     with QueryTest
-    with SparkSessionProvider {
+    with classic.SparkSessionProvider {
   override def spark: classic.SparkSession = super.spark.asInstanceOf[classic.SparkSession]
 
   // Runs func (which must trigger exactly one SQL execution) and returns the SQL metrics of that

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/classic/SharedSparkSession.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/classic/SharedSparkSession.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.test.classic
+
+import org.scalatest.{BeforeAndAfterEach, Suite}
+import org.scalatest.concurrent.Eventually
+
+import org.apache.spark.{sql, DebugFilesystem, SparkConf}
+
+/**
+ * Extends SharedSparkSession to explicitly provide [[classic.SparkSession]].
+ *
+ * Use this trait to indicate that this test is classic-only, i.e. it would not make sense to run
+ * this test with a [[org.apache.spark.sql.connect.SparkSession]].
+ */
+trait SharedSparkSession
+  extends sql.SharedSparkSession
+    with QueryTest
+    with SparkSessionProvider {
+  override def spark: classic.SparkSession = super.spark.asInstanceOf[classic.SparkSession]
+
+  // Runs func (which must trigger exactly one SQL execution) and returns the SQL metrics of that
+  // execution as a map keyed by (planNodeId, planNodeName, metricName) -> metricValue.
+  def runAndFetchMetrics(func: => Unit): Map[(Long, String, String), String] = {
+    val statusStore = spark.sharedState.statusStore
+    val oldCount = statusStore.executionsList().size
+
+    func
+
+    // Wait until the new execution is started and being tracked.
+    eventually(timeout(10.seconds), interval(10.milliseconds)) {
+      assert(statusStore.executionsCount() >= oldCount)
+    }
+
+    // Wait for listener to finish computing the metrics for the execution.
+    eventually(timeout(10.seconds), interval(10.milliseconds)) {
+      assert(statusStore.executionsList().nonEmpty &&
+        statusStore.executionsList().last.metricValues != null)
+    }
+
+    val exec = statusStore.executionsList().last
+    val execId = exec.executionId
+    val sqlMetrics = statusStore.planGraph(execId).allNodes
+      .flatMap(n => n.metrics.map(m => (m.accumulatorId, (n.id, n.name, m.name))))
+      .toMap
+    statusStore.executionMetrics(execId).map { case (k, v) => sqlMetrics(k) -> v }
+  }
+}

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperationSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperationSuite.scala
@@ -31,7 +31,7 @@ import org.mockito.invocation.InvocationOnMock
 
 import org.apache.spark.sql.classic.{DataFrame, SparkSession}
 import org.apache.spark.sql.hive.thriftserver.ui.HiveThriftServer2EventManager
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{GeographyType, GeometryType, IntegerType, NullType, StringType, StructField, StructType}
 
 class SparkExecuteStatementOperationSuite extends SharedClassicSparkSession {

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperationSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperationSuite.scala
@@ -31,10 +31,10 @@ import org.mockito.invocation.InvocationOnMock
 
 import org.apache.spark.sql.classic.{DataFrame, SparkSession}
 import org.apache.spark.sql.hive.thriftserver.ui.HiveThriftServer2EventManager
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{GeographyType, GeometryType, IntegerType, NullType, StringType, StructField, StructType}
 
-class SparkExecuteStatementOperationSuite extends SharedSparkSession {
+class SparkExecuteStatementOperationSuite extends SharedClassicSparkSession {
 
   test("SPARK-17112 `select null` via JDBC triggers IllegalArgumentException in ThriftServer") {
     val field1 = StructField("NULL", NullType)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/OptimizeHiveMetadataOnlyQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/OptimizeHiveMetadataOnlyQuerySuite.scala
@@ -25,10 +25,11 @@ import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.catalyst.plans.logical.{Distinct, Filter, Project, SubqueryAlias}
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf.OPTIMIZER_METADATA_ONLY
+import org.apache.spark.sql.test.ClassicSQLTestUtils
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 class OptimizeHiveMetadataOnlyQuerySuite extends QueryTest with TestHiveSingleton
-    with BeforeAndAfter {
+    with BeforeAndAfter with ClassicSQLTestUtils {
 
   import spark.implicits._
   import spark.toRichColumn

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/OptimizeHiveMetadataOnlyQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/OptimizeHiveMetadataOnlyQuerySuite.scala
@@ -25,11 +25,11 @@ import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.catalyst.plans.logical.{Distinct, Filter, Project, SubqueryAlias}
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf.OPTIMIZER_METADATA_ONLY
-import org.apache.spark.sql.test.ClassicSQLTestUtils
+import org.apache.spark.sql.test.ClassicQueryTest
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 class OptimizeHiveMetadataOnlyQuerySuite extends QueryTest with TestHiveSingleton
-    with BeforeAndAfter with ClassicSQLTestUtils {
+    with BeforeAndAfter with ClassicQueryTest {
 
   import spark.implicits._
   import spark.toRichColumn

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/OptimizeHiveMetadataOnlyQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/OptimizeHiveMetadataOnlyQuerySuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.catalyst.plans.logical.{Distinct, Filter, Project, SubqueryAlias}
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf.OPTIMIZER_METADATA_ONLY
-import org.apache.spark.sql.test.ClassicQueryTest
+import org.apache.spark.sql.test.classic.{QueryTest => ClassicQueryTest}
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 class OptimizeHiveMetadataOnlyQuerySuite extends QueryTest with TestHiveSingleton

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.hive.HiveUtils.{builtinHiveVersion => hiveVersion}
 import org.apache.spark.sql.hive.test.{HiveTestJars, TestHive, TestUDTFJar}
 import org.apache.spark.sql.hive.test.TestHive._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.ClassicSQLTestUtils
+import org.apache.spark.sql.test.ClassicQueryTest
 import org.apache.spark.tags.SlowHiveTest
 
 case class TestData(a: Int, b: String)
@@ -47,7 +47,7 @@ case class TestData(a: Int, b: String)
  * included in the hive distribution.
  */
 @SlowHiveTest
-class HiveQuerySuite extends HiveComparisonTest with ClassicSQLTestUtils with BeforeAndAfter {
+class HiveQuerySuite extends HiveComparisonTest with ClassicQueryTest with BeforeAndAfter {
   import classicTestImplicits._
 
   private val originalCrossJoinEnabled = TestHive.conf.crossJoinEnabled

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.{SparkFiles, TestUtils}
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.Project
@@ -37,6 +37,7 @@ import org.apache.spark.sql.hive.HiveUtils.{builtinHiveVersion => hiveVersion}
 import org.apache.spark.sql.hive.test.{HiveTestJars, TestHive, TestUDTFJar}
 import org.apache.spark.sql.hive.test.TestHive._
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.ClassicSQLTestUtils
 import org.apache.spark.tags.SlowHiveTest
 
 case class TestData(a: Int, b: String)
@@ -46,8 +47,8 @@ case class TestData(a: Int, b: String)
  * included in the hive distribution.
  */
 @SlowHiveTest
-class HiveQuerySuite extends HiveComparisonTest with QueryTest with BeforeAndAfter {
-  import testImplicits._
+class HiveQuerySuite extends HiveComparisonTest with ClassicSQLTestUtils with BeforeAndAfter {
+  import classicTestImplicits._
 
   private val originalCrossJoinEnabled = TestHive.conf.crossJoinEnabled
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.hive.HiveUtils.{builtinHiveVersion => hiveVersion}
 import org.apache.spark.sql.hive.test.{HiveTestJars, TestHive, TestUDTFJar}
 import org.apache.spark.sql.hive.test.TestHive._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.ClassicQueryTest
+import org.apache.spark.sql.test.classic.{QueryTest => ClassicQueryTest}
 import org.apache.spark.tags.SlowHiveTest
 
 case class TestData(a: Int, b: String)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.functions.{call_function, max}
 import org.apache.spark.sql.hive.test.{TestHiveSingleton, TestUDTFJar}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.ClassicQueryTest
+import org.apache.spark.sql.test.classic.{QueryTest => ClassicQueryTest}
 import org.apache.spark.tags.SlowHiveTest
 import org.apache.spark.util.Utils
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -59,7 +59,6 @@ case class ListStringCaseClass(l: Seq[String])
 @SlowHiveTest
 class HiveUDFSuite extends QueryTest with TestHiveSingleton with ClassicSQLTestUtils {
   import spark.implicits._
-  import classicTestImplicits.castToImpl
 
   import spark.udf
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -41,6 +41,7 @@ import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.functions.{call_function, max}
 import org.apache.spark.sql.hive.test.{TestHiveSingleton, TestUDTFJar}
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.ClassicSQLTestUtils
 import org.apache.spark.tags.SlowHiveTest
 import org.apache.spark.util.Utils
 
@@ -56,9 +57,9 @@ case class ListStringCaseClass(l: Seq[String])
  * A test suite for Hive custom UDFs.
  */
 @SlowHiveTest
-class HiveUDFSuite extends QueryTest with TestHiveSingleton {
+class HiveUDFSuite extends QueryTest with TestHiveSingleton with ClassicSQLTestUtils {
   import spark.implicits._
-  import testImplicits.castToImpl
+  import classicTestImplicits.castToImpl
 
   import spark.udf
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.functions.{call_function, max}
 import org.apache.spark.sql.hive.test.{TestHiveSingleton, TestUDTFJar}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.ClassicSQLTestUtils
+import org.apache.spark.sql.test.ClassicQueryTest
 import org.apache.spark.tags.SlowHiveTest
 import org.apache.spark.util.Utils
 
@@ -57,7 +57,7 @@ case class ListStringCaseClass(l: Seq[String])
  * A test suite for Hive custom UDFs.
  */
 @SlowHiveTest
-class HiveUDFSuite extends QueryTest with TestHiveSingleton with ClassicSQLTestUtils {
+class HiveUDFSuite extends QueryTest with TestHiveSingleton with ClassicQueryTest {
   import spark.implicits._
 
   import spark.udf

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.pipelines.graph
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.pipelines.utils.{PipelineTest, TestGraphRegistrationContext}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{IntegerType, StructType}
 
 /**

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectInvalidPipelineSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.pipelines.graph
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.pipelines.utils.{PipelineTest, TestGraphRegistrationContext}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructType}
 
 /**
@@ -28,7 +28,7 @@ import org.apache.spark.sql.types.{IntegerType, StructType}
  * examples are all semantically correct but contain logical errors which should be found
  * when connect is called and thrown when validate() is called.
  */
-class ConnectInvalidPipelineSuite extends PipelineTest with SharedSparkSession {
+class ConnectInvalidPipelineSuite extends PipelineTest with SharedClassicSparkSession {
 
   test("Missing source") {
     class P extends TestGraphRegistrationContext(spark) {

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectValidPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectValidPipelineSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.plans.logical.Union
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.pipelines.utils.{PipelineTest, TestGraphRegistrationContext}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectValidPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ConnectValidPipelineSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.plans.logical.Union
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.pipelines.utils.{PipelineTest, TestGraphRegistrationContext}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -31,7 +31,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
  * examples are all semantically correct and logically correct and connect should not result in any
  * errors.
  */
-class ConnectValidPipelineSuite extends PipelineTest with SharedSparkSession {
+class ConnectValidPipelineSuite extends PipelineTest with SharedClassicSparkSession {
   test("Extra simple") {
     val session = spark
     import session.implicits._

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.connector.expressions.{ClusterByTransform, Expressio
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.pipelines.graph.DatasetManager.TableMaterializationException
 import org.apache.spark.sql.pipelines.utils.{BaseCoreExecutionTest, TestGraphRegistrationContext}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils.exceptionString
 

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/MaterializeTablesSuite.scala
@@ -26,11 +26,11 @@ import org.apache.spark.sql.connector.expressions.{ClusterByTransform, Expressio
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.pipelines.graph.DatasetManager.TableMaterializationException
 import org.apache.spark.sql.pipelines.utils.{BaseCoreExecutionTest, TestGraphRegistrationContext}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils.exceptionString
 
-class DefaultMaterializeTablesSuite extends MaterializeTablesSuite with SharedSparkSession
+class DefaultMaterializeTablesSuite extends MaterializeTablesSuite with SharedClassicSparkSession
 
 /**
  * Local integration tests for materialization of `Table`s in a `DataflowGraph` to make sure

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/PipelineUpdateContextImplSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/PipelineUpdateContextImplSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.pipelines.graph
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.pipelines.utils.{PipelineTest, TestGraphRegistrationContext}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 class PipelineUpdateContextImplSuite extends PipelineTest with SharedClassicSparkSession {
 

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/PipelineUpdateContextImplSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/PipelineUpdateContextImplSuite.scala
@@ -19,9 +19,9 @@ package org.apache.spark.sql.pipelines.graph
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.pipelines.utils.{PipelineTest, TestGraphRegistrationContext}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
-class PipelineUpdateContextImplSuite extends PipelineTest with SharedSparkSession {
+class PipelineUpdateContextImplSuite extends PipelineTest with SharedClassicSparkSession {
 
   test("validateStorageRoot should accept valid URIs with schemes") {
     val validStorageRoots = Seq(

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SinkExecutionSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SinkExecutionSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.classic.DataFrame
 import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, StreamingQueryWrapper}
 import org.apache.spark.sql.pipelines.utils.{ExecutionTest, TestGraphRegistrationContext}
 import org.apache.spark.sql.streaming.StreamingQuery
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 class SinkExecutionSuite extends ExecutionTest with SharedClassicSparkSession {
   def createDataflowGraph(

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SinkExecutionSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SinkExecutionSuite.scala
@@ -24,9 +24,9 @@ import org.apache.spark.sql.classic.DataFrame
 import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, StreamingQueryWrapper}
 import org.apache.spark.sql.pipelines.utils.{ExecutionTest, TestGraphRegistrationContext}
 import org.apache.spark.sql.streaming.StreamingQuery
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
-class SinkExecutionSuite extends ExecutionTest with SharedSparkSession {
+class SinkExecutionSuite extends ExecutionTest with SharedClassicSparkSession {
   def createDataflowGraph(
       inputs: DataFrame,
       sinkName: String,

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.sql.pipelines.utils.{PipelineTest, TestGraphRegistrationContext}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{LongType, StructType}
 import org.apache.spark.util.Utils
 

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlPipelineSuite.scala
@@ -20,11 +20,11 @@ import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.sql.pipelines.utils.{PipelineTest, TestGraphRegistrationContext}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{LongType, StructType}
 import org.apache.spark.util.Utils
 
-class SqlPipelineSuite extends PipelineTest with SharedSparkSession {
+class SqlPipelineSuite extends PipelineTest with SharedClassicSparkSession {
   private val externalTable1Ident = fullyQualifiedIdentifier("external_t1")
   private val externalTable2Ident = fullyQualifiedIdentifier("external_t2")
 

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlQueryOriginSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlQueryOriginSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.pipelines.graph
 
 import org.apache.spark.sql.pipelines.Language
 import org.apache.spark.sql.pipelines.utils.PipelineTest
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 class SqlQueryOriginSuite extends PipelineTest with SharedClassicSparkSession {
   test("basic test") {

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlQueryOriginSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SqlQueryOriginSuite.scala
@@ -18,9 +18,9 @@ package org.apache.spark.sql.pipelines.graph
 
 import org.apache.spark.sql.pipelines.Language
 import org.apache.spark.sql.pipelines.utils.PipelineTest
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
-class SqlQueryOriginSuite extends PipelineTest with SharedSparkSession {
+class SqlQueryOriginSuite extends PipelineTest with SharedClassicSparkSession {
   test("basic test") {
     val sqlQueryOrigins = SqlGraphRegistrationContext.splitSqlFileIntoQueries(
       spark,

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SystemMetadataSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SystemMetadataSuite.scala
@@ -22,12 +22,12 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, StreamingQueryWrapper}
 import org.apache.spark.sql.pipelines.utils.{ExecutionTest, TestGraphRegistrationContext}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
 class SystemMetadataSuite
     extends ExecutionTest
     with SystemMetadataTestHelpers
-    with SharedSparkSession {
+    with SharedClassicSparkSession {
 
     gridTest(
       "flow checkpoint for ST wrote to the expected location when fullRefresh ="

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SystemMetadataSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/SystemMetadataSuite.scala
@@ -22,7 +22,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, StreamingQueryWrapper}
 import org.apache.spark.sql.pipelines.utils.{ExecutionTest, TestGraphRegistrationContext}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 class SystemMetadataSuite
     extends ExecutionTest

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/TriggeredGraphExecutionSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/TriggeredGraphExecutionSuite.scala
@@ -28,10 +28,10 @@ import org.apache.spark.sql.pipelines.common.{FlowStatus, RunState}
 import org.apache.spark.sql.pipelines.graph.TriggeredGraphExecution.StreamState
 import org.apache.spark.sql.pipelines.logging.{EventLevel, FlowProgress}
 import org.apache.spark.sql.pipelines.utils.{ExecutionTest, TestGraphRegistrationContext}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
-class TriggeredGraphExecutionSuite extends ExecutionTest with SharedSparkSession {
+class TriggeredGraphExecutionSuite extends ExecutionTest with SharedClassicSparkSession {
 
   /** Returns a Dataset of Longs from the table with the given identifier. */
   private def getTable(identifier: TableIdentifier): Dataset[Long] = {

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/TriggeredGraphExecutionSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/TriggeredGraphExecutionSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.pipelines.common.{FlowStatus, RunState}
 import org.apache.spark.sql.pipelines.graph.TriggeredGraphExecution.StreamState
 import org.apache.spark.sql.pipelines.logging.{EventLevel, FlowProgress}
 import org.apache.spark.sql.pipelines.utils.{ExecutionTest, TestGraphRegistrationContext}
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
 class TriggeredGraphExecutionSuite extends ExecutionTest with SharedClassicSparkSession {

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ViewSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ViewSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.pipelines.common.FlowStatus
 import org.apache.spark.sql.pipelines.logging.EventLevel
 import org.apache.spark.sql.pipelines.utils.ExecutionTest
-import org.apache.spark.sql.test.SharedClassicSparkSession
+import org.apache.spark.sql.test.classic.{SharedSparkSession => SharedClassicSparkSession}
 
 class ViewSuite extends ExecutionTest with SharedClassicSparkSession {
   private val externalTable1Ident = fullyQualifiedIdentifier("external_t1")

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ViewSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/ViewSuite.scala
@@ -21,9 +21,9 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.pipelines.common.FlowStatus
 import org.apache.spark.sql.pipelines.logging.EventLevel
 import org.apache.spark.sql.pipelines.utils.ExecutionTest
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.SharedClassicSparkSession
 
-class ViewSuite extends ExecutionTest with SharedSparkSession {
+class ViewSuite extends ExecutionTest with SharedClassicSparkSession {
   private val externalTable1Ident = fullyQualifiedIdentifier("external_t1")
 
   override def beforeEach(): Unit = {

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/BaseCoreExecutionTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/BaseCoreExecutionTest.scala
@@ -21,7 +21,6 @@ import org.apache.spark.sql.pipelines.graph.{DataflowGraph, DatasetManager, Pipe
 import org.apache.spark.sql.test.ClassicSQLTestUtils
 
 trait BaseCoreExecutionTest extends ExecutionTest with ClassicSQLTestUtils {
-  import classicTestImplicits._
 
   /**
    * Materializes the given graph using the provided context.

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/BaseCoreExecutionTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/BaseCoreExecutionTest.scala
@@ -18,9 +18,10 @@
 package org.apache.spark.sql.pipelines.utils
 
 import org.apache.spark.sql.pipelines.graph.{DataflowGraph, DatasetManager, PipelineUpdateContext}
+import org.apache.spark.sql.test.ClassicSQLTestUtils
 
-trait BaseCoreExecutionTest extends ExecutionTest {
-  import testImplicits._
+trait BaseCoreExecutionTest extends ExecutionTest with ClassicSQLTestUtils {
+  import classicTestImplicits._
 
   /**
    * Materializes the given graph using the provided context.

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/BaseCoreExecutionTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/BaseCoreExecutionTest.scala
@@ -18,9 +18,9 @@
 package org.apache.spark.sql.pipelines.utils
 
 import org.apache.spark.sql.pipelines.graph.{DataflowGraph, DatasetManager, PipelineUpdateContext}
-import org.apache.spark.sql.test.ClassicSQLTestUtils
+import org.apache.spark.sql.test.ClassicQueryTest
 
-trait BaseCoreExecutionTest extends ExecutionTest with ClassicSQLTestUtils {
+trait BaseCoreExecutionTest extends ExecutionTest with ClassicQueryTest {
 
   /**
    * Materializes the given graph using the provided context.

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/BaseCoreExecutionTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/BaseCoreExecutionTest.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.pipelines.utils
 
 import org.apache.spark.sql.pipelines.graph.{DataflowGraph, DatasetManager, PipelineUpdateContext}
-import org.apache.spark.sql.test.ClassicQueryTest
+import org.apache.spark.sql.test.classic.{QueryTest => ClassicQueryTest}
 
 trait BaseCoreExecutionTest extends ExecutionTest with ClassicQueryTest {
 

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
@@ -34,10 +34,12 @@ import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.pipelines.graph.{DataflowGraph, PipelineUpdateContextImpl, SqlGraphRegistrationContext}
 import org.apache.spark.sql.pipelines.utils.PipelineTest.cleanupMetastore
+import org.apache.spark.sql.test.ClassicSQLTestUtils
 
 abstract class PipelineTest
   extends QueryTest
   with StorageRootMixin
+  with ClassicSQLTestUtils
   with SparkErrorTestMixin
   with TargetCatalogAndDatabaseMixin
   with Logging

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
@@ -34,12 +34,12 @@ import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.pipelines.graph.{DataflowGraph, PipelineUpdateContextImpl, SqlGraphRegistrationContext}
 import org.apache.spark.sql.pipelines.utils.PipelineTest.cleanupMetastore
-import org.apache.spark.sql.test.ClassicSQLTestUtils
+import org.apache.spark.sql.test.ClassicQueryTest
 
 abstract class PipelineTest
   extends QueryTest
   with StorageRootMixin
-  with ClassicSQLTestUtils
+  with ClassicQueryTest
   with SparkErrorTestMixin
   with TargetCatalogAndDatabaseMixin
   with Logging

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.pipelines.graph.{DataflowGraph, PipelineUpdateContextImpl, SqlGraphRegistrationContext}
 import org.apache.spark.sql.pipelines.utils.PipelineTest.cleanupMetastore
-import org.apache.spark.sql.test.ClassicQueryTest
+import org.apache.spark.sql.test.classic.{QueryTest => ClassicQueryTest}
 
 abstract class PipelineTest
   extends QueryTest

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/utils/PipelineTest.scala
@@ -44,7 +44,6 @@ abstract class PipelineTest
   with TargetCatalogAndDatabaseMixin
   with Logging
   with Eventually {
-  import testImplicits._
 
   protected def startPipelineAndWaitForCompletion(
        unresolvedDataflowGraph: DataflowGraph): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

The PR adds `SharedClassicSparkSession` and `ClassicSQLTestUtils` helpers that provide/use `classic.SparkSession` and then changes `SharedSparkSession` to provide only an abstract `sql.SparkSession`.

The PR is split in the following sections:

1. Add small refactors that reduce usage of classic-only APIs / prepare the main change
2. Adding placeholders for `ClassicSQLTestUtils` and `SharedClassicSparkSession`
3. Replace `SQLTestUtils` and `SharedSparkSession` with their `Classic`-subtraits wherever needed
4. Move classic-only stuff to the `Classic`-subtraits, only provide abstract session in `SharedSparkSession`

### Why are the changes needed?

For historical reasons, many tests use `SharedSparkSession`, even though they do not necessarily are strictly classic-only.
This change "lifts" `SharedSparkSession` to be more abstract, so that potentially some test traits/classes could be extend in such a way that a `connect.SparkSession` is supplied.

The added `SharedClassicSparkSession` and `ClassicSQLTestUtils` provide the needed helpers for classic-only suites.

### Does this PR introduce _any_ user-facing change?

No. This is test-only and mostly type-level.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

The initial patch was 'hand-written'. The patch was then rebased onto the 'SQLTestUtils merged into QueryTest' changes via claude code.