### PR TITLE
[SPARK-56493][K8S] Replace `GzipCompressorOutputStream` with Java `GZIPOutputStream`

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
@@ -20,14 +20,13 @@ import java.io.{Closeable, File, FileInputStream, FileOutputStream, PrintWriter}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import java.util.concurrent.CountDownLatch
-import java.util.zip.{ZipEntry, ZipOutputStream}
+import java.util.zip.{GZIPOutputStream, ZipEntry, ZipOutputStream}
 
 import scala.jdk.CollectionConverters._
 
 import io.fabric8.kubernetes.client.dsl.ExecListener
 import io.fabric8.kubernetes.client.dsl.ExecListener.Response
 import org.apache.commons.compress.archivers.tar.{TarArchiveEntry, TarArchiveOutputStream}
-import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream
 import org.apache.commons.io.output.ByteArrayOutputStream
 
 import org.apache.spark.{SPARK_VERSION, SparkException}
@@ -158,7 +157,7 @@ object Utils extends Logging {
     ) { fis =>
       Utils.tryWithResource(
         new TarArchiveOutputStream(
-          new GzipCompressorOutputStream(
+          new GZIPOutputStream(
             new FileOutputStream(oFile)))
       ) { tOut =>
         val tarEntry = new TarArchiveEntry(fileToTarGz, fileToTarGz.getName)

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -412,6 +412,11 @@ This file is divided into 3 sections:
     <customMessage>Use contentEquals of SparkFileUtils or Utils instead.</customMessage>
   </check>
 
+  <check customId="commonscompresscompressors" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">org\.apache\.commons\.compress\.compressors\b</parameter></parameters>
+    <customMessage>Use Java API instead</customMessage>
+  </check>
+
   <check customId="commonslang2" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">org\.apache\.commons\.lang\.</parameter></parameters>
     <customMessage>Use Commons Lang 3 classes (package org.apache.commons.lang3.*) instead


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces `org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream` with Java's built-in `java.util.zip.GZIPOutputStream` in K8s integration test `Utils`, and adds a Scalastyle rule to ban `org.apache.commons.compress.compressors` package.

### Why are the changes needed?

To reduce reliance on the `commons-compress` library by using the Java standard library equivalent.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the existing tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.6)