### PR TITLE
[SPARK-56495][CONNECT] Remove `CountingOutputStream` overhead from `SparkConnectAddArtifactsHandler`

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
@@ -23,7 +23,6 @@ import java.util.zip.{CheckedOutputStream, CRC32}
 import scala.collection.mutable
 import scala.util.control.NonFatal
 
-import com.google.common.io.CountingOutputStream
 import io.grpc.stub.StreamObserver
 
 import org.apache.spark.SparkRuntimeException
@@ -228,8 +227,7 @@ class SparkConnectAddArtifactsHandler(val responseObserver: StreamObserver[AddAr
     Files.createDirectories(stagedPath.getParent)
 
     private val fileOut = Files.newOutputStream(stagedPath)
-    private val countingOut = new CountingOutputStream(fileOut)
-    private val checksumOut = new CheckedOutputStream(countingOut, new CRC32)
+    private val checksumOut = new CheckedOutputStream(fileOut, new CRC32)
     private val overallChecksum = new CRC32()
 
     private val builder = ArtifactSummary.newBuilder().setName(name)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the unused `CountingOutputStream` (from Google Guava) in `SparkConnectAddArtifactsHandler`. The `countingOut` variable was wrapping the file output stream but its count was never read anywhere. The `CheckedOutputStream` now wraps `fileOut` directly.

### Why are the changes needed?

The `CountingOutputStream` adds an unnecessary dependency on Google Guava and an extra layer in the output stream chain without being used. Removing it simplifies the code.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)