### PR TITLE
[SPARK-56496][CORE] Unify stage retry limit checks into canRetryStage helper in DAGScheduler

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -274,11 +274,12 @@ private[spark] class DAGScheduler(
    *  - [[maxStageAttempts]]: an absolute ceiling on the *total* number of attempts ever made
    *    for a stage. This counter is never cleared.
    *
-   * Note: the test-only [[disallowStageRetryForTest]] flag forces an abort regardless of these
-   * limits and is checked separately by each call site.
+   * Additionally, if the test-only flag [[disallowStageRetryForTest]] is set, the stage is
+   * aborted regardless of the above limits.
    */
   private def canRetryStage(stage: Stage): Boolean = {
-    stage.failedAttemptIds.size < maxConsecutiveStageAttempts &&
+    !disallowStageRetryForTest &&
+      stage.failedAttemptIds.size < maxConsecutiveStageAttempts &&
       stage.getNextAttemptId < maxStageAttempts
   }
 
@@ -2144,7 +2145,7 @@ private[spark] class DAGScheduler(
     }
 
     stage.failedAttemptIds.add(stage.latestInfo.attemptNumber())
-    val shouldAbortStage = !canRetryStage(stage) || disallowStageRetryForTest
+    val shouldAbortStage = !canRetryStage(stage)
     markStageAsFinished(stage, Some(reason), willRetry = !shouldAbortStage)
 
     if (shouldAbortStage) {
@@ -2388,8 +2389,7 @@ private[spark] class DAGScheduler(
             failedStage.failedAttemptIds.add(task.stageAttemptId)
           }
 
-          val shouldAbortStage =
-            (!canRetryStage(failedStage) || disallowStageRetryForTest)
+          val shouldAbortStage = !canRetryStage(failedStage)
 
           // It is likely that we receive multiple FetchFailed for a single stage (because we have
           // multiple tasks running concurrently on different executors). In that case, it is
@@ -2583,7 +2583,7 @@ private[spark] class DAGScheduler(
           failedStage.failedAttemptIds.add(task.stageAttemptId)
           // TODO Refactor the failure handling logic to combine similar code with that of
           // FetchFailed.
-          val shouldAbortStage = !canRetryStage(failedStage) || disallowStageRetryForTest
+          val shouldAbortStage = !canRetryStage(failedStage)
 
           if (shouldAbortStage) {
             val abortMessage = if (disallowStageRetryForTest) {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -247,15 +247,39 @@ private[spark] class DAGScheduler(
 
   /**
    * Number of consecutive stage attempts allowed before a stage is aborted.
+   * The consecutive counter is cleared when a stage succeeds, so failures from different
+   * "runs" of the same stage do not accumulate against this limit.
+   * See [[canRetryStage]] for how this interacts with [[maxStageAttempts]].
    */
   private[scheduler] val maxConsecutiveStageAttempts =
     sc.conf.get(config.STAGE_MAX_CONSECUTIVE_ATTEMPTS)
 
   /**
-   * Max stage attempts allowed before a stage is aborted.
+   * Absolute ceiling on the total number of attempts ever made for a stage (consecutive or not).
+   * Computed as the maximum of [[maxConsecutiveStageAttempts]] and the configured value of
+   * [[config.STAGE_MAX_ATTEMPTS]], so that the total ceiling is never lower than the consecutive
+   * limit. See [[canRetryStage]] for how this interacts with [[maxConsecutiveStageAttempts]].
    */
   private[scheduler] val maxStageAttempts: Int = {
     Math.max(maxConsecutiveStageAttempts, sc.conf.get(config.STAGE_MAX_ATTEMPTS))
+  }
+
+  /**
+   * Returns true if the stage may be retried after a failure, false if it should be aborted.
+   *
+   * Two independent limits are enforced; whichever triggers first causes the stage to be aborted:
+   *  - [[maxConsecutiveStageAttempts]]: caps the number of *consecutive* failed attempts.
+   *    This counter is reset when the stage succeeds, so transient failures in a long-running
+   *    job do not permanently accumulate.
+   *  - [[maxStageAttempts]]: an absolute ceiling on the *total* number of attempts ever made
+   *    for a stage. This counter is never cleared.
+   *
+   * Note: the test-only [[disallowStageRetryForTest]] flag forces an abort regardless of these
+   * limits and is checked separately by each call site.
+   */
+  private def canRetryStage(stage: Stage): Boolean = {
+    stage.failedAttemptIds.size < maxConsecutiveStageAttempts &&
+      stage.getNextAttemptId < maxStageAttempts
   }
 
   /**
@@ -2120,17 +2144,19 @@ private[spark] class DAGScheduler(
     }
 
     stage.failedAttemptIds.add(stage.latestInfo.attemptNumber())
-    val shouldAbortStage = stage.failedAttemptIds.size >= maxConsecutiveStageAttempts ||
-      disallowStageRetryForTest
+    val shouldAbortStage = !canRetryStage(stage) || disallowStageRetryForTest
     markStageAsFinished(stage, Some(reason), willRetry = !shouldAbortStage)
 
     if (shouldAbortStage) {
       val abortMessage = if (disallowStageRetryForTest) {
         "Stage will not retry stage due to testing config. Most recent failure " +
           s"reason: $reason"
-      } else {
+      } else if (stage.failedAttemptIds.size >= maxConsecutiveStageAttempts) {
         s"$stage (${stage.name}) has failed the maximum allowable number of " +
           s"times: $maxConsecutiveStageAttempts. Most recent failure reason: $reason"
+      } else {
+        s"$stage (${stage.name}) has exceeded the maximum allowable total stage " +
+          s"attempts: $maxStageAttempts. Most recent failure reason: $reason"
       }
       abortStage(stage, s"rollback failed due to: $abortMessage", None)
     } else {
@@ -2363,8 +2389,7 @@ private[spark] class DAGScheduler(
           }
 
           val shouldAbortStage =
-            failedStage.failedAttemptIds.size >= maxConsecutiveStageAttempts ||
-            disallowStageRetryForTest
+            (!canRetryStage(failedStage) || disallowStageRetryForTest)
 
           // It is likely that we receive multiple FetchFailed for a single stage (because we have
           // multiple tasks running concurrently on different executors). In that case, it is
@@ -2427,9 +2452,13 @@ private[spark] class DAGScheduler(
           if (shouldAbortStage) {
             val abortMessage = if (disallowStageRetryForTest) {
               "Fetch failure will not retry stage due to testing config"
-            } else {
+            } else if (failedStage.failedAttemptIds.size >= maxConsecutiveStageAttempts) {
               s"$failedStage (${failedStage.name}) has failed the maximum allowable number of " +
                 s"times: $maxConsecutiveStageAttempts. Most recent failure reason:\n" +
+                failureMessage
+            } else {
+              s"$failedStage (${failedStage.name}) has exceeded the maximum allowable total " +
+                s"stage attempts: $maxStageAttempts. Most recent failure reason:\n" +
                 failureMessage
             }
             abortStage(failedStage, abortMessage, None)
@@ -2554,17 +2583,18 @@ private[spark] class DAGScheduler(
           failedStage.failedAttemptIds.add(task.stageAttemptId)
           // TODO Refactor the failure handling logic to combine similar code with that of
           // FetchFailed.
-          val shouldAbortStage =
-            failedStage.failedAttemptIds.size >= maxConsecutiveStageAttempts ||
-              disallowStageRetryForTest
+          val shouldAbortStage = !canRetryStage(failedStage) || disallowStageRetryForTest
 
           if (shouldAbortStage) {
             val abortMessage = if (disallowStageRetryForTest) {
               "Barrier stage will not retry stage due to testing config. Most recent failure " +
                 s"reason: $message"
-            } else {
+            } else if (failedStage.failedAttemptIds.size >= maxConsecutiveStageAttempts) {
               s"$failedStage (${failedStage.name}) has failed the maximum allowable number of " +
                 s"times: $maxConsecutiveStageAttempts. Most recent failure reason: $message"
+            } else {
+              s"$failedStage (${failedStage.name}) has exceeded the maximum allowable total " +
+                s"stage attempts: $maxStageAttempts. Most recent failure reason: $message"
             }
             abortStage(failedStage, abortMessage, None)
           } else {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -249,7 +249,7 @@ private[spark] class DAGScheduler(
    * Number of consecutive stage attempts allowed before a stage is aborted.
    * The consecutive counter is cleared when a stage succeeds, so failures from different
    * "runs" of the same stage do not accumulate against this limit.
-   * See [[canRetryStage]] for how this interacts with [[maxStageAttempts]].
+   * See [[stageAbortReason]] for how this interacts with [[maxStageAttempts]].
    */
   private[scheduler] val maxConsecutiveStageAttempts =
     sc.conf.get(config.STAGE_MAX_CONSECUTIVE_ATTEMPTS)
@@ -258,29 +258,43 @@ private[spark] class DAGScheduler(
    * Absolute ceiling on the total number of attempts ever made for a stage (consecutive or not).
    * Computed as the maximum of [[maxConsecutiveStageAttempts]] and the configured value of
    * [[config.STAGE_MAX_ATTEMPTS]], so that the total ceiling is never lower than the consecutive
-   * limit. See [[canRetryStage]] for how this interacts with [[maxConsecutiveStageAttempts]].
+   * limit. See [[stageAbortReason]] for how this interacts with [[maxConsecutiveStageAttempts]].
    */
   private[scheduler] val maxStageAttempts: Int = {
     Math.max(maxConsecutiveStageAttempts, sc.conf.get(config.STAGE_MAX_ATTEMPTS))
   }
 
   /**
-   * Returns true if the stage may be retried after a failure, false if it should be aborted.
+   * If the stage must be aborted, returns `Some(abortMessage)` describing which limit was hit.
+   * If the stage may be retried, returns `None`.
    *
    * Two independent limits are enforced; whichever triggers first causes the stage to be aborted:
    *  - [[maxConsecutiveStageAttempts]]: caps the number of *consecutive* failed attempts.
    *    This counter is reset when the stage succeeds, so transient failures in a long-running
    *    job do not permanently accumulate.
    *  - [[maxStageAttempts]]: an absolute ceiling on the *total* number of attempts ever made
-   *    for a stage. This counter is never cleared.
+   *    for a stage. The attempt counter it bounds (`nextAttemptId`) is never cleared.
    *
    * Additionally, if the test-only flag [[disallowStageRetryForTest]] is set, the stage is
    * aborted regardless of the above limits.
    */
-  private def canRetryStage(stage: Stage): Boolean = {
-    !disallowStageRetryForTest &&
-      stage.failedAttemptIds.size < maxConsecutiveStageAttempts &&
-      stage.getNextAttemptId < maxStageAttempts
+  private def stageAbortReason(
+      stage: Stage,
+      failureMessage: String): Option[String] = {
+    if (disallowStageRetryForTest) {
+      Some(s"$stage (${stage.name}) will not retry due to testing config." +
+        s" Most recent failure reason: $failureMessage")
+    } else if (stage.failedAttemptIds.size >= maxConsecutiveStageAttempts) {
+      Some(s"$stage (${stage.name}) has failed the maximum allowable" +
+        s" number of times: $maxConsecutiveStageAttempts." +
+        s" Most recent failure reason: $failureMessage")
+    } else if (stage.getNextAttemptId >= maxStageAttempts) {
+      Some(s"$stage (${stage.name}) has exceeded the maximum allowable" +
+        s" total stage attempts: $maxStageAttempts." +
+        s" Most recent failure reason: $failureMessage")
+    } else {
+      None
+    }
   }
 
   /**
@@ -2145,21 +2159,13 @@ private[spark] class DAGScheduler(
     }
 
     stage.failedAttemptIds.add(stage.latestInfo.attemptNumber())
-    val shouldAbortStage = !canRetryStage(stage)
+    val abortReason = stageAbortReason(stage, reason)
+    val shouldAbortStage = abortReason.isDefined
     markStageAsFinished(stage, Some(reason), willRetry = !shouldAbortStage)
 
     if (shouldAbortStage) {
-      val abortMessage = if (disallowStageRetryForTest) {
-        "Stage will not retry stage due to testing config. Most recent failure " +
-          s"reason: $reason"
-      } else if (stage.failedAttemptIds.size >= maxConsecutiveStageAttempts) {
-        s"$stage (${stage.name}) has failed the maximum allowable number of " +
-          s"times: $maxConsecutiveStageAttempts. Most recent failure reason: $reason"
-      } else {
-        s"$stage (${stage.name}) has exceeded the maximum allowable total stage " +
-          s"attempts: $maxStageAttempts. Most recent failure reason: $reason"
-      }
-      abortStage(stage, s"rollback failed due to: $abortMessage", None)
+      abortStage(stage,
+        s"rollback failed due to: ${abortReason.get}", None)
     } else {
       // In case multiple task failures triggered for a single stage attempt, ensure we only
       // resubmit the failed stage once.
@@ -2389,7 +2395,8 @@ private[spark] class DAGScheduler(
             failedStage.failedAttemptIds.add(task.stageAttemptId)
           }
 
-          val shouldAbortStage = !canRetryStage(failedStage)
+          val abortReason = stageAbortReason(failedStage, failureMessage)
+          val shouldAbortStage = abortReason.isDefined
 
           // It is likely that we receive multiple FetchFailed for a single stage (because we have
           // multiple tasks running concurrently on different executors). In that case, it is
@@ -2450,18 +2457,7 @@ private[spark] class DAGScheduler(
           }
 
           if (shouldAbortStage) {
-            val abortMessage = if (disallowStageRetryForTest) {
-              "Fetch failure will not retry stage due to testing config"
-            } else if (failedStage.failedAttemptIds.size >= maxConsecutiveStageAttempts) {
-              s"$failedStage (${failedStage.name}) has failed the maximum allowable number of " +
-                s"times: $maxConsecutiveStageAttempts. Most recent failure reason:\n" +
-                failureMessage
-            } else {
-              s"$failedStage (${failedStage.name}) has exceeded the maximum allowable total " +
-                s"stage attempts: $maxStageAttempts. Most recent failure reason:\n" +
-                failureMessage
-            }
-            abortStage(failedStage, abortMessage, None)
+            abortStage(failedStage, abortReason.get, None)
           } else { // update failedStages and make sure a ResubmitFailedStages event is enqueued
             // TODO: Cancel running tasks in the failed stage -- cf. SPARK-17064
             val noResubmitEnqueued = !failedStages.contains(failedStage)
@@ -2583,20 +2579,11 @@ private[spark] class DAGScheduler(
           failedStage.failedAttemptIds.add(task.stageAttemptId)
           // TODO Refactor the failure handling logic to combine similar code with that of
           // FetchFailed.
-          val shouldAbortStage = !canRetryStage(failedStage)
+          val abortReason = stageAbortReason(failedStage, message)
+          val shouldAbortStage = abortReason.isDefined
 
           if (shouldAbortStage) {
-            val abortMessage = if (disallowStageRetryForTest) {
-              "Barrier stage will not retry stage due to testing config. Most recent failure " +
-                s"reason: $message"
-            } else if (failedStage.failedAttemptIds.size >= maxConsecutiveStageAttempts) {
-              s"$failedStage (${failedStage.name}) has failed the maximum allowable number of " +
-                s"times: $maxConsecutiveStageAttempts. Most recent failure reason: $message"
-            } else {
-              s"$failedStage (${failedStage.name}) has exceeded the maximum allowable total " +
-                s"stage attempts: $maxStageAttempts. Most recent failure reason: $message"
-            }
-            abortStage(failedStage, abortMessage, None)
+            abortStage(failedStage, abortReason.get, None)
           } else {
             failedStage match {
               case failedMapStage: ShuffleMapStage =>

--- a/core/src/test/scala/org/apache/spark/ExternalShuffleServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExternalShuffleServiceSuite.scala
@@ -110,7 +110,7 @@ class ExternalShuffleServiceSuite extends ShuffleSuite with Eventually {
     val e = intercept[SparkException] {
       rdd.count()
     }
-    e.getMessage should include ("Fetch failure will not retry stage due to testing config")
+    e.getMessage should include ("will not retry due to testing config.")
   }
 
   test("SPARK-25888: using external shuffle service fetching disk persisted blocks") {

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -5980,6 +5980,60 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     }
   }
 
+  test("SPARK-56496: maxStageAttempts enforced in failure path when consecutive limit not reached") {
+    // Verify that maxStageAttempts is checked in the failure-handling path (not only in
+    // submitStage), so the stage is aborted as soon as the total-attempts ceiling is hit
+    // even when the consecutive-failure counter has been cleared by an intervening success.
+    setupStageAbortTest(sc)
+    doAnswer(_ => 5).when(scheduler).maxStageAttempts
+
+    // 3-stage pipeline: stage 0 -> stage 1 -> stage 2 (result)
+    val shuffleOneRdd = new MyRDD(sc, 2, Nil).cache()
+    val shuffleDepOne = new ShuffleDependency(shuffleOneRdd, new HashPartitioner(2))
+    val shuffleTwoRdd = new MyRDD(sc, 2, List(shuffleDepOne), tracker = mapOutputTracker).cache()
+    val shuffleDepTwo = new ShuffleDependency(shuffleTwoRdd, new HashPartitioner(1))
+    val finalRdd = new MyRDD(sc, 1, List(shuffleDepTwo), tracker = mapOutputTracker)
+    submit(finalRdd, Array(0))
+
+    // Stage 1 fails 3 consecutive times due to fetch failures from stage 0.
+    // maxConsecutiveStageAttempts = 4, so 3 failures do not yet trigger the consecutive limit.
+    // maxStageAttempts = 5, so total nextAttemptId (= 3 at this point) is still under the limit.
+    for (attempt <- 0 until 3) {
+      completeShuffleMapStageSuccessfully(0, attempt, numShufflePartitions = 2)
+      completeNextStageWithFetchFailure(1, attempt, shuffleDepOne)
+      resubmitFailedStages()
+      assert(scheduler.runningStages.nonEmpty)
+      assert(!ended)
+    }
+
+    // Stage 1 succeeds on attempt 3, clearing the consecutive failure counter.
+    // Stage 1's nextAttemptId is now 4.
+    completeShuffleMapStageSuccessfully(0, 3, numShufflePartitions = 2)
+    completeShuffleMapStageSuccessfully(1, 3, numShufflePartitions = 1)
+
+    // Stage 2 runs but fails due to a fetch failure from stage 1, triggering stage 1 to retry.
+    completeNextStageWithFetchFailure(2, 0, shuffleDepTwo)
+    resubmitFailedStages()
+
+    completeShuffleMapStageSuccessfully(0, 4, numShufflePartitions = 2)
+
+    // Stage 1's 5th attempt (attempt 4) fails.
+    // Consecutive failures = 1 (cleared by earlier success), well below
+    // maxConsecutiveStageAttempts. However, nextAttemptId = 5 >= maxStageAttempts = 5,
+    // so the job must be aborted in the failure handler (not submitStage).
+    completeNextStageWithFetchFailure(1, 4, shuffleDepOne)
+
+    sc.listenerBus.waitUntilEmpty()
+    assert(ended)
+    jobResult match {
+      case JobFailed(reason) =>
+        // The failure-path message should report the total-attempts limit, not the consecutive one.
+        assert(reason.getMessage.contains("exceeded the maximum allowable total stage attempts: 5"),
+          s"Unexpected failure reason: ${reason.getMessage}")
+      case other => fail(s"expected JobFailed, not $other")
+    }
+  }
+
   test("SPARK-53564: RpcTimeout while submitting stage should not fail the job/application") {
     val shuffleMapRdd = new MyRDD(sc, 2, Nil)
     shuffleMapRdd.cache()

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -5980,7 +5980,8 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     }
   }
 
-  test("SPARK-56496: maxStageAttempts enforced in failure path when consecutive limit not reached") {
+  test("SPARK-56496: maxStageAttempts enforced in failure path when " +
+    "consecutive limit not reached") {
     // Verify that maxStageAttempts is checked in the failure-handling path (not only in
     // submitStage), so the stage is aborted as soon as the total-attempts ceiling is hit
     // even when the consecutive-failure counter has been cleared by an intervening success.

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -6001,7 +6001,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     for (attempt <- 0 until 3) {
       completeShuffleMapStageSuccessfully(0, attempt, numShufflePartitions = 2)
       completeNextStageWithFetchFailure(1, attempt, shuffleDepOne)
-      resubmitFailedStages()
+      scheduler.resubmitFailedStages()
       assert(scheduler.runningStages.nonEmpty)
       assert(!ended)
     }
@@ -6013,7 +6013,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
 
     // Stage 2 runs but fails due to a fetch failure from stage 1, triggering stage 1 to retry.
     completeNextStageWithFetchFailure(2, 0, shuffleDepTwo)
-    resubmitFailedStages()
+    scheduler.resubmitFailedStages()
 
     completeShuffleMapStageSuccessfully(0, 4, numShufflePartitions = 2)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Introduce a `canRetryStage(stage)` private helper in `DAGScheduler` that enforces both retry limits in one place: `maxConsecutiveStageAttempts` (caps consecutive failures, cleared on success) and `maxStageAttempts` (absolute total-attempts ceiling, never cleared).
- Replace three independent inline `shouldAbortStage` computations (non-fetch failure path, fetch-failure path, barrier-stage failure path) — each of which previously only checked the consecutive limit — with calls to the new helper.
- Both limits are now documented as *independently enforced*; whichever triggers first aborts the stage.
- Abort messages now correctly identify which limit was exceeded (consecutive vs. total).
- Add unit test that verifies the total-attempts limit is enforced in the failure path even when the consecutive counter was cleared by an intervening stage success.

### Why are the changes needed?
Fix the inconsistent behavior between fetch-failure paths and non-fetch-failure paths.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Verified by a new unit test in DAGSchedulerSuite.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Opus 4.6
