### PR TITLE
[SPARK-56502][CORE] Fix integer overflow in DirectByteBufferOutputStream capacity check

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/DirectByteBufferOutputStream.scala
+++ b/core/src/main/scala/org/apache/spark/util/DirectByteBufferOutputStream.scala
@@ -36,18 +36,23 @@ private[spark] class DirectByteBufferOutputStream(capacity: Int) extends OutputS
 
   override def write(b: Int): Unit = {
     checkNotClosed()
-    ensureCapacity(buffer.position() + 1)
+    ensureCapacity(buffer.position().toLong + 1)
     buffer.put(b.toByte)
   }
 
   override def write(b: Array[Byte], off: Int, len: Int): Unit = {
     checkNotClosed()
-    ensureCapacity(buffer.position() + len)
+    ensureCapacity(buffer.position().toLong + len)
     buffer.put(b, off, len)
   }
 
-  private def ensureCapacity(minCapacity: Int): Unit = {
-    if (minCapacity > buffer.capacity()) grow(minCapacity)
+  private def ensureCapacity(minCapacity: Long): Unit = {
+    if (minCapacity > Int.MaxValue) {
+      throw SparkException.internalError(
+        s"DirectByteBufferOutputStream cannot grow beyond 2GB limit " +
+        s"(requested $minCapacity bytes)")
+    }
+    if (minCapacity > buffer.capacity()) grow(minCapacity.toInt)
   }
 
   /**
@@ -56,7 +61,7 @@ private[spark] class DirectByteBufferOutputStream(capacity: Int) extends OutputS
    */
   private def grow(minCapacity: Int): Unit = {
     val oldCapacity = buffer.capacity()
-    var newCapacity = oldCapacity << 1
+    var newCapacity = math.min(oldCapacity.toLong << 1, Int.MaxValue).toInt
     if (newCapacity < minCapacity) newCapacity = minCapacity
     val oldBuffer = buffer
     oldBuffer.flip()

--- a/core/src/test/scala/org/apache/spark/util/DirectByteBufferOutputStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/DirectByteBufferOutputStreamSuite.scala
@@ -38,4 +38,22 @@ class DirectByteBufferOutputStreamSuite extends SparkFunSuite {
     // val arr = new Array[Byte](size)
     // b.get(arr)
   }
+
+  // write() checks capacity before reading from the source array, so we can use
+  // a small array with a large len to trigger the overflow without allocating 2GB.
+  test("write(Array[Byte]) throws instead of SIGSEGV when position + len overflows Int") {
+    val o = new DirectByteBufferOutputStream(16)
+    o.write(new Array[Byte](16), 0, 16)
+
+    // position(16) + Int.MaxValue overflows Int; should throw, not SIGSEGV in buffer.put()
+    val ex = intercept[SparkException] {
+      o.write(new Array[Byte](1), 0, Int.MaxValue)
+    }
+    assert(ex.getMessage.contains("cannot grow beyond 2GB limit"))
+    o.close()
+  }
+
+  // write(Int) has the same Long promotion fix but can only overflow when
+  // position == Int.MaxValue, which requires a 2GB buffer. Both write paths
+  // share the same ensureCapacity(Long) check covered by the test above.
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`DirectByteBufferOutputStream.write(b, off, len)` computes `buffer.position() + len` using Int arithmetic. When the sum exceeds `Integer.MAX_VALUE`, it wraps to a negative value, bypassing the `ensureCapacity`
guard. The subsequent `buffer.put()` writes past the allocated buffer, causing a JVM SIGSEGV.

Example stack trace:
```
J 17470 c2 org.apache.spark.util.DirectByteBufferOutputStream.write([BII)V (25 bytes) @ 0x00007f47dcaaa7d2 [0x00007f47dcaaa5c0+0x0000000000000212]
J 30250 c2 java.nio.channels.Channels$WritableByteChannelImpl.write(Ljava/nio/ByteBuffer;)I java.base@17.0.18 (151 bytes) @ 0x00007f47dd81ffd4 [0x00007f47dd81fd00+0x00000000000002d4]
J 21322 c1 org.apache.arrow.vector.ipc.WriteChannel.write(Ljava/nio/ByteBuffer;)J (64 bytes) @ 0x00007f47cdb37184 [0x00007f47cdb36d20+0x0000000000000464]
J 23536 c1 org.apache.arrow.vector.ipc.WriteChannel.writeIntLittleEndian(I)J (17 bytes) @ 0x00007f47cdd1fe8c [0x00007f47cdd1fce0+0x00000000000001ac]
j  org.apache.arrow.vector.ipc.message.MessageSerializer.serialize(Lorg/apache/arrow/vector/ipc/WriteChannel;Lorg/apache/arrow/vector/ipc/message/ArrowRecordBatch;Lorg/apache/arrow/vector/ipc/message/IpcOption;)Lorg/apache/arrow/vector/ipc/message/ArrowBlock;+58
j  org.apache.arrow.vector.ipc.ArrowWriter.writeRecordBatch(Lorg/apache/arrow/vector/ipc/message/ArrowRecordBatch;)Lorg/apache/arrow/vector/ipc/message/ArrowBlock;+9
j  org.apache.arrow.vector.ipc.ArrowWriter.writeBatch()V+28
J 29845 c1 org.apache.spark.sql.execution.python.BasicPythonArrowInput.writeNextBatchToArrowStream(Lorg/apache/arrow/vector/VectorSchemaRoot;Lorg/apache/arrow/vector/ipc/ArrowStreamWriter;Ljava/io/DataOutputStream;Lscala/collection/Iterator;)Z (233 bytes) @ 0x00007f47cde9603c [0x00007f47cde949e0+0x000000000000165c]
...
```

This PR:
- Changes `ensureCapacity` to accept a `Long` parameter and reject requests exceeding `Int.MaxValue` with a clear `SparkException`
- Promotes `position() + len` and `position() + 1` to Long arithmetic in both `write()` overloads
- Caps `grow()`'s capacity doubling at `Int.MaxValue` to prevent the same class of overflow

### Why are the changes needed?

Without this fix, writing more than ~2GB of cumulative data to a `DirectByteBufferOutputStream` can crash the JVM with a SIGSEGV instead of throwing a catchable exception.

### Does this PR introduce _any_ user-facing change?

No. The stream is `private[spark]`. The only behavioral change is that an overflow now throws `SparkException` instead of crashing the JVM.

### How was this patch tested?

Added a unit test in `DirectByteBufferOutputStreamSuite` that triggers the overflow path through `write(Array[Byte])` and verifies `SparkException` is thrown. The test uses a small source array with a large `len`
— this is valid because `ensureCapacity` checks capacity before `buffer.put()` reads from the array.

### Was this patch authored or co-authored using generative AI tooling?

Yes.
