### PR TITLE
[SPARK-56507][ML][PYTHON][TESTS] Reduce maxIter in CrossValidator test to speed up CI

### DIFF
--- a/python/pyspark/ml/tests/connect/test_legacy_mode_tuning.py
+++ b/python/pyspark/ml/tests/connect/test_legacy_mode_tuning.py
@@ -202,7 +202,7 @@ class CrossValidatorTestsMixin:
         lorv2 = LORV2(numTrainWorkers=2, featuresCol="scaled_features")
         pipeline = Pipeline(stages=[scaler, lorv2])
 
-        grid2 = ParamGridBuilder().addGrid(lorv2.maxIter, [2, 5]).build()
+        grid2 = ParamGridBuilder().addGrid(lorv2.maxIter, [2, 3]).build()
         cv = CrossValidator(
             estimator=pipeline,
             estimatorParamMaps=grid2,
@@ -220,7 +220,7 @@ class CrossValidatorTestsMixin:
         )
         pd.testing.assert_frame_equal(transformed_result, expected_transformed_result)
 
-        assert cv_model.bestModel.stages[1].getMaxIter() == 5
+        assert cv_model.bestModel.stages[1].getMaxIter() == 3
 
         # trial of index 2 should have better metric value
         # because it sets higher `maxIter` param.
@@ -254,7 +254,7 @@ class CrossValidatorTestsMixin:
                 assert cv_model.bestModel.uid == loaded_cv_model.bestModel.uid
                 assert cv_model.bestModel.stages[0].uid == loaded_cv_model.bestModel.stages[0].uid
                 assert cv_model.bestModel.stages[1].uid == loaded_cv_model.bestModel.stages[1].uid
-                assert loaded_cv_model.bestModel.stages[1].getMaxIter() == 5
+                assert loaded_cv_model.bestModel.stages[1].getMaxIter() == 3
 
                 np.testing.assert_allclose(cv_model.avgMetrics, loaded_cv_model.avgMetrics)
                 np.testing.assert_allclose(cv_model.stdMetrics, loaded_cv_model.stdMetrics)
@@ -278,7 +278,7 @@ class CrossValidatorTestsMixin:
 
         lorv2 = LORV2(numTrainWorkers=2)
 
-        grid2 = ParamGridBuilder().addGrid(lorv2.maxIter, [2, 5]).build()
+        grid2 = ParamGridBuilder().addGrid(lorv2.maxIter, [2, 3]).build()
         cv = CrossValidator(
             estimator=lorv2,
             estimatorParamMaps=grid2,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Reduce the `maxIter` param grid from `[2, 5]` to `[2, 3]` in `test_crossvalidator_on_pipeline` and `test_crossvalidator_with_fold_col` in `CrossValidatorTestsMixin`.

### Why are the changes needed?

These two tests are among the slowest in the PySpark ML CI suite:
- `CrossValidatorTestsOnConnect.test_crossvalidator_on_pipeline`: **71s**
- `CrossValidatorTests.test_crossvalidator_on_pipeline`: **69s**

Each test builds a Pipeline (StandardScaler + LogisticRegression) and runs CrossValidator with `numTrainWorkers=2`, which launches TorchDistributor for every fold × param combination. With `numFolds=3` (default) and 2 param values, that is 3 × 2 = 6 distributed training runs + 1 refit = **7 TorchDistributor invocations**.

Reducing `maxIter` from `[2, 5]` to `[2, 3]` decreases the per-run training time while still preserving the test semantics: the test asserts that the higher `maxIter` model produces a better metric, and `maxIter=3` vs `maxIter=2` is still sufficient to demonstrate that.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests. The affected tests (`test_crossvalidator_on_pipeline` and `test_crossvalidator_with_fold_col`) are modified to use the reduced param grid and updated assertions.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code