### PR TITLE
[SPARK-56512][CORE] Avoid redundant BlockId parsing in ShuffleBlockFetcherIterator

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -309,8 +309,9 @@ final class ShuffleBlockFetcherIterator(
             buf.retain()
             remainingBlocks -= blockId
             blockOOMRetryCounts.remove(blockId)
-            updateMergedReqsDuration(BlockId(blockId).isShuffleChunk)
-            results.put(SuccessFetchResult(BlockId(blockId), infoMap(blockId)._2,
+            val blkId = BlockId(blockId)
+            updateMergedReqsDuration(blkId.isShuffleChunk)
+            results.put(SuccessFetchResult(blkId, infoMap(blockId)._2,
               address, infoMap(blockId)._1, buf, remainingBlocks.isEmpty))
             logDebug("remainingBlocks: " + remainingBlocks)
             enqueueDeferredFetchRequestIfNecessary()


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR caches the result of `BlockId.apply(blockId)` into a local variable in `ShuffleBlockFetcherIterator.onBlockFetchSuccess`, avoiding parsing the same block ID string twice.

### Why are the changes needed?
`BlockId.apply()` sequentially matches the input string against 20 patterns. In the current code, it is called twice on the same `blockId` string within `onBlockFetchSuccess`:

```scala
updateMergedReqsDuration(BlockId(blockId).isShuffleChunk)
results.put(SuccessFetchResult(BlockId(blockId), ...))
```

This callback is on the hot path of shuffle data fetching — invoked once per block for every shuffle read. Parsing once and reusing the result eliminates redundant case matching.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Pass Github Actions

### Was this patch authored or co-authored using generative AI tooling?
No