### PR TITLE
[WIP][SPARK-56514][SQL] Allow catalog Table objects to be passed directly to read.table() and writeTo()

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -76,6 +76,8 @@ class Table(NamedTuple):
         '`spark_catalog`.`default`.`my_table`'
         """
 
+        # Must mirror Scala's QuotingUtils.quoteIdentifier: wrap in backticks,
+        # doubling any embedded backtick.
         def quote(part: str) -> str:
             return "`" + part.replace("`", "``") + "`"
 

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -57,6 +57,36 @@ class Table(NamedTuple):
         else:
             return None
 
+    @property
+    def qualifiedName(self) -> str:
+        """
+        Returns the fully qualified, backtick-quoted name of this table suitable for use as
+        a table identifier in SQL or directly with :meth:`DataFrameReader.table` and
+        :meth:`DataFrame.writeTo`.
+
+        .. versionadded:: 4.2.0
+
+        Examples
+        --------
+        >>> from pyspark.sql.catalog import Table
+        >>> t = Table(name="my_table", catalog="spark_catalog",
+        ...           namespace=["default"], description=None,
+        ...           tableType="MANAGED", isTemporary=False)
+        >>> t.qualifiedName
+        '`spark_catalog`.`default`.`my_table`'
+        """
+
+        def quote(part: str) -> str:
+            return "`" + part.replace("`", "``") + "`"
+
+        parts = []
+        if self.catalog is not None:
+            parts.append(self.catalog)
+        if self.namespace is not None:
+            parts.extend(self.namespace)
+        parts.append(self.name)
+        return ".".join(quote(p) for p in parts)
+
 
 class Column(NamedTuple):
     name: str

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1910,7 +1910,11 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     groupby = groupBy
     drop_duplicates = dropDuplicates
 
-    def writeTo(self, table: str) -> "DataFrameWriterV2":
+    def writeTo(self, table: Union[str, "Table"]) -> "DataFrameWriterV2":
+        from pyspark.sql.catalog import Table
+
+        if isinstance(table, Table):
+            table = table.qualifiedName
         return DataFrameWriterV2(self, table)
 
     def mergeInto(self, table: str, condition: Column) -> "MergeIntoWriter":

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -2342,7 +2342,12 @@ class DataFrame(ParentDataFrame):
             plan=self._plan.to_proto(self._session.client),
         )
 
-    def writeTo(self, table: str) -> "DataFrameWriterV2":
+    def writeTo(self, table: Union[str, "Table"]) -> "DataFrameWriterV2":
+        from pyspark.sql.catalog import Table
+
+        if isinstance(table, Table):
+            table = table.qualifiedName
+
         def cb(ei: "ExecutionInfo") -> None:
             self._execution_info = ei
 

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     from pyspark.sql.connect._typing import ColumnOrName, OptionalPrimitiveType
     from pyspark.sql.connect.session import SparkSession
     from pyspark.sql.metrics import ExecutionInfo
+    from pyspark.sql.catalog import Table
 
 __all__ = ["DataFrameReader", "DataFrameWriter"]
 
@@ -149,7 +150,11 @@ class DataFrameReader(OptionUtils):
 
         return DataFrame(plan, self._client)
 
-    def table(self, tableName: str) -> "DataFrame":
+    def table(self, tableName: Union[str, "Table"]) -> "DataFrame":
+        from pyspark.sql.catalog import Table
+
+        if isinstance(tableName, Table):
+            tableName = tableName.qualifiedName
         return self._df(Read(tableName, self._options))
 
     table.__doc__ = PySparkDataFrameReader.table.__doc__

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -6278,10 +6278,15 @@ class DataFrame:
         .. versionchanged:: 3.4.0
             Supports Spark Connect.
 
+        .. versionchanged:: 4.2.0
+            ``table`` may be a :class:`~pyspark.sql.catalog.Table` object returned by
+            :meth:`~pyspark.sql.Catalog.getTable` or :meth:`~pyspark.sql.Catalog.listTables`.
+
         Parameters
         ----------
-        table : str
-            Target table name to write to.
+        table : str or :class:`~pyspark.sql.catalog.Table`
+            Target table name to write to, or a catalog :class:`~pyspark.sql.catalog.Table`
+            object.
 
         Returns
         -------

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
     )
     from pyspark.sql.plot import PySparkPlotAccessor
     from pyspark.sql.metrics import ExecutionInfo
+    from pyspark.sql import catalog
 
 
 __all__ = ["DataFrame", "DataFrameNaFunctions", "DataFrameStatFunctions"]
@@ -6264,7 +6265,7 @@ class DataFrame:
         ...
 
     @dispatch_df_method
-    def writeTo(self, table: str) -> DataFrameWriterV2:
+    def writeTo(self, table: Union[str, "catalog.Table"]) -> DataFrameWriterV2:
         """
         Create a write configuration builder for v2 sources.
 

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -522,7 +522,7 @@ class DataFrameReader(OptionUtils):
                 },
             )
 
-    def table(self, tableName: str) -> "DataFrame":
+    def table(self, tableName: Union[str, "Table"]) -> "DataFrame":
         """Returns the specified table as a :class:`DataFrame`.
 
         .. versionadded:: 1.4.0
@@ -530,10 +530,14 @@ class DataFrameReader(OptionUtils):
         .. versionchanged:: 3.4.0
             Supports Spark Connect.
 
+        .. versionchanged:: 4.2.0
+            ``tableName`` may be a :class:`~pyspark.sql.catalog.Table` object returned by
+            :meth:`~pyspark.sql.Catalog.getTable` or :meth:`~pyspark.sql.Catalog.listTables`.
+
         Parameters
         ----------
-        tableName : str
-            string, name of the table.
+        tableName : str or :class:`~pyspark.sql.catalog.Table`
+            Name of the table, or a :class:`~pyspark.sql.catalog.Table` catalog object.
 
         Examples
         --------
@@ -556,6 +560,10 @@ class DataFrameReader(OptionUtils):
         +---+
         >>> _ = spark.sql("DROP TABLE tblA")
         """
+        from pyspark.sql.catalog import Table
+
+        if isinstance(tableName, Table):
+            tableName = tableName.qualifiedName
         return self._df(self._jreader.table(tableName))
 
     def changes(self, tableName: str) -> "DataFrame":

--- a/python/pyspark/sql/tests/test_catalog.py
+++ b/python/pyspark/sql/tests/test_catalog.py
@@ -651,14 +651,26 @@ class CatalogTestsMixin:
             self.assertEqual(rows[1][0], 2)
             self.assertEqual(rows[1][1], "b")
 
-            # writeTo accepts a Table object directly; typical use: filter listTables then write
-            non_temp = [t for t in spark.catalog.listTables("default") if not t.isTemporary]
-            self.assertEqual(len(non_temp), 1)
-            spark.createDataFrame([(3, "c")], ["id", "name"]).writeTo(non_temp[0]).append()
-            rows = sorted(spark.read.table(t).collect(), key=lambda r: r[0])
-            self.assertEqual(len(rows), 3)
-            self.assertEqual(rows[2][0], 3)
-            self.assertEqual(rows[2][1], "c")
+        # writeTo accepts a Table object directly; requires a V2 catalog
+        # typical use: filter listTables then write
+        with self.sql_conf(
+            {
+                "spark.sql.catalog.testcat": (
+                    "org.apache.spark.sql.connector.catalog.InMemoryTableCatalog"
+                )
+            }
+        ):
+            spark.sql("CREATE NAMESPACE IF NOT EXISTS testcat.ns")
+            with self.table("testcat.ns.tbl"):
+                spark.sql("CREATE TABLE testcat.ns.tbl (id INT, name STRING) USING foo")
+                non_temp = [
+                    t
+                    for t in spark.catalog.listTables("testcat.ns")
+                    if not t.isTemporary
+                ]
+                self.assertEqual(len(non_temp), 1)
+                spark.createDataFrame([(3, "c")], ["id", "name"]).writeTo(non_temp[0]).append()
+                self.assertEqual(spark.read.table(non_temp[0]).count(), 1)
 
 
 class CatalogTests(CatalogTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/test_catalog.py
+++ b/python/pyspark/sql/tests/test_catalog.py
@@ -588,6 +588,78 @@ class CatalogTestsMixin:
             spark.sql(f"INSERT INTO {t} VALUES (1)")
             spark.catalog.analyzeTable(t, noScan=True)
 
+    def test_table_qualified_name(self):
+        from pyspark.sql.catalog import Table
+
+        # fully qualified: catalog + namespace + name
+        t = Table(
+            name="tbl", catalog="cat", namespace=["db"], description=None,
+            tableType="MANAGED", isTemporary=False
+        )
+        self.assertEqual(t.qualifiedName, "`cat`.`db`.`tbl`")
+
+        # no catalog
+        t = Table(
+            name="tbl", catalog=None, namespace=["db"], description=None,
+            tableType="MANAGED", isTemporary=False
+        )
+        self.assertEqual(t.qualifiedName, "`db`.`tbl`")
+
+        # multi-part namespace
+        t = Table(
+            name="tbl", catalog="cat", namespace=["ns1", "ns2"], description=None,
+            tableType="MANAGED", isTemporary=False
+        )
+        self.assertEqual(t.qualifiedName, "`cat`.`ns1`.`ns2`.`tbl`")
+
+        # temporary view: no catalog, no namespace
+        t = Table(
+            name="tmp", catalog=None, namespace=None, description=None,
+            tableType="TEMPORARY", isTemporary=True
+        )
+        self.assertEqual(t.qualifiedName, "`tmp`")
+
+        # names with special characters are backtick-escaped
+        t = Table(
+            name="my-tbl", catalog="my-cat", namespace=["my-db"], description=None,
+            tableType="MANAGED", isTemporary=False
+        )
+        self.assertEqual(t.qualifiedName, "`my-cat`.`my-db`.`my-tbl`")
+
+        # embedded backticks are doubled
+        t = Table(
+            name="t`b", catalog=None, namespace=["d`b"], description=None,
+            tableType="MANAGED", isTemporary=False
+        )
+        self.assertEqual(t.qualifiedName, "`d``b`.`t``b`")
+
+    def test_read_table_and_write_to_accept_table_object(self):
+        spark = self.spark
+        t_name = "py_catalog_tbl_obj_t"
+        with self.table(t_name):
+            spark.sql(f"CREATE TABLE {t_name} (id INT, name STRING) USING parquet")
+            spark.sql(f"INSERT INTO {t_name} VALUES (1, 'a'), (2, 'b')")
+
+            # getTable returns a Table whose qualifiedName can be used with read.table / writeTo
+            t = spark.catalog.getTable(f"default.{t_name}")
+            self.assertEqual(t.qualifiedName, f"`spark_catalog`.`default`.`{t_name}`")
+
+            # read.table accepts a Table object directly
+            rows = sorted(spark.read.table(t).collect(), key=lambda r: r[0])
+            self.assertEqual(rows[0][0], 1)
+            self.assertEqual(rows[0][1], "a")
+            self.assertEqual(rows[1][0], 2)
+            self.assertEqual(rows[1][1], "b")
+
+            # writeTo accepts a Table object directly; typical use: filter listTables then write
+            non_temp = [t for t in spark.catalog.listTables("default") if not t.isTemporary]
+            self.assertEqual(len(non_temp), 1)
+            spark.createDataFrame([(3, "c")], ["id", "name"]).writeTo(non_temp[0]).append()
+            rows = sorted(spark.read.table(t).collect(), key=lambda r: r[0])
+            self.assertEqual(len(rows), 3)
+            self.assertEqual(rows[2][0], 3)
+            self.assertEqual(rows[2][1], "c")
+
 
 class CatalogTests(CatalogTestsMixin, ReusedSQLTestCase):
     pass

--- a/python/pyspark/sql/tests/test_catalog.py
+++ b/python/pyspark/sql/tests/test_catalog.py
@@ -588,6 +588,19 @@ class CatalogTestsMixin:
             spark.sql(f"INSERT INTO {t} VALUES (1)")
             spark.catalog.analyzeTable(t, noScan=True)
 
+    def test_qualified_name_consistent_with_jvm(self):
+        # Verify that the Python qualifiedName quoting is consistent with the JVM parser:
+        # a name produced by Python must be accepted by Spark and resolve to the same table.
+        spark = self.spark
+        with self.table("qn_consistency_tab"):
+            spark.sql("CREATE TABLE qn_consistency_tab (id INT) USING parquet")
+            t = spark.catalog.getTable("spark_catalog.default.qn_consistency_tab")
+            # The Python-computed qualifiedName must be parseable by Spark as the same table.
+            self.assertEqual(
+                spark.read.table(t.qualifiedName).schema,
+                spark.read.table(t).schema,
+            )
+
     def test_table_qualified_name(self):
         from pyspark.sql.catalog import Table
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -498,6 +498,28 @@ abstract class DataFrameReader {
   def table(tableName: String): DataFrame
 
   /**
+   * Returns the specified table as a `DataFrame` using a [[org.apache.spark.sql.catalog.Table]]
+   * object returned by `spark.catalog.getTable` or `spark.catalog.listTables`. This avoids
+   * manually reconstructing the qualified name string.
+   *
+   * {{{
+   *   val t = spark.catalog.getTable("spark_catalog.default.my_table")
+   *   val df = spark.read.table(t)
+   *
+   *   // iterate over all tables in a database
+   *   spark.catalog.listTables("my_db").collect().foreach { t =>
+   *     spark.read.table(t).show()
+   *   }
+   * }}}
+   *
+   * @param table
+   *   a `Table` object as returned by the catalog API.
+   * @since 4.2.0
+   */
+  def table(table: org.apache.spark.sql.catalog.Table): DataFrame =
+    this.table(table.qualifiedName)
+
+  /**
    * Returns the row-level changes (Change Data Capture) from the specified table as a
    * `DataFrame`. Currently this API is only supported for Data Source V2 tables whose catalog
    * implements `TableCatalog.loadChangelog()`.

--- a/sql/api/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3245,6 +3245,29 @@ abstract class Dataset[T] extends Serializable {
   def writeTo(table: String): DataFrameWriterV2[T]
 
   /**
+   * Create a write configuration builder for v2 sources using a
+   * [[org.apache.spark.sql.catalog.Table]] object returned by `spark.catalog.getTable` or
+   * `spark.catalog.listTables`. This avoids manually reconstructing the qualified name string.
+   *
+   * {{{
+   *   val t = spark.catalog.getTable("spark_catalog.default.my_table")
+   *   df.writeTo(t).append()
+   *
+   *   // copy all tables from one catalog to another
+   *   spark.catalog.listTables("my_db").collect().foreach { t =>
+   *     spark.read.table(t).writeTo(t).createOrReplace()
+   *   }
+   * }}}
+   *
+   * @param table
+   *   a `Table` object as returned by the catalog API.
+   * @group basic
+   * @since 4.2.0
+   */
+  def writeTo(table: org.apache.spark.sql.catalog.Table): DataFrameWriterV2[T] =
+    writeTo(table.qualifiedName)
+
+  /**
    * Returns the content of the Dataset as a Dataset of JSON strings.
    *
    * @since 2.0.0

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalog/interface.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalog/interface.scala
@@ -151,6 +151,27 @@ class Table(
     if (namespace != null && namespace.length == 1) namespace(0) else null
   }
 
+  /**
+   * Returns the fully qualified, backtick-quoted name of this table suitable for use as a table
+   * identifier in SQL or directly with [[org.apache.spark.sql.DataFrameReader#table]] and
+   * [[org.apache.spark.sql.Dataset#writeTo]].
+   *
+   * {{{
+   *   val t = spark.catalog.getTable("spark_catalog.default.my_table")
+   *   val df = spark.read.table(t)
+   *   df.writeTo(t).append()
+   * }}}
+   *
+   * @since 4.2.0
+   */
+  def qualifiedName: String = {
+    import org.apache.spark.sql.catalyst.util.QuotingUtils
+    QuotingUtils.quoteNameParts(
+      Option(catalog).toSeq ++
+        Option(namespace).toSeq.flatMap(_.toSeq) ++
+        Seq(name))
+  }
+
   override def toString: String = {
     "Table[" +
       s"name='$name', " +

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/CatalogSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/CatalogSuite.scala
@@ -475,4 +475,28 @@ class CatalogSuite extends ConnectFunSuite with RemoteSparkSession with SQLHelpe
       }
     }
   }
+
+  test("read.table and writeTo accept catalog Table object") {
+    val session = spark
+    import session.implicits._
+
+    val t = "connect_catalog_tbl_obj_t"
+    withTable(t) {
+      spark.sql(s"CREATE TABLE $t (id INT, name STRING) USING parquet").collect()
+      spark.sql(s"INSERT INTO $t VALUES (1, 'a'), (2, 'b')").collect()
+
+      val tableObj = spark.catalog.getTable(s"default.$t")
+      assert(tableObj.qualifiedName == s"`spark_catalog`.`default`.`$t`")
+
+      // read.table accepts a Table object
+      val rows = spark.read.table(tableObj).collect().map(r => (r.getInt(0), r.getString(1))).toSet
+      assert(rows == Set((1, "a"), (2, "b")))
+
+      // writeTo accepts a Table object; typical use: filter listTables then write
+      val nonTemp = spark.catalog.listTables("default").collect().filter(!_.isTemporary)
+      assert(nonTemp.length == 1)
+      Seq((3, "c"), (4, "d")).toDF("id", "name").writeTo(nonTemp.head).append()
+      assert(spark.read.table(tableObj).count() == 4)
+    }
+  }
 }

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/CatalogSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/CatalogSuite.scala
@@ -491,12 +491,20 @@ class CatalogSuite extends ConnectFunSuite with RemoteSparkSession with SQLHelpe
       // read.table accepts a Table object
       val rows = spark.read.table(tableObj).collect().map(r => (r.getInt(0), r.getString(1))).toSet
       assert(rows == Set((1, "a"), (2, "b")))
+    }
 
-      // writeTo accepts a Table object; typical use: filter listTables then write
-      val nonTemp = spark.catalog.listTables("default").collect().filter(!_.isTemporary)
-      assert(nonTemp.length == 1)
-      Seq((3, "c"), (4, "d")).toDF("id", "name").writeTo(nonTemp.head).append()
-      assert(spark.read.table(tableObj).count() == 4)
+    // writeTo accepts a Table object; requires a V2 catalog
+    // typical use: filter listTables then write
+    withSQLConf("spark.sql.catalog.testcat" ->
+        "org.apache.spark.sql.connector.catalog.InMemoryTableCatalog") {
+      spark.sql("CREATE NAMESPACE IF NOT EXISTS testcat.ns").collect()
+      withTable("testcat.ns.tbl") {
+        spark.sql("CREATE TABLE testcat.ns.tbl (id INT, name STRING) USING foo").collect()
+        val nonTemp = spark.catalog.listTables("testcat.ns").collect().filter(!_.isTemporary)
+        assert(nonTemp.length == 1)
+        Seq((3, "c"), (4, "d")).toDF("id", "name").writeTo(nonTemp.head).append()
+        assert(spark.read.table(nonTemp.head).count() == 2)
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
@@ -901,4 +901,29 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
     insertDF.cache()
     checkAnswer(spark.table("testcat.table_name"), Seq(Row(1, "a"), Row(2, "b")))
   }
+
+  test("writeTo accepts catalog Table object from catalog API") {
+    spark.sql("CREATE TABLE testcat.table_name (id bigint, data string) USING foo")
+    val t = spark.catalog.getTable("testcat.table_name")
+
+    spark.table("source").writeTo(t).append()
+    checkAnswer(
+      spark.table("testcat.table_name"),
+      Seq(Row(1L, "a"), Row(2L, "b"), Row(3L, "c")))
+
+    spark.table("source2").writeTo(t).append()
+    checkAnswer(
+      spark.table("testcat.table_name"),
+      Seq(Row(1L, "a"), Row(2L, "b"), Row(3L, "c"), Row(4L, "d"), Row(5L, "e"), Row(6L, "f")))
+  }
+
+  test("read.table accepts catalog Table object from catalog API") {
+    spark.sql("CREATE TABLE testcat.table_name (id bigint, data string) USING foo")
+    spark.sql("INSERT INTO testcat.table_name VALUES (1, 'a'), (2, 'b')")
+    val t = spark.catalog.getTable("testcat.table_name")
+
+    checkAnswer(
+      spark.read.table(t),
+      Seq(Row(1L, "a"), Row(2L, "b")))
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -500,6 +500,26 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
       "Table[name='volley', tableType='world', isTemporary='true']")
   }
 
+  test("Table.qualifiedName") {
+    // catalog + namespace + name
+    assert(new Table("tbl", "cat", Array("db"), null, "MANAGED", false).qualifiedName ==
+      "`cat`.`db`.`tbl`")
+    // no catalog
+    assert(new Table("tbl", null, Array("db"), null, "MANAGED", false).qualifiedName ==
+      "`db`.`tbl`")
+    // multi-part namespace
+    assert(new Table("tbl", "cat", Array("ns1", "ns2"), null, "MANAGED", false).qualifiedName ==
+      "`cat`.`ns1`.`ns2`.`tbl`")
+    // temporary view: no catalog, no namespace
+    assert(new Table("tmp", null, null, null, "TEMPORARY", true).qualifiedName == "`tmp`")
+    // names with special characters are backtick-escaped
+    assert(new Table("my-tbl", "my-cat", Array("my-db"), null, "MANAGED", false).qualifiedName ==
+      "`my-cat`.`my-db`.`my-tbl`")
+    // embedded backticks are doubled
+    assert(new Table("t`b", null, Array("d`b"), null, "MANAGED", false).qualifiedName ==
+      "`d``b`.`t``b`")
+  }
+
   test("Function.toString") {
     assert(
       new Function("nama", "databasa", "commenta", "classNameAh", isTemporary = true).toString ==
@@ -1236,6 +1256,35 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
     spark.sql(s"INSERT INTO $t VALUES (1)")
     spark.catalog.analyzeTable(t, noScan = true)
     spark.catalog.dropTable(t)
+  }
+
+  test("read.table and writeTo accept catalog Table object") {
+    // read.table with session-catalog Table
+    val tName = "catalog_api_tbl_obj_t"
+    spark.sql(s"DROP TABLE IF EXISTS $tName")
+    spark.sql(s"CREATE TABLE $tName (id INT, name STRING) USING parquet")
+    spark.sql(s"INSERT INTO $tName VALUES (1, 'a'), (2, 'b')")
+    try {
+      val t = spark.catalog.getTable(s"default.$tName")
+      assert(t.qualifiedName == s"`spark_catalog`.`default`.`$tName`")
+      val rows = spark.read.table(t).collect().map(r => (r.getInt(0), r.getString(1))).toSet
+      assert(rows == Set((1, "a"), (2, "b")))
+    } finally {
+      spark.catalog.dropTable(tName)
+    }
+
+    // writeTo with V2 catalog Table
+    sql("CREATE NAMESPACE IF NOT EXISTS testcat.ns")
+    sql("CREATE TABLE testcat.ns.writetarget (id INT, name STRING) USING foo")
+    try {
+      val t = spark.catalog.getTable("testcat.ns.writetarget")
+      assert(t.qualifiedName == "`testcat`.`ns`.`writetarget`")
+      spark.createDataFrame(Seq((3, "c"), (4, "d"))).toDF("id", "name").writeTo(t).append()
+      val rows = spark.read.table(t).collect().map(r => (r.getInt(0), r.getString(1))).toSet
+      assert(rows == Set((3, "c"), (4, "d")))
+    } finally {
+      sql("DROP TABLE testcat.ns.writetarget")
+    }
   }
 
   private def getConstructorParameterValues(obj: DefinedByConstructorParams): Seq[AnyRef] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds `Table.qualifiedName` and two new overloads so that `Table` objects returned by `spark.catalog.getTable()` / `spark.catalog.listTables()` can be passed directly to `spark.read.table()` and `df.writeTo()`, removing the need to manually reconstruct a qualified name string.

**New API (`@since 4.2.0`):**
- `Table.qualifiedName: String` — returns the fully qualified, backtick-quoted identifier (e.g. `` `spark_catalog`.`default`.`my_table` ``)
- `DataFrameReader.table(table: Table): DataFrame`
- `Dataset.writeTo(table: Table): DataFrameWriterV2[T]`

All three are also available in PySpark (classic and Connect) as `Table.qualifiedName`, `DataFrameReader.table(table)`, and `DataFrame.writeTo(table)`.

### Why are the changes needed?

A common pattern is filtering `listTables()` results and then loading or writing each table:

```scala
// before
val tables = spark.catalog.listTables("mydb").collect().filter(!_.isTemporary)
tables.foreach { t =>
  val name = Seq(t.catalog, t.namespace.mkString("."), t.name).mkString(".")
  spark.read.table(name).writeTo(name).append()
}

// after
val tables = spark.catalog.listTables("mydb").collect().filter(!_.isTemporary)
tables.foreach { t =>
  spark.read.table(t).writeTo(t).append()
}
```

The catalog API already gives you a fully-described `Table` object; requiring callers to disassemble and re-join it as a string is unnecessary friction.

### Does this PR introduce _any_ user-facing change?

Yes. Three new API methods are added in Scala and Python, all marked `@since 4.2.0` / `versionadded:: 4.2.0`. No existing behavior is changed.

### How was this patch tested?

- **`sql/api` (Scala):** `Table.qualifiedName` unit tests covering full qualification, missing catalog/namespace, multi-part namespace, special characters, and embedded backticks.
- **Classic Scala:** `CatalogSuite` integration test for `read.table(Table)` (session catalog) and `writeTo(Table)` (V2 catalog); `DataFrameWriterV2Suite` end-to-end tests for both overloads.
- **Connect Scala:** `connect/CatalogSuite` integration test covering `read.table(Table)` and `writeTo(Table)`.
- **PySpark / Connect Python:** `test_table_qualified_name` (6 cases) and `test_read_table_and_write_to_accept_table_object` in `CatalogTestsMixin`, which runs against both `CatalogTests` (classic) and `CatalogParityTests` (Connect).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 4.6 (claude.ai/code)