### PR TITLE
[SPARK-56518][PYTHON] Add current_path to PySpark functions

### DIFF
--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -639,6 +639,7 @@ Misc Functions
     bitmap_count
     current_catalog
     current_database
+    current_path
     current_schema
     current_user
     input_file_block_length

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -4414,6 +4414,13 @@ def current_catalog() -> Column:
 current_catalog.__doc__ = pysparkfuncs.current_catalog.__doc__
 
 
+def current_path() -> Column:
+    return _invoke_function("current_path")
+
+
+current_path.__doc__ = pysparkfuncs.current_path.__doc__
+
+
 def current_database() -> Column:
     return _invoke_function("current_database")
 

--- a/python/pyspark/sql/functions/__init__.py
+++ b/python/pyspark/sql/functions/__init__.py
@@ -505,6 +505,7 @@ __all__ = [  # noqa: F405
     "bitmap_count",
     "current_catalog",
     "current_database",
+    "current_path",
     "current_schema",
     "current_user",
     "input_file_block_length",

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -13617,6 +13617,31 @@ def current_catalog() -> Column:
 
 
 @_try_remote_functions
+def current_path() -> Column:
+    """Returns the current SQL path as a comma-separated list of qualified schema names.
+
+    .. versionadded:: 4.2.0
+
+    See Also
+    --------
+    :meth:`pyspark.sql.functions.current_catalog`
+    :meth:`pyspark.sql.functions.current_database`
+    :meth:`pyspark.sql.functions.current_schema`
+
+    Examples
+    --------
+    >>> import pyspark.sql.functions as sf
+    >>> spark.range(1).select(sf.current_path()).show() # doctest: +SKIP
+    +----------------------------------------------------+
+    |                                      current_path()|
+    +----------------------------------------------------+
+    |system.builtin,system.session,spark_catalog.default |
+    +----------------------------------------------------+
+    """
+    return _invoke_function("current_path")
+
+
+@_try_remote_functions
 def current_database() -> Column:
     """Returns the current database.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the `current_path()` function to PySpark to match the JVM-side `current_path()` added in SPARK-56489.

The following files were updated:
- `python/pyspark/sql/functions/builtin.py` — added the `current_path()` function definition with docstring.
- `python/pyspark/sql/functions/__init__.py` — added `current_path` to `__all__`.
- `python/pyspark/sql/connect/functions/builtin.py` — added the Spark Connect stub.

### Why are the changes needed?

SPARK-56489 added `CURRENT_PATH()` as a builtin SQL expression and registered it in `org.apache.spark.sql.functions`, but the corresponding PySpark function was not added. This causes `test_function_parity` in `test_functions.py` to fail because the test checks that every function in the JVM `functions` object has a corresponding PySpark function (or is explicitly excluded).

### Does this PR introduce _any_ user-facing change?

Yes. `pyspark.sql.functions.current_path()` is now available and returns the current SQL path as a comma-separated list of qualified schema names (e.g. `system.builtin,system.session,spark_catalog.default`). This is a new function on the unreleased master branch only.

### How was this patch tested?

The existing `test_function_parity` test in `python/pyspark/sql/tests/test_functions.py` covers this change — it will now pass since `current_path` is no longer missing from PySpark.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor (Claude Opus 4.6)