### PR TITLE
[SPARK-56520][SQL] Persist SQL PATH in views and SQL functions, expose in DESCRIBE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SQLFunction.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SQLFunction.scala
@@ -179,9 +179,20 @@ case class SQLFunction(
     props.put(CREATE_TIME, createTimeMs.toString)
     props.toMap
   }
+
+  /** Frozen PATH string persisted when the function was created with SQL PATH enabled. */
+  def functionStoredResolutionPath: Option[String] =
+    properties.get(SQLFunction.FUNCTION_RESOLUTION_PATH)
 }
 
 object SQLFunction {
+
+  /**
+   * Persisted frozen PATH for SQL function bodies when created with [[SQLConf.PATH_ENABLED]].
+   * Serialized as a JSON array of path entries (same format as
+   * [[CatalogTable.VIEW_RESOLUTION_PATH]]).
+   */
+  val FUNCTION_RESOLUTION_PATH: String = "function.resolutionPath"
 
   private val SQL_FUNCTION_PREFIX = "sqlFunction."
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SqlPathFormat.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SqlPathFormat.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.catalog
+
+import scala.util.Try
+
+import org.json4s.JsonAST.{JArray, JObject, JString, JValue}
+import org.json4s.jackson.JsonMethods.parse
+
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+/**
+ * Formatting helpers for the SQL Path stored in view and SQL function
+ * metadata. The on-disk property stores path entries as a JSON array
+ * of arrays:
+ * {{{
+ *   [["spark_catalog","default"],["system","builtin"]]
+ * }}}
+ * `toDescribeJson` converts these to the object form used by
+ * `DESCRIBE AS JSON`:
+ * {{{
+ *   {"catalog_name": "spark_catalog", "namespace": ["default"]}
+ * }}}
+ * This supports multi-level namespaces.
+ */
+private[sql] object SqlPathFormat {
+
+  /**
+   * Build a JSON value for DESCRIBE AS JSON from a stored resolution
+   * path string (JSON array of arrays persisted in the property).
+   */
+  def toDescribeJson(storedPathStr: String): Option[JValue] = {
+    Try(parse(storedPathStr)) match {
+      case scala.util.Success(JArray(entries)) if entries.nonEmpty =>
+        val converted = entries.flatMap {
+          case JArray(parts) =>
+            val partStrs = parts.collect { case JString(s) => s }
+            if (partStrs.isEmpty) None
+            else Some(JObject(
+              "catalog_name" -> JString(partStrs.head),
+              "namespace" -> JArray(
+                partStrs.tail.map(JString).toList)))
+          case _ => None
+        }
+        if (converted.nonEmpty) Some(JArray(converted)) else None
+      case _ => None
+    }
+  }
+
+  /**
+   * Format a JSON path value (array of objects with catalog_name and
+   * namespace) as a human-readable string for DESCRIBE EXTENDED.
+   * Example: `` `spark_catalog`.`default`, `system`.`builtin` ``
+   */
+  def formatForDisplay(jValue: JValue): Option[String] = {
+    jValue match {
+      case JArray(entries) =>
+        Some(entries.map {
+          case JObject(fields) =>
+            val m = fields.toMap
+            val cat = m.get("catalog_name")
+              .map(_.values.toString).getOrElse("")
+            val ns = m.get("namespace") match {
+              case Some(JArray(parts)) =>
+                parts.map(_.values.toString)
+              case _ => Nil
+            }
+            val parts = (cat +: ns).filter(_.nonEmpty)
+            if (parts.nonEmpty) parts.quoted else ""
+          case _ => ""
+        }.mkString(", "))
+      case _ => Some(jValue.values.toString)
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -83,6 +83,7 @@ trait MetadataMapSupport {
           case JLong(value) => Some(new Date(value).toString)
           case _ => Some(jValue.values.toString)
         }
+      case "SQL Path" => SqlPathFormat.formatForDisplay(jValue)
       case _ => None
     }
     reformattedValue.map(value => key -> value)
@@ -610,6 +611,15 @@ case class CatalogTable(
     }
   }
 
+  /**
+   * Frozen SQL PATH stored when the view was created with [[SQLConf.PATH_ENABLED]].
+   * Serialized as a JSON array of path entries (each entry an array of identifier parts);
+   * virtual markers (e.g. `system.current_schema`) are materialized and, for persisted
+   * views, `system.session` is omitted.
+   */
+  def viewStoredResolutionPath: Option[String] =
+    properties.get(CatalogTable.VIEW_RESOLUTION_PATH)
+
   /** Syntactic sugar to update a field in `storage`. */
   def withNewStorage(
       locationUri: Option[URI] = storage.locationUri,
@@ -674,6 +684,13 @@ case class CatalogTable(
       if (viewCatalogAndNamespaceInfos.nonEmpty) {
         import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
         map += "View Catalog and Namespace" -> JString(viewCatalogAndNamespaceInfos.quoted)
+      }
+      if (SQLConf.get.pathEnabled) {
+        viewStoredResolutionPath.foreach { pathStr =>
+          SqlPathFormat.toDescribeJson(pathStr).foreach { json =>
+            map += "SQL Path" -> json
+          }
+        }
       }
       val viewQueryOutputColumns: JValue = Try {
         if (viewSchemaMode == SchemaEvolution) {
@@ -764,6 +781,9 @@ object CatalogTable {
   val VIEW_REFERRED_TEMP_VARIABLE_NAMES = VIEW_PREFIX + "referredTempVariablesNames"
 
   val VIEW_SCHEMA_MODE = VIEW_PREFIX + "schemaMode"
+
+  /** Frozen expanded PATH at view creation (PATH feature); not a SQL config property. */
+  val VIEW_RESOLUTION_PATH = VIEW_PREFIX + "resolutionPath"
 
   val VIEW_STORING_ANALYZED_PLAN = VIEW_PREFIX + "storingAnalyzedPlan"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -244,6 +244,10 @@ private[sql] object CatalogManager {
       isFullyQualifiedSystemSessionViewName(nameParts)
   }
 
+  /** True if a SQL path entry is the well-known `system.session` entry. */
+  def isSystemSessionPathEntry(parts: Seq[String]): Boolean =
+    parts == Seq(SYSTEM_CATALOG_NAME, SESSION_NAMESPACE)
+
   /**
    * A single entry in the session SQL path: either a literal schema
    * or the current-schema marker.
@@ -272,4 +276,40 @@ private[sql] object CatalogManager {
       currentCatalog: String,
       currentNamespace: Seq[String]): Seq[Seq[String]] =
     entries.map(_.resolve(currentCatalog, currentNamespace))
+
+  /**
+   * Compute the resolved path entries to persist in view or SQL function metadata.
+   * When PATH is enabled, resolves the stored session path (or falls back to the
+   * legacy resolutionSearchPath). If `stripSession` is true, removes `system.session`
+   * entries (persisted objects cannot reference temporary objects).
+   */
+  def pathEntriesForPersistence(
+      catalogManager: CatalogManager,
+      conf: SQLConf,
+      stripSession: Boolean): Seq[Seq[String]] = {
+    if (!conf.pathEnabled) return Seq.empty
+    val currentCatalog = catalogManager.currentCatalog.name()
+    val currentNamespace = catalogManager.currentNamespace.toSeq
+    val entries = catalogManager.sessionPathEntries match {
+      case Some(stored) =>
+        resolvePathEntries(stored, currentCatalog, currentNamespace)
+      case None =>
+        val catalogPath =
+          (currentCatalog +: currentNamespace).toSeq
+        conf.resolutionSearchPath(catalogPath)
+    }
+    if (stripSession) {
+      entries.filterNot(isSystemSessionPathEntry)
+    } else {
+      entries
+    }
+  }
+
+  /** Serialize resolved path entries to JSON for storage in view/function properties. */
+  def serializePathEntries(entries: Seq[Seq[String]]): String = {
+    import org.json4s.JsonAST.{JArray, JString}
+    import org.json4s.jackson.JsonMethods.compact
+    compact(JArray(entries.map(parts =>
+      JArray(parts.map(JString(_)).toList)).toList))
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CreateSQLFunctionCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CreateSQLFunctionCommand.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.Inner
 import org.apache.spark.sql.catalyst.plans.logical.{LateralJoin, LocalRelation, LogicalPlan, OneRowRelation, Project, Range, UnresolvedWith, View}
 import org.apache.spark.sql.catalyst.trees.TreePattern.UNRESOLVED_ATTRIBUTE
+import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdentifierHelper
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.command.CreateUserDefinedFunctionCommand._
@@ -512,10 +513,23 @@ case class CreateSQLFunctionCommand(
     }
     val tempVars = ViewHelper.collectTemporaryVariables(analyzed)
 
+    // Capture the effective resolution path at function creation time so the function
+    // body resolves with the same path regardless of the caller's session path later.
+    val expandedPathEntries = CatalogManager.pathEntriesForPersistence(
+      manager, conf, stripSession = !isTemp)
+    val resolutionPathProps =
+      if (expandedPathEntries.nonEmpty) {
+        Map(SQLFunction.FUNCTION_RESOLUTION_PATH ->
+          CatalogManager.serializePathEntries(expandedPathEntries))
+      } else {
+        Map.empty[String, String]
+      }
+
     sqlConfigsToProps(conf, SQL_CONFIG_PREFIX) ++
       catalogAndNamespaceToProps(
         manager.currentCatalog.name,
         manager.currentNamespace.toIndexedSeq) ++
-      referredTempNamesToProps(tempViews, tempFunctions, tempVars)
+      referredTempNamesToProps(tempViews, tempFunctions, tempVars) ++
+      resolutionPathProps
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DescribeFunctionCommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DescribeFunctionCommandUtils.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command
+
+import java.util
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.FunctionIdentifier
+import org.apache.spark.sql.catalyst.catalog.{SQLFunction, SqlPathFormat, UserDefinedFunction}
+import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
+
+/**
+ * Helpers for [[DescribeFunctionCommand]] to retrieve and format
+ * the frozen SQL PATH stored in SQL function metadata.
+ */
+private[command] object DescribeFunctionCommandUtils {
+
+  /**
+   * Returns the frozen SQL PATH persisted for a SQL function, formatted
+   * for display. Persistent functions: loads [[CatalogFunction]] metadata
+   * from the catalog. Temporary SQL UDFs (not in catalog): falls back to
+   * parsing the usage JSON blob produced by [[SQLFunction.toExpressionInfo]].
+   */
+  private[command] def storedResolutionPathString(
+      sparkSession: SparkSession,
+      identifier: FunctionIdentifier,
+      info: ExpressionInfo): Option[String] = {
+    val rawJson = try {
+      val meta = sparkSession.sessionState.catalog
+        .getFunctionMetadata(identifier)
+      if (meta.isUserDefinedFunction) {
+        val udf = UserDefinedFunction.fromCatalogFunction(
+          meta,
+          sparkSession.sessionState.sqlParser)
+        udf.asInstanceOf[SQLFunction].functionStoredResolutionPath
+      } else {
+        None
+      }
+    } catch {
+      case _: org.apache.spark.sql.catalyst.analysis
+        .NoSuchFunctionException |
+          _: org.apache.spark.sql.catalyst.analysis
+            .NoSuchDatabaseException =>
+        extractResolutionPathFromSqlUdfUsage(info.getUsage)
+    }
+    rawJson.flatMap(formatStoredPath)
+  }
+
+  private def formatStoredPath(pathStr: String): Option[String] = {
+    SqlPathFormat.toDescribeJson(pathStr)
+      .flatMap(SqlPathFormat.formatForDisplay)
+  }
+
+  /**
+   * For temporary SQL UDFs not in the catalog, the resolution path may
+   * be embedded in the ExpressionInfo usage JSON blob. Returns None if
+   * the usage string is not JSON or does not contain the path key.
+   */
+  private def extractResolutionPathFromSqlUdfUsage(
+      usage: String): Option[String] = {
+    if (usage == null || usage.isEmpty) return None
+    try {
+      val map = UserDefinedFunction.mapper.readValue(
+        usage, classOf[util.HashMap[String, String]])
+      Option(map.get(SQLFunction.FUNCTION_RESOLUTION_PATH))
+        .filter(_.nonEmpty)
+    } catch {
+      case e: com.fasterxml.jackson.core.JsonProcessingException =>
+        throw new org.apache.spark.SparkException(
+          s"Corrupted SQL UDF metadata: expected JSON usage blob " +
+          s"but failed to parse: ${e.getMessage}", e)
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.command
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
-import org.apache.spark.sql.catalyst.catalog.{CatalogFunction, FunctionResource}
+import org.apache.spark.sql.catalyst.catalog.{CatalogFunction, FunctionResource, SQLFunction}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, ExpressionInfo}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.StringUtils
@@ -117,14 +117,25 @@ case class DescribeFunctionCommand(
       Row(s"Function: $name") :: Row(s"Usage: ${info.getUsage}") :: Nil
     }
 
+    val sqlPathRows =
+      if (isExtended &&
+        sparkSession.sessionState.conf.pathEnabled &&
+        SQLFunction.isSQLFunction(info.getClassName)) {
+        DescribeFunctionCommandUtils
+          .storedResolutionPathString(sparkSession, identifier, info)
+          .map(s => Seq(Row(s"SQL Path: $s")))
+          .getOrElse(Nil)
+      } else {
+        Nil
+      }
+
     if (isExtended) {
-      result :+ Row(s"Extended Usage:${info.getExtended}")
+      (result ++ sqlPathRows) :+ Row(s"Extended Usage:${info.getExtended}")
     } else {
       result
     }
   }
 }
-
 
 /**
  * The DDL command that drops a function.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, SubqueryExpr
 import org.apache.spark.sql.catalyst.plans.logical.{AnalysisOnlyCommand, CreateTempView, CTEInChildren, CTERelationDef, LogicalPlan, Project, View, WithCTE}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.classic.ClassicConversions.castToImpl
+import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.NamespaceHelper
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -339,7 +340,8 @@ case class AlterViewSchemaBindingCommand(name: TableIdentifier, viewSchemaMode: 
       session,
       viewMeta.viewQueryColumnNames.toArray,
       viewMeta.schema.fieldNames,
-      viewSchemaMode)
+      viewSchemaMode,
+      captureNewPath = false)
 
     val updatedViewMeta = viewMeta.copy(properties = newProperties)
 
@@ -450,6 +452,13 @@ object ViewHelper extends SQLConfHelper with Logging with CapturesConfig {
   }
 
   /**
+   * Remove the frozen resolution path from `properties` so it can be recomputed.
+   */
+  private def removeResolutionPath(properties: Map[String, String]): Map[String, String] = {
+    properties.filterNot { case (key, _) => key == VIEW_RESOLUTION_PATH }
+  }
+
+  /**
    * Remove the temporary object names in `properties`.
    */
   private def removeReferredTempNames(properties: Map[String, String]): Map[String, String] = {
@@ -473,6 +482,9 @@ object ViewHelper extends SQLConfHelper with Logging with CapturesConfig {
    * @param properties the `properties` in CatalogTable.
    * @param session the spark session.
    * @param analyzedPlan the analyzed logical plan that represents the child of a view.
+   * @param stripSystemSessionFromStoredPath when true (persisted views), omit `system.session`
+   *                                           from [[VIEW_RESOLUTION_PATH]]; temporary views keep
+   *                                           it so nested temp resolution still works.
    * @return new view properties including view default database and query column names properties.
    */
   def generateViewProperties(
@@ -483,7 +495,9 @@ object ViewHelper extends SQLConfHelper with Logging with CapturesConfig {
       viewSchemaMode: ViewSchemaMode,
       tempViewNames: Seq[Seq[String]] = Seq.empty,
       tempFunctionNames: Seq[String] = Seq.empty,
-      tempVariableNames: Seq[Seq[String]] = Seq.empty): Map[String, String] = {
+      tempVariableNames: Seq[Seq[String]] = Seq.empty,
+      stripSystemSessionFromStoredPath: Boolean = true,
+      captureNewPath: Boolean = true): Map[String, String] = {
 
     val conf = session.sessionState.conf
 
@@ -501,13 +515,34 @@ object ViewHelper extends SQLConfHelper with Logging with CapturesConfig {
 
     // Generate the view default catalog and namespace, as well as captured SQL configs.
     val manager = session.sessionState.catalogManager
-    removeReferredTempNames(removeSQLConfigs(removeQueryColumnNames(properties))) ++
+    // Capture the effective resolution path at view creation time so the view body
+    // resolves with the same path regardless of the caller's session path later.
+    // When captureNewPath is false (e.g. ALTER VIEW SCHEMA BINDING), preserve the
+    // existing frozen path instead of overwriting with the current session path.
+    val resolutionPathProps = if (captureNewPath) {
+      val expandedPathEntries = CatalogManager.pathEntriesForPersistence(
+        manager, conf, stripSession = stripSystemSessionFromStoredPath)
+      if (expandedPathEntries.nonEmpty) {
+        Map(VIEW_RESOLUTION_PATH -> CatalogManager.serializePathEntries(expandedPathEntries))
+      } else {
+        Map.empty[String, String]
+      }
+    } else {
+      properties.get(VIEW_RESOLUTION_PATH) match {
+        case Some(v) => Map(VIEW_RESOLUTION_PATH -> v)
+        case None => Map.empty[String, String]
+      }
+    }
+
+    removeResolutionPath(
+      removeReferredTempNames(removeSQLConfigs(removeQueryColumnNames(properties)))) ++
       catalogAndNamespaceToProps(
         manager.currentCatalog.name, manager.currentNamespace.toImmutableArraySeq) ++
       sqlConfigsToProps(conf, VIEW_SQL_CONFIG_PREFIX) ++
       queryColumnNameProps ++
       referredTempNamesToProps(tempViewNames, tempFunctionNames, tempVariableNames) ++
-      viewSchemaModeToProps(viewSchemaMode)
+      viewSchemaModeToProps(viewSchemaMode) ++
+      resolutionPathProps
   }
 
   /**
@@ -743,8 +778,15 @@ object ViewHelper extends SQLConfHelper with Logging with CapturesConfig {
     // TBLPROPERTIES is not allowed for temporary view, so we don't use it for
     // generating temporary view properties
     val newProperties = generateViewProperties(
-      Map.empty, session, analyzedPlan.schema.fieldNames, viewSchema.fieldNames, SchemaUnsupported,
-      tempViews, tempFunctions, tempVariables)
+      Map.empty,
+      session,
+      analyzedPlan.schema.fieldNames,
+      viewSchema.fieldNames,
+      SchemaUnsupported,
+      tempViews,
+      tempFunctions,
+      tempVariables,
+      stripSystemSessionFromStoredPath = false)
 
     CatalogTable(
       identifier = viewName,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DescribeTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DescribeTableSuiteBase.scala
@@ -347,9 +347,13 @@ case class DescribeTableJson(
     view_original_text: Option[String] = None,
     view_schema_mode: Option[String] = None,
     view_catalog_and_namespace: Option[String] = None,
+    sql_path: Option[List[SqlPathEntry]] = None,
     view_query_output_columns: Option[List[String]] = None,
     view_creation_spark_configuration: Option[Map[String, String]] = None
 )
+
+/** Used for sql_path field of DescribeTableJson */
+case class SqlPathEntry(catalog_name: String, namespace: List[String])
 
 /** Used for columns field of DescribeTableJson */
 case class TableColumn(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.SPARK_VERSION
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.execution.command
-import org.apache.spark.sql.execution.command.{DescribeTableJson, Field, TableColumn, Type}
+import org.apache.spark.sql.execution.command.{DescribeTableJson, Field, SqlPathEntry, TableColumn, Type}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StringType
 
@@ -604,6 +604,36 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
           }
         }
       }
+  }
+
+  test("DESCRIBE EXTENDED AS JSON for view shows SQL Path when PATH is enabled") {
+    withSQLConf(SQLConf.PATH_ENABLED.key -> "true") {
+      withNamespaceAndTable("ns", "table") { t =>
+        withView("path_view") {
+          spark.sql(s"CREATE TABLE $t (id INT) USING parquet")
+          spark.sql("SET PATH = spark_catalog.default, system.builtin")
+          spark.sql(s"CREATE VIEW path_view AS SELECT * FROM $t")
+
+          // AS JSON
+          val jsonDf = spark.sql("DESCRIBE EXTENDED path_view AS JSON")
+          val jsonStr = jsonDf.select("json_metadata").head().getString(0)
+          val parsed = parse(jsonStr).extract[DescribeTableJson]
+          assert(parsed.sql_path.isDefined, s"sql_path should be present, got: $jsonStr")
+          assert(parsed.sql_path.get == List(
+            SqlPathEntry("spark_catalog", List("default")),
+            SqlPathEntry("system", List("builtin"))),
+            s"sql_path entries should match exactly, got: ${parsed.sql_path.get}")
+
+          // Regular DESCRIBE EXTENDED
+          val extDf = spark.sql("DESCRIBE EXTENDED path_view")
+          val rows = extDf.collect().map(r =>
+            (0 until r.length).map(r.getString).mkString("\t"))
+          assert(rows.exists(_.contains(
+            "spark_catalog.default, system.builtin")),
+            s"DESCRIBE EXTENDED should show exact SQL Path, got:\n${rows.mkString("\n")}")
+        }
+      }
+    }
   }
 
   test("DESCRIBE AS JSON for column throws Analysis Exception") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

When `spark.sql.path.enabled` is true, persist the effective resolution path at creation time for views and SQL functions, and expose it in DESCRIBE output.

**View persistence (`views.scala`):**
- Store the frozen path as JSON in `view.resolutionPath` property at CREATE VIEW time.
- Persisted views strip `system.session` from the stored path since persistent views cannot reference temporary objects (session scope). Temporary views keep it because temp objects can reference other temp objects.

**SQL function persistence (`CreateSQLFunctionCommand.scala`, `SQLFunction.scala`):**
- Store the frozen path as JSON in `function.resolutionPath` property at CREATE FUNCTION time.
- Same stripping rules as views.

**Storage format:**
- Path entries are serialized as JSON arrays: `[["spark_catalog","default"],["system","builtin"]]`
- This naturally supports multi-level namespaces (nested schemas), e.g. `[["catalog","ns1","ns2"]]`.

**DESCRIBE output for views (`interface.scala`):**
- `DESCRIBE EXTENDED` / `DESCRIBE FORMATTED` shows `SQL Path` with backtick-quoted entries (e.g. `` `spark_catalog`.`default`, `system`.`builtin` ``).
- `DESCRIBE ... AS JSON` exposes `sql_path` as an array of objects, consistent with `describeIdentifier`:
  ```json
  "sql_path": [
    {"catalog_name": "spark_catalog", "namespace": ["default"]},
    {"catalog_name": "system", "namespace": ["builtin"]}
  ]
  ```

**DESCRIBE FUNCTION EXTENDED for SQL UDFs (`functions.scala`):**
- Shows `SQL Path` line for SQL UDFs when PATH is enabled and a stored path exists.
- For persistent functions, reads from catalog metadata; for temp SQL UDFs, extracts from the usage JSON blob.

**Backward compatibility:**
- Old views/functions created without PATH enabled have no `resolutionPath` property. They fall back to the default resolution path (`resolutionSearchPath` with session function resolution order).

The stored path is **not yet used during analysis** -- frozen path resolution comes in a follow-up PR. This PR only persists and displays the metadata.

### Why are the changes needed?

Views and SQL functions need to capture the resolution path at creation time so that their body can later resolve with the same path, independent of the caller's session path. This is the SQL-standard behavior for view and routine body resolution.

Part of [SPARK-54810](https://issues.apache.org/jira/browse/SPARK-54810). Depends on [SPARK-56501](https://github.com/apache/spark/pull/55364) (SET PATH syntax).

### Does this PR introduce _any_ user-facing change?

Yes.
- `DESCRIBE EXTENDED` on views shows `SQL Path` when PATH is enabled.
- `DESCRIBE FUNCTION EXTENDED` on SQL UDFs shows `SQL Path` when PATH is enabled.
- `DESCRIBE ... AS JSON` includes `sql_path` field for views when PATH is enabled.
- View and SQL function metadata now includes the frozen resolution path.

### How was this patch tested?

- `DescribeTableSuite`: new test verifying `DESCRIBE EXTENDED view AS JSON` includes `sql_path` with correct structure, and regular `DESCRIBE EXTENDED` shows `SQL Path` (both V1 catalog V1 and V2 command variants).
- `DescribeTableSuiteBase`: added `SqlPathEntry` case class and `sql_path` field to `DescribeTableJson` for JSON deserialization.
- `SetPathSuite`: all 22 existing tests pass (no regressions).
- Compiled and tested locally with SBT.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.6