### PR TITLE
[MINOR][INFRA] AGENTS.md: require ASCII-only source files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ SQL golden file tests are managed by `SQLQueryTestSuite` and its variants. Read 
 
 Spark Connect protocol is defined in proto files under `sql/connect/common/src/main/protobuf/`. Read the README there before modifying proto definitions.
 
+Avoid introducing non-ASCII characters in code or comments. String literals may contain non-ASCII when the content requires it (error messages, test data, etc.). Identifiers are ASCII by convention. The common failure mode is typographic characters (em-dash, smart quotes, ellipsis, non-breaking space) sneaking into comments; scalastyle flags some of these. Spot-check before committing: `grep -rn -P "[^\x00-\x7F]" <files>`.
+
 ## Build and Test
 
 Build and tests can take a long time. Before running tests, ask the user if they have more changes to make.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a short paragraph to `AGENTS.md` telling AI coding agents that all Spark source files must be ASCII-only (per scalastyle's `nonascii.message` rule), and documenting a simple `grep -P "[^\x00-\x7F]"` check to verify before committing.

### Why are the changes needed?

When LLMs write code or prose-like comments, they tend to produce typographic characters (em-dash, smart quotes, ellipsis, non-breaking space). These sail through local editing and fail in CI under the scalastyle `nonascii.message` rule, wasting a CI cycle. A one-paragraph rule in `AGENTS.md` is enough to prevent this.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only change in `AGENTS.md`.

### How was this patch tested?

Not needed - documentation-only.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Anthropic)