### PR TITLE
[SPARK-56256][PYTHON][DOCS][FOLLOWUP] Document SparkSession.emptyDataFrame in API reference

### DIFF
--- a/python/docs/source/reference/pyspark.sql/spark_session.rst
+++ b/python/docs/source/reference/pyspark.sql/spark_session.rst
@@ -52,6 +52,7 @@ See also :class:`SparkSession`.
     SparkSession.conf
     SparkSession.createDataFrame
     SparkSession.dataSource
+    SparkSession.emptyDataFrame
     SparkSession.getActiveSession
     SparkSession.getTags
     SparkSession.interruptAll


### PR DESCRIPTION

### What changes were proposed in this pull request?

Adds `SparkSession.emptyDataFrame` to the PySpark API reference RST file so the new API introduced in #55055 shows up in the generated documentation.

### Why are the changes needed?

The `SparkSession.emptyDataFrame` API was added in SPARK-56256 but was not listed in `python/docs/source/reference/pyspark.sql/spark_session.rst`, so it is missing from the published API reference.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only change.

### How was this patch tested?

Docs-only change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)

