### PR TITLE
[SPARK-38101][CORE] Retry INTERNAL_ERROR_BROADCAST when fetching map statuses

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer
 import java.util.concurrent.{ConcurrentHashMap, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
+import scala.annotation.tailrec
 import scala.collection
 import scala.collection.mutable.{HashMap, ListBuffer, Map, Set}
 import scala.concurrent.{ExecutionContext, Future}
@@ -1442,6 +1443,43 @@ private[spark] class MapOutputTrackerWorker(conf: SparkConf) extends MapOutputTr
       shuffleId: Int,
       conf: SparkConf,
       canFetchMergeResult: Boolean): (Array[MapStatus], Array[MergeStatus]) = {
+
+    def isBroadcastVariableNotFoundException(e: SparkException): Boolean = {
+      // these exceptions occur when broadcast variable sent to executor got destroyed
+      // before fetching the broadcast blocks finished
+      e.getMessage.equals("Unable to deserialize broadcasted output statuses") &&
+        Option(e.getCause)
+          .filter(_.isInstanceOf[IOException])
+          .flatMap(e => Option(e.getCause))
+          .filter(_.isInstanceOf[SparkException])
+          .map(_.asInstanceOf[SparkException])
+          .exists(e => Some(e.getMessage).exists(msg =>
+            // this exception occurs when broadcast variable does not exist anymore
+            msg.startsWith("[INTERNAL_ERROR_BROADCAST] Failed to get ") &&
+              Option(e.getCondition).exists(_.equals("INTERNAL_ERROR_BROADCAST")) ||
+              // this exception occurs when broadcast variable exists but a block is not found
+              msg.startsWith("Block broadcast_") && msg.endsWith(" does not exist") &&
+                Option(e.getCondition).exists(_.equals("_LEGACY_ERROR_TEMP_3031"))
+          ))
+    }
+
+    @tailrec
+    def retryUnknownBroadcastVariables[T](fetch: => T, label: String)(func: T => Unit): Unit = {
+      // fetch the statuses
+      val t = fetch
+      try {
+        func(t)
+      } catch {
+        case e: SparkException if isBroadcastVariableNotFoundException(e) =>
+          logInfo(s"Retrying getting $label statuses due to unknown broadcast variable")
+          retryUnknownBroadcastVariables(fetch, label)(func)
+        case e: SparkException =>
+          throw new MetadataFetchFailedException(shuffleId, -1,
+            s"Unable to deserialize broadcasted $label statuses" +
+              s" for shuffle $shuffleId: " + e.getCause)
+      }
+    }
+
     if (canFetchMergeResult) {
       val mapOutputStatuses = mapStatuses.get(shuffleId).orNull
       val mergeOutputStatuses = mergeStatuses.get(shuffleId).orNull
@@ -1456,18 +1494,14 @@ private[spark] class MapOutputTrackerWorker(conf: SparkConf) extends MapOutputTr
           if (fetchedMapStatuses == null || fetchedMergeStatuses == null) {
             logInfo(log"Doing the fetch; tracker endpoint = " +
               log"${MDC(RPC_ENDPOINT_REF, trackerEndpoint)}")
-            val fetchedBytes =
-              askTracker[(Array[Byte], Array[Byte])](GetMapAndMergeResultStatuses(shuffleId))
-            try {
+            def ask: Any => (Array[Byte], Array[Byte]) = askTracker[(Array[Byte], Array[Byte])](_)
+            retryUnknownBroadcastVariables(
+              ask(GetMapAndMergeResultStatuses(shuffleId)), "map/merge"
+            ) { case (mapStatusBytes, mergeStatusBytes) =>
               fetchedMapStatuses =
-                MapOutputTracker.deserializeOutputStatuses[MapStatus](fetchedBytes._1, conf)
+                MapOutputTracker.deserializeOutputStatuses[MapStatus](mapStatusBytes, conf)
               fetchedMergeStatuses =
-                MapOutputTracker.deserializeOutputStatuses[MergeStatus](fetchedBytes._2, conf)
-            } catch {
-              case e: SparkException =>
-                throw new MetadataFetchFailedException(shuffleId, -1,
-                  s"Unable to deserialize broadcasted map/merge statuses" +
-                    s" for shuffle $shuffleId: " + e.getCause)
+                MapOutputTracker.deserializeOutputStatuses[MergeStatus](mergeStatusBytes, conf)
             }
             logInfo("Got the map/merge output locations")
             mapStatuses.put(shuffleId, fetchedMapStatuses)
@@ -1491,15 +1525,12 @@ private[spark] class MapOutputTrackerWorker(conf: SparkConf) extends MapOutputTr
           if (fetchedStatuses == null) {
             logInfo(log"Doing the fetch; tracker endpoint =" +
               log" ${MDC(RPC_ENDPOINT_REF, trackerEndpoint)}")
-            val fetchedBytes = askTracker[Array[Byte]](GetMapOutputStatuses(shuffleId))
-            try {
+            def ask: Any => Array[Byte] = askTracker[Array[Byte]](_)
+            retryUnknownBroadcastVariables(
+              ask(GetMapOutputStatuses(shuffleId)), "map"
+            ) { fetchedBytes =>
               fetchedStatuses =
                 MapOutputTracker.deserializeOutputStatuses[MapStatus](fetchedBytes, conf)
-            } catch {
-              case e: SparkException =>
-                throw new MetadataFetchFailedException(shuffleId, -1,
-                  s"Unable to deserialize broadcasted map statuses for shuffle $shuffleId: " +
-                    e.getCause)
             }
             logInfo("Got the map output locations")
             mapStatuses.put(shuffleId, fetchedStatuses)

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -751,6 +751,72 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
     }
   }
 
+  test("SPARK-38101: concurrent updateMapOutput not interfering with getStatuses") {
+    val newConf = new SparkConf
+    newConf.set(RPC_MESSAGE_MAX_SIZE, 1)
+    newConf.set(RPC_ASK_TIMEOUT, "1") // Fail fast
+    newConf.set(SHUFFLE_MAPOUTPUT_MIN_SIZE_FOR_BROADCAST, 0L) // Always send broadcast variables
+
+    // needs TorrentBroadcast so need a SparkContext
+    withSpark(new SparkContext("local", "MapOutputTrackerSuite", newConf)) {sc =>
+      val hostname = "localhost"
+      val rpcEnv = createRpcEnv("spark", hostname, 0, new SecurityManager(sc.conf))
+
+      val masterTracker = newTrackerMaster(sc.conf)
+      masterTracker.trackerEndpoint = rpcEnv.setupEndpoint(MapOutputTracker.ENDPOINT_NAME,
+        new MapOutputTrackerMasterEndpoint(rpcEnv, masterTracker, sc.conf))
+
+      val workerRpcEnv = createRpcEnv("spark-slave", hostname, 0, new SecurityManager(sc.conf))
+      val workerTracker = new MapOutputTrackerWorker(sc.conf)
+      workerTracker.trackerEndpoint =
+        workerRpcEnv.setupEndpointRef(rpcEnv.address, MapOutputTracker.ENDPOINT_NAME)
+
+      masterTracker.registerShuffle(1, 4, 2)
+
+      val bmIdOne = BlockManagerId(s"exec-1", "host", 1000)
+      val bmIdTwo = BlockManagerId(s"exec-2", "host", 2000)
+      masterTracker.registerMapOutput(1, 0, MapStatus(bmIdOne, Array(1000L, 10000L), mapTaskId = 0))
+      masterTracker.registerMapOutput(1, 1, MapStatus(bmIdOne, Array(1000L, 10000L), mapTaskId = 1))
+      masterTracker.registerMapOutput(1, 2, MapStatus(bmIdTwo, Array(1000L, 10000L), mapTaskId = 2))
+      masterTracker.registerMapOutput(1, 3, MapStatus(bmIdTwo, Array(1000L, 10000L), mapTaskId = 3))
+
+      assert(0 == masterTracker.getNumCachedSerializedBroadcast)
+      assert(workerTracker.getMapSizesByExecutorId(1, 0).toSeq.length === 2)
+      assert(workerTracker.getMapSizesByExecutorId(1, 1).toSeq.length === 2)
+      assert(1 == masterTracker.getNumCachedSerializedBroadcast)
+      masterTracker.updateMapOutput(1, 0, bmIdOne)
+      assert(0 == masterTracker.getNumCachedSerializedBroadcast)
+
+      // some thread keeps updating the map outputs
+      @volatile
+      var updaterShutdown = false
+      val updater = new Thread(new Runnable {
+        override def run(): Unit = {
+          while (!updaterShutdown) {
+            // map output does not change, but updateMapOutput invalidates cached broadcasts
+            masterTracker.updateMapOutput(1, 0, bmIdOne)
+            masterTracker.updateMapOutput(1, 1, bmIdOne)
+            masterTracker.updateMapOutput(1, 2, bmIdTwo)
+            masterTracker.updateMapOutput(1, 3, bmIdTwo)
+          }
+        }
+      })
+      updater.start()
+
+      1 to 100 foreach { i =>
+        assert(workerTracker.getMapSizesByExecutorId(1, 0).toSeq.length === 2)
+        assert(workerTracker.getMapSizesByExecutorId(1, 1).toSeq.length === 2)
+        // updating epoch invalidates map status cache in worker, so this always sends requests
+        workerTracker.updateEpoch(masterTracker.getEpoch + i)
+      }
+
+      // shutdown updater thread
+      updaterShutdown = true
+      updater.join(1000)
+      assert(!updater.isAlive)
+    }
+  }
+
   test("SPARK-36892: Batch fetch should be enabled in some scenarios with push based shuffle") {
     conf.set(PUSH_BASED_SHUFFLE_ENABLED, true)
     conf.set(IS_TESTING, true)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Retry `INTERNAL_ERROR_BROADCAST` immediately when fetching the broadcast variable fails. Retrying will create a new broadcast variable on the driver. This should eventually succeed.

Fixes #54723. Supersedes #54987.

### Why are the changes needed?
Executors may fail when fetching map statuses while map status are modified:

    Unable to deserialize broadcasted map statuses for shuffle 1: java.io.IOException: org.apache.spark.SparkException:
    [INTERNAL_ERROR_BROADCAST] Failed to get broadcast_3_piece0 of broadcast_3 SQLSTATE: XX000

The issue occurs when

1. an executor fetches map statuses via `getStatuses` (to get to know where to read shuffle data from)
2. those map statuses are too large so the driver wraps them into a broadcast variable
3. the broadcast variable gets deserialized by the executor (which works) and the value (the map status) is fetched from the driver
4. in the meantime, on the driver an `updateMapOutput` occurred, which invalidates the cached broadcast variable and deletes the broadcast variable value
5. the executor cannot fetch the broadcast variable value and throws an exception

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Unit test.

### Was this patch authored or co-authored using generative AI tooling?
No.