### PR TITLE
[SPARK-56488][BUILD][3.5] Bump Scala 2.13 to 2.13.9 on branch-3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3678,8 +3678,16 @@
     <profile>
       <id>scala-2.13</id>
       <properties>
-        <scala.version>2.13.8</scala.version>
+        <scala.version>2.13.9</scala.version>
         <scala.binary.version>2.13</scala.binary.version>
+        <!--
+          SPARK-56488: Clear maven.compiler.target to prevent scala-maven-plugin
+          from auto-converting it into scalac -release 8. With Scala >= 2.13.9,
+          the plugin maps target to -release, but -release 8 uses ct.sym which hides
+          sun.* packages needed by Spark at compile time.
+        -->
+        <maven.compiler.source />
+        <maven.compiler.target />
       </properties>
       <build>
         <pluginManagement>
@@ -3693,7 +3701,6 @@
                   <arg>-deprecation</arg>
                   <arg>-feature</arg>
                   <arg>-explaintypes</arg>
-                  <arg>-target:jvm-1.8</arg>
                   <arg>-Wconf:cat=deprecation:wv,any:e</arg>
                   <arg>-Wunused:imports</arg>
                   <!--

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -1056,7 +1056,7 @@ trait ShowCreateTableCommandBase extends SQLConfHelper {
     metadata
       .comment
       .map("COMMENT '" + escapeSingleQuotedString(_) + "'\n")
-      .foreach(builder.append)
+      .foreach(s => builder.append(s))
   }
 
   protected def showTableProperties(metadata: CatalogTable, builder: StringBuilder): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
@@ -70,7 +70,7 @@ case class ShowCreateTableExec(
   private def showTableUsing(table: Table, builder: StringBuilder): Unit = {
     Option(table.properties.get(TableCatalog.PROP_PROVIDER))
       .map("USING " + escapeSingleQuotedString(_) + "\n")
-      .foreach(builder.append)
+      .foreach(s => builder.append(s))
   }
 
   private def showTableOptions(
@@ -123,7 +123,7 @@ case class ShowCreateTableExec(
     if (isManagedOption.isEmpty || !isManagedOption.get.equalsIgnoreCase("true")) {
       Option(table.properties.get(TableCatalog.PROP_LOCATION))
         .map("LOCATION '" + escapeSingleQuotedString(_) + "'\n")
-        .foreach(builder.append)
+        .foreach(s => builder.append(s))
     }
   }
 
@@ -150,7 +150,7 @@ case class ShowCreateTableExec(
   private def showTableComment(table: Table, builder: StringBuilder): Unit = {
     Option(table.properties.get(TableCatalog.PROP_COMMENT))
       .map("COMMENT '" + escapeSingleQuotedString(_) + "'\n")
-      .foreach(builder.append)
+      .foreach(s => builder.append(s))
   }
 
   private def concatByMultiLines(iter: Iterable[String]): String = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Scala 2.13 from 2.13.8 to 2.13.9 to fix CVE-2022-36944 (CVSS 9.8). Includes build fixes required for 2.13.9 compatibility: clearing `maven.compiler.target` to avoid `-release 8` from scala-maven-plugin, removing deprecated `-target:jvm-1.8`, and fixing `StringBuilder.append` overload ambiguity.

### Why are the changes needed?

To fix CVE-2022-36944.

### Does this PR introduce _any_ user-facing change?

Yes. Users building with the `-Pscala-2.13` profile will now use Scala 2.13.9 instead of 2.13.8.

### How was this patch tested?

Compilation verified with both Scala 2.12 and 2.13.

### Was this patch authored or co-authored using generative AI tooling?

Generated by: Claude Opus 4.6 