### PR TITLE
[SPARK-56527][CORE] Rename internal config name `spark.ui.(jettyS -> jetty.s)topTimeout`

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -265,10 +265,11 @@ private[spark] object UI {
     .booleanConf
     .createWithDefault(true)
 
-  val UI_JETTY_STOP_TIMEOUT = ConfigBuilder("spark.ui.jettyStopTimeout")
+  val UI_JETTY_STOP_TIMEOUT = ConfigBuilder("spark.ui.jetty.stopTimeout")
     .internal()
     .doc("Timeout for Jetty servers started in UIs, such as SparkUI, HistoryUI, etc, to stop.")
     .version("4.0.0")
+    .withAlternative("spark.ui.jettyStopTimeout")
     .timeConf(TimeUnit.MILLISECONDS)
     .createWithDefaultString("30s")
 

--- a/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
+++ b/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
@@ -1189,7 +1189,7 @@ spark.ui.enabled
 spark.ui.filters
 spark.ui.groupSQLSubExecutionEnabled
 spark.ui.heapHistogramEnabled
-spark.ui.jettyStopTimeout
+spark.ui.jetty.stopTimeout
 spark.ui.killEnabled
 spark.ui.liveUpdate.minFlushPeriod
 spark.ui.liveUpdate.period


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR renames the internal UI configuration `spark.ui.jettyStopTimeout` to `spark.ui.jetty.stopTimeout` and registers the old name as an alternative via `withAlternative` for backward compatibility.

### Why are the changes needed?

Like `spark.rpc.netty.`, grouping Jetty-related settings under the `spark.ui.jetty.*` namespace makes the configuration hierarchy cleaner and leaves room for additional Jetty-related options in the future.

### Does this PR introduce _any_ user-facing change?

No. The configuration is `.internal()`, and the old key `spark.ui.jettyStopTimeout` still works via `withAlternative`.

### How was this patch tested?

Pass the CIs. The configuration is referenced only by the existing `UI_JETTY_STOP_TIMEOUT` entry, and the binding-policy-exceptions list was updated accordingly.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7