### PR TITLE
[SPARK-56528][CORE] Make Jetty SniHostCheck configurable

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -142,6 +142,16 @@ private[spark] object UI {
     .bytesConf(ByteUnit.BYTE)
     .createWithDefaultString("8k")
 
+  val UI_JETTY_SNI_HOST_CHECK = ConfigBuilder("spark.ui.jetty.sniHostCheckEnabled")
+    .internal()
+    .doc("Whether to enable Jetty's SNI host check on the Spark UI HTTPS connector. " +
+      "Since SPARK-45522 (Jetty 10+), Spark has disabled SNI host check to preserve " +
+      "backward compatibility with standalone deployments. Set to true to enforce " +
+      "SNI host checking for stricter security.")
+    .version("4.2.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val UI_TIMELINE_ENABLED = ConfigBuilder("spark.ui.timelineEnabled")
     .doc("Whether to display event timeline data on UI pages.")
     .version("3.4.0")

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -335,9 +335,11 @@ private[spark] object JettyUtils extends Logging {
       val securePort = sslOptions.createJettySslContextFactoryServer().map { factory =>
 
         // SPARK-45522: SniHostCheck defaulted to true since Jetty 10,
-        // this will affect the standalone deployment.
+        // this will affect the standalone deployment. Exposed via
+        // spark.ui.jetty.sniHostCheckEnabled so operators can enable
+        // it when stricter host checking is desired.
         val src = new SecureRequestCustomizer()
-        src.setSniHostCheck(false)
+        src.setSniHostCheck(conf.get(UI_JETTY_SNI_HOST_CHECK))
         httpConfig.addCustomizer(src)
 
         val securePort = sslOptions.port.getOrElse(if (port > 0) Utils.userPort(port, 400) else 0)

--- a/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
+++ b/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
@@ -1189,6 +1189,7 @@ spark.ui.enabled
 spark.ui.filters
 spark.ui.groupSQLSubExecutionEnabled
 spark.ui.heapHistogramEnabled
+spark.ui.jetty.sniHostCheckEnabled
 spark.ui.jetty.stopTimeout
 spark.ui.killEnabled
 spark.ui.liveUpdate.minFlushPeriod


### PR DESCRIPTION
### What changes were proposed in this pull request?

As a part of [SPARK-55556: Improve Web Security](https://issues.apache.org/jira/browse/SPARK-55556), this PR introduces a new configuration `spark.ui.jetty.sniHostCheckEnabled` that controls Jetty's SNI host check on the Spark UI HTTPS connector. `sniHostCheck` is recommended by Jetty community as we can see that the default value of Jetty is `true` already. The previously Spark-side hardcoded `SecureRequestCustomizer.setSniHostCheck(false)` call in `JettyUtils` is replaced with a value driven by this configuration.

The default value is `false`, preserving the existing behavior introduced in SPARK-45522.
- https://github.com/apache/spark/pull/43765

### Why are the changes needed?

In the Jetty usage, `jetty.ssl.sniHostCheck=false` is supposed to override the default behavior. However, since SPARK-45522 (Jetty 10+), Spark has set `SniHostCheck` to `false` strictly to preserve backward compatibility with standalone deployments. Operators who want stricter host checking for security have no way to enable it without patching source. Exposing this as a configuration lets users opt in to SNI host checking when desired.

### Does this PR introduce _any_ user-facing change?

No. A new configuration `spark.ui.jetty.sniHostCheckEnabled` (default: `false`) is added in Spark 4.2.0. The default preserves the current behavior, so existing deployments are unaffected.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)