### PR TITLE
[SPARK-56529][PYTHON] Fix SCALAR_ARROW_ITER_UDF perf regression from enforce_schema refactor

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -137,14 +137,16 @@ class ArrowBatchTransformer:
         pa.RecordBatch
             RecordBatch with columns reordered and types coerced to match target schema.
         """
-        import pyarrow as pa
+        # Fast path (hot): schema already matches (ignoring metadata).
+        # Single C++ call; handles empty-vs-empty case too.
+        if batch.schema.equals(arrow_schema, check_metadata=False):
+            return batch
 
+        # Edge case (cold): preserve prior "empty passthrough" semantics.
         if batch.num_columns == 0 or len(arrow_schema) == 0:
             return batch
 
-        # Fast path: schema already matches (ignoring metadata), no work needed
-        if batch.schema.equals(arrow_schema, check_metadata=False):
-            return batch
+        import pyarrow as pa
 
         # Check if columns are in the same order (by name) as the target schema.
         # If so, use index-based access (faster than name lookup).

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2642,10 +2642,11 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
         assert num_udfs == 1, "One SCALAR_ARROW_ITER UDF expected here."
         udf_func, args_offsets, kwargs_offsets, return_type = udfs[0]
 
-        # Pre-compute target Arrow type for output coercion
+        # Pre-compute target Arrow type and schema for output coercion
         arrow_return_type = to_arrow_type(
             return_type, timezone="UTC", prefers_large_types=runner_conf.use_large_var_types
         )
+        target_schema = pa.schema([pa.field("_0", arrow_return_type)])
 
         def func(split_index: int, data: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
             """Apply scalar Arrow iterator UDF"""
@@ -2664,13 +2665,18 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             # Call UDF and verify result type (iterator of pa.Array)
             verified_iter = verify_result(pa.Array)(udf_func(args_iter))
 
-            # Process results: enforce schema and assemble into RecordBatch
-            target_schema = pa.schema([pa.field("_0", arrow_return_type)])
-
+            # Process results: assemble into RecordBatch and coerce type.
+            # When result type matches target, build the batch with schema=target_schema
+            # so enforce_schema's fast path is near-free (pyarrow caches the schema
+            # fingerprint); otherwise fall back to name-based construction and let
+            # enforce_schema perform the cast.
             def process_results():
                 for result in verified_iter:
-                    batch = pa.RecordBatch.from_arrays([result], ["_0"])
-                    yield ArrowBatchTransformer.enforce_schema(batch, target_schema, safecheck=True)
+                    if result.type == arrow_return_type:
+                        batch = pa.RecordBatch.from_arrays([result], schema=target_schema)
+                    else:
+                        batch = pa.RecordBatch.from_arrays([result], ["_0"])
+                    yield ArrowBatchTransformer.enforce_schema(batch, target_schema)
 
             # Apply row limit check (fail-fast)
             limited = verify_output_row_limit(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to SPARK-56166, which replaced manual column-wise type
coercion with `ArrowBatchTransformer.enforce_schema` in several places.
Benchmarks showed the `worker.py` change for `SQL_SCALAR_ARROW_ITER_UDF`
introduced a ~1 us/batch overhead, regressing high-frequency iter UDF
scenarios (`sm_batch_few_col identity` was the worst case).

This PR keeps `ArrowBatchTransformer.enforce_schema(batch, schema)` as the
batch-level entry point, and recovers pre-refactor performance via two
changes:

1. **`worker.py` (SCALAR_ARROW_ITER_UDF)**: when the UDF result type already
   matches the declared return type (the hot path), construct the RecordBatch
   with `schema=target_schema` instead of `names=["_0"]`. pyarrow caches the
   schema fingerprint, so the subsequent `enforce_schema` fast path
   (`batch.schema.equals(target_schema)`) becomes near-free. On type mismatch,
   fall back to name-based construction and let `enforce_schema` perform the
   cast:

   ```python
   def process_results():
       for result in verified_iter:
           if result.type == arrow_return_type:
               batch = pa.RecordBatch.from_arrays([result], schema=target_schema)
           else:
               batch = pa.RecordBatch.from_arrays([result], ["_0"])
           yield ArrowBatchTransformer.enforce_schema(batch, target_schema)
   ```

   `target_schema` is also hoisted out of the per-split `func` closure.

2. **`conversion.py` (`ArrowBatchTransformer.enforce_schema`)**: hot-path
   reordering with no API or semantic change:
   - Reorder: fast-path `schema.equals` check before the edge-case
     `num_columns == 0 or len(arrow_schema) == 0` branch
   - Delay `import pyarrow as pa` to the slow path

### Why are the changes needed?

`enforce_schema` added ~1 us/batch vs the inlined `coerce_arrow_array` it
replaced. For scalar arrow iter UDFs, `process_results` runs once per streamed
batch, so the per-call overhead accumulates. End-to-end ASV
`ScalarArrowIterUDFTimeBench.time_worker[sm_batch_few_col, identity_udf]`
(sample_time=3.0s, `--python=same`):

| state                                | median               |
|--------------------------------------|----------------------|
| pre-refactor baseline (coerce_arrow) | ~24.7 ms             |
| after SPARK-56166 (regression)       | 25.4 +/- 0.3 ms      |
| **this PR**                          | **24.8 +/- 0.02 ms** |

#### Where the ~1 us/batch came from (cProfile, per-call self time)

30 runs x 1500 batches => 45000 `enforce_schema` calls; measured on
pyarrow 23.0.1, Python 3.12, Linux x86_64:

| state                                     | enforce_schema tottime | per-call  |
|-------------------------------------------|------------------------|-----------|
| regression (SPARK-56166)                  | 0.077 s                | **1.71 us** |
| + hot-path reorder only (caller `names=`) | 0.062 s                | 1.38 us   |
| **this PR (caller `schema=target_schema`)** | 0.013 s              | **0.29 us** |

(cProfile hook overhead inflates absolute numbers but the deltas are
reliable.)

Breaking down the 1.71 us in the regressed path:

- ~0.5 us Python classmethod call + kwargs-only unpacking + frame setup.
- ~0.3 us `batch.schema` attribute access, which constructs a fresh pyarrow
  `Schema` object from the C++ RecordBatch on each call.
- ~0.3 us `schema.equals(target, check_metadata=False)`, which walks fields
  C++-side comparing name / type / nullable for the just-constructed batch
  schema vs the target.

Microbenchmarks corroborating the per-stage costs (pyarrow 23.0.1, int64
array of 1000 rows, 500k iterations each):

| operation                                                                 | time (us) |
|---------------------------------------------------------------------------|-----------|
| `pa.RecordBatch.from_arrays([arr], ['_0'])`                               | 1.05      |
| `pa.RecordBatch.from_arrays([arr], schema=target_schema)`                 | 1.27      |
| `batch.schema.equals(target, check_metadata=False)`, fresh `names=` batch | 1.06      |
| `batch.schema.equals(target, check_metadata=False)`, `schema=` batch      | **0.12**  |
| `arr.type != target_type` (Array-level C attr check)                      | 0.07      |

At 1500 batches per run, the saved ~1.4 us per call accounts for ~2.1 ms of
the 0.6 ms observed wall-clock difference after amortizing the per-batch
work around it.

#### Why the fix works

`pa.RecordBatch.from_arrays(arrays, schema=target_schema)` attaches
`target_schema` directly to the resulting batch. The subsequent
`batch.schema.equals(target_schema)` then short-circuits via the cached
schema fingerprint (effectively identity-based), dropping the per-call
`schema`-related cost (items 2+3 above) from ~0.6 us to ~0.12 us.

Root-cause summary: `enforce_schema` is not slow on its own; the prior code
path constructed each batch in a way that forced pyarrow to rebuild and
fully compare the schema every call. This PR picks the batch-construction
path that lets pyarrow re-use its cached schema, while keeping
`enforce_schema` as the coercion entry point.

Safety: `from_arrays(..., schema=X)` does not validate that the input
arrays' types match `X` (it reinterprets the underlying buffers). The
`worker.py` change only takes this path after an explicit
`result.type == arrow_return_type` check; on mismatch it falls back to
`names=["_0"]` construction and lets `enforce_schema` perform the
(correctly-erroring) cast.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `python/pyspark/sql/tests/test_conversion.py` (30 tests) pass.
- ASV benchmark confirms the regression is fully recovered (table above).
- cProfile confirms `enforce_schema` per-call self time drops from 1.71 us
  (regressed) to 0.29 us (this PR).

### Was this patch authored or co-authored using generative AI tooling?

No.
