### PR TITLE
[SPARK-56530][BUILD] Upgrade Maven to 3.9.15

### DIFF
--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -27,7 +27,7 @@ license: |
 ## Apache Maven
 
 The Maven-based build is the build of reference for Apache Spark.
-Building Spark using Maven requires Maven 3.9.13 and Java 17/21.
+Building Spark using Maven requires Maven 3.9.15 and Java 17/21.
 Spark requires Scala 2.13; support for Scala 2.12 was removed in Spark 4.0.0.
 
 ### Setting up Maven's Memory Usage

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <java.version>17</java.version>
     <java.minimum.version>17.0.11</java.minimum.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
-    <maven.version>3.9.14</maven.version>
+    <maven.version>3.9.15</maven.version>
     <exec-maven-plugin.version>3.6.1</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.9.1</asm.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades `Maven` to 3.9.15.

### Why are the changes needed?

To use the latest Maven version.
- https://maven.apache.org/docs/3.9.15/release-notes.html
  - https://github.com/apache/maven/pull/11876
    - https://github.com/codehaus-plexus/plexus-utils/pull/304
  - https://github.com/apache/maven/pull/11865
    - https://github.com/fusesource/jansi/pull/318
    - https://github.com/fusesource/jansi/issues/317
- https://github.com/apache/maven/releases/tag/maven-3.9.15

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check the log.
- https://github.com/dongjoon-hyun/spark/actions/runs/24586452868/job/71897297495

```
Using `mvn` from path: /home/runner/work/spark/spark/build/apache-maven-3.9.15/bin/mvn
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)