### PR TITLE
[SPARK-56531][BUILD][TESTS] Upgrade `bouncycastle` to 1.84

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
     <maven-antrun.version>3.1.0</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.11.0</commons-cli.version>
-    <bouncycastle.version>1.83</bouncycastle.version>
+    <bouncycastle.version>1.84</bouncycastle.version>
     <tink.version>1.20.0</tink.version>
     <datasketches.version>6.2.0</datasketches.version>
     <netty.version>4.2.12.Final</netty.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade the test dependency `bcpkix-jdk18on` (and the transitively-managed `bcprov-jdk18on`) to `1.84`.

### Why are the changes needed?

To bring the latest bug fixes and improvements from Bouncy Castle.
  - https://www.bouncycastle.org/download/bouncy-castle-java/?filter=java%3Drelease-1-84
    - https://github.com/apache/spark/security/dependabot/184
    - https://github.com/apache/spark/security/dependabot/185

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7