### PR TITLE
[SPARK-56532][CORE] Add `closeQuietly(AutoCloseable)` overload to `SparkErrorUtils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkErrorUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkErrorUtils.scala
@@ -152,6 +152,17 @@ private[spark] trait SparkErrorUtils extends Logging {
       }
     }
   }
+
+  /** Try to close by ignoring all exceptions. */
+  def closeQuietly(closeable: AutoCloseable): Unit = {
+    if (closeable != null) {
+      try {
+        closeable.close()
+      } catch {
+        case _: Exception =>
+      }
+    }
+  }
 }
 
 private[spark] object SparkErrorUtils extends SparkErrorUtils


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a new `closeQuietly(AutoCloseable)` overload to `SparkErrorUtils`, alongside the existing `closeQuietly(Closeable)`.

**The existing API**
https://github.com/apache/spark/blob/0cdbb43624d07fc6ed10586bd20fcb52f39f1685/common/utils/src/main/scala/org/apache/spark/util/SparkErrorUtils.scala#L146

**New API**
```scala
def closeQuietly(closeable: AutoCloseable): Unit
```

### Why are the changes needed?

`Closeable` extends `AutoCloseable`, so the existing helper cannot accept resources that implement `AutoCloseable` only. Common examples include JDBC types (`Connection`, `Statement`, `ResultSet`), `java.util.stream.Stream`, and RocksDB native handles (`Statistics`, `Options`, `ColumnFamilyOptions`, etc.). Without this overload, call sites must duplicate the `try { x.close() } catch { case _: Exception => }` pattern or cast to `Closeable`. Adding the overload removes that boilerplate and keeps the quiet-close semantics uniform across all closeable kinds.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7