### PR TITLE
[SPARK-56535][INFRA] Fix base image build when Docker cache is cold

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -154,6 +154,6 @@ RUN python3.13 -m pip install $BASIC_PIP_PKGS unittest-xml-reporting $CONNECT_PI
     python3.13 -m pip cache purge
 
 # Remove unused installation packages to free up disk space
-RUN apt-get remove --purge -y 'humanity-icon-theme' 'nodejs-doc'
+RUN apt-get update && apt-get remove --purge -y 'humanity-icon-theme' 'nodejs-doc'
 RUN apt-get autoremove --purge -y
 RUN apt-get clean


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `apt-get update` before `apt-get remove` in Dockerfile RUN instruction that was missing it.

### Why are the changes needed?

When the Docker layer cache is cold (no cached layers from previous builds), `apt-get remove` commands that rely on a package index from a prior cached layer fail with exit code 100. This was reported in a [failed build](https://github.com/holdenk/spark/actions/runs/24588868686/job/71905113736).

The fix ensures the `apt-get remove` RUN instruction refreshes the package index first, making the build resilient to missing cache.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review of the Dockerfile.

### Was this patch authored or co-authored using generative AI tooling?

Yes