### PR TITLE
[SPARK-56429][DOCS] Clarify differences between nullValue and emptyValue CSV options

### DIFF
--- a/docs/sql-data-sources-csv.md
+++ b/docs/sql-data-sources-csv.md
@@ -141,13 +141,13 @@ Data source options of CSV can be set via:
   <tr>
     <td><code>nullValue</code></td>
     <td></td>
-    <td>Sets the string representation of a null value. Since 2.0.1, this <code>nullValue</code> param applies to all supported types including the string type.</td>
+    <td>Sets the string that, when encountered in the CSV input, is treated as a SQL NULL. For example, if set to <code>"NA"</code>, any field containing <code>NA</code> will be read as null. This also applies when the value is enclosed by the <code>quote</code> character (e.g., <code>"NA"</code> with the default double-quote). Since 2.0.1, this applies to all supported types including the string type.</td>
     <td>read/write</td>
   </tr>
   <tr>
     <td><code>nanValue</code></td>
     <td>NaN</td>
-    <td>Sets the string representation of a non-number value.</td>
+    <td>Sets the string that, when encountered in the CSV input, is treated as NaN (Not a Number) for float and double type columns.</td>
     <td>read</td>
   </tr>
   <tr>
@@ -237,7 +237,7 @@ Data source options of CSV can be set via:
   <tr>
     <td><code>emptyValue</code></td>
     <td><code></code> (for reading), <code>""</code> (for writing)</td>
-    <td>Sets the string representation of an empty value.</td>
+    <td>Sets the value to substitute when a quoted empty string (<code>""</code>) is encountered in the CSV input. Only applies to string type columns. Unlike <code>nullValue</code> (which matches input to produce null), this specifies the value to produce in the DataFrame.</td>
     <td>read/write</td>
   </tr>
   <tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update the CSV data source documentation to clarify how `nullValue`, `emptyValue`, and `nanValue` differ from each other:

- `nullValue`: when this exact string is encountered in the CSV input, Spark treats the field as SQL NULL.
- `emptyValue`: when a quoted empty string (`""`) is encountered, Spark substitutes this value instead. Only applies to string type columns.
- `nanValue`: when this string is encountered, Spark treats it as NaN for float/double columns.

### Why are the changes needed?

The previous descriptions used the same pattern ("Sets the string representation of ...") for all three options, which is misleading because `nullValue` matches input to produce null, while `emptyValue` specifies the output value to substitute. See [SPARK-56429](https://issues.apache.org/jira/browse/SPARK-56429).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Documentation-only change.

### Was this patch authored or co-authored using generative AI tooling?

Yes.