### PR TITLE
[SPARK-56018][INFRA][FOLLOW-UP] Install black for older branches in Python CodeGen check

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -840,7 +840,13 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.12'
+    - name: Install dependencies for Python CodeGen check (branch-3.5, branch-4.0, branch-4.1)
+      if: inputs.branch == 'branch-3.5' || inputs.branch == 'branch-4.0' || inputs.branch == 'branch-4.1'
+      run: |
+        python3.12 -m pip install 'black==26.3.1' 'protobuf==6.33.5' 'mypy==1.8.0' 'mypy-protobuf==3.3.0'
+        python3.12 -m pip list
     - name: Install dependencies for Python CodeGen check
+      if: inputs.branch != 'branch-3.5' && inputs.branch != 'branch-4.0' && inputs.branch != 'branch-4.1'
       run: |
         python3.12 -m pip install 'ruff==0.14.8' 'protobuf==6.33.5' 'mypy==1.8.0' 'mypy-protobuf==3.3.0'
         python3.12 -m pip list


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a conditional step in the `buf` job of `build_and_test.yml` to install `black` for older branches while keeping `ruff` for `master` and newer branches.


### Why are the changes needed?
SPARK-56018 replaced `black` with `ruff` as the Python formatter in the "Install dependencies for Python CodeGen check" step. However, this workflow is also used by scheduled builds for older branches, whose `gen-protos.sh` still calls `black` for formatting. This causes those builds to fail with:

```
+ black --config /home/runner/work/spark/spark/dev/pyproject.toml gen/proto/python
/home/runner/work/spark/spark/dev/gen-protos.sh: line 119: black: command not found
Traceback (most recent call last):
  File "/home/runner/work/spark/spark/./dev/check-protos.py", line 84, in <module>
Start checking the generated codes in pyspark-connect.
RUN: /home/runner/work/spark/spark/dev/gen-protos.sh connect /tmp/check_connect__protos6imuoe88
    check_protos(
  File "/home/runner/work/spark/spark/./dev/check-protos.py", line 49, in check_protos
    run_cmd(f"{SPARK_HOME}/dev/gen-protos.sh {module_name} {tmp}")
  File "/home/runner/work/spark/spark/./dev/check-protos.py", line 43, in run_cmd
    return subprocess.check_output(cmd.split(" ")).decode("utf-8")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/runner/work/spark/spark/dev/gen-protos.sh', 'connect', '/tmp/check_connect__protos6imuoe88']' returned non-zero exit status 127.
```

For example: https://github.com/apache/spark/actions/runs/24597946594/job/71931532850


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Monitor the daily test results for branch-4.1 after merging.


### Was this patch authored or co-authored using generative AI tooling?
No
