### PR TITLE
[SPARK-55830][SQL] Fix JDBC predicate pushdown dropping driver properties

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -42,9 +42,12 @@ class JDBCOptions(
   def this(parameters: Map[String, String]) = this(CaseInsensitiveMap(parameters))
 
   def this(url: String, table: String, parameters: Map[String, String]) = {
-    this(CaseInsensitiveMap(parameters ++ Map(
+    // SPARK-55830: Use CaseInsensitiveMap.++ to preserve original key case.
+    // The inherited Map.++ iterates via CaseInsensitiveMap.iterator which returns
+    // lowercased keys, causing custom JDBC driver properties to lose their original case.
+    this(CaseInsensitiveMap(parameters) ++ Map(
       JDBCOptions.JDBC_URL -> url,
-      JDBCOptions.JDBC_TABLE_NAME -> table)))
+      JDBCOptions.JDBC_TABLE_NAME -> table))
   }
 
   /**
@@ -280,9 +283,10 @@ class JdbcOptionsInWrite(
   def this(parameters: Map[String, String]) = this(CaseInsensitiveMap(parameters))
 
   def this(url: String, table: String, parameters: Map[String, String]) = {
-    this(CaseInsensitiveMap(parameters ++ Map(
+    // SPARK-55830: Use CaseInsensitiveMap.++ to preserve original key case.
+    this(CaseInsensitiveMap(parameters) ++ Map(
       JDBCOptions.JDBC_URL -> url,
-      JDBCOptions.JDBC_TABLE_NAME -> table)))
+      JDBCOptions.JDBC_TABLE_NAME -> table))
   }
 
   require(

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -2365,6 +2365,25 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       )
     }
   }
+
+  test("SPARK-55830: predicate path should preserve custom driver properties") {
+    val props = new Properties()
+    props.setProperty("socketFactory", "com.example.MyFactory")
+    props.setProperty("cloudSqlInstance", "project:region:instance")
+    props.setProperty("user", "testuser")
+
+    // Simulate the predicate path from classic/DataFrameReader.scala:
+    // val params = extraOptions ++ connectionProperties.asScala
+    val extraOptions = CaseInsensitiveMap[String](Map.empty)
+    val params = extraOptions ++ props.asScala
+    val options = new JDBCOptions(url, "TEST.PEOPLE", params)
+
+    val connProps = options.asConnectionProperties
+    // Custom driver properties must preserve original case
+    assert(connProps.getProperty("socketFactory") === "com.example.MyFactory")
+    assert(connProps.getProperty("cloudSqlInstance") === "project:region:instance")
+    assert(connProps.getProperty("user") === "testuser")
+  }
 }
 
 object JDBCSuite {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When using `spark.read.jdbc()` with predicates, custom JDBC driver properties (like `socketFactory`, `cloudSqlInstance`) were silently dropped, causing connection failures. Without predicates, the same properties worked fine.

### Root Cause

In `JDBCOptions`, the constructor `this(url, table, parameters: Map[String, String])` did:
```scala
this(CaseInsensitiveMap(parameters ++ Map(JDBC_URL -> url, JDBC_TABLE_NAME -> table)))
```

When `parameters` is a `CaseInsensitiveMap` (which it is in the predicate code path), `parameters ++ Map(...)` calls the **inherited** `Map.++` (because the static type is `Map[String, String]`). The inherited `Map.++` iterates `this` using `CaseInsensitiveMap.iterator`, which returns **lowercased keys** from `keyLowerCasedMap`. This creates a plain `HashMap` with lowercased keys, losing the original case.

JDBC drivers expect case-sensitive property names (e.g., `socketFactory`, not `socketfactory`), so `asConnectionProperties` returns properties with wrong-cased keys, and `Properties.getProperty("socketFactory")` returns `null`.

### Fix

Wrap `parameters` in `CaseInsensitiveMap` first, then use `CaseInsensitiveMap.++` which preserves original key case via the `updated()` method:
```scala
this(CaseInsensitiveMap(parameters) ++ Map(JDBC_URL -> url, JDBC_TABLE_NAME -> table))
```

Applied to both `JDBCOptions` and `JdbcOptionsInWrite`.

## How was this patch tested?

Added a unit test in `JDBCSuite` that simulates the predicate code path: creates `JDBCOptions` from `CaseInsensitiveMap ++ Properties.asScala` and verifies `asConnectionProperties` preserves original key case.

## Does this PR introduce _any_ user-facing change?

Yes. Custom JDBC driver properties (e.g., `socketFactory`, `cloudSqlInstance`) now work correctly when using `spark.read.jdbc()` with predicates.

### Was this patch authored or co-authored using generative AI tooling?
Yes