### PR TITLE
[SPARK-52382][PYTHON] Fix TypeError when collecting MapType with ArrayType keys

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -1040,6 +1040,11 @@ class ArrowTableToRowsConversion:
                 dataType.valueType, none_on_identity=True, binary_as_bytes=binary_as_bytes
             )
 
+            def _make_hashable(v: Any) -> Any:
+                if isinstance(v, list):
+                    return tuple(_make_hashable(e) for e in v)
+                return v
+
             if key_conv is None:
                 if value_conv is None:
 
@@ -1049,7 +1054,7 @@ class ArrowTableToRowsConversion:
                         else:
                             assert isinstance(value, list)
                             assert all(isinstance(t, tuple) and len(t) == 2 for t in value)
-                            return dict(value)
+                            return dict((_make_hashable(t[0]), t[1]) for t in value)
 
                 else:
 
@@ -1059,7 +1064,7 @@ class ArrowTableToRowsConversion:
                         else:
                             assert isinstance(value, list)
                             assert all(isinstance(t, tuple) and len(t) == 2 for t in value)
-                            return dict((t[0], value_conv(t[1])) for t in value)
+                            return dict((_make_hashable(t[0]), value_conv(t[1])) for t in value)
 
             else:
                 if value_conv is None:
@@ -1070,7 +1075,7 @@ class ArrowTableToRowsConversion:
                         else:
                             assert isinstance(value, list)
                             assert all(isinstance(t, tuple) and len(t) == 2 for t in value)
-                            return dict((key_conv(t[0]), t[1]) for t in value)
+                            return dict((_make_hashable(key_conv(t[0])), t[1]) for t in value)
 
                 else:
 
@@ -1080,7 +1085,9 @@ class ArrowTableToRowsConversion:
                         else:
                             assert isinstance(value, list)
                             assert all(isinstance(t, tuple) and len(t) == 2 for t in value)
-                            return dict((key_conv(t[0]), value_conv(t[1])) for t in value)
+                            return dict(
+                                (_make_hashable(key_conv(t[0])), value_conv(t[1])) for t in value
+                            )
 
             return convert_map
 

--- a/python/pyspark/sql/tests/test_collection.py
+++ b/python/pyspark/sql/tests/test_collection.py
@@ -22,6 +22,7 @@ from pyspark.loose_version import LooseVersion
 from pyspark.sql.types import (
     Row,
     ArrayType,
+    MapType,
     StringType,
     IntegerType,
     StructType,
@@ -438,7 +439,14 @@ class DataFrameCollectionTests(
     DataFrameCollectionTestsMixin,
     ReusedSQLTestCase,
 ):
-    pass
+    def test_collect_map_with_array_key(self):
+        # SPARK-52382: MapType with ArrayType key should not raise TypeError on collect()
+        schema = StructType([StructField("m", MapType(ArrayType(StringType()), StringType()))])
+        data = [Row(m={("A", "B"): "foo", ("X", "Y", "Z"): "bar"})]
+        df = self.spark.createDataFrame(data, schema)
+        result = df.collect()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].m, {("A", "B"): "foo", ("X", "Y", "Z"): "bar"})
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -3002,8 +3002,16 @@ def _create_converter(dataType: DataType) -> Callable:
     elif isinstance(dataType, MapType):
         kconv = _create_converter(dataType.keyType)
         vconv = _create_converter(dataType.valueType)
+
+        def _make_hashable(v: Any) -> Any:
+            if isinstance(v, list):
+                return tuple(_make_hashable(e) for e in v)
+            return v
+
         return lambda row: (
-            dict((kconv(k), vconv(v)) for k, v in row.items()) if row is not None else None
+            dict((_make_hashable(kconv(k)), vconv(v)) for k, v in row.items())
+            if row is not None
+            else None
         )
 
     elif isinstance(dataType, NullType):

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvaluatePython.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvaluatePython.scala
@@ -58,6 +58,17 @@ object EvaluatePython {
   }
 
   /**
+   * Recursively converts java.util.ArrayList to Array so that Pyrolite pickles them as
+   * Python tuples (which are hashable) instead of lists. This is needed for map keys
+   * that contain ArrayType, since Python dicts require hashable keys.
+   */
+  private def makeHashable(obj: Any): Any = obj match {
+    case list: java.util.ArrayList[_] =>
+      list.asScala.map(makeHashable).toArray
+    case _ => obj
+  }
+
+  /**
    * Helper for converting from Catalyst type to java type suitable for Pickle.
    */
   def toJava(
@@ -87,7 +98,9 @@ object EvaluatePython {
       case (map: MapData, mt: MapType) =>
         val jmap = new java.util.HashMap[Any, Any](map.numElements())
         map.foreach(mt.keyType, mt.valueType, (k, v) => {
-          jmap.put(toJava(k, mt.keyType, binaryAsBytes), toJava(v, mt.valueType, binaryAsBytes))
+          jmap.put(
+            makeHashable(toJava(k, mt.keyType, binaryAsBytes)),
+            toJava(v, mt.valueType, binaryAsBytes))
         })
         jmap
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `TypeError: unhashable type: 'list'` when calling `collect()` on a DataFrame with `MapType(ArrayType(...), ...)` columns.

**JVM side (`EvaluatePython.scala`):** Added `makeHashable()` that recursively converts `java.util.ArrayList` to `Array` for map keys before pickling. Pyrolite pickles Java arrays as Python tuples (hashable) instead of lists (unhashable).

**Python side (`types.py`, `conversion.py`):** Added `_make_hashable()` in MapType converters to convert list keys to tuples, covering both the classic pickle path and the Arrow/Spark Connect path.

### Why are the changes needed?

`MapType` with `ArrayType` keys is valid per the PySpark documentation, but `collect()` fails because:
1. JVM converts array keys to `java.util.ArrayList`
2. Pyrolite pickles these as Python lists
3. Python dicts require hashable keys, and lists are not hashable

### Does this PR introduce _any_ user-facing change?

Yes. `DataFrame.collect()` now works correctly for `MapType` columns with `ArrayType` keys. Array keys are returned as tuples instead of raising `TypeError`.

### How was this patch tested?

Added `test_collect_map_with_array_key` in `test_collection.py` that creates a DataFrame with `MapType(ArrayType(StringType()), StringType())`, calls `collect()`, and verifies the result.

### Was this patch authored or co-authored using generative AI tooling?

Yes.