### PR TITLE
[SPARK-56540][INFRA] Add libuv1-dev to CI Docker images to fix R package fs build failure

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile.base
+++ b/dev/create-release/spark-rm/Dockerfile.base
@@ -61,6 +61,7 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     libssl-dev \
     libtiff5-dev \
+    libuv1-dev \
     libwebp-dev \
     libxml2-dev \
     msmtp \

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update && apt-get install -y \
     libpython3-dev \
     libssl-dev \
     libtiff5-dev \
+    libuv1-dev \
     libwebp-dev \
     libxml2-dev \
     nodejs \

--- a/dev/spark-test-image/docs/Dockerfile
+++ b/dev/spark-test-image/docs/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update && apt-get install -y \
     libpython3-dev \
     libssl-dev \
     libtiff5-dev \
+    libuv1-dev \
     libwebp-dev \
     libxml2-dev \
     nodejs \

--- a/dev/spark-test-image/lint/Dockerfile
+++ b/dev/spark-test-image/lint/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     libssl-dev \
     libtiff5-dev \
+    libuv1-dev \
     libwebp-dev \
     libxml2-dev \
     nodejs \

--- a/dev/spark-test-image/sparkr/Dockerfile
+++ b/dev/spark-test-image/sparkr/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update && apt-get install -y \
     libpython3-dev \
     libssl-dev \
     libtiff5-dev \
+    libuv1-dev \
     libwebp-dev \
     libxml2-dev \
     pandoc \


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `libuv1-dev` to the `apt-get install` list in all five CI Dockerfiles that install R packages:

- `dev/spark-test-image/sparkr/Dockerfile`
- `dev/spark-test-image/lint/Dockerfile`
- `dev/spark-test-image/docs/Dockerfile`
- `dev/infra/Dockerfile`
- `dev/create-release/spark-rm/Dockerfile.base`


### Why are the changes needed?
The R package `fs` now requires system library `libuv` (`uv.h`). `fs` is a transitive dependency of both `rmarkdown` (via `sass` → `bslib`) and `testthat` (via `pkgload`).

When the Docker layer cache is valid, the pre-built R packages are reused and everything works fine. But when the cache is invalidated (e.g. base image digest changes), the R packages are compiled from source. Without `libuv1-dev` installed, `fs` fails to configure:

```
Configuration failed because libuv was not found. Try installing:
 * deb: libuv1-dev (Debian, Ubuntu, etc)
...
<stdin>:1:10: fatal error: uv.h: No such file or directory
ERROR: configuration failed for package 'fs'
```

This triggers a cascade:

```
fs (missing libuv) → FAIL
  └→ sass → FAIL
       └→ bslib → FAIL
            └→ rmarkdown → FAIL
  └→ pkgload → FAIL
       └→ testthat → FAIL
```

The image build itself still "succeeds" because `install.packages()` in R does not return a non-zero exit code when individual packages fail to install -- it logs warnings but continues. So the Docker image gets pushed with `rmarkdown` and `testthat` missing, and the SparkR job fails at test time:

```
Error in library(testthat) : there is no package called 'testthat'
```

```
Error: processing vignette 'sparkr-vignettes.Rmd' failed with diagnostics:
there is no package called 'rmarkdown'
```

Example failure: https://github.com/LuciferYang/spark/actions/runs/24612026450/job/71969572946


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code
