### PR TITLE
[SPARK-54216][SQL] Add regression tests for V2 table cache refresh with immutable Table instances

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -2681,6 +2681,53 @@ class CachedTableSuite extends QueryTest
     }
   }
 
+  test("SPARK-54216: refreshTable should return fresh data for V2 tables with immutable Table") {
+    val t = "testcat.tbl"
+    withTable(t) {
+      sql(s"CREATE TABLE $t (id int, data string) USING foo")
+      sql(s"INSERT INTO $t VALUES (1, 'a'), (2, 'b')")
+
+      // Cache the table and verify initial data
+      sql(s"CACHE TABLE $t")
+      assertCached(sql(s"SELECT * FROM $t"))
+      checkAnswer(sql(s"SELECT * FROM $t"), Seq(Row(1, "a"), Row(2, "b")))
+
+      // Insert new data
+      sql(s"INSERT INTO $t VALUES (3, 'c')")
+
+      // Refresh the table cache
+      spark.catalog.refreshTable(t)
+
+      // After refresh, the cache should return fresh data including the new row
+      assertCached(sql(s"SELECT * FROM $t"))
+      checkAnswer(sql(s"SELECT * FROM $t"), Seq(Row(1, "a"), Row(2, "b"), Row(3, "c")))
+    }
+  }
+
+  test("SPARK-54216: recacheByPlan should return fresh data for V2 tables") {
+    val t = "testcat.tbl"
+    withTable(t) {
+      sql(s"CREATE TABLE $t (id int, data string) USING foo")
+      sql(s"INSERT INTO $t VALUES (1, 'a'), (2, 'b')")
+
+      // Cache via DataFrame API
+      spark.table(t).cache().count()
+      assertCached(sql(s"SELECT * FROM $t"))
+      checkAnswer(sql(s"SELECT * FROM $t"), Seq(Row(1, "a"), Row(2, "b")))
+
+      // Insert new data
+      sql(s"INSERT INTO $t VALUES (3, 'c')")
+
+      // Recache by plan
+      val plan = spark.table(t).queryExecution.analyzed
+      cacheManager.recacheByPlan(spark, plan)
+
+      // After recache, should return fresh data
+      assertCached(sql(s"SELECT * FROM $t"))
+      checkAnswer(sql(s"SELECT * FROM $t"), Seq(Row(1, "a"), Row(2, "b"), Row(3, "c")))
+    }
+  }
+
   private def cacheManager = spark.sharedState.cacheManager
 
   private def pinTable(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add regression tests verifying that `refreshTable()` and `recacheByPlan()` return fresh data for DataSource V2 tables with immutable Table instances (`copyOnLoad=true`).

### Why are the changes needed?

SPARK-54216 describes a bug where cached V2 table queries return stale data after `refreshTable()`. Investigation shows the underlying issue was already fixed by:
- **SPARK-54387**: Fixed recaching of DSv2 tables by calling `V2TableRefreshUtil.refresh()` before re-executing cached plans
- **SPARK-54424**: Refined the fix with `tryRefreshPlan` and `tryRebuildCacheEntry` for better error handling

However, there were no explicit regression tests for the exact scenario described in SPARK-54216. These tests serve as coverage for that scenario.

### Does this PR introduce any user-facing change?

No (test-only).

### How was this patch tested?

Two new tests in `CachedTableSuite`:
1. `refreshTable should return fresh data for V2 tables with immutable Table` - tests `CACHE TABLE` + `INSERT` + `refreshTable` flow
2. `recacheByPlan should return fresh data for V2 tables` - tests `DataFrame.cache()` + `INSERT` + `recacheByPlan` flow

Both tests pass on current master.

### Was this patch authored or co-authored using generative AI tooling?

Yes