### PR TITLE
[SPARK-54908][SQL] Support dateFormat option during JSON schema inference

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/DateFormatter.scala
@@ -31,6 +31,14 @@ import org.apache.spark.unsafe.types.UTF8String
 sealed trait DateFormatter extends Serializable {
   def parse(s: String): Int // returns days since epoch
 
+  def parseOptional(s: String): Option[Int] = {
+    try {
+      Some(parse(s))
+    } catch {
+      case _: Exception => None
+    }
+  }
+
   def format(days: Int): String
   def format(date: Date): String
   def format(localDate: LocalDate): String
@@ -58,6 +66,22 @@ class Iso8601DateFormatter(
       val localDate = toLocalDate(formatter.parse(s))
       localDateToDays(localDate)
     } catch checkParsedDiff(s, legacyFormatter.parse)
+  }
+
+  override def parseOptional(s: String): Option[Int] = {
+    val pp = new java.text.ParsePosition(0)
+    val parsed = formatter.parseUnresolved(s, pp)
+    // pp.getIndex == s.length ensures the entire string was consumed,
+    // not just a prefix like "2024-07-02" matching "yyyy-MM-dd" in "2024-07-02 extra"
+    if (pp.getErrorIndex == -1 && pp.getIndex == s.length) {
+      try {
+        Some(localDateToDays(toLocalDate(parsed)))
+      } catch {
+        case _: Exception => None
+      }
+    } else {
+      None
+    }
   }
 
   override def format(localDate: LocalDate): String = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
@@ -55,6 +55,12 @@ class JsonInferSchema(private val options: JSONOptions) extends Serializable wit
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = true,
     forTimestampNTZ = true)
+  private lazy val dateFormatter = DateFormatter(
+    options.dateFormatInRead,
+    options.locale,
+    FAST_DATE_FORMAT,
+    isParsing = true)
+  private val inferDate = options.dateFormatInRead.isDefined
 
   private val ignoreCorruptFiles = options.ignoreCorruptFiles
   private val ignoreMissingFiles = options.ignoreMissingFiles
@@ -192,9 +198,13 @@ class JsonInferSchema(private val options: JSONOptions) extends Serializable wit
             // this behavior now. See SPARK-46769 for more details.
             if (SparkDateTimeUtils.stringToTimestampWithoutTimeZone(utf8Value, false).isDefined) {
               TimestampType
+            } else if (inferDate && dateFormatter.parseOptional(field).isDefined) {
+              DateType
             } else {
               StringType
             }
+          } else if (inferDate && dateFormatter.parseOptional(field).isDefined) {
+            DateType
           } else {
             StringType
           }
@@ -455,6 +465,12 @@ object JsonInferSchema {
           compatibleType(t1, DecimalType.forType(t2), defaultDataType)
 
         case (TimestampNTZType, TimestampType) | (TimestampType, TimestampNTZType) =>
+          TimestampType
+
+        case (DateType, TimestampNTZType) | (TimestampNTZType, DateType) =>
+          TimestampNTZType
+
+        case (DateType, TimestampType) | (TimestampType, DateType) =>
           TimestampType
 
         case (_, _) => defaultDataType

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -2894,6 +2894,78 @@ abstract class JsonSuite
       Date.valueOf("2020-1-12")))
   }
 
+  test("SPARK-54908: dateFormat option should be used during schema inference") {
+    // Date-only strings should be inferred as DateType when dateFormat is specified
+    val ds = Seq("""{"created_at": "02JUL14", "updated_at": "02JUL14 12:17:43"}""").toDS()
+    val schema = spark.read
+      .option("dateFormat", "ddMMMyy")
+      .option("timestampFormat", "ddMMMyy HH:mm:ss")
+      .option("inferTimestamp", true)
+      .json(ds)
+      .schema
+    assert(schema("created_at").dataType === DateType)
+    assert(schema("updated_at").dataType === TimestampType)
+  }
+
+  test("SPARK-54908: timestamp takes precedence over date when both formats match") {
+    // When a string matches both timestampFormat and dateFormat, timestamp wins
+    val ds = Seq(
+      """{"v": "2024"}""",
+      """{"v": "2025"}""",
+      """{"v": "2026"}"""
+    ).toDS().repartition(3)
+    val schema = spark.read
+      .option("timestampFormat", "yyyy")
+      .option("dateFormat", "yyyy")
+      .option("inferTimestamp", true)
+      .json(ds)
+      .schema
+    assert(schema("v").dataType === TimestampType)
+  }
+
+  test("SPARK-54908: date inferred when timestamp format does not match") {
+    // timestampFormat=yyyy-MM-dd HH:mm:ss won't match "2024-07-02", but dateFormat will
+    val ds = Seq("""{"v": "2024-07-02"}""").toDS()
+    val schema = spark.read
+      .option("timestampFormat", "yyyy-MM-dd HH:mm:ss")
+      .option("dateFormat", "yyyy-MM-dd")
+      .option("inferTimestamp", true)
+      .json(ds)
+      .schema
+    assert(schema("v").dataType === DateType)
+  }
+
+  test("SPARK-54908: no date inference without explicit dateFormat") {
+    // "02/Jul/2024" looks like a date but won't match any default timestamp parser,
+    // and without dateFormat set, date inference is skipped -> StringType
+    val ds = Seq("""{"v": "02/Jul/2024"}""").toDS()
+    val schema = spark.read
+      .option("inferTimestamp", true)
+      .json(ds)
+      .schema
+    assert(schema("v").dataType === StringType)
+  }
+
+  test("SPARK-54908: type coercion merges DateType and TimestampType across rows") {
+    val ds = Seq(
+      """{"v": "2024-07-02"}""",
+      """{"v": "2024-07-02 10:30:00"}""",
+      """{"v": "2024-08-15"}""",
+      """{"v": "2024-08-15 14:00:00"}""",
+      """{"v": "2024-08-15 14:00:00"}""",
+      """{"v": "2024-08-15"}"""
+    ).toDS().repartition(4)
+    withSQLConf(SQLConf.TIMESTAMP_TYPE.key -> "TIMESTAMP_LTZ") {
+      val schema = spark.read
+        .option("dateFormat", "yyyy-MM-dd")
+        .option("timestampFormat", "yyyy-MM-dd HH:mm:ss")
+        .option("inferTimestamp", true)
+        .json(ds)
+        .schema
+      assert(schema("v").dataType === TimestampType)
+    }
+  }
+
   test("exception mode for parsing date/timestamp string") {
     val ds = Seq("{'t': '2020-01-27T20:06:11.847-08000'}").toDS()
     val json = spark.read


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add date type inference in JsonInferSchema using the dateFormat option, mirroring existing timestamp inference.

### Why are the changes needed?
The dateFormat option is documented but has no effect during schema inference, while timestampFormat works correctly.

### Does this PR introduce any user-facing change?
Yes, JSON schema inference now correctly infers DateType when dateFormat is specified.

### How was this patch tested?
Added unit tests verifying date inference with custom dateFormat.

### Was this patch authored or co-authored using generative AI tooling?
Yes