### PR TITLE
[SPARK-34914][CORE] Local mode supports Hadoop Delegation Token

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/SupportsDelegationToken.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SupportsDelegationToken.scala
@@ -23,7 +23,7 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager
 
 /**
- * A mix-in trait for SchedulerBackends that support delegation tokens.
+ * A mix-in trait for SchedulerBackend that supports delegation tokens.
  */
 private[spark] trait SupportsDelegationToken {
 
@@ -38,9 +38,7 @@ private[spark] trait SupportsDelegationToken {
   protected def createTokenManager(): Option[HadoopDelegationTokenManager] = None
 
   /**
-   * Called when a new set of delegation tokens is sent to the driver. Child classes can override
-   * this method but should always call this implementation, which handles token distribution to
-   * executors.
+   * Called when a new set of delegation tokens is sent to the driver.
    */
   protected def updateDelegationTokens(tokens: Array[Byte]): Unit
 

--- a/core/src/main/scala/org/apache/spark/scheduler/SupportsDelegationToken.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SupportsDelegationToken.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import org.apache.hadoop.security.UserGroupInformation
+
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.deploy.security.HadoopDelegationTokenManager
+
+/**
+ * A mix-in trait for SchedulerBackends that support delegation tokens.
+ */
+private[spark] trait SupportsDelegationToken {
+
+  // The token manager used to create security tokens.
+  protected var delegationTokenManager: Option[HadoopDelegationTokenManager] = None
+
+  /**
+   * Create the delegation token manager to be used for the application. This method is called
+   * once during the start of the scheduler backend (so after the object has already been
+   * fully constructed), only if security is enabled in the Hadoop configuration.
+   */
+  protected def createTokenManager(): Option[HadoopDelegationTokenManager] = None
+
+  /**
+   * Called when a new set of delegation tokens is sent to the driver. Child classes can override
+   * this method but should always call this implementation, which handles token distribution to
+   * executors.
+   */
+  protected def updateDelegationTokens(tokens: Array[Byte]): Unit
+
+  protected def setupTokenManager(): Unit = {
+    if (UserGroupInformation.isSecurityEnabled) {
+      delegationTokenManager = createTokenManager()
+      delegationTokenManager.foreach { dtm =>
+        val ugi = UserGroupInformation.getCurrentUser
+        val tokens = if (dtm.renewalEnabled) {
+          dtm.start()
+        } else {
+          val creds = ugi.getCredentials
+          dtm.obtainDelegationTokens(creds)
+          if (creds.numberOfTokens() > 0 || creds.numberOfSecretKeys() > 0) {
+            SparkHadoopUtil.get.serialize(creds)
+          } else {
+            null
+          }
+        }
+        if (tokens != null) {
+          updateDelegationTokens(tokens)
+        }
+      }
+    }
+  }
+
+  protected def stopTokenManager(): Unit = {
+    delegationTokenManager.foreach(_.stop())
+  }
+}

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -25,11 +25,9 @@ import scala.collection.mutable.{HashMap, HashSet, Queue}
 import scala.concurrent.Future
 
 import com.google.common.cache.CacheBuilder
-import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.spark.{ExecutorAllocationClient, SparkEnv, TaskState}
 import org.apache.spark.deploy.SparkHadoopUtil
-import org.apache.spark.deploy.security.HadoopDelegationTokenManager
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.executor.ExecutorLogUrlHandler
 import org.apache.spark.internal.{config, Logging}

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -56,7 +56,8 @@ import org.apache.spark.util.ArrayImplicits._
  */
 private[spark]
 class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: RpcEnv)
-  extends ExecutorAllocationClient with SchedulerBackend with Logging {
+  extends ExecutorAllocationClient with SchedulerBackend
+    with SupportsDelegationToken with Logging {
 
   // Use an atomic variable to track total number of cores in the cluster for simplicity and speed
   protected val totalCoreCount = new AtomicInteger(0)
@@ -132,9 +133,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
   // Current set of delegation tokens to send to executors.
   private val delegationTokens = new AtomicReference[Array[Byte]]()
-
-  // The token manager used to create security tokens.
-  private var delegationTokenManager: Option[HadoopDelegationTokenManager] = None
 
   private val reviveThread =
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("driver-revive-thread")
@@ -621,26 +619,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   }
 
   override def start(): Unit = {
-    if (UserGroupInformation.isSecurityEnabled()) {
-      delegationTokenManager = createTokenManager()
-      delegationTokenManager.foreach { dtm =>
-        val ugi = UserGroupInformation.getCurrentUser()
-        val tokens = if (dtm.renewalEnabled) {
-          dtm.start()
-        } else {
-          val creds = ugi.getCredentials()
-          dtm.obtainDelegationTokens(creds)
-          if (creds.numberOfTokens() > 0 || creds.numberOfSecretKeys() > 0) {
-            SparkHadoopUtil.get.serialize(creds)
-          } else {
-            null
-          }
-        }
-        if (tokens != null) {
-          updateDelegationTokens(tokens)
-        }
-      }
-    }
+    setupTokenManager()
   }
 
   protected def createDriverEndpoint(): DriverEndpoint = new DriverEndpoint()
@@ -661,7 +640,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     reviveThread.shutdownNow()
     cleanupService.foreach(_.shutdownNow())
     stopExecutors()
-    delegationTokenManager.foreach(_.stop())
+    stopTokenManager()
     try {
       if (driverEndpoint != null) {
         driverEndpoint.askSync[Boolean](StopDriver)
@@ -1047,18 +1026,11 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   }
 
   /**
-   * Create the delegation token manager to be used for the application. This method is called
-   * once during the start of the scheduler backend (so after the object has already been
-   * fully constructed), only if security is enabled in the Hadoop configuration.
-   */
-  protected def createTokenManager(): Option[HadoopDelegationTokenManager] = None
-
-  /**
    * Called when a new set of delegation tokens is sent to the driver. Child classes can override
    * this method but should always call this implementation, which handles token distribution to
    * executors.
    */
-  protected def updateDelegationTokens(tokens: Array[Byte]): Unit = {
+  override protected def updateDelegationTokens(tokens: Array[Byte]): Unit = {
     SparkHadoopUtil.get.addDelegationTokens(tokens, conf)
     delegationTokens.set(tokens)
     executorDataMap.values.foreach { ed =>

--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
@@ -20,12 +20,13 @@ package org.apache.spark.scheduler.local
 import java.io.File
 import java.net.URL
 import java.nio.ByteBuffer
+
 import org.apache.spark.{SparkConf, SparkContext, SparkEnv, TaskState}
 import org.apache.spark.TaskState.TaskState
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager
 import org.apache.spark.executor.{Executor, ExecutorBackend}
-import org.apache.spark.internal.{LogKeys, Logging, config}
+import org.apache.spark.internal.{config, Logging, LogKeys}
 import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle}
 import org.apache.spark.resource.{ResourceInformation, ResourceProfile}
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpointRef, RpcEnv, ThreadSafeRpcEndpoint}

--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
@@ -20,15 +20,12 @@ package org.apache.spark.scheduler.local
 import java.io.File
 import java.net.URL
 import java.nio.ByteBuffer
-
-import org.apache.hadoop.security.UserGroupInformation
-
 import org.apache.spark.{SparkConf, SparkContext, SparkEnv, TaskState}
 import org.apache.spark.TaskState.TaskState
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager
 import org.apache.spark.executor.{Executor, ExecutorBackend}
-import org.apache.spark.internal.{config, Logging, LogKeys}
+import org.apache.spark.internal.{LogKeys, Logging, config}
 import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle}
 import org.apache.spark.resource.{ResourceInformation, ResourceProfile}
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpointRef, RpcEnv, ThreadSafeRpcEndpoint}
@@ -116,7 +113,7 @@ private[spark] class LocalSchedulerBackend(
     conf: SparkConf,
     scheduler: TaskSchedulerImpl,
     val totalCores: Int)
-  extends SchedulerBackend with ExecutorBackend with Logging {
+  extends SchedulerBackend with ExecutorBackend with SupportsDelegationToken with Logging {
 
   private val appId = conf.get("spark.test.appId", "local-" + System.currentTimeMillis)
   private var localEndpoint: RpcEndpointRef = null
@@ -126,7 +123,14 @@ private[spark] class LocalSchedulerBackend(
     override def conf: SparkConf = LocalSchedulerBackend.this.conf
     override def onStopRequest(): Unit = stop(SparkAppHandle.State.KILLED)
   }
-  private var delegationTokenManager: Option[HadoopDelegationTokenManager] = None
+
+  override protected def createTokenManager(): Option[HadoopDelegationTokenManager] = {
+    Some(new HadoopDelegationTokenManager(conf, scheduler.sc.hadoopConfiguration, localEndpoint))
+  }
+
+  override protected def updateDelegationTokens(tokens: Array[Byte]): Unit = {
+    SparkHadoopUtil.get.addDelegationTokens(tokens, conf)
+  }
 
   /**
    * Returns a list of URLs representing the user classpath.
@@ -146,7 +150,7 @@ private[spark] class LocalSchedulerBackend(
     localEndpoint = rpcEnv.setupEndpoint("LocalSchedulerBackendEndpoint", executorEndpoint)
 
     // call this after localEndpoint is assigned
-    setupDelegationTokenManager()
+    setupTokenManager()
 
     listenerBus.post(SparkListenerExecutorAdded(
       System.currentTimeMillis,
@@ -188,8 +192,8 @@ private[spark] class LocalSchedulerBackend(
   }
 
   private def stop(finalState: SparkAppHandle.State): Unit = {
-    delegationTokenManager.foreach(_.stop())
     localEndpoint.ask(StopExecutor)
+    stopTokenManager()
     try {
       launcherBackend.setState(finalState)
     } finally {
@@ -199,29 +203,5 @@ private[spark] class LocalSchedulerBackend(
 
   override def getTaskThreadDump(taskId: Long, executorId: String): Option[ThreadStackTrace] = {
     localEndpoint.askSync[Option[ThreadStackTrace]](TaskThreadDump(taskId))
-  }
-
-  private def setupDelegationTokenManager(): Unit = {
-    if (UserGroupInformation.isSecurityEnabled) {
-      delegationTokenManager = Some(
-        new HadoopDelegationTokenManager(conf, scheduler.sc.hadoopConfiguration, localEndpoint))
-      delegationTokenManager.foreach { dtm =>
-        val ugi = UserGroupInformation.getCurrentUser
-        val tokens = if (dtm.renewalEnabled) {
-          dtm.start()
-        } else {
-          val creds = ugi.getCredentials
-          dtm.obtainDelegationTokens(creds)
-          if (creds.numberOfTokens() > 0 || creds.numberOfSecretKeys() > 0) {
-            SparkHadoopUtil.get.serialize(creds)
-          } else {
-            null
-          }
-        }
-        if (tokens != null) {
-          SparkHadoopUtil.get.addDelegationTokens(tokens, conf)
-        }
-      }
-    }
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
@@ -146,7 +146,7 @@ private[spark] class LocalSchedulerBackend(
     localEndpoint = rpcEnv.setupEndpoint("LocalSchedulerBackendEndpoint", executorEndpoint)
 
     // call this after localEndpoint is assigned
-    updateDelegationTokens()
+    setupDelegationTokenManager()
 
     listenerBus.post(SparkListenerExecutorAdded(
       System.currentTimeMillis,
@@ -201,7 +201,7 @@ private[spark] class LocalSchedulerBackend(
     localEndpoint.askSync[Option[ThreadStackTrace]](TaskThreadDump(taskId))
   }
 
-  private def updateDelegationTokens(): Unit = {
+  private def setupDelegationTokenManager(): Unit = {
     if (UserGroupInformation.isSecurityEnabled) {
       delegationTokenManager = Some(
         new HadoopDelegationTokenManager(conf, scheduler.sc.hadoopConfiguration, localEndpoint))

--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
@@ -21,15 +21,19 @@ import java.io.File
 import java.net.URL
 import java.nio.ByteBuffer
 
+import org.apache.hadoop.security.UserGroupInformation
+
 import org.apache.spark.{SparkConf, SparkContext, SparkEnv, TaskState}
 import org.apache.spark.TaskState.TaskState
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.deploy.security.HadoopDelegationTokenManager
 import org.apache.spark.executor.{Executor, ExecutorBackend}
 import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle}
 import org.apache.spark.resource.{ResourceInformation, ResourceProfile}
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpointRef, RpcEnv, ThreadSafeRpcEndpoint}
 import org.apache.spark.scheduler._
-import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.TaskThreadDump
+import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.{TaskThreadDump, UpdateDelegationTokens}
 import org.apache.spark.scheduler.cluster.ExecutorInfo
 import org.apache.spark.status.api.v1.ThreadStackTrace
 import org.apache.spark.util.Utils
@@ -78,6 +82,9 @@ private[spark] class LocalEndpoint(
 
     case KillTask(taskId, interruptThread, reason) =>
       executor.killTask(taskId, interruptThread, reason)
+
+    case UpdateDelegationTokens(tokens) =>
+      SparkHadoopUtil.get.addDelegationTokens(tokens, scheduler.conf)
   }
 
   override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
@@ -132,6 +139,8 @@ private[spark] class LocalSchedulerBackend(
   launcherBackend.connect()
 
   override def start(): Unit = {
+    updateDelegationTokens()
+
     val rpcEnv = SparkEnv.get.rpcEnv
     val executorEndpoint = new LocalEndpoint(rpcEnv, userClassPath, scheduler, this, totalCores)
     localEndpoint = rpcEnv.setupEndpoint("LocalSchedulerBackendEndpoint", executorEndpoint)
@@ -185,5 +194,25 @@ private[spark] class LocalSchedulerBackend(
 
   override def getTaskThreadDump(taskId: Long, executorId: String): Option[ThreadStackTrace] = {
     localEndpoint.askSync[Option[ThreadStackTrace]](TaskThreadDump(taskId))
+  }
+
+  private def updateDelegationTokens(): Unit = {
+    if (UserGroupInformation.isSecurityEnabled()) {
+      val delegationTokenManager =
+        new HadoopDelegationTokenManager(conf, scheduler.sc.hadoopConfiguration, localEndpoint)
+      val ugi = UserGroupInformation.getCurrentUser()
+      val tokens = if (delegationTokenManager.renewalEnabled) {
+        delegationTokenManager.start()
+      } else {
+        val creds = ugi.getCredentials()
+        delegationTokenManager.obtainDelegationTokens(creds)
+        if (creds.numberOfTokens() > 0 || creds.numberOfSecretKeys() > 0) {
+          SparkHadoopUtil.get.serialize(creds)
+        } else {
+          null
+        }
+      }
+      SparkHadoopUtil.get.addDelegationTokens(tokens, conf)
+    }
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
@@ -83,8 +83,9 @@ private[spark] class LocalEndpoint(
     case KillTask(taskId, interruptThread, reason) =>
       executor.killTask(taskId, interruptThread, reason)
 
-    case UpdateDelegationTokens(tokens) =>
-      SparkHadoopUtil.get.addDelegationTokens(tokens, scheduler.conf)
+    case UpdateDelegationTokens(tokenBytes) =>
+      logInfo(s"Received tokens of ${tokenBytes.length} bytes")
+      SparkHadoopUtil.get.addDelegationTokens(tokenBytes, scheduler.conf)
   }
 
   override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
@@ -125,6 +126,7 @@ private[spark] class LocalSchedulerBackend(
     override def conf: SparkConf = LocalSchedulerBackend.this.conf
     override def onStopRequest(): Unit = stop(SparkAppHandle.State.KILLED)
   }
+  private var delegationTokenManager: Option[HadoopDelegationTokenManager] = None
 
   /**
    * Returns a list of URLs representing the user classpath.
@@ -185,6 +187,7 @@ private[spark] class LocalSchedulerBackend(
 
   private def stop(finalState: SparkAppHandle.State): Unit = {
     localEndpoint.ask(StopExecutor)
+    delegationTokenManager.foreach(_.stop())
     try {
       launcherBackend.setState(finalState)
     } finally {
@@ -198,21 +201,25 @@ private[spark] class LocalSchedulerBackend(
 
   private def updateDelegationTokens(): Unit = {
     if (UserGroupInformation.isSecurityEnabled()) {
-      val delegationTokenManager =
-        new HadoopDelegationTokenManager(conf, scheduler.sc.hadoopConfiguration, localEndpoint)
-      val ugi = UserGroupInformation.getCurrentUser()
-      val tokens = if (delegationTokenManager.renewalEnabled) {
-        delegationTokenManager.start()
-      } else {
-        val creds = ugi.getCredentials()
-        delegationTokenManager.obtainDelegationTokens(creds)
-        if (creds.numberOfTokens() > 0 || creds.numberOfSecretKeys() > 0) {
-          SparkHadoopUtil.get.serialize(creds)
+      delegationTokenManager = Some(
+        new HadoopDelegationTokenManager(conf, scheduler.sc.hadoopConfiguration, localEndpoint))
+      delegationTokenManager.foreach { dtm =>
+        val ugi = UserGroupInformation.getCurrentUser()
+        val tokens = if (dtm.renewalEnabled) {
+          dtm.start()
         } else {
-          null
+          val creds = ugi.getCredentials()
+          dtm.obtainDelegationTokens(creds)
+          if (creds.numberOfTokens() > 0 || creds.numberOfSecretKeys() > 0) {
+            SparkHadoopUtil.get.serialize(creds)
+          } else {
+            null
+          }
+        }
+        if (tokens != null) {
+          SparkHadoopUtil.get.addDelegationTokens(tokens, conf)
         }
       }
-      SparkHadoopUtil.get.addDelegationTokens(tokens, conf)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
@@ -28,7 +28,7 @@ import org.apache.spark.TaskState.TaskState
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.security.HadoopDelegationTokenManager
 import org.apache.spark.executor.{Executor, ExecutorBackend}
-import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.internal.{config, Logging, LogKeys}
 import org.apache.spark.launcher.{LauncherBackend, SparkAppHandle}
 import org.apache.spark.resource.{ResourceInformation, ResourceProfile}
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpointRef, RpcEnv, ThreadSafeRpcEndpoint}
@@ -84,7 +84,7 @@ private[spark] class LocalEndpoint(
       executor.killTask(taskId, interruptThread, reason)
 
     case UpdateDelegationTokens(tokenBytes) =>
-      logInfo(s"Received tokens of ${tokenBytes.length} bytes")
+      logInfo(log"Received tokens of ${MDC(LogKeys.NUM_BYTES, tokenBytes.length)} bytes")
       SparkHadoopUtil.get.addDelegationTokens(tokenBytes, scheduler.conf)
   }
 
@@ -141,11 +141,13 @@ private[spark] class LocalSchedulerBackend(
   launcherBackend.connect()
 
   override def start(): Unit = {
-    updateDelegationTokens()
-
     val rpcEnv = SparkEnv.get.rpcEnv
     val executorEndpoint = new LocalEndpoint(rpcEnv, userClassPath, scheduler, this, totalCores)
     localEndpoint = rpcEnv.setupEndpoint("LocalSchedulerBackendEndpoint", executorEndpoint)
+
+    // call this after localEndpoint is assigned
+    updateDelegationTokens()
+
     listenerBus.post(SparkListenerExecutorAdded(
       System.currentTimeMillis,
       executorEndpoint.localExecutorId,
@@ -186,8 +188,8 @@ private[spark] class LocalSchedulerBackend(
   }
 
   private def stop(finalState: SparkAppHandle.State): Unit = {
-    localEndpoint.ask(StopExecutor)
     delegationTokenManager.foreach(_.stop())
+    localEndpoint.ask(StopExecutor)
     try {
       launcherBackend.setState(finalState)
     } finally {
@@ -200,15 +202,15 @@ private[spark] class LocalSchedulerBackend(
   }
 
   private def updateDelegationTokens(): Unit = {
-    if (UserGroupInformation.isSecurityEnabled()) {
+    if (UserGroupInformation.isSecurityEnabled) {
       delegationTokenManager = Some(
         new HadoopDelegationTokenManager(conf, scheduler.sc.hadoopConfiguration, localEndpoint))
       delegationTokenManager.foreach { dtm =>
-        val ugi = UserGroupInformation.getCurrentUser()
+        val ugi = UserGroupInformation.getCurrentUser
         val tokens = if (dtm.renewalEnabled) {
           dtm.start()
         } else {
-          val creds = ugi.getCredentials()
+          val creds = ugi.getCredentials
           dtm.obtainDelegationTokens(creds)
           if (creds.numberOfTokens() > 0 || creds.numberOfSecretKeys() > 0) {
             SparkHadoopUtil.get.serialize(creds)

--- a/docs/security.md
+++ b/docs/security.md
@@ -945,7 +945,7 @@ mechanism (see `java.util.ServiceLoader`). Implementations of
 `org.apache.spark.security.HadoopDelegationTokenProvider` can be made available to Spark
 by listing their names in the corresponding file in the jar's `META-INF/services` directory.
 
-Delegation token support is currently only supported in YARN and Kubernetes mode. Consult the
+Delegation token support is currently only supported in Local, YARN and Kubernetes mode. Consult the
 deployment-specific page for more information.
 
 The following options provides finer-grained control for this feature:

--- a/docs/security.md
+++ b/docs/security.md
@@ -945,7 +945,7 @@ mechanism (see `java.util.ServiceLoader`). Implementations of
 `org.apache.spark.security.HadoopDelegationTokenProvider` can be made available to Spark
 by listing their names in the corresponding file in the jar's `META-INF/services` directory.
 
-Delegation token support is currently only supported in Local, YARN and Kubernetes mode. Consult the
+Delegation token support is currently only supported in Local, YARN and Kubernetes modes. Consult the
 deployment-specific page for more information.
 
 The following options provides finer-grained control for this feature:

--- a/docs/security.md
+++ b/docs/security.md
@@ -924,9 +924,8 @@ In most cases, Spark relies on the credentials of the current logged in user whe
 to Kerberos-aware services. Such credentials can be obtained by logging in to the configured KDC
 with tools like `kinit`.
 
-When talking to Hadoop-based services, Spark needs to obtain delegation tokens so that non-local
-processes can authenticate. Spark ships with support for HDFS and other Hadoop file systems, Hive
-and HBase.
+When talking to Hadoop-based services, Spark needs to obtain delegation tokens so that processes
+can authenticate. Spark ships with support for HDFS and other Hadoop file systems, Hive and HBase.
 
 When using a Hadoop filesystem (such HDFS or WebHDFS), Spark will acquire the relevant tokens
 for the service hosting the user's home directory.
@@ -1039,7 +1038,7 @@ documentation to find out instructions on how to ensure cluster mode is used for
 ## Secure Interaction with Kubernetes
 
 When talking to Hadoop-based services behind Kerberos, it was noted that Spark needs to obtain delegation tokens
-so that non-local processes can authenticate. These delegation tokens in Kubernetes are stored in Secrets that are
+so that processes can authenticate. These delegation tokens in Kubernetes are stored in Secrets that are
 shared by the Driver and its Executors. As such, there are three ways of submitting a Kerberos job:
 
 In all cases you must define the environment variable: `HADOOP_CONF_DIR` or

--- a/docs/security.md
+++ b/docs/security.md
@@ -945,8 +945,8 @@ mechanism (see `java.util.ServiceLoader`). Implementations of
 `org.apache.spark.security.HadoopDelegationTokenProvider` can be made available to Spark
 by listing their names in the corresponding file in the jar's `META-INF/services` directory.
 
-Delegation token support is currently only supported in Local, YARN and Kubernetes modes. Consult the
-deployment-specific page for more information.
+Delegation token support is currently only supported in Local, YARN and Kubernetes modes.
+Consult the deployment-specific page for more information.
 
 The following options provides finer-grained control for this feature:
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

This PR is based on @ulysses-you's original work - https://github.com/apache/spark/pull/32009

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Set up `HadoopDelegationTokenManager` in `LocalSchedulerBackend` when `UserGroupInformation.isSecurityEnabled` to make local mode support Hadoop Delegation Token.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Local mode is useful for some production use cases, this PR enables it to work on kerberized environments.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Tested in a Kerberized Hadoop cluster, with several combinations.

- Hadoop HDFS/YARN 3.4.3, Hive Metastore 2.3.10
- Grafana Loki is used to collect logs
- `hdfs-site.xml` - `dfs.namenode.delegation.key.update-interval=300000` (5 min)
- `hdfs-site.xml` - `dfs.namenode.delegation.token.max-lifetime=600000` (10 min)

#### Case: local mode with TGT cache and `--proxy-user`

```
kinit ...
spark-shell --master=local --proxy-user=foo ...
```
Success fetch HDFS/HMS Delegation Token, and able to CREATE and SELECT Hive tables

<img width="1747" height="600" alt="image" src="https://github.com/user-attachments/assets/c93b0ae8-4cef-44c4-b993-1eca837bee91" />

#### Case: local mode with keytab
```
spark-shell --master=local --principal foo --keytab /path/bar ...
```
Success fetch HDFS/HMS Delegation Token, and is able to CREATE and SELECT Hive tables, also able to renew HDFS Delegation Token

<img width="1746" height="1076" alt="Xnip2026-04-20_16-45-46" src="https://github.com/user-attachments/assets/5feec4f5-a49d-4e58-b2f1-0b649a8ff06d" />

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Code is crafted by hand, and Claude Opus 4.7 is used for review before submitting.