### PR TITLE
[MINOR][SQL] Fix duplicated word typos in code comments

### DIFF
--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
@@ -75,7 +75,7 @@ private[sql] class ProtobufOptions(
     parameters.get("mode").map(ParseMode.fromString).getOrElse(FailFastMode)
 
   /**
-   * Adds support for recursive fields. If this option is is not specified, recursive fields are
+   * Adds support for recursive fields. If this option is not specified, recursive fields are
    * not permitted. Setting it to 1 drops the recursive fields, 0 allows it to be recursed once,
    * and 3 allows it to be recursed twice and so on, up to 10. Values larger than 10 are not
    * allowed in order avoid inadvertently creating very large schemas. If a Protobuf message

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -218,7 +218,7 @@ object SQLExecution extends Logging {
                     case NonFatal(e) =>
                       logDebug("Failed to generate SparkPlanInfo", e)
                       // If the queryExecution already failed before this, we are not able to
-                      // generate the the plan info, so we use and empty graphviz node to make the
+                      // generate the plan info, so we use an empty graphviz node to make the
                       // UI happy
                       SparkPlanInfo.EMPTY
                   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinator.scala
@@ -323,7 +323,7 @@ private class StateStoreCoordinator(
       // Check if any loaded provider id is already loaded in other executor.
       val providerIdsToUnload = providerIdsToCheck.filter { providerId =>
         val providerLoc = instances.get(providerId)
-        // This provider is is already loaded in other executor. Marked it to unload.
+        // This provider is already loaded in other executor. Marked it to unload.
         providerLoc.map(_ != taskLocation).getOrElse(false)
       }
       // Check if the store is lagging behind in snapshot uploads


### PR DESCRIPTION

**Repo:** apache/spark (⭐ 39000)
**Type:** docs
**Files changed:** 3
**Lines:** +3/-3

## What
Fixes three duplicated-word typos in inline code comments: "is is" in
`ProtobufOptions.scala`, "the the ... and empty" in `SQLExecution.scala`
(also corrects the adjacent "and" → "an"), and "is is" in
`StateStoreCoordinator.scala`.

## Why
Small comment cleanup that improves readability of the code. Apache Spark
routinely accepts `[MINOR]` typo-only PRs for comments and docs, so this
is low-friction maintenance value with zero behavior change.

## Testing
Comment-only change — no tests required and no runtime behavior changed.
Verified diff is exactly 3 lines and confined to comment text via
`git diff --stat`.

## Risk
Low — comments only, no code paths touched.
