### PR TITLE
[SPARK-56553][BUILD] Upgrade `extra-enforcer-rules` to 1.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2721,7 +2721,7 @@
             <dependency>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>extra-enforcer-rules</artifactId>
-              <version>1.11.0</version>
+              <version>1.12.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `extra-enforcer-rules` to 1.12.0.

### Why are the changes needed?

To bring the latest bug fixes and improvements. This plugin dependency powers the `EnforceBytecodeVersion` rule used by our `enforce-versions` enforcer execution, which guards against binaries built for an incompatible JDK target.

- https://github.com/mojohaus/extra-enforcer-rules/releases/tag/1.12.0
  - https://github.com/mojohaus/extra-enforcer-rules/pull/350

### Does this PR introduce _any_ user-facing change?

No. This is a build-only dependency change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)