### PR TITLE
[SPARK-56475][PYTHON][TESTS] Add ASV benchmark for SQL_SCALAR_PANDAS_ITER_UDF

### DIFF
--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -1168,6 +1168,42 @@ class ScalarPandasUDFPeakmemBench(_ScalarPandasBenchMixin, _PeakmemBenchBase):
     pass
 
 
+# -- SQL_SCALAR_PANDAS_ITER_UDF ---------------------------------------------
+# UDF receives ``Iterator[pandas.Series]``, returns ``Iterator[pandas.Series]``.
+
+
+class _ScalarPandasIterBenchMixin(_ScalarPandasBenchMixin):
+    """Mixin for SQL_SCALAR_PANDAS_ITER_UDF benchmarks."""
+
+    def _identity_pandas_iter(it):
+        return (s for s in it)
+
+    def _sort_pandas_iter(it):
+        for s in it:
+            yield s.sort_values().reset_index(drop=True)
+
+    def _nullcheck_pandas_iter(it):
+        for s in it:
+            yield s.notna()
+
+    _eval_type = PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF
+    _udfs = {
+        "identity_udf": (_identity_pandas_iter, None, [0]),
+        "sort_udf": (_sort_pandas_iter, None, [0]),
+        "nullcheck_udf": (_nullcheck_pandas_iter, BooleanType(), [0]),
+    }
+    params = [list(_ScalarPandasBenchMixin._scenario_configs), list(_udfs)]
+    param_names = ["scenario", "udf"]
+
+
+class ScalarPandasIterUDFTimeBench(_ScalarPandasIterBenchMixin, _TimeBenchBase):
+    pass
+
+
+class ScalarPandasIterUDFPeakmemBench(_ScalarPandasIterBenchMixin, _PeakmemBenchBase):
+    pass
+
+
 # -- SQL_WINDOW_AGG_ARROW_UDF ------------------------------------------------
 # UDF receives ``pa.Array`` columns for the entire window partition, returns scalar.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add ASV microbenchmarks for `SQL_SCALAR_PANDAS_ITER_UDF` eval type in `bench_eval_type.py`.

The new `_ScalarPandasIterBenchMixin` extends `_ScalarPandasBenchMixin` and only overrides `_eval_type` and `_udfs` with iterator-style UDFs.


### Why are the changes needed?

This is part of the PySpark Serializer & EvalType Refactor effort (SPARK-55724). We need baseline benchmarks for every eval type before refactoring the serialization path, so we can detect performance regressions. 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran all 54 benchmarks (27 time + 27 peakmem) locally with `python/asv run --python=same`:

```
ScalarPandasIterUDFTimeBench.time_worker                                                                       ok
=================== ============== ============ ===============
--                                      udf
------------------- -------------------------------------------
      scenario       identity_udf    sort_udf    nullcheck_udf
=================== ============== ============ ===============
  sm_batch_few_col     257+/-2ms      341+/-2ms      285+/-3ms
 sm_batch_many_col    203+/-0.8ms   216+/-0.9ms     208+/-3ms
  lg_batch_few_col     787+/-6ms    1.04+/-0.01s    807+/-8ms
 lg_batch_many_col    854+/-10ms     913+/-20ms     864+/-30ms
     pure_ints        148+/-0.8ms   225+/-0.7ms    159+/-0.8ms
    pure_floats        147+/-3ms     215+/-3ms      160+/-1ms
    pure_strings       801+/-1ms      1.13+/-0s    792+/-20ms
      pure_ts          250+/-1ms     293+/-2ms     287+/-30ms
    mixed_types        481+/-1ms     544+/-2ms      494+/-4ms
=================== ============== ============ ===============

ScalarPandasIterUDFPeakmemBench.peakmem_worker                                          ok
=================== ============== ========== ===============
--                                     udf
------------------- -----------------------------------------
      scenario       identity_udf   sort_udf   nullcheck_udf
=================== ============== ========== ===============
  sm_batch_few_col       480M         481M          479M
 sm_batch_many_col       480M         481M          481M
  lg_batch_few_col       623M         623M          602M
 lg_batch_many_col       627M         628M          627M
     pure_ints           545M         546M          543M
    pure_floats          543M         544M          543M
    pure_strings         567M         566M          561M
      pure_ts            546M         546M          546M
    mixed_types          529M         529M          525M
=================== ============== ========== ===============
```

### Was this patch authored or co-authored using generative AI tooling?

No.