### PR TITLE
[SPARK-56387][PYTHON][FOLLOWUP] Use namedtuple instead of dict to have be backward compatible

### DIFF
--- a/python/pyspark/sql/_typing.pyi
+++ b/python/pyspark/sql/_typing.pyi
@@ -19,11 +19,9 @@
 from typing import (
     Any,
     Callable,
-    Dict,
     List,
     Optional,
     Tuple,
-    TypedDict,
     TypeVar,
     Union,
 )
@@ -31,10 +29,8 @@ from typing_extensions import Literal, Protocol
 
 import datetime
 import decimal
-import pstats
 
 from pyspark._typing import PrimitiveType
-from pyspark.profiler import CodeMapDict
 import pyspark.sql.types
 from pyspark.sql.column import Column
 from pyspark.sql.tvf_argument import TableValuedFunctionArgument
@@ -85,9 +81,3 @@ class UserDefinedFunctionLike(Protocol):
     def returnType(self) -> pyspark.sql.types.DataType: ...
     def __call__(self, *args: ColumnOrName) -> Column: ...
     def asNondeterministic(self) -> UserDefinedFunctionLike: ...
-
-class ProfileResult(TypedDict, total=False):
-    perf: pstats.Stats
-    memory: CodeMapDict
-
-ProfileResults = Dict[Union[int, str], ProfileResult]

--- a/python/pyspark/sql/connect/profiler.py
+++ b/python/pyspark/sql/connect/profiler.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 from pyspark.sql.profiler import ProfilerCollector, ProfileResultsParam
 
 if TYPE_CHECKING:
-    from pyspark.sql._typing import ProfileResults
+    from pyspark.sql.profiler import ProfileResults
 
 
 class ConnectProfilerCollector(ProfilerCollector):

--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -27,10 +27,10 @@ from typing import (
     Dict,
     Iterable,
     Literal,
+    NamedTuple,
     Optional,
     Tuple,
     Union,
-    TYPE_CHECKING,
     overload,
 )
 import warnings
@@ -50,8 +50,19 @@ from pyspark.profiler import (
     PStatsParam,
 )
 
-if TYPE_CHECKING:
-    from pyspark.sql._typing import ProfileResults
+
+class ProfileResult(NamedTuple):
+    perf: Optional[pstats.Stats] = None
+    memory: Optional[CodeMapDict] = None
+
+    def __bool__(self) -> bool:
+        return self.perf is not None or self.memory is not None
+
+    def replace(self, **kwargs: Any) -> "ProfileResult":
+        return self._replace(**kwargs)
+
+
+ProfileResults = Dict[Union[int, str], ProfileResult]
 
 
 class _ProfileResultsParam(AccumulatorParam["ProfileResults"]):
@@ -69,16 +80,9 @@ class _ProfileResultsParam(AccumulatorParam["ProfileResults"]):
             if key not in value1:
                 value1[key] = result
             else:
-                perf = PStatsParam.addInPlace(
-                    value1[key].get("perf", None), result.get("perf", None)
-                )
-                if perf is not None:
-                    value1[key]["perf"] = perf
-                memory = MemUsageParam.addInPlace(
-                    value1[key].get("memory", None), result.get("memory", None)
-                )
-                if memory is not None:
-                    value1[key]["memory"] = memory
+                perf = PStatsParam.addInPlace(value1[key].perf, result.perf)
+                memory = MemUsageParam.addInPlace(value1[key].memory, result.memory)
+                value1[key] = ProfileResult(perf=perf, memory=memory)
         return value1
 
 
@@ -108,7 +112,7 @@ class WorkerPerfProfiler:
         # make it picklable
         st.stream = None  # type: ignore[attr-defined]
         st.strip_dirs()
-        self._accumulator.add({self._result_key: {"perf": st}})
+        self._accumulator.add({self._result_key: ProfileResult(perf=st)})
 
     def __enter__(self) -> "WorkerPerfProfiler":
         self.start()
@@ -156,7 +160,7 @@ class WorkerMemoryProfiler:
             filename: list(line_iterator)
             for filename, line_iterator in self._profiler.code_map.items()
         }
-        self._accumulator.add({self._result_key: {"memory": codemap_dict}})
+        self._accumulator.add({self._result_key: ProfileResult(memory=codemap_dict)})
 
     def __enter__(self) -> "WorkerMemoryProfiler":
         self.start()
@@ -223,9 +227,9 @@ class ProfilerCollector(ABC):
     def _perf_profile_results(self) -> Dict[Union[int, str], pstats.Stats]:
         with self._lock:
             return {
-                result_id: result["perf"]
+                result_id: result.perf
                 for result_id, result in self._profile_results.items()
-                if result.get("perf", None) is not None
+                if result.perf is not None
             }
 
     def show_memory_profiles(self, id: Optional[Union[int, str]] = None) -> None:
@@ -269,9 +273,9 @@ class ProfilerCollector(ABC):
     def _memory_profile_results(self) -> Dict[Union[int, str], CodeMapDict]:
         with self._lock:
             return {
-                result_id: result["memory"]
+                result_id: result.memory
                 for result_id, result in self._profile_results.items()
-                if result.get("memory", None) is not None
+                if result.memory is not None
             }
 
     @property
@@ -365,12 +369,12 @@ class ProfilerCollector(ABC):
         with self._lock:
             if id is not None:
                 if id in self._profile_results:
-                    self._profile_results[id].pop("perf", None)
+                    self._profile_results[id] = self._profile_results[id].replace(perf=None)
                     if not self._profile_results[id]:
                         self._profile_results.pop(id)
             else:
                 for id in list(self._profile_results.keys()):
-                    self._profile_results[id].pop("perf", None)
+                    self._profile_results[id] = self._profile_results[id].replace(perf=None)
                     if not self._profile_results[id]:
                         self._profile_results.pop(id)
 
@@ -389,12 +393,12 @@ class ProfilerCollector(ABC):
         with self._lock:
             if id is not None:
                 if id in self._profile_results:
-                    self._profile_results[id].pop("memory", None)
+                    self._profile_results[id] = self._profile_results[id].replace(memory=None)
                     if not self._profile_results[id]:
                         self._profile_results.pop(id)
             else:
                 for id in list(self._profile_results.keys()):
-                    self._profile_results[id].pop("memory", None)
+                    self._profile_results[id] = self._profile_results[id].replace(memory=None)
                     if not self._profile_results[id]:
                         self._profile_results.pop(id)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Use `NamedTuple` instead of `dict` for profiling results to keep backward compatibility.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`dict` is great but the connect client also uses this code path, so we need to be backward compatible. `NamedTuple` is a tuple so it can be unpacked, but it also gives us flexibility and type checks so we don't have to do `value[0]` which does not make sense.

Also, by making it a custom class, it's much easier to be backward compatible in the future.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Need CI result.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.