### PR TITLE
[SPARK-56555][K8S] Add ubuntu mirror repositories to K8s Dockerfile for redundancy

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -34,6 +34,13 @@ ARG spark_uid=185
 # docker build -t spark:latest -f kubernetes/dockerfiles/spark/Dockerfile .
 
 RUN set -ex && \
+    if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
+      printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources; \
+    elif [ -f /etc/apt/sources.list ]; then \
+      grep -q 'archive.ubuntu.com' /etc/apt/sources.list 2>/dev/null && \
+      sed 's|archive.ubuntu.com|mirrors.edge.kernel.org|g;s|security.ubuntu.com|mirrors.edge.kernel.org|g' \
+        /etc/apt/sources.list > /etc/apt/sources.list.d/mirror.list || true; \
+    fi && \
     apt-get update && \
     ln -s /lib /lib64 && \
     apt install -y --no-install-recommends bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools logrotate libssl-dev && \


### PR DESCRIPTION
### What changes were proposed in this pull request?
Similar to #55389, this PR adds ubuntu mirror repositories to K8s Dockerfiles for redundancy.
mirrors.edge.kernel.org seems sufficiently public and reliable.

### Why are the changes needed?
Sometimes, ubuntu repositories including archive.ubuntu.com and security.ubuntu.com are very slow, causing `docker build` failure.
We saw such failure on GA.
https://github.com/sarutak/spark/actions/runs/24552461498/job/71781474186

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually confirmed `docker build` works with modified Dockerfile.

### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Opus 4.6
