### PR TITLE
[SPARK-56556][INFRA] Reject `.jar` and `.class` files in CI

### DIFF
--- a/dev/is-changed.py
+++ b/dev/is-changed.py
@@ -66,6 +66,14 @@ def main():
             os.environ["GITHUB_SHA"], target_ref=os.environ["GITHUB_PREV_SHA"]
         )
 
+    rejected = [f for f in changed_files if f.endswith(".jar") or f.endswith(".class")]
+    if rejected:
+        raise SystemExit(
+            "Cannot add .jar or .class files to the repository "
+            f"({', '.join(rejected)}). "
+            "Generate them dynamically at test time instead."
+        )
+
     changed_modules = determine_modules_to_test(
         determine_modules_for_files(changed_files), deduplicated=False
     )

--- a/dev/is-changed.py
+++ b/dev/is-changed.py
@@ -68,7 +68,7 @@ def main():
 
     rejected = [f for f in changed_files if f.endswith(".jar") or f.endswith(".class")]
     if rejected:
-        raise SystemExit(
+        sys.exit(
             "Cannot add .jar or .class files to the repository "
             f"({', '.join(rejected)}). "
             "Generate them dynamically at test time instead."


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a part of SPARK-56352, adding a check to `dev/is-changed.py` that rejects any `.jar` or `.class` files in the changeset, preventing pre-built binaries from being added back to the repository.

### Why are the changes needed?
SPARK-56352 removed all pre-built test binaries and replaced them with dynamic generation at test time. SPARK-56471 then removed the previous workaround that used allowlists (`dev/test-jars.txt` / `dev/test-classes.txt`) to manage exceptions.
This PR adds a simpler guardrail that unconditionally rejects `.jar` and `.class` files, since there is no longer any legitimate reason to add them to the repository.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Created two branches on my repository based on top of this change for test. One includes `test1.jar` and the other include `test2.class`. This change successfully rejected these files.

https://github.com/sarutak/spark/actions/runs/24767728240/job/72465976471
```
Cannot add .jar or .class files to the repository (test1.jar). Generate them dynamically at test time instead.
```

https://github.com/sarutak/spark/actions/runs/24767736638/job/72466002649
```
Cannot add .jar or .class files to the repository (test2.class). Generate them dynamically at test time instead.
```

### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Opus 4.6
