### PR TITLE
[MINOR][CONNECT] Fix user_agent length error message in Python Connect client

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -305,7 +305,8 @@ class ChannelBuilder:
         ua_len = len(urllib.parse.quote(user_agent))
         if ua_len > 2048:
             raise SparkConnectException(
-                f"'user_agent' parameter should not exceed 2048 characters, found {len} characters."
+                f"'user_agent' parameter should not exceed 2048 characters after URL "
+                f"escaping, found {ua_len} characters."
             )
         return " ".join(
             [


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to replace `len` to `ua_len` so error message is formatted properly. 

### Why are the changes needed?

Otherwise, the formatter would fail.

### Does this PR introduce _any_ user-facing change?

No, it just changes the error message.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No