### PR TITLE
[SPARK-56557][SQL][TESTS] Use abstract SparkSession in SparkPlanTest

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanTest.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution
 import scala.util.control.NonFatal
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.{classic, DataFrame, Row, SparkSessionProvider, SQLContext}
+import org.apache.spark.sql.{DataFrame, Row, SparkSessionProvider, SQLContext}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.classic.ClassicConversions._
@@ -31,7 +31,6 @@ import org.apache.spark.sql.test.SQLTestUtils
  * class's test helper methods can be used, see [[SortSuite]].
  */
 private[sql] abstract class SparkPlanTest extends SparkFunSuite with SparkSessionProvider {
-  override protected def spark: classic.SparkSession
 
   /**
    * Runs the plan and makes sure the answer matches the expected result.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the classic `SparkSession` override from `SparkPlanTest`, letting it inherit the abstract `SparkSession` from `SparkSessionProvider`. Also remove the now-unused `classic` import.

```scala
// Before
private[sql] abstract class SparkPlanTest extends SparkFunSuite with SparkSessionProvider {
  override protected def spark: classic.SparkSession
  ...
}

// After
private[sql] abstract class SparkPlanTest extends SparkFunSuite with SparkSessionProvider {
  ...
}
```

The existing `import org.apache.spark.sql.classic.ClassicConversions._` handles implicit conversions to classic types where needed internally (e.g., when passing `spark.sparkSession` to `new QueryExecution(...)` which takes a classic `SparkSession`).

### Why are the changes needed?

`SparkPlanTest` currently requires a `classic.SparkSession`, which tightly couples it to the classic implementation. Widening the type to the abstract `SparkSession` follows the same pattern as [SPARK-56483](https://issues.apache.org/jira/browse/SPARK-56483) (SQLTestUtilsBase) — makes the test infrastructure more uniform and reduces direct references to the classic package in test utilities.

12 test suites extend `SparkPlanTest` and continue to work unchanged: `SortSuite`, `ExchangeSuite`, `BroadcastExchangeSuite`, `ReuseExchangeAndSubquerySuite`, `TakeOrderedAndProjectSuite`, `BaseScriptTransformationSuite`, `InnerJoinSuite`, `OuterJoinSuite`, `ExistenceJoinSuite`, `SingleJoinSuite`, `BatchEvalPythonExecSuite`, `ExtractPythonUDFsSuite`.

### Does this PR introduce _any_ user-facing change?

No. `SparkPlanTest` is `private[sql]`.

### How was this patch tested?

CI compilation across all modules.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)