### PR TITLE
[SPARK-54119][SQL] Extend V2 TableInfo for view definitions and dependencies

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DelegatingCatalogExtension.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DelegatingCatalogExtension.java
@@ -112,6 +112,12 @@ public abstract class DelegatingCatalogExtension implements CatalogExtension {
   }
 
   @Override
+  public Table createTable(Identifier ident, TableInfo tableInfo)
+      throws TableAlreadyExistsException, NoSuchNamespaceException {
+    return asTableCatalog().createTable(ident, tableInfo);
+  }
+
+  @Override
   public Table alterTable(
       Identifier ident,
       TableChange... changes) throws NoSuchTableException {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Dependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Dependency.java
@@ -17,29 +17,23 @@
 
 package org.apache.spark.sql.connector.catalog;
 
-import java.util.Objects;
-
 import org.apache.spark.annotation.Evolving;
 
+/**
+ * Represents a dependency of a SQL object such as a view or metric view.
+ * <p>
+ * A dependency is one of: {@link TableDependency} or {@link FunctionDependency}.
+ *
+ * @since 4.2.0
+ */
 @Evolving
-public interface TableSummary {
-    String MANAGED_TABLE_TYPE = "MANAGED";
-    String EXTERNAL_TABLE_TYPE = "EXTERNAL";
-    String VIEW_TABLE_TYPE = "VIEW";
-    String FOREIGN_TABLE_TYPE = "FOREIGN";
-    String METRIC_VIEW_TABLE_TYPE = "METRIC_VIEW";
+public interface Dependency {
 
-    Identifier identifier();
-    String tableType();
+  static TableDependency table(String tableFullName) {
+    return new TableDependency(tableFullName);
+  }
 
-    static TableSummary of(Identifier identifier, String tableType) {
-        return new TableSummaryImpl(identifier, tableType);
-    }
-}
-
-record TableSummaryImpl(Identifier identifier, String tableType) implements TableSummary {
-    TableSummaryImpl {
-      Objects.requireNonNull(identifier, "Identifier of a table summary object cannot be null");
-      Objects.requireNonNull(tableType, "Table type of a table summary object cannot be null");
-    }
+  static FunctionDependency function(String functionFullName) {
+    return new FunctionDependency(functionFullName);
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DependencyList.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DependencyList.java
@@ -21,25 +21,26 @@ import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
 
+/**
+ * A list of dependencies for a SQL object such as a view or metric view.
+ * <p>
+ * <ul>
+ *   <li>When {@code null}, the dependency information is not provided.</li>
+ *   <li>When the array is empty, dependencies are provided but the object has none.</li>
+ *   <li>When the array is non-empty, each entry describes one dependency.</li>
+ * </ul>
+ *
+ * @param dependencies array of dependencies
+ * @since 4.2.0
+ */
 @Evolving
-public interface TableSummary {
-    String MANAGED_TABLE_TYPE = "MANAGED";
-    String EXTERNAL_TABLE_TYPE = "EXTERNAL";
-    String VIEW_TABLE_TYPE = "VIEW";
-    String FOREIGN_TABLE_TYPE = "FOREIGN";
-    String METRIC_VIEW_TABLE_TYPE = "METRIC_VIEW";
+public record DependencyList(Dependency[] dependencies) {
 
-    Identifier identifier();
-    String tableType();
+  public DependencyList {
+    Objects.requireNonNull(dependencies, "dependencies must not be null");
+  }
 
-    static TableSummary of(Identifier identifier, String tableType) {
-        return new TableSummaryImpl(identifier, tableType);
-    }
-}
-
-record TableSummaryImpl(Identifier identifier, String tableType) implements TableSummary {
-    TableSummaryImpl {
-      Objects.requireNonNull(identifier, "Identifier of a table summary object cannot be null");
-      Objects.requireNonNull(tableType, "Table type of a table summary object cannot be null");
-    }
+  public static DependencyList of(Dependency... dependencies) {
+    return new DependencyList(dependencies);
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/FunctionDependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/FunctionDependency.java
@@ -21,25 +21,18 @@ import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
 
+/**
+ * A function dependency of a SQL object.
+ * <p>
+ * The dependent function is identified by its fully-qualified three-part name
+ * in the form {@code catalog_name.schema_name.function_name}.
+ *
+ * @param functionFullName fully-qualified three-part function name
+ * @since 4.2.0
+ */
 @Evolving
-public interface TableSummary {
-    String MANAGED_TABLE_TYPE = "MANAGED";
-    String EXTERNAL_TABLE_TYPE = "EXTERNAL";
-    String VIEW_TABLE_TYPE = "VIEW";
-    String FOREIGN_TABLE_TYPE = "FOREIGN";
-    String METRIC_VIEW_TABLE_TYPE = "METRIC_VIEW";
-
-    Identifier identifier();
-    String tableType();
-
-    static TableSummary of(Identifier identifier, String tableType) {
-        return new TableSummaryImpl(identifier, tableType);
-    }
-}
-
-record TableSummaryImpl(Identifier identifier, String tableType) implements TableSummary {
-    TableSummaryImpl {
-      Objects.requireNonNull(identifier, "Identifier of a table summary object cannot be null");
-      Objects.requireNonNull(tableType, "Table type of a table summary object cannot be null");
-    }
+public record FunctionDependency(String functionFullName) implements Dependency {
+  public FunctionDependency {
+    Objects.requireNonNull(functionFullName, "functionFullName must not be null");
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableDependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableDependency.java
@@ -21,25 +21,18 @@ import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
 
+/**
+ * A table dependency of a SQL object.
+ * <p>
+ * The dependent table is identified by its fully-qualified three-part name
+ * in the form {@code catalog_name.schema_name.table_name}.
+ *
+ * @param tableFullName fully-qualified three-part table name
+ * @since 4.2.0
+ */
 @Evolving
-public interface TableSummary {
-    String MANAGED_TABLE_TYPE = "MANAGED";
-    String EXTERNAL_TABLE_TYPE = "EXTERNAL";
-    String VIEW_TABLE_TYPE = "VIEW";
-    String FOREIGN_TABLE_TYPE = "FOREIGN";
-    String METRIC_VIEW_TABLE_TYPE = "METRIC_VIEW";
-
-    Identifier identifier();
-    String tableType();
-
-    static TableSummary of(Identifier identifier, String tableType) {
-        return new TableSummaryImpl(identifier, tableType);
-    }
-}
-
-record TableSummaryImpl(Identifier identifier, String tableType) implements TableSummary {
-    TableSummaryImpl {
-      Objects.requireNonNull(identifier, "Identifier of a table summary object cannot be null");
-      Objects.requireNonNull(tableType, "Table type of a table summary object cannot be null");
-    }
+public record TableDependency(String tableFullName) implements Dependency {
+  public TableDependency {
+    Objects.requireNonNull(tableFullName, "tableFullName must not be null");
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableInfo.java
@@ -30,6 +30,9 @@ public class TableInfo {
   private final Map<String, String> properties;
   private final Transform[] partitions;
   private final Constraint[] constraints;
+  private final String tableType;
+  private final String viewDefinition;
+  private final DependencyList viewDependencies;
 
   /**
    * Constructor for TableInfo used by the builder.
@@ -40,6 +43,9 @@ public class TableInfo {
     this.properties = builder.properties;
     this.partitions = builder.partitions;
     this.constraints = builder.constraints;
+    this.tableType = builder.tableType;
+    this.viewDefinition = builder.viewDefinition;
+    this.viewDependencies = builder.viewDependencies;
   }
 
   public Column[] columns() {
@@ -60,11 +66,39 @@ public class TableInfo {
 
   public Constraint[] constraints() { return constraints; }
 
+  /**
+   * The table type (e.g. "MANAGED", "EXTERNAL", "VIEW", "METRIC_VIEW").
+   * May be null if the connector should infer the type from properties.
+   *
+   * @see TableSummary for table type constants
+   * @since 4.2.0
+   */
+  public String tableType() { return tableType; }
+
+  /**
+   * The view definition text. For metric views this is the YAML body;
+   * for regular views this would be the SQL text. May be null for non-view tables.
+   *
+   * @since 4.2.0
+   */
+  public String viewDefinition() { return viewDefinition; }
+
+  /**
+   * The list of dependencies for this view or metric view. May be null
+   * if dependency information is not provided.
+   *
+   * @since 4.2.0
+   */
+  public DependencyList viewDependencies() { return viewDependencies; }
+
   public static class Builder {
     private Column[] columns = new Column[0];
     private Map<String, String> properties = new HashMap<>();
     private Transform[] partitions = new Transform[0];
     private Constraint[] constraints = new Constraint[0];
+    private String tableType;
+    private String viewDefinition;
+    private DependencyList viewDependencies;
 
     public Builder withColumns(Column[] columns) {
       this.columns = columns;
@@ -83,6 +117,24 @@ public class TableInfo {
 
     public Builder withConstraints(Constraint[] constraints) {
       this.constraints = constraints;
+      return this;
+    }
+
+    /** @since 4.2.0 */
+    public Builder withTableType(String tableType) {
+      this.tableType = tableType;
+      return this;
+    }
+
+    /** @since 4.2.0 */
+    public Builder withViewDefinition(String viewDefinition) {
+      this.viewDefinition = viewDefinition;
+      return this;
+    }
+
+    /** @since 4.2.0 */
+    public Builder withViewDependencies(DependencyList viewDependencies) {
+      this.viewDependencies = viewDependencies;
       return this;
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extends the V2 catalog API surface to carry view-style metadata that the upcoming metric view V2-catalog support needs:

- New `Dependency` interface with two implementations, `TableDependency` and `FunctionDependency`, plus a `DependencyList` record. They model a SQL object's dependencies in a structured way.
- `TableInfo`: add three optional fields plumbed through the existing `TableInfo.Builder` API:
  - `tableType` (String) — e.g. "MANAGED", "EXTERNAL", "METRIC_VIEW".
  - `viewDefinition` (String) — the view body (YAML for metric views, SQL for views).
  - `viewDependencies` (`DependencyList`) — explicit list of source objects this view depends on.
- `TableSummary`: add the `METRIC_VIEW_TABLE_TYPE = "METRIC_VIEW"` constant alongside the existing `MANAGED_TABLE_TYPE` / `EXTERNAL_TABLE_TYPE` / `VIEW_TABLE_TYPE` / `FOREIGN_TABLE_TYPE`.
- `DelegatingCatalogExtension`: forward the `createTable(Identifier, TableInfo)` overload to the delegate so that catalogs wrapping a real `TableCatalog` (e.g. via Delta) propagate the new fields instead of silently dropping them.

### Why are the changes needed?

When CREATE VIEW WITH METRICS targets a non-session V2 catalog, the connector must be able to persist the YAML body and the list of source tables so that the metric view can be reloaded and re-analyzed later. This PR is the foundational API change; the behavior change (CREATE/DROP routing on V2 catalogs) lands in follow-up PRs.

### Does this PR introduce _any_ user-facing change?

No. The new fields on `TableInfo` are optional and default to null; existing connectors that ignore them continue to work unchanged. The `DelegatingCatalogExtension` change is a fix for the V2 API contract: the default `TableCatalog#createTable(Identifier, TableInfo)` in the base interface dropped these fields, so without this change catalogs that delegate (such as Delta wrapping another `TableCatalog`) would silently lose any caller-provided `tableType`/`viewDefinition`/ `viewDependencies`.

### How was this patch tested?

No new tests in this PR; the new API is exercised by the follow-up PRs (`MetricViewV2CatalogSuite`). Existing catalyst tests pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor (Claude)

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->
