### PR TITLE
[SPARK-54560] Safe type filtering in QueryPlan._subqueries to prevent ClassCastException in AQE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -527,7 +527,18 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
   def subqueries: Seq[PlanType] = _subqueries()
 
   private val _subqueries = new TransientBestEffortLazyVal(() => {
-    val planFamily = QueryPlan.planFamilyClass(getClass)
+    // Determine the plan family (the direct subclass of QueryPlan, e.g. LogicalPlan
+    // or SparkPlan) for this plan. In AQE, a SparkPlan can transiently hold
+    // PlanExpressions whose `.plan` is still a LogicalPlan (or vice-versa) because
+    // logical-to-physical planning runs separately for the main and sub-queries.
+    // Filtering by plan family prevents a `ClassCastException` on the cast below.
+    val planFamily: Class[_] = {
+      var c: Class[_] = getClass
+      while (c != null && c.getSuperclass != classOf[QueryPlan[_]]) {
+        c = c.getSuperclass
+      }
+      if (c != null) c else classOf[QueryPlan[_]]
+    }
     expressions.filter(_.containsPattern(PLAN_EXPRESSION)).flatMap(_.collect {
       case e: PlanExpression[_] if planFamily.isInstance(e.plan) =>
         e.plan.asInstanceOf[PlanType]
@@ -870,20 +881,5 @@ object QueryPlan extends PredicateHelper {
     case str: String if (str == null || str.isEmpty) => s"${fieldName}: None"
     case str: String => s"${fieldName}: ${str}"
     case _ => throw new IllegalArgumentException(s"Unsupported type for argument values: $values")
-  }
-
-  /**
-   * Returns the direct subclass of [[QueryPlan]] in the given class's hierarchy.
-   * Used to determine the "plan family" (e.g. LogicalPlan, SparkPlan) for safe type filtering.
-   */
-  def planFamilyClass(clazz: Class[_]): Class[_] = {
-    val base = classOf[QueryPlan[_]]
-    var current: Class[_] = clazz
-    while (current != null) {
-      val parent: Class[_] = current.getSuperclass
-      if (parent == base) return current
-      current = parent
-    }
-    base
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -526,11 +526,13 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    */
   def subqueries: Seq[PlanType] = _subqueries()
 
-  private val _subqueries = new TransientBestEffortLazyVal(() =>
+  private val _subqueries = new TransientBestEffortLazyVal(() => {
+    val planFamily = QueryPlan.planFamilyClass(getClass)
     expressions.filter(_.containsPattern(PLAN_EXPRESSION)).flatMap(_.collect {
-      case e: PlanExpression[_] => e.plan.asInstanceOf[PlanType]
+      case e: PlanExpression[_] if planFamily.isInstance(e.plan) =>
+        e.plan.asInstanceOf[PlanType]
     })
-  )
+  })
 
   /**
    * All the subqueries of the current plan node and all its children. Nested subqueries are also
@@ -868,5 +870,20 @@ object QueryPlan extends PredicateHelper {
     case str: String if (str == null || str.isEmpty) => s"${fieldName}: None"
     case str: String => s"${fieldName}: ${str}"
     case _ => throw new IllegalArgumentException(s"Unsupported type for argument values: $values")
+  }
+
+  /**
+   * Returns the direct subclass of [[QueryPlan]] in the given class's hierarchy.
+   * Used to determine the "plan family" (e.g. LogicalPlan, SparkPlan) for safe type filtering.
+   */
+  def planFamilyClass(clazz: Class[_]): Class[_] = {
+    val base = classOf[QueryPlan[_]]
+    var current: Class[_] = clazz
+    while (current != null) {
+      val parent: Class[_] = current.getSuperclass
+      if (parent == base) return current
+      current = parent
+    }
+    base
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/QueryPlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/QueryPlanSuite.scala
@@ -24,11 +24,11 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, ListQuery, Literal, NamedExpression, Rand}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, ExprId, ListQuery, Literal, NamedExpression, PlanExpression, Rand}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LocalRelation, LogicalPlan, Project, Union}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin, TreePattern}
-import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.types.{DataType, IntegerType}
 
 class QueryPlanSuite extends SparkFunSuite {
 
@@ -186,17 +186,78 @@ class QueryPlanSuite extends SparkFunSuite {
     assert(visited.forall(_.containsPattern(TreePattern.FILTER)))
   }
 
-  test("SPARK-54560: subqueries filters out plans of incompatible type") {
+  test("SPARK-54560: subqueries includes plans of the same plan family") {
     val a: NamedExpression = AttributeReference("a", IntegerType)()
     val innerPlan = Project(Seq(a), UnresolvedRelation(TableIdentifier("t", None)))
 
-    // Normal case: LogicalPlan with LogicalPlan subquery should still work.
-    val normalPlan = Filter(ListQuery(innerPlan), UnresolvedRelation(TableIdentifier("t", None)))
-    assert(normalPlan.subqueries.size == 1)
+    // Baseline: a LogicalPlan containing a ListQuery (whose `.plan` is a LogicalPlan)
+    // should expose the subquery in `subqueries`. This verifies the common path is
+    // unchanged by the SPARK-54560 fix.
+    val logicalOuter = Filter(ListQuery(innerPlan), UnresolvedRelation(TableIdentifier("t", None)))
+    assert(logicalOuter.subqueries.size === 1)
+    assert(logicalOuter.subqueries.head eq innerPlan)
+  }
 
-    // Test planFamilyClass utility returns the correct direct subclass of QueryPlan.
-    assert(QueryPlan.planFamilyClass(classOf[Project]) == classOf[LogicalPlan])
-    assert(QueryPlan.planFamilyClass(classOf[Filter]) == classOf[LogicalPlan])
-    assert(QueryPlan.planFamilyClass(classOf[LocalRelation]) == classOf[LogicalPlan])
+  test("SPARK-54560: subqueries excludes plans of an incompatible plan family") {
+    // This is the regression test for SPARK-54560. In AQE, a SparkPlan can
+    // transiently hold a PlanExpression whose `.plan` is still a LogicalPlan
+    // (or vice-versa) because logical-to-physical planning runs separately for
+    // the main and sub-queries. Before the fix, `_subqueries` blindly cast such
+    // plans to the enclosing plan's type, and the resulting unchecked generic
+    // Seq[PlanType] would cause a ClassCastException as soon as downstream code
+    // used a PlanType-specific method on the element.
+    //
+    // We simulate the cross-family scenario with a minimal alternative plan
+    // family (QueryPlanSuite.FakePhysicalPlan) holding a PlanExpression whose
+    // `.plan` is a LogicalPlan. With the fix, `subqueries` filters the
+    // incompatible plan out; without the fix, it would be included.
+
+    val a: NamedExpression = AttributeReference("a", IntegerType)()
+    val logicalChild: LogicalPlan =
+      Project(Seq(a), UnresolvedRelation(TableIdentifier("t", None)))
+
+    val fakePhysicalOuter = QueryPlanSuite.FakePhysicalPlan(
+      Seq(QueryPlanSuite.FakePlanExpr(logicalChild)))
+
+    assert(fakePhysicalOuter.subqueries.isEmpty,
+      "LogicalPlan subquery should be filtered out of FakePhysicalPlan.subqueries " +
+        "(regression for SPARK-54560)")
+  }
+}
+
+object QueryPlanSuite {
+  /**
+   * A minimal alternative plan family used only by the SPARK-54560 regression
+   * test. Distinct from [[LogicalPlan]] and [[SparkPlan]]. The `exprs` field is
+   * a product member so `QueryPlan.expressions` surfaces them automatically.
+   */
+  case class FakePhysicalPlan(exprs: Seq[Expression]) extends QueryPlan[FakePhysicalPlan] {
+    override def output: Seq[AttributeReference] = Nil
+    override def children: Seq[FakePhysicalPlan] = Nil
+    override protected def withNewChildrenInternal(
+        newChildren: IndexedSeq[FakePhysicalPlan]): FakePhysicalPlan = this
+  }
+
+  /**
+   * A minimal [[PlanExpression]] whose wrapped plan is a [[LogicalPlan]]. Used
+   * only by the SPARK-54560 regression test to construct a cross-family
+   * embedding. `eval` and `doGenCode` are not exercised by the test; they
+   * throw to make misuse loud.
+   */
+  case class FakePlanExpr(plan: LogicalPlan) extends PlanExpression[LogicalPlan] {
+    override def exprId: ExprId = ExprId(0)
+    override def dataType: DataType = IntegerType
+    override def nullable: Boolean = true
+    override def children: Seq[Expression] = Nil
+    override def withNewPlan(newPlan: LogicalPlan): FakePlanExpr = copy(plan = newPlan)
+    override protected def withNewChildrenInternal(
+        newChildren: IndexedSeq[Expression]): FakePlanExpr = this
+    override def eval(input: org.apache.spark.sql.catalyst.InternalRow): Any =
+      throw new UnsupportedOperationException("FakePlanExpr is test-only and not evaluable")
+    override protected def doGenCode(
+        ctx: org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext,
+        ev: org.apache.spark.sql.catalyst.expressions.codegen.ExprCode):
+      org.apache.spark.sql.catalyst.expressions.codegen.ExprCode =
+      throw new UnsupportedOperationException("FakePlanExpr is test-only and not codegen-able")
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/QueryPlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/QueryPlanSuite.scala
@@ -185,4 +185,18 @@ class QueryPlanSuite extends SparkFunSuite {
     assert(visited.size == 2)
     assert(visited.forall(_.containsPattern(TreePattern.FILTER)))
   }
+
+  test("SPARK-54560: subqueries filters out plans of incompatible type") {
+    val a: NamedExpression = AttributeReference("a", IntegerType)()
+    val innerPlan = Project(Seq(a), UnresolvedRelation(TableIdentifier("t", None)))
+
+    // Normal case: LogicalPlan with LogicalPlan subquery should still work.
+    val normalPlan = Filter(ListQuery(innerPlan), UnresolvedRelation(TableIdentifier("t", None)))
+    assert(normalPlan.subqueries.size == 1)
+
+    // Test planFamilyClass utility returns the correct direct subclass of QueryPlan.
+    assert(QueryPlan.planFamilyClass(classOf[Project]) == classOf[LogicalPlan])
+    assert(QueryPlan.planFamilyClass(classOf[Filter]) == classOf[LogicalPlan])
+    assert(QueryPlan.planFamilyClass(classOf[LocalRelation]) == classOf[LogicalPlan])
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace the unsafe `asInstanceOf[PlanType]` cast in `QueryPlan._subqueries` with safe runtime type filtering. The fix determines the "plan family" (the direct subclass of `QueryPlan`, e.g. `LogicalPlan` or `SparkPlan`) of the current plan node and only includes subquery plans that belong to the same family.

Changes:
- Added a guard condition `planFamily.isInstance(e.plan)` to the pattern match in `_subqueries`, so only type-compatible subquery plans are included.
- Added `QueryPlan.planFamilyClass` utility method that walks the class hierarchy to find the direct subclass of `QueryPlan` for a given class.

### Why are the changes needed?

`QueryPlan._subqueries` performs an unsafe `e.plan.asInstanceOf[PlanType]` cast without verifying the runtime type. In AQE, logical-to-physical planning happens separately for main and sub queries, and they can be out-of-sync at a specific point. This means a `SparkPlan` instance can invoke `subqueries` where some of its subquery plans are still `LogicalPlan`, causing a `ClassCastException` when the returned plans are later used as `SparkPlan`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Added a regression test in `QueryPlanSuite` that verifies:
  - Normal subquery extraction still works (LogicalPlan with LogicalPlan subquery)
  - `planFamilyClass` correctly identifies `LogicalPlan` as the plan family for `Project`, `Filter`, and `LocalRelation`
- All existing `QueryPlanSuite` tests pass.

### Was this patch authored or co-authored using generative AI tooling?

Yes