### PR TITLE
[SPARK-56562][PYTHON][TESTS] Add ASV microbenchmark for SQL_GROUPED_AGG_PANDAS_UDF

### DIFF
--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -680,6 +680,80 @@ class GroupedAggArrowIterUDFPeakmemBench(_GroupedAggArrowIterBenchMixin, _Peakme
     pass
 
 
+# -- SQL_GROUPED_AGG_PANDAS_UDF ------------------------------------------------
+# UDF receives ``pd.Series`` columns per group, returns scalar.
+
+
+class _GroupedAggPandasBenchMixin:
+    """Provides _write_scenario for SQL_GROUPED_AGG_PANDAS_UDF."""
+
+    def _grouped_agg_pandas_sum(col):
+        """Sum a single Pandas Series."""
+        return col.sum()
+
+    def _grouped_agg_pandas_mean_multi(col0, col1):
+        """Mean of two Pandas Series combined."""
+        return (col0.mean() or 0) + (col1.mean() or 0)
+
+    _scenario_configs = {
+        "few_groups_sm": (50, 5_000, 5),
+        "few_groups_lg": (50, 50_000, 5),
+        "many_groups_sm": (2_000, 500, 5),
+        "many_groups_lg": (500, 10_000, 5),
+        "wide_cols": (200, 5_000, 20),
+    }
+
+    @staticmethod
+    def _build_scenario(name):
+        """Build a single scenario by name."""
+        np.random.seed(42)
+        num_groups, rows_per_group, n_cols = _GroupedAggPandasBenchMixin._scenario_configs[name]
+        return MockDataFactory.make_grouped_batches(
+            num_groups=num_groups,
+            num_rows=rows_per_group,
+            num_cols=n_cols,
+            spark_type_pool=MockDataFactory.NUMERIC_TYPES,
+            batch_size=rows_per_group,
+        )
+
+    _udfs = {
+        "sum_udf": _grouped_agg_pandas_sum,
+        "mean_multi_udf": _grouped_agg_pandas_mean_multi,
+    }
+    params = [list(_scenario_configs), list(_udfs)]
+    param_names = ["scenario", "udf"]
+
+    def _write_scenario(self, scenario, udf_name, buf):
+        groups, _schema = self._build_scenario(scenario)
+        udf_func = self._udfs[udf_name]
+
+        # sum_udf uses 1 arg, mean_multi_udf uses 2 args
+        if "multi" in udf_name:
+            arg_offsets = [0, 1]
+        else:
+            arg_offsets = [0]
+
+        return_type = DoubleType()
+
+        def write_udf(b):
+            MockProtocolWriter.write_udf_payload(udf_func, return_type, arg_offsets, b)
+
+        MockProtocolWriter.write_worker_input(
+            PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
+            write_udf,
+            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, num_dfs=1, buf=b),
+            buf,
+        )
+
+
+class GroupedAggPandasUDFTimeBench(_GroupedAggPandasBenchMixin, _TimeBenchBase):
+    pass
+
+
+class GroupedAggPandasUDFPeakmemBench(_GroupedAggPandasBenchMixin, _PeakmemBenchBase):
+    pass
+
+
 # -- SQL_GROUPED_MAP_ARROW_UDF ------------------------------------------------
 # UDF receives ``pa.Table``, returns ``pa.Table``.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add ASV microbenchmarks for `SQL_GROUPED_AGG_PANDAS_UDF` in `bench_eval_type.py`.

### Why are the changes needed?

Part of [SPARK-55724](https://issues.apache.org/jira/browse/SPARK-55724) (Micro-benchmark PySpark Eval Types). Establishes a performance baseline for `SQL_GROUPED_AGG_PANDAS_UDF` before refactoring.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`COLUMNS=120 asv run --python=same --bench "GroupedAggPandas" --attribute "repeat=(3,5,10.0)"`:

**GroupedAggPandasUDFTimeBench** (`SQL_GROUPED_AGG_PANDAS_UDF`):
```
================ ============ ================
--                            udf
---------------- -----------------------------
    scenario       sum_udf     mean_multi_udf
================ ============ ================
 few_groups_sm    33.5±0.2ms     36.0±0.2ms
 few_groups_lg    52.9±0.3ms     59.9±2ms
 many_groups_sm   1.23±0.01s     1.32±0.01s
 many_groups_lg    350±3ms        379±1ms
   wide_cols       359±1ms       378±0.7ms
================ ============ ================
```

**GroupedAggPandasUDFPeakmemBench** (`SQL_GROUPED_AGG_PANDAS_UDF`):
```
================ ========= ================
--                          udf
---------------- --------------------------
    scenario      sum_udf   mean_multi_udf
================ ========= ================
 few_groups_sm     472M          470M
 few_groups_lg     535M          533M
 many_groups_sm    501M          499M
 many_groups_lg    606M          604M
   wide_cols       587M          585M
================ ========= ================
```

### Was this patch authored or co-authored using generative AI tooling?

No.