### PR TITLE
[SPARK-56564][SQL] Fix V2 write path to use CommitDeniedException for proper speculation handling

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources.v2
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.{SparkEnv, SparkException, TaskContext}
+import org.apache.spark.executor.CommitDeniedException
 import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.{InternalRow, ProjectingInternalRow}
@@ -587,11 +588,15 @@ trait WritingSparkTask[W <: DataWriter[InternalRow]] extends Logging with Serial
 
           dataWriter.commit()
         } else {
-          val commitDeniedException = QueryExecutionErrors.commitDeniedError(
-            partId, taskId, attemptId, stageId, stageAttempt)
-          logInfo(log"${MDC(LogKeys.ERROR, commitDeniedException.getMessage)}")
-          // throwing CommitDeniedException will trigger the catch block for abort
-          throw commitDeniedException
+          val message = s"Commit denied for partition $partId " +
+            s"(task $taskId, attempt $attemptId, stage $stageId.$stageAttempt)."
+          logInfo(log"${MDC(LogKeys.ERROR, message)}")
+          // Throw CommitDeniedException (not a plain SparkException) so that the executor
+          // recognizes this as a commit denial and reports TaskCommitDenied to the driver.
+          // TaskCommitDenied has countTowardsTaskFailures=false, which prevents speculative
+          // task attempts from being counted as real failures and aborting the stage.
+          // This matches the V1 write path behavior in SparkHadoopMapRedUtil.commitTask().
+          throw new CommitDeniedException(message, stageId, partId, attemptId)
         }
 
       } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the V2 DataSource write path (`WritingSparkTask`) to throw `CommitDeniedException` instead of a plain `SparkException` when the `OutputCommitCoordinator` denies a task's commit request.

### Why are the changes needed?

When speculation is enabled, the `OutputCommitCoordinator` authorizes one task attempt per partition and denies the rest. The V1 write path (`SparkHadoopMapRedUtil.commitTask()`) correctly throws `CommitDeniedException`, which the executor converts to `TaskCommitDenied` with `countTowardsTaskFailures=false`. However, the V2 write path uses `QueryExecutionErrors.commitDeniedError()` which returns a plain `SparkException`. The executor does not recognize this as a commit denial, so each denied speculative attempt counts as a real task failure. After `spark.task.maxFailures` (default 4) denials, the stage is incorrectly aborted.

**V1 path (SparkHadoopMapRedUtil.scala:79-85) — correct:**
```scala
if (canCommit) {
  performCommit()
} else {
  committer.abortTask(mrTaskContext)
  throw new CommitDeniedException(message, ctx.stageId(), splitId, ctx.attemptNumber())
  // → Executor catches CommitDeniedException (Executor.scala:777)
  // → Converts to TaskCommitDenied (countTowardsTaskFailures=false) ✓
}
```

**V2 path (WriteToDataSourceV2Exec.scala:590) — before this fix:**
```scala
if (commitAuthorized) {
  dataWriter.commit()
} else {
  throw QueryExecutionErrors.commitDeniedError(partId, taskId, attemptId, stageId, stageAttempt)
  // → Returns plain SparkException
  // → Executor generic Throwable handler (countTowardsTaskFailures=true) ✗
}
```

The executor handling in `Executor.scala:777`:
```scala
case CausedBy(cDE: CommitDeniedException) =>
  val reason = cDE.toTaskCommitDeniedReason  // → TaskCommitDenied
  execBackend.statusUpdate(taskId, TaskState.KILLED, ser.serialize(reason))
  // ↑ This path is never hit for V2 writes because they throw SparkException

case t: Throwable =>
  // ↑ V2 commit denials fall through here, counted as real failures
```

### Does this PR introduce _any_ user-facing change?

Yes. V2 DataSource write jobs with speculation enabled will no longer spuriously fail when speculative task attempts are denied commit by the `OutputCommitCoordinator`. Previously, each commit denial was counted as a task failure, causing stages to abort after `spark.task.maxFailures` denials.

### How was this patch tested?

Existing tests. The `OutputCommitCoordinator`, `TaskSetManager`, and `CommitDeniedException` handling are already well-tested — this fix simply ensures the V2 write path uses the correct exception type that these components already expect.

### Was this patch authored or co-authored using generative AI tooling?

Yes, co-authored with Claude Code.

Closes #55469