### PR TITLE
[SPARK-56032][SQL][FOLLOWUP] Emit FilterExec CSE precomputes per-predicate to preserve short-circuit

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -254,41 +254,76 @@ case class FilterExec(condition: Expression, child: SparkPlan)
   override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
     val numOutput = metricTerm(ctx, "numOutputRows")
 
-    // Apply CSE to otherPreds only (notNullPreds are simple IsNotNull checks with no CSE value).
-    val (inputVarsCode, subExprsCode, predicateCode) =
+    // Apply CSE to otherPreds. Two invariants we must preserve:
+    //   (a) Short-circuit order: otherPreds are evaluated sequentially and each may
+    //       `continue;` out of the row. A precomputation hoisted ahead of an earlier
+    //       otherPred would run for rows that predicate would have filtered out,
+    //       turning a filtered-out row into a thrown exception for any expression that
+    //       can throw (overflow, error class, etc.). SPARK-56032's original placement of
+    //       subExprsCode at the top of the `do { }` block broke this.
+    //   (b) Null guards: IsNotNull predicates must short-circuit before CSE
+    //       precomputation sees a null-bearing row. Otherwise CSE's
+    //       `value_X = isNull ? default : <compute>` materializes `null` into `value_X`
+    //       for non-primitive types, which downstream accessors (e.g.
+    //       `value_X.isNullAt(0)`) may NPE on without consulting `isNull_X`.
+    //
+    // The fix for (a): emit each common subexpression's precompute *just before* the
+    // first otherPred that references it, not all at the top of the `do { }` block.
+    // A later otherPred still reuses the cached value -- it just doesn't pay the cost
+    // for rows that an earlier otherPred rejected.
+    //
+    // The fix for (b): emit all IsNotNull short-circuits upfront and bind otherPreds
+    // (and the CSE analysis) against the tightened `output`. `notNullAttributes` are
+    // guaranteed non-null by the time any otherPred (or any CSE precompute) runs, so
+    // the tightened-nullability optimization inside the predicate bodies is restored.
+    // This also supersedes the child.output binding workaround from SPARK-56431.
+    val (prologueCode, predicateCode) =
       if (conf.subexpressionEliminationEnabled && otherPreds.nonEmpty) {
-        // Bind against child.output (not output) so that columns in
-        // notNullAttributes keep their original nullable=true for the
-        // CSE precomputation, which runs BEFORE IsNotNull short-circuits.
-        val boundOtherPreds = otherPreds.map(
-          BindReferences.bindReference(_, child.output))
+        val notNullShortCircuitCode = generatePredicateCode(
+          ctx, child.output, input, output, notNullPreds, Seq.empty, notNullAttributes)
+
         // Pre-evaluate input variables before CSE analysis: CSE clears
-        // ctx.currentVars[i].code as a side effect; without this pre-evaluation, Janino fails
-        // with "Unknown variable or type" when notNullPreds reference the same input columns.
+        // ctx.currentVars[i].code as a side effect; without this pre-evaluation, Janino
+        // fails when otherPreds reference the same input columns that CSE already
+        // consumed.
         val otherPredInputAttrs = AttributeSet(otherPreds.flatMap(_.references))
         val inputVarsEvalCode = evaluateRequiredVariables(
           child.output, input, otherPredInputAttrs)
 
+        val boundOtherPreds = otherPreds.map(BindReferences.bindReference(_, output))
         val subExprs = ctx.subexpressionEliminationForWholeStageCodegen(boundOtherPreds)
+
+        // Group CSE states by the index of the first otherPred that references them.
+        // `evaluateSubExprEliminationState` recursively emits each state's children
+        // before the state itself and marks emitted code as `EmptyBlock`, so emitting
+        // a later group whose states depend on an earlier group's states is a no-op
+        // for the already-emitted dependencies.
+        val statesByFirstUse: Map[Int, Seq[SubExprEliminationState]] =
+          subExprs.states.toSeq.groupBy { case (exprEq, _) =>
+            boundOtherPreds.indexWhere(_.exists(e => ExpressionEquals(e) == exprEq))
+          }.map { case (idx, kvs) => idx -> kvs.map(_._2) }
+
         val predCode: String = {
-          var code = ""
+          val parts = new StringBuilder
           ctx.withSubExprEliminationExprs(subExprs.states) {
-            code = generatePredicateCode(
-              ctx, child.output, input, child.output, notNullPreds, otherPreds, notNullAttributes)
+            boundOtherPreds.zipWithIndex.foreach { case (bound, idx) =>
+              statesByFirstUse.get(idx).foreach { states =>
+                parts.append(ctx.evaluateSubExprEliminationState(states))
+                parts.append('\n')
+              }
+              val ev = ExpressionCanonicalizer.execute(bound).genCode(ctx)
+              val nullCheck = if (bound.nullable) s"${ev.isNull} || " else ""
+              parts.append(ev.code.toString)
+              parts.append(s"\nif (${nullCheck}!${ev.value}) continue;\n")
+            }
             Seq.empty
           }
-          code
+          parts.toString
         }
-        // Note: subExprs.exprCodesNeedEvaluate is intentionally not used here, unlike ProjectExec.
-        // evaluateRequiredVariables above cleared input[i].code = EmptyBlock for all
-        // otherPredInputAttrs before CSE analysis ran, so getLocalInputVariableValues never
-        // adds them to exprCodesNeedEvaluate -- it is always empty. Do NOT replace the
-        // pre-evaluation above with evaluateVariables(subExprs.exprCodesNeedEvaluate):
-        // that would leave notNullPreds referencing undeclared variables (Janino: "Unknown
-        // variable or type") for any input column shared between notNullPreds and otherPreds.
-        (inputVarsEvalCode, ctx.evaluateSubExprEliminationState(subExprs.states.values), predCode)
+
+        (notNullShortCircuitCode + "\n" + inputVarsEvalCode, predCode)
       } else {
-        ("", "", generatePredicateCode(
+        ("", generatePredicateCode(
           ctx, child.output, input, output, notNullPreds, otherPreds, notNullAttributes))
       }
 
@@ -304,8 +339,7 @@ case class FilterExec(condition: Expression, child: SparkPlan)
     // Note: wrap in "do { } while (false);", so the generated checks can jump out with "continue;"
     s"""
        |do {
-       |  $inputVarsCode
-       |  $subExprsCode
+       |  $prologueCode
        |  $predicateCode
        |  $numOutput.add(1);
        |  ${consume(ctx, resultVars)}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -257,7 +257,7 @@ case class FilterExec(condition: Expression, child: SparkPlan)
     // Apply CSE to otherPreds. Two invariants we must preserve:
     //   (a) Short-circuit order: otherPreds are evaluated sequentially and each may
     //       `continue;` out of the row. A precomputation hoisted ahead of an earlier
-    //       otherPred would run for rows that predicate would have filtered out,
+    //       otherPred would run for rows an earlier otherPred would have filtered out,
     //       turning a filtered-out row into a thrown exception for any expression that
     //       can throw (overflow, error class, etc.). SPARK-56032's original placement of
     //       subExprsCode at the top of the `do { }` block broke this.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -1057,4 +1057,31 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       checkAnswer(filtered, Seq(Row(2), Row(4)))
     }
   }
+
+  test("SPARK-56032: FilterExec CSE is placed at the first otherPred that references it") {
+    // Three separate conjuncts:
+    //   - x > 0: cheap guard, rejects x=0.
+    //   - (100 / x) > 0:  first user of `100 / x`.
+    //   - (100 / x) < 1000: second user of `100 / x`.
+    // `100 / x` is CSE'd across the two later conjuncts. The precompute must be emitted
+    // just before the first user (otherPreds(1)), NOT at the top of the do { } block --
+    // otherwise x=0 evaluates 100 / 0 under ANSI and throws before x > 0 rejects.
+    val schema = StructType(Seq(
+      StructField("x", IntegerType, nullable = false)))
+    val data = spark.sparkContext.parallelize(Seq(
+      Row(0), Row(2), Row(4)))
+
+    withSQLConf(
+      SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "true",
+      SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.ANSI_ENABLED.key -> "true") {
+      val df = spark.createDataFrame(data, schema)
+      val filtered = df.where("x > 0 AND (100 / x) > 0 AND (100 / x) < 1000")
+      val plan = filtered.queryExecution.executedPlan
+      assert(plan.exists(_.isInstanceOf[WholeStageCodegenExec]),
+        "Filter should be in whole-stage codegen")
+      checkAnswer(filtered, Seq(Row(2), Row(4)))
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -1029,4 +1029,32 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
         Row(new JBigDecimal("80.00"), new JBigDecimal("100.00"))))
     }
   }
+
+  test("SPARK-56032: FilterExec CSE preserves short-circuit across predicates") {
+    // CSE'd subexpressions in a *later* otherPred must not be hoisted above an *earlier*
+    // otherPred's short-circuit, otherwise rows the earlier predicate would have rejected
+    // still pay the cost of the later predicate's throw-prone expression.
+    val schema = StructType(Seq(
+      StructField("x", IntegerType, nullable = false)))
+    val data = spark.sparkContext.parallelize(Seq(
+      Row(0), Row(2), Row(4)))
+
+    withSQLConf(
+      SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "true",
+      SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.ANSI_ENABLED.key -> "true") {
+      val df = spark.createDataFrame(data, schema)
+      // Two otherPreds:
+      //   - x > 0: cheap, rejects the x=0 row.
+      //   - ((100 / x) > 0 OR (100 / x) < 1000): references `100 / x` twice, which CSE
+      //     will pull out. If the precompute is hoisted to the top of the do { } block,
+      //     it runs 100/0 on the x=0 row under ANSI and throws before x > 0 rejects.
+      val filtered = df.where("x > 0 AND ((100 / x) > 0 OR (100 / x) < 1000)")
+      val plan = filtered.queryExecution.executedPlan
+      assert(plan.exists(_.isInstanceOf[WholeStageCodegenExec]),
+        "Filter should be in whole-stage codegen")
+      checkAnswer(filtered, Seq(Row(2), Row(4)))
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -1031,9 +1031,16 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
   }
 
   test("SPARK-56032: FilterExec CSE preserves short-circuit across predicates") {
-    // CSE'd subexpressions in a *later* otherPred must not be hoisted above an *earlier*
-    // otherPred's short-circuit, otherwise rows the earlier predicate would have rejected
-    // still pay the cost of the later predicate's throw-prone expression.
+    // A CSE'd subexpression must not be hoisted above an earlier otherPred's short-circuit,
+    // otherwise rows an earlier otherPred would have rejected still pay the cost of the
+    // later predicate's throw-prone expression. Two shapes worth exercising:
+    //   - CSE within one conjunct: `x > 0 AND ((100 / x) > 0 OR (100 / x) < 1000)` --
+    //     `100 / x` appears twice inside otherPreds(1) only.
+    //   - CSE across two conjuncts: `x > 0 AND (100 / x) > 0 AND (100 / x) < 1000` --
+    //     `100 / x` is shared between otherPreds(1) and otherPreds(2); the precompute
+    //     must be emitted just before otherPreds(1), not at the top of the do { } block.
+    // In both shapes, hoisting to the top of the do { } block evaluates 100 / 0 on the
+    // x=0 row under ANSI and throws before x > 0 rejects.
     val schema = StructType(Seq(
       StructField("x", IntegerType, nullable = false)))
     val data = spark.sparkContext.parallelize(Seq(
@@ -1045,43 +1052,16 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
       SQLConf.ANSI_ENABLED.key -> "true") {
       val df = spark.createDataFrame(data, schema)
-      // Two otherPreds:
-      //   - x > 0: cheap, rejects the x=0 row.
-      //   - ((100 / x) > 0 OR (100 / x) < 1000): references `100 / x` twice, which CSE
-      //     will pull out. If the precompute is hoisted to the top of the do { } block,
-      //     it runs 100/0 on the x=0 row under ANSI and throws before x > 0 rejects.
-      val filtered = df.where("x > 0 AND ((100 / x) > 0 OR (100 / x) < 1000)")
-      val plan = filtered.queryExecution.executedPlan
-      assert(plan.exists(_.isInstanceOf[WholeStageCodegenExec]),
-        "Filter should be in whole-stage codegen")
-      checkAnswer(filtered, Seq(Row(2), Row(4)))
-    }
-  }
-
-  test("SPARK-56032: FilterExec CSE is placed at the first otherPred that references it") {
-    // Three separate conjuncts:
-    //   - x > 0: cheap guard, rejects x=0.
-    //   - (100 / x) > 0:  first user of `100 / x`.
-    //   - (100 / x) < 1000: second user of `100 / x`.
-    // `100 / x` is CSE'd across the two later conjuncts. The precompute must be emitted
-    // just before the first user (otherPreds(1)), NOT at the top of the do { } block --
-    // otherwise x=0 evaluates 100 / 0 under ANSI and throws before x > 0 rejects.
-    val schema = StructType(Seq(
-      StructField("x", IntegerType, nullable = false)))
-    val data = spark.sparkContext.parallelize(Seq(
-      Row(0), Row(2), Row(4)))
-
-    withSQLConf(
-      SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "true",
-      SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
-      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
-      SQLConf.ANSI_ENABLED.key -> "true") {
-      val df = spark.createDataFrame(data, schema)
-      val filtered = df.where("x > 0 AND (100 / x) > 0 AND (100 / x) < 1000")
-      val plan = filtered.queryExecution.executedPlan
-      assert(plan.exists(_.isInstanceOf[WholeStageCodegenExec]),
-        "Filter should be in whole-stage codegen")
-      checkAnswer(filtered, Seq(Row(2), Row(4)))
+      Seq(
+        "x > 0 AND ((100 / x) > 0 OR (100 / x) < 1000)",
+        "x > 0 AND (100 / x) > 0 AND (100 / x) < 1000"
+      ).foreach { predicate =>
+        val filtered = df.where(predicate)
+        val plan = filtered.queryExecution.executedPlan
+        assert(plan.exists(_.isInstanceOf[WholeStageCodegenExec]),
+          s"Filter should be in whole-stage codegen for: $predicate")
+        checkAnswer(filtered, Seq(Row(2), Row(4)))
+      }
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`FilterExec.doConsume` (after SPARK-56032 + SPARK-56431) emits all CSE precomputation at the top of the `do { } while (false);` block, before any `otherPred` runs. If a common subexpression is used only by a later `otherPred`, it is still hoisted ahead of every earlier predicate's `continue;` short-circuit. For expressions that throw on invalid input, that turns rows an earlier predicate would have rejected into thrown exceptions.

This PR moves each common subexpression's precompute to just before the first `otherPred` that references it. Later `otherPred`s still reuse the cached value; earlier `otherPred`s pay no cost for subexpressions they do not use. `evaluateSubExprEliminationState` already emits each state's children recursively and marks emitted code as `EmptyBlock`, so cross-group dependencies (a state in group `i` whose child lives in group `j < i`) fold into the earlier emission and later emissions of the already-emitted child are no-ops.

With the reorder, binding `otherPreds` against the tightened `output` is again safe: all `IsNotNull` short-circuits are emitted upfront, so `notNullAttributes` columns are guaranteed non-null by the time any `otherPred` (or any CSE precompute) runs. This supersedes the SPARK-56431 `child.output` binding workaround.

### Why are the changes needed?

Regression in throw-prone predicates. For example:

```sql
SELECT COUNT(*) FROM t
WHERE x > 0 AND ((100 / x) > 0 OR (100 / x) < 1000)
```

Under ANSI, `100 / 0` throws `DIVIDE_BY_ZERO`. Pre-fix, the hoisted CSE precompute of `100 / x` runs for every row before `x > 0` has a chance to reject `x = 0`, so the query throws instead of returning a count. Other CSE'd throw-prone expressions (`to_utc_timestamp` on extreme timestamps, datetime overflow in ANSI mode, geospatial functions on the wrong geometry type in downstream consumers, etc.) hit the same pattern.

Other operators with CSE (`ProjectExec`, `HashAggregateExec`, `AggregateCodegenSupport`) are unaffected because none of them short-circuit between expressions with `continue;` — every input row flows through every expression, so hoisting is semantically transparent.

### Does this PR introduce _any_ user-facing change?

No. The generated code is functionally equivalent to the non-CSE path: no row has any predicate evaluated that a prior `continue;` would have skipped.

### How was this patch tested?

- Existing `WholeStageCodegenSuite` "SPARK-56032: subexpression elimination in FilterExec codegen" (CSE savings on `a + b`): passes.
- Existing `WholeStageCodegenSuite` "SPARK-56431: CSE in FilterExec preserves null guards for notNull columns" (`Decimal` NPE repro): passes.
- New `WholeStageCodegenSuite` "SPARK-56032: FilterExec CSE preserves short-circuit across predicates": uses `x > 0 AND ((100 / x) > 0 OR (100 / x) < 1000)` under ANSI; passes with this fix, fails on master without it.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7