### PR TITLE
[SPARK-56563][SQL][TESTS] Merge SparkPlanTest into QueryTest/QueryTestBase

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -36,13 +36,13 @@ import org.scalatest.concurrent.Eventually
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.ExtendedAnalysisException
 import org.apache.spark.sql.catalyst.FunctionIdentifier
-import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog.DEFAULT_DATABASE
 import org.apache.spark.sql.catalyst.plans._
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.classic.ClassicConversions._
-import org.apache.spark.sql.execution.{FilterExec, QueryExecution, SQLExecution}
+import org.apache.spark.sql.execution.{FilterExec, QueryExecution, SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecution
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.execution.datasources.DataSourceUtils
@@ -535,6 +535,95 @@ trait QueryTestBase
       .map(_.toFile.length).sum
   }
 
+  /**
+   * Runs the plan and makes sure the answer matches the expected result.
+   * @param input the input data to be used.
+   * @param planFunction a function which accepts the input SparkPlan and uses it to instantiate
+   *                     the physical operator that's being tested.
+   * @param expectedAnswer the expected result in a [[Seq]] of [[Row]]s.
+   * @param sortAnswers if true, the answers will be sorted by their toString representations prior
+   *                    to being compared.
+   */
+  protected def checkAnswer(
+      input: DataFrame,
+      planFunction: SparkPlan => SparkPlan,
+      expectedAnswer: Seq[Row],
+      sortAnswers: Boolean = true): Unit = {
+    doCheckAnswer(
+      input :: Nil,
+      (plans: Seq[SparkPlan]) => planFunction(plans.head),
+      expectedAnswer,
+      sortAnswers)
+  }
+
+  /**
+   * Runs the plan and makes sure the answer matches the expected result.
+   * @param left the left input data to be used.
+   * @param right the right input data to be used.
+   * @param planFunction a function which accepts the input SparkPlan and uses it to instantiate
+   *                     the physical operator that's being tested.
+   * @param expectedAnswer the expected result in a [[Seq]] of [[Row]]s.
+   * @param sortAnswers if true, the answers will be sorted by their toString representations prior
+   *                    to being compared.
+   */
+  protected def checkAnswer2(
+      left: DataFrame,
+      right: DataFrame,
+      planFunction: (SparkPlan, SparkPlan) => SparkPlan,
+      expectedAnswer: Seq[Row],
+      sortAnswers: Boolean = true): Unit = {
+    doCheckAnswer(
+      left :: right :: Nil,
+      (plans: Seq[SparkPlan]) => planFunction(plans(0), plans(1)),
+      expectedAnswer,
+      sortAnswers)
+  }
+
+  /**
+   * Runs the plan and makes sure the answer matches the expected result.
+   * @param input the input data to be used.
+   * @param planFunction a function which accepts a sequence of input SparkPlans and uses them to
+   *                     instantiate the physical operator that's being tested.
+   * @param expectedAnswer the expected result in a [[Seq]] of [[Row]]s.
+   * @param sortAnswers if true, the answers will be sorted by their toString representations prior
+   *                    to being compared.
+   */
+  protected def doCheckAnswer(
+      input: Seq[DataFrame],
+      planFunction: Seq[SparkPlan] => SparkPlan,
+      expectedAnswer: Seq[Row],
+      sortAnswers: Boolean = true): Unit = {
+    QueryTest
+      .checkAnswer(input, planFunction, expectedAnswer, sortAnswers, spark.sqlContext) match {
+        case Some(errorMessage) => fail(errorMessage)
+        case None =>
+    }
+  }
+
+  /**
+   * Runs the plan and makes sure the answer matches the result produced by a reference plan.
+   * @param input the input data to be used.
+   * @param planFunction a function which accepts the input SparkPlan and uses it to instantiate
+   *                     the physical operator that's being tested.
+   * @param expectedPlanFunction a function which accepts the input SparkPlan and uses it to
+   *                             instantiate a reference implementation of the physical operator
+   *                             that's being tested. The result of executing this plan will be
+   *                             treated as the source-of-truth for the test.
+   * @param sortAnswers if true, the answers will be sorted by their toString representations prior
+   *                    to being compared.
+   */
+  protected def checkThatPlansAgree(
+      input: DataFrame,
+      planFunction: SparkPlan => SparkPlan,
+      expectedPlanFunction: SparkPlan => SparkPlan,
+      sortAnswers: Boolean = true): Unit = {
+    QueryTest.checkAnswer(
+        input, planFunction, expectedPlanFunction, sortAnswers, spark.sqlContext) match {
+      case Some(errorMessage) => fail(errorMessage)
+      case None =>
+    }
+  }
+
 }
 
 /**
@@ -972,6 +1061,130 @@ object QueryTest extends Assertions {
     }
 
     capturedQueryExecutions
+  }
+
+  /**
+   * Runs the plan and makes sure the answer matches the result produced by a reference plan.
+   * @param input the input data to be used.
+   * @param planFunction a function which accepts the input SparkPlan and uses it to instantiate
+   *                     the physical operator that's being tested.
+   * @param expectedPlanFunction a function which accepts the input SparkPlan and uses it to
+   *                             instantiate a reference implementation of the physical operator
+   *                             that's being tested. The result of executing this plan will be
+   *                             treated as the source-of-truth for the test.
+   */
+  def checkAnswer(
+      input: DataFrame,
+      planFunction: SparkPlan => SparkPlan,
+      expectedPlanFunction: SparkPlan => SparkPlan,
+      sortAnswers: Boolean,
+      spark: SQLContext): Option[String] = {
+
+    val outputPlan = planFunction(input.queryExecution.sparkPlan)
+    val expectedOutputPlan = expectedPlanFunction(input.queryExecution.sparkPlan)
+
+    val expectedAnswer: Seq[Row] = try {
+      executePlan(expectedOutputPlan, spark)
+    } catch {
+      case NonFatal(e) =>
+        val errorMessage =
+          s"""
+             | Exception thrown while executing Spark plan to calculate expected answer:
+             | $expectedOutputPlan
+             | == Exception ==
+             | $e
+             | ${org.apache.spark.sql.catalyst.util.stackTraceToString(e)}
+          """.stripMargin
+        return Some(errorMessage)
+    }
+
+    val actualAnswer: Seq[Row] = try {
+      executePlan(outputPlan, spark)
+    } catch {
+      case NonFatal(e) =>
+        val errorMessage =
+          s"""
+             | Exception thrown while executing Spark plan:
+             | $outputPlan
+             | == Exception ==
+             | $e
+             | ${org.apache.spark.sql.catalyst.util.stackTraceToString(e)}
+          """.stripMargin
+        return Some(errorMessage)
+    }
+
+    compareAnswers(actualAnswer, expectedAnswer, sortAnswers).map { errorMessage =>
+      s"""
+         | Results do not match.
+         | Actual result Spark plan:
+         | $outputPlan
+         | Expected result Spark plan:
+         | $expectedOutputPlan
+         | $errorMessage
+       """.stripMargin
+    }
+  }
+
+  /**
+   * Runs the plan and makes sure the answer matches the expected result.
+   * @param input the input data to be used.
+   * @param planFunction a function which accepts the input SparkPlan and uses it to instantiate
+   *                     the physical operator that's being tested.
+   * @param expectedAnswer the expected result in a [[Seq]] of [[Row]]s.
+   * @param sortAnswers if true, the answers will be sorted by their toString representations prior
+   *                    to being compared.
+   */
+  def checkAnswer(
+      input: Seq[DataFrame],
+      planFunction: Seq[SparkPlan] => SparkPlan,
+      expectedAnswer: Seq[Row],
+      sortAnswers: Boolean,
+      spark: SQLContext): Option[String] = {
+
+    val outputPlan = planFunction(input.map(_.queryExecution.sparkPlan))
+
+    val sparkAnswer: Seq[Row] = try {
+      executePlan(outputPlan, spark)
+    } catch {
+      case NonFatal(e) =>
+        val errorMessage =
+          s"""
+             | Exception thrown while executing Spark plan:
+             | $outputPlan
+             | == Exception ==
+             | $e
+             | ${org.apache.spark.sql.catalyst.util.stackTraceToString(e)}
+          """.stripMargin
+        return Some(errorMessage)
+    }
+
+    compareAnswers(sparkAnswer, expectedAnswer, sortAnswers).map { errorMessage =>
+      s"""
+         | Results do not match for Spark plan:
+         | $outputPlan
+         | $errorMessage
+       """.stripMargin
+    }
+  }
+
+  /**
+   * Runs the plan
+   * @param outputPlan SparkPlan to be executed
+   * @param spark SqlContext used for execution of the plan
+   */
+  def executePlan(outputPlan: SparkPlan, spark: SQLContext): Seq[Row] = {
+    val execution = new QueryExecution(spark.sparkSession, LocalRelation(Nil)) {
+      override lazy val sparkPlan: SparkPlan = outputPlan transform {
+        case plan: SparkPlan =>
+          val inputMap = plan.children.flatMap(_.output).map(a => (a.name, a)).toMap
+          plan transformExpressions {
+            case UnresolvedAttribute(Seq(u)) =>
+              inputMap.getOrElse(u,
+                sys.error(s"Invalid Test: Cannot resolve $u given input $inputMap"))
+          }
+      }
+    }
+    execution.executedPlan.executeCollectPublic().toSeq
   }
 
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanTest.scala
@@ -17,237 +17,46 @@
 
 package org.apache.spark.sql.execution
 
-import scala.util.control.NonFatal
-
-import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.{DataFrame, QueryTest, Row, SparkSessionProvider, SQLContext}
-import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
-import org.apache.spark.sql.classic.ClassicConversions._
+import org.apache.spark.sql.{DataFrame, QueryTest, Row, SQLContext}
 
 /**
- * Base class for writing tests for individual physical operators. For an example of how this
- * class's test helper methods can be used, see [[SortSuite]].
+ * Kept as an empty alias of [[QueryTest]] for backward compatibility with existing subclasses.
+ * New test suites should extend [[QueryTest]] directly.
  */
-private[sql] abstract class SparkPlanTest extends SparkFunSuite with SparkSessionProvider {
+@deprecated("Use QueryTest directly instead.", "4.2.0")
+private[sql] trait SparkPlanTest extends QueryTest
+
+@deprecated("Use QueryTest directly instead.", "4.2.0")
+private[sql] object SparkPlanTest {
 
   /**
-   * Runs the plan and makes sure the answer matches the expected result.
-   * @param input the input data to be used.
-   * @param planFunction a function which accepts the input SparkPlan and uses it to instantiate
-   *                     the physical operator that's being tested.
-   * @param expectedAnswer the expected result in a [[Seq]] of [[Row]]s.
-   * @param sortAnswers if true, the answers will be sorted by their toString representations prior
-   *                    to being compared.
-   */
-  protected def checkAnswer(
-      input: DataFrame,
-      planFunction: SparkPlan => SparkPlan,
-      expectedAnswer: Seq[Row],
-      sortAnswers: Boolean = true): Unit = {
-    doCheckAnswer(
-      input :: Nil,
-      (plans: Seq[SparkPlan]) => planFunction(plans.head),
-      expectedAnswer,
-      sortAnswers)
-  }
-
-  /**
-   * Runs the plan and makes sure the answer matches the expected result.
-   * @param left the left input data to be used.
-   * @param right the right input data to be used.
-   * @param planFunction a function which accepts the input SparkPlan and uses it to instantiate
-   *                     the physical operator that's being tested.
-   * @param expectedAnswer the expected result in a [[Seq]] of [[Row]]s.
-   * @param sortAnswers if true, the answers will be sorted by their toString representations prior
-   *                    to being compared.
-   */
-  protected def checkAnswer2(
-      left: DataFrame,
-      right: DataFrame,
-      planFunction: (SparkPlan, SparkPlan) => SparkPlan,
-      expectedAnswer: Seq[Row],
-      sortAnswers: Boolean = true): Unit = {
-    doCheckAnswer(
-      left :: right :: Nil,
-      (plans: Seq[SparkPlan]) => planFunction(plans(0), plans(1)),
-      expectedAnswer,
-      sortAnswers)
-  }
-
-  /**
-   * Runs the plan and makes sure the answer matches the expected result.
-   * @param input the input data to be used.
-   * @param planFunction a function which accepts a sequence of input SparkPlans and uses them to
-   *                     instantiate the physical operator that's being tested.
-   * @param expectedAnswer the expected result in a [[Seq]] of [[Row]]s.
-   * @param sortAnswers if true, the answers will be sorted by their toString representations prior
-   *                    to being compared.
-   */
-  protected def doCheckAnswer(
-      input: Seq[DataFrame],
-      planFunction: Seq[SparkPlan] => SparkPlan,
-      expectedAnswer: Seq[Row],
-      sortAnswers: Boolean = true): Unit = {
-    SparkPlanTest
-      .checkAnswer(input, planFunction, expectedAnswer, sortAnswers, spark.sqlContext) match {
-        case Some(errorMessage) => fail(errorMessage)
-        case None =>
-    }
-  }
-
-  /**
-   * Runs the plan and makes sure the answer matches the result produced by a reference plan.
-   * @param input the input data to be used.
-   * @param planFunction a function which accepts the input SparkPlan and uses it to instantiate
-   *                     the physical operator that's being tested.
-   * @param expectedPlanFunction a function which accepts the input SparkPlan and uses it to
-   *                             instantiate a reference implementation of the physical operator
-   *                             that's being tested. The result of executing this plan will be
-   *                             treated as the source-of-truth for the test.
-   * @param sortAnswers if true, the answers will be sorted by their toString representations prior
-   *                    to being compared.
-   */
-  protected def checkThatPlansAgree(
-      input: DataFrame,
-      planFunction: SparkPlan => SparkPlan,
-      expectedPlanFunction: SparkPlan => SparkPlan,
-      sortAnswers: Boolean = true): Unit = {
-    SparkPlanTest.checkAnswer(
-        input, planFunction, expectedPlanFunction, sortAnswers, spark.sqlContext) match {
-      case Some(errorMessage) => fail(errorMessage)
-      case None =>
-    }
-  }
-}
-
-/**
- * Helper methods for writing tests of individual physical operators.
- */
-object SparkPlanTest {
-
-  /**
-   * Runs the plan and makes sure the answer matches the result produced by a reference plan.
-   * @param input the input data to be used.
-   * @param planFunction a function which accepts the input SparkPlan and uses it to instantiate
-   *                     the physical operator that's being tested.
-   * @param expectedPlanFunction a function which accepts the input SparkPlan and uses it to
-   *                             instantiate a reference implementation of the physical operator
-   *                             that's being tested. The result of executing this plan will be
-   *                             treated as the source-of-truth for the test.
+   * Kept as a thin alias of [[QueryTest.checkAnswer]] for backward compatibility.
+   * New callers should use [[QueryTest.checkAnswer]] directly.
    */
   def checkAnswer(
       input: DataFrame,
       planFunction: SparkPlan => SparkPlan,
       expectedPlanFunction: SparkPlan => SparkPlan,
       sortAnswers: Boolean,
-      spark: SQLContext): Option[String] = {
-
-    val outputPlan = planFunction(input.queryExecution.sparkPlan)
-    val expectedOutputPlan = expectedPlanFunction(input.queryExecution.sparkPlan)
-
-    val expectedAnswer: Seq[Row] = try {
-      executePlan(expectedOutputPlan, spark)
-    } catch {
-      case NonFatal(e) =>
-        val errorMessage =
-          s"""
-             | Exception thrown while executing Spark plan to calculate expected answer:
-             | $expectedOutputPlan
-             | == Exception ==
-             | $e
-             | ${org.apache.spark.sql.catalyst.util.stackTraceToString(e)}
-          """.stripMargin
-        return Some(errorMessage)
-    }
-
-    val actualAnswer: Seq[Row] = try {
-      executePlan(outputPlan, spark)
-    } catch {
-      case NonFatal(e) =>
-        val errorMessage =
-          s"""
-             | Exception thrown while executing Spark plan:
-             | $outputPlan
-             | == Exception ==
-             | $e
-             | ${org.apache.spark.sql.catalyst.util.stackTraceToString(e)}
-          """.stripMargin
-        return Some(errorMessage)
-    }
-
-    QueryTest.compareAnswers(actualAnswer, expectedAnswer, sortAnswers).map { errorMessage =>
-      s"""
-         | Results do not match.
-         | Actual result Spark plan:
-         | $outputPlan
-         | Expected result Spark plan:
-         | $expectedOutputPlan
-         | $errorMessage
-       """.stripMargin
-    }
-  }
+      spark: SQLContext): Option[String] =
+    QueryTest.checkAnswer(input, planFunction, expectedPlanFunction, sortAnswers, spark)
 
   /**
-   * Runs the plan and makes sure the answer matches the expected result.
-   * @param input the input data to be used.
-   * @param planFunction a function which accepts the input SparkPlan and uses it to instantiate
-   *                     the physical operator that's being tested.
-   * @param expectedAnswer the expected result in a [[Seq]] of [[Row]]s.
-   * @param sortAnswers if true, the answers will be sorted by their toString representations prior
-   *                    to being compared.
+   * Kept as a thin alias of [[QueryTest.checkAnswer]] for backward compatibility.
+   * New callers should use [[QueryTest.checkAnswer]] directly.
    */
   def checkAnswer(
       input: Seq[DataFrame],
       planFunction: Seq[SparkPlan] => SparkPlan,
       expectedAnswer: Seq[Row],
       sortAnswers: Boolean,
-      spark: SQLContext): Option[String] = {
-
-    val outputPlan = planFunction(input.map(_.queryExecution.sparkPlan))
-
-    val sparkAnswer: Seq[Row] = try {
-      executePlan(outputPlan, spark)
-    } catch {
-      case NonFatal(e) =>
-        val errorMessage =
-          s"""
-             | Exception thrown while executing Spark plan:
-             | $outputPlan
-             | == Exception ==
-             | $e
-             | ${org.apache.spark.sql.catalyst.util.stackTraceToString(e)}
-          """.stripMargin
-        return Some(errorMessage)
-    }
-
-    QueryTest.compareAnswers(sparkAnswer, expectedAnswer, sortAnswers).map { errorMessage =>
-      s"""
-         | Results do not match for Spark plan:
-         | $outputPlan
-         | $errorMessage
-       """.stripMargin
-    }
-  }
+      spark: SQLContext): Option[String] =
+    QueryTest.checkAnswer(input, planFunction, expectedAnswer, sortAnswers, spark)
 
   /**
-   * Runs the plan
-   * @param outputPlan SparkPlan to be executed
-   * @param spark SqlContext used for execution of the plan
+   * Kept as a thin alias of [[QueryTest.executePlan]] for backward compatibility.
+   * New callers should use [[QueryTest.executePlan]] directly.
    */
-  def executePlan(outputPlan: SparkPlan, spark: SQLContext): Seq[Row] = {
-    val execution = new QueryExecution(spark.sparkSession, LocalRelation(Nil)) {
-      override lazy val sparkPlan: SparkPlan = outputPlan transform {
-        case plan: SparkPlan =>
-          val inputMap = plan.children.flatMap(_.output).map(a => (a.name, a)).toMap
-          plan transformExpressions {
-            case UnresolvedAttribute(Seq(u)) =>
-              inputMap.getOrElse(u,
-                sys.error(s"Invalid Test: Cannot resolve $u given input $inputMap"))
-          }
-      }
-    }
-    execution.executedPlan.executeCollectPublic().toSeq
-  }
+  def executePlan(outputPlan: SparkPlan, spark: SQLContext): Seq[Row] =
+    QueryTest.executePlan(outputPlan, spark)
 }
-

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorizedSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorizedSuite.scala
@@ -788,7 +788,7 @@ class ParquetVectorizedSuite extends QueryTest with ParquetTest with SharedSpark
       fileSchema: MessageType,
       readStore: PageReadStore,
       expected: Seq[Row],
-      batchSize: Int = NUM_VALUES): Unit = {
+      batchSize: Int): Unit = {
     import scala.jdk.CollectionConverters._
 
     val recordReader = new VectorizedParquetRecordReader(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Followup to SPARK-55910 / SPARK-56560. Merge the helper methods from `SparkPlanTest` (in `org.apache.spark.sql.execution`) into `QueryTest`/`QueryTestBase` (in `org.apache.spark.sql`), and reduce `SparkPlanTest` to a thin deprecated alias for backward compatibility.

Moved into `trait QueryTestBase` (non-anyfun instance helpers — no `test(...)` dependency, so they don't need the `AnyFunSuite` mixin that `QueryTest` adds):
- `checkAnswer(DataFrame, SparkPlan => SparkPlan, Seq[Row], Boolean)`
- `checkAnswer2(DataFrame, DataFrame, (SparkPlan, SparkPlan) => SparkPlan, Seq[Row], Boolean)`
- `doCheckAnswer(Seq[DataFrame], Seq[SparkPlan] => SparkPlan, Seq[Row], Boolean)`
- `checkThatPlansAgree(DataFrame, SparkPlan => SparkPlan, SparkPlan => SparkPlan, Boolean)`

Moved into `object QueryTest` (static helpers):
- `checkAnswer(DataFrame, SparkPlan => SparkPlan, SparkPlan => SparkPlan, Boolean, SQLContext)`
- `checkAnswer(Seq[DataFrame], Seq[SparkPlan] => SparkPlan, Seq[Row], Boolean, SQLContext)`
- `executePlan(SparkPlan, SQLContext)`

`SparkPlanTest` becomes:
- `@deprecated private[sql] trait SparkPlanTest extends QueryTest`
- `@deprecated private[sql] object SparkPlanTest { /* thin delegates to QueryTest */ }`

Existing subclasses (`SortSuite`, `ExchangeSuite`, `BroadcastExchangeSuite`, `InnerJoinSuite`, `OuterJoinSuite`, `ExistenceJoinSuite`, `SingleJoinSuite`, `TakeOrderedAndProjectSuite`, `ReuseExchangeAndSubquerySuite`, `BatchEvalPythonExecSuite`, `ExtractPythonUDFsSuite`, `BaseScriptTransformationSuite`) and call sites of `SparkPlanTest.{checkAnswer, executePlan}` (in `BaseScriptTransformationSuite`, `SingleJoinSuite`, `HiveScriptTransformationSuite`) keep working unchanged via the deprecated aliases.

Also dropped the `= NUM_VALUES` default on the private `ParquetVectorizedSuite.checkAnswer` to avoid the Scala "multiple overloaded alternatives ... define default arguments" error against the new `QueryTestBase.checkAnswer` (both call sites already pass `batchSize` explicitly, so behavior is unchanged).

### Why are the changes needed?

Consolidates the test-helper surface into `QueryTest`/`QueryTestBase`, matching the direction of SPARK-55910/SPARK-56560. New test suites can extend `QueryTest` directly instead of having to pick between `QueryTest` and `SparkPlanTest`.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Locally compiled `sql/Test/compile` and `hive/Test/compile`. Ran `SortSuite` (255 tests), `ParquetVectorizedSuite` (25 tests), and `SingleJoinSuite` (36 tests) — all pass. Relying on CI for full test run.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7