### PR TITLE
[SPARK-56566][SS] Stop applying prev lower bound to transformWithState timer scans

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/transformwithstate/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/operators/stateful/transformwithstate/TransformWithStateExec.scala
@@ -248,11 +248,17 @@ case class TransformWithStateExec(
       timeMode: TimeMode,
       processorHandle: StatefulProcessorHandleImpl): Iterator[InternalRow] = {
     val numExpiredTimers = longMetric("numExpiredTimers")
+    // SPARK-56566: Timers are always scanned without a lower bound (full scan up to the current
+    // batch timestamp / eviction watermark). We intentionally do not pass
+    // prevBatchTimestampMs / lateEventsWatermark as the exclusive lower bound here:
+    // registerTimer has no guard on the registered expiry, so a user-registered timer with expiry
+    // at or below the previous batch's lower bound would be silently dropped by a bounded scan.
+    // Revisit once registerTimer enforces ts > currentBatchTimestamp / watermark.
     timeMode match {
       case ProcessingTime =>
         assert(batchTimestampMs.isDefined)
         val batchTimestamp = batchTimestampMs.get
-        processorHandle.getExpiredTimers(batchTimestamp, prevBatchTimestampMs)
+        processorHandle.getExpiredTimers(batchTimestamp)
           .flatMap { case (keyObj, expiryTimestampMs) =>
             numExpiredTimers += 1
             handleTimerRows(keyObj, expiryTimestampMs, processorHandle)
@@ -261,26 +267,7 @@ case class TransformWithStateExec(
       case EventTime =>
         assert(eventTimeWatermarkForEviction.isDefined)
         val watermark = eventTimeWatermarkForEviction.get
-        // Use the late-events watermark as the scan lower bound only when we can prove that
-        // it equals the previous batch's eviction watermark for this operator. That holds
-        // when STATEFUL_OPERATOR_ALLOW_MULTIPLE is true.
-        //
-        // When STATEFUL_OPERATOR_ALLOW_MULTIPLE is false (legacy mode), lateEvents == eviction
-        // for the same batch, so using it would collapse the eviction range to (wm, wm] = empty
-        // and silently stop firing timers. Fall back to None (full scan) in that mode, as we
-        // don't expect the legacy mode to be used by many users.
-        //
-        // The prevBatchTimestampMs.isDefined check guards against the first batch, where
-        // watermark propagation yields Some(0) for late events even though no timers have been
-        // processed yet, which would incorrectly skip timers registered at timestamp 0.
-        val prevWatermark =
-          if (prevBatchTimestampMs.isDefined &&
-              conf.getConf(SQLConf.STATEFUL_OPERATOR_ALLOW_MULTIPLE)) {
-            eventTimeWatermarkForLateEvents
-          } else {
-            None
-          }
-        processorHandle.getExpiredTimers(watermark, prevWatermark)
+        processorHandle.getExpiredTimers(watermark)
           .flatMap { case (keyObj, expiryTimestampMs) =>
             numExpiredTimers += 1
             handleTimerRows(keyObj, expiryTimestampMs, processorHandle)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -720,6 +720,74 @@ class RunningCountStatefulProcessorWithMultipleTimers
   }
 }
 
+// SPARK-56566: Registers a processing-time timer at ts=0 on the second (and later) input
+// for each key. Used to guard the invariant that timers registered with an
+// expiry at or below the previous batch's timestamp (which registerTimer
+// does not currently forbid) still fire in the current batch. A bounded
+// range scan over `(prevBatchTimestampMs, batchTimestampMs]` in
+// `processTimers` would silently drop such timers; this test pins that
+// down until registerTimer grows an explicit validation.
+class RunningCountStatefulProcessorWithPastProcTimeTimer
+  extends RunningCountStatefulProcessor {
+
+  override def handleInputRows(
+      key: String,
+      inputRows: Iterator[String],
+      timerValues: TimerValues): Iterator[(String, String)] = {
+    val currCount = Option(_countState.get()).getOrElse(0L)
+
+    if (currCount >= 1) {
+      getHandle.registerTimer(0L)
+    }
+
+    val count = currCount + 1
+    _countState.update(count)
+    Iterator((key, count.toString))
+  }
+
+  override def handleExpiredTimer(
+      key: String,
+      timerValues: TimerValues,
+      expiredTimerInfo: ExpiredTimerInfo): Iterator[(String, String)] = {
+    Iterator((key, "-1"))
+  }
+}
+
+// SPARK-56566: Event-time counterpart of [[RunningCountStatefulProcessorWithPastProcTimeTimer]].
+// Registers an event-time timer at ts=0 on the second (and later) input for each key. A bounded
+// scan would silently drop the timer - the test pins the behavior of no-lower-bound guarantee
+// until registerTimer enforces `ts > watermark` itself.
+class MaxEventTimeWithPastEventTimeTimerStatefulProcessor
+  extends StatefulProcessor[String, (String, Long), (String, Int)]
+  with Logging {
+  @transient private var _hasInput: ValueState[Boolean] = _
+
+  override def init(outputMode: OutputMode, timeMode: TimeMode): Unit = {
+    _hasInput = getHandle.getValueState[Boolean](
+      "hasInput", Encoders.scalaBoolean, TTLConfig.NONE)
+  }
+
+  override def handleInputRows(
+      key: String,
+      inputRows: Iterator[(String, Long)],
+      timerValues: TimerValues): Iterator[(String, Int)] = {
+    val seen = Option(_hasInput.get()).getOrElse(false)
+    if (seen) {
+      getHandle.registerTimer(0L)
+    }
+    _hasInput.update(true)
+    val maxEventTimeSec = inputRows.map(_._2).max
+    Iterator((key, maxEventTimeSec.toInt))
+  }
+
+  override def handleExpiredTimer(
+      key: String,
+      timerValues: TimerValues,
+      expiredTimerInfo: ExpiredTimerInfo): Iterator[(String, Int)] = {
+    Iterator((key, -1))
+  }
+}
+
 class MaxEventTimeStatefulProcessor
   extends StatefulProcessor[String, (String, Long), (String, Int)]
   with Logging {
@@ -1323,6 +1391,84 @@ abstract class TransformWithStateSuite extends StateStoreMetricsTest
         CheckNewAnswer(("a", -1), ("b", 31))
       )
     }
+  }
+
+  test("SPARK-56566: transformWithState - processing time timer registered at " +
+    "ts <= prevBatchTimestampMs must still fire") {
+    // registerTimer does not currently restrict the expiry timestamp, so a
+    // user can legally register a timer at ts=0 while the current batch's
+    // clock is 2000 and prevBatchTimestampMs is 1000. processTimers must
+    // still fire it in the current batch. This test pins that behavior so
+    // any future optimization that bounds the timer scan from below (e.g.
+    // via prevBatchTimestampMs) cannot silently drop such timers.
+    val clock = new StreamManualClock
+
+    val inputData = MemoryStream[String]
+    val result = inputData.toDS()
+      .groupByKey(x => x)
+      .transformWithState(
+        new RunningCountStatefulProcessorWithPastProcTimeTimer(),
+        TimeMode.ProcessingTime(),
+        OutputMode.Update())
+
+    testStream(result, OutputMode.Update())(
+      StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock),
+      AddData(inputData, "a"),
+      AdvanceManualClock(1 * 1000),
+      CheckNewAnswer(("a", "1")),
+      Execute { q =>
+        assert(q.lastProgress.stateOperators(0).customMetrics.get("numRegisteredTimers") === 0)
+        assert(q.lastProgress.stateOperators(0).customMetrics.get("numExpiredTimers") === 0)
+      },
+
+      AddData(inputData, "a"),
+      AdvanceManualClock(1 * 1000),
+      CheckNewAnswer(("a", "2"), ("a", "-1")),
+      Execute { q =>
+        assert(q.lastProgress.stateOperators(0).customMetrics.get("numRegisteredTimers") === 1)
+        assert(q.lastProgress.stateOperators(0).customMetrics.get("numExpiredTimers") === 1)
+      },
+
+      StopStream
+    )
+  }
+
+  test("SPARK-56566: transformWithState - event time timer registered at " +
+    "ts <= watermark must still fire") {
+    // Event-time counterpart of the processing-time regression test above.
+    // registerTimer does not restrict the expiry timestamp, so a user can
+    // register an event-time timer at ts=0 while the current batch's
+    // eviction watermark is 20000 and the previous batch's was 5000.
+    // processTimers must still fire it in the current batch. This test
+    // pins that behavior so any future optimization that bounds the timer
+    // scan from below (e.g. via eventTimeWatermarkForLateEvents) cannot
+    // silently drop such timers.
+    val inputData = MemoryStream[(String, Int)]
+    val result =
+      inputData.toDS()
+        .select($"_1".as("key"), timestamp_seconds($"_2").as("eventTime"))
+        .withWatermark("eventTime", "10 seconds")
+        .as[(String, Long)]
+        .groupByKey(_._1)
+        .transformWithState(
+          new MaxEventTimeWithPastEventTimeTimerStatefulProcessor(),
+          TimeMode.EventTime(),
+          OutputMode.Update())
+
+    testStream(result, OutputMode.Update())(
+      StartStream(),
+
+      // Batch 1: eventTime=15s -> eviction watermark=5s. No past timer yet.
+      AddData(inputData, ("a", 15)),
+      CheckNewAnswer(("a", 15)),
+
+      // Batch 2: eventTime=30s -> eviction watermark=20s. The previous
+      // batch's eviction watermark (5s) is what a bounded scan would use as
+      // the exclusive lower bound. The processor registers a timer at ts=0,
+      // which is strictly below that. It must still fire here.
+      AddData(inputData, ("a", 30)),
+      CheckNewAnswer(("a", 30), ("a", -1))
+    )
   }
 
   test("transformWithState - timer duration should be reflected in metrics") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes `TransformWithStateExec.processTimers` to stop passing `prevBatchTimestampMs` / `eventTimeWatermarkForLateEvents` as the exclusive lower bound to `processorHandle.getExpiredTimers(...)`. Timer scans now always run without a lower bound (full scan up to the current batch timestamp / eviction watermark).

Concretely:
- ProcessingTime branch: `getExpiredTimers(batchTimestamp, prevBatchTimestampMs)` -> `getExpiredTimers(batchTimestamp)`.
- EventTime branch: the `STATEFUL_OPERATOR_ALLOW_MULTIPLE` conditional that computed `prevWatermark` is removed; `getExpiredTimers(watermark, prevWatermark)` -> `getExpiredTimers(watermark)`.

The `TimerStateImpl.getExpiredTimers` signature is unchanged — its `prevExpiryTimestampMs` parameter (added in SPARK-56400) is retained as a library primitive so that we can re-enable the optimization in the future once `registerTimer` enforces `ts > currentBatchTimestamp / watermark` server-side.

`TTLState.ttlEvictionIterator` is also unchanged. TTL expirations are always strictly above `prevBatchTimestampMs` by construction (TTL is processing-time-only, `ttlDuration` is validated `> 0`, and `batchTimestampMs` is monotonically non-decreasing), so the TTL path is not affected by this bug.

### Why are the changes needed?

SPARK-56400 introduced a bounded `rangeScan` in `TimerStateImpl.getExpiredTimers` whose exclusive lower bound is `prevBatchTimestampMs` (ProcessingTime) or `eventTimeWatermarkForLateEvents` (EventTime, multi-op — the default). `registerTimer` has guard on the registered expiry, so a user can legally call `registerTimer(ts)` with `ts` at or below that lower bound. In that case the bounded scan excludes the entry, and because the lower bound is monotonically non-decreasing across batches, the timer is never fired in any subsequent batch either — silently lost.

Reproduction:

- ProcessingTime: from batch 2 onwards (`prevBatchTimestampMs` is non-`None`), any `registerTimer(ts <= prevBatchTimestampMs)` never fires.
- EventTime (default `STATEFUL_OPERATOR_ALLOW_MULTIPLE=true`): any `registerTimer(ts <= eventTimeWatermarkForLateEvents)` never fires.
- EventTime legacy single-op (`STATEFUL_OPERATOR_ALLOW_MULTIPLE=false`): unaffected — `processTimers` already falls back to a full scan in that mode.
Affected idioms the bug silently breaks:
- `registerTimer(0L)` as a "fire on the next batch" pattern.
- Event-time timers derived from a record's `event_time` in multi-op chains where a downstream operator's late-events watermark is looser than the upstream.
- Any `registerTimer(ts)` that hits `ts <= prev` even once — the timer is dead forever unless the user also calls `deleteTimer`.

Reverting the lower bound is the most conservative fix. A complementary follow-up (tracked separately) should restrict the valid timestamp range on `registerTimer` so that `ts > currentBatchTimestamp / watermark` is enforced; after that lands we can re-enable the bounded scan.

### Does this PR introduce _any_ user-facing change?

No, since the bug wasn't released yet.

### How was this patch tested?

New UTs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7