### PR TITLE
[SPARK-56574][K8S] Add Java-friendly `KubernetesDriverSpec.getSystemPropertiesAsJavaMap`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesDriverSpec.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesDriverSpec.scala
@@ -37,7 +37,12 @@ case class KubernetesDriverSpec(
     pod: SparkPod,
     driverPreKubernetesResources: Seq[HasMetadata],
     driverKubernetesResources: Seq[HasMetadata],
-    systemProperties: Map[String, String])
+    systemProperties: Map[String, String]) {
+
+  /** Get system properties as a Java-friendly map. */
+  @Since("4.2.0")
+  def getSystemPropertiesAsJavaMap: JMap[String, String] = systemProperties.asJava
+}
 
 @Unstable
 @DeveloperApi

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesDriverSpecSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesDriverSpecSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.deploy.k8s
 
-import java.util.{Arrays, HashMap}
+import java.util.{Arrays, HashMap, Map => JMap}
 
 import io.fabric8.kubernetes.api.model.{ContainerBuilder, HasMetadata, PodBuilder, SecretBuilder}
 
@@ -50,6 +50,12 @@ class KubernetesDriverSpecSuite extends SparkFunSuite {
     assert(spec.driverKubernetesResources.length === 1)
     assert(spec.driverKubernetesResources.head === secret)
     assert(spec.systemProperties === Map("spark.key1" -> "value1", "spark.key2" -> "value2"))
+
+    val javaProps = spec.getSystemPropertiesAsJavaMap
+    assert(javaProps.isInstanceOf[JMap[_, _]])
+    assert(javaProps.size() === 2)
+    assert(javaProps.get("spark.key1") === "value1")
+    assert(javaProps.get("spark.key2") === "value2")
   }
 
   test("create from empty Java collections") {
@@ -63,5 +69,6 @@ class KubernetesDriverSpecSuite extends SparkFunSuite {
     assert(spec.driverPreKubernetesResources.isEmpty)
     assert(spec.driverKubernetesResources.isEmpty)
     assert(spec.systemProperties.isEmpty)
+    assert(spec.getSystemPropertiesAsJavaMap.isEmpty)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a Java-friendly accessor `getSystemPropertiesAsJavaMap` to `KubernetesDriverSpec` that returns `java.util.Map[String, String]` instead of the Scala `Map[String, String]` exposed by the case class field.

```scala
@Since("4.2.0")
def getSystemPropertiesAsJavaMap: JMap[String, String] = systemProperties.asJava
```

### Why are the changes needed?

`KubernetesDriverSpec` is annotated as `@DeveloperApi` and is intended to be consumed both internally and by the Spark K8s operator. In SPARK 4.2.0, a Java-friendly factory `KubernetesDriverSpec.create(...)` was added so Java callers can construct the spec with `java.util.List` / `java.util.Map`. However, the read path is still asymmetric: `spec.systemProperties` returns `scala.collection.immutable.Map`, which is awkward for Java consumers (different `get()` / `size()` signatures, requires `JavaConverters` or `CollectionConverters` on the caller side).

This change completes the symmetry between construction and access, following the existing `SparkConf.getAllAsJavaMap` pattern.

### Does this PR introduce _any_ user-facing change?

No (new additive API only; no behavior change for existing callers).

### How was this patch tested?

Pass the CIs with the updated `KubernetesDriverSpecSuite`, which now asserts the returned value is a `java.util.Map` and exercises both the populated and empty cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)