### PR TITLE
[SPARK-56577][BUILD] Upgrade `ap-loader` to 4.3-13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
     <mima.version>1.1.4</mima.version>
 
     <!-- Version used in Profiler -->
-    <ap-loader.version>4.3-12</ap-loader.version>
+    <ap-loader.version>4.3-13</ap-loader.version>
 
     <CodeCacheSize>128m</CodeCacheSize>
     <!-- Needed for consistent times -->


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `ap-loader` dependency to 4.3-13 for Apache Spark 4.2.0.

### Why are the changes needed?

To bring the latest bug fixes and improvements from `ap-loader`.

- https://github.com/jvm-profiling-tools/ap-loader/releases/tag/4.3-13 (2026-03-12)
  - https://github.com/async-profiler/async-profiler/releases/tag/v4.3
    - https://github.com/async-profiler/async-profiler/issues/1547: Native lock profiling
    - https://github.com/async-profiler/async-profiler/issues/1566: Filter cpu/wall profiles by latency
    - https://github.com/async-profiler/async-profiler/pull/1568: Expose async-profiler metrics in Prometheus format
    - https://github.com/async-profiler/async-profiler/pull/1628: async-profiler.jar as Java agent; remote control via JMX

Please note that there is a release tag for 4.4-13 but it's not published and available in Maven Cental yet.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)