### PR TITLE
[SPARK-56578][BUILD] Upgrade `versions-maven-plugin` to 2.21.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
     <scalatest-maven-plugin.version>2.2.0</scalatest-maven-plugin.version>
     <scala-maven-plugin.version>4.9.9</scala-maven-plugin.version>
     <maven.scaladoc.skip>false</maven.scaladoc.skip>
-    <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
+    <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <scalafmt.validateOnly>true</scalafmt.validateOnly>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `versions-maven-plugin` to 2.21.0 for Apache Spark 4.2.0.

### Why are the changes needed?

To bring the latest bug fixes and improvements. Release notes:
- https://github.com/mojohaus/versions/releases/tag/2.21.0 (2026-01-18)
- https://github.com/mojohaus/versions/releases/tag/2.20.0
- https://github.com/mojohaus/versions/releases/tag/2.19.0

### Does this PR introduce _any_ user-facing change?

No, this is a build-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7