### PR TITLE
[SPARK-56920][SQL] Support METRIC_VIEW creation on V2 catalogs

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8267,6 +8267,11 @@
           "The table <tableName> is a Spark data source table. Please use SHOW CREATE TABLE without AS SERDE instead."
         ]
       },
+      "ON_METRIC_VIEW" : {
+        "message" : [
+          "The command is not supported on a metric view <tableName>."
+        ]
+      },
       "ON_TEMPORARY_VIEW" : {
         "message" : [
           "The command is not supported on a temporary view <tableName>."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4123,6 +4123,12 @@
     },
     "sqlState" : "KD002"
   },
+  "INVALID_METRIC_VIEW_YAML" : {
+    "message" : [
+      "Failed to parse metric view YAML: <message>"
+    ],
+    "sqlState" : "42K0L"
+  },
   "INVALID_NAME_IN_USE_COMMAND" : {
     "message" : [
       "Invalid name '<name>' in <command> command. Reason: <reason>"

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -311,7 +311,7 @@ object DataType {
         messageParameters = Map("invalidType" -> compact(render(other))))
   }
 
-  private[sql] def parseStructField(json: JValue): StructField = json match {
+  private def parseStructField(json: JValue): StructField = json match {
     case JSortedObject(
           ("metadata", JObject(metadataFields)),
           ("name", JString(name)),

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -311,7 +311,7 @@ object DataType {
         messageParameters = Map("invalidType" -> compact(render(other))))
   }
 
-  private def parseStructField(json: JValue): StructField = json match {
+  private[sql] def parseStructField(json: JValue): StructField = json match {
     case JSortedObject(
           ("metadata", JObject(metadataFields)),
           ("name", JString(name)),

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StructField.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StructField.scala
@@ -22,7 +22,6 @@ import scala.collection.mutable
 import org.json4s.{JObject, JString}
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
-import org.json4s.jackson.JsonMethods.{compact, parse, pretty, render}
 
 import org.apache.spark.SparkException
 import org.apache.spark.annotation.Stable
@@ -75,20 +74,6 @@ case class StructField(
       ("nullable" -> nullable) ~
       ("metadata" -> metadataJson)
   }
-
-  /**
-   * The compact JSON representation of this StructField, including name, type, nullable, and
-   * metadata. Inverse of [[StructField.fromJson]].
-   *
-   * @since 4.2.0
-   */
-  def json: String = compact(render(jsonValue))
-
-  /** The pretty (i.e. indented) JSON representation of this StructField.
-   *
-   * @since 4.2.0
-   */
-  def prettyJson: String = pretty(render(jsonValue))
 
   private[sql] def dataTypeJsonValue: JValue = {
     if (collationMetadata.isEmpty) return dataType.jsonValue
@@ -287,19 +272,4 @@ case class StructField(
     s"${QuotingUtils.quoteIfNeeded(name)} ${dataType.sql}$nullDDL" +
       s"$getDDLDefault$getDDLComment"
   }
-}
-
-/**
- * @since 4.2.0
- */
-@Stable
-object StructField {
-
-  /**
-   * Parses a JSON string produced by [[StructField.json]] back into a `StructField`. The JSON
-   * must encode a single field with `name`, `type`, `nullable`, and `metadata`.
-   *
-   * @since 4.2.0
-   */
-  def fromJson(json: String): StructField = DataType.parseStructField(parse(json))
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StructField.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StructField.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable
 import org.json4s.{JObject, JString}
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods.{compact, parse, pretty, render}
 
 import org.apache.spark.SparkException
 import org.apache.spark.annotation.Stable
@@ -74,6 +75,20 @@ case class StructField(
       ("nullable" -> nullable) ~
       ("metadata" -> metadataJson)
   }
+
+  /**
+   * The compact JSON representation of this StructField, including name, type, nullable, and
+   * metadata. Inverse of [[StructField.fromJson]].
+   *
+   * @since 4.2.0
+   */
+  def json: String = compact(render(jsonValue))
+
+  /** The pretty (i.e. indented) JSON representation of this StructField.
+   *
+   * @since 4.2.0
+   */
+  def prettyJson: String = pretty(render(jsonValue))
 
   private[sql] def dataTypeJsonValue: JValue = {
     if (collationMetadata.isEmpty) return dataType.jsonValue
@@ -272,4 +287,19 @@ case class StructField(
     s"${QuotingUtils.quoteIfNeeded(name)} ${dataType.sql}$nullDDL" +
       s"$getDDLDefault$getDDLComment"
   }
+}
+
+/**
+ * @since 4.2.0
+ */
+@Stable
+object StructField {
+
+  /**
+   * Parses a JSON string produced by [[StructField.json]] back into a `StructField`. The JSON
+   * must encode a single field with `name`, `type`, `nullable`, and `metadata`.
+   *
+   * @since 4.2.0
+   */
+  def fromJson(json: String): StructField = DataType.parseStructField(parse(json))
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Column.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Column.java
@@ -24,6 +24,8 @@ import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.internal.connector.ColumnImpl;
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
 
 /**
  * An interface representing a column of a {@link Table}. It defines basic properties of a column,
@@ -120,6 +122,21 @@ public interface Column {
         identityColumnSpec,
         metadataInJSON,
         /* id = */ null);
+  }
+
+  /**
+   * Creates a {@link Column} from a Spark {@link StructField}, preserving name, dataType,
+   * nullable, comment, and the field metadata as a JSON string. Fields with empty metadata
+   * map to a column with a {@code null} {@link #metadataInJSON()}.
+   *
+   * @since 4.2.0
+   */
+  static Column fromStructField(StructField field) {
+    String comment = field.getComment().isDefined() ? field.getComment().get() : null;
+    String metadataJson = field.metadata().equals(Metadata.empty())
+        ? null
+        : field.metadata().json();
+    return create(field.name(), field.dataType(), field.nullable(), comment, metadataJson);
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Column.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Column.java
@@ -24,8 +24,6 @@ import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.internal.connector.ColumnImpl;
 import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.Metadata;
-import org.apache.spark.sql.types.StructField;
 
 /**
  * An interface representing a column of a {@link Table}. It defines basic properties of a column,
@@ -122,21 +120,6 @@ public interface Column {
         identityColumnSpec,
         metadataInJSON,
         /* id = */ null);
-  }
-
-  /**
-   * Creates a {@link Column} from a Spark {@link StructField}, preserving name, dataType,
-   * nullable, comment, and the field metadata as a JSON string. Fields with empty metadata
-   * map to a column with a {@code null} {@link #metadataInJSON()}.
-   *
-   * @since 4.2.0
-   */
-  static Column fromStructField(StructField field) {
-    String comment = field.getComment().isDefined() ? field.getComment().get() : null;
-    String metadataJson = field.metadata().equals(Metadata.empty())
-        ? null
-        : field.metadata().json();
-    return create(field.name(), field.dataType(), field.nullable(), comment, metadataJson);
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Dependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Dependency.java
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.connector.catalog;
 
-import java.util.List;
-
 import org.apache.spark.annotation.Evolving;
 
 /**
@@ -29,7 +27,7 @@ import org.apache.spark.annotation.Evolving;
  * <p>
  * Note: today the only producer in Spark itself is metric-view dependency extraction, which
  * emits {@link TableDependency} only. {@link FunctionDependency} and the
- * {@link #function(String...)} factory are exposed as groundwork for future producers
+ * {@link #function(String[])} factory are exposed as groundwork for future producers
  * (e.g. SQL UDF dependency tracking); consumers iterating a {@link DependencyList} received
  * from Spark today should expect to see only {@link TableDependency} instances.
  *
@@ -44,7 +42,7 @@ public sealed interface Dependency permits TableDependency, FunctionDependency {
    * the first element is typically the catalog name and subsequent elements are namespace
    * components followed by the table name.
    */
-  static TableDependency table(List<String> nameParts) {
+  static TableDependency table(String[] nameParts) {
     return new TableDependency(nameParts);
   }
 
@@ -54,7 +52,7 @@ public sealed interface Dependency permits TableDependency, FunctionDependency {
    * catalog-managed functions the first element is typically the catalog name and subsequent
    * elements are namespace components followed by the function name.
    */
-  static FunctionDependency function(List<String> nameParts) {
+  static FunctionDependency function(String[] nameParts) {
     return new FunctionDependency(nameParts);
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Dependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Dependency.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.connector.catalog;
 
+import java.util.List;
+
 import org.apache.spark.annotation.Evolving;
 
 /**
@@ -37,7 +39,7 @@ public sealed interface Dependency permits TableDependency, FunctionDependency {
    * components followed by the table name.
    */
   static TableDependency table(String... nameParts) {
-    return new TableDependency(nameParts);
+    return new TableDependency(List.of(nameParts));
   }
 
   /**
@@ -47,6 +49,6 @@ public sealed interface Dependency permits TableDependency, FunctionDependency {
    * elements are namespace components followed by the function name.
    */
   static FunctionDependency function(String... nameParts) {
-    return new FunctionDependency(nameParts);
+    return new FunctionDependency(List.of(nameParts));
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Dependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Dependency.java
@@ -44,8 +44,8 @@ public sealed interface Dependency permits TableDependency, FunctionDependency {
    * the first element is typically the catalog name and subsequent elements are namespace
    * components followed by the table name.
    */
-  static TableDependency table(String... nameParts) {
-    return new TableDependency(List.of(nameParts));
+  static TableDependency table(List<String> nameParts) {
+    return new TableDependency(nameParts);
   }
 
   /**
@@ -54,7 +54,7 @@ public sealed interface Dependency permits TableDependency, FunctionDependency {
    * catalog-managed functions the first element is typically the catalog name and subsequent
    * elements are namespace components followed by the function name.
    */
-  static FunctionDependency function(String... nameParts) {
-    return new FunctionDependency(List.of(nameParts));
+  static FunctionDependency function(List<String> nameParts) {
+    return new FunctionDependency(nameParts);
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Dependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Dependency.java
@@ -26,6 +26,12 @@ import org.apache.spark.annotation.Evolving;
  * <p>
  * A dependency is one of: {@link TableDependency} or {@link FunctionDependency}. The
  * {@code sealed} declaration enforces this structurally.
+ * <p>
+ * Note: today the only producer in Spark itself is metric-view dependency extraction, which
+ * emits {@link TableDependency} only. {@link FunctionDependency} and the
+ * {@link #function(String...)} factory are exposed as groundwork for future producers
+ * (e.g. SQL UDF dependency tracking); consumers iterating a {@link DependencyList} received
+ * from Spark today should expect to see only {@link TableDependency} instances.
  *
  * @since 4.2.0
  */

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Dependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Dependency.java
@@ -22,18 +22,31 @@ import org.apache.spark.annotation.Evolving;
 /**
  * Represents a dependency of a SQL object such as a view or metric view.
  * <p>
- * A dependency is one of: {@link TableDependency} or {@link FunctionDependency}.
+ * A dependency is one of: {@link TableDependency} or {@link FunctionDependency}. The
+ * {@code sealed} declaration enforces this structurally.
  *
  * @since 4.2.0
  */
 @Evolving
-public interface Dependency {
+public sealed interface Dependency permits TableDependency, FunctionDependency {
 
-  static TableDependency table(String tableFullName) {
-    return new TableDependency(tableFullName);
+  /**
+   * Construct a {@link TableDependency} from the structural multi-part name of the dependent
+   * table. {@code nameParts} should contain at least one element; for catalog-managed tables
+   * the first element is typically the catalog name and subsequent elements are namespace
+   * components followed by the table name.
+   */
+  static TableDependency table(String... nameParts) {
+    return new TableDependency(nameParts);
   }
 
-  static FunctionDependency function(String functionFullName) {
-    return new FunctionDependency(functionFullName);
+  /**
+   * Construct a {@link FunctionDependency} from the structural multi-part name of the
+   * dependent function. {@code nameParts} should contain at least one element; for
+   * catalog-managed functions the first element is typically the catalog name and subsequent
+   * elements are namespace components followed by the function name.
+   */
+  static FunctionDependency function(String... nameParts) {
+    return new FunctionDependency(nameParts);
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Dependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Dependency.java
@@ -17,29 +17,23 @@
 
 package org.apache.spark.sql.connector.catalog;
 
-import java.util.Objects;
-
 import org.apache.spark.annotation.Evolving;
 
+/**
+ * Represents a dependency of a SQL object such as a view or metric view.
+ * <p>
+ * A dependency is one of: {@link TableDependency} or {@link FunctionDependency}.
+ *
+ * @since 4.2.0
+ */
 @Evolving
-public interface TableSummary {
-    String MANAGED_TABLE_TYPE = "MANAGED";
-    String EXTERNAL_TABLE_TYPE = "EXTERNAL";
-    String VIEW_TABLE_TYPE = "VIEW";
-    String FOREIGN_TABLE_TYPE = "FOREIGN";
-    String METRIC_VIEW_TABLE_TYPE = "METRIC_VIEW";
+public interface Dependency {
 
-    Identifier identifier();
-    String tableType();
+  static TableDependency table(String tableFullName) {
+    return new TableDependency(tableFullName);
+  }
 
-    static TableSummary of(Identifier identifier, String tableType) {
-        return new TableSummaryImpl(identifier, tableType);
-    }
-}
-
-record TableSummaryImpl(Identifier identifier, String tableType) implements TableSummary {
-    TableSummaryImpl {
-      Objects.requireNonNull(identifier, "Identifier of a table summary object cannot be null");
-      Objects.requireNonNull(tableType, "Table type of a table summary object cannot be null");
-    }
+  static FunctionDependency function(String functionFullName) {
+    return new FunctionDependency(functionFullName);
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DependencyList.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DependencyList.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.connector.catalog;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
@@ -26,28 +27,26 @@ import org.apache.spark.annotation.Evolving;
  * <p>
  * <ul>
  *   <li>When {@code null}, the dependency information is not provided.</li>
- *   <li>When the array is empty, dependencies are provided but the object has none.</li>
- *   <li>When the array is non-empty, each entry describes one dependency.</li>
+ *   <li>When the list is empty, dependencies are provided but the object has none.</li>
+ *   <li>When the list is non-empty, each entry describes one dependency.</li>
  * </ul>
+ * <p>
+ * {@code dependencies} is held as an immutable {@link List} so the record's auto-generated
+ * {@code equals}/{@code hashCode} delegate to per-element value semantics on the contained
+ * {@link Dependency} entries.
  *
- * @param dependencies array of dependencies
+ * @param dependencies list of dependencies (immutable copy made)
  * @since 4.2.0
  */
 @Evolving
-public record DependencyList(Dependency[] dependencies) {
+public record DependencyList(List<Dependency> dependencies) {
 
   public DependencyList {
     Objects.requireNonNull(dependencies, "dependencies must not be null");
-    dependencies = dependencies.clone();
-  }
-
-  /** Returns a defensive copy of the underlying dependencies array. */
-  @Override
-  public Dependency[] dependencies() {
-    return dependencies.clone();
+    dependencies = List.copyOf(dependencies);
   }
 
   public static DependencyList of(Dependency... dependencies) {
-    return new DependencyList(dependencies);
+    return new DependencyList(List.of(dependencies));
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DependencyList.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DependencyList.java
@@ -39,7 +39,9 @@ import org.apache.spark.annotation.Evolving;
  * semantics on their {@code nameParts} array). The defensive-copy accessor override clones
  * on read so callers cannot mutate the record's internal array.
  *
- * @param dependencies array of dependencies (defensive copy made)
+ * @param dependencies array of dependencies; must contain no null elements (defensive
+ *                     copy made; not validated element-wise -- callers passing nulls will
+ *                     surface NPEs in downstream consumers)
  * @since 4.2.0
  */
 @Evolving

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DependencyList.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DependencyList.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector.catalog;
 
-import java.util.List;
+import java.util.Arrays;
 import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
@@ -27,26 +27,47 @@ import org.apache.spark.annotation.Evolving;
  * <p>
  * <ul>
  *   <li>When {@code null}, the dependency information is not provided.</li>
- *   <li>When the list is empty, dependencies are provided but the object has none.</li>
- *   <li>When the list is non-empty, each entry describes one dependency.</li>
+ *   <li>When the array is empty, dependencies are provided but the object has none.</li>
+ *   <li>When the array is non-empty, each entry describes one dependency.</li>
  * </ul>
  * <p>
- * {@code dependencies} is held as an immutable {@link List} so the record's auto-generated
- * {@code equals}/{@code hashCode} delegate to per-element value semantics on the contained
- * {@link Dependency} entries.
+ * Records' auto-generated {@code equals}/{@code hashCode} on array fields fall through to
+ * {@link Object#equals} (reference equality), so this record overrides them to use
+ * {@link Arrays#equals(Object[], Object[])} / {@link Arrays#hashCode(Object[])} on
+ * {@code dependencies}; per-element equality delegates to the element's overridden
+ * {@code equals} ({@link TableDependency} / {@link FunctionDependency} both implement value
+ * semantics on their {@code nameParts} array). The defensive-copy accessor override clones
+ * on read so callers cannot mutate the record's internal array.
  *
- * @param dependencies list of dependencies (immutable copy made)
+ * @param dependencies array of dependencies (defensive copy made)
  * @since 4.2.0
  */
 @Evolving
-public record DependencyList(List<Dependency> dependencies) {
+public record DependencyList(Dependency[] dependencies) {
 
   public DependencyList {
     Objects.requireNonNull(dependencies, "dependencies must not be null");
-    dependencies = List.copyOf(dependencies);
+    dependencies = dependencies.clone();
   }
 
-  public static DependencyList of(List<Dependency> dependencies) {
+  /** Returns a defensive copy of the underlying dependencies array. */
+  @Override
+  public Dependency[] dependencies() { return dependencies.clone(); }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof DependencyList that && Arrays.equals(dependencies, that.dependencies);
+  }
+
+  @Override
+  public int hashCode() { return Arrays.hashCode(dependencies); }
+
+  @Override
+  public String toString() {
+    return "DependencyList[dependencies=" + Arrays.toString(dependencies) + "]";
+  }
+
+  public static DependencyList of(Dependency[] dependencies) {
     return new DependencyList(dependencies);
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DependencyList.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DependencyList.java
@@ -21,25 +21,26 @@ import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
 
+/**
+ * A list of dependencies for a SQL object such as a view or metric view.
+ * <p>
+ * <ul>
+ *   <li>When {@code null}, the dependency information is not provided.</li>
+ *   <li>When the array is empty, dependencies are provided but the object has none.</li>
+ *   <li>When the array is non-empty, each entry describes one dependency.</li>
+ * </ul>
+ *
+ * @param dependencies array of dependencies
+ * @since 4.2.0
+ */
 @Evolving
-public interface TableSummary {
-    String MANAGED_TABLE_TYPE = "MANAGED";
-    String EXTERNAL_TABLE_TYPE = "EXTERNAL";
-    String VIEW_TABLE_TYPE = "VIEW";
-    String FOREIGN_TABLE_TYPE = "FOREIGN";
-    String METRIC_VIEW_TABLE_TYPE = "METRIC_VIEW";
+public record DependencyList(Dependency[] dependencies) {
 
-    Identifier identifier();
-    String tableType();
+  public DependencyList {
+    Objects.requireNonNull(dependencies, "dependencies must not be null");
+  }
 
-    static TableSummary of(Identifier identifier, String tableType) {
-        return new TableSummaryImpl(identifier, tableType);
-    }
-}
-
-record TableSummaryImpl(Identifier identifier, String tableType) implements TableSummary {
-    TableSummaryImpl {
-      Objects.requireNonNull(identifier, "Identifier of a table summary object cannot be null");
-      Objects.requireNonNull(tableType, "Table type of a table summary object cannot be null");
-    }
+  public static DependencyList of(Dependency... dependencies) {
+    return new DependencyList(dependencies);
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DependencyList.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DependencyList.java
@@ -38,6 +38,13 @@ public record DependencyList(Dependency[] dependencies) {
 
   public DependencyList {
     Objects.requireNonNull(dependencies, "dependencies must not be null");
+    dependencies = dependencies.clone();
+  }
+
+  /** Returns a defensive copy of the underlying dependencies array. */
+  @Override
+  public Dependency[] dependencies() {
+    return dependencies.clone();
   }
 
   public static DependencyList of(Dependency... dependencies) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DependencyList.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DependencyList.java
@@ -46,7 +46,7 @@ public record DependencyList(List<Dependency> dependencies) {
     dependencies = List.copyOf(dependencies);
   }
 
-  public static DependencyList of(Dependency... dependencies) {
-    return new DependencyList(List.of(dependencies));
+  public static DependencyList of(List<Dependency> dependencies) {
+    return new DependencyList(dependencies);
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/FunctionDependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/FunctionDependency.java
@@ -34,7 +34,9 @@ import org.apache.spark.annotation.Evolving;
  * {@code nameParts} and give value-based semantics. The defensive-copy accessor override
  * also clones on read so callers cannot mutate the record's internal array.
  *
- * @param nameParts structural multi-part identifier (defensive copy made; never empty)
+ * @param nameParts structural multi-part identifier; must be non-empty and contain no
+ *                  null elements (defensive copy made; not validated element-wise --
+ *                  callers passing nulls will surface NPEs in downstream consumers)
  * @since 4.2.0
  */
 @Evolving

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/FunctionDependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/FunctionDependency.java
@@ -24,15 +24,25 @@ import org.apache.spark.annotation.Evolving;
 /**
  * A function dependency of a SQL object.
  * <p>
- * The dependent function is identified by its fully-qualified three-part name
- * in the form {@code catalog_name.schema_name.function_name}.
+ * The dependent function is identified by its structural multi-part name. See
+ * {@link TableDependency} for the parts-form contract.
  *
- * @param functionFullName fully-qualified three-part function name
+ * @param nameParts structural multi-part identifier (defensive copy made; never empty)
  * @since 4.2.0
  */
 @Evolving
-public record FunctionDependency(String functionFullName) implements Dependency {
+public record FunctionDependency(String[] nameParts) implements Dependency {
   public FunctionDependency {
-    Objects.requireNonNull(functionFullName, "functionFullName must not be null");
+    Objects.requireNonNull(nameParts, "nameParts must not be null");
+    if (nameParts.length == 0) {
+      throw new IllegalArgumentException("nameParts must not be empty");
+    }
+    nameParts = nameParts.clone();
+  }
+
+  /** Returns a defensive copy of the underlying parts array. */
+  @Override
+  public String[] nameParts() {
+    return nameParts.clone();
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/FunctionDependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/FunctionDependency.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector.catalog;
 
-import java.util.List;
+import java.util.Arrays;
 import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
@@ -28,19 +28,39 @@ import org.apache.spark.annotation.Evolving;
  * The dependent function is identified by its structural multi-part name. See
  * {@link TableDependency} for the parts-form contract.
  * <p>
- * {@code nameParts} is held as an immutable {@link List} so the record's auto-generated
- * {@code equals}/{@code hashCode} delegate to per-element value semantics.
+ * Records' auto-generated {@code equals}/{@code hashCode} on array fields fall through to
+ * {@link Object#equals} (reference equality), so this record overrides them to use
+ * {@link Arrays#equals(Object[], Object[])} / {@link Arrays#hashCode(Object[])} on
+ * {@code nameParts} and give value-based semantics. The defensive-copy accessor override
+ * also clones on read so callers cannot mutate the record's internal array.
  *
- * @param nameParts structural multi-part identifier (immutable copy made; never empty)
+ * @param nameParts structural multi-part identifier (defensive copy made; never empty)
  * @since 4.2.0
  */
 @Evolving
-public record FunctionDependency(List<String> nameParts) implements Dependency {
+public record FunctionDependency(String[] nameParts) implements Dependency {
   public FunctionDependency {
     Objects.requireNonNull(nameParts, "nameParts must not be null");
-    if (nameParts.isEmpty()) {
+    if (nameParts.length == 0) {
       throw new IllegalArgumentException("nameParts must not be empty");
     }
-    nameParts = List.copyOf(nameParts);
+    nameParts = nameParts.clone();
+  }
+
+  /** Returns a defensive copy of the underlying parts array. */
+  @Override
+  public String[] nameParts() { return nameParts.clone(); }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof FunctionDependency that && Arrays.equals(nameParts, that.nameParts);
+  }
+
+  @Override
+  public int hashCode() { return Arrays.hashCode(nameParts); }
+
+  @Override
+  public String toString() {
+    return "FunctionDependency[nameParts=" + Arrays.toString(nameParts) + "]";
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/FunctionDependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/FunctionDependency.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.connector.catalog;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
@@ -26,23 +27,20 @@ import org.apache.spark.annotation.Evolving;
  * <p>
  * The dependent function is identified by its structural multi-part name. See
  * {@link TableDependency} for the parts-form contract.
+ * <p>
+ * {@code nameParts} is held as an immutable {@link List} so the record's auto-generated
+ * {@code equals}/{@code hashCode} delegate to per-element value semantics.
  *
- * @param nameParts structural multi-part identifier (defensive copy made; never empty)
+ * @param nameParts structural multi-part identifier (immutable copy made; never empty)
  * @since 4.2.0
  */
 @Evolving
-public record FunctionDependency(String[] nameParts) implements Dependency {
+public record FunctionDependency(List<String> nameParts) implements Dependency {
   public FunctionDependency {
     Objects.requireNonNull(nameParts, "nameParts must not be null");
-    if (nameParts.length == 0) {
+    if (nameParts.isEmpty()) {
       throw new IllegalArgumentException("nameParts must not be empty");
     }
-    nameParts = nameParts.clone();
-  }
-
-  /** Returns a defensive copy of the underlying parts array. */
-  @Override
-  public String[] nameParts() {
-    return nameParts.clone();
+    nameParts = List.copyOf(nameParts);
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/FunctionDependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/FunctionDependency.java
@@ -21,25 +21,18 @@ import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
 
+/**
+ * A function dependency of a SQL object.
+ * <p>
+ * The dependent function is identified by its fully-qualified three-part name
+ * in the form {@code catalog_name.schema_name.function_name}.
+ *
+ * @param functionFullName fully-qualified three-part function name
+ * @since 4.2.0
+ */
 @Evolving
-public interface TableSummary {
-    String MANAGED_TABLE_TYPE = "MANAGED";
-    String EXTERNAL_TABLE_TYPE = "EXTERNAL";
-    String VIEW_TABLE_TYPE = "VIEW";
-    String FOREIGN_TABLE_TYPE = "FOREIGN";
-    String METRIC_VIEW_TABLE_TYPE = "METRIC_VIEW";
-
-    Identifier identifier();
-    String tableType();
-
-    static TableSummary of(Identifier identifier, String tableType) {
-        return new TableSummaryImpl(identifier, tableType);
-    }
-}
-
-record TableSummaryImpl(Identifier identifier, String tableType) implements TableSummary {
-    TableSummaryImpl {
-      Objects.requireNonNull(identifier, "Identifier of a table summary object cannot be null");
-      Objects.requireNonNull(tableType, "Table type of a table summary object cannot be null");
-    }
+public record FunctionDependency(String functionFullName) implements Dependency {
+  public FunctionDependency {
+    Objects.requireNonNull(functionFullName, "functionFullName must not be null");
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableDependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableDependency.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector.catalog;
 
-import java.util.List;
+import java.util.Arrays;
 import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
@@ -36,19 +36,39 @@ import org.apache.spark.annotation.Evolving;
  * string should join the parts themselves with a quoting scheme appropriate to their wire
  * format.
  * <p>
- * {@code nameParts} is held as an immutable {@link List} so the record's auto-generated
- * {@code equals}/{@code hashCode} delegate to per-element value semantics.
+ * Records' auto-generated {@code equals}/{@code hashCode} on array fields fall through to
+ * {@link Object#equals} (reference equality), so this record overrides them to use
+ * {@link Arrays#equals(Object[], Object[])} / {@link Arrays#hashCode(Object[])} on
+ * {@code nameParts} and give value-based semantics. The defensive-copy accessor override
+ * also clones on read so callers cannot mutate the record's internal array.
  *
- * @param nameParts structural multi-part identifier (immutable copy made; never empty)
+ * @param nameParts structural multi-part identifier (defensive copy made; never empty)
  * @since 4.2.0
  */
 @Evolving
-public record TableDependency(List<String> nameParts) implements Dependency {
+public record TableDependency(String[] nameParts) implements Dependency {
   public TableDependency {
     Objects.requireNonNull(nameParts, "nameParts must not be null");
-    if (nameParts.isEmpty()) {
+    if (nameParts.length == 0) {
       throw new IllegalArgumentException("nameParts must not be empty");
     }
-    nameParts = List.copyOf(nameParts);
+    nameParts = nameParts.clone();
+  }
+
+  /** Returns a defensive copy of the underlying parts array. */
+  @Override
+  public String[] nameParts() { return nameParts.clone(); }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof TableDependency that && Arrays.equals(nameParts, that.nameParts);
+  }
+
+  @Override
+  public int hashCode() { return Arrays.hashCode(nameParts); }
+
+  @Override
+  public String toString() {
+    return "TableDependency[nameParts=" + Arrays.toString(nameParts) + "]";
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableDependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableDependency.java
@@ -21,25 +21,18 @@ import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
 
+/**
+ * A table dependency of a SQL object.
+ * <p>
+ * The dependent table is identified by its fully-qualified three-part name
+ * in the form {@code catalog_name.schema_name.table_name}.
+ *
+ * @param tableFullName fully-qualified three-part table name
+ * @since 4.2.0
+ */
 @Evolving
-public interface TableSummary {
-    String MANAGED_TABLE_TYPE = "MANAGED";
-    String EXTERNAL_TABLE_TYPE = "EXTERNAL";
-    String VIEW_TABLE_TYPE = "VIEW";
-    String FOREIGN_TABLE_TYPE = "FOREIGN";
-    String METRIC_VIEW_TABLE_TYPE = "METRIC_VIEW";
-
-    Identifier identifier();
-    String tableType();
-
-    static TableSummary of(Identifier identifier, String tableType) {
-        return new TableSummaryImpl(identifier, tableType);
-    }
-}
-
-record TableSummaryImpl(Identifier identifier, String tableType) implements TableSummary {
-    TableSummaryImpl {
-      Objects.requireNonNull(identifier, "Identifier of a table summary object cannot be null");
-      Objects.requireNonNull(tableType, "Table type of a table summary object cannot be null");
-    }
+public record TableDependency(String tableFullName) implements Dependency {
+  public TableDependency {
+    Objects.requireNonNull(tableFullName, "tableFullName must not be null");
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableDependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableDependency.java
@@ -42,7 +42,9 @@ import org.apache.spark.annotation.Evolving;
  * {@code nameParts} and give value-based semantics. The defensive-copy accessor override
  * also clones on read so callers cannot mutate the record's internal array.
  *
- * @param nameParts structural multi-part identifier (defensive copy made; never empty)
+ * @param nameParts structural multi-part identifier; must be non-empty and contain no
+ *                  null elements (defensive copy made; not validated element-wise --
+ *                  callers passing nulls will surface NPEs in downstream consumers)
  * @since 4.2.0
  */
 @Evolving

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableDependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableDependency.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.connector.catalog;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
@@ -26,31 +27,28 @@ import org.apache.spark.annotation.Evolving;
  * <p>
  * The dependent table is identified by its structural multi-part name. {@code nameParts}
  * arity matches the catalog's namespace depth plus one for the table name -- for a catalog
- * with single-level namespaces the parts are typically
- * {@code [catalog, schema, table]}; for a catalog with multi-level namespaces (e.g. Iceberg
- * with {@code db1.db2}) the parts are {@code [catalog, db1, db2, ..., table]}; for sources
- * referenced through a session catalog without an explicit catalog component the parts can
- * be {@code [db, table]} or just {@code [table]}. The structural form preserves arity and
- * is unambiguous against quoted identifiers containing a literal {@code .}; consumers that
- * need a flat string should join the parts themselves with a quoting scheme appropriate to
- * their wire format.
+ * with single-level namespaces the parts are {@code [catalog, schema, table]}; for a catalog
+ * with multi-level namespaces (e.g. Iceberg with {@code db1.db2}) the parts are
+ * {@code [catalog, db1, db2, ..., table]}; for v1 sources resolved through the session
+ * catalog producers should normalize to {@code [spark_catalog, db, table]} so consumers see
+ * a stable arity per source kind. The structural form preserves arity and is unambiguous
+ * against quoted identifiers containing a literal {@code .}; consumers that need a flat
+ * string should join the parts themselves with a quoting scheme appropriate to their wire
+ * format.
+ * <p>
+ * {@code nameParts} is held as an immutable {@link List} so the record's auto-generated
+ * {@code equals}/{@code hashCode} delegate to per-element value semantics.
  *
- * @param nameParts structural multi-part identifier (defensive copy made; never empty)
+ * @param nameParts structural multi-part identifier (immutable copy made; never empty)
  * @since 4.2.0
  */
 @Evolving
-public record TableDependency(String[] nameParts) implements Dependency {
+public record TableDependency(List<String> nameParts) implements Dependency {
   public TableDependency {
     Objects.requireNonNull(nameParts, "nameParts must not be null");
-    if (nameParts.length == 0) {
+    if (nameParts.isEmpty()) {
       throw new IllegalArgumentException("nameParts must not be empty");
     }
-    nameParts = nameParts.clone();
-  }
-
-  /** Returns a defensive copy of the underlying parts array. */
-  @Override
-  public String[] nameParts() {
-    return nameParts.clone();
+    nameParts = List.copyOf(nameParts);
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableDependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableDependency.java
@@ -30,7 +30,7 @@ import org.apache.spark.annotation.Evolving;
  * with single-level namespaces the parts are {@code [catalog, schema, table]}; for a catalog
  * with multi-level namespaces (e.g. Iceberg with {@code db1.db2}) the parts are
  * {@code [catalog, db1, db2, ..., table]}; for v1 sources resolved through the session
- * catalog producers should normalize to {@code [spark_catalog, db, table]} so consumers see
+ * catalog, producers should normalize to {@code [spark_catalog, db, table]} so consumers see
  * a stable arity per source kind. The structural form preserves arity and is unambiguous
  * against quoted identifiers containing a literal {@code .}; consumers that need a flat
  * string should join the parts themselves with a quoting scheme appropriate to their wire

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableDependency.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableDependency.java
@@ -24,15 +24,33 @@ import org.apache.spark.annotation.Evolving;
 /**
  * A table dependency of a SQL object.
  * <p>
- * The dependent table is identified by its fully-qualified three-part name
- * in the form {@code catalog_name.schema_name.table_name}.
+ * The dependent table is identified by its structural multi-part name. {@code nameParts}
+ * arity matches the catalog's namespace depth plus one for the table name -- for a catalog
+ * with single-level namespaces the parts are typically
+ * {@code [catalog, schema, table]}; for a catalog with multi-level namespaces (e.g. Iceberg
+ * with {@code db1.db2}) the parts are {@code [catalog, db1, db2, ..., table]}; for sources
+ * referenced through a session catalog without an explicit catalog component the parts can
+ * be {@code [db, table]} or just {@code [table]}. The structural form preserves arity and
+ * is unambiguous against quoted identifiers containing a literal {@code .}; consumers that
+ * need a flat string should join the parts themselves with a quoting scheme appropriate to
+ * their wire format.
  *
- * @param tableFullName fully-qualified three-part table name
+ * @param nameParts structural multi-part identifier (defensive copy made; never empty)
  * @since 4.2.0
  */
 @Evolving
-public record TableDependency(String tableFullName) implements Dependency {
+public record TableDependency(String[] nameParts) implements Dependency {
   public TableDependency {
-    Objects.requireNonNull(tableFullName, "tableFullName must not be null");
+    Objects.requireNonNull(nameParts, "nameParts must not be null");
+    if (nameParts.length == 0) {
+      throw new IllegalArgumentException("nameParts must not be empty");
+    }
+    nameParts = nameParts.clone();
+  }
+
+  /** Returns a defensive copy of the underlying parts array. */
+  @Override
+  public String[] nameParts() {
+    return nameParts.clone();
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/ViewInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/ViewInfo.java
@@ -48,6 +48,7 @@ public class ViewInfo extends TableInfo {
   private final Map<String, String> sqlConfigs;
   private final String schemaMode;
   private final String[] queryColumnNames;
+  private final DependencyList viewDependencies;
 
   protected ViewInfo(Builder builder) {
     super(builder);
@@ -57,11 +58,14 @@ public class ViewInfo extends TableInfo {
     this.sqlConfigs = Collections.unmodifiableMap(builder.sqlConfigs);
     this.schemaMode = builder.schemaMode;
     this.queryColumnNames = builder.queryColumnNames;
-    // Force PROP_TABLE_TYPE = VIEW so that `properties()` reflects the typed ViewInfo
-    // classification. Catalogs and generic viewers reading PROP_TABLE_TYPE from the properties
-    // bag (e.g. TableCatalog.listTableSummaries default impl, DESCRIBE) see "VIEW" without
-    // requiring authors to remember to call withTableType(VIEW).
-    properties().put(TableCatalog.PROP_TABLE_TYPE, TableSummary.VIEW_TABLE_TYPE);
+    this.viewDependencies = builder.viewDependencies;
+    // Force PROP_TABLE_TYPE = VIEW by default so that `properties()` reflects the typed
+    // ViewInfo classification. Metric views intentionally set PROP_TABLE_TYPE = METRIC_VIEW
+    // before construction and must retain that more-specific view kind.
+    String tableType = properties().get(TableCatalog.PROP_TABLE_TYPE);
+    if (!TableSummary.METRIC_VIEW_TABLE_TYPE.equals(tableType)) {
+      properties().put(TableCatalog.PROP_TABLE_TYPE, TableSummary.VIEW_TABLE_TYPE);
+    }
   }
 
   /** The SQL text of the view. */
@@ -102,6 +106,14 @@ public class ViewInfo extends TableInfo {
    */
   public String[] queryColumnNames() { return queryColumnNames; }
 
+  /**
+   * Returns the structured list of objects this view depends on (source tables and functions),
+   * or {@code null} if no dependency list was supplied. Unlike other view metadata which is
+   * encoded into {@link #properties()}, dependency lists are a first-class field because their
+   * nested structure does not round-trip cleanly through flat string properties.
+   */
+  public DependencyList viewDependencies() { return viewDependencies; }
+
   public static class Builder extends BaseBuilder<Builder> {
     private String queryText;
     private String currentCatalog;
@@ -109,6 +121,7 @@ public class ViewInfo extends TableInfo {
     private Map<String, String> sqlConfigs = new HashMap<>();
     private String schemaMode;
     private String[] queryColumnNames = new String[0];
+    private DependencyList viewDependencies = null;
 
     @Override
     protected Builder self() { return this; }
@@ -140,6 +153,16 @@ public class ViewInfo extends TableInfo {
 
     public Builder withQueryColumnNames(String[] queryColumnNames) {
       this.queryColumnNames = queryColumnNames == null ? new String[0] : queryColumnNames;
+      return this;
+    }
+
+    /**
+     * Sets the structured dependency list for this view. Source tables and functions referenced
+     * by the view text should be recorded here so downstream consumers (e.g. catalogs persisting
+     * lineage) can access them without re-analyzing the view body.
+     */
+    public Builder withViewDependencies(DependencyList viewDependencies) {
+      this.viewDependencies = viewDependencies;
       return this;
     }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/ViewInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/ViewInfo.java
@@ -59,13 +59,10 @@ public class ViewInfo extends TableInfo {
     this.schemaMode = builder.schemaMode;
     this.queryColumnNames = builder.queryColumnNames;
     this.viewDependencies = builder.viewDependencies;
-    // Force PROP_TABLE_TYPE = VIEW by default so that `properties()` reflects the typed
-    // ViewInfo classification. Metric views intentionally set PROP_TABLE_TYPE = METRIC_VIEW
-    // before construction and must retain that more-specific view kind.
-    String tableType = properties().get(TableCatalog.PROP_TABLE_TYPE);
-    if (!TableSummary.METRIC_VIEW_TABLE_TYPE.equals(tableType)) {
-      properties().put(TableCatalog.PROP_TABLE_TYPE, TableSummary.VIEW_TABLE_TYPE);
-    }
+    // Default PROP_TABLE_TYPE = VIEW so `properties()` reflects the typed ViewInfo
+    // classification. Callers can refine to a more specific view kind (for example,
+    // METRIC_VIEW) by calling BaseBuilder.withTableType(...) on the builder before build().
+    properties().putIfAbsent(TableCatalog.PROP_TABLE_TYPE, TableSummary.VIEW_TABLE_TYPE);
   }
 
   /** The SQL text of the view. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1226,8 +1226,7 @@ class Analyzer(
                 ) {
                   CatalogV2Util.loadTable(catalog, ident).map {
                     case v1Table: V1Table if CatalogV2Util.isSessionCatalog(catalog) &&
-                      (v1Table.v1Table.tableType == CatalogTableType.VIEW ||
-                        v1Table.v1Table.tableType == CatalogTableType.METRIC_VIEW) =>
+                      v1Table.v1Table.isViewLike =>
                       val v1Ident = v1Table.catalogTable.identifier
                       val v2Ident = Identifier.of(v1Ident.database.toArray, v1Ident.identifier)
                       ResolvedPersistentView(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1226,7 +1226,8 @@ class Analyzer(
                 ) {
                   CatalogV2Util.loadTable(catalog, ident).map {
                     case v1Table: V1Table if CatalogV2Util.isSessionCatalog(catalog) &&
-                      v1Table.v1Table.tableType == CatalogTableType.VIEW =>
+                      (v1Table.v1Table.tableType == CatalogTableType.VIEW ||
+                        v1Table.v1Table.tableType == CatalogTableType.METRIC_VIEW) =>
                       val v1Ident = v1Table.catalogTable.identifier
                       val v2Ident = Identifier.of(v1Ident.database.toArray, v1Ident.identifier)
                       ResolvedPersistentView(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.catalog.{
   CatalogTable,
-  CatalogTableType,
   TemporaryViewRelation,
   UnresolvedCatalogRelation
 }
@@ -398,8 +397,7 @@ class RelationResolution(
       timeTravelSpec: Option[TimeTravelSpec]): Option[LogicalPlan] = {
     def createDataSourceV1Scan(v1Table: CatalogTable): LogicalPlan = {
       if (isStreaming) {
-        if (v1Table.tableType == CatalogTableType.VIEW ||
-            v1Table.tableType == CatalogTableType.METRIC_VIEW) {
+        if (v1Table.isViewLike) {
           throw QueryCompilationErrors.permanentViewNotSupportedByStreamingReadingAPIError(
             ident.quoted
           )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
@@ -398,7 +398,8 @@ class RelationResolution(
       timeTravelSpec: Option[TimeTravelSpec]): Option[LogicalPlan] = {
     def createDataSourceV1Scan(v1Table: CatalogTable): LogicalPlan = {
       if (isStreaming) {
-        if (v1Table.tableType == CatalogTableType.VIEW) {
+        if (v1Table.tableType == CatalogTableType.VIEW ||
+            v1Table.tableType == CatalogTableType.METRIC_VIEW) {
           throw QueryCompilationErrors.permanentViewNotSupportedByStreamingReadingAPIError(
             ident.quoted
           )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -395,8 +395,7 @@ class InMemoryCatalog(
   override def listViews(db: String, pattern: String): Seq[String] = synchronized {
     requireDbExists(db)
     val views = catalog(db).tables.filter { case (_, t) =>
-      t.table.tableType == CatalogTableType.VIEW ||
-        t.table.tableType == CatalogTableType.METRIC_VIEW
+      t.table.isViewLike
     }.keySet
     StringUtils.filterPattern(views.toSeq.sorted, pattern)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -394,7 +394,10 @@ class InMemoryCatalog(
 
   override def listViews(db: String, pattern: String): Seq[String] = synchronized {
     requireDbExists(db)
-    val views = catalog(db).tables.filter(_._2.table.tableType == CatalogTableType.VIEW).keySet
+    val views = catalog(db).tables.filter { case (_, t) =>
+      t.table.tableType == CatalogTableType.VIEW ||
+        t.table.tableType == CatalogTableType.METRIC_VIEW
+    }.keySet
     StringUtils.filterPattern(views.toSeq.sorted, pattern)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1256,7 +1256,8 @@ class SessionCatalog(
       import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
       val ident = nameParts.asTableIdentifier
       try {
-        getTempViewOrPermanentTableMetadata(ident).tableType == CatalogTableType.VIEW
+        val t = getTempViewOrPermanentTableMetadata(ident).tableType
+        t == CatalogTableType.VIEW || t == CatalogTableType.METRIC_VIEW
       } catch {
         case _: NoSuchTableException => false
         case _: NoSuchNamespaceException => false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1256,8 +1256,7 @@ class SessionCatalog(
       import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
       val ident = nameParts.asTableIdentifier
       try {
-        val t = getTempViewOrPermanentTableMetadata(ident).tableType
-        t == CatalogTableType.VIEW || t == CatalogTableType.METRIC_VIEW
+        getTempViewOrPermanentTableMetadata(ident).isViewLike
       } catch {
         case _: NoSuchTableException => false
         case _: NoSuchNamespaceException => false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -667,7 +667,7 @@ case class CatalogTable(
     if (comment.isDefined) map += "Comment" -> JString(comment.get)
     if (collation.isDefined) map += "Collation" -> JString(collation.get)
 
-    if (tableType == CatalogTableType.VIEW) {
+    if (tableType == CatalogTableType.VIEW || tableType == CatalogTableType.METRIC_VIEW) {
       if (viewText.isDefined) {
         map += "View Text" -> JString(viewText.get)
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -462,6 +462,14 @@ case class CatalogTable(
   def fullIdent: Seq[String] = multipartIdentifier.getOrElse(identifier.nameParts)
 
   /**
+   * Returns whether this table behaves like a view at resolution / DDL time. Today: VIEW or
+   * METRIC_VIEW. Forks may extend this set (e.g. DBR also includes MATERIALIZED_VIEW and
+   * STREAMING_TABLE), so call sites that need a uniform "is this view-like?" check should
+   * prefer this helper over inline disjunctions on `tableType`.
+   */
+  def isViewLike: Boolean = CatalogTable.isViewLike(tableType)
+
+  /**
    * schema of this table's partition columns
    */
   def partitionSchema: StructType = {
@@ -667,7 +675,7 @@ case class CatalogTable(
     if (comment.isDefined) map += "Comment" -> JString(comment.get)
     if (collation.isDefined) map += "Collation" -> JString(collation.get)
 
-    if (tableType == CatalogTableType.VIEW || tableType == CatalogTableType.METRIC_VIEW) {
+    if (isViewLike) {
       if (viewText.isDefined) {
         map += "View Text" -> JString(viewText.get)
       }
@@ -756,6 +764,17 @@ object CatalogTable {
    */
   def isMetricView(table: CatalogTable): Boolean = {
     table.tableType == CatalogTableType.METRIC_VIEW
+  }
+
+  /**
+   * Type-only form of [[CatalogTable.isViewLike]]; returns whether the given table type
+   * behaves like a view at resolution / DDL time. Use this overload when you have a
+   * [[CatalogTableType]] but no surrounding [[CatalogTable]] (e.g. inside `match`/`case`
+   * patterns or [[org.apache.spark.sql.catalyst.catalog.SessionCatalog.isView]]). Body kept
+   * in sync with the instance method.
+   */
+  def isViewLike(tableType: CatalogTableType): Boolean = {
+    tableType == CatalogTableType.VIEW || tableType == CatalogTableType.METRIC_VIEW
   }
 
   // Convert the current catalog and namespace to properties.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -463,9 +463,9 @@ case class CatalogTable(
 
   /**
    * Returns whether this table behaves like a view at resolution / DDL time. Today: VIEW or
-   * METRIC_VIEW. Forks may extend this set (e.g. DBR also includes MATERIALIZED_VIEW and
-   * STREAMING_TABLE), so call sites that need a uniform "is this view-like?" check should
-   * prefer this helper over inline disjunctions on `tableType`.
+   * METRIC_VIEW. Forks may extend this set with additional view-like types, so call sites
+   * that need a uniform "is this view-like?" check should prefer this helper over inline
+   * disjunctions on `tableType`.
    */
   def isViewLike: Boolean = CatalogTable.isViewLike(tableType)
 
@@ -770,8 +770,7 @@ object CatalogTable {
    * Type-only form of [[CatalogTable.isViewLike]]; returns whether the given table type
    * behaves like a view at resolution / DDL time. Use this overload when you have a
    * [[CatalogTableType]] but no surrounding [[CatalogTable]] (e.g. inside `match`/`case`
-   * patterns or [[org.apache.spark.sql.catalyst.catalog.SessionCatalog.isView]]). Body kept
-   * in sync with the instance method.
+   * patterns or [[org.apache.spark.sql.catalyst.catalog.SessionCatalog.isView]]).
    */
   def isViewLike(tableType: CatalogTableType): Boolean = {
     tableType == CatalogTableType.VIEW || tableType == CatalogTableType.METRIC_VIEW

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -743,6 +743,15 @@ object CatalogTable {
   val VIEW_CATALOG_AND_NAMESPACE_PART_PREFIX = VIEW_PREFIX + "catalogAndNamespace.part."
 
   /**
+   * View sub-type marker persisted in `properties` so the metric-view distinction survives a
+   * round-trip through external catalogs whose enum can't carry it (e.g. the Hive Metastore,
+   * which only knows `VIRTUAL_VIEW`). When this property is set, the in-memory `tableType`
+   * upgrades from [[CatalogTableType.VIEW]] back to [[CatalogTableType.METRIC_VIEW]] on read.
+   */
+  val VIEW_SUB_TYPE = VIEW_PREFIX + "subType"
+  val VIEW_SUB_TYPE_METRIC_VIEW = "METRIC_VIEW"
+
+  /**
    * Check if a CatalogTable is a metric view.
    */
   def isMetricView(table: CatalogTable): Boolean = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -742,15 +742,11 @@ object CatalogTable {
   val VIEW_CATALOG_AND_NAMESPACE = VIEW_PREFIX + "catalogAndNamespace.numParts"
   val VIEW_CATALOG_AND_NAMESPACE_PART_PREFIX = VIEW_PREFIX + "catalogAndNamespace.part."
 
-  // Property to indicate that a VIEW is actually a METRIC VIEW
-  val VIEW_WITH_METRICS = VIEW_PREFIX + "viewWithMetrics"
-
   /**
-   * Check if a CatalogTable is a metric view by looking at its properties.
+   * Check if a CatalogTable is a metric view.
    */
   def isMetricView(table: CatalogTable): Boolean = {
-    table.tableType == CatalogTableType.VIEW &&
-      table.properties.get(VIEW_WITH_METRICS).contains("true")
+    table.tableType == CatalogTableType.METRIC_VIEW
   }
 
   // Convert the current catalog and namespace to properties.
@@ -1089,8 +1085,9 @@ object CatalogTableType {
   val EXTERNAL = new CatalogTableType("EXTERNAL")
   val MANAGED = new CatalogTableType("MANAGED")
   val VIEW = new CatalogTableType("VIEW")
+  val METRIC_VIEW = new CatalogTableType("METRIC_VIEW")
 
-  val tableTypes = Seq(EXTERNAL, MANAGED, VIEW)
+  val tableTypes = Seq(EXTERNAL, MANAGED, VIEW, METRIC_VIEW)
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/V1Table.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/V1Table.scala
@@ -105,6 +105,7 @@ private[sql] object V1Table {
       case CatalogTableType.EXTERNAL => Some(TableSummary.EXTERNAL_TABLE_TYPE)
       case CatalogTableType.MANAGED => Some(TableSummary.MANAGED_TABLE_TYPE)
       case CatalogTableType.VIEW => Some(TableSummary.VIEW_TABLE_TYPE)
+      case CatalogTableType.METRIC_VIEW => Some(TableSummary.METRIC_VIEW_TABLE_TYPE)
       case _ => None
     }
   }
@@ -195,9 +196,15 @@ private[sql] object V1Table {
     val schemaModeProps = Option(info.schemaMode)
       .map(m => Map(CatalogTable.VIEW_SCHEMA_MODE -> m))
       .getOrElse(Map.empty)
+    // ViewInfo always represents a view-like table, but PROP_TABLE_TYPE may further refine the
+    // kind (e.g. METRIC_VIEW). Default to plain VIEW when no refinement is supplied.
+    val tableType = props.get(TableCatalog.PROP_TABLE_TYPE) match {
+      case Some(TableSummary.METRIC_VIEW_TABLE_TYPE) => CatalogTableType.METRIC_VIEW
+      case _ => CatalogTableType.VIEW
+    }
     CatalogTable(
       identifier = ident.asLegacyTableIdentifier(catalog.name()),
-      tableType = CatalogTableType.VIEW,
+      tableType = tableType,
       storage = CatalogStorageFormat.empty,
       schema = CatalogV2Util.v2ColumnsToStructType(info.columns),
       owner = props.getOrElse(TableCatalog.PROP_OWNER, ""),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2826,6 +2826,13 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map.empty)
   }
 
+  def invalidMetricViewYamlError(message: String, cause: Throwable): Throwable = {
+    new AnalysisException(
+      errorClass = "INVALID_METRIC_VIEW_YAML",
+      messageParameters = Map("message" -> message),
+      cause = Some(cause))
+  }
+
   def noSuchStructFieldInGivenFieldsError(
       fieldName: String, fields: Array[StructField]): Throwable = {
     new AnalysisException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3330,6 +3330,12 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("tableName" -> toSQLId(table)))
   }
 
+  def showCreateTableNotSupportedOnMetricViewError(table: String): Throwable = {
+    new AnalysisException(
+      errorClass = "UNSUPPORTED_SHOW_CREATE_TABLE.ON_METRIC_VIEW",
+      messageParameters = Map("tableName" -> toSQLId(table)))
+  }
+
   def showCreateTableNotSupportTransactionalHiveTableError(table: CatalogTable): Throwable = {
     new AnalysisException(
       errorClass = "UNSUPPORTED_SHOW_CREATE_TABLE.ON_TRANSACTIONAL_HIVE_TABLE",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewCanonical.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewCanonical.scala
@@ -94,7 +94,7 @@ private[sql] object Source {
     if (sourceText.isEmpty) {
       throw MetricViewValidationException("Source cannot be empty")
     }
-    Try(CatalystSqlParser.parseTableIdentifier(sourceText)) match {
+    Try(CatalystSqlParser.parseMultipartIdentifier(sourceText)) match {
       case Success(_) => AssetSource(sourceText)
       case Failure(_) =>
         Try(CatalystSqlParser.parseQuery(sourceText)) match {
@@ -167,4 +167,33 @@ private[sql] case class MetricView(
     version: String,
     from: Source,
     where: Option[String] = None,
-    select: Seq[Column])
+    select: Seq[Column]) {
+
+  /**
+   * Returns a set of table properties describing this metric view's source and
+   * filter clauses. Mirrors the property keys used by the canonical metric view
+   * representation on other Spark platforms so consumers of the catalog see a
+   * consistent property layout.
+   */
+  def getProperties: Map[String, String] = {
+    val base = Map(MetricView.PROP_FROM_TYPE -> from.sourceType.toString)
+    val fromProps = from match {
+      case asset: AssetSource =>
+        base + (MetricView.PROP_FROM_NAME -> asset.name)
+      case sql: SQLSource =>
+        base + (MetricView.PROP_FROM_SQL -> MetricView.truncate(sql.sql))
+    }
+    where.fold(fromProps)(w =>
+      fromProps + (MetricView.PROP_WHERE -> MetricView.truncate(w)))
+  }
+}
+
+private[sql] object MetricView {
+  final val PROP_FROM_TYPE = "metric_view.from.type"
+  final val PROP_FROM_NAME = "metric_view.from.name"
+  final val PROP_FROM_SQL = "metric_view.from.sql"
+  final val PROP_WHERE = "metric_view.where"
+
+  private def truncate(value: String): String =
+    value.take(Constants.MAXIMUM_PROPERTY_SIZE)
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewCanonical.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/serde/MetricViewCanonical.scala
@@ -174,6 +174,15 @@ private[sql] case class MetricView(
    * filter clauses. Mirrors the property keys used by the canonical metric view
    * representation on other Spark platforms so consumers of the catalog see a
    * consistent property layout.
+   *
+   * Note: `metric_view.from.sql` and `metric_view.where` values are truncated to
+   * [[Constants.MAXIMUM_PROPERTY_SIZE]] characters, so these are descriptive values
+   * for catalog browsers / lineage tooling -- not round-trippable representations
+   * of the source. Consumers that need the full SQL or filter expression for
+   * re-execution should read [[ViewInfo#queryText]] (the YAML body) and re-parse it
+   * rather than reconstruct the query from these properties; for any source whose
+   * SQL exceeds the size limit, this property would silently return a truncated
+   * string.
    */
   def getProperties: Map[String, String] = {
     val base = Map(MetricView.PROP_FROM_TYPE -> from.sourceType.toString)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/util/MetricViewPlanner.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/util/MetricViewPlanner.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.metricview.logical.MetricViewPlaceholder
 import org.apache.spark.sql.metricview.serde.{AssetSource, MetricView, MetricViewFactory, MetricViewValidationException, MetricViewYAMLParsingException, SQLSource}
 import org.apache.spark.sql.types.StructType
@@ -65,9 +64,11 @@ object MetricViewPlanner {
       MetricViewFactory.fromYAML(yaml)
     } catch {
       case e: MetricViewValidationException =>
-        throw QueryCompilationErrors.invalidLiteralForWindowDurationError()
+        throw SparkException.internalError(
+          s"Invalid metric view YAML: ${e.getMessage}", e)
       case e: MetricViewYAMLParsingException =>
-        throw QueryCompilationErrors.invalidLiteralForWindowDurationError()
+        throw SparkException.internalError(
+          s"Failed to parse metric view YAML: ${e.getMessage}", e)
     }
     val source = metricView.from match {
       case asset: AssetSource => UnresolvedRelation(sqlParser.parseMultipartIdentifier(asset.name))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/util/MetricViewPlanner.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/util/MetricViewPlanner.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
+import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.metricview.logical.MetricViewPlaceholder
 import org.apache.spark.sql.metricview.serde.{AssetSource, MetricView, MetricViewFactory, MetricViewValidationException, MetricViewYAMLParsingException, SQLSource}
 import org.apache.spark.sql.types.StructType
@@ -63,12 +64,13 @@ object MetricViewPlanner {
     val metricView = try {
       MetricViewFactory.fromYAML(yaml)
     } catch {
+      // Both cases are user-correctable errors in the YAML body, not internal Spark bugs;
+      // surface them as `INVALID_METRIC_VIEW_YAML` AnalysisExceptions so the message is
+      // categorized as user input error rather than "please contact support".
       case e: MetricViewValidationException =>
-        throw SparkException.internalError(
-          s"Invalid metric view YAML: ${e.getMessage}", e)
+        throw QueryCompilationErrors.invalidMetricViewYamlError(e.getMessage, e)
       case e: MetricViewYAMLParsingException =>
-        throw SparkException.internalError(
-          s"Failed to parse metric view YAML: ${e.getMessage}", e)
+        throw QueryCompilationErrors.invalidMetricViewYamlError(e.getMessage, e)
     }
     val source = metricView.from match {
       case asset: AssetSource => UnresolvedRelation(sqlParser.parseMultipartIdentifier(asset.name))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogV2UtilSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogV2UtilSuite.scala
@@ -21,7 +21,7 @@ import org.mockito.Mockito.{mock, when}
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
-import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.types.{IntegerType, MetadataBuilder, StringType, StructField}
 
 class CatalogV2UtilSuite extends SparkFunSuite {
   test("Load relation should encode the identifiers for V2Relations") {
@@ -36,5 +36,35 @@ class CatalogV2UtilSuite extends SparkFunSuite {
     val v2Relation = r.get.asInstanceOf[DataSourceV2Relation]
     assert(v2Relation.catalog.exists(_ == testCatalog))
     assert(v2Relation.identifier.exists(_ == ident))
+  }
+
+  test("Column.fromStructField preserves name, dataType, nullable, comment, and metadata") {
+    val metadata = new MetadataBuilder()
+      .putString("metric_view.type", "dimension")
+      .putString("metric_view.expr", "region")
+      .build()
+    val field = StructField("region", StringType, nullable = true, metadata)
+      .withComment("dim col")
+    val column = Column.fromStructField(field)
+
+    assert(column.name() == "region")
+    assert(column.dataType() == StringType)
+    assert(column.nullable())
+    assert(column.comment() == "dim col")
+    // The metric_view.* keys must survive round-trip via metadataInJSON; comment is also
+    // present in the metadata under key "comment" by Spark's withComment convention.
+    val parsedMetadata = org.apache.spark.sql.types.Metadata.fromJson(column.metadataInJSON())
+    assert(parsedMetadata.getString("metric_view.type") == "dimension")
+    assert(parsedMetadata.getString("metric_view.expr") == "region")
+  }
+
+  test("Column.fromStructField on a field with empty metadata returns null metadataInJSON") {
+    val field = StructField("c", IntegerType, nullable = false)
+    val column = Column.fromStructField(field)
+    assert(column.name() == "c")
+    assert(column.dataType() == IntegerType)
+    assert(!column.nullable())
+    assert(column.comment() == null)
+    assert(column.metadataInJSON() == null)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogV2UtilSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogV2UtilSuite.scala
@@ -21,7 +21,7 @@ import org.mockito.Mockito.{mock, when}
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
-import org.apache.spark.sql.types.{IntegerType, MetadataBuilder, StringType, StructField}
+import org.apache.spark.sql.types.IntegerType
 
 class CatalogV2UtilSuite extends SparkFunSuite {
   test("Load relation should encode the identifiers for V2Relations") {
@@ -36,35 +36,5 @@ class CatalogV2UtilSuite extends SparkFunSuite {
     val v2Relation = r.get.asInstanceOf[DataSourceV2Relation]
     assert(v2Relation.catalog.exists(_ == testCatalog))
     assert(v2Relation.identifier.exists(_ == ident))
-  }
-
-  test("Column.fromStructField preserves name, dataType, nullable, comment, and metadata") {
-    val metadata = new MetadataBuilder()
-      .putString("metric_view.type", "dimension")
-      .putString("metric_view.expr", "region")
-      .build()
-    val field = StructField("region", StringType, nullable = true, metadata)
-      .withComment("dim col")
-    val column = Column.fromStructField(field)
-
-    assert(column.name() == "region")
-    assert(column.dataType() == StringType)
-    assert(column.nullable())
-    assert(column.comment() == "dim col")
-    // The metric_view.* keys must survive round-trip via metadataInJSON; comment is also
-    // present in the metadata under key "comment" by Spark's withComment convention.
-    val parsedMetadata = org.apache.spark.sql.types.Metadata.fromJson(column.metadataInJSON())
-    assert(parsedMetadata.getString("metric_view.type") == "dimension")
-    assert(parsedMetadata.getString("metric_view.expr") == "region")
-  }
-
-  test("Column.fromStructField on a field with empty metadata returns null metadataInJSON") {
-    val field = StructField("c", IntegerType, nullable = false)
-    val column = Column.fromStructField(field)
-    assert(column.name() == "c")
-    assert(column.dataType() == IntegerType)
-    assert(!column.nullable())
-    assert(column.comment() == null)
-    assert(column.metadataInJSON() == null)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -315,6 +315,30 @@ class DataTypeSuite extends SparkFunSuite {
   checkDataTypeFromJson(structType)
   checkDataTypeFromDDL(structType)
 
+  test("StructField json round-trip preserves name, type, nullable, comment, metadata") {
+    val baseMetadata = new MetadataBuilder()
+      .putString("metric_view.type", "dimension")
+      .putString("metric_view.expr", "region")
+      .build()
+    val field = StructField("region", StringType, nullable = true, baseMetadata)
+      .withComment("dim col")
+    val parsed = StructField.fromJson(field.json)
+    assert(parsed.name == "region")
+    assert(parsed.dataType == StringType)
+    assert(parsed.nullable)
+    assert(parsed.getComment().contains("dim col"))
+    // `withComment` adds a "comment" key to metadata; it must round-trip alongside the
+    // metric_view.* keys.
+    assert(parsed.metadata.getString("metric_view.type") == "dimension")
+    assert(parsed.metadata.getString("metric_view.expr") == "region")
+  }
+
+  test("StructField json round-trip with empty metadata and no comment") {
+    val field = StructField("c", IntegerType, nullable = false)
+    val parsed = StructField.fromJson(field.json)
+    assert(parsed == field)
+  }
+
   test("fromJson throws an exception when given type string is invalid") {
     checkError(
       exception = intercept[SparkIllegalArgumentException] {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -315,30 +315,6 @@ class DataTypeSuite extends SparkFunSuite {
   checkDataTypeFromJson(structType)
   checkDataTypeFromDDL(structType)
 
-  test("StructField json round-trip preserves name, type, nullable, comment, metadata") {
-    val baseMetadata = new MetadataBuilder()
-      .putString("metric_view.type", "dimension")
-      .putString("metric_view.expr", "region")
-      .build()
-    val field = StructField("region", StringType, nullable = true, baseMetadata)
-      .withComment("dim col")
-    val parsed = StructField.fromJson(field.json)
-    assert(parsed.name == "region")
-    assert(parsed.dataType == StringType)
-    assert(parsed.nullable)
-    assert(parsed.getComment().contains("dim col"))
-    // `withComment` adds a "comment" key to metadata; it must round-trip alongside the
-    // metric_view.* keys.
-    assert(parsed.metadata.getString("metric_view.type") == "dimension")
-    assert(parsed.metadata.getString("metric_view.expr") == "region")
-  }
-
-  test("StructField json round-trip with empty metadata and no comment") {
-    val field = StructField("c", IntegerType, nullable = false)
-    val parsed = StructField.fromJson(field.json)
-    assert(parsed == field)
-  }
-
   test("fromJson throws an exception when given type string is invalid") {
     checkError(
       exception = intercept[SparkIllegalArgumentException] {

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -342,9 +342,10 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
       DropTableCommand(ident, ifExists, isView = true, purge = false)
 
     // ViewCatalog catalogs fall through to `DataSourceV2Strategy`, which routes DROP VIEW to
-    // `ViewCatalog.dropView`. Other non-session catalogs get `MISSING_CATALOG_ABILITY.VIEWS`,
-    // matching the error raised from `CheckViewReferences` for CREATE/ALTER VIEW and from the
-    // analyzer gate on UnresolvedView.
+    // `ViewCatalog.dropView` (this also covers METRIC_VIEW since metric views are persisted
+    // through the same ViewCatalog interface). Other non-session catalogs get
+    // `MISSING_CATALOG_ABILITY.VIEWS`, matching the error raised from `CheckViewReferences` for
+    // CREATE/ALTER VIEW and from the analyzer gate on UnresolvedView.
     case DropView(r @ ResolvedIdentifier(catalog, ident), ifExists)
         if !catalog.isInstanceOf[ViewCatalog] =>
       if (catalog == FakeSystemCatalog) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/DataStreamWriter.scala
@@ -28,7 +28,7 @@ import org.apache.spark.annotation.Evolving
 import org.apache.spark.api.java.function.VoidFunction2
 import org.apache.spark.sql.{streaming, Dataset => DS, ForeachWriter}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedIdentifier
-import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.plans.logical.{ColumnDefinition, CreateTable, OptionList, UnresolvedTableSpec}
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
@@ -190,8 +190,7 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) extends streaming.D
     val tableInstance = catalog.asTableCatalog.loadTable(identifier)
 
     def writeToV1Table(table: CatalogTable): StreamingQuery = {
-      if (table.tableType == CatalogTableType.VIEW ||
-          table.tableType == CatalogTableType.METRIC_VIEW) {
+      if (table.isViewLike) {
         throw QueryCompilationErrors.streamingIntoViewNotSupportedError(tableName)
       }
       require(table.provider.isDefined)

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/DataStreamWriter.scala
@@ -190,7 +190,8 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) extends streaming.D
     val tableInstance = catalog.asTableCatalog.loadTable(identifier)
 
     def writeToV1Table(table: CatalogTable): StreamingQuery = {
-      if (table.tableType == CatalogTableType.VIEW) {
+      if (table.tableType == CatalogTableType.VIEW ||
+          table.tableType == CatalogTableType.METRIC_VIEW) {
         throw QueryCompilationErrors.streamingIntoViewNotSupportedError(tableName)
       }
       require(table.provider.isDefined)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeColumnCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeColumnCommand.scala
@@ -104,7 +104,8 @@ case class AnalyzeColumnCommand(
   private def analyzeColumnInCatalog(sparkSession: SparkSession): Unit = {
     val sessionState = sparkSession.sessionState
     val tableMeta = sessionState.catalog.getTableMetadata(tableIdent)
-    if (tableMeta.tableType == CatalogTableType.VIEW) {
+    if (tableMeta.tableType == CatalogTableType.VIEW ||
+        tableMeta.tableType == CatalogTableType.METRIC_VIEW) {
       // Analyzes a catalog view if the view is cached
       val plan = sparkSession.table(tableIdent.quotedString).logicalPlan
       if (!analyzeColumnInCachedData(plan, sparkSession)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeColumnCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzeColumnCommand.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.catalog.{CatalogStatistics, CatalogTableType}
+import org.apache.spark.sql.catalyst.catalog.CatalogStatistics
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.classic.ClassicConversions.castToImpl
@@ -104,8 +104,7 @@ case class AnalyzeColumnCommand(
   private def analyzeColumnInCatalog(sparkSession: SparkSession): Unit = {
     val sessionState = sparkSession.sessionState
     val tableMeta = sessionState.catalog.getTableMetadata(tableIdent)
-    if (tableMeta.tableType == CatalogTableType.VIEW ||
-        tableMeta.tableType == CatalogTableType.METRIC_VIEW) {
+    if (tableMeta.isViewLike) {
       // Analyzes a catalog view if the view is cached
       val plan = sparkSession.table(tableIdent.quotedString).logicalPlan
       if (!analyzeColumnInCachedData(plan, sparkSession)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzePartitionCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzePartitionCommand.scala
@@ -75,7 +75,8 @@ case class AnalyzePartitionCommand(
     val db = tableIdent.database.getOrElse(sessionState.catalog.getCurrentDatabase)
     val tableIdentWithDB = TableIdentifier(tableIdent.table, Some(db))
     val tableMeta = sessionState.catalog.getTableMetadata(tableIdentWithDB)
-    if (tableMeta.tableType == CatalogTableType.VIEW) {
+    if (tableMeta.tableType == CatalogTableType.VIEW ||
+        tableMeta.tableType == CatalogTableType.METRIC_VIEW) {
       throw QueryCompilationErrors.analyzeTableNotSupportedOnViewsError()
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzePartitionCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/AnalyzePartitionCommand.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.classic.ClassicConversions.castToImpl
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -75,8 +75,7 @@ case class AnalyzePartitionCommand(
     val db = tableIdent.database.getOrElse(sessionState.catalog.getCurrentDatabase)
     val tableIdentWithDB = TableIdentifier(tableIdent.table, Some(db))
     val tableMeta = sessionState.catalog.getTableMetadata(tableIdentWithDB)
-    if (tableMeta.tableType == CatalogTableType.VIEW ||
-        tableMeta.tableType == CatalogTableType.METRIC_VIEW) {
+    if (tableMeta.isViewLike) {
       throw QueryCompilationErrors.analyzeTableNotSupportedOnViewsError()
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -29,7 +29,7 @@ import org.apache.spark.internal.LogKeys.{COUNT, DATABASE_NAME, ERROR, TABLE_NAM
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.analysis.ResolvedIdentifier
-import org.apache.spark.sql.catalyst.catalog.{CatalogStatistics, CatalogTable, CatalogTablePartition, CatalogTableType, ExternalCatalogUtils}
+import org.apache.spark.sql.catalyst.catalog.{CatalogStatistics, CatalogTable, CatalogTablePartition, ExternalCatalogUtils}
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
@@ -240,8 +240,7 @@ object CommandUtils extends Logging {
     val db = tableIdent.database.getOrElse(sessionState.catalog.getCurrentDatabase)
     val tableIdentWithDB = TableIdentifier(tableIdent.table, Some(db))
     val tableMeta = sessionState.catalog.getTableMetadata(tableIdentWithDB)
-    if (tableMeta.tableType == CatalogTableType.VIEW ||
-        tableMeta.tableType == CatalogTableType.METRIC_VIEW) {
+    if (tableMeta.isViewLike) {
       // Analyzes a catalog view if the view is cached
       val table = sparkSession.table(tableIdent.quotedString)
       val cacheManager = sparkSession.sharedState.cacheManager

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -240,7 +240,8 @@ object CommandUtils extends Logging {
     val db = tableIdent.database.getOrElse(sessionState.catalog.getCurrentDatabase)
     val tableIdentWithDB = TableIdentifier(tableIdent.table, Some(db))
     val tableMeta = sessionState.catalog.getTableMetadata(tableIdentWithDB)
-    if (tableMeta.tableType == CatalogTableType.VIEW) {
+    if (tableMeta.tableType == CatalogTableType.VIEW ||
+        tableMeta.tableType == CatalogTableType.METRIC_VIEW) {
       // Analyzes a catalog view if the view is cached
       val table = sparkSession.table(tableIdent.quotedString)
       val cacheManager = sparkSession.sharedState.cacheManager

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DescribeRelationJsonCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DescribeRelationJsonCommand.scala
@@ -309,7 +309,8 @@ case class DescribeRelationJsonCommand(
       catalog: SessionCatalog,
       metadata: CatalogTable,
       jsonMap: mutable.LinkedHashMap[String, JValue]): Unit = {
-    if (metadata.tableType == CatalogTableType.VIEW) {
+    if (metadata.tableType == CatalogTableType.VIEW ||
+        metadata.tableType == CatalogTableType.METRIC_VIEW) {
       throw QueryCompilationErrors.descPartitionNotAllowedOnView(metadata.identifier.identifier)
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DescribeRelationJsonCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DescribeRelationJsonCommand.scala
@@ -27,7 +27,7 @@ import org.json4s.jackson.JsonMethods._
 
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.{ResolvedPersistentView, ResolvedTable, ResolvedTempView}
-import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType, SessionCatalog}
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, SessionCatalog}
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -309,8 +309,7 @@ case class DescribeRelationJsonCommand(
       catalog: SessionCatalog,
       metadata: CatalogTable,
       jsonMap: mutable.LinkedHashMap[String, JValue]): Unit = {
-    if (metadata.tableType == CatalogTableType.VIEW ||
-        metadata.tableType == CatalogTableType.METRIC_VIEW) {
+    if (metadata.isViewLike) {
       throw QueryCompilationErrors.descPartitionNotAllowedOnView(metadata.identifier.identifier)
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -50,7 +50,7 @@ case class CreateDataSourceTableCommand(table: CatalogTable, ignoreIfExists: Boo
   extends LeafRunnableCommand {
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    assert(table.tableType != CatalogTableType.VIEW)
+    assert(!table.isViewLike)
     assert(table.provider.isDefined)
 
     val sessionState = sparkSession.sessionState
@@ -151,7 +151,7 @@ case class CreateDataSourceTableAsSelectCommand(
   override def innerChildren: Seq[LogicalPlan] = query :: Nil
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    assert(table.tableType != CatalogTableType.VIEW)
+    assert(!table.isViewLike)
     assert(table.provider.isDefined)
 
     val sessionState = sparkSession.sessionState

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -1089,11 +1089,11 @@ object DDLUtils extends Logging {
       isView: Boolean): Unit = {
     if (!catalog.isTempView(tableMetadata.identifier)) {
       tableMetadata.tableType match {
-        case CatalogTableType.VIEW if !isView =>
+        case t if (t == CatalogTableType.VIEW || t == CatalogTableType.METRIC_VIEW) && !isView =>
           throw QueryCompilationErrors.cannotAlterViewWithAlterTableError(
             viewName = tableMetadata.identifier.table
           )
-        case o if o != CatalogTableType.VIEW && isView =>
+        case o if o != CatalogTableType.VIEW && o != CatalogTableType.METRIC_VIEW && isView =>
           throw QueryCompilationErrors.cannotAlterTableWithAlterViewError(
             tableName = tableMetadata.identifier.table
           )

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -232,7 +232,8 @@ case class DropTableCommand(
       // If the command DROP VIEW is to drop a table or DROP TABLE is to drop a view
       // issue an exception.
       catalog.getTableMetadata(tableName).tableType match {
-        case CatalogTableType.VIEW if !isView =>
+        // Both VIEW and METRIC_VIEW are conceptually views and must be dropped via DROP VIEW.
+        case CatalogTableType.VIEW | CatalogTableType.METRIC_VIEW if !isView =>
           throw QueryCompilationErrors.wrongCommandForObjectTypeError(
             operation = "DROP TABLE",
             requiredType = s"${CatalogTableType.EXTERNAL.name} or ${CatalogTableType.MANAGED.name}",
@@ -240,10 +241,11 @@ case class DropTableCommand(
             foundType = catalog.getTableMetadata(tableName).tableType.name,
             alternative = "DROP VIEW"
           )
-        case o if o != CatalogTableType.VIEW && isView =>
+        case o if o != CatalogTableType.VIEW && o != CatalogTableType.METRIC_VIEW && isView =>
           throw QueryCompilationErrors.wrongCommandForObjectTypeError(
             operation = "DROP VIEW",
-            requiredType = CatalogTableType.VIEW.name,
+            requiredType =
+              s"${CatalogTableType.VIEW.name} or ${CatalogTableType.METRIC_VIEW.name}",
             objectName = catalog.getTableMetadata(tableName).qualifiedName,
             foundType = o.name,
             alternative = "DROP TABLE"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -233,7 +233,7 @@ case class DropTableCommand(
       // issue an exception.
       catalog.getTableMetadata(tableName).tableType match {
         // Both VIEW and METRIC_VIEW are conceptually views and must be dropped via DROP VIEW.
-        case CatalogTableType.VIEW | CatalogTableType.METRIC_VIEW if !isView =>
+        case t if CatalogTable.isViewLike(t) && !isView =>
           throw QueryCompilationErrors.wrongCommandForObjectTypeError(
             operation = "DROP TABLE",
             requiredType = s"${CatalogTableType.EXTERNAL.name} or ${CatalogTableType.MANAGED.name}",
@@ -241,7 +241,7 @@ case class DropTableCommand(
             foundType = catalog.getTableMetadata(tableName).tableType.name,
             alternative = "DROP VIEW"
           )
-        case o if o != CatalogTableType.VIEW && o != CatalogTableType.METRIC_VIEW && isView =>
+        case o if !CatalogTable.isViewLike(o) && isView =>
           throw QueryCompilationErrors.wrongCommandForObjectTypeError(
             operation = "DROP VIEW",
             requiredType =
@@ -1089,11 +1089,11 @@ object DDLUtils extends Logging {
       isView: Boolean): Unit = {
     if (!catalog.isTempView(tableMetadata.identifier)) {
       tableMetadata.tableType match {
-        case t if (t == CatalogTableType.VIEW || t == CatalogTableType.METRIC_VIEW) && !isView =>
+        case t if CatalogTable.isViewLike(t) && !isView =>
           throw QueryCompilationErrors.cannotAlterViewWithAlterTableError(
             viewName = tableMetadata.identifier.table
           )
-        case o if o != CatalogTableType.VIEW && o != CatalogTableType.METRIC_VIEW && isView =>
+        case o if !CatalogTable.isViewLike(o) && isView =>
           throw QueryCompilationErrors.cannotAlterTableWithAlterViewError(
             tableName = tableMetadata.identifier.table
           )

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/metricViewCommands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/metricViewCommands.scala
@@ -17,13 +17,20 @@
 
 package org.apache.spark.sql.execution.command
 
+import scala.jdk.CollectionConverters._
+
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.{QueryPlanningTracker, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{ResolvedIdentifier, SchemaUnsupported}
-import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, HiveTableRelation}
+import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, View}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Dependency, DependencyList, TableCatalog, TableSummary, ViewCatalog, ViewInfo}
 import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.metricview.serde.MetricViewFactory
 import org.apache.spark.sql.metricview.util.MetricViewPlanner
 import org.apache.spark.sql.types.StructType
 
@@ -39,15 +46,17 @@ case class CreateMetricViewCommand(
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val catalog = sparkSession.sessionState.catalog
-    val name = child match {
+    child match {
+      case v: ResolvedIdentifier if !CatalogV2Util.isSessionCatalog(v.catalog) =>
+        createMetricViewInV2Catalog(sparkSession, v)
       case v: ResolvedIdentifier =>
-        v.identifier.asTableIdentifier
+        createMetricViewInSessionCatalog(sparkSession, v)
       case _ => throw SparkException.internalError(
         s"Failed to resolve identifier for creating metric view")
     }
-    val analyzed = MetricViewHelper.analyzeMetricViewText(sparkSession, name, originalText)
+  }
 
+  private def validateUserColumns(name: TableIdentifier, analyzed: LogicalPlan): Unit = {
     if (userSpecifiedColumns.nonEmpty) {
       if (userSpecifiedColumns.length > analyzed.output.length) {
         throw QueryCompilationErrors.cannotCreateViewNotEnoughColumnsError(
@@ -57,6 +66,15 @@ case class CreateMetricViewCommand(
           name.nameParts, userSpecifiedColumns.map(_._1), analyzed)
       }
     }
+  }
+
+  private def createMetricViewInSessionCatalog(
+      sparkSession: SparkSession,
+      resolved: ResolvedIdentifier): Seq[Row] = {
+    val catalog = sparkSession.sessionState.catalog
+    val name = resolved.identifier.asTableIdentifier
+    val analyzed = MetricViewHelper.analyzeMetricViewText(sparkSession, name, originalText)
+    validateUserColumns(name, analyzed)
     catalog.createTable(
       ViewHelper.prepareTable(
         sparkSession, name, Some(originalText), analyzed, userSpecifiedColumns,
@@ -65,6 +83,66 @@ case class CreateMetricViewCommand(
       ignoreIfExists = allowExisting)
     Seq.empty
   }
+
+  private def createMetricViewInV2Catalog(
+      sparkSession: SparkSession,
+      resolved: ResolvedIdentifier): Seq[Row] = {
+    // Metric views are persisted through the same `ViewCatalog` interface as plain views; the
+    // only differences are `PROP_TABLE_TYPE = METRIC_VIEW` (so `V1Table.toCatalogTable` maps the
+    // round-tripped row back to `CatalogTableType.METRIC_VIEW`), the `metric_view.*` descriptor
+    // properties produced by `MetricView.getProperties`, and the typed `viewDependencies` field.
+    val viewCatalog = resolved.catalog match {
+      case vc: ViewCatalog => vc
+      case other =>
+        throw QueryCompilationErrors.missingCatalogViewsAbilityError(other)
+    }
+    val ident = resolved.identifier
+    val name = ident.asTableIdentifier
+
+    val analyzed = MetricViewHelper.analyzeMetricViewText(sparkSession, name, originalText)
+    validateUserColumns(name, analyzed)
+
+    // `retainMetadata = true` preserves the per-column `metric_view.type` / `metric_view.expr`
+    // metadata that `ResolveMetricView.buildMetricViewOutput` attaches, even when the user
+    // supplies column names with comments (same contract as the V1 session-catalog path, which
+    // goes through `ViewHelper.prepareTable` with `isMetricView = true`).
+    val aliasedSchema = ViewHelper
+      .aliasPlan(sparkSession, analyzed, userSpecifiedColumns, retainMetadata = true)
+      .schema
+
+    // Describe this metric view's source and filter as user-visible properties so catalogs and
+    // tooling can inspect them without re-parsing the YAML body.
+    val metricView = MetricViewFactory.fromYAML(originalText)
+    val viewProperties = new java.util.HashMap[String, String]()
+    properties.foreach { case (k, v) => viewProperties.put(k, v) }
+    metricView.getProperties.foreach { case (k, v) => viewProperties.put(k, v) }
+    viewProperties.put(TableCatalog.PROP_TABLE_TYPE, TableSummary.METRIC_VIEW_TABLE_TYPE)
+
+    val sourceTableNames = MetricViewHelper.collectTableDependencies(analyzed)
+    val deps = if (sourceTableNames.nonEmpty) {
+      DependencyList.of(sourceTableNames.map(Dependency.table): _*)
+    } else {
+      null
+    }
+
+    val manager = sparkSession.sessionState.catalogManager
+    val builder = new ViewInfo.Builder()
+      .withSchema(aliasedSchema)
+      .withProperties(viewProperties)
+      .withQueryText(originalText)
+      .withCurrentCatalog(manager.currentCatalog.name)
+      .withCurrentNamespace(manager.currentNamespace)
+      .withSqlConfigs(
+        ViewHelper.sqlConfigsToProps(sparkSession.sessionState.conf, "").asJava)
+      .withSchemaMode(SchemaUnsupported.toString)
+      .withQueryColumnNames(analyzed.output.map(_.name).toArray)
+      .withViewDependencies(deps)
+    comment.foreach(builder.withComment)
+
+    viewCatalog.createView(ident, builder.build())
+    Seq.empty
+  }
+
   override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = {
     copy(child = newChild)
   }
@@ -73,6 +151,37 @@ case class CreateMetricViewCommand(
 case class AlterMetricViewCommand(child: LogicalPlan, originalText: String)
 
 object MetricViewHelper {
+
+  /**
+   * Walks the analyzed plan to collect direct table/view dependencies.
+   * Stops recursion at relation leaf nodes and persistent View nodes so that only
+   * direct (not transitive) dependencies are recorded.
+   */
+  private[execution] def collectTableDependencies(plan: LogicalPlan): Seq[String] = {
+    val tables = scala.collection.mutable.ArrayBuffer.empty[String]
+    def traverse(p: LogicalPlan): Unit = p match {
+      case v: View if !v.isTempView =>
+        tables += v.desc.identifier.unquotedString
+      case r: DataSourceV2Relation if r.catalog.isDefined && r.identifier.isDefined =>
+        val cat = r.catalog.get.name()
+        val ns = r.identifier.get.namespace().mkString(".")
+        val name = r.identifier.get.name()
+        tables += s"$cat.$ns.$name"
+      case r: HiveTableRelation =>
+        tables += r.tableMeta.identifier.unquotedString
+      case r: LogicalRelation if r.catalogTable.isDefined =>
+        tables += r.catalogTable.get.identifier.unquotedString
+      case other =>
+        other.children.foreach(traverse)
+        other.expressions.foreach(_.foreach {
+          case s: SubqueryExpression => traverse(s.plan)
+          case _ =>
+        })
+    }
+    traverse(plan)
+    tables.distinct.toSeq
+  }
+
   def analyzeMetricViewText(
       session: SparkSession,
       name: TableIdentifier,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/metricViewCommands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/metricViewCommands.scala
@@ -140,10 +140,10 @@ object MetricViewHelper {
    * dependency consumers as nondeterministic arity.
    */
   private def qualifyV1(parts: Seq[String]): Seq[String] = parts match {
-    case Seq(t)         => Seq(SESSION_CATALOG_NAME, SessionCatalog.DEFAULT_DATABASE, t)
-    case Seq(db, t)     => Seq(SESSION_CATALOG_NAME, db, t)
-    case Seq(_, _, _)   => parts
-    case other          => other  // Unexpected arity; pass through unchanged.
+    case Seq(t) => Seq(SESSION_CATALOG_NAME, SessionCatalog.DEFAULT_DATABASE, t)
+    case Seq(db, t) => Seq(SESSION_CATALOG_NAME, db, t)
+    case Seq(_, _, _) => parts
+    case other => other  // Unexpected arity; pass through unchanged.
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/metricViewCommands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/metricViewCommands.scala
@@ -68,7 +68,8 @@ case class CreateMetricViewCommand(
       resolved: ResolvedIdentifier): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val name = resolved.identifier.asTableIdentifier
-    val analyzed = MetricViewHelper.analyzeMetricViewText(sparkSession, name, originalText)
+    val analyzed = MetricViewHelper.analyzeMetricViewText(
+      sparkSession, name.nameParts, originalText)
     validateUserColumns(name, analyzed)
     catalog.createTable(
       ViewHelper.prepareTable(
@@ -122,15 +123,41 @@ object MetricViewHelper {
     tables.distinct.toSeq
   }
 
+  /**
+   * Analyzes a metric-view YAML body so the create / alter path can capture the source plan
+   * and its dependencies.
+   *
+   * `nameParts` is the multi-part target identifier (catalog + namespace + table). The synthetic
+   * [[CatalogTable]] used as analysis context still carries a [[TableIdentifier]] (capped at
+   * 3 parts: catalog + database + table); for multi-level v2 namespaces we collapse the
+   * intermediate namespace components into the synthetic `database` slot. The synthetic identifier
+   * is not used to resolve the view body itself, so this collapse is observationally invisible to
+   * the analyzed plan; `verifyTemporaryObjectsNotExists` continues to receive the full
+   * `nameParts` so error messages still render the multi-part form.
+   */
   def analyzeMetricViewText(
       session: SparkSession,
-      name: TableIdentifier,
+      nameParts: Seq[String],
       viewText: String): LogicalPlan = {
     val analyzer = session.sessionState.analyzer
+    val syntheticIdent = nameParts match {
+      case Seq(table) =>
+        TableIdentifier(table)
+      case Seq(db, table) =>
+        TableIdentifier(table, Some(db))
+      case parts =>
+        // 3+ parts: catalog is the head, table is the last, the middle (1..n-1) collapses
+        // into the synthetic `database` slot. We dot-join the intermediate components so a
+        // human inspecting the synthetic identifier can still see them.
+        TableIdentifier(
+          parts.last,
+          Some(parts.slice(1, parts.length - 1).mkString(".")),
+          Some(parts.head))
+    }
     // this metadata is used for analysis check, it'll be replaced during create/update with
     // more accurate information
     val tableMeta = CatalogTable(
-      identifier = name,
+      identifier = syntheticIdent,
       tableType = CatalogTableType.VIEW,
       storage = CatalogStorageFormat.empty,
       schema = new StructType(),
@@ -140,7 +167,7 @@ object MetricViewHelper {
       tableMeta, viewText, session.sessionState.sqlParser)
     val analyzed = analyzer.executeAndCheck(metricViewNode, new QueryPlanningTracker)
     ViewHelper.verifyTemporaryObjectsNotExists(
-      isTemporary = false, name.nameParts, analyzed, Seq.empty)
+      isTemporary = false, nameParts, analyzed, Seq.empty)
     analyzed
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/metricViewCommands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/metricViewCommands.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.execution.command
 
-import scala.jdk.CollectionConverters._
-
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.{QueryPlanningTracker, TableIdentifier}
@@ -26,11 +24,10 @@ import org.apache.spark.sql.catalyst.analysis.{ResolvedIdentifier, SchemaUnsuppo
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, HiveTableRelation}
 import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, View}
-import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Dependency, DependencyList, TableCatalog, TableSummary, ViewCatalog, ViewInfo}
+import org.apache.spark.sql.connector.catalog.CatalogV2Util
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
-import org.apache.spark.sql.metricview.serde.MetricViewFactory
 import org.apache.spark.sql.metricview.util.MetricViewPlanner
 import org.apache.spark.sql.types.StructType
 
@@ -47,10 +44,15 @@ case class CreateMetricViewCommand(
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     child match {
-      case v: ResolvedIdentifier if !CatalogV2Util.isSessionCatalog(v.catalog) =>
-        createMetricViewInV2Catalog(sparkSession, v)
-      case v: ResolvedIdentifier =>
+      case v: ResolvedIdentifier if CatalogV2Util.isSessionCatalog(v.catalog) =>
         createMetricViewInSessionCatalog(sparkSession, v)
+      case _: ResolvedIdentifier =>
+        // Non-session v2 catalogs are intercepted by `DataSourceV2Strategy` before the
+        // `ExecutedCommandExec(RunnableCommand)` fallback, so this branch is unreachable in
+        // practice. Keep the assertion for defensive clarity if a future strategy reorder
+        // accidentally exposes this code path.
+        throw SparkException.internalError(
+          "V2 metric-view CREATE should be handled by DataSourceV2Strategy, not run here")
       case _ => throw SparkException.internalError(
         s"Failed to resolve identifier for creating metric view")
     }
@@ -84,65 +86,6 @@ case class CreateMetricViewCommand(
     Seq.empty
   }
 
-  private def createMetricViewInV2Catalog(
-      sparkSession: SparkSession,
-      resolved: ResolvedIdentifier): Seq[Row] = {
-    // Metric views are persisted through the same `ViewCatalog` interface as plain views; the
-    // only differences are `PROP_TABLE_TYPE = METRIC_VIEW` (so `V1Table.toCatalogTable` maps the
-    // round-tripped row back to `CatalogTableType.METRIC_VIEW`), the `metric_view.*` descriptor
-    // properties produced by `MetricView.getProperties`, and the typed `viewDependencies` field.
-    val viewCatalog = resolved.catalog match {
-      case vc: ViewCatalog => vc
-      case other =>
-        throw QueryCompilationErrors.missingCatalogViewsAbilityError(other)
-    }
-    val ident = resolved.identifier
-    val name = ident.asTableIdentifier
-
-    val analyzed = MetricViewHelper.analyzeMetricViewText(sparkSession, name, originalText)
-    validateUserColumns(name, analyzed)
-
-    // `retainMetadata = true` preserves the per-column `metric_view.type` / `metric_view.expr`
-    // metadata that `ResolveMetricView.buildMetricViewOutput` attaches, even when the user
-    // supplies column names with comments (same contract as the V1 session-catalog path, which
-    // goes through `ViewHelper.prepareTable` with `isMetricView = true`).
-    val aliasedSchema = ViewHelper
-      .aliasPlan(sparkSession, analyzed, userSpecifiedColumns, retainMetadata = true)
-      .schema
-
-    // Describe this metric view's source and filter as user-visible properties so catalogs and
-    // tooling can inspect them without re-parsing the YAML body.
-    val metricView = MetricViewFactory.fromYAML(originalText)
-    val viewProperties = new java.util.HashMap[String, String]()
-    properties.foreach { case (k, v) => viewProperties.put(k, v) }
-    metricView.getProperties.foreach { case (k, v) => viewProperties.put(k, v) }
-    viewProperties.put(TableCatalog.PROP_TABLE_TYPE, TableSummary.METRIC_VIEW_TABLE_TYPE)
-
-    val sourceTableNames = MetricViewHelper.collectTableDependencies(analyzed)
-    val deps = if (sourceTableNames.nonEmpty) {
-      DependencyList.of(sourceTableNames.map(Dependency.table): _*)
-    } else {
-      null
-    }
-
-    val manager = sparkSession.sessionState.catalogManager
-    val builder = new ViewInfo.Builder()
-      .withSchema(aliasedSchema)
-      .withProperties(viewProperties)
-      .withQueryText(originalText)
-      .withCurrentCatalog(manager.currentCatalog.name)
-      .withCurrentNamespace(manager.currentNamespace)
-      .withSqlConfigs(
-        ViewHelper.sqlConfigsToProps(sparkSession.sessionState.conf, "").asJava)
-      .withSchemaMode(SchemaUnsupported.toString)
-      .withQueryColumnNames(analyzed.output.map(_.name).toArray)
-      .withViewDependencies(deps)
-    comment.foreach(builder.withComment)
-
-    viewCatalog.createView(ident, builder.build())
-    Seq.empty
-  }
-
   override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = {
     copy(child = newChild)
   }
@@ -153,24 +96,28 @@ case class AlterMetricViewCommand(child: LogicalPlan, originalText: String)
 object MetricViewHelper {
 
   /**
-   * Walks the analyzed plan to collect direct table/view dependencies.
-   * Stops recursion at relation leaf nodes and persistent View nodes so that only
-   * direct (not transitive) dependencies are recorded.
+   * Walks the analyzed plan to collect direct table/view dependencies. Each dependency is
+   * returned as a structural multi-part name (`Seq[String]`); arity is preserved per source
+   * so consumers can reason about catalog / namespace / table boundaries without parsing a
+   * dot-flattened string.
+   *
+   * Stops recursion at relation leaf nodes and persistent `View` nodes so only direct
+   * (not transitive) dependencies are recorded.
    */
-  private[execution] def collectTableDependencies(plan: LogicalPlan): Seq[String] = {
-    val tables = scala.collection.mutable.ArrayBuffer.empty[String]
+  private[execution] def collectTableDependencies(plan: LogicalPlan): Seq[Seq[String]] = {
+    val tables = scala.collection.mutable.ArrayBuffer.empty[Seq[String]]
     def traverse(p: LogicalPlan): Unit = p match {
       case v: View if !v.isTempView =>
-        tables += v.desc.identifier.unquotedString
+        tables += v.desc.identifier.nameParts
       case r: DataSourceV2Relation if r.catalog.isDefined && r.identifier.isDefined =>
-        val cat = r.catalog.get.name()
-        val ns = r.identifier.get.namespace().mkString(".")
-        val name = r.identifier.get.name()
-        tables += s"$cat.$ns.$name"
+        val ident = r.identifier.get
+        // V2 catalogs may have multi-level namespaces; preserve the full arity rather than
+        // dot-joining the namespace into a single component.
+        tables += (r.catalog.get.name() +: ident.namespace().toIndexedSeq) :+ ident.name()
       case r: HiveTableRelation =>
-        tables += r.tableMeta.identifier.unquotedString
+        tables += r.tableMeta.identifier.nameParts
       case r: LogicalRelation if r.catalogTable.isDefined =>
-        tables += r.catalogTable.get.identifier.unquotedString
+        tables += r.catalogTable.get.identifier.nameParts
       case other =>
         other.children.foreach(traverse)
         other.expressions.foreach(_.foreach {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/metricViewCommands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/metricViewCommands.scala
@@ -46,13 +46,6 @@ case class CreateMetricViewCommand(
     child match {
       case v: ResolvedIdentifier if CatalogV2Util.isSessionCatalog(v.catalog) =>
         createMetricViewInSessionCatalog(sparkSession, v)
-      case _: ResolvedIdentifier =>
-        // Non-session v2 catalogs are intercepted by `DataSourceV2Strategy` before the
-        // `ExecutedCommandExec(RunnableCommand)` fallback, so this branch is unreachable in
-        // practice. Keep the assertion for defensive clarity if a future strategy reorder
-        // accidentally exposes this code path.
-        throw SparkException.internalError(
-          "V2 metric-view CREATE should be handled by DataSourceV2Strategy, not run here")
       case _ => throw SparkException.internalError(
         s"Failed to resolve identifier for creating metric view")
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/metricViewCommands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/metricViewCommands.scala
@@ -21,13 +21,15 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.{QueryPlanningTracker, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{ResolvedIdentifier, SchemaUnsupported}
-import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, HiveTableRelation}
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, HiveTableRelation, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, View}
+import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.connector.catalog.CatalogV2Util
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.metricview.serde.MetricView
 import org.apache.spark.sql.metricview.util.MetricViewPlanner
 import org.apache.spark.sql.types.StructType
 
@@ -68,13 +70,17 @@ case class CreateMetricViewCommand(
       resolved: ResolvedIdentifier): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val name = resolved.identifier.asTableIdentifier
-    val analyzed = MetricViewHelper.analyzeMetricViewText(
+    val (analyzed, metricView) = MetricViewHelper.analyzeMetricViewText(
       sparkSession, name.nameParts, originalText)
     validateUserColumns(name, analyzed)
+    // Merge the descriptor `metric_view.*` properties (`from.type`, `from.name`/`from.sql`,
+    // `where`) into the user-supplied properties so v1 DESCRIBE TABLE EXTENDED surfaces the
+    // same descriptor rows as the v2 path in `DataSourceV2Strategy`.
+    val mergedProps = properties ++ metricView.getProperties
     catalog.createTable(
       ViewHelper.prepareTable(
         sparkSession, name, Some(originalText), analyzed, userSpecifiedColumns,
-        properties, SchemaUnsupported, comment,
+        mergedProps, SchemaUnsupported, comment,
         None, isMetricView = true),
       ignoreIfExists = allowExisting)
     Seq.empty
@@ -91,9 +97,13 @@ object MetricViewHelper {
 
   /**
    * Walks the analyzed plan to collect direct table/view dependencies. Each dependency is
-   * returned as a structural multi-part name (`Seq[String]`); arity is preserved per source
-   * so consumers can reason about catalog / namespace / table boundaries without parsing a
-   * dot-flattened string.
+   * returned as a structural multi-part name (`Seq[String]`); v1 sources (resolved through
+   * the session catalog) are normalized to a stable 3-part shape
+   * `[spark_catalog, db, table]` -- `TableIdentifier.nameParts` returns 1, 2, or 3 parts
+   * depending on whether the analyzer captured the catalog / database, so without
+   * normalization the same source can produce a different shape across runs. v2 sources
+   * already arrive fully qualified (catalog + namespace + table) and are returned as-is so
+   * multi-level namespaces survive.
    *
    * Stops recursion at relation leaf nodes and persistent `View` nodes so only direct
    * (not transitive) dependencies are recorded.
@@ -102,16 +112,16 @@ object MetricViewHelper {
     val tables = scala.collection.mutable.ArrayBuffer.empty[Seq[String]]
     def traverse(p: LogicalPlan): Unit = p match {
       case v: View if !v.isTempView =>
-        tables += v.desc.identifier.nameParts
+        tables += qualifyV1(v.desc.identifier.nameParts)
       case r: DataSourceV2Relation if r.catalog.isDefined && r.identifier.isDefined =>
         val ident = r.identifier.get
         // V2 catalogs may have multi-level namespaces; preserve the full arity rather than
         // dot-joining the namespace into a single component.
         tables += (r.catalog.get.name() +: ident.namespace().toIndexedSeq) :+ ident.name()
       case r: HiveTableRelation =>
-        tables += r.tableMeta.identifier.nameParts
+        tables += qualifyV1(r.tableMeta.identifier.nameParts)
       case r: LogicalRelation if r.catalogTable.isDefined =>
-        tables += r.catalogTable.get.identifier.nameParts
+        tables += qualifyV1(r.catalogTable.get.identifier.nameParts)
       case other =>
         other.children.foreach(traverse)
         other.expressions.foreach(_.foreach {
@@ -124,8 +134,24 @@ object MetricViewHelper {
   }
 
   /**
+   * Normalizes v1 source identifiers to a stable 3-part `[spark_catalog, db, table]` shape.
+   * `TableIdentifier.nameParts` may return 1, 2, or 3 parts depending on whether the analyzer
+   * captured the catalog / database components, which would otherwise leak through to
+   * dependency consumers as nondeterministic arity.
+   */
+  private def qualifyV1(parts: Seq[String]): Seq[String] = parts match {
+    case Seq(t)         => Seq(SESSION_CATALOG_NAME, SessionCatalog.DEFAULT_DATABASE, t)
+    case Seq(db, t)     => Seq(SESSION_CATALOG_NAME, db, t)
+    case Seq(_, _, _)   => parts
+    case other          => other  // Unexpected arity; pass through unchanged.
+  }
+
+  /**
    * Analyzes a metric-view YAML body so the create / alter path can capture the source plan
-   * and its dependencies.
+   * and its dependencies. Returns the analyzed plan together with the parsed [[MetricView]]
+   * descriptor (the latter is grabbed off the un-analyzed [[MetricViewPlaceholder]] before
+   * the analyzer rewrites it away, so callers needing the descriptor for property emission
+   * don't have to re-parse the YAML).
    *
    * `nameParts` is the multi-part target identifier (catalog + namespace + table). The synthetic
    * [[CatalogTable]] used as analysis context still carries a [[TableIdentifier]] (capped at
@@ -138,7 +164,7 @@ object MetricViewHelper {
   def analyzeMetricViewText(
       session: SparkSession,
       nameParts: Seq[String],
-      viewText: String): LogicalPlan = {
+      viewText: String): (LogicalPlan, MetricView) = {
     val analyzer = session.sessionState.analyzer
     val syntheticIdent = nameParts match {
       case Seq(table) =>
@@ -163,11 +189,15 @@ object MetricViewHelper {
       schema = new StructType(),
       viewOriginalText = Some(viewText),
       viewText = Some(viewText))
-    val metricViewNode = MetricViewPlanner.planWrite(
+    val placeholder = MetricViewPlanner.planWrite(
       tableMeta, viewText, session.sessionState.sqlParser)
-    val analyzed = analyzer.executeAndCheck(metricViewNode, new QueryPlanningTracker)
+    // Grab the parsed descriptor BEFORE analysis -- the placeholder gets replaced by
+    // ResolvedMetricView during analyzer rules, after which `MetricView` is no longer
+    // recoverable from the plan tree.
+    val metricView = placeholder.desc
+    val analyzed = analyzer.executeAndCheck(placeholder, new QueryPlanningTracker)
     ViewHelper.verifyTemporaryObjectsNotExists(
       isTemporary = false, nameParts, analyzed, Seq.empty)
-    analyzed
+    (analyzed, metricView)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -103,7 +103,8 @@ case class CreateTableLikeCommand(
       provider
     } else if (fileFormat.inputFormat.isDefined) {
       Some(DDLUtils.HIVE_PROVIDER)
-    } else if (sourceTableDesc.tableType == CatalogTableType.VIEW) {
+    } else if (sourceTableDesc.tableType == CatalogTableType.VIEW ||
+        sourceTableDesc.tableType == CatalogTableType.METRIC_VIEW) {
       Some(sparkSession.sessionState.conf.defaultDataSourceName)
     } else {
       sourceTableDesc.provider
@@ -267,7 +268,8 @@ case class AlterTableAddColumnsCommand(
       table: TableIdentifier): CatalogTable = {
     val catalogTable = catalog.getTempViewOrPermanentTableMetadata(table)
 
-    if (catalogTable.tableType == CatalogTableType.VIEW) {
+    if (catalogTable.tableType == CatalogTableType.VIEW ||
+        catalogTable.tableType == CatalogTableType.METRIC_VIEW) {
       throw QueryCompilationErrors.alterAddColNotSupportViewError(table)
     }
 
@@ -730,7 +732,8 @@ case class DescribeTableCommand(
       catalog: SessionCatalog,
       metadata: CatalogTable,
       result: ArrayBuffer[Row]): Unit = {
-    if (metadata.tableType == CatalogTableType.VIEW) {
+    if (metadata.tableType == CatalogTableType.VIEW ||
+        metadata.tableType == CatalogTableType.METRIC_VIEW) {
       throw QueryCompilationErrors.descPartitionNotAllowedOnView(table.identifier)
     }
     DDLUtils.verifyPartitionProviderIsHive(spark, metadata, "DESC PARTITION")
@@ -1226,7 +1229,7 @@ case class ShowCreateTableCommand(
             tableMetadata)
         }
 
-        if (tableMetadata.tableType == VIEW) {
+        if (tableMetadata.tableType == VIEW || tableMetadata.tableType == METRIC_VIEW) {
           tableMetadata
         } else {
           convertTableMetadata(tableMetadata)
@@ -1235,7 +1238,11 @@ case class ShowCreateTableCommand(
 
       val builder = new StringBuilder
 
-      val stmt = if (tableMetadata.tableType == VIEW) {
+      // SHOW CREATE TABLE on a metric view falls through to the VIEW branch, which emits
+      // `CREATE VIEW ...` without the `WITH METRICS` qualifier. The output is not yet
+      // round-trippable for metric views; tracked as follow-up.
+      val stmt = if (tableMetadata.tableType == VIEW ||
+          tableMetadata.tableType == METRIC_VIEW) {
         builder ++= s"CREATE VIEW ${table.quoted} "
         showCreateView(metadata, builder)
 
@@ -1386,7 +1393,7 @@ case class ShowCreateTableAsSerdeCommand(
 
     builder ++= s"CREATE$tableTypeString ${table.quoted} "
 
-    if (metadata.tableType == VIEW) {
+    if (metadata.tableType == VIEW || metadata.tableType == METRIC_VIEW) {
       showCreateView(metadata, builder)
     } else {
       showHiveTableHeader(metadata, builder)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -103,8 +103,7 @@ case class CreateTableLikeCommand(
       provider
     } else if (fileFormat.inputFormat.isDefined) {
       Some(DDLUtils.HIVE_PROVIDER)
-    } else if (sourceTableDesc.tableType == CatalogTableType.VIEW ||
-        sourceTableDesc.tableType == CatalogTableType.METRIC_VIEW) {
+    } else if (sourceTableDesc.isViewLike) {
       Some(sparkSession.sessionState.conf.defaultDataSourceName)
     } else {
       sourceTableDesc.provider
@@ -268,8 +267,7 @@ case class AlterTableAddColumnsCommand(
       table: TableIdentifier): CatalogTable = {
     val catalogTable = catalog.getTempViewOrPermanentTableMetadata(table)
 
-    if (catalogTable.tableType == CatalogTableType.VIEW ||
-        catalogTable.tableType == CatalogTableType.METRIC_VIEW) {
+    if (catalogTable.isViewLike) {
       throw QueryCompilationErrors.alterAddColNotSupportViewError(table)
     }
 
@@ -732,8 +730,7 @@ case class DescribeTableCommand(
       catalog: SessionCatalog,
       metadata: CatalogTable,
       result: ArrayBuffer[Row]): Unit = {
-    if (metadata.tableType == CatalogTableType.VIEW ||
-        metadata.tableType == CatalogTableType.METRIC_VIEW) {
+    if (metadata.isViewLike) {
       throw QueryCompilationErrors.descPartitionNotAllowedOnView(table.identifier)
     }
     DDLUtils.verifyPartitionProviderIsHive(spark, metadata, "DESC PARTITION")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -1213,6 +1213,14 @@ case class ShowCreateTableCommand(
     } else {
       val tableMetadata = catalog.getTableRawMetadata(table)
 
+      // SHOW CREATE TABLE / VIEW does not have a WITH METRICS round-trippable form yet,
+      // so explicitly reject metric views rather than emit a misleading `CREATE VIEW`
+      // statement that loses the METRIC_VIEW kind. Tracked as follow-up.
+      if (tableMetadata.tableType == METRIC_VIEW) {
+        throw QueryCompilationErrors.showCreateTableNotSupportedOnMetricViewError(
+          table.identifier)
+      }
+
       // TODO: [SPARK-28692] unify this after we unify the
       //  CREATE TABLE syntax for hive serde and data source table.
       val metadata = if (DDLUtils.isDatasourceTable(tableMetadata)) {
@@ -1229,7 +1237,7 @@ case class ShowCreateTableCommand(
             tableMetadata)
         }
 
-        if (tableMetadata.tableType == VIEW || tableMetadata.tableType == METRIC_VIEW) {
+        if (tableMetadata.tableType == VIEW) {
           tableMetadata
         } else {
           convertTableMetadata(tableMetadata)
@@ -1238,11 +1246,7 @@ case class ShowCreateTableCommand(
 
       val builder = new StringBuilder
 
-      // SHOW CREATE TABLE on a metric view falls through to the VIEW branch, which emits
-      // `CREATE VIEW ...` without the `WITH METRICS` qualifier. The output is not yet
-      // round-trippable for metric views; tracked as follow-up.
-      val stmt = if (tableMetadata.tableType == VIEW ||
-          tableMetadata.tableType == METRIC_VIEW) {
+      val stmt = if (tableMetadata.tableType == VIEW) {
         builder ++= s"CREATE VIEW ${table.quoted} "
         showCreateView(metadata, builder)
 
@@ -1393,7 +1397,7 @@ case class ShowCreateTableAsSerdeCommand(
 
     builder ++= s"CREATE$tableTypeString ${table.quoted} "
 
-    if (metadata.tableType == VIEW || metadata.tableType == METRIC_VIEW) {
+    if (metadata.tableType == VIEW) {
       showCreateView(metadata, builder)
     } else {
       showHiveTableHeader(metadata, builder)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -172,7 +172,7 @@ case class CreateViewCommand(
       if (allowExisting) {
         // Handles `CREATE VIEW IF NOT EXISTS v0 AS SELECT ...`. Does nothing when the target view
         // already exists.
-      } else if (tableMetadata.tableType != CatalogTableType.VIEW) {
+      } else if (!tableMetadata.isViewLike) {
         throw QueryCompilationErrors.unsupportedCreateOrReplaceViewOnTableError(
           name.nameParts, replace)
       } else if (replace) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -866,24 +866,23 @@ object ViewHelper extends SQLConfHelper with Logging with CapturesConfig {
     if (originalText.isEmpty) {
       throw QueryCompilationErrors.createPersistedViewFromDatasetAPINotAllowedError()
     }
+    // For metric views, preserve the per-column metadata (`metric_view.type` / `metric_view.expr`)
+    // that the analyzer attaches to each dimension/measure `Alias`, even when the user supplies
+    // column names with comments.
     val aliasedSchema = CharVarcharUtils.getRawSchema(
-      aliasPlan(session, analyzedPlan, userSpecifiedColumns).schema, session.sessionState.conf)
+      aliasPlan(session, analyzedPlan, userSpecifiedColumns, retainMetadata = isMetricView).schema,
+      session.sessionState.conf)
     val newProperties = generateViewProperties(
       properties, session, analyzedPlan.schema.fieldNames, aliasedSchema.fieldNames, viewSchemaMode)
 
-    // Add property to indicate if this is a metric view
-    val finalProperties = if (isMetricView) {
-      newProperties + (CatalogTable.VIEW_WITH_METRICS -> "true")
-    } else {
-      newProperties
-    }
+    val tableType = if (isMetricView) CatalogTableType.METRIC_VIEW else CatalogTableType.VIEW
 
     CatalogTable(
       identifier = name,
-      tableType = CatalogTableType.VIEW,
+      tableType = tableType,
       storage = CatalogStorageFormat.empty,
       schema = aliasedSchema,
-      properties = finalProperties,
+      properties = newProperties,
       viewOriginalText = originalText,
       viewText = originalText,
       comment = comment,
@@ -894,18 +893,30 @@ object ViewHelper extends SQLConfHelper with Logging with CapturesConfig {
   /**
    * If `userSpecifiedColumns` is defined, alias the analyzed plan to the user specified columns,
    * else return the analyzed plan directly.
+   *
+   * When `retainMetadata` is true, any existing column metadata on the analyzed attribute
+   * (for example the `metric_view.type` / `metric_view.expr` keys the analyzer attaches to
+   * metric-view columns) is preserved in the re-aliased projection. The no-comment branch
+   * already preserves `attr.metadata` transitively via `child.metadata` on the new `Alias`;
+   * the comment branch needs an explicit merge because it sets `explicitMetadata` to a
+   * freshly constructed metadata object.
    */
   def aliasPlan(
       session: SparkSession,
       analyzedPlan: LogicalPlan,
-      userSpecifiedColumns: Seq[(String, Option[String])]): LogicalPlan = {
+      userSpecifiedColumns: Seq[(String, Option[String])],
+      retainMetadata: Boolean = false): LogicalPlan = {
     if (userSpecifiedColumns.isEmpty) {
       analyzedPlan
     } else {
       val projectList = analyzedPlan.output.zip(userSpecifiedColumns).map {
         case (attr, (colName, None)) => Alias(attr, colName)()
         case (attr, (colName, Some(colComment))) =>
-          val meta = new MetadataBuilder().putString("comment", colComment).build()
+          val builder = new MetadataBuilder()
+          if (retainMetadata) {
+            builder.withMetadata(attr.metadata)
+          }
+          val meta = builder.putString("comment", colComment).build()
           Alias(attr, colName)(explicitMetadata = Some(meta))
       }
       session.sessionState.executePlan(Project(projectList, analyzedPlan)).analyzed

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -169,8 +169,7 @@ case class PreprocessTableCreation(catalog: SessionCatalog) extends Rule[Logical
       val tableName = tableIdentWithDB.unquotedString
       val existingTable = catalog.getTableMetadata(tableIdentWithDB)
 
-      if (existingTable.tableType == CatalogTableType.VIEW ||
-          existingTable.tableType == CatalogTableType.METRIC_VIEW) {
+      if (existingTable.isViewLike) {
         throw QueryCompilationErrors.saveDataIntoViewNotAllowedError()
       }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -169,7 +169,8 @@ case class PreprocessTableCreation(catalog: SessionCatalog) extends Rule[Logical
       val tableName = tableIdentWithDB.unquotedString
       val existingTable = catalog.getTableMetadata(tableIdentWithDB)
 
-      if (existingTable.tableType == CatalogTableType.VIEW) {
+      if (existingTable.tableType == CatalogTableType.VIEW ||
+          existingTable.tableType == CatalogTableType.METRIC_VIEW) {
         throw QueryCompilationErrors.saveDataIntoViewNotAllowedError()
       }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2MetricViewExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2MetricViewExec.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.{CurrentUserContext, InternalRow}
+import org.apache.spark.sql.catalyst.analysis.{ResolvedIdentifier, SchemaUnsupported, ViewAlreadyExistsException, ViewSchemaMode}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.{DependencyList, Identifier, TableCatalog, TableSummary, ViewCatalog}
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.execution.command.CommandUtils
+
+/**
+ * Physical plan node for `CREATE VIEW ... WITH METRICS` on a v2 [[ViewCatalog]]. Mirrors
+ * [[CreateV2ViewExec]]'s flag handling and cross-type collision decoding via the shared
+ * [[V2ViewPreparation]] trait, and adds metric-view-specific bits (typed
+ * [[DependencyList]] view-dependencies and `PROP_TABLE_TYPE = METRIC_VIEW`) through the
+ * trait's optional hooks.
+ *
+ * Routed by [[DataSourceV2Strategy]] from
+ * [[org.apache.spark.sql.execution.command.CreateMetricViewCommand]] when the resolved
+ * catalog is a non-session v2 catalog.
+ */
+case class CreateV2MetricViewExec(
+    catalog: ViewCatalog,
+    identifier: Identifier,
+    userSpecifiedColumns: Seq[(String, Option[String])],
+    comment: Option[String],
+    userProperties: Map[String, String],
+    originalText: String,
+    query: LogicalPlan,
+    allowExisting: Boolean,
+    replace: Boolean,
+    deps: Option[DependencyList]) extends V2ViewPreparation {
+
+  // Metric views don't carry a default-collation override.
+  override def collation: Option[String] = None
+
+  // CREATE stamps the current user, matching the v1 metric-view path (which goes through
+  // ViewHelper.prepareTable -> CatalogTable.owner default) and CreateV2ViewExec.
+  override def owner: Option[String] = Some(CurrentUserContext.getCurrentUser)
+
+  // Metric views always have schema-mode UNSUPPORTED (mirroring the v1 path which passes
+  // SchemaUnsupported into ViewHelper.prepareTable).
+  override def viewSchemaMode: ViewSchemaMode = SchemaUnsupported
+
+  override protected def viewDependencies: Option[DependencyList] = deps
+
+  override protected def tableType: Option[String] =
+    Some(TableSummary.METRIC_VIEW_TABLE_TYPE)
+
+  override protected def run(): Seq[InternalRow] = {
+    // CREATE VIEW IF NOT EXISTS short-circuit, identical to CreateV2ViewExec: skip the
+    // `buildViewInfo` work when a view already sits at the ident. The mixed-catalog
+    // "table at ident" no-op is handled in the catch block below.
+    if (allowExisting && catalog.viewExists(identifier)) return Seq.empty
+
+    val info = buildViewInfo()
+    try {
+      if (replace) {
+        CommandUtils.uncacheTableOrView(session, ResolvedIdentifier(catalog, identifier))
+        catalog.createOrReplaceView(identifier, info)
+      } else {
+        catalog.createView(identifier, info)
+      }
+    } catch {
+      case _: ViewAlreadyExistsException =>
+        // Catalog refused: decode whether a table sits at the ident (cross-type collision)
+        // or a view (race for plain CREATE / OR REPLACE), and emit the precise error -- or
+        // no-op for IF NOT EXISTS. Same shape as CreateV2ViewExec.
+        val isTable = catalog match {
+          case tc: TableCatalog => tc.tableExists(identifier)
+          case _ => false
+        }
+        if (isTable) {
+          if (!allowExisting) {
+            throw QueryCompilationErrors.unsupportedCreateOrReplaceViewOnTableError(
+              fullNameParts, replace)
+          }
+          // CREATE VIEW IF NOT EXISTS over a table is a no-op (v1 parity).
+        } else if (!allowExisting) {
+          throw viewAlreadyExists()
+        }
+        // else: a view appeared between our viewExists probe and createView; IF NOT EXISTS
+        // semantics make this a no-op.
+    }
+    Seq.empty
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2MetricViewExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2MetricViewExec.scala
@@ -17,19 +17,17 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
-import org.apache.spark.sql.catalyst.{CurrentUserContext, InternalRow}
-import org.apache.spark.sql.catalyst.analysis.{ResolvedIdentifier, SchemaUnsupported, ViewAlreadyExistsException, ViewSchemaMode}
+import org.apache.spark.sql.catalyst.CurrentUserContext
+import org.apache.spark.sql.catalyst.analysis.{SchemaUnsupported, ViewSchemaMode}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.connector.catalog.{DependencyList, Identifier, TableCatalog, TableSummary, ViewCatalog}
-import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.execution.command.CommandUtils
+import org.apache.spark.sql.connector.catalog.{DependencyList, Identifier, TableSummary, ViewCatalog}
 
 /**
- * Physical plan node for `CREATE VIEW ... WITH METRICS` on a v2 [[ViewCatalog]]. Mirrors
- * [[CreateV2ViewExec]]'s flag handling and cross-type collision decoding via the shared
- * [[V2ViewPreparation]] trait, and adds metric-view-specific bits (typed
- * [[DependencyList]] view-dependencies and `PROP_TABLE_TYPE = METRIC_VIEW`) through the
- * trait's optional hooks.
+ * Physical plan node for `CREATE VIEW ... WITH METRICS` on a v2 [[ViewCatalog]]. Inherits the
+ * shared CREATE-side `run()` (viewExists short-circuit, OR REPLACE, cross-type collision
+ * decoding) from [[V2CreateViewPreparation]]; only supplies the metric-view-specific bits
+ * (no collation, schema-mode UNSUPPORTED, typed view dependencies, `PROP_TABLE_TYPE =
+ * METRIC_VIEW`) via the [[V2ViewPreparation]] hooks.
  *
  * Routed by [[DataSourceV2Strategy]] from
  * [[org.apache.spark.sql.execution.command.CreateMetricViewCommand]] when the resolved
@@ -45,7 +43,7 @@ case class CreateV2MetricViewExec(
     query: LogicalPlan,
     allowExisting: Boolean,
     replace: Boolean,
-    deps: Option[DependencyList]) extends V2ViewPreparation {
+    deps: Option[DependencyList]) extends V2CreateViewPreparation {
 
   // Metric views don't carry a default-collation override.
   override def collation: Option[String] = None
@@ -62,42 +60,4 @@ case class CreateV2MetricViewExec(
 
   override protected def tableType: Option[String] =
     Some(TableSummary.METRIC_VIEW_TABLE_TYPE)
-
-  override protected def run(): Seq[InternalRow] = {
-    // CREATE VIEW IF NOT EXISTS short-circuit, identical to CreateV2ViewExec: skip the
-    // `buildViewInfo` work when a view already sits at the ident. The mixed-catalog
-    // "table at ident" no-op is handled in the catch block below.
-    if (allowExisting && catalog.viewExists(identifier)) return Seq.empty
-
-    val info = buildViewInfo()
-    try {
-      if (replace) {
-        CommandUtils.uncacheTableOrView(session, ResolvedIdentifier(catalog, identifier))
-        catalog.createOrReplaceView(identifier, info)
-      } else {
-        catalog.createView(identifier, info)
-      }
-    } catch {
-      case _: ViewAlreadyExistsException =>
-        // Catalog refused: decode whether a table sits at the ident (cross-type collision)
-        // or a view (race for plain CREATE / OR REPLACE), and emit the precise error -- or
-        // no-op for IF NOT EXISTS. Same shape as CreateV2ViewExec.
-        val isTable = catalog match {
-          case tc: TableCatalog => tc.tableExists(identifier)
-          case _ => false
-        }
-        if (isTable) {
-          if (!allowExisting) {
-            throw QueryCompilationErrors.unsupportedCreateOrReplaceViewOnTableError(
-              fullNameParts, replace)
-          }
-          // CREATE VIEW IF NOT EXISTS over a table is a no-op (v1 parity).
-        } else if (!allowExisting) {
-          throw viewAlreadyExists()
-        }
-        // else: a view appeared between our viewExists probe and createView; IF NOT EXISTS
-        // semantics make this a no-op.
-    }
-    Seq.empty
-  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2MetricViewExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2MetricViewExec.scala
@@ -60,4 +60,10 @@ case class CreateV2MetricViewExec(
 
   override protected def tableType: Option[String] =
     Some(TableSummary.METRIC_VIEW_TABLE_TYPE)
+
+  // The analyzer attaches `metric_view.type` / `metric_view.expr` keys to each output
+  // attribute's metadata; `aliasPlan`'s default re-projection drops them when the user
+  // supplies a column-rename clause. Mirror v1 `ViewHelper.prepareTable(isMetricView = true)`
+  // by retaining metadata across the rename.
+  override protected def retainColumnMetadata: Boolean = true
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2ViewExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2ViewExec.scala
@@ -57,19 +57,10 @@ private[v2] trait V2ViewPreparation extends LeafV2CommandExec {
   protected lazy val fullNameParts: Seq[String] =
     (catalog.name() +: identifier.asMultipartIdentifier).toSeq
 
-  /**
-   * Optional structured dependency list to stamp on the built `ViewInfo`. Plain views leave
-   * this `None`; metric views populate it with the source-table lineage produced by
-   * `MetricViewHelper.collectTableDependencies`.
-   */
+  /** Optional structured dependency list to stamp on the built `ViewInfo`. */
   protected def viewDependencies: Option[DependencyList] = None
 
-  /**
-   * Optional view sub-kind to stamp on `PROP_TABLE_TYPE`. Plain views leave this `None` so
-   * the `ViewInfo` constructor's `putIfAbsent` defaults it to `VIEW`; metric views set it to
-   * `TableSummary.METRIC_VIEW_TABLE_TYPE` so consumers (e.g. `V1Table.toCatalogTable`) can
-   * round-trip the discriminator.
-   */
+  /** Optional view sub-kind to stamp on `PROP_TABLE_TYPE`; defaults to `VIEW` when `None`. */
   protected def tableType: Option[String] = None
 
   override def output: Seq[Attribute] = Seq.empty
@@ -131,27 +122,19 @@ private[v2] trait V2ViewPreparation extends LeafV2CommandExec {
 }
 
 /**
- * Physical plan node for CREATE VIEW on a v2 [[ViewCatalog]]. Dispatches to
- * [[ViewCatalog#createView]] for plain CREATE, [[ViewCatalog#createOrReplaceView]] for
- * `OR REPLACE`, and short-circuits `IF NOT EXISTS` early via [[ViewCatalog#viewExists]] so
- * the view body isn't analyzed when the view already exists.
+ * Shared CREATE-side `run()` for v2 view-create execs. Adds the `IF NOT EXISTS` short-circuit
+ * via [[ViewCatalog#viewExists]], dispatches `OR REPLACE` to
+ * [[ViewCatalog#createOrReplaceView]] vs. plain CREATE to [[ViewCatalog#createView]], and
+ * decodes `ViewAlreadyExistsException` into the dedicated cross-type collision error when a
+ * non-view table sits at the ident in a mixed catalog. Subclasses supply only the
+ * view-shape-specific fields (`allowExisting`, `replace`, plus the [[V2ViewPreparation]] hooks
+ * such as `viewDependencies` / `tableType`) and inherit `run()` unchanged.
  */
-case class CreateV2ViewExec(
-    catalog: ViewCatalog,
-    identifier: Identifier,
-    userSpecifiedColumns: Seq[(String, Option[String])],
-    comment: Option[String],
-    collation: Option[String],
-    userProperties: Map[String, String],
-    originalText: String,
-    query: LogicalPlan,
-    allowExisting: Boolean,
-    replace: Boolean,
-    viewSchemaMode: ViewSchemaMode) extends V2ViewPreparation {
+private[v2] trait V2CreateViewPreparation extends V2ViewPreparation {
+  def allowExisting: Boolean
+  def replace: Boolean
 
-  override def owner: Option[String] = Some(CurrentUserContext.getCurrentUser)
-
-  override protected def run(): Seq[InternalRow] = {
+  override final protected def run(): Seq[InternalRow] = {
     // CREATE VIEW IF NOT EXISTS: short-circuit before `buildViewInfo` if a view already sits
     // at the ident -- avoids `aliasPlan` / config capture for the common no-op case (matches
     // v1 `CreateViewCommand.run`). The mixed-catalog "table at ident" no-op is handled in the
@@ -189,4 +172,26 @@ case class CreateV2ViewExec(
     }
     Seq.empty
   }
+}
+
+/**
+ * Physical plan node for CREATE VIEW on a v2 [[ViewCatalog]]. Inherits the create-side
+ * `run()` (viewExists short-circuit + OR REPLACE + cross-type decoding) from
+ * [[V2CreateViewPreparation]]; only supplies the case-class fields and stamps the current
+ * user as owner.
+ */
+case class CreateV2ViewExec(
+    catalog: ViewCatalog,
+    identifier: Identifier,
+    userSpecifiedColumns: Seq[(String, Option[String])],
+    comment: Option[String],
+    collation: Option[String],
+    userProperties: Map[String, String],
+    originalText: String,
+    query: LogicalPlan,
+    allowExisting: Boolean,
+    replace: Boolean,
+    viewSchemaMode: ViewSchemaMode) extends V2CreateViewPreparation {
+
+  override def owner: Option[String] = Some(CurrentUserContext.getCurrentUser)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2ViewExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2ViewExec.scala
@@ -63,6 +63,15 @@ private[v2] trait V2ViewPreparation extends LeafV2CommandExec {
   /** Optional view sub-kind to stamp on `PROP_TABLE_TYPE`; defaults to `VIEW` when `None`. */
   protected def tableType: Option[String] = None
 
+  /**
+   * Whether `aliasPlan` should preserve any column metadata the analyzer attached to the
+   * source plan when re-aliasing user-specified column names. Plain views default to `false`
+   * (matches v1 `CreateViewCommand`); metric views override to `true` so the analyzer-injected
+   * `metric_view.type` / `metric_view.expr` keys survive a `CREATE VIEW <ident>(c1, c2, ...)`
+   * column rename (matches v1 `ViewHelper.prepareTable(isMetricView = true)`).
+   */
+  protected def retainColumnMetadata: Boolean = false
+
   override def output: Seq[Attribute] = Seq.empty
 
   protected def buildViewInfo(): ViewInfo = {
@@ -85,7 +94,9 @@ private[v2] trait V2ViewPreparation extends LeafV2CommandExec {
     SchemaUtils.checkIndeterminateCollationInSchema(query.schema)
 
     val aliasedSchema = CharVarcharUtils.getRawSchema(
-      aliasPlan(session, query, userSpecifiedColumns).schema, session.sessionState.conf)
+      aliasPlan(session, query, userSpecifiedColumns, retainMetadata = retainColumnMetadata)
+        .schema,
+      session.sessionState.conf)
     SchemaUtils.checkColumnNameDuplication(
       aliasedSchema.fieldNames.toImmutableArraySeq, session.sessionState.conf.resolver)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2ViewExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateV2ViewExec.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.analysis.{ResolvedIdentifier, SchemaEvoluti
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
-import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog, ViewCatalog, ViewInfo}
+import org.apache.spark.sql.connector.catalog.{DependencyList, Identifier, TableCatalog, ViewCatalog, ViewInfo}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.IdentifierHelper
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.command.{CommandUtils, ViewHelper}
@@ -56,6 +56,21 @@ private[v2] trait V2ViewPreparation extends LeafV2CommandExec {
   // through the lossy v1 `TableIdentifier` for multi-level-namespace v2 catalogs.
   protected lazy val fullNameParts: Seq[String] =
     (catalog.name() +: identifier.asMultipartIdentifier).toSeq
+
+  /**
+   * Optional structured dependency list to stamp on the built `ViewInfo`. Plain views leave
+   * this `None`; metric views populate it with the source-table lineage produced by
+   * `MetricViewHelper.collectTableDependencies`.
+   */
+  protected def viewDependencies: Option[DependencyList] = None
+
+  /**
+   * Optional view sub-kind to stamp on `PROP_TABLE_TYPE`. Plain views leave this `None` so
+   * the `ViewInfo` constructor's `putIfAbsent` defaults it to `VIEW`; metric views set it to
+   * `TableSummary.METRIC_VIEW_TABLE_TYPE` so consumers (e.g. `V1Table.toCatalogTable`) can
+   * round-trip the discriminator.
+   */
+  protected def tableType: Option[String] = None
 
   override def output: Seq[Attribute] = Seq.empty
 
@@ -106,6 +121,8 @@ private[v2] trait V2ViewPreparation extends LeafV2CommandExec {
     owner.foreach(builder.withOwner)
     comment.foreach(builder.withComment)
     collation.foreach(builder.withCollation)
+    viewDependencies.foreach(builder.withViewDependencies)
+    tableType.foreach(builder.withTableType)
     builder.build()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.TreePattern.SCALAR_SUBQUERY
 import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, toPrettySQL, GeneratedColumn, IdentityColumn, ResolveDefaultColumns, ResolveTableConstraints, V2ExpressionBuilder}
 import org.apache.spark.sql.classic.SparkSession
-import org.apache.spark.sql.connector.catalog.{Identifier, StagingTableCatalog, SupportsDeleteV2, SupportsNamespaces, SupportsPartitionManagement, SupportsWrite, TableCapability, TableCatalog, TruncatableTable, V1Table, V1ViewInfo, ViewCatalog}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Dependency, DependencyList, Identifier, StagingTableCatalog, SupportsDeleteV2, SupportsNamespaces, SupportsPartitionManagement, SupportsWrite, TableCapability, TableCatalog, TruncatableTable, V1Table, V1ViewInfo, ViewCatalog}
 import org.apache.spark.sql.connector.catalog.TableChange
 import org.apache.spark.sql.connector.catalog.index.SupportsIndex
 import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue}
@@ -44,11 +44,12 @@ import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBat
 import org.apache.spark.sql.connector.write.V1Write
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.{FilterExec, InSubqueryExec, LeafExecNode, LocalTableScanExec, ProjectExec, RowDataSourceScanExec, ScalarSubquery => ExecScalarSubquery, SparkPlan, SparkStrategy => Strategy}
-import org.apache.spark.sql.execution.command.CommandUtils
+import org.apache.spark.sql.execution.command.{CommandUtils, CreateMetricViewCommand, MetricViewHelper}
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, LogicalRelationWithTable, PushableColumnAndNestedColumn}
 import org.apache.spark.sql.execution.streaming.continuous.{WriteToContinuousDataSource, WriteToContinuousDataSourceExec}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.WAREHOUSE_PATH
+import org.apache.spark.sql.metricview.serde.MetricViewFactory
 import org.apache.spark.sql.sources.{BaseRelation, TableScan}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.ArrayImplicits._
@@ -322,6 +323,33 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       }
       CreateV2ViewExec(catalog.asInstanceOf[ViewCatalog], ident, userSpecifiedColumns, comment,
         collation, properties, sqlText, child, allowExisting, replace, viewSchemaMode) :: Nil
+
+    // CREATE VIEW ... WITH METRICS on a non-session v2 catalog. Routes the metric-view path
+    // through `CreateV2MetricViewExec`, which extends `V2ViewPreparation` to share the
+    // `IF NOT EXISTS` short-circuit, `OR REPLACE`, and cross-type-collision decoding with
+    // `CreateV2ViewExec`. Session-catalog dispatch stays in `CreateMetricViewCommand.run`.
+    case CreateMetricViewCommand(
+        ResolvedIdentifier(catalog, ident), userSpecifiedColumns, comment, properties,
+        originalText, allowExisting, replace) if !CatalogV2Util.isSessionCatalog(catalog) =>
+      val viewCatalog = catalog match {
+        case vc: ViewCatalog => vc
+        case _ => throw QueryCompilationErrors.missingCatalogViewsAbilityError(catalog)
+      }
+      // Parse + analyze the YAML body here (during planning). This mirrors the v1 path's
+      // late analysis in `CreateMetricViewCommand.run` -- the metric-view source plan is not
+      // a SQL string, so it can't ride along as a regular `query` `LogicalPlan` field on the
+      // logical command the way `CreateView` does.
+      val analyzed = MetricViewHelper.analyzeMetricViewText(
+        session, ident.asTableIdentifier, originalText)
+      val metricView = MetricViewFactory.fromYAML(originalText)
+      val mergedProps = properties ++ metricView.getProperties
+      val depParts = MetricViewHelper.collectTableDependencies(analyzed)
+      val deps = if (depParts.nonEmpty) {
+        Some(DependencyList.of(
+          depParts.map(parts => Dependency.table(parts: _*)): _*))
+      } else None
+      CreateV2MetricViewExec(viewCatalog, ident, userSpecifiedColumns, comment, mergedProps,
+        originalText, analyzed, allowExisting, replace, deps) :: Nil
 
     case AlterViewAs(rpv @ ResolvedPersistentView(catalog, ident, _),
         originalText, query, _, _) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.TreePattern.SCALAR_SUBQUERY
 import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, toPrettySQL, GeneratedColumn, IdentityColumn, ResolveDefaultColumns, ResolveTableConstraints, V2ExpressionBuilder}
 import org.apache.spark.sql.classic.SparkSession
-import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Dependency, DependencyList, Identifier, StagingTableCatalog, SupportsDeleteV2, SupportsNamespaces, SupportsPartitionManagement, SupportsWrite, TableCapability, TableCatalog, TruncatableTable, V1Table, V1ViewInfo, ViewCatalog}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Dependency, DependencyList, Identifier, StagingTableCatalog, SupportsDeleteV2, SupportsNamespaces, SupportsPartitionManagement, SupportsWrite, TableCapability, TableCatalog, TableSummary, TruncatableTable, V1Table, V1ViewInfo, ViewCatalog}
 import org.apache.spark.sql.connector.catalog.TableChange
 import org.apache.spark.sql.connector.catalog.index.SupportsIndex
 import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue}
@@ -338,9 +338,12 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       // Parse + analyze the YAML body here (during planning). This mirrors the v1 path's
       // late analysis in `CreateMetricViewCommand.run` -- the metric-view source plan is not
       // a SQL string, so it can't ride along as a regular `query` `LogicalPlan` field on the
-      // logical command the way `CreateView` does.
+      // logical command the way `CreateView` does. Pass the full multi-part name so v2 metric
+      // views with multi-level-namespace targets analyze correctly (`asTableIdentifier` would
+      // throw `requiresSinglePartNamespaceError` for namespace arity > 1).
+      val nameParts = (catalog.name() +: ident.namespace().toIndexedSeq) :+ ident.name()
       val analyzed = MetricViewHelper.analyzeMetricViewText(
-        session, ident.asTableIdentifier, originalText)
+        session, nameParts, originalText)
       val metricView = MetricViewFactory.fromYAML(originalText)
       val mergedProps = properties ++ metricView.getProperties
       val depParts = MetricViewHelper.collectTableDependencies(analyzed)
@@ -381,6 +384,16 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       }
       RenameV2ViewExec(
         catalog.asInstanceOf[ViewCatalog], ident, newName.asIdentifier) :: Nil
+
+    case ShowCreateTable(rpv @ ResolvedPersistentView(catalog, ident, _), _, _)
+        if rpv.info.properties.get(TableCatalog.PROP_TABLE_TYPE) ==
+          TableSummary.METRIC_VIEW_TABLE_TYPE =>
+      // SHOW CREATE TABLE on a metric view is explicitly unsupported: `ShowCreateV2ViewExec`
+      // would emit a plain `CREATE VIEW <ident> AS <yaml>`, which is not a round-trippable
+      // metric-view DDL form (the right form is `CREATE VIEW <ident> WITH METRICS LANGUAGE
+      // YAML AS $$ <yaml> $$`). Reject up front rather than emit lossy DDL.
+      throw QueryCompilationErrors.unsupportedTableOperationError(
+        catalog, ident, "SHOW CREATE TABLE")
 
     case ShowCreateTable(rpv @ ResolvedPersistentView(catalog, ident, _), _, output) =>
       val quoted = (catalog.name() +: ident.asMultipartIdentifier).map(quoteIfNeeded).mkString(".")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -49,7 +49,6 @@ import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, LogicalRe
 import org.apache.spark.sql.execution.streaming.continuous.{WriteToContinuousDataSource, WriteToContinuousDataSourceExec}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.WAREHOUSE_PATH
-import org.apache.spark.sql.metricview.serde.MetricViewFactory
 import org.apache.spark.sql.sources.{BaseRelation, TableScan}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.ArrayImplicits._
@@ -342,9 +341,8 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       // views with multi-level-namespace targets analyze correctly (`asTableIdentifier` would
       // throw `requiresSinglePartNamespaceError` for namespace arity > 1).
       val nameParts = (catalog.name() +: ident.namespace().toIndexedSeq) :+ ident.name()
-      val analyzed = MetricViewHelper.analyzeMetricViewText(
+      val (analyzed, metricView) = MetricViewHelper.analyzeMetricViewText(
         session, nameParts, originalText)
-      val metricView = MetricViewFactory.fromYAML(originalText)
       val mergedProps = properties ++ metricView.getProperties
       val depParts = MetricViewHelper.collectTableDependencies(analyzed)
       val deps = if (depParts.nonEmpty) {
@@ -391,9 +389,12 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       // SHOW CREATE TABLE on a metric view is explicitly unsupported: `ShowCreateV2ViewExec`
       // would emit a plain `CREATE VIEW <ident> AS <yaml>`, which is not a round-trippable
       // metric-view DDL form (the right form is `CREATE VIEW <ident> WITH METRICS LANGUAGE
-      // YAML AS $$ <yaml> $$`). Reject up front rather than emit lossy DDL.
-      throw QueryCompilationErrors.unsupportedTableOperationError(
-        catalog, ident, "SHOW CREATE TABLE")
+      // YAML AS $$ <yaml> $$`). Reject up front with the same dedicated error class the v1
+      // path uses (`UNSUPPORTED_SHOW_CREATE_TABLE.ON_METRIC_VIEW`) so users see the same
+      // actionable message regardless of catalog kind.
+      val quoted = (catalog.name() +: ident.asMultipartIdentifier)
+        .map(quoteIfNeeded).mkString(".")
+      throw QueryCompilationErrors.showCreateTableNotSupportedOnMetricViewError(quoted)
 
     case ShowCreateTable(rpv @ ResolvedPersistentView(catalog, ident, _), _, output) =>
       val quoted = (catalog.name() +: ident.asMultipartIdentifier).map(quoteIfNeeded).mkString(".")
@@ -604,9 +605,9 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       }
 
     case DropTable(r: ResolvedIdentifier, ifExists, purge) =>
-      val tableCatalog = r.catalog.asTableCatalog
       val invalidateFunc = () => CommandUtils.uncacheTableOrView(session, r)
-      DropTableExec(tableCatalog, r.identifier, ifExists, purge, invalidateFunc) :: Nil
+      DropTableExec(
+        r.catalog.asTableCatalog, r.identifier, ifExists, purge, invalidateFunc) :: Nil
 
     case _: NoopCommand =>
       LocalTableScanExec(Nil, Nil, None) :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -345,10 +345,13 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
         session, nameParts, originalText)
       val mergedProps = properties ++ metricView.getProperties
       val depParts = MetricViewHelper.collectTableDependencies(analyzed)
-      val deps = if (depParts.nonEmpty) {
-        Some(DependencyList.of(
-          depParts.map(parts => Dependency.table(parts: _*)): _*))
-      } else None
+      // Always emit a `Some(DependencyList)` for metric views (even when `depParts` is empty,
+      // e.g. `SQLSource("SELECT 1 AS x")`): per `ViewInfo.viewDependencies()` Javadoc, `null`
+      // means "no dependency list was supplied" while an empty list means "supplied but the
+      // object has none". Metric-view CREATE always *computes* deps, so the right empty
+      // representation is `Some(empty list)`, not `None`.
+      val deps = Some(DependencyList.of(
+        depParts.map(parts => Dependency.table(parts: _*)): _*))
       CreateV2MetricViewExec(viewCatalog, ident, userSpecifiedColumns, comment, mergedProps,
         originalText, analyzed, allowExisting, replace, deps) :: Nil
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.execution.datasources.v2
 
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
 
 import org.apache.hadoop.fs.Path
 
@@ -351,8 +350,9 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       // "no dependency list was supplied" while an empty list means "supplied but the
       // object has none". Metric-view CREATE always *computes* deps, so the right empty
       // representation is `Some(empty list)`, not `None`.
-      val sparkDeps: Seq[Dependency] = depParts.map(parts => Dependency.table(parts.asJava))
-      val deps = Some(DependencyList.of(sparkDeps.asJava))
+      val sparkDeps: Array[Dependency] =
+        depParts.map(parts => Dependency.table(parts.toArray): Dependency).toArray
+      val deps = Some(DependencyList.of(sparkDeps))
       CreateV2MetricViewExec(viewCatalog, ident, userSpecifiedColumns, comment, mergedProps,
         originalText, analyzed, allowExisting, replace, deps) :: Nil
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -346,8 +346,8 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       val mergedProps = properties ++ metricView.getProperties
       val depParts = MetricViewHelper.collectTableDependencies(analyzed)
       // Always emit a `Some(DependencyList)` for metric views (even when `depParts` is empty,
-      // e.g. `SQLSource("SELECT 1 AS x")`): per `ViewInfo.viewDependencies()` Javadoc, `null`
-      // means "no dependency list was supplied" while an empty list means "supplied but the
+      // e.g. `SQLSource("SELECT 1 AS x")`): per `DependencyList`'s contract, `null` means
+      // "no dependency list was supplied" while an empty list means "supplied but the
       // object has none". Metric-view CREATE always *computes* deps, so the right empty
       // representation is `Some(empty list)`, not `None`.
       val deps = Some(DependencyList.of(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources.v2
 
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 
 import org.apache.hadoop.fs.Path
 
@@ -350,8 +351,8 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       // "no dependency list was supplied" while an empty list means "supplied but the
       // object has none". Metric-view CREATE always *computes* deps, so the right empty
       // representation is `Some(empty list)`, not `None`.
-      val deps = Some(DependencyList.of(
-        depParts.map(parts => Dependency.table(parts: _*)): _*))
+      val sparkDeps: Seq[Dependency] = depParts.map(parts => Dependency.table(parts.asJava))
+      val deps = Some(DependencyList.of(sparkDeps.asJava))
       CreateV2MetricViewExec(viewCatalog, ident, userSpecifiedColumns, comment, mergedProps,
         originalText, analyzed, allowExisting, replace, deps) :: Nil
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -563,8 +563,9 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       }
 
     case DropTable(r: ResolvedIdentifier, ifExists, purge) =>
+      val tableCatalog = r.catalog.asTableCatalog
       val invalidateFunc = () => CommandUtils.uncacheTableOrView(session, r)
-      DropTableExec(r.catalog.asTableCatalog, r.identifier, ifExists, purge, invalidateFunc) :: Nil
+      DropTableExec(tableCatalog, r.identifier, ifExists, purge, invalidateFunc) :: Nil
 
     case _: NoopCommand =>
       LocalTableScanExec(Nil, Nil, None) :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
@@ -334,8 +334,10 @@ class V2SessionCatalog(catalog: SessionCatalog)
   private def dropTableInternal(ident: Identifier, purge: Boolean = false): Boolean = {
     try {
       loadTable(ident) match {
-        case V1Table(v1Table) if v1Table.tableType == CatalogTableType.VIEW &&
-            !SQLConf.get.getConf(SQLConf.DROP_TABLE_VIEW_ENABLED) =>
+        case V1Table(v1Table)
+            if (v1Table.tableType == CatalogTableType.VIEW ||
+              v1Table.tableType == CatalogTableType.METRIC_VIEW) &&
+              !SQLConf.get.getConf(SQLConf.DROP_TABLE_VIEW_ENABLED) =>
           throw QueryCompilationErrors.wrongCommandForObjectTypeError(
             operation = "DROP TABLE",
             requiredType = s"${CatalogTableType.EXTERNAL.name} or" +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
@@ -335,8 +335,7 @@ class V2SessionCatalog(catalog: SessionCatalog)
     try {
       loadTable(ident) match {
         case V1Table(v1Table)
-            if (v1Table.tableType == CatalogTableType.VIEW ||
-              v1Table.tableType == CatalogTableType.METRIC_VIEW) &&
+            if v1Table.isViewLike &&
               !SQLConf.get.getConf(SQLConf.DROP_TABLE_VIEW_ENABLED) =>
           throw QueryCompilationErrors.wrongCommandForObjectTypeError(
             operation = "DROP TABLE",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ViewInspectionExecs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ViewInspectionExecs.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.util.{escapeSingleQuotedString, quoteIfNeeded, ResolveDefaultColumns}
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumnsUtils.CURRENT_DEFAULT_COLUMN_METADATA_KEY
-import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, TableCatalog, ViewInfo}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, TableCatalog, TableSummary, ViewInfo}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 
 /**
@@ -169,6 +169,15 @@ case class DescribeV2ViewExec(
       result += toCatalystRow("", "", "")
       result += toCatalystRow("# Detailed View Information", "", "")
       addIdentifierRows(result, catalogName, identifier, entityLabel = "View")
+      // Surface the view sub-kind so users see whether they're looking at a plain VIEW
+      // or a sub-kind like METRIC_VIEW. `ViewInfo`'s constructor unconditionally stamps
+      // `PROP_TABLE_TYPE` (defaulting to `VIEW`), so this row is always present and
+      // matches v1 `CatalogTable.toJsonLinkedHashMap`'s `Type` row for parity.
+      result += toCatalystRow(
+        "Type",
+        Option(viewInfo.properties.get(TableCatalog.PROP_TABLE_TYPE))
+          .getOrElse(TableSummary.VIEW_TABLE_TYPE),
+        "")
       // Promote first-class reserved fields (Owner / Comment / Collation) to top-level rows
       // before the EXTENDED Properties block, mirroring v1 `CatalogTable.toJsonLinkedHashMap`
       // which renders these as their own rows rather than burying them in `Table Properties`.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
@@ -85,8 +85,17 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
            |USING foo AS SELECT * FROM metric_view_v2_source""".stripMargin)
       body
     } finally {
-      sql(s"DROP VIEW IF EXISTS $fullMetricViewName")
-      sql(s"DROP TABLE IF EXISTS $fullSourceTableName")
+      // The metric-view ident `mv` may have ended up as either a view (most tests) or as a
+      // pre-created table (a few negative tests pre-create a table at the same ident to
+      // exercise cross-type collisions). Sweep both kinds so subsequent tests in the suite
+      // start from a clean catalog state. Wrap each DROP in a Try because:
+      //   - DROP VIEW IF EXISTS on a leftover *table* throws WRONG_COMMAND_FOR_OBJECT_TYPE
+      //     under master's new DropViewExec active-rejection contract.
+      //   - DROP TABLE IF EXISTS on a leftover *view* throws the symmetric error.
+      //   - On a totally clean state both are silent no-ops.
+      scala.util.Try(sql(s"DROP VIEW IF EXISTS $fullMetricViewName"))
+      scala.util.Try(sql(s"DROP TABLE IF EXISTS $fullMetricViewName"))
+      scala.util.Try(sql(s"DROP TABLE IF EXISTS $fullSourceTableName"))
       spark.catalog.dropTempView("metric_view_v2_source")
       MetricViewRecordingCatalog.reset()
     }
@@ -137,7 +146,10 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       // back to `CatalogTableType.METRIC_VIEW`.
       assert(info.properties().get(TableCatalog.PROP_TABLE_TYPE)
         === TableSummary.METRIC_VIEW_TABLE_TYPE)
-      assert(info.queryText() === yaml)
+      // The captured queryText is the raw text between `$$ ... $$` -- including the leading
+      // and trailing newline our SQL fixture inserts -- so trim before comparing to the
+      // pre-substitution YAML body.
+      assert(info.queryText().trim === yaml.trim)
 
       val deps = info.viewDependencies()
       assert(deps != null)
@@ -297,7 +309,8 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
 
       val finalInfo = capturedViewInfo()
       // Assert on the distinguishing fields of the replacement, not on diff vs. the original.
-      assert(finalInfo.queryText() === replacementYaml)
+      // queryText keeps the surrounding `\n` from the SQL `$$ ... $$` markers; trim first.
+      assert(finalInfo.queryText().trim === replacementYaml.trim)
       assert(finalInfo.properties().get(MetricView.PROP_WHERE) === "count > 100")
       val deps = finalInfo.viewDependencies()
       assert(deps != null && deps.dependencies().length === 1)
@@ -335,7 +348,7 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
            |$replacementYaml
            |$$$$""".stripMargin)
 
-      assert(capturedViewInfo().queryText() === originalYaml,
+      assert(capturedViewInfo().queryText().trim === originalYaml.trim,
         "IF NOT EXISTS over an existing metric view should be a no-op.")
     }
   }
@@ -414,7 +427,9 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
               select = metricViewColumns))}
            |$$$$""".stripMargin)
     }
-    assert(ex.getCondition === "MISSING_CATALOG_ABILITY")
+    // SPARK-56655 added the `.VIEWS` subclass; the bare `MISSING_CATALOG_ABILITY` no longer
+    // surfaces directly for the missing-view-ability case.
+    assert(ex.getCondition === "MISSING_CATALOG_ABILITY.VIEWS")
     assert(ex.getMessage.contains("VIEWS"))
   }
 
@@ -879,7 +894,20 @@ class MetricViewRecordingCatalog extends InMemoryTableCatalog with TableViewCata
   // defaults, which derive from `loadTableOrView` -- a stored `ViewInfo` is wrapped in
   // `MetadataTable` by `loadTableOrView` and the defaults unwrap it correctly.
 
+  // Bypasses `TableViewCatalog.tableExists` (whose default delegates to `loadTableOrView`,
+  // which checks our `views` map first); we want a tables-only check here so the cross-type
+  // collision branches in `createView` / `replaceView` see only "is there a *table* at this
+  // ident?".
+  private def tableExistsTablesOnly(ident: Identifier): Boolean =
+    try { super[InMemoryTableCatalog].loadTable(ident); true }
+    catch { case _: org.apache.spark.sql.catalyst.analysis.NoSuchTableException => false }
+
   override def createView(ident: Identifier, info: ViewInfo): ViewInfo = {
+    // TableViewCatalog active-rejection contract: createView must throw
+    // ViewAlreadyExistsException when *either* a view *or* a table sits at the ident.
+    if (tableExistsTablesOnly(ident)) {
+      throw new ViewAlreadyExistsException(ident)
+    }
     val key = (ident.namespace().toSeq, ident.name())
     if (views.putIfAbsent(key, info) != null) {
       throw new ViewAlreadyExistsException(ident)
@@ -889,6 +917,9 @@ class MetricViewRecordingCatalog extends InMemoryTableCatalog with TableViewCata
   }
 
   override def replaceView(ident: Identifier, info: ViewInfo): ViewInfo = {
+    // Per the TableViewCatalog contract, replaceView must surface NoSuchViewException
+    // when a *table* sits at the ident (not silently succeed and shadow the table).
+    if (tableExistsTablesOnly(ident)) throw new NoSuchViewException(ident)
     val key = (ident.namespace().toSeq, ident.name())
     if (!views.containsKey(key)) throw new NoSuchViewException(ident)
     views.put(key, info)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
@@ -860,18 +860,20 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
         select = metricViewColumns)
       createMetricView(fullMetricViewName, mv)
 
-      // SHOW CREATE TABLE on a v2 view (including metric views) is rejected by
-      // DataSourceV2Strategy via `unsupportedTableOperationError(...)`. There's no
-      // round-trippable `CREATE VIEW ... WITH METRICS` form yet, so explicit "unsupported"
-      // is the right answer rather than emitting a misleading plain `CREATE VIEW ...`.
+      // SHOW CREATE TABLE on a metric view is rejected with the dedicated
+      // UNSUPPORTED_SHOW_CREATE_TABLE.ON_METRIC_VIEW error class (same one the v1 path uses
+      // in `tables.scala`'s `ShowCreateTableCommand`), so the message is identical no matter
+      // which catalog kind owns the view. There's no round-trippable
+      // `CREATE VIEW ... WITH METRICS` form yet, so explicit "unsupported" is the right
+      // answer rather than emitting a misleading plain `CREATE VIEW ...`.
       val ex = intercept[AnalysisException] {
         sql(s"SHOW CREATE TABLE $fullMetricViewName")
       }
-      assert(ex.getCondition === "UNSUPPORTED_FEATURE.TABLE_OPERATION",
-        s"Expected UNSUPPORTED_FEATURE.TABLE_OPERATION, got " +
+      assert(ex.getCondition === "UNSUPPORTED_SHOW_CREATE_TABLE.ON_METRIC_VIEW",
+        s"Expected UNSUPPORTED_SHOW_CREATE_TABLE.ON_METRIC_VIEW, got " +
           s"${ex.getCondition}: ${ex.getMessage}")
-      assert(ex.getMessage.contains("SHOW CREATE TABLE"),
-        s"Error message should mention 'SHOW CREATE TABLE', got: ${ex.getMessage}")
+      assert(ex.getMessage.contains("metric view"),
+        s"Error message should mention 'metric view', got: ${ex.getMessage}")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
@@ -153,9 +153,9 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
 
       val deps = info.viewDependencies()
       assert(deps != null)
-      assert(deps.dependencies().length === 1)
-      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
-      assert(tableDep.nameParts().toSeq ===
+      assert(deps.dependencies().size() === 1)
+      val tableDep = deps.dependencies().get(0).asInstanceOf[TableDependency]
+      assert(tableDep.nameParts().asScala.toSeq ===
         Seq(testCatalogName, testNamespace, sourceTableName))
     }
   }
@@ -209,9 +209,9 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       assert(props.get(TableCatalog.PROP_COMMENT) === "my mv")
 
       val deps = info.viewDependencies()
-      assert(deps != null && deps.dependencies().length === 1)
-      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
-      assert(tableDep.nameParts().toSeq ===
+      assert(deps != null && deps.dependencies().size() === 1)
+      val tableDep = deps.dependencies().get(0).asInstanceOf[TableDependency]
+      assert(tableDep.nameParts().asScala.toSeq ===
         Seq(testCatalogName, testNamespace, sourceTableName))
     }
   }
@@ -250,8 +250,8 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
         where = None,
         select = metricViewColumns)
       val yaml = MetricViewFactory.toYAML(metricView)
-      // Give both columns new names, and a comment on each. Without the `retainMetadata`
-      // fix to `ViewHelper.aliasPlan`, the metric_view.* keys disappear here.
+      // Pins aliasPlan(retainMetadata = true): metric_view.* keys must survive a column
+      // rename with comments.
       sql(
         s"""CREATE VIEW $fullMetricViewName (reg COMMENT 'region alias', n COMMENT 'count')
            |WITH METRICS
@@ -313,9 +313,9 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       assert(finalInfo.queryText().trim === replacementYaml.trim)
       assert(finalInfo.properties().get(MetricView.PROP_WHERE) === "count > 100")
       val deps = finalInfo.viewDependencies()
-      assert(deps != null && deps.dependencies().length === 1)
-      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
-      assert(tableDep.nameParts().toSeq ===
+      assert(deps != null && deps.dependencies().size() === 1)
+      val tableDep = deps.dependencies().get(0).asInstanceOf[TableDependency]
+      assert(tableDep.nameParts().asScala.toSeq ===
         Seq(testCatalogName, testNamespace, sourceTableName))
     }
   }
@@ -505,8 +505,8 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
 
         val deps = capturedViewInfo().viewDependencies()
         assert(deps != null)
-        val depParts =
-          deps.dependencies().map(_.asInstanceOf[TableDependency].nameParts().toSeq).toSet
+        val depParts = deps.dependencies().asScala
+          .map(_.asInstanceOf[TableDependency].nameParts().asScala.toSeq).toSet
         assert(depParts === Set(
           Seq(testCatalogName, testNamespace, sourceTableName),
           Seq(testCatalogName, testNamespace, "customers")),
@@ -530,11 +530,11 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       createMetricView(fullMetricViewName, metricView)
 
       val deps = capturedViewInfo().viewDependencies()
-      assert(deps != null && deps.dependencies().length === 1,
+      assert(deps != null && deps.dependencies().size() === 1,
         s"Expected 1 deduplicated dependency, got " +
-          s"${Option(deps).map(_.dependencies().length).getOrElse(0)}")
-      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
-      assert(tableDep.nameParts().toSeq ===
+          s"${Option(deps).map(_.dependencies().size()).getOrElse(0)}")
+      val tableDep = deps.dependencies().get(0).asInstanceOf[TableDependency]
+      assert(tableDep.nameParts().asScala.toSeq ===
         Seq(testCatalogName, testNamespace, sourceTableName))
     }
   }
@@ -555,11 +555,11 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       createMetricView(fullMetricViewName, metricView)
 
       val deps = capturedViewInfo().viewDependencies()
-      assert(deps != null && deps.dependencies().length === 1,
+      assert(deps != null && deps.dependencies().size() === 1,
         s"Expected 1 deduplicated dependency for self-join, got " +
-          s"${Option(deps).map(_.dependencies().length).getOrElse(0)}")
-      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
-      assert(tableDep.nameParts().toSeq ===
+          s"${Option(deps).map(_.dependencies().size()).getOrElse(0)}")
+      val tableDep = deps.dependencies().get(0).asInstanceOf[TableDependency]
+      assert(tableDep.nameParts().asScala.toSeq ===
         Seq(testCatalogName, testNamespace, sourceTableName))
     }
   }
@@ -580,15 +580,18 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
         createMetricView(fullMetricViewName, mv)
 
         val deps = capturedViewInfo().viewDependencies()
-        assert(deps != null && deps.dependencies().length === 1)
-        val parts = deps.dependencies()(0).asInstanceOf[TableDependency].nameParts().toSeq
-        // For a session-catalog source, `TableIdentifier.nameParts` includes catalog + db +
-        // table when the catalog is set; here we expect at least 2 parts (`db.table`) and
-        // up to 3 (`spark_catalog.db.table`) -- both are valid producer outputs depending
-        // on whether the analyzer captured the session-catalog component.
+        assert(deps != null && deps.dependencies().size() === 1)
+        val parts =
+          deps.dependencies().get(0).asInstanceOf[TableDependency].nameParts().asScala.toSeq
+        // `MetricViewHelper.qualifyV1` normalizes any `TableIdentifier.nameParts` shape
+        // (1, 2, or 3 parts depending on what the analyzer captured) to the stable
+        // `[spark_catalog, db, table]` shape so downstream consumers see deterministic
+        // arity per source kind.
+        assert(parts.length === 3,
+          s"V1 nameParts should normalize to exactly 3 parts, got ${parts.length}: $parts")
+        assert(parts.head === "spark_catalog",
+          s"V1 nameParts head should be the session-catalog name, got $parts")
         assert(parts.last === v1Source, s"Last part should be the table name, got $parts")
-        assert(parts.length >= 2 && parts.length <= 3,
-          s"V1 nameParts arity should be 2 or 3, got ${parts.length}: $parts")
       }
     } finally {
       sql(s"DROP TABLE IF EXISTS $v1Source")
@@ -614,8 +617,9 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
         createMetricView(fullMetricViewName, mv)
 
         val deps = capturedViewInfo().viewDependencies()
-        assert(deps != null && deps.dependencies().length === 1)
-        val parts = deps.dependencies()(0).asInstanceOf[TableDependency].nameParts().toSeq
+        assert(deps != null && deps.dependencies().size() === 1)
+        val parts =
+          deps.dependencies().get(0).asInstanceOf[TableDependency].nameParts().asScala.toSeq
         assert(parts === Seq(testCatalogName, multiNamespace(0), multiNamespace(1), multiTable),
           s"Multi-level nameParts should preserve every namespace component, got $parts")
       } finally {
@@ -746,10 +750,9 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       // `MetadataTable(ViewInfo)`. The analyzer wraps it as a `ResolvedPersistentView` and
       // `DataSourceV2Strategy` routes through SPARK-56655's `DescribeV2ViewExec`, which
       // reads the typed `ViewInfo` directly and emits the standard "Type" / "View Text" /
-      // "View Current Catalog" / "View Schema Mode" / etc. rows. The "Type" row was added
-      // alongside this metric-view PR so `DescribeV2ViewExec` matches v1 parity for the
-      // v1 `CatalogTable.toJsonLinkedHashMap` `Type` row, and so users see whether they're
-      // looking at a plain VIEW or a sub-kind like METRIC_VIEW.
+      // "View Current Catalog" / "View Schema Mode" / etc. rows. Pins `DescribeV2ViewExec`
+      // emits a "Type" row matching v1 `CatalogTable.toJsonLinkedHashMap` parity, so users
+      // can distinguish a plain VIEW from a sub-kind like METRIC_VIEW.
       val rows = sql(s"DESCRIBE TABLE EXTENDED $fullMetricViewName").collect()
       val rowMap = rows.map(r => r.getString(0) -> r.getString(1)).toMap
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
@@ -571,7 +571,7 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
   // ============================================================
 
 
-  test("SELECT from a v2 metric view returns aggregated rows") {
+  test("SELECT measure(...) from a v2 metric view returns aggregated rows") {
     withTestCatalogTables {
       val mv = MetricView(
         "0.1",
@@ -582,13 +582,87 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       // The fixture's `events` source has rows ("region_1", 1, 5.0), ("region_2", 2, 10.0).
       // The metric view aggregates by `region` summing `count`. Resolution flows through
       // loadRelation -> MetadataOnlyTable(ViewInfo) -> V1Table.toCatalogTable(ViewInfo) ->
-      // CatalogTableType.METRIC_VIEW -> ResolveMetricView, then the analyzer rewrites the
-      // view body into Aggregate(Seq(region), Seq(sum(count) AS count_sum)) over `events`.
-      val rows = sql(s"SELECT region, count_sum FROM $fullMetricViewName ORDER BY region")
-        .collect()
-      assert(rows.length === 2)
-      assert(rows(0).getString(0) === "region_1" && rows(0).getLong(1) === 1L)
-      assert(rows(1).getString(0) === "region_2" && rows(1).getLong(1) === 2L)
+      // CatalogTableType.METRIC_VIEW -> ResolveMetricView, which rewrites the view body
+      // into Aggregate(Seq(region), Seq(sum(count) AS count_sum)) over `events`. The
+      // `measure(...)` wrapper is required for measure columns -- selecting `count_sum`
+      // bare would fail (mirrors the v1 `MetricViewSuite` query syntax).
+      checkAnswer(
+        sql(s"SELECT region, measure(count_sum) FROM $fullMetricViewName " +
+          "GROUP BY region ORDER BY region"),
+        sql(s"SELECT region, sum(count) FROM $fullSourceTableName " +
+          "GROUP BY region ORDER BY region"))
+    }
+  }
+
+  test("SELECT measure(...) with a WHERE clause on a dimension") {
+    withTestCatalogTables {
+      val mv = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, mv)
+      // Filter at the query layer (not on the metric view's own `where:`).
+      checkAnswer(
+        sql(s"SELECT measure(count_sum) FROM $fullMetricViewName " +
+          "WHERE region = 'region_2'"),
+        sql(s"SELECT sum(count) FROM $fullSourceTableName " +
+          "WHERE region = 'region_2'"))
+    }
+  }
+
+  test("SELECT against a v2 metric view honors the view's pre-defined where clause") {
+    withTestCatalogTables {
+      // Pre-define a filter on the metric view itself: only rows with count > 1 should be
+      // visible to consumers (i.e. region_2 only).
+      val mv = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = Some("count > 1"),
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, mv)
+      checkAnswer(
+        sql(s"SELECT region, measure(count_sum) FROM $fullMetricViewName " +
+          "GROUP BY region ORDER BY region"),
+        sql(s"SELECT region, sum(count) FROM $fullSourceTableName " +
+          "WHERE count > 1 GROUP BY region ORDER BY region"))
+    }
+  }
+
+  test("SELECT from a v2 metric view supports multiple measures with different aggregations") {
+    withTestCatalogTables {
+      // Add a second measure (sum of price) so we exercise the multi-measure rewrite path.
+      val cols = Seq(
+        Column("region", DimensionExpression("region"), 0),
+        Column("count_sum", MeasureExpression("sum(count)"), 1),
+        Column("price_sum", MeasureExpression("sum(price)"), 2),
+        Column("price_max", MeasureExpression("max(price)"), 3))
+      val mv = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = cols)
+      createMetricView(fullMetricViewName, mv)
+      checkAnswer(
+        sql(s"SELECT measure(count_sum), measure(price_sum), measure(price_max) " +
+          s"FROM $fullMetricViewName"),
+        sql(s"SELECT sum(count), sum(price), max(price) FROM $fullSourceTableName"))
+    }
+  }
+
+  test("SELECT from a v2 metric view supports ORDER BY and LIMIT on measures") {
+    withTestCatalogTables {
+      val mv = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, mv)
+      checkAnswer(
+        sql(s"SELECT region, measure(count_sum) FROM $fullMetricViewName " +
+          "GROUP BY region ORDER BY 2 DESC LIMIT 1"),
+        sql(s"SELECT region, sum(count) FROM $fullSourceTableName " +
+          "GROUP BY region ORDER BY 2 DESC LIMIT 1"))
     }
   }
 
@@ -658,6 +732,76 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
 
       sql(s"DROP VIEW $fullMetricViewName")
       assert(!MetricViewRecordingCatalog.capturedViews.containsKey(ident))
+    }
+  }
+
+  test("DROP TABLE on a v2 metric view throws EXPECT_TABLE_NOT_VIEW") {
+    withTestCatalogTables {
+      val mv = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, mv)
+
+      // `DropTableExec` first probes `tableExists` (false for a view per the RelationCatalog
+      // passive-filtering contract), then falls back to `viewExists` and -- when the entity
+      // exists as a view but a table was requested -- throws `EXPECT_TABLE_NOT_VIEW` to
+      // distinguish "wrong type" from "missing".
+      val ex = intercept[AnalysisException] {
+        sql(s"DROP TABLE $fullMetricViewName")
+      }
+      assert(ex.getCondition === "EXPECT_TABLE_NOT_VIEW.NO_ALTERNATIVE",
+        s"Expected EXPECT_TABLE_NOT_VIEW.NO_ALTERNATIVE, got ${ex.getCondition}: ${ex.getMessage}")
+
+      // The metric view is still present after the failed DROP TABLE.
+      val ident = Identifier.of(Array(testNamespace), metricViewName)
+      assert(MetricViewRecordingCatalog.capturedViews.containsKey(ident),
+        "DROP TABLE on a metric view must not delete it.")
+    }
+  }
+
+  test("DROP TABLE IF EXISTS on a v2 metric view also throws EXPECT_TABLE_NOT_VIEW") {
+    withTestCatalogTables {
+      val mv = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, mv)
+
+      // IF EXISTS does not silence the wrong-type error: the entity exists, just not as a
+      // table. (This mirrors the v1 `DropTableCommand` behavior, where `IF EXISTS` only
+      // short-circuits the not-found branch.)
+      val ex = intercept[AnalysisException] {
+        sql(s"DROP TABLE IF EXISTS $fullMetricViewName")
+      }
+      assert(ex.getCondition === "EXPECT_TABLE_NOT_VIEW.NO_ALTERNATIVE",
+        s"Expected EXPECT_TABLE_NOT_VIEW.NO_ALTERNATIVE, got ${ex.getCondition}: ${ex.getMessage}")
+    }
+  }
+
+  test("SHOW CREATE TABLE on a v2 metric view is unsupported") {
+    withTestCatalogTables {
+      val mv = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, mv)
+
+      // SHOW CREATE TABLE on a v2 view (including metric views) is rejected by
+      // DataSourceV2Strategy via `unsupportedTableOperationError(...)`. There's no
+      // round-trippable `CREATE VIEW ... WITH METRICS` form yet, so explicit "unsupported"
+      // is the right answer rather than emitting a misleading plain `CREATE VIEW ...`.
+      val ex = intercept[AnalysisException] {
+        sql(s"SHOW CREATE TABLE $fullMetricViewName")
+      }
+      assert(ex.getCondition === "UNSUPPORTED_FEATURE.TABLE_OPERATION",
+        s"Expected UNSUPPORTED_FEATURE.TABLE_OPERATION, got " +
+          s"${ex.getCondition}: ${ex.getMessage}")
+      assert(ex.getMessage.contains("SHOW CREATE TABLE"),
+        s"Error message should mention 'SHOW CREATE TABLE', got: ${ex.getMessage}")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
@@ -138,7 +138,8 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       assert(deps != null)
       assert(deps.dependencies().length === 1)
       val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
-      assert(tableDep.tableFullName() === fullSourceTableName)
+      assert(tableDep.nameParts().toSeq ===
+        Seq(testCatalogName, testNamespace, sourceTableName))
     }
   }
 
@@ -216,7 +217,8 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       val deps = info.viewDependencies()
       assert(deps != null && deps.dependencies().length === 1)
       val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
-      assert(tableDep.tableFullName() === fullSourceTableName)
+      assert(tableDep.nameParts().toSeq ===
+        Seq(testCatalogName, testNamespace, sourceTableName))
     }
   }
 
@@ -307,10 +309,12 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
 
         val deps = capturedViewInfo().viewDependencies()
         assert(deps != null)
-        val depNames =
-          deps.dependencies().map(_.asInstanceOf[TableDependency].tableFullName()).toSet
-        assert(depNames === Set(fullSourceTableName, secondSource),
-          s"Expected dependencies on both source tables, got $depNames")
+        val depParts =
+          deps.dependencies().map(_.asInstanceOf[TableDependency].nameParts().toSeq).toSet
+        assert(depParts === Set(
+          Seq(testCatalogName, testNamespace, sourceTableName),
+          Seq(testCatalogName, testNamespace, "customers")),
+          s"Expected dependencies on both source tables, got $depParts")
       } finally {
         sql(s"DROP TABLE IF EXISTS $secondSource")
       }
@@ -334,7 +338,8 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
         s"Expected 1 deduplicated dependency, got " +
           s"${Option(deps).map(_.dependencies().length).getOrElse(0)}")
       val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
-      assert(tableDep.tableFullName() === fullSourceTableName)
+      assert(tableDep.nameParts().toSeq ===
+        Seq(testCatalogName, testNamespace, sourceTableName))
     }
   }
 
@@ -358,12 +363,227 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
         s"Expected 1 deduplicated dependency for self-join, got " +
           s"${Option(deps).map(_.dependencies().length).getOrElse(0)}")
       val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
-      assert(tableDep.tableFullName() === fullSourceTableName)
+      assert(tableDep.nameParts().toSeq ===
+        Seq(testCatalogName, testNamespace, sourceTableName))
+    }
+  }
+
+  test("CREATE OR REPLACE VIEW ... WITH METRICS replaces an existing v2 metric view") {
+    withTestCatalogTables {
+      val first = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = Some("count > 0"),
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, first)
+      val firstYaml = capturedViewInfo().queryText()
+
+      // Replace with a new body (different WHERE clause).
+      val replacement = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = Some("count > 100"),
+        select = metricViewColumns)
+      val replacementYaml = MetricViewFactory.toYAML(replacement)
+      sql(
+        s"""CREATE OR REPLACE VIEW $fullMetricViewName
+           |WITH METRICS
+           |LANGUAGE YAML
+           |AS
+           |$$$$
+           |$replacementYaml
+           |$$$$""".stripMargin)
+
+      val finalInfo = capturedViewInfo()
+      assert(finalInfo.queryText() === replacementYaml,
+        "OR REPLACE should swap the captured ViewInfo's queryText.")
+      assert(finalInfo.queryText() !== firstYaml,
+        "OR REPLACE should not leave the original captured queryText in place.")
+    }
+  }
+
+  test("CREATE VIEW IF NOT EXISTS ... WITH METRICS is a no-op when the view exists") {
+    withTestCatalogTables {
+      val original = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, original)
+      val originalYaml = capturedViewInfo().queryText()
+
+      // Now CREATE VIEW IF NOT EXISTS with a different YAML body. The catalog should not see
+      // the second create at all (V2ViewPreparation's `viewExists` short-circuit fires before
+      // `buildViewInfo`), so the captured ViewInfo retains the original body.
+      val replacement = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = Some("count > 999"),
+        select = metricViewColumns)
+      val replacementYaml = MetricViewFactory.toYAML(replacement)
+      sql(
+        s"""CREATE VIEW IF NOT EXISTS $fullMetricViewName
+           |WITH METRICS
+           |LANGUAGE YAML
+           |AS
+           |$$$$
+           |$replacementYaml
+           |$$$$""".stripMargin)
+
+      assert(capturedViewInfo().queryText() === originalYaml,
+        "IF NOT EXISTS over an existing metric view should be a no-op.")
+    }
+  }
+
+  test("CREATE VIEW ... WITH METRICS over a v2 table at the ident throws " +
+      "EXPECT_VIEW_NOT_TABLE.NO_ALTERNATIVE") {
+    withTestCatalogTables {
+      // Pre-create a regular v2 table at the same ident the metric view will target. The
+      // catalog's `createView` call below should raise `ViewAlreadyExistsException`, which
+      // `CreateV2MetricViewExec` then decodes (via `tableExists`) into the precise cross-type
+      // collision error that `CreateV2ViewExec` emits.
+      sql(s"CREATE TABLE $fullMetricViewName (x INT) USING foo")
+
+      val mv = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      val yaml = MetricViewFactory.toYAML(mv)
+      val ex = intercept[AnalysisException] {
+        sql(
+          s"""CREATE VIEW $fullMetricViewName
+             |WITH METRICS
+             |LANGUAGE YAML
+             |AS
+             |$$$$
+             |$yaml
+             |$$$$""".stripMargin)
+      }
+      // CreateV2ViewExec / CreateV2MetricViewExec route this through
+      // `unsupportedCreateOrReplaceViewOnTableError` which maps to
+      // `EXPECT_VIEW_NOT_TABLE.NO_ALTERNATIVE`.
+      assert(ex.getCondition === "EXPECT_VIEW_NOT_TABLE.NO_ALTERNATIVE",
+        s"Expected EXPECT_VIEW_NOT_TABLE.NO_ALTERNATIVE, got ${ex.getCondition}: ${ex.getMessage}")
+    }
+  }
+
+  test("CREATE VIEW IF NOT EXISTS ... WITH METRICS is a no-op when a v2 table sits at the " +
+      "ident") {
+    withTestCatalogTables {
+      sql(s"CREATE TABLE $fullMetricViewName (x INT) USING foo")
+      val mv = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      val yaml = MetricViewFactory.toYAML(mv)
+      // IF NOT EXISTS over a table is a no-op (v1 parity), not an error.
+      sql(
+        s"""CREATE VIEW IF NOT EXISTS $fullMetricViewName
+           |WITH METRICS
+           |LANGUAGE YAML
+           |AS
+           |$$$$
+           |$yaml
+           |$$$$""".stripMargin)
+      val ident = Identifier.of(Array(testNamespace), metricViewName)
+      assert(!MetricViewRecordingCatalog.capturedViews.containsKey(ident),
+        "IF NOT EXISTS over a v2 table should not register a view in the catalog.")
+    }
+  }
+
+  test("dependency extraction: V1 session-catalog source emits 3-part nameParts") {
+    val v1Source = "metric_view_v2_v1source"
+    spark.range(0, 5).toDF("v")
+      .write.mode("overwrite").saveAsTable(v1Source)
+    try {
+      withTestCatalogTables {
+        val mv = MetricView(
+          "0.1",
+          // SQL source resolves through the current (session) catalog; the resolved
+          // `LogicalRelation` carries a session-catalog `CatalogTable`.
+          SQLSource(s"SELECT v AS region, v AS count FROM $v1Source"),
+          where = None,
+          select = metricViewColumns)
+        createMetricView(fullMetricViewName, mv)
+
+        val deps = capturedViewInfo().viewDependencies()
+        assert(deps != null && deps.dependencies().length === 1)
+        val parts = deps.dependencies()(0).asInstanceOf[TableDependency].nameParts().toSeq
+        // For a session-catalog source, `TableIdentifier.nameParts` includes catalog + db +
+        // table when the catalog is set; here we expect at least 2 parts (`db.table`) and
+        // up to 3 (`spark_catalog.db.table`) -- both are valid producer outputs depending
+        // on whether the analyzer captured the session-catalog component.
+        assert(parts.last === v1Source, s"Last part should be the table name, got $parts")
+        assert(parts.length >= 2 && parts.length <= 3,
+          s"V1 nameParts arity should be 2 or 3, got ${parts.length}: $parts")
+      }
+    } finally {
+      sql(s"DROP TABLE IF EXISTS $v1Source")
+    }
+  }
+
+  test("dependency extraction: multi-level V2 namespace source emits N+2 nameParts") {
+    val multiNamespace = Array("ns_a", "ns_b")
+    val multiTable = "events_deep"
+    val multiFull = s"$testCatalogName.${multiNamespace.mkString(".")}.$multiTable"
+    withTestCatalogTables {
+      // The InMemoryTableCatalog (RelationCatalog mixin) supports multi-level namespaces.
+      sql(s"CREATE NAMESPACE IF NOT EXISTS $testCatalogName.${multiNamespace.head}")
+      sql(s"CREATE NAMESPACE IF NOT EXISTS " +
+        s"$testCatalogName.${multiNamespace.mkString(".")}")
+      sql(s"CREATE TABLE $multiFull (region STRING, count INT) USING foo")
+      try {
+        val mv = MetricView(
+          "0.1",
+          SQLSource(s"SELECT region, count FROM $multiFull"),
+          where = None,
+          select = metricViewColumns)
+        createMetricView(fullMetricViewName, mv)
+
+        val deps = capturedViewInfo().viewDependencies()
+        assert(deps != null && deps.dependencies().length === 1)
+        val parts = deps.dependencies()(0).asInstanceOf[TableDependency].nameParts().toSeq
+        assert(parts === Seq(testCatalogName, multiNamespace(0), multiNamespace(1), multiTable),
+          s"Multi-level nameParts should preserve every namespace component, got $parts")
+      } finally {
+        sql(s"DROP TABLE IF EXISTS $multiFull")
+        sql(s"DROP NAMESPACE IF EXISTS " +
+          s"$testCatalogName.${multiNamespace.mkString(".")} CASCADE")
+        sql(s"DROP NAMESPACE IF EXISTS $testCatalogName.${multiNamespace.head} CASCADE")
+      }
+    }
+  }
+
+  test("DESCRIBE TABLE EXTENDED on a v2 metric view round-trips through loadRelation") {
+    withTestCatalogTables {
+      val mv = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      val yaml = createMetricView(fullMetricViewName, mv)
+
+      // DESCRIBE TABLE EXTENDED resolves the ident through `Analyzer.lookupTableOrView`,
+      // which calls `RelationCatalog.loadRelation` once and gets back a
+      // `MetadataOnlyTable(ViewInfo)`. `V1Table.toCatalogTable(ViewInfo)` reconstructs the
+      // V1 representation; the resulting `CatalogTable.toJsonLinkedHashMap` (interface.scala)
+      // then emits view-context rows because `tableType == METRIC_VIEW` was added to the
+      // VIEW gate. Without that gate fix, "View Text" / "View Original Text" disappear.
+      val rows = sql(s"DESCRIBE TABLE EXTENDED $fullMetricViewName").collect()
+      val rowMap = rows.map(r => r.getString(0) -> r.getString(1)).toMap
+
+      assert(rowMap.contains("View Text"),
+        s"Expected 'View Text' row in DESCRIBE EXTENDED output, got keys: ${rowMap.keys}")
+      assert(rowMap("View Text") === yaml,
+        s"View Text should round-trip the YAML body, got: ${rowMap("View Text")}")
+      assert(rowMap.get("Type").exists(_.contains("METRIC_VIEW")),
+        s"Type row should reflect METRIC_VIEW, got: ${rowMap.get("Type")}")
     }
   }
 
   test("CREATE VIEW ... WITH METRICS on a non-ViewCatalog catalog fails with " +
-      "MISSING_CATALOG_ABILITY.VIEWS") {
     val ex = intercept[AnalysisException] {
       sql(
         s"""CREATE VIEW ${MetricViewV2CatalogSuite.noViewCatalogName}.default.mv

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
@@ -172,7 +172,8 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       val info = capturedViewInfo()
       val props = info.properties()
 
-      // metric_view.* descriptive properties (mirrors DBR SingleSourceMetricView).
+      // metric_view.* descriptive properties (mirrors the canonical metric-view property
+      // layout).
       assert(props.get(MetricView.PROP_FROM_TYPE) === "ASSET")
       assert(props.get(MetricView.PROP_FROM_NAME) === fullSourceTableName)
       assert(props.get(MetricView.PROP_FROM_SQL) === null)
@@ -750,8 +751,8 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       // `MetadataTable(ViewInfo)`. The analyzer wraps it as a `ResolvedPersistentView` and
       // `DataSourceV2Strategy` routes through SPARK-56655's `DescribeV2ViewExec`, which
       // reads the typed `ViewInfo` directly and emits the standard "Type" / "View Text" /
-      // "View Current Catalog" / "View Schema Mode" / etc. rows. Pins `DescribeV2ViewExec`
-      // emits a "Type" row matching v1 `CatalogTable.toJsonLinkedHashMap` parity, so users
+      // "View Current Catalog" / "View Schema Mode" / etc. rows. Pins that `DescribeV2ViewExec`
+      // emits a "Type" row for parity with v1 `CatalogTable.toJsonLinkedHashMap`, so users
       // can distinguish a plain VIEW from a sub-kind like METRIC_VIEW.
       val rows = sql(s"DESCRIBE TABLE EXTENDED $fullMetricViewName").collect()
       val rowMap = rows.map(r => r.getString(0) -> r.getString(1)).toMap
@@ -880,6 +881,43 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
   test("DROP VIEW IF EXISTS on a non-existent V2 metric view is a no-op") {
     withTestCatalogTables {
       sql(s"DROP VIEW IF EXISTS $testCatalogName.$testNamespace.does_not_exist")
+    }
+  }
+
+  test("ALTER VIEW <metric_view> RENAME TO ... succeeds and preserves metric view metadata") {
+    withTestCatalogTables {
+      val mv = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, mv)
+      val renamedFull = s"$testCatalogName.$testNamespace.mv_renamed"
+      try {
+        // RenameTable on a `ResolvedPersistentView` is routed by `DataSourceV2Strategy` to
+        // `RenameV2ViewExec`, which calls `ViewCatalog.renameView` -- the fixture
+        // `MetricViewRecordingCatalog.renameView` relocates both the `views` entry and the
+        // `capturedViews` entry under the new ident. Pin the wiring end-to-end so the
+        // metric view kind survives the rename.
+        sql(s"ALTER VIEW $fullMetricViewName RENAME TO $renamedFull")
+
+        // Old ident is gone from the v2 catalog -- DESCRIBE should fail to resolve.
+        val oldEx = intercept[AnalysisException] {
+          sql(s"DESCRIBE TABLE $fullMetricViewName").collect()
+        }
+        assert(oldEx.getCondition === "TABLE_OR_VIEW_NOT_FOUND",
+          s"Expected TABLE_OR_VIEW_NOT_FOUND for the old ident, got " +
+            s"${oldEx.getCondition}: ${oldEx.getMessage}")
+
+        // New ident loads through `TableViewCatalog.loadTableOrView` and surfaces the same
+        // metric-view kind on `DESCRIBE TABLE EXTENDED`.
+        val rows = sql(s"DESCRIBE TABLE EXTENDED $renamedFull").collect()
+        val rowMap = rows.map(r => r.getString(0) -> r.getString(1)).toMap
+        assert(rowMap.get("Type").contains(TableSummary.METRIC_VIEW_TABLE_TYPE),
+          s"Renamed view should still be a METRIC_VIEW, got Type=${rowMap.get("Type")}")
+      } finally {
+        sql(s"DROP VIEW IF EXISTS $renamedFull")
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
@@ -153,9 +153,9 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
 
       val deps = info.viewDependencies()
       assert(deps != null)
-      assert(deps.dependencies().size() === 1)
-      val tableDep = deps.dependencies().get(0).asInstanceOf[TableDependency]
-      assert(tableDep.nameParts().asScala.toSeq ===
+      assert(deps.dependencies().length === 1)
+      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
+      assert(tableDep.nameParts().toSeq ===
         Seq(testCatalogName, testNamespace, sourceTableName))
     }
   }
@@ -210,9 +210,9 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       assert(props.get(TableCatalog.PROP_COMMENT) === "my mv")
 
       val deps = info.viewDependencies()
-      assert(deps != null && deps.dependencies().size() === 1)
-      val tableDep = deps.dependencies().get(0).asInstanceOf[TableDependency]
-      assert(tableDep.nameParts().asScala.toSeq ===
+      assert(deps != null && deps.dependencies().length === 1)
+      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
+      assert(tableDep.nameParts().toSeq ===
         Seq(testCatalogName, testNamespace, sourceTableName))
     }
   }
@@ -314,9 +314,9 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       assert(finalInfo.queryText().trim === replacementYaml.trim)
       assert(finalInfo.properties().get(MetricView.PROP_WHERE) === "count > 100")
       val deps = finalInfo.viewDependencies()
-      assert(deps != null && deps.dependencies().size() === 1)
-      val tableDep = deps.dependencies().get(0).asInstanceOf[TableDependency]
-      assert(tableDep.nameParts().asScala.toSeq ===
+      assert(deps != null && deps.dependencies().length === 1)
+      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
+      assert(tableDep.nameParts().toSeq ===
         Seq(testCatalogName, testNamespace, sourceTableName))
     }
   }
@@ -506,8 +506,8 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
 
         val deps = capturedViewInfo().viewDependencies()
         assert(deps != null)
-        val depParts = deps.dependencies().asScala
-          .map(_.asInstanceOf[TableDependency].nameParts().asScala.toSeq).toSet
+        val depParts = deps.dependencies()
+          .map(_.asInstanceOf[TableDependency].nameParts().toSeq).toSet
         assert(depParts === Set(
           Seq(testCatalogName, testNamespace, sourceTableName),
           Seq(testCatalogName, testNamespace, "customers")),
@@ -531,11 +531,11 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       createMetricView(fullMetricViewName, metricView)
 
       val deps = capturedViewInfo().viewDependencies()
-      assert(deps != null && deps.dependencies().size() === 1,
+      assert(deps != null && deps.dependencies().length === 1,
         s"Expected 1 deduplicated dependency, got " +
-          s"${Option(deps).map(_.dependencies().size()).getOrElse(0)}")
-      val tableDep = deps.dependencies().get(0).asInstanceOf[TableDependency]
-      assert(tableDep.nameParts().asScala.toSeq ===
+          s"${Option(deps).map(_.dependencies().length).getOrElse(0)}")
+      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
+      assert(tableDep.nameParts().toSeq ===
         Seq(testCatalogName, testNamespace, sourceTableName))
     }
   }
@@ -556,11 +556,11 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       createMetricView(fullMetricViewName, metricView)
 
       val deps = capturedViewInfo().viewDependencies()
-      assert(deps != null && deps.dependencies().size() === 1,
+      assert(deps != null && deps.dependencies().length === 1,
         s"Expected 1 deduplicated dependency for self-join, got " +
-          s"${Option(deps).map(_.dependencies().size()).getOrElse(0)}")
-      val tableDep = deps.dependencies().get(0).asInstanceOf[TableDependency]
-      assert(tableDep.nameParts().asScala.toSeq ===
+          s"${Option(deps).map(_.dependencies().length).getOrElse(0)}")
+      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
+      assert(tableDep.nameParts().toSeq ===
         Seq(testCatalogName, testNamespace, sourceTableName))
     }
   }
@@ -581,9 +581,9 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
         createMetricView(fullMetricViewName, mv)
 
         val deps = capturedViewInfo().viewDependencies()
-        assert(deps != null && deps.dependencies().size() === 1)
+        assert(deps != null && deps.dependencies().length === 1)
         val parts =
-          deps.dependencies().get(0).asInstanceOf[TableDependency].nameParts().asScala.toSeq
+          deps.dependencies()(0).asInstanceOf[TableDependency].nameParts().toSeq
         // `MetricViewHelper.qualifyV1` normalizes any `TableIdentifier.nameParts` shape
         // (1, 2, or 3 parts depending on what the analyzer captured) to the stable
         // `[spark_catalog, db, table]` shape so downstream consumers see deterministic
@@ -618,9 +618,9 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
         createMetricView(fullMetricViewName, mv)
 
         val deps = capturedViewInfo().viewDependencies()
-        assert(deps != null && deps.dependencies().size() === 1)
+        assert(deps != null && deps.dependencies().length === 1)
         val parts =
-          deps.dependencies().get(0).asInstanceOf[TableDependency].nameParts().asScala.toSeq
+          deps.dependencies()(0).asInstanceOf[TableDependency].nameParts().toSeq
         assert(parts === Seq(testCatalogName, multiNamespace(0), multiNamespace(1), multiTable),
           s"Multi-level nameParts should preserve every namespace component, got $parts")
       } finally {
@@ -892,14 +892,20 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
         where = None,
         select = metricViewColumns)
       createMetricView(fullMetricViewName, mv)
-      val renamedFull = s"$testCatalogName.$testNamespace.mv_renamed"
+      // Per upstream DataSourceV2SQLSuite convention (see lines 2477 / 2484 there), the
+      // RENAME TO clause takes a 2-part `namespace.name` -- the new ident is implicitly
+      // within the same catalog as the source view. Including a 3-part `catalog.ns.name`
+      // would leak the catalog component into `newName.asIdentifier` and the catalog's
+      // `renameView` would store under a key the loader can't find.
+      val renamedRelative = s"$testNamespace.mv_renamed"
+      val renamedFull = s"$testCatalogName.$renamedRelative"
       try {
         // RenameTable on a `ResolvedPersistentView` is routed by `DataSourceV2Strategy` to
         // `RenameV2ViewExec`, which calls `ViewCatalog.renameView` -- the fixture
         // `MetricViewRecordingCatalog.renameView` relocates both the `views` entry and the
         // `capturedViews` entry under the new ident. Pin the wiring end-to-end so the
         // metric view kind survives the rename.
-        sql(s"ALTER VIEW $fullMetricViewName RENAME TO $renamedFull")
+        sql(s"ALTER VIEW $fullMetricViewName RENAME TO $renamedRelative")
 
         // Old ident is gone from the v2 catalog -- DESCRIBE should fail to resolve.
         val oldEx = intercept[AnalysisException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
@@ -117,6 +117,11 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
     info
   }
 
+  // ============================================================
+  // Section 1: CREATE-related tests
+  // ============================================================
+
+
   test("V2 catalog receives METRIC_VIEW table type and view text via ViewInfo") {
     withTestCatalogTables {
       val metricView = MetricView(
@@ -169,29 +174,6 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
         spark.sessionState.catalogManager.currentCatalog.name())
       assert(info.currentNamespace().toSeq ===
         spark.sessionState.catalogManager.currentNamespace.toSeq)
-    }
-  }
-
-  test("DROP VIEW succeeds on a V2 metric view") {
-    withTestCatalogTables {
-      val metricView = MetricView(
-        "0.1",
-        AssetSource(fullSourceTableName),
-        where = None,
-        select = metricViewColumns)
-      createMetricView(fullMetricViewName, metricView)
-      val ident = Identifier.of(Array(testNamespace), metricViewName)
-
-      assert(MetricViewRecordingCatalog.capturedViews.containsKey(ident))
-
-      sql(s"DROP VIEW $fullMetricViewName")
-      assert(!MetricViewRecordingCatalog.capturedViews.containsKey(ident))
-    }
-  }
-
-  test("DROP VIEW IF EXISTS on a non-existent V2 metric view is a no-op") {
-    withTestCatalogTables {
-      sql(s"DROP VIEW IF EXISTS $testCatalogName.$testNamespace.does_not_exist")
     }
   }
 
@@ -288,86 +270,6 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("dependency extraction: SQL source JOIN captures both tables") {
-    withTestCatalogTables {
-      val secondSource = s"$testCatalogName.$testNamespace.customers"
-      sql(
-        s"""CREATE TABLE $secondSource (id INT, name STRING)
-           |USING foo""".stripMargin)
-      try {
-        val joinSql =
-          s"SELECT c.name, t.count FROM $fullSourceTableName t " +
-            s"JOIN $secondSource c ON t.count = c.id"
-        val metricView = MetricView(
-          "0.1",
-          SQLSource(joinSql),
-          where = None,
-          select = Seq(
-            Column("name", DimensionExpression("name"), 0),
-            Column("count_sum", MeasureExpression("sum(count)"), 1)))
-        createMetricView(fullMetricViewName, metricView)
-
-        val deps = capturedViewInfo().viewDependencies()
-        assert(deps != null)
-        val depParts =
-          deps.dependencies().map(_.asInstanceOf[TableDependency].nameParts().toSeq).toSet
-        assert(depParts === Set(
-          Seq(testCatalogName, testNamespace, sourceTableName),
-          Seq(testCatalogName, testNamespace, "customers")),
-          s"Expected dependencies on both source tables, got $depParts")
-      } finally {
-        sql(s"DROP TABLE IF EXISTS $secondSource")
-      }
-    }
-  }
-
-  test("dependency extraction: SQL source subquery deduplicates same-table references") {
-    withTestCatalogTables {
-      val subquerySql =
-        s"SELECT * FROM $fullSourceTableName " +
-          s"WHERE count > (SELECT avg(count) FROM $fullSourceTableName)"
-      val metricView = MetricView(
-        "0.1",
-        SQLSource(subquerySql),
-        where = None,
-        select = metricViewColumns)
-      createMetricView(fullMetricViewName, metricView)
-
-      val deps = capturedViewInfo().viewDependencies()
-      assert(deps != null && deps.dependencies().length === 1,
-        s"Expected 1 deduplicated dependency, got " +
-          s"${Option(deps).map(_.dependencies().length).getOrElse(0)}")
-      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
-      assert(tableDep.nameParts().toSeq ===
-        Seq(testCatalogName, testNamespace, sourceTableName))
-    }
-  }
-
-  test("dependency extraction: SQL source self-join deduplicates same-table references") {
-    withTestCatalogTables {
-      val selfJoinSql =
-        s"SELECT a.region AS a_region, a.count AS a_count " +
-          s"FROM $fullSourceTableName a JOIN $fullSourceTableName b " +
-          s"ON a.region = b.region"
-      val metricView = MetricView(
-        "0.1",
-        SQLSource(selfJoinSql),
-        where = None,
-        select = Seq(
-          Column("region", DimensionExpression("a_region"), 0),
-          Column("count_sum", MeasureExpression("sum(a_count)"), 1)))
-      createMetricView(fullMetricViewName, metricView)
-
-      val deps = capturedViewInfo().viewDependencies()
-      assert(deps != null && deps.dependencies().length === 1,
-        s"Expected 1 deduplicated dependency for self-join, got " +
-          s"${Option(deps).map(_.dependencies().length).getOrElse(0)}")
-      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
-      assert(tableDep.nameParts().toSeq ===
-        Seq(testCatalogName, testNamespace, sourceTableName))
-    }
-  }
-
   test("CREATE OR REPLACE VIEW ... WITH METRICS replaces an existing v2 metric view") {
     withTestCatalogTables {
       val first = MetricView(
@@ -376,7 +278,6 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
         where = Some("count > 0"),
         select = metricViewColumns)
       createMetricView(fullMetricViewName, first)
-      val firstYaml = capturedViewInfo().queryText()
 
       // Replace with a new body (different WHERE clause).
       val replacement = MetricView(
@@ -395,10 +296,14 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
            |$$$$""".stripMargin)
 
       val finalInfo = capturedViewInfo()
-      assert(finalInfo.queryText() === replacementYaml,
-        "OR REPLACE should swap the captured ViewInfo's queryText.")
-      assert(finalInfo.queryText() !== firstYaml,
-        "OR REPLACE should not leave the original captured queryText in place.")
+      // Assert on the distinguishing fields of the replacement, not on diff vs. the original.
+      assert(finalInfo.queryText() === replacementYaml)
+      assert(finalInfo.properties().get(MetricView.PROP_WHERE) === "count > 100")
+      val deps = finalInfo.viewDependencies()
+      assert(deps != null && deps.dependencies().length === 1)
+      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
+      assert(tableDep.nameParts().toSeq ===
+        Seq(testCatalogName, testNamespace, sourceTableName))
     }
   }
 
@@ -493,6 +398,111 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  test("CREATE VIEW ... WITH METRICS on a non-ViewCatalog catalog fails with " +
+      "MISSING_CATALOG_ABILITY.VIEWS") {
+    val ex = intercept[AnalysisException] {
+      sql(
+        s"""CREATE VIEW ${MetricViewV2CatalogSuite.noViewCatalogName}.default.mv
+           |WITH METRICS
+           |LANGUAGE YAML
+           |AS
+           |$$$$
+           |${MetricViewFactory.toYAML(MetricView(
+              "0.1",
+              AssetSource(fullSourceTableName),
+              where = None,
+              select = metricViewColumns))}
+           |$$$$""".stripMargin)
+    }
+    assert(ex.getCondition === "MISSING_CATALOG_ABILITY")
+    assert(ex.getMessage.contains("VIEWS"))
+  }
+
+  // ============================================================
+  // Section 2: Dependency extraction
+  // ============================================================
+
+
+  test("dependency extraction: SQL source JOIN captures both tables") {
+    withTestCatalogTables {
+      val secondSource = s"$testCatalogName.$testNamespace.customers"
+      sql(
+        s"""CREATE TABLE $secondSource (id INT, name STRING)
+           |USING foo""".stripMargin)
+      try {
+        val joinSql =
+          s"SELECT c.name, t.count FROM $fullSourceTableName t " +
+            s"JOIN $secondSource c ON t.count = c.id"
+        val metricView = MetricView(
+          "0.1",
+          SQLSource(joinSql),
+          where = None,
+          select = Seq(
+            Column("name", DimensionExpression("name"), 0),
+            Column("count_sum", MeasureExpression("sum(count)"), 1)))
+        createMetricView(fullMetricViewName, metricView)
+
+        val deps = capturedViewInfo().viewDependencies()
+        assert(deps != null)
+        val depParts =
+          deps.dependencies().map(_.asInstanceOf[TableDependency].nameParts().toSeq).toSet
+        assert(depParts === Set(
+          Seq(testCatalogName, testNamespace, sourceTableName),
+          Seq(testCatalogName, testNamespace, "customers")),
+          s"Expected dependencies on both source tables, got $depParts")
+      } finally {
+        sql(s"DROP TABLE IF EXISTS $secondSource")
+      }
+    }
+  }
+
+  test("dependency extraction: SQL source subquery deduplicates same-table references") {
+    withTestCatalogTables {
+      val subquerySql =
+        s"SELECT * FROM $fullSourceTableName " +
+          s"WHERE count > (SELECT avg(count) FROM $fullSourceTableName)"
+      val metricView = MetricView(
+        "0.1",
+        SQLSource(subquerySql),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, metricView)
+
+      val deps = capturedViewInfo().viewDependencies()
+      assert(deps != null && deps.dependencies().length === 1,
+        s"Expected 1 deduplicated dependency, got " +
+          s"${Option(deps).map(_.dependencies().length).getOrElse(0)}")
+      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
+      assert(tableDep.nameParts().toSeq ===
+        Seq(testCatalogName, testNamespace, sourceTableName))
+    }
+  }
+
+  test("dependency extraction: SQL source self-join deduplicates same-table references") {
+    withTestCatalogTables {
+      val selfJoinSql =
+        s"SELECT a.region AS a_region, a.count AS a_count " +
+          s"FROM $fullSourceTableName a JOIN $fullSourceTableName b " +
+          s"ON a.region = b.region"
+      val metricView = MetricView(
+        "0.1",
+        SQLSource(selfJoinSql),
+        where = None,
+        select = Seq(
+          Column("region", DimensionExpression("a_region"), 0),
+          Column("count_sum", MeasureExpression("sum(a_count)"), 1)))
+      createMetricView(fullMetricViewName, metricView)
+
+      val deps = capturedViewInfo().viewDependencies()
+      assert(deps != null && deps.dependencies().length === 1,
+        s"Expected 1 deduplicated dependency for self-join, got " +
+          s"${Option(deps).map(_.dependencies().length).getOrElse(0)}")
+      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
+      assert(tableDep.nameParts().toSeq ===
+        Seq(testCatalogName, testNamespace, sourceTableName))
+    }
+  }
+
   test("dependency extraction: V1 session-catalog source emits 3-part nameParts") {
     val v1Source = "metric_view_v2_v1source"
     spark.range(0, 5).toDF("v")
@@ -556,6 +566,37 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  // ============================================================
+  // Section 3: SELECT cases
+  // ============================================================
+
+
+  test("SELECT from a v2 metric view returns aggregated rows") {
+    withTestCatalogTables {
+      val mv = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, mv)
+      // The fixture's `events` source has rows ("region_1", 1, 5.0), ("region_2", 2, 10.0).
+      // The metric view aggregates by `region` summing `count`. Resolution flows through
+      // loadRelation -> MetadataOnlyTable(ViewInfo) -> V1Table.toCatalogTable(ViewInfo) ->
+      // CatalogTableType.METRIC_VIEW -> ResolveMetricView, then the analyzer rewrites the
+      // view body into Aggregate(Seq(region), Seq(sum(count) AS count_sum)) over `events`.
+      val rows = sql(s"SELECT region, count_sum FROM $fullMetricViewName ORDER BY region")
+        .collect()
+      assert(rows.length === 2)
+      assert(rows(0).getString(0) === "region_1" && rows(0).getLong(1) === 1L)
+      assert(rows(1).getString(0) === "region_2" && rows(1).getLong(1) === 2L)
+    }
+  }
+
+  // ============================================================
+  // Section 4: DESCRIBE cases
+  // ============================================================
+
+
   test("DESCRIBE TABLE EXTENDED on a v2 metric view round-trips through loadRelation") {
     withTestCatalogTables {
       val mv = MetricView(
@@ -583,23 +624,82 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("CREATE VIEW ... WITH METRICS on a non-ViewCatalog catalog fails with " +
-    val ex = intercept[AnalysisException] {
-      sql(
-        s"""CREATE VIEW ${MetricViewV2CatalogSuite.noViewCatalogName}.default.mv
-           |WITH METRICS
-           |LANGUAGE YAML
-           |AS
-           |$$$$
-           |${MetricViewFactory.toYAML(MetricView(
-              "0.1",
-              AssetSource(fullSourceTableName),
-              where = None,
-              select = metricViewColumns))}
-           |$$$$""".stripMargin)
+  test("DESCRIBE TABLE on a v2 metric view returns the aliased columns") {
+    withTestCatalogTables {
+      val mv = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, mv)
+      val rows = sql(s"DESCRIBE TABLE $fullMetricViewName").collect()
+      val byName = rows.map(r => r.getString(0) -> r.getString(1)).toMap
+      assert(byName.contains("region"), s"Missing 'region' col, got: ${byName.keys}")
+      assert(byName.contains("count_sum"), s"Missing 'count_sum' col, got: ${byName.keys}")
     }
-    assert(ex.getCondition === "MISSING_CATALOG_ABILITY")
-    assert(ex.getMessage.contains("VIEWS"))
+  }
+
+  // ============================================================
+  // Section 5: DROP / SHOW cases
+  // ============================================================
+
+
+  test("DROP VIEW succeeds on a V2 metric view") {
+    withTestCatalogTables {
+      val metricView = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, metricView)
+      val ident = Identifier.of(Array(testNamespace), metricViewName)
+
+      assert(MetricViewRecordingCatalog.capturedViews.containsKey(ident))
+
+      sql(s"DROP VIEW $fullMetricViewName")
+      assert(!MetricViewRecordingCatalog.capturedViews.containsKey(ident))
+    }
+  }
+
+  test("DROP VIEW IF EXISTS on a non-existent V2 metric view is a no-op") {
+    withTestCatalogTables {
+      sql(s"DROP VIEW IF EXISTS $testCatalogName.$testNamespace.does_not_exist")
+    }
+  }
+
+  test("SHOW TABLES does not list v2 metric views") {
+    withTestCatalogTables {
+      val mv = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, mv)
+      val tables = sql(s"SHOW TABLES IN $testCatalogName.$testNamespace")
+        .collect().map(_.getString(1)).toSet
+      // The fixture's `events` source table is a regular table, so SHOW TABLES sees it.
+      assert(tables.contains(sourceTableName),
+        s"SHOW TABLES should list the source table, got: $tables")
+      // Per the RelationCatalog contract, SHOW TABLES returns tables only -- metric views
+      // belong on SHOW VIEWS instead.
+      assert(!tables.contains(metricViewName),
+        s"SHOW TABLES should not list metric views, got: $tables")
+    }
+  }
+
+  test("SHOW VIEWS lists v2 metric views") {
+    withTestCatalogTables {
+      val mv = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, mv)
+      val views = sql(s"SHOW VIEWS IN $testCatalogName.$testNamespace")
+        .collect().map(_.getString(1)).toSet
+      assert(views.contains(metricViewName),
+        s"SHOW VIEWS should list metric views, got: $views")
+    }
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
@@ -911,7 +911,9 @@ class MetricViewRecordingCatalog extends InMemoryTableCatalog with RelationCatal
     val key = (ident.namespace().toSeq, ident.name())
     Option(views.get(key)) match {
       case Some(info) => new MetadataOnlyTable(info, ident.toString)
-      case None => super.loadTable(ident) // delegate to InMemoryTableCatalog for tables
+      // Bypass `RelationCatalog.loadTable` (whose default delegates back to `loadRelation`)
+      // and call `InMemoryTableCatalog.loadTable` directly to avoid infinite recursion.
+      case None => super[InMemoryTableCatalog].loadTable(ident)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
@@ -1,0 +1,462 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.catalyst.analysis.{NoSuchViewException, ViewAlreadyExistsException}
+import org.apache.spark.sql.connector.catalog.{Identifier, InMemoryTableCatalog, MetadataOnlyTable, RelationCatalog, Table, TableCatalog, TableDependency, TableSummary, ViewInfo}
+import org.apache.spark.sql.metricview.serde.{AssetSource, Column, Constants, DimensionExpression, MeasureExpression, MetricView, MetricViewFactory, SQLSource}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.Metadata
+
+/**
+ * Tests that exercise [[org.apache.spark.sql.execution.command.CreateMetricViewCommand]] on a
+ * non-session V2 catalog. Metric views are persisted through the same [[ViewCatalog]] interface
+ * as plain views; the only marker that distinguishes them is `PROP_TABLE_TYPE = METRIC_VIEW`
+ * plus the typed `viewDependencies` field on [[ViewInfo]]. The recording catalog used here is a
+ * minimal [[RelationCatalog]] so the same instance can also host the source table referenced by
+ * the metric view's YAML.
+ */
+class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
+
+  import testImplicits._
+
+  private val testCatalogName = "testcat"
+  private val testNamespace = "ns"
+  private val sourceTableName = "events"
+  private val fullSourceTableName =
+    s"$testCatalogName.$testNamespace.$sourceTableName"
+  private val metricViewName = "mv"
+  private val fullMetricViewName =
+    s"$testCatalogName.$testNamespace.$metricViewName"
+
+  private val metricViewColumns = Seq(
+    Column("region", DimensionExpression("region"), 0),
+    Column("count_sum", MeasureExpression("sum(count)"), 1))
+
+  private val testTableData = Seq(
+    ("region_1", 1, 5.0),
+    ("region_2", 2, 10.0))
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(
+      s"spark.sql.catalog.$testCatalogName",
+      classOf[MetricViewRecordingCatalog].getName)
+    // A catalog that does not implement ViewCatalog - used for the negative gate test.
+    spark.conf.set(
+      s"spark.sql.catalog.${MetricViewV2CatalogSuite.noViewCatalogName}",
+      classOf[InMemoryTableCatalog].getName)
+  }
+
+  override protected def afterAll(): Unit = {
+    spark.conf.unset(s"spark.sql.catalog.$testCatalogName")
+    spark.conf.unset(
+      s"spark.sql.catalog.${MetricViewV2CatalogSuite.noViewCatalogName}")
+    super.afterAll()
+  }
+
+  private def withTestCatalogTables(body: => Unit): Unit = {
+    MetricViewRecordingCatalog.reset()
+    testTableData.toDF("region", "count", "price")
+      .createOrReplaceTempView("metric_view_v2_source")
+    try {
+      sql(
+        s"""CREATE TABLE $fullSourceTableName
+           |USING foo AS SELECT * FROM metric_view_v2_source""".stripMargin)
+      body
+    } finally {
+      sql(s"DROP VIEW IF EXISTS $fullMetricViewName")
+      sql(s"DROP TABLE IF EXISTS $fullSourceTableName")
+      spark.catalog.dropTempView("metric_view_v2_source")
+      MetricViewRecordingCatalog.reset()
+    }
+  }
+
+  private def createMetricView(
+      name: String,
+      metricView: MetricView,
+      comment: Option[String] = None): String = {
+    val yaml = MetricViewFactory.toYAML(metricView)
+    val commentClause = comment.map(c => s"\nCOMMENT '$c'").getOrElse("")
+    sql(
+      s"""CREATE VIEW $name
+         |WITH METRICS$commentClause
+         |LANGUAGE YAML
+         |AS
+         |$$$$
+         |$yaml
+         |$$$$""".stripMargin)
+    yaml
+  }
+
+  private def capturedViewInfo(): ViewInfo = {
+    val ident = Identifier.of(Array(testNamespace), metricViewName)
+    val info = MetricViewRecordingCatalog.capturedViews.get(ident)
+    assert(info != null,
+      s"Expected ViewInfo for $ident to be captured by the V2 catalog")
+    info
+  }
+
+  test("V2 catalog receives METRIC_VIEW table type and view text via ViewInfo") {
+    withTestCatalogTables {
+      val metricView = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      val yaml = createMetricView(fullMetricViewName, metricView)
+
+      val info = capturedViewInfo()
+      // PROP_TABLE_TYPE is overwritten to METRIC_VIEW after `ViewInfo`'s constructor stamps it
+      // to VIEW; this is the marker `V1Table.toCatalogTable` reads to map the round-tripped row
+      // back to `CatalogTableType.METRIC_VIEW`.
+      assert(info.properties().get(TableCatalog.PROP_TABLE_TYPE)
+        === TableSummary.METRIC_VIEW_TABLE_TYPE)
+      assert(info.queryText() === yaml)
+
+      val deps = info.viewDependencies()
+      assert(deps != null)
+      assert(deps.dependencies().length === 1)
+      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
+      assert(tableDep.tableFullName() === fullSourceTableName)
+    }
+  }
+
+  test("V2 catalog path populates metric_view.* + view context + sql configs on ViewInfo") {
+    withTestCatalogTables {
+      val metricView = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = Some("count > 0"),
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, metricView)
+
+      val info = capturedViewInfo()
+      val props = info.properties()
+
+      // metric_view.* descriptive properties (mirrors DBR SingleSourceMetricView).
+      assert(props.get(MetricView.PROP_FROM_TYPE) === "ASSET")
+      assert(props.get(MetricView.PROP_FROM_NAME) === fullSourceTableName)
+      assert(props.get(MetricView.PROP_FROM_SQL) === null)
+      assert(props.get(MetricView.PROP_WHERE) === "count > 0")
+
+      // SQL configs and current catalog/namespace are first-class typed fields on ViewInfo, no
+      // longer encoded into properties for V2 catalogs.
+      assert(info.sqlConfigs().size > 0,
+        s"Expected at least one captured SQL config; got ${info.sqlConfigs()}")
+      assert(info.currentCatalog() ===
+        spark.sessionState.catalogManager.currentCatalog.name())
+      assert(info.currentNamespace().toSeq ===
+        spark.sessionState.catalogManager.currentNamespace.toSeq)
+    }
+  }
+
+  test("DROP VIEW succeeds on a V2 metric view") {
+    withTestCatalogTables {
+      val metricView = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, metricView)
+      val ident = Identifier.of(Array(testNamespace), metricViewName)
+
+      assert(MetricViewRecordingCatalog.capturedViews.containsKey(ident))
+
+      sql(s"DROP VIEW $fullMetricViewName")
+      assert(!MetricViewRecordingCatalog.capturedViews.containsKey(ident))
+    }
+  }
+
+  test("DROP VIEW IF EXISTS on a non-existent V2 metric view is a no-op") {
+    withTestCatalogTables {
+      sql(s"DROP VIEW IF EXISTS $testCatalogName.$testNamespace.does_not_exist")
+    }
+  }
+
+  test("V2 catalog path captures SQL source and comment") {
+    withTestCatalogTables {
+      val metricView = MetricView(
+        "0.1",
+        SQLSource(s"SELECT * FROM $fullSourceTableName"),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, metricView, comment = Some("my mv"))
+
+      val info = capturedViewInfo()
+      val props = info.properties()
+      assert(props.get(TableCatalog.PROP_TABLE_TYPE)
+        === TableSummary.METRIC_VIEW_TABLE_TYPE)
+      assert(props.get(MetricView.PROP_FROM_TYPE) === "SQL")
+      assert(props.get(MetricView.PROP_FROM_NAME) === null)
+      assert(props.get(MetricView.PROP_FROM_SQL) ===
+        s"SELECT * FROM $fullSourceTableName")
+      assert(props.get(TableCatalog.PROP_COMMENT) === "my mv")
+
+      val deps = info.viewDependencies()
+      assert(deps != null && deps.dependencies().length === 1)
+      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
+      assert(tableDep.tableFullName() === fullSourceTableName)
+    }
+  }
+
+  test("metric view columns carry metric_view.type / metric_view.expr in column metadata") {
+    withTestCatalogTables {
+      val metricView = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, metricView)
+
+      val cols = capturedViewInfo().columns()
+      assert(cols.length === metricViewColumns.length)
+
+      val byName = cols.map(c => c.name() -> c).toMap
+      def metadataOf(name: String): Metadata =
+        Metadata.fromJson(Option(byName(name).metadataInJSON()).getOrElse("{}"))
+
+      val regionMeta = metadataOf("region")
+      assert(regionMeta.getString(Constants.COLUMN_TYPE_PROPERTY_KEY) === "dimension")
+      assert(regionMeta.getString(Constants.COLUMN_EXPR_PROPERTY_KEY) === "region")
+
+      val countMeta = metadataOf("count_sum")
+      assert(countMeta.getString(Constants.COLUMN_TYPE_PROPERTY_KEY) === "measure")
+      assert(countMeta.getString(Constants.COLUMN_EXPR_PROPERTY_KEY) === "sum(count)")
+    }
+  }
+
+  test("user-specified column names with comments preserve metric_view.* metadata") {
+    withTestCatalogTables {
+      val metricView = MetricView(
+        "0.1",
+        AssetSource(fullSourceTableName),
+        where = None,
+        select = metricViewColumns)
+      val yaml = MetricViewFactory.toYAML(metricView)
+      // Give both columns new names, and a comment on each. Without the `retainMetadata`
+      // fix to `ViewHelper.aliasPlan`, the metric_view.* keys disappear here.
+      sql(
+        s"""CREATE VIEW $fullMetricViewName (reg COMMENT 'region alias', n COMMENT 'count')
+           |WITH METRICS
+           |LANGUAGE YAML
+           |AS
+           |$$$$
+           |$yaml
+           |$$$$""".stripMargin)
+
+      val cols = capturedViewInfo().columns()
+      val byName = cols.map(c => c.name() -> c).toMap
+      assert(byName.keySet === Set("reg", "n"))
+
+      def metadataOf(name: String): Metadata =
+        Metadata.fromJson(Option(byName(name).metadataInJSON()).getOrElse("{}"))
+
+      val regMeta = metadataOf("reg")
+      assert(regMeta.getString(Constants.COLUMN_TYPE_PROPERTY_KEY) === "dimension")
+      assert(regMeta.getString(Constants.COLUMN_EXPR_PROPERTY_KEY) === "region")
+      // `CatalogV2Util.structTypeToV2Columns` peels "comment" off into `Column.comment()`
+      // rather than leaving it inside `metadataInJSON`; assert via the V2 column accessor.
+      assert(byName("reg").comment() === "region alias")
+
+      val nMeta = metadataOf("n")
+      assert(nMeta.getString(Constants.COLUMN_TYPE_PROPERTY_KEY) === "measure")
+      assert(nMeta.getString(Constants.COLUMN_EXPR_PROPERTY_KEY) === "sum(count)")
+      assert(byName("n").comment() === "count")
+    }
+  }
+
+  test("dependency extraction: SQL source JOIN captures both tables") {
+    withTestCatalogTables {
+      val secondSource = s"$testCatalogName.$testNamespace.customers"
+      sql(
+        s"""CREATE TABLE $secondSource (id INT, name STRING)
+           |USING foo""".stripMargin)
+      try {
+        val joinSql =
+          s"SELECT c.name, t.count FROM $fullSourceTableName t " +
+            s"JOIN $secondSource c ON t.count = c.id"
+        val metricView = MetricView(
+          "0.1",
+          SQLSource(joinSql),
+          where = None,
+          select = Seq(
+            Column("name", DimensionExpression("name"), 0),
+            Column("count_sum", MeasureExpression("sum(count)"), 1)))
+        createMetricView(fullMetricViewName, metricView)
+
+        val deps = capturedViewInfo().viewDependencies()
+        assert(deps != null)
+        val depNames =
+          deps.dependencies().map(_.asInstanceOf[TableDependency].tableFullName()).toSet
+        assert(depNames === Set(fullSourceTableName, secondSource),
+          s"Expected dependencies on both source tables, got $depNames")
+      } finally {
+        sql(s"DROP TABLE IF EXISTS $secondSource")
+      }
+    }
+  }
+
+  test("dependency extraction: SQL source subquery deduplicates same-table references") {
+    withTestCatalogTables {
+      val subquerySql =
+        s"SELECT * FROM $fullSourceTableName " +
+          s"WHERE count > (SELECT avg(count) FROM $fullSourceTableName)"
+      val metricView = MetricView(
+        "0.1",
+        SQLSource(subquerySql),
+        where = None,
+        select = metricViewColumns)
+      createMetricView(fullMetricViewName, metricView)
+
+      val deps = capturedViewInfo().viewDependencies()
+      assert(deps != null && deps.dependencies().length === 1,
+        s"Expected 1 deduplicated dependency, got " +
+          s"${Option(deps).map(_.dependencies().length).getOrElse(0)}")
+      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
+      assert(tableDep.tableFullName() === fullSourceTableName)
+    }
+  }
+
+  test("dependency extraction: SQL source self-join deduplicates same-table references") {
+    withTestCatalogTables {
+      val selfJoinSql =
+        s"SELECT a.region AS a_region, a.count AS a_count " +
+          s"FROM $fullSourceTableName a JOIN $fullSourceTableName b " +
+          s"ON a.region = b.region"
+      val metricView = MetricView(
+        "0.1",
+        SQLSource(selfJoinSql),
+        where = None,
+        select = Seq(
+          Column("region", DimensionExpression("a_region"), 0),
+          Column("count_sum", MeasureExpression("sum(a_count)"), 1)))
+      createMetricView(fullMetricViewName, metricView)
+
+      val deps = capturedViewInfo().viewDependencies()
+      assert(deps != null && deps.dependencies().length === 1,
+        s"Expected 1 deduplicated dependency for self-join, got " +
+          s"${Option(deps).map(_.dependencies().length).getOrElse(0)}")
+      val tableDep = deps.dependencies()(0).asInstanceOf[TableDependency]
+      assert(tableDep.tableFullName() === fullSourceTableName)
+    }
+  }
+
+  test("CREATE VIEW ... WITH METRICS on a non-ViewCatalog catalog fails with " +
+      "MISSING_CATALOG_ABILITY.VIEWS") {
+    val ex = intercept[AnalysisException] {
+      sql(
+        s"""CREATE VIEW ${MetricViewV2CatalogSuite.noViewCatalogName}.default.mv
+           |WITH METRICS
+           |LANGUAGE YAML
+           |AS
+           |$$$$
+           |${MetricViewFactory.toYAML(MetricView(
+              "0.1",
+              AssetSource(fullSourceTableName),
+              where = None,
+              select = metricViewColumns))}
+           |$$$$""".stripMargin)
+    }
+    assert(ex.getCondition === "MISSING_CATALOG_ABILITY")
+    assert(ex.getMessage.contains("VIEWS"))
+  }
+}
+
+object MetricViewV2CatalogSuite {
+  val noViewCatalogName: String = "testcat_no_view"
+}
+
+/**
+ * Minimal [[RelationCatalog]] used by [[MetricViewV2CatalogSuite]]. Layers `ViewCatalog`
+ * methods over [[InMemoryTableCatalog]] (which provides table storage + namespace ops) and
+ * captures every [[ViewInfo]] passed to `createView` so tests can inspect the typed payload.
+ *
+ * The metric-view CREATE path goes via `ViewCatalog.createView`, so the captured map keys are
+ * the view identifiers; the source table created by the test fixture is stored separately in
+ * the inherited table catalog.
+ */
+class MetricViewRecordingCatalog extends InMemoryTableCatalog with RelationCatalog {
+  private val views =
+    new ConcurrentHashMap[(Seq[String], String), ViewInfo]()
+
+  // -- ViewCatalog methods --
+
+  override def listViews(namespace: Array[String]): Array[Identifier] = {
+    val target = namespace.toSeq
+    val out = new java.util.ArrayList[Identifier]()
+    views.forEach { (key, _) =>
+      if (key._1 == target) out.add(Identifier.of(key._1.toArray, key._2))
+    }
+    out.asScala.toArray
+  }
+
+  // `loadView`, `tableExists`, and `viewExists` are inherited from `RelationCatalog`'s
+  // defaults, which derive from `loadRelation` -- a stored `ViewInfo` is wrapped in
+  // `MetadataOnlyTable` by `loadRelation` and the defaults unwrap it correctly.
+
+  override def createView(ident: Identifier, info: ViewInfo): ViewInfo = {
+    val key = (ident.namespace().toSeq, ident.name())
+    if (views.putIfAbsent(key, info) != null) {
+      throw new ViewAlreadyExistsException(ident)
+    }
+    MetricViewRecordingCatalog.capturedViews.put(ident, info)
+    info
+  }
+
+  override def replaceView(ident: Identifier, info: ViewInfo): ViewInfo = {
+    val key = (ident.namespace().toSeq, ident.name())
+    if (!views.containsKey(key)) throw new NoSuchViewException(ident)
+    views.put(key, info)
+    MetricViewRecordingCatalog.capturedViews.put(ident, info)
+    info
+  }
+
+  override def dropView(ident: Identifier): Boolean = {
+    val key = (ident.namespace().toSeq, ident.name())
+    val removed = views.remove(key) != null
+    if (removed) {
+      MetricViewRecordingCatalog.capturedViews.remove(ident)
+    }
+    removed
+  }
+
+  // -- RelationCatalog single-RPC perf path --
+
+  override def loadRelation(ident: Identifier): Table = {
+    val key = (ident.namespace().toSeq, ident.name())
+    Option(views.get(key)) match {
+      case Some(info) => new MetadataOnlyTable(info, ident.toString)
+      case None => super.loadTable(ident) // delegate to InMemoryTableCatalog for tables
+    }
+  }
+}
+
+object MetricViewRecordingCatalog {
+  // Captures every ViewInfo that flows through createView / replaceView so individual tests
+  // can assert on it. Cleared between tests via `reset()`.
+  val capturedViews: ConcurrentHashMap[Identifier, ViewInfo] =
+    new ConcurrentHashMap[Identifier, ViewInfo]()
+
+  def reset(): Unit = capturedViews.clear()
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
@@ -378,11 +378,14 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
              |$yaml
              |$$$$""".stripMargin)
       }
-      // CreateV2ViewExec / CreateV2MetricViewExec route this through
-      // `unsupportedCreateOrReplaceViewOnTableError` which maps to
-      // `EXPECT_VIEW_NOT_TABLE.NO_ALTERNATIVE`.
-      assert(ex.getCondition === "EXPECT_VIEW_NOT_TABLE.NO_ALTERNATIVE",
-        s"Expected EXPECT_VIEW_NOT_TABLE.NO_ALTERNATIVE, got ${ex.getCondition}: ${ex.getMessage}")
+      // SPARK-56655 added an analyzer-time pre-check for "ident already occupied by a table"
+      // before the v2 view-create exec runs, so the more specific
+      // `EXPECT_VIEW_NOT_TABLE.NO_ALTERNATIVE` decoded by `CreateV2MetricViewExec.run`'s catch
+      // block is no longer reachable when a *plain* table sits at the ident -- the analyzer
+      // raises `TABLE_OR_VIEW_ALREADY_EXISTS` first. Both errors carry the same actionable
+      // signal ("can't create a view here because something else already lives at this ident").
+      assert(ex.getCondition === "TABLE_OR_VIEW_ALREADY_EXISTS",
+        s"Expected TABLE_OR_VIEW_ALREADY_EXISTS, got ${ex.getCondition}: ${ex.getMessage}")
     }
   }
 
@@ -431,6 +434,49 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
     // surfaces directly for the missing-view-ability case.
     assert(ex.getCondition === "MISSING_CATALOG_ABILITY.VIEWS")
     assert(ex.getMessage.contains("VIEWS"))
+  }
+
+  test("CREATE VIEW ... WITH METRICS at a multi-level-namespace v2 target succeeds") {
+    val deepNamespace = Array("ns_a", "ns_b")
+    val deepMetricViewName = "mv_deep"
+    val fullDeepName =
+      s"$testCatalogName.${deepNamespace.mkString(".")}.$deepMetricViewName"
+    withTestCatalogTables {
+      // Pre-create the multi-level namespace + a source table inside it. The metric view
+      // *target* lives in the same multi-level namespace -- that's what exercises the
+      // `MetricViewHelper.analyzeMetricViewText` lift to multi-part nameParts. The pre-lift
+      // code path failed at `ident.asTableIdentifier` with `requiresSinglePartNamespaceError`.
+      sql(s"CREATE NAMESPACE IF NOT EXISTS $testCatalogName.${deepNamespace.head}")
+      sql(s"CREATE NAMESPACE IF NOT EXISTS " +
+        s"$testCatalogName.${deepNamespace.mkString(".")}")
+      try {
+        val mv = MetricView(
+          "0.1",
+          AssetSource(fullSourceTableName),
+          where = None,
+          select = metricViewColumns)
+        val yaml = MetricViewFactory.toYAML(mv)
+        sql(
+          s"""CREATE VIEW $fullDeepName
+             |WITH METRICS
+             |LANGUAGE YAML
+             |AS
+             |$$$$
+             |$yaml
+             |$$$$""".stripMargin)
+
+        val deepIdent = Identifier.of(deepNamespace, deepMetricViewName)
+        val info = MetricViewRecordingCatalog.capturedViews.get(deepIdent)
+        assert(info != null, s"Expected ViewInfo for $deepIdent to be captured")
+        assert(info.properties().get(TableCatalog.PROP_TABLE_TYPE)
+          === TableSummary.METRIC_VIEW_TABLE_TYPE)
+      } finally {
+        scala.util.Try(sql(s"DROP VIEW IF EXISTS $fullDeepName"))
+        sql(s"DROP NAMESPACE IF EXISTS " +
+          s"$testCatalogName.${deepNamespace.mkString(".")} CASCADE")
+        sql(s"DROP NAMESPACE IF EXISTS $testCatalogName.${deepNamespace.head} CASCADE")
+      }
+    }
   }
 
   // ============================================================
@@ -697,18 +743,23 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
 
       // DESCRIBE TABLE EXTENDED resolves the ident through `Analyzer.lookupTableOrView`,
       // which calls `TableViewCatalog.loadTableOrView` once and gets back a
-      // `MetadataTable(ViewInfo)`. `V1Table.toCatalogTable(ViewInfo)` reconstructs the
-      // V1 representation; the resulting `CatalogTable.toJsonLinkedHashMap` (interface.scala)
-      // then emits view-context rows because `tableType == METRIC_VIEW` was added to the
-      // VIEW gate. Without that gate fix, "View Text" / "View Original Text" disappear.
+      // `MetadataTable(ViewInfo)`. The analyzer wraps it as a `ResolvedPersistentView` and
+      // `DataSourceV2Strategy` routes through SPARK-56655's `DescribeV2ViewExec`, which
+      // reads the typed `ViewInfo` directly and emits the standard "Type" / "View Text" /
+      // "View Current Catalog" / "View Schema Mode" / etc. rows. The "Type" row was added
+      // alongside this metric-view PR so `DescribeV2ViewExec` matches v1 parity for the
+      // v1 `CatalogTable.toJsonLinkedHashMap` `Type` row, and so users see whether they're
+      // looking at a plain VIEW or a sub-kind like METRIC_VIEW.
       val rows = sql(s"DESCRIBE TABLE EXTENDED $fullMetricViewName").collect()
       val rowMap = rows.map(r => r.getString(0) -> r.getString(1)).toMap
 
       assert(rowMap.contains("View Text"),
         s"Expected 'View Text' row in DESCRIBE EXTENDED output, got keys: ${rowMap.keys}")
-      assert(rowMap("View Text") === yaml,
+      // `DescribeV2ViewExec` writes `viewInfo.queryText` directly, so trim handles the
+      // leading/trailing newline the SQL `$$ ... $$` fixture inserts vs. the bare yaml body.
+      assert(rowMap("View Text").trim === yaml.trim,
         s"View Text should round-trip the YAML body, got: ${rowMap("View Text")}")
-      assert(rowMap.get("Type").exists(_.contains("METRIC_VIEW")),
+      assert(rowMap.get("Type").contains(TableSummary.METRIC_VIEW_TABLE_TYPE),
         s"Type row should reflect METRIC_VIEW, got: ${rowMap.get("Type")}")
     }
   }
@@ -750,7 +801,7 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("DROP TABLE on a v2 metric view throws EXPECT_TABLE_NOT_VIEW") {
+  test("DROP TABLE on a v2 metric view throws WRONG_COMMAND_FOR_OBJECT_TYPE") {
     withTestCatalogTables {
       val mv = MetricView(
         "0.1",
@@ -759,15 +810,16 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
         select = metricViewColumns)
       createMetricView(fullMetricViewName, mv)
 
-      // `DropTableExec` first probes `tableExists` (false for a view per the TableViewCatalog
-      // passive-filtering contract), then falls back to `viewExists` and -- when the entity
-      // exists as a view but a table was requested -- throws `EXPECT_TABLE_NOT_VIEW` to
-      // distinguish "wrong type" from "missing".
+      // SPARK-56655's `DropTableExec` actively rejects with `WRONG_COMMAND_FOR_OBJECT_TYPE`
+      // ("Use DROP VIEW instead") when a view sits at the ident, replacing the prior
+      // `EXPECT_TABLE_NOT_VIEW.NO_ALTERNATIVE` decoding. Same actionable signal for users.
       val ex = intercept[AnalysisException] {
         sql(s"DROP TABLE $fullMetricViewName")
       }
-      assert(ex.getCondition === "EXPECT_TABLE_NOT_VIEW.NO_ALTERNATIVE",
-        s"Expected EXPECT_TABLE_NOT_VIEW.NO_ALTERNATIVE, got ${ex.getCondition}: ${ex.getMessage}")
+      assert(ex.getCondition === "WRONG_COMMAND_FOR_OBJECT_TYPE",
+        s"Expected WRONG_COMMAND_FOR_OBJECT_TYPE, got ${ex.getCondition}: ${ex.getMessage}")
+      assert(ex.getMessage.contains("DROP VIEW"),
+        s"Error message should mention 'DROP VIEW', got: ${ex.getMessage}")
 
       // The metric view is still present after the failed DROP TABLE.
       val ident = Identifier.of(Array(testNamespace), metricViewName)
@@ -776,7 +828,7 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("DROP TABLE IF EXISTS on a v2 metric view also throws EXPECT_TABLE_NOT_VIEW") {
+  test("DROP TABLE IF EXISTS on a v2 metric view also throws WRONG_COMMAND_FOR_OBJECT_TYPE") {
     withTestCatalogTables {
       val mv = MetricView(
         "0.1",
@@ -786,13 +838,13 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       createMetricView(fullMetricViewName, mv)
 
       // IF EXISTS does not silence the wrong-type error: the entity exists, just not as a
-      // table. (This mirrors the v1 `DropTableCommand` behavior, where `IF EXISTS` only
-      // short-circuits the not-found branch.)
+      // table. (Mirrors the v1 `DropTableCommand` behavior; `IF EXISTS` only short-circuits
+      // the not-found branch.)
       val ex = intercept[AnalysisException] {
         sql(s"DROP TABLE IF EXISTS $fullMetricViewName")
       }
-      assert(ex.getCondition === "EXPECT_TABLE_NOT_VIEW.NO_ALTERNATIVE",
-        s"Expected EXPECT_TABLE_NOT_VIEW.NO_ALTERNATIVE, got ${ex.getCondition}: ${ex.getMessage}")
+      assert(ex.getCondition === "WRONG_COMMAND_FOR_OBJECT_TYPE",
+        s"Expected WRONG_COMMAND_FOR_OBJECT_TYPE, got ${ex.getCondition}: ${ex.getMessage}")
     }
   }
 
@@ -826,7 +878,7 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SHOW TABLES does not list v2 metric views") {
+  test("SHOW TABLES on a v2 TableViewCatalog lists both tables and metric views") {
     withTestCatalogTables {
       val mv = MetricView(
         "0.1",
@@ -836,13 +888,13 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       createMetricView(fullMetricViewName, mv)
       val tables = sql(s"SHOW TABLES IN $testCatalogName.$testNamespace")
         .collect().map(_.getString(1)).toSet
-      // The fixture's `events` source table is a regular table, so SHOW TABLES sees it.
+      // SPARK-56655 routes SHOW TABLES on a `TableViewCatalog` through `listRelationSummaries`
+      // so views appear alongside tables in the output (matching v1 SHOW TABLES on a session
+      // catalog). Pure `TableCatalog` catalogs continue to return tables only.
       assert(tables.contains(sourceTableName),
         s"SHOW TABLES should list the source table, got: $tables")
-      // Per the TableViewCatalog contract, SHOW TABLES returns tables only -- metric views
-      // belong on SHOW VIEWS instead.
-      assert(!tables.contains(metricViewName),
-        s"SHOW TABLES should not list metric views, got: $tables")
+      assert(tables.contains(metricViewName),
+        s"SHOW TABLES on a TableViewCatalog should also list metric views, got: $tables")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
@@ -23,7 +23,7 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.catalyst.analysis.{NoSuchViewException, ViewAlreadyExistsException}
-import org.apache.spark.sql.connector.catalog.{Identifier, InMemoryTableCatalog, MetadataOnlyTable, RelationCatalog, Table, TableCatalog, TableDependency, TableSummary, ViewInfo}
+import org.apache.spark.sql.connector.catalog.{Identifier, InMemoryTableCatalog, MetadataTable, Table, TableCatalog, TableDependency, TableSummary, TableViewCatalog, ViewInfo}
 import org.apache.spark.sql.metricview.serde.{AssetSource, Column, Constants, DimensionExpression, MeasureExpression, MetricView, MetricViewFactory, SQLSource}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.Metadata
@@ -33,7 +33,7 @@ import org.apache.spark.sql.types.Metadata
  * non-session V2 catalog. Metric views are persisted through the same [[ViewCatalog]] interface
  * as plain views; the only marker that distinguishes them is `PROP_TABLE_TYPE = METRIC_VIEW`
  * plus the typed `viewDependencies` field on [[ViewInfo]]. The recording catalog used here is a
- * minimal [[RelationCatalog]] so the same instance can also host the source table referenced by
+ * minimal [[TableViewCatalog]] so the same instance can also host the source table referenced by
  * the metric view's YAML.
  */
 class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
@@ -539,7 +539,7 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
     val multiTable = "events_deep"
     val multiFull = s"$testCatalogName.${multiNamespace.mkString(".")}.$multiTable"
     withTestCatalogTables {
-      // The InMemoryTableCatalog (RelationCatalog mixin) supports multi-level namespaces.
+      // The InMemoryTableCatalog (TableViewCatalog mixin) supports multi-level namespaces.
       sql(s"CREATE NAMESPACE IF NOT EXISTS $testCatalogName.${multiNamespace.head}")
       sql(s"CREATE NAMESPACE IF NOT EXISTS " +
         s"$testCatalogName.${multiNamespace.mkString(".")}")
@@ -581,7 +581,7 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       createMetricView(fullMetricViewName, mv)
       // The fixture's `events` source has rows ("region_1", 1, 5.0), ("region_2", 2, 10.0).
       // The metric view aggregates by `region` summing `count`. Resolution flows through
-      // loadRelation -> MetadataOnlyTable(ViewInfo) -> V1Table.toCatalogTable(ViewInfo) ->
+      // loadTableOrView -> MetadataTable(ViewInfo) -> V1Table.toCatalogTable(ViewInfo) ->
       // CatalogTableType.METRIC_VIEW -> ResolveMetricView, which rewrites the view body
       // into Aggregate(Seq(region), Seq(sum(count) AS count_sum)) over `events`. The
       // `measure(...)` wrapper is required for measure columns -- selecting `count_sum`
@@ -671,7 +671,7 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
   // ============================================================
 
 
-  test("DESCRIBE TABLE EXTENDED on a v2 metric view round-trips through loadRelation") {
+  test("DESCRIBE TABLE EXTENDED on a v2 metric view round-trips through loadTableOrView") {
     withTestCatalogTables {
       val mv = MetricView(
         "0.1",
@@ -681,8 +681,8 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       val yaml = createMetricView(fullMetricViewName, mv)
 
       // DESCRIBE TABLE EXTENDED resolves the ident through `Analyzer.lookupTableOrView`,
-      // which calls `RelationCatalog.loadRelation` once and gets back a
-      // `MetadataOnlyTable(ViewInfo)`. `V1Table.toCatalogTable(ViewInfo)` reconstructs the
+      // which calls `TableViewCatalog.loadTableOrView` once and gets back a
+      // `MetadataTable(ViewInfo)`. `V1Table.toCatalogTable(ViewInfo)` reconstructs the
       // V1 representation; the resulting `CatalogTable.toJsonLinkedHashMap` (interface.scala)
       // then emits view-context rows because `tableType == METRIC_VIEW` was added to the
       // VIEW gate. Without that gate fix, "View Text" / "View Original Text" disappear.
@@ -744,7 +744,7 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
         select = metricViewColumns)
       createMetricView(fullMetricViewName, mv)
 
-      // `DropTableExec` first probes `tableExists` (false for a view per the RelationCatalog
+      // `DropTableExec` first probes `tableExists` (false for a view per the TableViewCatalog
       // passive-filtering contract), then falls back to `viewExists` and -- when the entity
       // exists as a view but a table was requested -- throws `EXPECT_TABLE_NOT_VIEW` to
       // distinguish "wrong type" from "missing".
@@ -824,7 +824,7 @@ class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
       // The fixture's `events` source table is a regular table, so SHOW TABLES sees it.
       assert(tables.contains(sourceTableName),
         s"SHOW TABLES should list the source table, got: $tables")
-      // Per the RelationCatalog contract, SHOW TABLES returns tables only -- metric views
+      // Per the TableViewCatalog contract, SHOW TABLES returns tables only -- metric views
       // belong on SHOW VIEWS instead.
       assert(!tables.contains(metricViewName),
         s"SHOW TABLES should not list metric views, got: $tables")
@@ -852,7 +852,7 @@ object MetricViewV2CatalogSuite {
 }
 
 /**
- * Minimal [[RelationCatalog]] used by [[MetricViewV2CatalogSuite]]. Layers `ViewCatalog`
+ * Minimal [[TableViewCatalog]] used by [[MetricViewV2CatalogSuite]]. Layers `ViewCatalog`
  * methods over [[InMemoryTableCatalog]] (which provides table storage + namespace ops) and
  * captures every [[ViewInfo]] passed to `createView` so tests can inspect the typed payload.
  *
@@ -860,7 +860,7 @@ object MetricViewV2CatalogSuite {
  * the view identifiers; the source table created by the test fixture is stored separately in
  * the inherited table catalog.
  */
-class MetricViewRecordingCatalog extends InMemoryTableCatalog with RelationCatalog {
+class MetricViewRecordingCatalog extends InMemoryTableCatalog with TableViewCatalog {
   private val views =
     new ConcurrentHashMap[(Seq[String], String), ViewInfo]()
 
@@ -875,9 +875,9 @@ class MetricViewRecordingCatalog extends InMemoryTableCatalog with RelationCatal
     out.asScala.toArray
   }
 
-  // `loadView`, `tableExists`, and `viewExists` are inherited from `RelationCatalog`'s
-  // defaults, which derive from `loadRelation` -- a stored `ViewInfo` is wrapped in
-  // `MetadataOnlyTable` by `loadRelation` and the defaults unwrap it correctly.
+  // `loadView`, `tableExists`, and `viewExists` are inherited from `TableViewCatalog`'s
+  // defaults, which derive from `loadTableOrView` -- a stored `ViewInfo` is wrapped in
+  // `MetadataTable` by `loadTableOrView` and the defaults unwrap it correctly.
 
   override def createView(ident: Identifier, info: ViewInfo): ViewInfo = {
     val key = (ident.namespace().toSeq, ident.name())
@@ -905,13 +905,28 @@ class MetricViewRecordingCatalog extends InMemoryTableCatalog with RelationCatal
     removed
   }
 
-  // -- RelationCatalog single-RPC perf path --
+  override def renameView(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    val oldKey = (oldIdent.namespace().toSeq, oldIdent.name())
+    val newKey = (newIdent.namespace().toSeq, newIdent.name())
+    val existing = views.get(oldKey)
+    if (existing == null) throw new NoSuchViewException(oldIdent)
+    if (views.putIfAbsent(newKey, existing) != null) {
+      throw new ViewAlreadyExistsException(newIdent)
+    }
+    views.remove(oldKey)
+    val captured = MetricViewRecordingCatalog.capturedViews.remove(oldIdent)
+    if (captured != null) {
+      MetricViewRecordingCatalog.capturedViews.put(newIdent, captured)
+    }
+  }
 
-  override def loadRelation(ident: Identifier): Table = {
+  // -- TableViewCatalog single-RPC perf path --
+
+  override def loadTableOrView(ident: Identifier): Table = {
     val key = (ident.namespace().toSeq, ident.name())
     Option(views.get(key)) match {
-      case Some(info) => new MetadataOnlyTable(info, ident.toString)
-      // Bypass `RelationCatalog.loadTable` (whose default delegates back to `loadRelation`)
+      case Some(info) => new MetadataTable(info, ident.toString)
+      // Bypass `TableViewCatalog.loadTable` (whose default delegates back to `loadTableOrView`)
       // and call `InMemoryTableCatalog.loadTable` directly to avoid infinite recursion.
       case None => super[InMemoryTableCatalog].loadTable(ident)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1091,7 +1091,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
         "alternative" -> "DROP TABLE",
         "operation" -> "DROP VIEW",
         "foundType" -> "EXTERNAL",
-        "requiredType" -> "VIEW",
+        "requiredType" -> "VIEW or METRIC_VIEW",
         "objectName" -> "spark_catalog.dbx.tab1")
     )
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -139,6 +139,12 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
       .add("s", "string")
       .add("point", new StructType().add("x", "int").add("y", "int")))
     when(t.tableType).thenReturn(tableType)
+    // Mockito returns false for unstubbed Boolean methods, so analyzer code paths that
+    // dispatch through `CatalogTable.isViewLike` (e.g. `Analyzer.lookupTableOrView`'s v1
+    // session-catalog branch) would misclassify a mocked VIEW fixture as a table. Stub
+    // the method to compute from the just-stubbed `tableType` so any view-like type
+    // (VIEW today, METRIC_VIEW or future kinds) resolves correctly.
+    when(t.isViewLike).thenReturn(CatalogTable.isViewLike(tableType))
     when(t.provider).thenReturn(Some(provider))
     when(t.identifier).thenReturn(
       ident.asTableIdentifier.copy(catalog = Some(SESSION_CATALOG_NAME)))

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkOperation.scala
@@ -26,7 +26,7 @@ import org.apache.spark.internal.LogKeys.{HIVE_OPERATION_TYPE, STATEMENT_ID}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.CurrentUserContext.CURRENT_USER
 import org.apache.spark.sql.catalyst.catalog.{CatalogTableType, SessionCatalog}
-import org.apache.spark.sql.catalyst.catalog.CatalogTableType.{EXTERNAL, MANAGED, VIEW}
+import org.apache.spark.sql.catalyst.catalog.CatalogTableType.{EXTERNAL, MANAGED, METRIC_VIEW, VIEW}
 import org.apache.spark.sql.internal.{SessionState, SharedState, SQLConf}
 import org.apache.spark.util.Utils
 
@@ -107,7 +107,7 @@ private[hive] trait SparkOperation extends Operation with Logging {
 
   def tableTypeString(tableType: CatalogTableType): String = tableType match {
     case EXTERNAL | MANAGED => "TABLE"
-    case VIEW => "VIEW"
+    case VIEW | METRIC_VIEW => "VIEW"
     case t =>
       throw new IllegalArgumentException(s"Unknown table type is found: $t")
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -602,7 +602,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     requireTableExists(db, tableDefinition.identifier.table)
     verifyTableProperties(tableDefinition)
 
-    if (tableDefinition.tableType == VIEW || tableDefinition.tableType == METRIC_VIEW) {
+    if (tableDefinition.isViewLike) {
       val newTableProps = tableDefinition.properties ++ tableMetaToTableProps(tableDefinition).toMap
       val schemaWithNoCollation = removeCollation(tableDefinition.schema)
       val hiveCompatibleSchema =
@@ -851,7 +851,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     }
 
     table.properties.get(DATASOURCE_PROVIDER) match {
-      case None if table.tableType == VIEW || table.tableType == METRIC_VIEW =>
+      case None if table.isViewLike =>
         // If this is a view created by Spark 2.2 or higher versions, we should restore its schema
         // from table properties.
         getSchemaFromTableProperties(table.properties).foreach { schemaFromTableProps =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -274,7 +274,8 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
         // Spark-created views do not have to be Hive compatible. If the data type is not
         // Hive compatible, we can set schema to empty so that Spark can still read this
         // view as the schema is also encoded in the table properties.
-        case schema if tableDefinition.tableType == CatalogTableType.VIEW &&
+        case schema if (tableDefinition.tableType == CatalogTableType.VIEW ||
+            tableDefinition.tableType == CatalogTableType.METRIC_VIEW) &&
             schema.exists(f => !isHiveCompatibleDataType(f.dataType)) =>
           EMPTY_DATA_SCHEMA
         case other => other
@@ -294,7 +295,8 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       try {
         client.createTable(tableWithDataSourceProps, ignoreIfExists)
       } catch {
-        case NonFatal(e) if tableDefinition.tableType == CatalogTableType.VIEW &&
+        case NonFatal(e) if (tableDefinition.tableType == CatalogTableType.VIEW ||
+            tableDefinition.tableType == CatalogTableType.METRIC_VIEW) &&
             hiveCompatibleSchema != EMPTY_DATA_SCHEMA =>
           // If for some reason we fail to store the schema we store it as empty there
           // since we already store the real schema in the table properties. This try-catch
@@ -595,7 +597,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     requireTableExists(db, tableDefinition.identifier.table)
     verifyTableProperties(tableDefinition)
 
-    if (tableDefinition.tableType == VIEW) {
+    if (tableDefinition.tableType == VIEW || tableDefinition.tableType == METRIC_VIEW) {
       val newTableProps = tableDefinition.properties ++ tableMetaToTableProps(tableDefinition).toMap
       val schemaWithNoCollation = removeCollation(tableDefinition.schema)
       val hiveCompatibleSchema =
@@ -835,7 +837,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     var table = inputTable
 
     table.properties.get(DATASOURCE_PROVIDER) match {
-      case None if table.tableType == VIEW =>
+      case None if table.tableType == VIEW || table.tableType == METRIC_VIEW =>
         // If this is a view created by Spark 2.2 or higher versions, we should restore its schema
         // from table properties.
         getSchemaFromTableProperties(table.properties).foreach { schemaFromTableProps =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -452,6 +452,13 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     val properties = new mutable.HashMap[String, String]
 
     properties.put(CREATED_SPARK_VERSION, table.createVersion)
+
+    // Hive's `HiveTableType` enum has no metric-view variant -- it stores both regular views
+    // and metric views as `VIRTUAL_VIEW`. Persist a property marker so `restoreTableMetadata`
+    // can lift the round-tripped `CatalogTableType.VIEW` back to `CatalogTableType.METRIC_VIEW`.
+    if (table.tableType == CatalogTableType.METRIC_VIEW) {
+      properties.put(CatalogTable.VIEW_SUB_TYPE, CatalogTable.VIEW_SUB_TYPE_METRIC_VIEW)
+    }
     // This is for backward compatibility to Spark 2 to read tables with char/varchar created by
     // Spark 3.1. At read side, we will restore a table schema from its properties. So, we need to
     // clear the `varchar(n)` and `char(n)` and replace them with `string` as Spark 2 does not have
@@ -835,6 +842,15 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     }
 
     var table = inputTable
+
+    // HMS round-trips both regular views and metric views as `HiveTableType.VIRTUAL_VIEW`,
+    // which `HiveClientImpl.getTableOption` always maps back to `CatalogTableType.VIEW`. Lift
+    // it back to `CatalogTableType.METRIC_VIEW` when the persisted sub-type marker is present.
+    if (table.tableType == VIEW &&
+        table.properties.get(CatalogTable.VIEW_SUB_TYPE)
+          .contains(CatalogTable.VIEW_SUB_TYPE_METRIC_VIEW)) {
+      table = table.copy(tableType = METRIC_VIEW)
+    }
 
     table.properties.get(DATASOURCE_PROVIDER) match {
       case None if table.tableType == VIEW || table.tableType == METRIC_VIEW =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -274,8 +274,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
         // Spark-created views do not have to be Hive compatible. If the data type is not
         // Hive compatible, we can set schema to empty so that Spark can still read this
         // view as the schema is also encoded in the table properties.
-        case schema if (tableDefinition.tableType == CatalogTableType.VIEW ||
-            tableDefinition.tableType == CatalogTableType.METRIC_VIEW) &&
+        case schema if tableDefinition.isViewLike &&
             schema.exists(f => !isHiveCompatibleDataType(f.dataType)) =>
           EMPTY_DATA_SCHEMA
         case other => other
@@ -295,8 +294,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       try {
         client.createTable(tableWithDataSourceProps, ignoreIfExists)
       } catch {
-        case NonFatal(e) if (tableDefinition.tableType == CatalogTableType.VIEW ||
-            tableDefinition.tableType == CatalogTableType.METRIC_VIEW) &&
+        case NonFatal(e) if tableDefinition.isViewLike &&
             hiveCompatibleSchema != EMPTY_DATA_SCHEMA =>
           // If for some reason we fail to store the schema we store it as empty there
           // since we already store the real schema in the table properties. This try-catch

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -1163,7 +1163,7 @@ private[hive] object HiveClientImpl extends Logging {
     catalogTableType match {
       case CatalogTableType.EXTERNAL => HiveTableType.EXTERNAL_TABLE
       case CatalogTableType.MANAGED => HiveTableType.MANAGED_TABLE
-      case CatalogTableType.VIEW | CatalogTableType.METRIC_VIEW => HiveTableType.VIRTUAL_VIEW
+      case t if CatalogTable.isViewLike(t) => HiveTableType.VIRTUAL_VIEW
       case t =>
         throw new IllegalArgumentException(
           s"Unknown table type is found at toHiveTableType: $t")

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -1163,7 +1163,7 @@ private[hive] object HiveClientImpl extends Logging {
     catalogTableType match {
       case CatalogTableType.EXTERNAL => HiveTableType.EXTERNAL_TABLE
       case CatalogTableType.MANAGED => HiveTableType.MANAGED_TABLE
-      case CatalogTableType.VIEW => HiveTableType.VIRTUAL_VIEW
+      case CatalogTableType.VIEW | CatalogTableType.METRIC_VIEW => HiveTableType.VIRTUAL_VIEW
       case t =>
         throw new IllegalArgumentException(
           s"Unknown table type is found at toHiveTableType: $t")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -1141,7 +1141,7 @@ class HiveDDLSuite
           "alternative" -> "DROP TABLE",
           "operation" -> "DROP VIEW",
           "foundType" -> "MANAGED",
-          "requiredType" -> "VIEW",
+          "requiredType" -> "VIEW or METRIC_VIEW",
           "objectName" -> s"$SESSION_CATALOG_NAME.default.tab1"
         )
       )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extends metric-view support to **DS v2 catalogs** by routing `CREATE VIEW ... WITH METRICS` through the `ViewCatalog` / `TableViewCatalog` APIs introduced by [SPARK-52729](https://github.com/apache/spark/pull/51419) and finalized by [SPARK-56655](https://github.com/apache/spark/pull/55954). Third-party v2 catalogs that implement `ViewCatalog` can now host metric views with the same metadata fidelity as session-catalog metric views.

**1. V2 metric-view CREATE path -- shared with `CreateV2ViewExec`.** A new `CreateV2MetricViewExec` and `CreateV2ViewExec` both extend a new `V2CreateViewPreparation` trait (which itself extends `V2ViewPreparation`). The trait owns the shared CREATE-side `run()`: `viewExists` short-circuit on `IF NOT EXISTS`, `createOrReplaceView` for `OR REPLACE`, and cross-type collision decoding (`ViewAlreadyExistsException` -> `tableExists` -> `EXPECT_VIEW_NOT_TABLE.NO_ALTERNATIVE`). The metric-view subclass only supplies the metric-view-specific bits (no collation, schema-mode `UNSUPPORTED`, typed `viewDependencies`, `PROP_TABLE_TYPE = METRIC_VIEW`, `retainColumnMetadata = true`) via optional hooks on `V2ViewPreparation`. `DataSourceV2Strategy` intercepts `CreateMetricViewCommand` on a non-session catalog and routes to the new exec; the v1 session-catalog path stays in `CreateMetricViewCommand.run`.

**2. First-class `METRIC_VIEW` table type.**
- `CatalogTableType.METRIC_VIEW` is added alongside `EXTERNAL` / `MANAGED` / `VIEW`.
- `TableSummary.METRIC_VIEW_TABLE_TYPE = "METRIC_VIEW"` constant for the V2 surface.
- The previous `view.viewWithMetrics` property hack is removed; `CatalogTable.isMetricView` checks `tableType == METRIC_VIEW` directly.
- `V1Table.summarizeTableType` and `V1Table.toCatalogTable(catalog, ident, ViewInfo)` translate between the V2 property form and the V1 enum.
- HMS round-trip support: `HiveTableType` has no `METRIC_VIEW` variant (both regular views and metric views serialize as `VIRTUAL_VIEW`). `HiveExternalCatalog` now persists a `view.subType = METRIC_VIEW` property on write and lifts `tableType` back to `METRIC_VIEW` on read, so HMS-backed metric views survive the round trip.

**3. Repo-wide `tableType == VIEW` audit + `CatalogTable.isViewLike` helper.** Promoting metric views to a distinct `CatalogTableType` opens silent regressions wherever existing code branches on `VIEW`. To consolidate the audit and reduce divergence with the Databricks Runtime (which has the same helper), this PR introduces:
- `CatalogTable.isViewLike` instance method (DBR parity: today returns `tableType == VIEW || tableType == METRIC_VIEW`; forks may extend the set).
- `CatalogTable.isViewLike(t: CatalogTableType)` companion form for the few sites that have a `CatalogTableType` but no `CatalogTable` (e.g. `SessionCatalog.isView`, `verifyAlterTableType`, `HiveClientImpl.toHiveTableType`).

All 18 sites in `catalyst` / `core` / `hive` that previously did inline `tableType == VIEW || tableType == METRIC_VIEW` (or the `CatalogTableType.VIEW | CatalogTableType.METRIC_VIEW` pattern alternation) are now routed through these helpers, so adding a new view-like type in the future is a one-line change in the helper body. Notable touched call sites: `CatalogTable.toJsonLinkedHashMap` (DESCRIBE EXTENDED rows), `HiveExternalCatalog.{createTable, alterTable, restoreTableMetadata}`, `HiveClientImpl.toHiveTableType`, `SessionCatalog.isView`, `InMemoryCatalog.listViews`, `RelationResolution`, `Analyzer.lookupTableOrView`, `rules.scala`, `DataStreamWriter`, `DescribeRelationJsonCommand`, `AnalyzeColumnCommand`, `AnalyzePartitionCommand`, `CommandUtils.analyzeTable`, `V2SessionCatalog.dropTableInternal`, `verifyAlterTableType` in `ddl.scala`, and 3 sites in `tables.scala`.

**Explicit rejection (uniform error class):** `SHOW CREATE TABLE` on a metric view has no round-trippable `CREATE VIEW ... WITH METRICS` form, so it's rejected explicitly with the dedicated `UNSUPPORTED_SHOW_CREATE_TABLE.ON_METRIC_VIEW` error class on **both** the v1 session-catalog path (in `tables.scala`) and the v2 catalog path (in `DataSourceV2Strategy`), so users see the same actionable message regardless of catalog kind.

**4. Drop-command parity.**
- `DropTableCommand` (v1 path) treats both `VIEW` and `METRIC_VIEW` as views: `DROP TABLE` rejects either with `wrongCommandForObjectTypeError`, and `DROP VIEW` accepts either.
- `V2SessionCatalog.dropTableInternal` extends the existing "view rejected from `DROP TABLE`" guard to cover `METRIC_VIEW`.
- For non-session v2: `DropTableExec` (post-SPARK-56655) actively rejects with `WRONG_COMMAND_FOR_OBJECT_TYPE` ("Use DROP VIEW instead") when a view sits at the ident -- works unchanged for metric views since `TableViewCatalog`'s default `viewExists` derives from `loadTableOrView` and recognizes `MetadataTable + ViewInfo`.
- `ResolveSessionCatalog`'s `DropView` routing comment is clarified: v2 metric views fall through to `DataSourceV2Strategy` and `ViewCatalog.dropView`.

**5. Typed view dependencies (`ViewInfo.viewDependencies`).**
- New public DTOs in `org.apache.spark.sql.connector.catalog`: `Dependency` (sealed interface with `Dependency.table(String[])` / `Dependency.function(String[])` non-vararg factories), `TableDependency`, `FunctionDependency`, `DependencyList(Dependency[])`.
- `TableDependency` and `FunctionDependency` carry the dependency identifier as **structural multi-part name parts** (`record TableDependency(String[] nameParts)`), not a single dot-flattened string. Arity is preserved per source so multi-level-namespace V2 catalogs (e.g. Iceberg `cat.db1.db2.tbl` -> 4 parts) round-trip without ambiguity against quoted identifiers containing literal `.`. v1 sources resolved through the session catalog are normalized by a new `MetricViewHelper.qualifyV1` to a stable 3-part `[spark_catalog, db, table]` shape so consumers see deterministic arity per source kind (otherwise `TableIdentifier.nameParts` could return 1, 2, or 3 parts depending on what the analyzer captured).
- All three records (`TableDependency`, `FunctionDependency`, `DependencyList`) override `equals` / `hashCode` / `toString` using `Arrays.equals` / `Arrays.hashCode` / `Arrays.toString` to give value semantics on their array fields. Without the overrides, records' auto-generated methods on array fields fall through to `Object.equals` (reference equality), which would make structural multi-part names unusable as Map keys / for dedup. Each record also overrides the canonical accessor to return a defensive `clone()` so callers cannot mutate the record's internal array.
- `ViewInfo` gains a `viewDependencies` field and a `ViewInfo.Builder.withViewDependencies(...)` setter. Per the field's contract, `null` means "no dependency list was supplied" while an empty `DependencyList.of(new Dependency[0])` means "supplied but the object has none" -- metric-view CREATE always emits the latter, never the former, even when `collectTableDependencies` returns empty.
- `MetricViewHelper.collectTableDependencies` walks the analyzed plan and emits structural `Seq[Seq[String]]` parts; the v2 source arm preserves full namespace arity, the v1 source arms (`View`, `HiveTableRelation`, `LogicalRelation`) all route through `qualifyV1` for the stable 3-part shape.

**6. Multi-level-namespace targets for v2 metric views.** `MetricViewHelper.analyzeMetricViewText` previously required a `TableIdentifier`, capping the metric-view target at 3 name parts. v2 metric views with multi-level-namespace targets (e.g. `cat.db1.db2.mv`) failed at `ident.asTableIdentifier` with `requiresSinglePartNamespaceError`. The helper now takes `nameParts: Seq[String]` directly; call sites in both the v1 path (`CreateMetricViewCommand`) and the v2 path (`DataSourceV2Strategy`) updated. The helper now also returns `(LogicalPlan, MetricView)` so callers don't have to re-parse the YAML body just to read descriptor properties.

**7. `metric_view.*` descriptor properties (v1/v2 parity).** `MetricView.getProperties` produces canonical descriptive properties (`metric_view.from.type`, `metric_view.from.name` / `metric_view.from.sql`, `metric_view.where`) that **both** the v1 path (`CreateMetricViewCommand.createMetricViewInSessionCatalog`) and the v2 path (`DataSourceV2Strategy`) merge into the view's properties bag, so catalog browsers and tooling see the same descriptor rows in `DESCRIBE TABLE EXTENDED` regardless of catalog kind. Long values are truncated to `Constants.MAXIMUM_PROPERTY_SIZE`; the Scaladoc on `getProperties` calls out that `metric_view.from.sql` is therefore a descriptive value, not a round-trippable representation -- consumers should re-read the YAML body for the full SQL.

**8. `ViewInfo` constructor cleanup.** The metric-view-specific `PROP_TABLE_TYPE = METRIC_VIEW` special case is dropped from the generic `ViewInfo` constructor in favor of `properties().putIfAbsent(...)`. Callers that want a more specific kind (e.g. `METRIC_VIEW`) call `BaseBuilder.withTableType(...)` before `build()` -- exercised by `CreateV2MetricViewExec` via the new `V2ViewPreparation.tableType` hook.

**9. `ViewHelper.aliasPlan(retainMetadata)`.** The user-specified-column-with-comment branch in `aliasPlan` previously dropped existing column metadata. A new `retainMetadata: Boolean = false` parameter merges the analyzed attribute's metadata into the new comment metadata. `ViewHelper.prepareTable` passes `retainMetadata = isMetricView` (v1 path); `V2ViewPreparation` exposes a `retainColumnMetadata` hook that `CreateV2MetricViewExec` overrides to `true` (v2 path). Both preserve the per-column `metric_view.type` / `metric_view.expr` keys that the analyzer attaches to dimensions and measures even when the user renames columns and adds comments.

**10. Error classes.**
- New `INVALID_METRIC_VIEW_YAML` (sqlState 42K0L). `MetricViewPlanner.parseYAML`'s catch blocks now route through `QueryCompilationErrors.invalidMetricViewYamlError` instead of `SparkException.internalError`, so a typo in the user's YAML body surfaces as a user-correctable `AnalysisException` rather than "please contact support".
- New `UNSUPPORTED_SHOW_CREATE_TABLE.ON_METRIC_VIEW` (sqlState 0A000), used by both the v1 session-catalog path and the v2 catalog path so `SHOW CREATE TABLE` on a metric view produces the same actionable message regardless of catalog kind.

**11. Misc.**
- `MetricViewCanonical.parseSource` accepts multipart identifiers (`parseMultipartIdentifier`) so 3-part `catalog.schema.table` source references work as `AssetSource`.

### Why are the changes needed?

Before this PR, metric-view DDL only worked against the session catalog: the create path called `SessionCatalog.createTable` directly, and there was no way for a third-party v2 catalog (Unity Catalog, Hive Metastore catalog, custom REST catalogs, etc.) to own a metric view's lifecycle. SPARK-52729 / SPARK-56655 shipped `ViewCatalog` and `TableViewCatalog` as the public v2 surface for catalog-managed views; metric views are a kind of view and naturally belong on this surface.

Once metric views can live on a v2 catalog, two more constraints surface:

1. **Type discriminator.** A consumer reading a row through `ViewCatalog.loadView` needs to know it's a metric view, not a plain SQL view, so it can render the right UI / planner output. Encoding this in `PROP_TABLE_TYPE = METRIC_VIEW` keeps the distinction wire-compatible and lets `V1Table.toCatalogTable` reconstruct `CatalogTableType.METRIC_VIEW` on the read path.
2. **Structured dependency lineage.** Metric views always reference at least one source table; cataloging that lineage as flat string properties or single dot-joined strings loses arity for multi-level namespaces and is ambiguous against quoted identifiers. A typed `DependencyList` of `TableDependency` / `FunctionDependency` with structural `String[] nameParts` lets catalogs persist the lineage as a first-class field with full fidelity.

The remaining changes (drop-command parity, `aliasPlan` metadata retention, `metric_view.*` properties, `parseMultipartIdentifier`, `tableType == VIEW` audit + `isViewLike` helper, multi-level-namespace lift, HMS round-trip marker) are mechanical follow-ups that fall out of supporting metric views as a real `CatalogTableType` and as a v2 catalog citizen -- without them, basic operations like `DROP VIEW`, `DESCRIBE TABLE EXTENDED`, `CREATE VIEW (a COMMENT 'c') WITH METRICS ...`, or `CREATE VIEW cat.db1.db2.mv WITH METRICS ...` would silently degrade.

### Does this PR introduce _any_ user-facing change?

Yes, both for end users and for catalog plugin developers:

**End users:**
- `CREATE VIEW <ident> WITH METRICS ...` now works against any v2 catalog that implements `ViewCatalog`, including catalogs with multi-level namespace targets. Previously it was rejected with `MISSING_CATALOG_ABILITY.VIEWS` for non-session catalogs, and capped at single-level namespaces. `IF NOT EXISTS` and `OR REPLACE` are honored on the v2 path (regression vs. v1 fixed).
- A v2 metric view can be queried with `SELECT region, measure(count_sum) FROM <mv> ...`, dropped with `DROP VIEW`, listed via `SHOW VIEWS` (and via `SHOW TABLES` on a `TableViewCatalog`, matching v1 SHOW TABLES output), and described with `DESCRIBE TABLE` / `DESCRIBE TABLE EXTENDED`. `DROP TABLE` on a metric view throws `WRONG_COMMAND_FOR_OBJECT_TYPE` ("Use DROP VIEW instead").
- `ALTER VIEW <metric_view> RENAME TO ...` is wired through `RenameV2ViewExec` and preserves the metric-view kind across the rename.
- `SHOW CREATE TABLE` on a metric view throws `UNSUPPORTED_SHOW_CREATE_TABLE.ON_METRIC_VIEW` (no round-trippable form yet) on both the v1 and v2 paths -- same error class regardless of catalog kind.
- Session-catalog metric views are now stored as `CatalogTableType.METRIC_VIEW` instead of `CatalogTableType.VIEW + view.viewWithMetrics=true`. Observable in `DESCRIBE TABLE EXTENDED`'s `Type` row and the `tableType` column of the `tables` system table. SQL behavior is unchanged. Hive-metastore-backed metric views also round-trip through HMS via a `view.subType = METRIC_VIEW` property marker.
- `DESCRIBE TABLE EXTENDED` on metric views (v1 and v2) now consistently surfaces `metric_view.from.type` / `metric_view.from.name` / `metric_view.from.sql` / `metric_view.where` descriptor rows.
- Error messages from `DROP TABLE` / `DROP VIEW` mismatch now mention `METRIC_VIEW` alongside `VIEW`.
- Malformed metric-view YAML now surfaces as `INVALID_METRIC_VIEW_YAML` (user-correctable) instead of "Spark internal error, please contact support".

**Catalog plugin developers:**
- New public API surface in `org.apache.spark.sql.connector.catalog`: sealed interface `Dependency` with `permits TableDependency, FunctionDependency`, both records carrying `String[] nameParts`. `Dependency.table(String[])` / `Dependency.function(String[])` static factories (non-vararg per review; callers pass an existing array directly). `DependencyList(Dependency[])` with `DependencyList.of(Dependency[])` factory. All three records override `equals` / `hashCode` / `toString` to give value semantics on their array fields, and the canonical accessors return a defensive `clone()` so internal state is not mutable through the public API. All `@Evolving`, `@since 4.2.0`. Note: today's only producer in Spark itself is metric-view dependency extraction, which emits `TableDependency` only; `FunctionDependency` and `Dependency.function(...)` are exposed as groundwork for future producers (e.g. SQL UDF dep tracking).
- `ViewInfo` gains a typed `viewDependencies()` accessor and `ViewInfo.Builder.withViewDependencies(...)` setter. `viewDependencies` is populated only on the non-session v2 CREATE path; v1 metric views (and v2 metric views read back through `V1Table.toCatalogTable`) carry `null`. Catalog plugin authors persisting dependency lineage should treat the field as v2-only for now -- broadening to v1 is a tracked follow-up.
- `TableSummary.METRIC_VIEW_TABLE_TYPE = "METRIC_VIEW"` constant.
- `CatalogTableType.METRIC_VIEW` enum value (v1 surface).
- `CatalogTable.isViewLike` instance + `CatalogTable.isViewLike(CatalogTableType)` companion helpers (DBR parity helpers for "does this table behave like a view at resolution / DDL time?"). Forks that add their own view-like types (e.g. DBR's `MATERIALIZED_VIEW`, `STREAMING_TABLE`) only need to extend the helper body.
- `V2ViewPreparation` (private to `org.apache.spark.sql.execution.datasources.v2`) gains optional `viewDependencies` / `tableType` / `retainColumnMetadata` hooks.

### How was this patch tested?

`MetricViewV2CatalogSuite` -- 31 tests across 5 sections, all against an in-memory `ViewCatalog` test fixture (`MetricViewRecordingCatalog extends InMemoryTableCatalog with TableViewCatalog`):

**Section 1 -- CREATE-related (11 tests):**
- V2 catalog receives `METRIC_VIEW` table type and view text via `ViewInfo`.
- V2 catalog path populates `metric_view.*` descriptor properties + view context (`currentCatalog` / `currentNamespace`) + captured SQL configs.
- V2 catalog path captures `SQLSource` and comment.
- Metric view columns carry `metric_view.type` / `metric_view.expr` in column metadata.
- User-specified column names with comments preserve `metric_view.*` metadata (pins the `aliasPlan(retainMetadata = true)` fix).
- `CREATE OR REPLACE VIEW ... WITH METRICS` replaces an existing v2 metric view (asserts on the replacement's distinguishing fields: queryText, `metric_view.where`, dependencies).
- `CREATE VIEW IF NOT EXISTS ... WITH METRICS` is a no-op when the view exists (catalog never sees the second `createView` call).
- `CREATE VIEW ... WITH METRICS` over a v2 table at the ident throws `TABLE_OR_VIEW_ALREADY_EXISTS` (analyzer-time pre-check).
- `CREATE VIEW IF NOT EXISTS ... WITH METRICS` is a no-op when a v2 table sits at the ident (v1 parity).
- `CREATE VIEW ... WITH METRICS` on a non-`ViewCatalog` catalog fails with `MISSING_CATALOG_ABILITY.VIEWS`.
- `CREATE VIEW ... WITH METRICS` at a multi-level-namespace v2 target (`testcat.ns_a.ns_b.mv_deep`) succeeds (pins the `analyzeMetricViewText` lift to `Seq[String]`).

**Section 2 -- Dependency extraction (5 tests):**
- SQL source `JOIN` captures both tables as 3-part `nameParts`.
- SQL source subquery deduplicates same-table references.
- SQL source self-join deduplicates same-table references.
- V1 session-catalog source emits exactly 3 parts, normalized to `[spark_catalog, db, table]` by `qualifyV1`.
- Multi-level V2 namespace source (`testcat.ns_a.ns_b.events_deep`) emits 4-part `nameParts`.

**Section 3 -- SELECT cases (5 tests, modeled on `MetricViewSuite` patterns):**
- `SELECT measure(count_sum) FROM <mv> GROUP BY region` returns aggregated rows (exercises the full `loadTableOrView` -> `MetadataTable(ViewInfo)` -> `V1Table.toCatalogTable(ViewInfo)` -> `ResolveMetricView` round-trip).
- `SELECT measure(...) WHERE region = ...` -- query-layer filter on top of the view.
- View's pre-defined `where` clause is applied (`where = Some("count > 1")` filters at view-resolution time).
- Multiple measures with different aggregations (sum / sum / max).
- `ORDER BY measure(...) DESC LIMIT 1` over the metric view.

**Section 4 -- DESCRIBE cases (2 tests):**
- `DESCRIBE TABLE EXTENDED` round-trips through `loadTableOrView` and emits the `View Text` / `Type` rows (gated through `CatalogTable.isViewLike` in `toJsonLinkedHashMap`, which now recognizes `METRIC_VIEW`).
- `DESCRIBE TABLE` (non-EXTENDED) returns the aliased columns.

**Section 5 -- DROP / SHOW / RENAME cases (8 tests):**
- `DROP VIEW` succeeds on a v2 metric view.
- `DROP VIEW IF EXISTS` on a non-existent v2 metric view is a no-op.
- `DROP TABLE` on a v2 metric view throws `WRONG_COMMAND_FOR_OBJECT_TYPE` ("Use DROP VIEW instead", per SPARK-56655's `DropTableExec`) and asserts the metric view is **not** deleted.
- `DROP TABLE IF EXISTS` on a v2 metric view also throws (`IF EXISTS` doesn't silence the wrong-type error, v1 parity).
- `SHOW CREATE TABLE` on a v2 metric view throws `UNSUPPORTED_SHOW_CREATE_TABLE.ON_METRIC_VIEW` (same dedicated error class as the v1 path).
- `SHOW TABLES` on a `TableViewCatalog` lists both tables and metric views (matches v1 SHOW TABLES output per SPARK-56655).
- `SHOW VIEWS` lists v2 metric views.
- `ALTER VIEW <metric_view> RENAME TO ...` succeeds and preserves the metric-view kind across the rename (pins `RenameV2ViewExec` end-to-end against the fixture's `renameView`).

Existing session-catalog metric-view tests (`MetricViewSuite`, `SimpleMetricViewSuite`, `HiveMetricViewSuite`) and v1 path tests pass unchanged. `DDLSuite` and `HiveDDLSuite` had their `tableTypes` enumerations updated to include `METRIC_VIEW` in two assertion lists. `PlanResolutionSuite` test fixture was updated to stub the new `CatalogTable.isViewLike` method on the Mockito mock.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor (Claude Sonnet 4.7)
