### PR TITLE
[SPARK-56582][BUILD][TESTS] Upgrade `snowflake-jdbc` to 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
     <mssql.jdbc.version>13.2.1.jre11</mssql.jdbc.version>
     <ojdbc17.version>23.26.1.0.0</ojdbc17.version>
     <databricks.jdbc.version>3.3.1</databricks.jdbc.version>
-    <snowflake.jdbc.version>4.0.2</snowflake.jdbc.version>
+    <snowflake.jdbc.version>4.1.0</snowflake.jdbc.version>
     <terajdbc.version>20.00.00.39</terajdbc.version>
     <!-- Used for SBT build to retrieve the Spark version -->
     <spark.version>${project.version}</spark.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `snowflake-jdbc` test dependency to 4.1.0 for Apache Spark 4.2.0 to use the recommended version.

### Why are the changes needed?

To bring the latest bug fixed version for testing:

- https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc-2026 (2026-04-08)
  - New features and updates
    - Added warning when using plain HTTP endpoints for OAuth authentication.
    - Added getRole, getWarehouse, and getDatabase API extension methods.
    - Removed the io.netty.tryReflectionSetAccessible system property setting, as it is no longer needed with modern Arrow/Netty versions.
  - Bug fixes
    - Fixed ObjectMapper initialization when DATE_OUTPUT_FORMAT is specified.
    - Fixed Netty native library conflict in thin JAR packaging.
    - Bumped Netty to 4.1.132.Final to address [CVE-2026-33870](https://nvd.nist.gov/vuln/detail/CVE-2026-33870) and [CVE-2026-33871](https://nvd.nist.gov/vuln/detail/CVE-2026-33871).
    - Fixed driver failure when a security manager prohibits access to system properties, environment variables, or security provider modifications.
    - Fixed crash in getColumns when a table contained an unrecognized column type.
    - Fixed session expiration when multiple sessions have different heartbeat intervals.
    - Fixed query context not being merged from failed query responses.

### Does this PR introduce _any_ user-facing change?

No. This is a test-only dependency.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7