### PR TITLE
[SPARK-56583][K8S] Skip `pip` upgrade and use `--break-system-packages` to avoid PEP 668 error in PySpark Dockerfile

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
@@ -31,7 +31,7 @@ USER 0
 RUN mkdir ${SPARK_HOME}/python
 RUN apt-get update && \
     apt install -y --no-install-recommends python3 python3-pip && \
-    pip3 install --no-cache-dir --upgrade pip setuptools && \
+    pip3 install --break-system-packages --no-cache-dir --upgrade setuptools && \
     apt-get clean && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to (1) skip additional `pip` upgrade and (2) add the `--break-system-packages` flag to the `pip3 install` command in the PySpark Kubernetes Dockerfile (`resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile`).

### Why are the changes needed?

Currently, Apache Spark CI is broken due to the K8s PySpark docker image building.

- **master**: https://github.com/apache/spark/actions/runs/24799280675/job/72577453527
- **branch-4.1**: https://github.com/apache/spark/actions/runs/24777943486/job/72501169416

With Python 3.12+ on Debian/Ubuntu-based images (e.g., Ubuntu Noble), the system Python enforces [PEP 668](https://peps.python.org/pep-0668/) and marks the environment as externally managed. As a result, `pip3 install --no-cache-dir --upgrade pip setuptools` fails during the Docker image build with:

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    ...
note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

Since the installation happens inside a dedicated container image where the system Python is only used for PySpark, it is safe to bypass the PEP 668 restriction with `--break-system-packages`.

### Does this PR introduce _any_ user-facing change?

No. This only restores the PySpark Kubernetes image build on Python 3.12+ base images.

### How was this patch tested?

Pass the CIs with the K8s integration test.

For the record, I also manually verified this patch with Apache Spark 4.2.0-preview4 like the following

```
$ bin/docker-image-tool.sh -r docker.io/apache -t 4.2.0-preview4 -p kubernetes/dockerfiles/spark/bindings/python/Dockerfile build
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7