### PR TITLE
[SPARK-56585][SQL][TESTS] Replace SparkPlanTest with QueryTest

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.ArrayImplicits._
 
-abstract class BaseScriptTransformationSuite extends SparkPlanTest with QueryTest {
+abstract class BaseScriptTransformationSuite extends QueryTest {
   import testImplicits._
   import ScriptTransformationIOSchema._
 
@@ -202,7 +202,7 @@ abstract class BaseScriptTransformationSuite extends SparkPlanTest with QueryTes
           output = Seq(AttributeReference("a", StringType)()),
           child = rowsDf.queryExecution.sparkPlan,
           ioschema = defaultIOSchema)
-      SparkPlanTest.executePlan(plan, spark.sqlContext)
+      QueryTest.executePlan(plan, spark.sqlContext)
     }
     assert(e.getMessage.contains("Subprocess exited with status"))
     assert(uncaughtExceptionHandler.exception.isEmpty)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BroadcastExchangeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BroadcastExchangeSuite.scala
@@ -32,8 +32,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.tags.ExtendedSQLTest
 
 @ExtendedSQLTest
-class BroadcastExchangeSuite extends SparkPlanTest
-  with SharedSparkSession
+class BroadcastExchangeSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
 
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeSuite.scala
@@ -45,7 +45,7 @@ case class ColumnarExchange(child: SparkPlan) extends Exchange {
     copy(child = newChild)
 }
 
-class ExchangeSuite extends SparkPlanTest with SharedSparkSession {
+class ExchangeSuite extends SharedSparkSession {
   import testImplicits._
 
   setupTestData()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ReuseExchangeAndSubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ReuseExchangeAndSubquerySuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class ReuseExchangeAndSubquerySuite extends SparkPlanTest with SharedSparkSession {
+class ReuseExchangeAndSubquerySuite extends SharedSparkSession {
 
   val tableFormat: String = "parquet"
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SortSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SortSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types._
  * Test sorting. Many of the test cases generate random data and compares the sorted result with one
  * sorted by a reference implementation ([[ReferenceSort]]).
  */
-class SortSuite extends SparkPlanTest with SharedSparkSession {
+class SortSuite extends SharedSparkSession {
   import testImplicits.newProductEncoder
   import testImplicits.localSeqToDatasetHolder
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/TakeOrderedAndProjectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/TakeOrderedAndProjectSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
 
-class TakeOrderedAndProjectSuite extends SparkPlanTest with SharedSparkSession {
+class TakeOrderedAndProjectSuite extends SharedSparkSession {
 
   private var rand: Random = _
   private var seed: Long = 0

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/ExistenceJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/ExistenceJoinSuite.scala
@@ -24,13 +24,13 @@ import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical.{Join, JoinHint}
 import org.apache.spark.sql.classic.DataFrame
-import org.apache.spark.sql.execution.{FilterExec, ProjectExec, SparkPlan, SparkPlanTest}
+import org.apache.spark.sql.execution.{FilterExec, ProjectExec, SparkPlan}
 import org.apache.spark.sql.execution.exchange.EnsureRequirements
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BooleanType, DoubleType, IntegerType, StructType}
 
-class ExistenceJoinSuite extends SparkPlanTest with SharedSparkSession {
+class ExistenceJoinSuite extends SharedSparkSession {
   import testImplicits.toRichColumn
 
   private val EnsureRequirements = new EnsureRequirements()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/InnerJoinSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
-class InnerJoinSuite extends SparkPlanTest with SharedSparkSession {
+class InnerJoinSuite extends SharedSparkSession {
   import testImplicits.newProductEncoder
   import testImplicits.localSeqToDatasetHolder
   import testImplicits.toRichColumn

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/OuterJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/OuterJoinSuite.scala
@@ -24,13 +24,13 @@ import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical.{Join, JoinHint}
 import org.apache.spark.sql.classic.DataFrame
-import org.apache.spark.sql.execution.{SparkPlan, SparkPlanTest}
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.exchange.EnsureRequirements
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestData}
 import org.apache.spark.sql.types.{DoubleType, IntegerType, StructType}
 
-class OuterJoinSuite extends SparkPlanTest with SharedSparkSession with SQLTestData {
+class OuterJoinSuite extends SharedSparkSession with SQLTestData {
   import testImplicits._
   setupTestData()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/SingleJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/SingleJoinSuite.scala
@@ -18,19 +18,19 @@
 package org.apache.spark.sql.execution.joins
 
 import org.apache.spark.SparkRuntimeException
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.optimizer.BuildRight
 import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical.{Join, JoinHint, Project}
 import org.apache.spark.sql.classic.DataFrame
-import org.apache.spark.sql.execution.{SparkPlan, SparkPlanTest}
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.exchange.EnsureRequirements
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{DoubleType, IntegerType, StructType}
 
-class SingleJoinSuite extends SparkPlanTest with SharedSparkSession {
+class SingleJoinSuite extends SharedSparkSession {
   import testImplicits.toRichColumn
 
   private val EnsureRequirements = new EnsureRequirements()
@@ -86,7 +86,7 @@ class SingleJoinSuite extends SparkPlanTest with SharedSparkSession {
         rightRows.queryExecution.sparkPlan)
       checkError(
         exception = intercept[SparkRuntimeException] {
-          SparkPlanTest.executePlan(outputPlan, spark.sqlContext)
+          QueryTest.executePlan(outputPlan, spark.sqlContext)
         },
         condition = "SCALAR_SUBQUERY_TOO_MANY_ROWS",
         parameters = Map.empty

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExecSuite.scala
@@ -24,13 +24,12 @@ import org.apache.spark.api.python.{PythonEvalType, SimplePythonFunction}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, GreaterThan, In}
 import org.apache.spark.sql.connector.catalog.CatalogManager
-import org.apache.spark.sql.execution.{FilterExec, InputAdapter, SparkPlanTest, WholeStageCodegenExec}
+import org.apache.spark.sql.execution.{FilterExec, InputAdapter, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BooleanType, DoubleType}
 
-class BatchEvalPythonExecSuite extends SparkPlanTest
-  with SharedSparkSession
+class BatchEvalPythonExecSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
   import testImplicits.newProductEncoder
   import testImplicits.localSeqToDatasetHolder

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFsSuite.scala
@@ -18,14 +18,14 @@
 package org.apache.spark.sql.execution.python
 
 import org.apache.spark.sql.catalyst.plans.logical.{ArrowEvalPython, BatchEvalPython, Limit, LocalLimit}
-import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan, SparkPlanTest}
+import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class ExtractPythonUDFsSuite extends SparkPlanTest with SharedSparkSession {
+class ExtractPythonUDFsSuite extends SharedSparkSession {
   import testImplicits._
 
   val batchedPythonUDF = new MyDummyPythonUDF

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
@@ -25,7 +25,7 @@ import org.apache.hadoop.hive.serde2.`lazy`.LazySimpleSerDe
 import org.scalatest.exceptions.TestFailedException
 
 import org.apache.spark.{SparkException, TestUtils}
-import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants
 import org.apache.spark.sql.execution._
@@ -114,7 +114,7 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
           output = Seq(AttributeReference("a", StringType)()),
           child = rowsDf.queryExecution.sparkPlan,
           ioschema = hiveIOSchema)
-      SparkPlanTest.executePlan(plan, hiveContext)
+      QueryTest.executePlan(plan, hiveContext)
     }
     assert(e.getMessage.contains("Subprocess exited with status"))
     assert(uncaughtExceptionHandler.exception.isEmpty)
@@ -151,7 +151,7 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
           output = Seq(AttributeReference("a", StringType)()),
           child = rowsDf.queryExecution.sparkPlan,
           ioschema = hiveIOSchema)
-      SparkPlanTest.executePlan(plan, hiveContext)
+      QueryTest.executePlan(plan, hiveContext)
     }
     assert(e.getMessage.contains("Subprocess exited with status"))
     assert(uncaughtExceptionHandler.exception.isEmpty)
@@ -389,7 +389,7 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
             AttributeReference("b", CalendarIntervalType)()),
           child = df.select($"a", $"b").queryExecution.sparkPlan,
           ioschema = hiveIOSchema)
-        SparkPlanTest.executePlan(plan, hiveContext)
+        QueryTest.executePlan(plan, hiveContext)
       }.getMessage
       assert(e1.contains("\"INTERVAL\" cannot be converted to Hive TypeInfo"))
 
@@ -401,7 +401,7 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
             AttributeReference("c", new TestUDT.MyDenseVectorUDT)()),
           child = df.select($"a", $"c").queryExecution.sparkPlan,
           ioschema = hiveIOSchema)
-        SparkPlanTest.executePlan(plan, hiveContext)
+        QueryTest.executePlan(plan, hiveContext)
       }.getMessage
       assert(e2.contains("UDT(\"ARRAY<DOUBLE>\") cannot be converted to Hive TypeInfo"))
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Followup to SPARK-56563. Migrate every in-tree caller from the empty alias `SparkPlanTest` (in `org.apache.spark.sql.execution`, deprecated) to `QueryTest` (in `org.apache.spark.sql`). `SparkPlanTest.scala` itself is left untouched — the deprecated `trait`/`object` aliases remain in place for downstream compatibility.

Mechanical changes across 13 files:

**`extends` list** — dropped `SparkPlanTest` from the parent list. Since `SharedSparkSession` and `QueryTest` already extend `QueryTest` (directly or transitively), the former `SparkPlanTest` reference was a pure duplicate:

| File | Before | After |
|---|---|---|
| `ReuseExchangeAndSubquerySuite` | `extends SparkPlanTest with SharedSparkSession` | `extends SharedSparkSession` |
| `SortSuite` | `extends SparkPlanTest with SharedSparkSession` | `extends SharedSparkSession` |
| `ExchangeSuite` | `extends SparkPlanTest with SharedSparkSession` | `extends SharedSparkSession` |
| `BroadcastExchangeSuite` | `extends SparkPlanTest with SharedSparkSession with AdaptiveSparkPlanHelper` | `extends SharedSparkSession with AdaptiveSparkPlanHelper` |
| `TakeOrderedAndProjectSuite` | `extends SparkPlanTest with SharedSparkSession` | `extends SharedSparkSession` |
| `BaseScriptTransformationSuite` | `extends SparkPlanTest with QueryTest` | `extends QueryTest` |
| `ExtractPythonUDFsSuite` | `extends SparkPlanTest with SharedSparkSession` | `extends SharedSparkSession` |
| `BatchEvalPythonExecSuite` | `extends SparkPlanTest with SharedSparkSession with AdaptiveSparkPlanHelper` | `extends SharedSparkSession with AdaptiveSparkPlanHelper` |
| `SingleJoinSuite` | `extends SparkPlanTest with SharedSparkSession` | `extends SharedSparkSession` |
| `InnerJoinSuite` | `extends SparkPlanTest with SharedSparkSession` | `extends SharedSparkSession` |
| `OuterJoinSuite` | `extends SparkPlanTest with SharedSparkSession with SQLTestData` | `extends SharedSparkSession with SQLTestData` |
| `ExistenceJoinSuite` | `extends SparkPlanTest with SharedSparkSession` | `extends SharedSparkSession` |

**Static calls** — `SparkPlanTest.executePlan` -> `QueryTest.executePlan` in:
- `BaseScriptTransformationSuite`
- `SingleJoinSuite`
- `HiveScriptTransformationSuite` (4 call sites)

**Imports** — removed `SparkPlanTest` from the `org.apache.spark.sql.execution.{...}` import lines in `BatchEvalPythonExecSuite`, `ExtractPythonUDFsSuite`, `ExistenceJoinSuite`, `OuterJoinSuite`, `SingleJoinSuite`. Added `import org.apache.spark.sql.QueryTest` to `SingleJoinSuite` and `HiveScriptTransformationSuite` for the static-method calls.

### Why are the changes needed?

Finishes the consolidation started in SPARK-56563 by migrating every in-tree caller to the canonical `QueryTest` in `org.apache.spark.sql`, so in-tree callers no longer trigger the deprecation warning on `SparkPlanTest`. The deprecated alias is still available for any downstream users.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Locally compiled `sql/Test/compile` and `hive/Test/compile` successfully. Ran `SingleJoinSuite` (36 tests), `ExchangeSuite` + `ReuseExchangeAndSubquerySuite` (10 tests total) — all pass. Relying on CI for full test run.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7