### PR TITLE
[SPARK-55959][SQL][FOLLOWUP] Gate map-lookup hash optimization on foldable input

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -444,263 +444,310 @@ trait GetArrayItemUtil {
 
 /**
  * Common trait for [[GetMapValue]] and [[ElementAt]].
+ *
+ * The lookup strategy is chosen once per expression instance via [[executor]]:
+ *   - [[PrebuiltHashExecutor]] when the map child is foldable, its key type supports
+ *     hashing, and its size meets [[SQLConf.MAP_LOOKUP_HASH_THRESHOLD]]. The hash index
+ *     is built once from the constant map and reused for every row.
+ *   - [[LinearExecutor]] otherwise (non-foldable maps, unsupported key types, or maps
+ *     below the threshold). Hash lookup is not used here because its per-row build cost
+ *     is higher than a linear scan when the index cannot be reused across rows.
+ *
+ * Each strategy owns both its interpreted eval and its codegen, grouped together, and
+ * [[getValueEval]] / [[doGetValueGenCode]] are thin delegators.
  */
 trait GetMapValueUtil extends BinaryExpression with ImplicitCastInputTypes {
 
-  @transient private var lastMap: MapData = _
-  @transient private var lastIndex: java.util.HashMap[Any, Int] = _
-
-  /**
-   * The threshold to determine whether to use hash lookup for map lookup expressions.
-   * If the map size is small, the cost of building hash map exceeds the cost of a linear scan.
-   * This is configured by `spark.sql.optimizer.mapLookupHashThreshold`.
-   */
   @transient private lazy val hashLookupThreshold =
     SQLConf.get.getConf(SQLConf.MAP_LOOKUP_HASH_THRESHOLD)
 
-  private def getOrBuildIndex(map: MapData, keyType: DataType): java.util.HashMap[Any, Int] = {
-    if (lastMap ne map) {
-      val keys = map.keyArray()
-      val len = keys.numElements()
-      val hm = new java.util.HashMap[Any, Int]((len * 1.5).toInt)
-      var i = 0
-      while (i < len) {
-        val k = keys.get(i, keyType)
-        hm.putIfAbsent(k, i)
-        i += 1
+  @transient private lazy val executor: MapLookupExecutor = chooseExecutor()
+
+  /**
+   * True iff this expression was resolved onto the hash lookup path at construction time.
+   * Visible for testing so suites can assert strategy choice without matching on
+   * path-dependent inner types.
+   */
+  private[expressions] def usesFoldableHashLookup: Boolean =
+    executor.isInstanceOf[PrebuiltHashExecutor]
+
+  /**
+   * Chooses an executor once per expression instance. The hash path is taken only for foldable
+   * map inputs whose key type passes [[TypeUtils.typeWithProperEquals]] -- the same predicate
+   * SPARK-55959's interpreted path already used for its hash fallback, so the interpreted and
+   * codegen paths stay in sync. (SPARK-55959 also carried a codegen-only `supportsHashLookup`
+   * whitelist which was a subset of this predicate; this refactor unifies both paths on one
+   * predicate.)
+   *
+   * Concretely: non-binary-equality [[StringType]] and [[BinaryType]] keys fall through to
+   * linear scan. [[VariantType]] keys are structurally unreachable here (rejected earlier by
+   * [[TypeUtils.checkForMapKeyType]]). [[GeographyType]] / [[GeometryType]] are `AtomicType`s
+   * with identity-inherited equals; if either becomes a valid map key in the future, proper
+   * hash/equals must be defined for them -- a pre-existing constraint that already applies
+   * to the interpretive hash path.
+   */
+  private def chooseExecutor(): MapLookupExecutor = left.dataType match {
+    case MapType(keyType, _, _)
+        if left.foldable && TypeUtils.typeWithProperEquals(keyType) =>
+      left.eval(null) match {
+        case map: MapData if map.numElements() >= hashLookupThreshold =>
+          val index = buildHashIndex(map, keyType)
+          val (buckets, hashMask) = buildHashBuckets(map, keyType)
+          new PrebuiltHashExecutor(
+            index, buckets, hashMask, map.keyArray(), map.valueArray())
+        case _ => LinearExecutor
       }
-      lastIndex = hm
-      lastMap = map
+    case _ => LinearExecutor
+  }
+
+  private def buildHashIndex(map: MapData, keyType: DataType): java.util.HashMap[Any, Int] = {
+    val keys = map.keyArray()
+    val len = keys.numElements()
+    val hm = new java.util.HashMap[Any, Int]((len * 1.5).toInt)
+    var i = 0
+    while (i < len) {
+      // putIfAbsent preserves first-match semantics for maps with duplicate keys (allowed at
+      // the physical level by [[ArrayBasedMapData]]), matching the linear scan path.
+      hm.putIfAbsent(keys.get(i, keyType), i)
+      i += 1
     }
-    lastIndex
+    hm
+  }
+
+  /**
+   * Builds a power-of-two open-addressed bucket table mapping `hash(key) & hashMask` to the
+   * key's index in `map.keyArray()`. Used by the codegen hash path so primitive-keyed lookups
+   * avoid autoboxing. The hash function must match [[GetMapValueUtil.genHash]] for the same
+   * `keyType`.
+   */
+  private def buildHashBuckets(map: MapData, keyType: DataType): (Array[Int], Int) = {
+    val keys = map.keyArray()
+    val len = keys.numElements()
+    // Power-of-two capacity, load factor < 0.5, min 4. Clamped to 2^30 so (cap - 1) fits in int.
+    val target = math.min(math.max(len.toLong * 2L - 1L, 1L), (1L << 30) - 1L).toInt
+    val cap = math.max(java.lang.Integer.highestOneBit(target) << 1, 4)
+    val buckets = new Array[Int](cap)
+    java.util.Arrays.fill(buckets, -1)
+    val mask = cap - 1
+    var i = 0
+    while (i < len) {
+      var h = hashKeyOnDriver(keys.get(i, keyType), keyType) & mask
+      // Open addressing with linear probing; duplicates take the next free slot so that the
+      // lookup (which stops at the first match) returns the first-inserted index -- matches
+      // [[buildHashIndex]] / [[ArrayBasedMapData]] first-wins semantics.
+      while (buckets(h) != -1) h = (h + 1) & mask
+      buckets(h) = i
+      i += 1
+    }
+    (buckets, mask)
+  }
+
+  /** Scala-side hash for a Spark value; mirrors [[GetMapValueUtil.genHash]] per keyType. */
+  private def hashKeyOnDriver(v: Any, keyType: DataType): Int = keyType match {
+    case BooleanType => if (v.asInstanceOf[Boolean]) 1 else 0
+    case ByteType => v.asInstanceOf[Byte].toInt
+    case ShortType => v.asInstanceOf[Short].toInt
+    case IntegerType | DateType | _: YearMonthIntervalType => v.asInstanceOf[Int]
+    case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType | _: TimeType =>
+      val l = v.asInstanceOf[Long]
+      (l ^ (l >>> 32)).toInt
+    case FloatType => java.lang.Float.floatToIntBits(v.asInstanceOf[Float])
+    case DoubleType =>
+      val l = java.lang.Double.doubleToLongBits(v.asInstanceOf[Double])
+      (l ^ (l >>> 32)).toInt
+    case _ => v.hashCode()
+  }
+
+  /** Java-side hash expression over the primitive/object `v`. Mirrors [[hashKeyOnDriver]]. */
+  private def genHash(v: String, keyType: DataType): String = keyType match {
+    case BooleanType => s"($v ? 1 : 0)"
+    case ByteType | ShortType | IntegerType | DateType | _: YearMonthIntervalType => s"$v"
+    case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType | _: TimeType =>
+      s"(int)($v ^ ($v >>> 32))"
+    case FloatType => s"Float.floatToIntBits($v)"
+    case DoubleType =>
+      s"(int)(Double.doubleToLongBits($v) ^ (Double.doubleToLongBits($v) >>> 32))"
+    case _ => s"$v.hashCode()"
   }
 
   def getValueEval(
       value: Any,
       ordinal: Any,
       keyType: DataType,
-      ordering: Ordering[Any]): Any = {
-    val map = value.asInstanceOf[MapData]
-    val length = map.numElements()
-
-    if (length < hashLookupThreshold || !TypeUtils.typeWithProperEquals(keyType)) {
-      getValueEvalLinear(map, ordinal, keyType, ordering)
-    } else {
-      val idx = getOrBuildIndex(map, keyType).getOrDefault(ordinal, -1)
-      if (idx == -1 || map.valueArray().isNullAt(idx)) {
-        null
-      } else {
-        map.valueArray().get(idx, dataType)
-      }
-    }
-  }
-
-  private def getValueEvalLinear(
-      map: MapData,
-      ordinal: Any,
-      keyType: DataType,
-      ordering: Ordering[Any]): Any = {
-    val length = map.numElements()
-    val keys = map.keyArray()
-    val values = map.valueArray()
-
-    var i = 0
-    var found = false
-    while (i < length && !found) {
-      if (ordering.equiv(keys.get(i, keyType), ordinal)) {
-        found = true
-      } else {
-        i += 1
-      }
-    }
-
-    if (!found || values.isNullAt(i)) {
-      null
-    } else {
-      values.get(i, dataType)
-    }
-  }
+      ordering: Ordering[Any]): Any =
+    executor.eval(value.asInstanceOf[MapData], ordinal, keyType, ordering)
 
   def doGetValueGenCode(
       ctx: CodegenContext,
       ev: ExprCode,
-      mapType: MapType): ExprCode = {
-    val keyType = mapType.keyType
-    if (supportsHashLookup(keyType)) {
-      doGetValueGenCodeWithHashOpt(ctx, ev, mapType)
-    } else {
-      doGetValueGenCodeLinear(ctx, ev, mapType)
-    }
+      mapType: MapType): ExprCode =
+    executor.genCode(ctx, ev, mapType)
+
+  /**
+   * Execution strategy for a map key lookup. Inner to the trait so each concrete strategy
+   * has closure access to `dataType` and `nullSafeCodeGen` on the enclosing expression.
+   *
+   * The `eval` signature is shaped by [[LinearExecutor]]'s needs; hash-based strategies may
+   * ignore `keyType` / `ordering` (their lookup uses pre-built state that does not depend
+   * on the runtime `map`, `keyType`, or `ordering`).
+   */
+  protected sealed trait MapLookupExecutor extends Serializable {
+    def eval(map: MapData, ordinal: Any, keyType: DataType, ordering: Ordering[Any]): Any
+    def genCode(ctx: CodegenContext, ev: ExprCode, mapType: MapType): ExprCode
   }
 
-  private def supportsHashLookup(keyType: DataType): Boolean = keyType match {
-    case BooleanType | ByteType | ShortType | IntegerType | LongType |
-         FloatType | DoubleType | DateType | TimestampType |
-         TimestampNTZType | _: YearMonthIntervalType |
-         _: DayTimeIntervalType | _: DecimalType | _: TimeType => true
-    case st: StringType if st.supportsBinaryEquality => true
-    case _ => false
-  }
+  /** Linear scan over the map's key array. Stateless; no pre-computation. */
+  protected object LinearExecutor extends MapLookupExecutor {
+    override def eval(
+        map: MapData,
+        ordinal: Any,
+        keyType: DataType,
+        ordering: Ordering[Any]): Any = {
+      val length = map.numElements()
+      val keys = map.keyArray()
+      val values = map.valueArray()
 
-  private def doGetValueGenCodeLinear(
-      ctx: CodegenContext,
-      ev: ExprCode,
-      mapType: MapType): ExprCode = {
-    val index = ctx.freshName("index")
-    val length = ctx.freshName("length")
-    val keys = ctx.freshName("keys")
-    val values = ctx.freshName("values")
-    val keyType = mapType.keyType
+      var i = 0
+      var found = false
+      while (i < length && !found) {
+        if (ordering.equiv(keys.get(i, keyType), ordinal)) {
+          found = true
+        } else {
+          i += 1
+        }
+      }
 
-    val keyJavaType = CodeGenerator.javaType(keyType)
-    val loopKey = ctx.freshName("loopKey")
-    val i = ctx.freshName("i")
-
-    val nullValueCheck = if (mapType.valueContainsNull) {
-      s"""
-         |else if ($values.isNullAt($index)) {
-         |  ${ev.isNull} = true;
-         |}
-       """.stripMargin
-    } else {
-      ""
+      if (!found || values.isNullAt(i)) null else values.get(i, dataType)
     }
 
-    nullSafeCodeGen(ctx, ev, (eval1, eval2) => {
-      s"""
-         |final int $length = $eval1.numElements();
-         |final ArrayData $keys = $eval1.keyArray();
-         |final ArrayData $values = $eval1.valueArray();
-         |int $index = -1;
-         |
-         |for (int $i = 0; $i < $length; $i++) {
-         |  $keyJavaType $loopKey = ${CodeGenerator.getValue(keys, keyType, i)};
-         |  if (${ctx.genEqual(keyType, loopKey, eval2)}) {
-         |    $index = $i;
-         |    break;
-         |  }
-         |}
-         |
-         |if ($index < 0) {
-         |  ${ev.isNull} = true;
-         |} $nullValueCheck else {
-         |  ${ev.value} = ${CodeGenerator.getValue(values, dataType, index)};
-         |}
-       """.stripMargin
-    })
+    override def genCode(
+        ctx: CodegenContext,
+        ev: ExprCode,
+        mapType: MapType): ExprCode = {
+      val index = ctx.freshName("index")
+      val length = ctx.freshName("length")
+      val keys = ctx.freshName("keys")
+      val values = ctx.freshName("values")
+      val keyType = mapType.keyType
+
+      val keyJavaType = CodeGenerator.javaType(keyType)
+      val loopKey = ctx.freshName("loopKey")
+      val i = ctx.freshName("i")
+
+      val nullValueCheck = if (mapType.valueContainsNull) {
+        s"""
+           |else if ($values.isNullAt($index)) {
+           |  ${ev.isNull} = true;
+           |}
+         """.stripMargin
+      } else {
+        ""
+      }
+
+      nullSafeCodeGen(ctx, ev, (eval1, eval2) => {
+        s"""
+           |final int $length = $eval1.numElements();
+           |final ArrayData $keys = $eval1.keyArray();
+           |final ArrayData $values = $eval1.valueArray();
+           |int $index = -1;
+           |
+           |for (int $i = 0; $i < $length; $i++) {
+           |  $keyJavaType $loopKey = ${CodeGenerator.getValue(keys, keyType, i)};
+           |  if (${ctx.genEqual(keyType, loopKey, eval2)}) {
+           |    $index = $i;
+           |    break;
+           |  }
+           |}
+           |
+           |if ($index < 0) {
+           |  ${ev.isNull} = true;
+           |} $nullValueCheck else {
+           |  ${ev.value} = ${CodeGenerator.getValue(values, dataType, index)};
+           |}
+         """.stripMargin
+      })
+    }
   }
 
   /**
-   * Generates code for map lookups.
-   * If the map size is small (less than HASH_LOOKUP_THRESHOLD), it uses a linear scan.
-   * If the map size is large, it builds a hash index for O(1) lookup.
+   * Hash-based lookup for foldable (constant) maps. All state is evaluated on the driver at
+   * construction time and reused for every row:
+   *   - `index`: generic `HashMap[Any, Int]` used by the interpreted path; avoids duplicating
+   *     the hash/equal logic on the Scala side for non-primitive keys.
+   *   - `buckets` / `hashMask`: power-of-two open-addressed `int[]` table used by codegen so
+   *     primitive-keyed lookups can use inline hash / primitive `==` compare without
+   *     autoboxing. Populated by [[GetMapValueUtil.buildHashBuckets]] using a Scala hash that
+   *     mirrors [[GetMapValueUtil.genHash]].
+   *   - `keys` / `values`: the constant map's key and value arrays, embedded in the generated
+   *     class via [[CodegenContext.addReferenceObj]].
    */
-  private def doGetValueGenCodeWithHashOpt(
-      ctx: CodegenContext,
-      ev: ExprCode,
-      mapType: MapType): ExprCode = {
-    val index = ctx.freshName("index")
-    val length = ctx.freshName("length")
-    val keys = ctx.freshName("keys")
-    val values = ctx.freshName("values")
-    val keyType = mapType.keyType
+  protected final class PrebuiltHashExecutor(
+      index: java.util.HashMap[Any, Int],
+      buckets: Array[Int],
+      hashMask: Int,
+      keys: ArrayData,
+      values: ArrayData) extends MapLookupExecutor {
 
-    val nullValueCheck = if (mapType.valueContainsNull) {
-      s"""
-         |else if ($values.isNullAt($index)) {
-         |  ${ev.isNull} = true;
-         |}
-       """.stripMargin
-    } else {
-      ""
+    // The runtime `map`, `keyType`, and `ordering` are ignored: the map is known to be the
+    // same constant on every row (the hash path is only chosen when `left.foldable`), and the
+    // pre-built `index` and `values` captured at construction time are what we consult.
+    override def eval(
+        map: MapData,
+        ordinal: Any,
+        keyType: DataType,
+        ordering: Ordering[Any]): Any = {
+      val idx = index.getOrDefault(ordinal, -1)
+      if (idx == -1 || values.isNullAt(idx)) null else values.get(idx, dataType)
     }
 
-    val keyJavaType = CodeGenerator.javaType(keyType)
-    val lastKeyArray = ctx.addMutableState("ArrayData", "lastKeyArray", v => s"$v = null;")
-    val hashBuckets = ctx.addMutableState("int[]", "hashBuckets", v => s"$v = null;")
-    val hashMask = ctx.addMutableState("int", "hashMask", v => s"$v = 0;")
-
-    def genHash(v: String): String = keyType match {
-      case BooleanType => s"($v ? 1 : 0)"
-      case ByteType | ShortType | IntegerType | DateType | _: YearMonthIntervalType => s"$v"
-      case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType | _: TimeType =>
-        s"(int)($v ^ ($v >>> 32))"
-      case FloatType => s"Float.floatToIntBits($v)"
-      case DoubleType =>
-        s"(int)(Double.doubleToLongBits($v) ^ (Double.doubleToLongBits($v) >>> 32))"
-      case _ => s"$v.hashCode()"
-    }
-
-    nullSafeCodeGen(ctx, ev, (eval1, eval2) => {
-      val i = ctx.freshName("i")
+    override def genCode(
+        ctx: CodegenContext,
+        ev: ExprCode,
+        mapType: MapType): ExprCode = {
+      val keyType = mapType.keyType
+      val bucketsRef = ctx.addReferenceObj("mapLookupBuckets", buckets, "int[]")
+      val keysRef = ctx.addReferenceObj("mapLookupKeys", keys, "ArrayData")
+      val valuesRef = ctx.addReferenceObj("mapLookupValues", values, "ArrayData")
+      val keyJavaType = CodeGenerator.javaType(keyType)
       val h = ctx.freshName("h")
-      val cap = ctx.freshName("cap")
       val idx = ctx.freshName("idx")
       val candidate = ctx.freshName("candidate")
-      val loopKey = ctx.freshName("loopKey")
+      val resultIdx = ctx.freshName("resultIdx")
 
-      val buildIndex =
+      nullSafeCodeGen(ctx, ev, (_, eval2) => {
+        val assignValue = if (mapType.valueContainsNull) {
+          s"""
+             |if ($valuesRef.isNullAt($resultIdx)) {
+             |  ${ev.isNull} = true;
+             |} else {
+             |  ${ev.value} = ${CodeGenerator.getValue(valuesRef, dataType, resultIdx)};
+             |}
+           """.stripMargin
+        } else {
+          s"${ev.value} = ${CodeGenerator.getValue(valuesRef, dataType, resultIdx)};"
+        }
+        // Inline open-addressing probe. Hash must match what `buildHashBuckets` used on the
+        // driver; `hashMask` is a power-of-two minus one, embedded as a literal.
         s"""
-           |int $cap = Math.max(Integer.highestOneBit(Math.max($length * 2 - 1, 1)) << 1, 4);
-           |if ($hashBuckets == null || $hashBuckets.length < $cap) {
-           |  $hashBuckets = new int[$cap];
-           |}
-           |java.util.Arrays.fill($hashBuckets, 0, $cap, -1);
-           |$hashMask = $cap - 1;
-           |for (int $i = 0; $i < $length; $i++) {
-           |  $keyJavaType $loopKey = ${CodeGenerator.getValue(keys, keyType, i)};
-           |  int $h = (${genHash(loopKey)}) & $hashMask;
-           |  while ($hashBuckets[$h] != -1) {
-           |    $h = ($h + 1) & $hashMask;
-           |  }
-           |  $hashBuckets[$h] = $i;
-           |}
-           |$lastKeyArray = $keys;
-         """.stripMargin
-
-      val lookup =
-        s"""
-           |int $h = (${genHash(eval2)}) & $hashMask;
-           |$index = -1;
-           |while ($hashBuckets[$h] != -1) {
-           |  int $idx = $hashBuckets[$h];
-           |  $keyJavaType $candidate = ${CodeGenerator.getValue(keys, keyType, idx)};
+           |int $h = (${genHash(eval2, keyType)}) & $hashMask;
+           |int $resultIdx = -1;
+           |while ($bucketsRef[$h] != -1) {
+           |  int $idx = $bucketsRef[$h];
+           |  $keyJavaType $candidate = ${CodeGenerator.getValue(keysRef, keyType, idx)};
            |  if (${ctx.genEqual(keyType, candidate, eval2)}) {
-           |    $index = $idx;
+           |    $resultIdx = $idx;
            |    break;
            |  }
            |  $h = ($h + 1) & $hashMask;
            |}
+           |if ($resultIdx < 0) {
+           |  ${ev.isNull} = true;
+           |} else {
+           |  $assignValue
+           |}
          """.stripMargin
-
-      s"""
-        final int $length = $eval1.numElements();
-        final ArrayData $keys = $eval1.keyArray();
-        final ArrayData $values = $eval1.valueArray();
-        int $index = -1;
-
-        if ($length >= $hashLookupThreshold) {
-          if ($keys != $lastKeyArray) {
-            $buildIndex
-          }
-          $lookup
-        } else {
-          for (int $i = 0; $i < $length; $i++) {
-            $keyJavaType $loopKey = ${CodeGenerator.getValue(keys, keyType, i)};
-            if (${ctx.genEqual(keyType, loopKey, eval2)}) {
-              $index = $i;
-              break;
-            }
-          }
-        }
-
-        if ($index < 0) {
-          ${ev.isNull} = true;
-        } $nullValueCheck else {
-          ${ev.value} = ${CodeGenerator.getValue(values, dataType, index)};
-        }
-      """
-    })
+      })
+    }
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2590,9 +2590,11 @@ object SQLConf {
     buildConf("spark.sql.optimizer.mapLookupHashThreshold")
       .internal()
       .doc("The minimum number of map entries to attempt hash-based lookup in `element_at` " +
-        "and the `[]` operator. Below this threshold, linear scan is used. For key types that " +
-        "do not support hashing (e.g. arrays, structs), linear scan is always used regardless " +
-        "of map size.")
+        "and the `[]` operator. Only applies to foldable map expressions (constants / literals), " +
+        "where the hash index can be built once and reused across all rows. Non-foldable maps " +
+        "always use linear scan to avoid per-row hash-table rebuild overhead. Below this " +
+        "threshold, linear scan is used. For key types that do not support hashing (e.g. " +
+        "arrays, structs, binary), linear scan is always used regardless of map size.")
       .version("4.2.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .intConf

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ComplexTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ComplexTypeSuite.scala
@@ -321,6 +321,69 @@ class ComplexTypeSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
+  test("GetMapValue - non-foldable map always uses linear scan") {
+    // With threshold=0, a foldable map would take the hash path. A non-foldable map (backed by
+    // a row column) must still fall back to linear scan, because its hash index cannot be
+    // reused across rows (building it per row is a perf regression vs. linear).
+    withSQLConf(SQLConf.MAP_LOOKUP_HASH_THRESHOLD.key -> "0") {
+      val mapType = MapType(IntegerType, IntegerType)
+      val mapData = ArrayBasedMapData(Map(1 -> 10, 2 -> 20, 3 -> 30))
+      val row = create_row(mapData)
+      val mapRef = BoundReference(0, mapType, nullable = true)
+      assert(!mapRef.foldable)
+
+      // Behavior still correct.
+      checkEvaluation(GetMapValue(mapRef, Literal(1)), 10, row)
+      checkEvaluation(GetMapValue(mapRef, Literal(2)), 20, row)
+      checkEvaluation(GetMapValue(mapRef, Literal(4)), null, row)
+
+      checkEvaluation(ElementAt(mapRef, Literal(3)), 30, row)
+      checkEvaluation(ElementAt(mapRef, Literal(99)), null, row)
+
+      // A null map from a non-foldable reference must still return null.
+      val nullRow = create_row(null)
+      checkEvaluation(GetMapValue(mapRef, Literal(1)), null, nullRow)
+
+      // Strategy choice: non-foldable input never takes the hash path, independent of
+      // threshold. This guards against future refactors that accidentally route every map
+      // through the hash executor (a regression that behavior-only tests wouldn't catch).
+      assert(!GetMapValue(mapRef, Literal(1)).usesFoldableHashLookup)
+      assert(!ElementAt(mapRef, Literal(1)).usesFoldableHashLookup)
+    }
+  }
+
+  test("GetMapValue - strategy choice for foldable maps") {
+    // Build a foldable map literal large enough to clear the default threshold. The
+    // strategy assertions here pair with the non-foldable test above: together they lock in
+    // that foldability, not size alone, gates the hash path.
+    val entries = (0 until 2000).map(i => i -> i.toString).toMap
+    val foldableLit = Literal.create(entries, MapType(IntegerType, StringType))
+    val smallLit = Literal.create(Map(1 -> "a"), MapType(IntegerType, StringType))
+    val binaryKeyLit = Literal.create(
+      Map(Array[Byte](1) -> 10), MapType(BinaryType, IntegerType))
+
+    // Foldable + above threshold + hashable key type --> PrebuiltHashExecutor.
+    withSQLConf(SQLConf.MAP_LOOKUP_HASH_THRESHOLD.key -> "1000") {
+      assert(GetMapValue(foldableLit, Literal(1)).usesFoldableHashLookup)
+      assert(ElementAt(foldableLit, Literal(1)).usesFoldableHashLookup)
+    }
+
+    // Foldable but below threshold --> LinearExecutor.
+    withSQLConf(SQLConf.MAP_LOOKUP_HASH_THRESHOLD.key -> "10000") {
+      assert(!GetMapValue(foldableLit, Literal(1)).usesFoldableHashLookup)
+    }
+
+    // Foldable, size=1, threshold=0 --> still LinearExecutor (threshold is >=, len < threshold
+    // is false here but we want to also confirm small maps don't regress with threshold=0).
+    withSQLConf(SQLConf.MAP_LOOKUP_HASH_THRESHOLD.key -> "0") {
+      assert(GetMapValue(smallLit, Literal(1)).usesFoldableHashLookup)
+
+      // Unsupported key type (BinaryType fails typeWithProperEquals) --> LinearExecutor even
+      // when foldable and threshold=0.
+      assert(!GetMapValue(binaryKeyLit, Literal(Array[Byte](1))).usesFoldableHashLookup)
+    }
+  }
+
   test("GetStructField") {
     val typeS = StructType(StructField("a", IntegerType) :: Nil)
     val struct = Literal.create(create_row(1), typeS)

--- a/sql/core/benchmarks/MapLookupBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/MapLookupBenchmark-jdk21-results.txt
@@ -1,273 +1,144 @@
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=1000000, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      10026          23010       11278          0.0     1002647.5       1.0X
-GetMapValue interpreted - Hash Lookup                         1198           1356         141          0.0      119820.5       8.4X
-GetMapValue codegen - Linear Lookup                          12500          17389        4235          0.0     1249953.2       0.8X
-GetMapValue codegen - Hash Lookup                             1631           1861         200          0.0      163089.3       6.1X
-ElementAt interpreted - Linear Lookup                        25953          26404         426          0.0     2595299.3       0.4X
-ElementAt interpreted - Hash Lookup                           1165           1360         299          0.0      116544.6       8.6X
-ElementAt codegen - Linear Lookup                            17482          18188         617          0.0     1748227.1       0.6X
-ElementAt codegen - Hash Lookup                               1869           2017         172          0.0      186850.1       5.4X
-
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=1000000, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      42492          42633         242          0.0     4249196.2       1.0X
-GetMapValue interpreted - Hash Lookup                         1464           1601         154          0.0      146399.6      29.0X
-GetMapValue codegen - Linear Lookup                          12001          20809        7629          0.0     1200106.8       3.5X
-GetMapValue codegen - Hash Lookup                             1800           1970         191          0.0      180018.1      23.6X
-ElementAt interpreted - Linear Lookup                        43724          44931        1073          0.0     4372412.0       1.0X
-ElementAt interpreted - Hash Lookup                           1171           1503         317          0.0      117088.2      36.3X
-ElementAt codegen - Linear Lookup                            24145          24366         360          0.0     2414490.0       1.8X
-ElementAt codegen - Hash Lookup                               1640           1862         197          0.0      163983.0      25.9X
-
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=1000000, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      57909          58999        1062          0.0     5790941.2       1.0X
-GetMapValue interpreted - Hash Lookup                         1113           1429         296          0.0      111346.2      52.0X
-GetMapValue codegen - Linear Lookup                          34713          35982        1174          0.0     3471341.5       1.7X
-GetMapValue codegen - Hash Lookup                             1663           1823         138          0.0      166340.3      34.8X
-ElementAt interpreted - Linear Lookup                        58047          58688         581          0.0     5804675.6       1.0X
-ElementAt interpreted - Hash Lookup                           1416           1545         114          0.0      141555.3      40.9X
-ElementAt codegen - Linear Lookup                            36685          36917         317          0.0     3668505.8       1.6X
-ElementAt codegen - Hash Lookup                               1834           1970         128          0.0      183373.1      31.6X
-
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=100000, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-----------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      1315           1318           4          0.0      131520.2       1.0X
-GetMapValue interpreted - Hash Lookup                         110            120          17          0.1       11046.6      11.9X
-GetMapValue codegen - Linear Lookup                           895            901           7          0.0       89512.7       1.5X
-GetMapValue codegen - Hash Lookup                             143            151          10          0.1       14283.0       9.2X
-ElementAt interpreted - Linear Lookup                        1281           1284           4          0.0      128062.2       1.0X
-ElementAt interpreted - Hash Lookup                           112            120          12          0.1       11174.7      11.8X
-ElementAt codegen - Linear Lookup                             894            896           1          0.0       89425.2       1.5X
-ElementAt codegen - Hash Lookup                               141            147          13          0.1       14054.9       9.4X
-
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=100000, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-----------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      1972           2017          40          0.0      197218.8       1.0X
-GetMapValue interpreted - Hash Lookup                         107            115          11          0.1       10704.7      18.4X
-GetMapValue codegen - Linear Lookup                          1265           1460         169          0.0      126465.9       1.6X
-GetMapValue codegen - Hash Lookup                             136            142           9          0.1       13647.2      14.5X
-ElementAt interpreted - Linear Lookup                        1696           1704           9          0.0      169598.3       1.2X
-ElementAt interpreted - Hash Lookup                           109            119          13          0.1       10856.4      18.2X
-ElementAt codegen - Linear Lookup                            1266           1272          10          0.0      126615.6       1.6X
-ElementAt codegen - Hash Lookup                               138            146          16          0.1       13831.2      14.3X
-
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=100000, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-----------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      2222           2228          11          0.0      222165.8       1.0X
-GetMapValue interpreted - Hash Lookup                         105            116          14          0.1       10477.0      21.2X
-GetMapValue codegen - Linear Lookup                          1645           1660          14          0.0      164490.3       1.4X
-GetMapValue codegen - Hash Lookup                             131            142          16          0.1       13062.0      17.0X
-ElementAt interpreted - Linear Lookup                        2506           2570          55          0.0      250633.2       0.9X
-ElementAt interpreted - Hash Lookup                           103            110          11          0.1       10314.8      21.5X
-ElementAt codegen - Linear Lookup                            1683           1707          21          0.0      168336.7       1.3X
-ElementAt codegen - Hash Lookup                               132            143          13          0.1       13191.2      16.8X
-
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=10000, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      136            142           3          0.1       13555.8       1.0X
-GetMapValue interpreted - Hash Lookup                         25             30           6          0.4        2495.6       5.4X
-GetMapValue codegen - Linear Lookup                           95             97           1          0.1        9488.8       1.4X
-GetMapValue codegen - Hash Lookup                             27             31           4          0.4        2680.3       5.1X
-ElementAt interpreted - Linear Lookup                        120            122           2          0.1       11953.9       1.1X
-ElementAt interpreted - Hash Lookup                           24             27           5          0.4        2361.7       5.7X
-ElementAt codegen - Linear Lookup                             95            100           8          0.1        9457.3       1.4X
-ElementAt codegen - Hash Lookup                               26             28           3          0.4        2577.3       5.3X
+GetMapValue interpreted - Linear Lookup                      199            208           8          0.1       19877.8       1.0X
+GetMapValue interpreted - Hash Lookup                         34             42           6          0.3        3359.9       5.9X
+GetMapValue codegen - Linear Lookup                          108            122          11          0.1       10801.0       1.8X
+GetMapValue codegen - Hash Lookup                             33             40           6          0.3        3309.1       6.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=10000, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      180            185           5          0.1       17965.3       1.0X
-GetMapValue interpreted - Hash Lookup                         22             24           2          0.4        2250.0       8.0X
-GetMapValue codegen - Linear Lookup                          136            137           1          0.1       13566.0       1.3X
-GetMapValue codegen - Hash Lookup                             25             28           4          0.4        2521.6       7.1X
-ElementAt interpreted - Linear Lookup                        174            177           3          0.1       17436.6       1.0X
-ElementAt interpreted - Hash Lookup                           23             25           4          0.4        2262.5       7.9X
-ElementAt codegen - Linear Lookup                            134            137           6          0.1       13379.1       1.3X
-ElementAt codegen - Hash Lookup                               24             28           4          0.4        2449.1       7.3X
+GetMapValue interpreted - Linear Lookup                      318            321           5          0.0       31756.2       1.0X
+GetMapValue interpreted - Hash Lookup                         28             32           5          0.4        2811.0      11.3X
+GetMapValue codegen - Linear Lookup                          141            148           8          0.1       14091.6       2.3X
+GetMapValue codegen - Hash Lookup                             31             34           5          0.3        3078.5      10.3X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=10000, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      233            235           1          0.0       23304.9       1.0X
-GetMapValue interpreted - Hash Lookup                         22             24           4          0.5        2150.9      10.8X
-GetMapValue codegen - Linear Lookup                          175            177           1          0.1       17518.0       1.3X
-GetMapValue codegen - Hash Lookup                             24             26           4          0.4        2410.4       9.7X
-ElementAt interpreted - Linear Lookup                        229            238          15          0.0       22886.9       1.0X
-ElementAt interpreted - Hash Lookup                           21             24           4          0.5        2128.1      11.0X
-ElementAt codegen - Linear Lookup                            175            176           1          0.1       17538.1       1.3X
-ElementAt codegen - Hash Lookup                               24             27           4          0.4        2398.8       9.7X
+GetMapValue interpreted - Linear Lookup                      223            236          15          0.0       22331.8       1.0X
+GetMapValue interpreted - Hash Lookup                         25             28           4          0.4        2501.9       8.9X
+GetMapValue codegen - Linear Lookup                          180            190          17          0.1       18000.7       1.2X
+GetMapValue codegen - Hash Lookup                             27             33           5          0.4        2748.2       8.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=1000, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      21             24           5          0.5        2069.1       1.0X
-GetMapValue interpreted - Hash Lookup                        14             16           3          0.7        1357.4       1.5X
-GetMapValue codegen - Linear Lookup                          18             20           3          0.6        1756.8       1.2X
-GetMapValue codegen - Hash Lookup                            14             16           4          0.7        1389.9       1.5X
-ElementAt interpreted - Linear Lookup                        21             22           4          0.5        2067.5       1.0X
-ElementAt interpreted - Hash Lookup                          14             16           3          0.7        1355.4       1.5X
-ElementAt codegen - Linear Lookup                            17             20           3          0.6        1709.6       1.2X
-ElementAt codegen - Hash Lookup                              13             16           4          0.8        1317.6       1.6X
+GetMapValue interpreted - Linear Lookup                      24             27           4          0.4        2424.6       1.0X
+GetMapValue interpreted - Hash Lookup                        17             20           4          0.6        1710.5       1.4X
+GetMapValue codegen - Linear Lookup                          21             24           4          0.5        2107.8       1.2X
+GetMapValue codegen - Hash Lookup                            17             19           3          0.6        1666.2       1.5X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=1000, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      22             24           3          0.4        2229.0       1.0X
-GetMapValue interpreted - Hash Lookup                        13             15           3          0.8        1257.1       1.8X
-GetMapValue codegen - Linear Lookup                          18             21           4          0.5        1821.8       1.2X
-GetMapValue codegen - Hash Lookup                            13             16           3          0.7        1336.1       1.7X
-ElementAt interpreted - Linear Lookup                        23             25           3          0.4        2268.2       1.0X
-ElementAt interpreted - Hash Lookup                          13             15           3          0.8        1251.0       1.8X
-ElementAt codegen - Linear Lookup                            19             20           3          0.5        1851.5       1.2X
-ElementAt codegen - Hash Lookup                              12             14           2          0.8        1208.9       1.8X
+GetMapValue interpreted - Linear Lookup                      26             29           4          0.4        2624.6       1.0X
+GetMapValue interpreted - Hash Lookup                        16             18           4          0.6        1580.4       1.7X
+GetMapValue codegen - Linear Lookup                          21             24           4          0.5        2111.6       1.2X
+GetMapValue codegen - Hash Lookup                            15             18           4          0.7        1504.7       1.7X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=1000, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      24             27           4          0.4        2388.1       1.0X
-GetMapValue interpreted - Hash Lookup                        12             15           3          0.8        1185.9       2.0X
-GetMapValue codegen - Linear Lookup                          20             22           3          0.5        1966.4       1.2X
-GetMapValue codegen - Hash Lookup                            12             14           2          0.8        1209.0       2.0X
-ElementAt interpreted - Linear Lookup                        24             27           3          0.4        2374.5       1.0X
-ElementAt interpreted - Hash Lookup                          12             14           2          0.8        1181.1       2.0X
-ElementAt codegen - Linear Lookup                            20             22           2          0.5        2027.9       1.2X
-ElementAt codegen - Hash Lookup                              12             14           2          0.8        1186.8       2.0X
+GetMapValue interpreted - Linear Lookup                      28             30           3          0.4        2803.3       1.0X
+GetMapValue interpreted - Hash Lookup                        15             16           3          0.7        1457.4       1.9X
+GetMapValue codegen - Linear Lookup                          22             26           6          0.5        2215.5       1.3X
+GetMapValue codegen - Hash Lookup                            15             16           2          0.7        1451.8       1.9X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=100, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                     12             13           2          0.8        1181.4       1.0X
-GetMapValue interpreted - Hash Lookup                       11             13           3          0.9        1116.8       1.1X
-GetMapValue codegen - Linear Lookup                         12             13           2          0.8        1181.9       1.0X
-GetMapValue codegen - Hash Lookup                           11             13           2          0.9        1102.2       1.1X
-ElementAt interpreted - Linear Lookup                       13             15           2          0.8        1330.9       0.9X
-ElementAt interpreted - Hash Lookup                         11             13           2          0.9        1129.0       1.0X
-ElementAt codegen - Linear Lookup                           11             13           2          0.9        1135.0       1.0X
-ElementAt codegen - Hash Lookup                             11             13           2          0.9        1122.6       1.1X
-
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=100, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                     12             12           2          0.9        1157.6       1.0X
-GetMapValue interpreted - Hash Lookup                       11             12           2          0.9        1079.0       1.1X
-GetMapValue codegen - Linear Lookup                         12             13           2          0.8        1192.9       1.0X
-GetMapValue codegen - Hash Lookup                           11             13           2          0.9        1115.4       1.0X
-ElementAt interpreted - Linear Lookup                       13             14           2          0.8        1274.4       0.9X
-ElementAt interpreted - Hash Lookup                         12             13           2          0.9        1151.2       1.0X
-ElementAt codegen - Linear Lookup                           11             12           2          0.9        1114.9       1.0X
-ElementAt codegen - Hash Lookup                             11             13           3          0.9        1063.8       1.1X
-
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=100, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                     12             13           2          0.8        1178.5       1.0X
-GetMapValue interpreted - Hash Lookup                       11             13           2          0.9        1120.2       1.1X
-GetMapValue codegen - Linear Lookup                         11             13           2          0.9        1136.8       1.0X
-GetMapValue codegen - Hash Lookup                           11             12           2          0.9        1090.8       1.1X
-ElementAt interpreted - Linear Lookup                       12             14           2          0.8        1208.6       1.0X
-ElementAt interpreted - Hash Lookup                         11             12           2          0.9        1070.0       1.1X
-ElementAt codegen - Linear Lookup                           12             13           2          0.9        1167.2       1.0X
-ElementAt codegen - Hash Lookup                             11             12           2          0.9        1077.1       1.1X
-
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=10, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                    11             13           2          0.9        1071.9       1.0X
-GetMapValue interpreted - Hash Lookup                      11             13           2          0.9        1123.4       1.0X
-GetMapValue codegen - Linear Lookup                        11             13           2          0.9        1130.3       0.9X
-GetMapValue codegen - Hash Lookup                          11             12           2          0.9        1102.7       1.0X
-ElementAt interpreted - Linear Lookup                      11             12           2          0.9        1075.3       1.0X
-ElementAt interpreted - Hash Lookup                        11             11           2          0.9        1059.3       1.0X
-ElementAt codegen - Linear Lookup                          10             12           2          1.0        1043.1       1.0X
-ElementAt codegen - Hash Lookup                            10             11           2          1.0        1037.0       1.0X
+GetMapValue interpreted - Linear Lookup                    14             15           2          0.7        1367.4       1.0X
+GetMapValue interpreted - Hash Lookup                      13             15           3          0.7        1349.2       1.0X
+GetMapValue codegen - Linear Lookup                        13             15           3          0.8        1304.0       1.0X
+GetMapValue codegen - Hash Lookup                          13             15           2          0.8        1332.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=10, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                    11             12           2          0.9        1070.1       1.0X
-GetMapValue interpreted - Hash Lookup                      11             13           2          0.9        1079.4       1.0X
-GetMapValue codegen - Linear Lookup                        10             12           2          1.0        1032.1       1.0X
-GetMapValue codegen - Hash Lookup                          11             13           2          0.9        1111.8       1.0X
-ElementAt interpreted - Linear Lookup                      11             12           2          0.9        1062.4       1.0X
-ElementAt interpreted - Hash Lookup                        11             13           2          0.9        1085.6       1.0X
-ElementAt codegen - Linear Lookup                          11             12           2          0.9        1076.0       1.0X
-ElementAt codegen - Hash Lookup                            10             12           2          1.0        1043.6       1.0X
+GetMapValue interpreted - Linear Lookup                    13             15           2          0.8        1322.7       1.0X
+GetMapValue interpreted - Hash Lookup                      13             14           3          0.8        1284.1       1.0X
+GetMapValue codegen - Linear Lookup                        12             14           2          0.8        1232.1       1.1X
+GetMapValue codegen - Hash Lookup                          13             15           3          0.8        1261.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=10, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                    10             11           2          1.0        1043.5       1.0X
-GetMapValue interpreted - Hash Lookup                      10             12           2          1.0        1040.9       1.0X
-GetMapValue codegen - Linear Lookup                        10             12           2          1.0        1021.2       1.0X
-GetMapValue codegen - Hash Lookup                          10             12           2          1.0        1048.9       1.0X
-ElementAt interpreted - Linear Lookup                      11             12           2          0.9        1053.8       1.0X
-ElementAt interpreted - Hash Lookup                        10             12           2          1.0        1018.0       1.0X
-ElementAt codegen - Linear Lookup                          10             11           2          1.0        1047.0       1.0X
-ElementAt codegen - Hash Lookup                            10             12           2          1.0        1026.8       1.0X
+GetMapValue interpreted - Linear Lookup                    12             15           3          0.8        1230.6       1.0X
+GetMapValue interpreted - Hash Lookup                      12             14           2          0.8        1196.1       1.0X
+GetMapValue codegen - Linear Lookup                        12             14           3          0.8        1227.1       1.0X
+GetMapValue codegen - Hash Lookup                          12             14           2          0.8        1205.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
-MapLookup (size=1, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                   11             11           2          0.9        1060.5       1.0X
-GetMapValue interpreted - Hash Lookup                     11             12           2          0.9        1061.4       1.0X
-GetMapValue codegen - Linear Lookup                       10             11           2          1.0        1018.5       1.0X
-GetMapValue codegen - Hash Lookup                         10             12           2          1.0        1045.5       1.0X
-ElementAt interpreted - Linear Lookup                     10             11           2          1.0        1047.3       1.0X
-ElementAt interpreted - Hash Lookup                       11             12           2          1.0        1051.0       1.0X
-ElementAt codegen - Linear Lookup                         10             12           2          1.0        1029.1       1.0X
-ElementAt codegen - Hash Lookup                           10             11           2          1.0        1013.0       1.0X
+MapLookup: non-foldable map column (size=1000, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                              939            970          27          0.0       93920.8       1.0X
+GetMapValue codegen                                                                  126            145          20          0.1       12595.4       7.5X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
-MapLookup (size=1, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                   10             11           2          1.0        1004.8       1.0X
-GetMapValue interpreted - Hash Lookup                     10             11           2          1.0         997.9       1.0X
-GetMapValue codegen - Linear Lookup                       10             11           2          1.0        1002.3       1.0X
-GetMapValue codegen - Hash Lookup                         10             11           2          1.0        1028.3       1.0X
-ElementAt interpreted - Linear Lookup                     10             12           2          1.0        1039.1       1.0X
-ElementAt interpreted - Hash Lookup                       10             11           2          1.0        1008.8       1.0X
-ElementAt codegen - Linear Lookup                         10             11           2          1.0         984.1       1.0X
-ElementAt codegen - Hash Lookup                           10             11           2          1.0         982.7       1.0X
+MapLookup: non-foldable map column (size=1000, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             1338           1347          16          0.0      133763.2       1.0X
+GetMapValue codegen                                                                  124            148          23          0.1       12401.6      10.8X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
-MapLookup (size=1, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                   10             10           1          1.0         984.1       1.0X
-GetMapValue interpreted - Hash Lookup                     10             11           2          1.0         991.0       1.0X
-GetMapValue codegen - Linear Lookup                       10             11           2          1.0         984.6       1.0X
-GetMapValue codegen - Hash Lookup                         10             11           2          1.0         985.1       1.0X
-ElementAt interpreted - Linear Lookup                     10             11           2          1.0         994.0       1.0X
-ElementAt interpreted - Hash Lookup                       10             11           2          1.0         988.4       1.0X
-ElementAt codegen - Linear Lookup                         10             11           2          1.0         969.3       1.0X
-ElementAt codegen - Hash Lookup                           10             11           2          1.0         979.9       1.0X
+MapLookup: non-foldable map column (size=1000, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             1739           1772          43          0.0      173913.1       1.0X
+GetMapValue codegen                                                                  119            142          22          0.1       11909.6      14.6X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=100, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             111            125          14          0.1       11075.0       1.0X
+GetMapValue codegen                                                                  26             31           4          0.4        2642.7       4.2X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=100, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             140            144           3          0.1       13985.5       1.0X
+GetMapValue codegen                                                                  26             31           4          0.4        2623.0       5.3X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=100, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             174            178           3          0.1       17363.2       1.0X
+GetMapValue codegen                                                                  26             31           4          0.4        2554.4       6.8X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=10, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             25             28           3          0.4        2535.8       1.0X
+GetMapValue codegen                                                                 14             17           3          0.7        1422.9       1.8X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=10, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             28             29           2          0.4        2774.9       1.0X
+GetMapValue codegen                                                                 14             16           3          0.7        1408.1       2.0X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=10, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             30             31           2          0.3        2972.7       1.0X
+GetMapValue codegen                                                                 14             16           3          0.7        1393.9       2.1X
 

--- a/sql/core/benchmarks/MapLookupBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/MapLookupBenchmark-jdk25-results.txt
@@ -1,273 +1,144 @@
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=1000000, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      29613          30212         849          0.0     2961282.8       1.0X
-GetMapValue interpreted - Hash Lookup                         1573           1720         127          0.0      157347.0      18.8X
-GetMapValue codegen - Linear Lookup                           5283          15168        8604          0.0      528254.8       5.6X
-GetMapValue codegen - Hash Lookup                             1803           2002         188          0.0      180305.1      16.4X
-ElementAt interpreted - Linear Lookup                        27158          27562         553          0.0     2715764.2       1.1X
-ElementAt interpreted - Hash Lookup                           1326           1574         307          0.0      132589.2      22.3X
-ElementAt codegen - Linear Lookup                             4953          15159        8850          0.0      495255.4       6.0X
-ElementAt codegen - Hash Lookup                               2006           2194         179          0.0      200622.1      14.8X
-
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=1000000, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      29550          38070        7378          0.0     2955023.1       1.0X
-GetMapValue interpreted - Hash Lookup                         1581           1853         408          0.0      158062.3      18.7X
-GetMapValue codegen - Linear Lookup                          29686          30480         693          0.0     2968596.7       1.0X
-GetMapValue codegen - Hash Lookup                             1522           1748         255          0.0      152202.0      19.4X
-ElementAt interpreted - Linear Lookup                        10169          31677       18640          0.0     1016905.7       2.9X
-ElementAt interpreted - Hash Lookup                           1171           1584         366          0.0      117069.3      25.2X
-ElementAt codegen - Linear Lookup                             6115          11592        9203          0.0      611468.4       4.8X
-ElementAt codegen - Hash Lookup                               1569           1680         111          0.0      156930.4      18.8X
-
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=1000000, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      13098          41457       24563          0.0     1309770.8       1.0X
-GetMapValue interpreted - Hash Lookup                         1455           1841         343          0.0      145480.8       9.0X
-GetMapValue codegen - Linear Lookup                          41874          43187        1877          0.0     4187354.3       0.3X
-GetMapValue codegen - Hash Lookup                             2039           2242         205          0.0      203886.9       6.4X
-ElementAt interpreted - Linear Lookup                        56593          57729        1561          0.0     5659287.7       0.2X
-ElementAt interpreted - Hash Lookup                           1355           1518         158          0.0      135468.6       9.7X
-ElementAt codegen - Linear Lookup                            39751          40310         500          0.0     3975123.7       0.3X
-ElementAt codegen - Hash Lookup                               1691           1923         315          0.0      169138.7       7.7X
-
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=100000, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-----------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      1246           1251           6          0.0      124601.4       1.0X
-GetMapValue interpreted - Hash Lookup                         113            122          14          0.1       11310.7      11.0X
-GetMapValue codegen - Linear Lookup                          1098           1105          10          0.0      109840.9       1.1X
-GetMapValue codegen - Hash Lookup                             144            155          18          0.1       14351.7       8.7X
-ElementAt interpreted - Linear Lookup                        1280           1292          11          0.0      128005.9       1.0X
-ElementAt interpreted - Hash Lookup                           113            121          11          0.1       11256.8      11.1X
-ElementAt codegen - Linear Lookup                            1097           1099           2          0.0      109718.9       1.1X
-ElementAt codegen - Hash Lookup                               145            157          18          0.1       14546.0       8.6X
-
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=100000, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-----------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      1688           1708          21          0.0      168766.8       1.0X
-GetMapValue interpreted - Hash Lookup                         114            121          11          0.1       11359.8      14.9X
-GetMapValue codegen - Linear Lookup                          1570           1573           3          0.0      156970.3       1.1X
-GetMapValue codegen - Hash Lookup                             139            148          14          0.1       13905.3      12.1X
-ElementAt interpreted - Linear Lookup                        1684           1728          41          0.0      168375.7       1.0X
-ElementAt interpreted - Hash Lookup                           107            119          11          0.1       10749.4      15.7X
-ElementAt codegen - Linear Lookup                            1572           1573           1          0.0      157227.0       1.1X
-ElementAt codegen - Hash Lookup                               139            150          16          0.1       13889.7      12.2X
-
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=100000, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-----------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      1952           2099         127          0.0      195172.8       1.0X
-GetMapValue interpreted - Hash Lookup                         106            114          11          0.1       10608.9      18.4X
-GetMapValue codegen - Linear Lookup                          2039           2045          10          0.0      203905.7       1.0X
-GetMapValue codegen - Hash Lookup                             139            147          15          0.1       13855.6      14.1X
-ElementAt interpreted - Linear Lookup                        2133           2164          27          0.0      213265.3       0.9X
-ElementAt interpreted - Hash Lookup                           108            123          19          0.1       10843.7      18.0X
-ElementAt codegen - Linear Lookup                            2040           2051          15          0.0      203988.3       1.0X
-ElementAt codegen - Hash Lookup                               140            148          15          0.1       13975.4      14.0X
-
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=10000, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      119            122           2          0.1       11896.7       1.0X
-GetMapValue interpreted - Hash Lookup                         25             28           4          0.4        2476.6       4.8X
-GetMapValue codegen - Linear Lookup                          124            126           3          0.1       12395.4       1.0X
-GetMapValue codegen - Hash Lookup                             26             30           5          0.4        2643.5       4.5X
-ElementAt interpreted - Linear Lookup                        116            121           3          0.1       11642.2       1.0X
-ElementAt interpreted - Hash Lookup                           23             27           5          0.4        2331.2       5.1X
-ElementAt codegen - Linear Lookup                            123            124           1          0.1       12277.5       1.0X
-ElementAt codegen - Hash Lookup                               25             27           2          0.4        2541.3       4.7X
+GetMapValue interpreted - Linear Lookup                      149            168          23          0.1       14940.7       1.0X
+GetMapValue interpreted - Hash Lookup                         29             37           6          0.3        2914.9       5.1X
+GetMapValue codegen - Linear Lookup                          103            113           9          0.1       10302.7       1.5X
+GetMapValue codegen - Hash Lookup                             29             34           5          0.3        2913.6       5.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=10000, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      172            175           1          0.1       17236.9       1.0X
-GetMapValue interpreted - Hash Lookup                         22             24           2          0.5        2192.1       7.9X
-GetMapValue codegen - Linear Lookup                          169            170           2          0.1       16851.4       1.0X
-GetMapValue codegen - Hash Lookup                             24             27           5          0.4        2379.3       7.2X
-ElementAt interpreted - Linear Lookup                        171            175           2          0.1       17115.7       1.0X
-ElementAt interpreted - Hash Lookup                           22             24           4          0.5        2209.8       7.8X
-ElementAt codegen - Linear Lookup                            169            170           1          0.1       16880.9       1.0X
-ElementAt codegen - Hash Lookup                               25             27           4          0.4        2500.4       6.9X
+GetMapValue interpreted - Linear Lookup                      173            186          10          0.1       17296.4       1.0X
+GetMapValue interpreted - Hash Lookup                         25             29           5          0.4        2480.4       7.0X
+GetMapValue codegen - Linear Lookup                          145            159          19          0.1       14515.1       1.2X
+GetMapValue codegen - Hash Lookup                             27             31           5          0.4        2652.8       6.5X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=10000, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      225            230           3          0.0       22512.3       1.0X
-GetMapValue interpreted - Hash Lookup                         21             24           4          0.5        2143.0      10.5X
-GetMapValue codegen - Linear Lookup                          215            216           2          0.0       21453.3       1.0X
-GetMapValue codegen - Hash Lookup                             23             26           4          0.4        2336.9       9.6X
-ElementAt interpreted - Linear Lookup                        228            230           2          0.0       22799.4       1.0X
-ElementAt interpreted - Hash Lookup                           21             24           5          0.5        2100.4      10.7X
-ElementAt codegen - Linear Lookup                            214            215           2          0.0       21386.2       1.1X
-ElementAt codegen - Hash Lookup                               23             26           5          0.4        2328.5       9.7X
+GetMapValue interpreted - Linear Lookup                      236            248          10          0.0       23628.2       1.0X
+GetMapValue interpreted - Hash Lookup                         23             26           4          0.4        2267.5      10.4X
+GetMapValue codegen - Linear Lookup                          188            193           5          0.1       18753.4       1.3X
+GetMapValue codegen - Hash Lookup                             25             29           4          0.4        2549.4       9.3X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=1000, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      19             23           4          0.5        1947.5       1.0X
-GetMapValue interpreted - Hash Lookup                        13             16           3          0.7        1346.7       1.4X
-GetMapValue codegen - Linear Lookup                          22             25           3          0.5        2211.2       0.9X
-GetMapValue codegen - Hash Lookup                            13             15           4          0.8        1257.3       1.5X
-ElementAt interpreted - Linear Lookup                        20             22           2          0.5        1985.4       1.0X
-ElementAt interpreted - Hash Lookup                          13             15           4          0.8        1297.9       1.5X
-ElementAt codegen - Linear Lookup                            23             25           3          0.4        2313.0       0.8X
-ElementAt codegen - Hash Lookup                              13             15           4          0.8        1285.5       1.5X
+GetMapValue interpreted - Linear Lookup                      23             26           4          0.4        2303.6       1.0X
+GetMapValue interpreted - Hash Lookup                        15             19           3          0.6        1549.1       1.5X
+GetMapValue codegen - Linear Lookup                          19             22           3          0.5        1905.2       1.2X
+GetMapValue codegen - Hash Lookup                            14             17           4          0.7        1445.3       1.6X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=1000, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      23             24           2          0.4        2250.7       1.0X
-GetMapValue interpreted - Hash Lookup                        12             15           3          0.8        1248.2       1.8X
-GetMapValue codegen - Linear Lookup                          27             29           3          0.4        2725.2       0.8X
-GetMapValue codegen - Hash Lookup                            13             14           3          0.8        1254.8       1.8X
-ElementAt interpreted - Linear Lookup                        22             24           4          0.5        2174.6       1.0X
-ElementAt interpreted - Hash Lookup                          13             15           2          0.8        1308.6       1.7X
-ElementAt codegen - Linear Lookup                            28             29           2          0.4        2755.9       0.8X
-ElementAt codegen - Hash Lookup                              13             14           2          0.8        1254.0       1.8X
+GetMapValue interpreted - Linear Lookup                      24             27           5          0.4        2387.8       1.0X
+GetMapValue interpreted - Hash Lookup                        15             18           3          0.7        1494.6       1.6X
+GetMapValue codegen - Linear Lookup                          19             23           4          0.5        1914.0       1.2X
+GetMapValue codegen - Hash Lookup                            14             15           2          0.7        1366.4       1.7X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=1000, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      24             26           2          0.4        2425.7       1.0X
-GetMapValue interpreted - Hash Lookup                        13             15           3          0.8        1264.2       1.9X
-GetMapValue codegen - Linear Lookup                          32             34           3          0.3        3150.3       0.8X
-GetMapValue codegen - Hash Lookup                            12             14           2          0.8        1246.0       1.9X
-ElementAt interpreted - Linear Lookup                        24             26           2          0.4        2425.3       1.0X
-ElementAt interpreted - Hash Lookup                          12             14           2          0.8        1224.1       2.0X
-ElementAt codegen - Linear Lookup                            31             33           2          0.3        3145.8       0.8X
-ElementAt codegen - Hash Lookup                              11             13           2          0.9        1143.9       2.1X
+GetMapValue interpreted - Linear Lookup                      27             30           4          0.4        2722.4       1.0X
+GetMapValue interpreted - Hash Lookup                        13             16           3          0.8        1319.8       2.1X
+GetMapValue codegen - Linear Lookup                          21             24           3          0.5        2108.9       1.3X
+GetMapValue codegen - Hash Lookup                            13             14           2          0.8        1301.9       2.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=100, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                     12             13           2          0.9        1170.0       1.0X
-GetMapValue interpreted - Hash Lookup                       11             13           2          0.9        1116.3       1.0X
-GetMapValue codegen - Linear Lookup                         12             14           2          0.8        1217.9       1.0X
-GetMapValue codegen - Hash Lookup                           10             12           3          1.0        1022.6       1.1X
-ElementAt interpreted - Linear Lookup                       11             13           2          0.9        1145.3       1.0X
-ElementAt interpreted - Hash Lookup                         10             12           2          1.0        1041.4       1.1X
-ElementAt codegen - Linear Lookup                           11             13           2          0.9        1142.6       1.0X
-ElementAt codegen - Hash Lookup                             11             12           2          1.0        1050.4       1.1X
-
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=100, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                     11             12           2          0.9        1116.4       1.0X
-GetMapValue interpreted - Hash Lookup                       11             13           2          0.9        1101.3       1.0X
-GetMapValue codegen - Linear Lookup                         11             12           2          0.9        1118.0       1.0X
-GetMapValue codegen - Hash Lookup                           10             11           2          1.0         992.0       1.1X
-ElementAt interpreted - Linear Lookup                       11             13           2          0.9        1143.3       1.0X
-ElementAt interpreted - Hash Lookup                         10             12           2          1.0        1036.5       1.1X
-ElementAt codegen - Linear Lookup                           11             12           2          0.9        1110.7       1.0X
-ElementAt codegen - Hash Lookup                             10             11           2          1.0         981.6       1.1X
-
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
-MapLookup (size=100, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                     11             12           2          0.9        1133.4       1.0X
-GetMapValue interpreted - Hash Lookup                       10             11           2          1.0         998.9       1.1X
-GetMapValue codegen - Linear Lookup                         12             13           2          0.9        1163.8       1.0X
-GetMapValue codegen - Hash Lookup                           10             11           2          1.0         989.1       1.1X
-ElementAt interpreted - Linear Lookup                       11             12           2          0.9        1135.1       1.0X
-ElementAt interpreted - Hash Lookup                         10             11           2          1.0         996.4       1.1X
-ElementAt codegen - Linear Lookup                           11             13           2          0.9        1140.3       1.0X
-ElementAt codegen - Hash Lookup                             10             11           2          1.0         970.8       1.2X
-
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=10, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                    10             11           2          1.0         994.1       1.0X
-GetMapValue interpreted - Hash Lookup                      10             11           2          1.0         990.1       1.0X
-GetMapValue codegen - Linear Lookup                        10             11           2          1.0         970.9       1.0X
-GetMapValue codegen - Hash Lookup                          10             11           2          1.0         958.9       1.0X
-ElementAt interpreted - Linear Lookup                      10             11           2          1.0        1011.1       1.0X
-ElementAt interpreted - Hash Lookup                        10             11           2          1.0         996.2       1.0X
-ElementAt codegen - Linear Lookup                          10             11           2          1.0         959.8       1.0X
-ElementAt codegen - Hash Lookup                            10             11           2          1.0         958.6       1.0X
+GetMapValue interpreted - Linear Lookup                    12             14           2          0.8        1225.7       1.0X
+GetMapValue interpreted - Hash Lookup                      12             13           2          0.9        1169.9       1.0X
+GetMapValue codegen - Linear Lookup                        11             13           2          0.9        1147.2       1.1X
+GetMapValue codegen - Hash Lookup                          11             13           3          0.9        1140.8       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=10, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                    10             11           2          1.0         981.1       1.0X
-GetMapValue interpreted - Hash Lookup                      10             11           2          1.0         977.1       1.0X
-GetMapValue codegen - Linear Lookup                         9             11           2          1.1         949.2       1.0X
-GetMapValue codegen - Hash Lookup                          10             11           2          1.0         959.6       1.0X
-ElementAt interpreted - Linear Lookup                      10             11           2          1.0        1010.3       1.0X
-ElementAt interpreted - Hash Lookup                        10             11           2          1.0        1018.2       1.0X
-ElementAt codegen - Linear Lookup                          10             11           2          1.0         972.2       1.0X
-ElementAt codegen - Hash Lookup                            10             11           2          1.0         998.7       1.0X
+GetMapValue interpreted - Linear Lookup                    11             13           2          0.9        1142.2       1.0X
+GetMapValue interpreted - Hash Lookup                      11             12           2          0.9        1100.3       1.0X
+GetMapValue codegen - Linear Lookup                        11             13           3          0.9        1077.0       1.1X
+GetMapValue codegen - Hash Lookup                          11             13           3          1.0        1050.2       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 MapLookup (size=10, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                    10             11           2          1.0        1022.4       1.0X
-GetMapValue interpreted - Hash Lookup                      10             12           2          1.0         992.3       1.0X
-GetMapValue codegen - Linear Lookup                        10             11           2          1.0        1013.1       1.0X
-GetMapValue codegen - Hash Lookup                          10             11           2          1.0        1001.9       1.0X
-ElementAt interpreted - Linear Lookup                      10             12           2          1.0        1045.1       1.0X
-ElementAt interpreted - Hash Lookup                        10             12           2          1.0        1041.5       1.0X
-ElementAt codegen - Linear Lookup                          10             11           2          1.0         994.5       1.0X
-ElementAt codegen - Hash Lookup                            10             12           2          1.0         996.8       1.0X
+GetMapValue interpreted - Linear Lookup                    11             13           2          0.9        1096.2       1.0X
+GetMapValue interpreted - Hash Lookup                      10             13           3          1.0        1048.4       1.0X
+GetMapValue codegen - Linear Lookup                        10             13           3          1.0        1044.4       1.0X
+GetMapValue codegen - Hash Lookup                          10             12           2          1.0        1004.8       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
-MapLookup (size=1, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                   10             12           2          1.0        1039.9       1.0X
-GetMapValue interpreted - Hash Lookup                     11             12           2          0.9        1055.8       1.0X
-GetMapValue codegen - Linear Lookup                       10             11           2          1.0         981.2       1.1X
-GetMapValue codegen - Hash Lookup                         10             12           2          1.0        1022.1       1.0X
-ElementAt interpreted - Linear Lookup                     10             11           2          1.0        1040.8       1.0X
-ElementAt interpreted - Hash Lookup                       10             13           3          1.0        1018.8       1.0X
-ElementAt codegen - Linear Lookup                         10             11           2          1.0         999.3       1.0X
-ElementAt codegen - Hash Lookup                           10             11           2          1.0        1022.8       1.0X
+MapLookup: non-foldable map column (size=1000, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                              878            883           5          0.0       87770.1       1.0X
+GetMapValue codegen                                                                  124            144          18          0.1       12398.5       7.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
-MapLookup (size=1, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                   10             11           2          1.0         964.3       1.0X
-GetMapValue interpreted - Hash Lookup                     10             11           2          1.0         974.7       1.0X
-GetMapValue codegen - Linear Lookup                       10             11           2          1.0         984.7       1.0X
-GetMapValue codegen - Hash Lookup                         10             11           2          1.0         981.5       1.0X
-ElementAt interpreted - Linear Lookup                     10             11           2          1.0        1015.1       0.9X
-ElementAt interpreted - Hash Lookup                       11             12           2          0.9        1057.9       0.9X
-ElementAt codegen - Linear Lookup                         10             11           2          1.0         991.9       1.0X
-ElementAt codegen - Hash Lookup                           10             11           2          1.0         995.4       1.0X
+MapLookup: non-foldable map column (size=1000, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             1205           1235          32          0.0      120486.2       1.0X
+GetMapValue codegen                                                                  118            141          26          0.1       11753.2      10.3X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
-MapLookup (size=1, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                   10             12           2          1.0        1018.2       1.0X
-GetMapValue interpreted - Hash Lookup                     10             11           2          1.0         962.3       1.1X
-GetMapValue codegen - Linear Lookup                        9             10           2          1.1         919.6       1.1X
-GetMapValue codegen - Hash Lookup                          9             10           2          1.1         912.6       1.1X
-ElementAt interpreted - Linear Lookup                      9             11           2          1.1         945.9       1.1X
-ElementAt interpreted - Hash Lookup                        9             11           2          1.1         944.0       1.1X
-ElementAt codegen - Linear Lookup                          9             11           2          1.1         923.1       1.1X
-ElementAt codegen - Hash Lookup                            9             11           2          1.1         931.4       1.1X
+MapLookup: non-foldable map column (size=1000, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             1566           1589          38          0.0      156570.9       1.0X
+GetMapValue codegen                                                                  120            144          16          0.1       12035.5      13.0X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=100, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                              99            109          10          0.1        9923.0       1.0X
+GetMapValue codegen                                                                  24             30           6          0.4        2406.0       4.1X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=100, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             130            143          11          0.1       12953.9       1.0X
+GetMapValue codegen                                                                  24             29           4          0.4        2416.5       5.4X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=100, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             154            160           4          0.1       15359.9       1.0X
+GetMapValue codegen                                                                  23             27           4          0.4        2298.5       6.7X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=10, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             22             25           3          0.4        2230.2       1.0X
+GetMapValue codegen                                                                 12             15           3          0.8        1237.7       1.8X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=10, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             24             26           1          0.4        2432.1       1.0X
+GetMapValue codegen                                                                 12             14           3          0.8        1199.6       2.0X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=10, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             27             28           2          0.4        2657.8       1.0X
+GetMapValue codegen                                                                 12             15           3          0.8        1235.3       2.2X
 

--- a/sql/core/benchmarks/MapLookupBenchmark-results.txt
+++ b/sql/core/benchmarks/MapLookupBenchmark-results.txt
@@ -1,273 +1,144 @@
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-MapLookup (size=1000000, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      22624          36868       12336          0.0     2262398.9       1.0X
-GetMapValue interpreted - Hash Lookup                         1693           1789         142          0.0      169332.4      13.4X
-GetMapValue codegen - Linear Lookup                           8798          29525       17951          0.0      879755.0       2.6X
-GetMapValue codegen - Hash Lookup                             2342           2482         147          0.0      234180.1       9.7X
-ElementAt interpreted - Linear Lookup                         7806          20753       20310          0.0      780558.3       2.9X
-ElementAt interpreted - Hash Lookup                           1807           1837          33          0.0      180659.2      12.5X
-ElementAt codegen - Linear Lookup                             7000          15056       13043          0.0      699956.1       3.2X
-ElementAt codegen - Hash Lookup                               2523           2619         114          0.0      252261.9       9.0X
-
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-MapLookup (size=1000000, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      11143          47997       31917          0.0     1114253.0       1.0X
-GetMapValue interpreted - Hash Lookup                         1528           1804         268          0.0      152839.8       7.3X
-GetMapValue codegen - Linear Lookup                           8654          21962       22963          0.0      865436.7       1.3X
-GetMapValue codegen - Hash Lookup                             2398           2532         117          0.0      239815.2       4.6X
-ElementAt interpreted - Linear Lookup                        66164          66399         205          0.0     6616373.1       0.2X
-ElementAt interpreted - Hash Lookup                           1521           1787         231          0.0      152062.6       7.3X
-ElementAt codegen - Linear Lookup                             8854          35996       23610          0.0      885415.4       1.3X
-ElementAt codegen - Hash Lookup                               2490           2536          73          0.0      248981.7       4.5X
-
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-MapLookup (size=1000000, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      88708          88898         270          0.0     8870788.8       1.0X
-GetMapValue interpreted - Hash Lookup                         1415           1557         223          0.0      141535.3      62.7X
-GetMapValue codegen - Linear Lookup                          11692          38390       27852          0.0     1169181.6       7.6X
-GetMapValue codegen - Hash Lookup                             2156           2306         170          0.0      215553.5      41.2X
-ElementAt interpreted - Linear Lookup                        89030          89097         114          0.0     8903010.9       1.0X
-ElementAt interpreted - Hash Lookup                           1501           1711         250          0.0      150081.7      59.1X
-ElementAt codegen - Linear Lookup                            67459          68732        1176          0.0     6745912.0       1.3X
-ElementAt codegen - Hash Lookup                               2479           2525          42          0.0      247904.1      35.8X
-
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-MapLookup (size=100000, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-----------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      1997           2258         227          0.0      199662.0       1.0X
-GetMapValue interpreted - Hash Lookup                         129            156          15          0.1       12896.4      15.5X
-GetMapValue codegen - Linear Lookup                          1783           1787           4          0.0      178315.4       1.1X
-GetMapValue codegen - Hash Lookup                             166            173           5          0.1       16604.0      12.0X
-ElementAt interpreted - Linear Lookup                        1973           1976           4          0.0      197333.1       1.0X
-ElementAt interpreted - Hash Lookup                           131            137           8          0.1       13079.7      15.3X
-ElementAt codegen - Linear Lookup                            1778           1784           5          0.0      177842.6       1.1X
-ElementAt codegen - Hash Lookup                               168            174           7          0.1       16823.4      11.9X
-
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-MapLookup (size=100000, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-----------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      2652           3109         396          0.0      265207.1       1.0X
-GetMapValue interpreted - Hash Lookup                         127            133           5          0.1       12725.6      20.8X
-GetMapValue codegen - Linear Lookup                          2202           2207           7          0.0      220180.4       1.2X
-GetMapValue codegen - Hash Lookup                             166            175          11          0.1       16576.3      16.0X
-ElementAt interpreted - Linear Lookup                        3331           3340          14          0.0      333090.9       0.8X
-ElementAt interpreted - Hash Lookup                           130            135           5          0.1       13035.5      20.3X
-ElementAt codegen - Linear Lookup                            2206           2211           5          0.0      220605.4       1.2X
-ElementAt codegen - Hash Lookup                               166            171           5          0.1       16619.1      16.0X
-
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-MapLookup (size=100000, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-----------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      4366           4370           5          0.0      436594.1       1.0X
-GetMapValue interpreted - Hash Lookup                         119            127           6          0.1       11904.2      36.7X
-GetMapValue codegen - Linear Lookup                          2880           2886           7          0.0      288000.1       1.5X
-GetMapValue codegen - Hash Lookup                             153            157           4          0.1       15253.2      28.6X
-ElementAt interpreted - Linear Lookup                        3417           3419           2          0.0      341703.2       1.3X
-ElementAt interpreted - Hash Lookup                           120            128          17          0.1       11961.5      36.5X
-ElementAt codegen - Linear Lookup                            3431           3433           2          0.0      343087.8       1.3X
-ElementAt codegen - Hash Lookup                               152            159           7          0.1       15183.9      28.8X
-
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
 MapLookup (size=10000, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      161            162           1          0.1       16111.0       1.0X
-GetMapValue interpreted - Hash Lookup                         32             35           3          0.3        3233.5       5.0X
-GetMapValue codegen - Linear Lookup                           81             83           2          0.1        8099.3       2.0X
-GetMapValue codegen - Hash Lookup                             35             38           4          0.3        3530.7       4.6X
-ElementAt interpreted - Linear Lookup                        160            163           3          0.1       16031.2       1.0X
-ElementAt interpreted - Hash Lookup                           32             35           3          0.3        3233.5       5.0X
-ElementAt codegen - Linear Lookup                             81             84           6          0.1        8058.3       2.0X
-ElementAt codegen - Hash Lookup                               35             37           2          0.3        3460.9       4.7X
+GetMapValue interpreted - Linear Lookup                      149            171          10          0.1       14884.1       1.0X
+GetMapValue interpreted - Hash Lookup                         34             40           4          0.3        3390.8       4.4X
+GetMapValue codegen - Linear Lookup                          124            128           3          0.1       12387.8       1.2X
+GetMapValue codegen - Hash Lookup                             36             39           4          0.3        3616.4       4.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
 MapLookup (size=10000, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      211            213           2          0.0       21128.4       1.0X
-GetMapValue interpreted - Hash Lookup                         31             32           2          0.3        3054.4       6.9X
-GetMapValue codegen - Linear Lookup                          102            103           1          0.1       10195.1       2.1X
-GetMapValue codegen - Hash Lookup                             33             35           3          0.3        3300.5       6.4X
-ElementAt interpreted - Linear Lookup                        211            212           1          0.0       21074.5       1.0X
-ElementAt interpreted - Hash Lookup                           30             32           2          0.3        3040.3       6.9X
-ElementAt codegen - Linear Lookup                            102            104           3          0.1       10176.9       2.1X
-ElementAt codegen - Hash Lookup                               33             35           3          0.3        3267.9       6.5X
+GetMapValue interpreted - Linear Lookup                      199            205           5          0.1       19922.4       1.0X
+GetMapValue interpreted - Hash Lookup                         30             33           3          0.3        3018.6       6.6X
+GetMapValue codegen - Linear Lookup                          169            173           3          0.1       16936.0       1.2X
+GetMapValue codegen - Hash Lookup                             33             35           3          0.3        3301.0       6.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
 MapLookup (size=10000, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      262            263           0          0.0       26217.5       1.0X
-GetMapValue interpreted - Hash Lookup                         30             32           3          0.3        2983.8       8.8X
-GetMapValue codegen - Linear Lookup                          123            125           3          0.1       12330.7       2.1X
-GetMapValue codegen - Hash Lookup                             32             34           2          0.3        3193.2       8.2X
-ElementAt interpreted - Linear Lookup                        262            264           5          0.0       26206.2       1.0X
-ElementAt interpreted - Hash Lookup                           29             31           2          0.3        2900.4       9.0X
-ElementAt codegen - Linear Lookup                            123            125           2          0.1       12281.0       2.1X
-ElementAt codegen - Hash Lookup                               31             33           3          0.3        3146.4       8.3X
+GetMapValue interpreted - Linear Lookup                      261            263           2          0.0       26139.9       1.0X
+GetMapValue interpreted - Hash Lookup                         28             30           3          0.4        2811.1       9.3X
+GetMapValue codegen - Linear Lookup                          222            227           5          0.0       22192.7       1.2X
+GetMapValue codegen - Hash Lookup                             31             35           4          0.3        3082.3       8.5X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
 MapLookup (size=1000, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      34             35           2          0.3        3356.9       1.0X
-GetMapValue interpreted - Hash Lookup                        21             23           2          0.5        2093.5       1.6X
-GetMapValue codegen - Linear Lookup                          26             27           2          0.4        2568.5       1.3X
-GetMapValue codegen - Hash Lookup                            21             23           2          0.5        2088.6       1.6X
-ElementAt interpreted - Linear Lookup                        33             35           1          0.3        3309.3       1.0X
-ElementAt interpreted - Hash Lookup                          21             22           1          0.5        2094.5       1.6X
-ElementAt codegen - Linear Lookup                            26             27           2          0.4        2588.7       1.3X
-ElementAt codegen - Hash Lookup                              21             22           1          0.5        2087.0       1.6X
+GetMapValue interpreted - Linear Lookup                      26             29           3          0.4        2622.2       1.0X
+GetMapValue interpreted - Hash Lookup                        19             22           2          0.5        1935.0       1.4X
+GetMapValue codegen - Linear Lookup                          25             27           2          0.4        2465.5       1.1X
+GetMapValue codegen - Hash Lookup                            19             21           2          0.5        1922.2       1.4X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
 MapLookup (size=1000, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      39             41           2          0.3        3894.9       1.0X
-GetMapValue interpreted - Hash Lookup                        20             22           2          0.5        2016.7       1.9X
-GetMapValue codegen - Linear Lookup                          28             29           2          0.4        2753.7       1.4X
-GetMapValue codegen - Hash Lookup                            21             22           1          0.5        2069.5       1.9X
-ElementAt interpreted - Linear Lookup                        39             40           1          0.3        3890.8       1.0X
-ElementAt interpreted - Hash Lookup                          20             22           2          0.5        2028.5       1.9X
-ElementAt codegen - Linear Lookup                            28             29           2          0.4        2777.9       1.4X
-ElementAt codegen - Hash Lookup                              20             21           1          0.5        2038.8       1.9X
+GetMapValue interpreted - Linear Lookup                      28             30           3          0.4        2833.2       1.0X
+GetMapValue interpreted - Hash Lookup                        18             20           2          0.5        1834.5       1.5X
+GetMapValue codegen - Linear Lookup                          26             28           3          0.4        2550.4       1.1X
+GetMapValue codegen - Hash Lookup                            18             19           2          0.6        1815.6       1.6X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
 MapLookup (size=1000, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                      44             45           1          0.2        4419.0       1.0X
-GetMapValue interpreted - Hash Lookup                        20             22           2          0.5        1987.5       2.2X
-GetMapValue codegen - Linear Lookup                          30             31           1          0.3        2958.1       1.5X
-GetMapValue codegen - Hash Lookup                            20             22           3          0.5        2019.9       2.2X
-ElementAt interpreted - Linear Lookup                        44             46           3          0.2        4386.5       1.0X
-ElementAt interpreted - Hash Lookup                          20             22           2          0.5        1969.9       2.2X
-ElementAt codegen - Linear Lookup                            30             32           3          0.3        3004.8       1.5X
-ElementAt codegen - Hash Lookup                              20             22           1          0.5        2032.5       2.2X
+GetMapValue interpreted - Linear Lookup                      31             32           2          0.3        3065.9       1.0X
+GetMapValue interpreted - Hash Lookup                        17             19           2          0.6        1715.7       1.8X
+GetMapValue codegen - Linear Lookup                          27             29           2          0.4        2704.6       1.1X
+GetMapValue codegen - Hash Lookup                            17             19           2          0.6        1729.0       1.8X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-MapLookup (size=100, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                     20             22           2          0.5        2019.1       1.0X
-GetMapValue interpreted - Hash Lookup                       19             21           2          0.5        1914.3       1.1X
-GetMapValue codegen - Linear Lookup                         20             22           2          0.5        1971.4       1.0X
-GetMapValue codegen - Hash Lookup                           19             21           2          0.5        1940.3       1.0X
-ElementAt interpreted - Linear Lookup                       20             22           2          0.5        2033.9       1.0X
-ElementAt interpreted - Hash Lookup                         19             20           2          0.5        1906.2       1.1X
-ElementAt codegen - Linear Lookup                           19             20           1          0.5        1901.1       1.1X
-ElementAt codegen - Hash Lookup                             19             20           2          0.5        1881.5       1.1X
-
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-MapLookup (size=100, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                     20             22           2          0.5        2038.5       1.0X
-GetMapValue interpreted - Hash Lookup                       18             20           2          0.5        1849.4       1.1X
-GetMapValue codegen - Linear Lookup                         19             21           2          0.5        1920.8       1.1X
-GetMapValue codegen - Hash Lookup                           19             20           1          0.5        1855.1       1.1X
-ElementAt interpreted - Linear Lookup                       20             22           2          0.5        2040.9       1.0X
-ElementAt interpreted - Hash Lookup                         19             20           1          0.5        1916.7       1.1X
-ElementAt codegen - Linear Lookup                           19             21           2          0.5        1917.0       1.1X
-ElementAt codegen - Hash Lookup                             19             20           1          0.5        1875.5       1.1X
-
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-MapLookup (size=100, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                     21             22           1          0.5        2121.5       1.0X
-GetMapValue interpreted - Hash Lookup                       18             20           1          0.5        1839.0       1.2X
-GetMapValue codegen - Linear Lookup                         19             20           1          0.5        1923.0       1.1X
-GetMapValue codegen - Hash Lookup                           18             20           1          0.5        1840.3       1.2X
-ElementAt interpreted - Linear Lookup                       21             22           1          0.5        2086.0       1.0X
-ElementAt interpreted - Hash Lookup                         19             20           1          0.5        1871.2       1.1X
-ElementAt codegen - Linear Lookup                           19             21           1          0.5        1913.4       1.1X
-ElementAt codegen - Hash Lookup                             18             19           1          0.5        1840.8       1.2X
-
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
 MapLookup (size=10, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                    19             20           1          0.5        1875.0       1.0X
-GetMapValue interpreted - Hash Lookup                      19             20           2          0.5        1865.2       1.0X
-GetMapValue codegen - Linear Lookup                        18             19           1          0.5        1843.4       1.0X
-GetMapValue codegen - Hash Lookup                          19             21           2          0.5        1891.7       1.0X
-ElementAt interpreted - Linear Lookup                      19             20           1          0.5        1866.3       1.0X
-ElementAt interpreted - Hash Lookup                        19             20           1          0.5        1864.8       1.0X
-ElementAt codegen - Linear Lookup                          18             19           1          0.6        1812.8       1.0X
-ElementAt codegen - Hash Lookup                            18             19           1          0.5        1847.9       1.0X
+GetMapValue interpreted - Linear Lookup                    16             18           2          0.6        1634.9       1.0X
+GetMapValue interpreted - Hash Lookup                      16             18           2          0.6        1613.5       1.0X
+GetMapValue codegen - Linear Lookup                        16             17           1          0.6        1586.8       1.0X
+GetMapValue codegen - Hash Lookup                          16             17           2          0.6        1579.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
 MapLookup (size=10, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                    18             19           1          0.6        1789.4       1.0X
-GetMapValue interpreted - Hash Lookup                      18             19           1          0.5        1818.3       1.0X
-GetMapValue codegen - Linear Lookup                        18             19           1          0.5        1820.4       1.0X
-GetMapValue codegen - Hash Lookup                          18             19           2          0.6        1812.6       1.0X
-ElementAt interpreted - Linear Lookup                      18             19           1          0.5        1831.7       1.0X
-ElementAt interpreted - Hash Lookup                        19             19           1          0.5        1858.2       1.0X
-ElementAt codegen - Linear Lookup                          18             19           1          0.5        1820.1       1.0X
-ElementAt codegen - Hash Lookup                            18             19           1          0.5        1822.6       1.0X
+GetMapValue interpreted - Linear Lookup                    16             17           2          0.6        1588.9       1.0X
+GetMapValue interpreted - Hash Lookup                      16             17           1          0.6        1588.2       1.0X
+GetMapValue codegen - Linear Lookup                        16             16           1          0.6        1552.6       1.0X
+GetMapValue codegen - Hash Lookup                          16             17           1          0.6        1552.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
 MapLookup (size=10, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                    18             19           1          0.5        1834.2       1.0X
-GetMapValue interpreted - Hash Lookup                      18             19           1          0.5        1821.2       1.0X
-GetMapValue codegen - Linear Lookup                        18             19           1          0.5        1838.8       1.0X
-GetMapValue codegen - Hash Lookup                          18             19           1          0.6        1791.8       1.0X
-ElementAt interpreted - Linear Lookup                      18             19           1          0.6        1797.1       1.0X
-ElementAt interpreted - Hash Lookup                        18             19           1          0.6        1793.7       1.0X
-ElementAt codegen - Linear Lookup                          18             19           1          0.6        1803.3       1.0X
-ElementAt codegen - Hash Lookup                            18             19           1          0.6        1796.1       1.0X
+GetMapValue interpreted - Linear Lookup                    16             17           2          0.6        1562.6       1.0X
+GetMapValue interpreted - Hash Lookup                      16             17           1          0.6        1551.1       1.0X
+GetMapValue codegen - Linear Lookup                        15             17           2          0.6        1541.1       1.0X
+GetMapValue codegen - Hash Lookup                          15             17           2          0.7        1521.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-MapLookup (size=1, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                   18             19           1          0.6        1794.5       1.0X
-GetMapValue interpreted - Hash Lookup                     18             19           1          0.6        1815.4       1.0X
-GetMapValue codegen - Linear Lookup                       18             19           1          0.6        1791.0       1.0X
-GetMapValue codegen - Hash Lookup                         18             19           1          0.6        1774.3       1.0X
-ElementAt interpreted - Linear Lookup                     18             19           1          0.6        1810.9       1.0X
-ElementAt interpreted - Hash Lookup                       18             19           1          0.5        1822.9       1.0X
-ElementAt codegen - Linear Lookup                         18             19           1          0.6        1775.3       1.0X
-ElementAt codegen - Hash Lookup                           18             19           1          0.6        1769.4       1.0X
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=1000, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                              912            945          32          0.0       91177.5       1.0X
+GetMapValue codegen                                                                  121            149          16          0.1       12104.6       7.5X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-MapLookup (size=1, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                   18             19           1          0.6        1793.9       1.0X
-GetMapValue interpreted - Hash Lookup                     18             19           1          0.6        1793.4       1.0X
-GetMapValue codegen - Linear Lookup                       18             19           1          0.6        1765.9       1.0X
-GetMapValue codegen - Hash Lookup                         18             19           1          0.6        1788.2       1.0X
-ElementAt interpreted - Linear Lookup                     18             19           1          0.6        1772.9       1.0X
-ElementAt interpreted - Hash Lookup                       18             19           1          0.6        1790.7       1.0X
-ElementAt codegen - Linear Lookup                         18             19           1          0.6        1778.2       1.0X
-ElementAt codegen - Hash Lookup                           17             19           1          0.6        1743.9       1.0X
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=1000, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             1302           1321          20          0.0      130163.7       1.0X
+GetMapValue codegen                                                                  120            140          14          0.1       12033.0      10.8X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-MapLookup (size=1, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------
-GetMapValue interpreted - Linear Lookup                   18             19           2          0.6        1798.7       1.0X
-GetMapValue interpreted - Hash Lookup                     18             19           1          0.6        1752.1       1.0X
-GetMapValue codegen - Linear Lookup                       18             18           1          0.6        1755.0       1.0X
-GetMapValue codegen - Hash Lookup                         17             19           2          0.6        1748.2       1.0X
-ElementAt interpreted - Linear Lookup                     18             19           1          0.6        1764.6       1.0X
-ElementAt interpreted - Hash Lookup                       18             19           1          0.6        1756.2       1.0X
-ElementAt codegen - Linear Lookup                         18             19           1          0.6        1755.2       1.0X
-ElementAt codegen - Hash Lookup                           17             19           1          0.6        1741.8       1.0X
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=1000, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             1668           1679          12          0.0      166807.4       1.0X
+GetMapValue codegen                                                                  120            141          12          0.1       12036.3      13.9X
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=100, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             107            113           4          0.1       10715.2       1.0X
+GetMapValue codegen                                                                  30             32           3          0.3        2974.3       3.6X
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=100, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             142            148          11          0.1       14168.0       1.0X
+GetMapValue codegen                                                                  30             32           3          0.3        2954.6       4.8X
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=100, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             176            182           5          0.1       17624.5       1.0X
+GetMapValue codegen                                                                  29             32           3          0.3        2888.2       6.1X
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=10, hit=1.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             29             30           2          0.3        2857.8       1.0X
+GetMapValue codegen                                                                 18             20           2          0.6        1806.1       1.6X
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=10, hit=0.5, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             31             34           5          0.3        3099.9       1.0X
+GetMapValue codegen                                                                 18             19           2          0.6        1770.0       1.8X
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+MapLookup: non-foldable map column (size=10, hit=0.0, type=IntegerType):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+GetMapValue interpreted                                                             33             35           3          0.3        3319.2       1.0X
+GetMapValue codegen                                                                 18             20           2          0.5        1824.9       1.8X
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/MapLookupBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/MapLookupBenchmark.scala
@@ -65,7 +65,8 @@ object MapLookupBenchmark extends SqlBasedBenchmark {
 
     // Create a DataFrame with a single column 'm' containing the map,
     // and 'k' containing the key to lookup.
-    // Use `typedLit` to create the map literal directly.
+    // Use `typedLit` to create the map literal directly, which makes `m` a foldable
+    // expression so the hash index can be built once and reused across rows.
     val keys = (0 until mapSize).toArray
     val map = keys.zip(keys.map(_.toString)).toMap
     val mapCol = typedLit(map)
@@ -77,8 +78,9 @@ object MapLookupBenchmark extends SqlBasedBenchmark {
 
     val lookupDf = lookupKeys.toDF("key").select(mapCol.as("m"), $"key")
 
+    // Only measure `GetMapValue` here: `ElementAt` on a map delegates to the same
+    // `GetMapValueUtil` machinery, so its numbers would track `GetMapValue` exactly.
     val expr = col("m").getItem(col("key"))
-    val elementAtExpr = element_at(col("m"), col("key"))
 
     benchmark.addCase("GetMapValue interpreted - Linear Lookup") { _ =>
       withSQLConf(
@@ -120,43 +122,64 @@ object MapLookupBenchmark extends SqlBasedBenchmark {
       }
     }
 
-    benchmark.addCase("ElementAt interpreted - Linear Lookup") { _ =>
-      withSQLConf(
-        SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
-        SQLConf.CODEGEN_FACTORY_MODE.key -> "NO_CODEGEN",
-        SQLConf.MAP_LOOKUP_HASH_THRESHOLD.key -> Int.MaxValue.toString,
-        SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> ConvertToLocalRelation.ruleName) {
-        lookupDf.select(elementAtExpr).noop()
-      }
+    benchmark.run()
+    System.gc()
+  }
+
+  /**
+   * Benchmark map lookup when the map comes from a row column (non-foldable). This is the
+   * common production shape (e.g. `SELECT my_map_col['k'] FROM t`). Hash lookup must not be
+   * used here regardless of threshold - with the foldable gate, `MAP_LOOKUP_HASH_THRESHOLD=0`
+   * still routes to linear scan. This benchmark verifies there is no per-row regression.
+   */
+  private def runMapCol(
+      mapSize: Int,
+      hitRate: Double,
+      keyType: DataType): Unit = {
+    val numRows = 10000
+
+    val benchmark = new Benchmark(
+      s"MapLookup: non-foldable map column (size=$mapSize, hit=$hitRate, type=$keyType)",
+      numRows,
+      NUMBER_OF_ITER,
+      output = output)
+
+    import spark.implicits._
+
+    val keys = (0 until mapSize).toArray
+    val map = keys.zip(keys.map(_.toString)).toMap
+
+    val lookupKeys = (0 until numRows).map { i =>
+      if (i < numRows * hitRate) keys(i % mapSize) else -1
     }
 
-    benchmark.addCase("ElementAt interpreted - Hash Lookup") { _ =>
+    // Column `m` is a non-foldable attribute reference: each row carries its own map value.
+    val lookupDf = lookupKeys.map(k => (map, k)).toDF("m", "key")
+
+    // Only measure `GetMapValue` here (see `run`); `ElementAt` on a map takes the same path.
+    val expr = col("m").getItem(col("key"))
+
+    // Non-foldable maps always take the linear path regardless of threshold. Setting
+    // threshold=0 (the most aggressive hash-path setting) verifies the foldable gate still
+    // blocks the hash path - if it were ever reintroduced for non-foldable maps, this
+    // benchmark would regress visibly.
+    benchmark.addCase("GetMapValue interpreted") { _ =>
       withSQLConf(
         SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
         SQLConf.CODEGEN_FACTORY_MODE.key -> "NO_CODEGEN",
         SQLConf.MAP_LOOKUP_HASH_THRESHOLD.key -> 0.toString,
         SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> ConvertToLocalRelation.ruleName) {
-        lookupDf.select(elementAtExpr).noop()
+        lookupDf.select(expr).noop()
       }
     }
 
-    benchmark.addCase("ElementAt codegen - Linear Lookup") { _ =>
-      withSQLConf(
-        SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
-        SQLConf.CODEGEN_FACTORY_MODE.key -> "CODEGEN_ONLY",
-        SQLConf.MAP_LOOKUP_HASH_THRESHOLD.key -> Int.MaxValue.toString,
-        SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> ConvertToLocalRelation.ruleName) {
-        lookupDf.select(elementAtExpr).noop()
-      }
-    }
-
-    benchmark.addCase("ElementAt codegen - Hash Lookup") { _ =>
+    benchmark.addCase("GetMapValue codegen") { _ =>
       withSQLConf(
         SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
         SQLConf.CODEGEN_FACTORY_MODE.key -> "CODEGEN_ONLY",
         SQLConf.MAP_LOOKUP_HASH_THRESHOLD.key -> 0.toString,
         SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> ConvertToLocalRelation.ruleName) {
-        lookupDf.select(elementAtExpr).noop()
+        lookupDf.select(expr).noop()
       }
     }
 
@@ -165,11 +188,21 @@ object MapLookupBenchmark extends SqlBasedBenchmark {
   }
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
-    val sizes = Seq(1000000, 100000, 10000, 1000, 100, 10, 1)
-    for (size <- sizes) {
+    // Three sizes spanning three orders of magnitude: 10000 is well above the default
+    // threshold (hash wins clearly), 1000 is at the threshold, and 10 is well below it
+    // (hash overhead dominates -- justifies the threshold default). Upper bound is capped
+    // because task serialization of a 1M-entry literal exceeds sbt's default 8g heap.
+    for (size <- Seq(10000, 1000, 10)) {
       run(size, 1.0, IntegerType)
       run(size, 0.5, IntegerType)
       run(size, 0.0, IntegerType)
+    }
+    // Non-foldable map column carries one map per row, so total memory scales with
+    // `numRows * mapSize`. Cap `mapSize` at 1000 here to stay safely below the driver heap.
+    for (size <- Seq(1000, 100, 10)) {
+      runMapCol(size, 1.0, IntegerType)
+      runMapCol(size, 0.5, IntegerType)
+      runMapCol(size, 0.0, IntegerType)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to #54748 (SPARK-55959). That PR added a hash-based lookup path to
`GetMapValueUtil` gated by `spark.sql.optimizer.mapLookupHashThreshold`, but the
hash table was rebuilt per row for non-foldable map columns because the
reference-identity cache (`$keys != $lastKeyArray` / `lastMap ne map`) only
hits when the `MapData` instance is reused across rows. `UnsafeRow.getMap()`
allocates a fresh `UnsafeMapData` on every call, so the cache never hit in the
common production case. The benchmark used `typedLit(map)` (a `Literal` whose
`eval` returns the same Scala object every row), which masked the miss.

This PR:
1. **Gates the hash path on `child.foldable`.** Non-foldable maps always use the
   linear scan - their hash index cannot be reused across rows, so the per-row
   build cost would exceed the scan it replaces.
2. **Restructures the two execution paths as a strategy ADT on the trait:**
   a `MapLookupExecutor` sealed inner trait with `LinearExecutor` (stateless
   path-dependent `object`) and `PrebuiltHashExecutor` (holds the pre-built
   lookup state for a constant map). `getValueEval` and `doGetValueGenCode`
   become one-line delegators; the choice is made once in `chooseExecutor`.
   This replaces the null-sentinel `foldableMapIndex` field and the
   `if (index != null)` branches that were duplicated between eval and codegen.
3. **Simplifies codegen:** no runtime threshold branch, no mutable state, no
   reference-identity check. For the foldable path, the `int[] buckets` open-
   addressing table, the `keyArray` / `valueArray`, and the generic
   `HashMap[Any, Int]` (for interpreted) are built once on the driver and
   embedded in the generated class via `addReferenceObj`. The generated per-row
   codegen still uses SPARK-55959's inline primitive hash over the bucket array
   - no autoboxing in the hot loop.
4. **Unifies the type predicate on `TypeUtils.typeWithProperEquals`;** removes
   the codegen-only `supportsHashLookup` whitelist. The two predicates agreed
   on all *reachable* map-key types in practice (Variant is prohibited by
   `checkForMapKeyType`; Geography/Geometry with inherited Object equals
   already have this constraint on SPARK-55959's interpretive path). Unifying
   on one predicate removes a drift hazard.
5. **Adds `usesFoldableHashLookup` (visible for testing)** on `GetMapValueUtil`
   so tests can assert strategy choice directly, plus updates the config doc
   and minor grammar fixes.

### Why are the changes needed?

For realistic queries like `SELECT my_map_col['k'] FROM t` with maps above
the default threshold (1000 entries), the hash path was rebuilding the table
per row. Per-row hash build (O(n) hash computes + array writes) has higher
constant factors than the O(n) linear scan it replaces for a single lookup
per row, so the original optimization could regress this shape. Gating on
foldability ensures the index is only built when it can actually be reused
across rows - which is the regime where it wins.

Local benchmark evidence confirming both that (a) the fix eliminates the
non-foldable regression and (b) foldable-map performance is unchanged vs
SPARK-55959 is posted below in the PR conversation.

### Does this PR introduce _any_ user-facing change?

No. Behavior for foldable map lookups (constants / literals) is unchanged.
Non-foldable map lookups revert to the pre-SPARK-55959 linear-scan path,
which fixes the latent regression.

### How was this patch tested?

- Existing parameterized tests in `ComplexTypeSuite` and
  `CollectionExpressionsSuite` continue to pass with both `threshold=0`
  (hash path taken for foldable maps) and `threshold=Int.MaxValue` (linear
  path taken).
- New test `GetMapValue - non-foldable map always uses linear scan`:
  behavior + `usesFoldableHashLookup` assertion - a `BoundReference`-backed
  map column (non-foldable) evaluates correctly for both `GetMapValue` and
  `ElementAt`, and is confirmed to land on `LinearExecutor` even with
  `threshold=0`.
- New test `GetMapValue - strategy choice for foldable maps`: asserts that a
  foldable map above threshold lands on `PrebuiltHashExecutor`, below
  threshold falls back to `LinearExecutor`, and that unsupported key types
  (e.g. `BinaryType`) always land on `LinearExecutor` regardless of
  threshold.
- Benchmark code adds a `runMapCol` variant so the non-foldable shape is
  measured alongside the existing foldable-literal cases (local results
  posted below; `*-results.txt` should be regenerated on CI for consistent
  hardware).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7