### PR TITLE
[SPARK-56522][SQL][TESTS][FOLLOWUP] Replace em-dash with ASCII in `VectorizedRleValuesReaderSuite` docstring

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReaderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReaderSuite.scala
@@ -134,8 +134,8 @@ private object VectorizedRleValuesReaderSuite {
 
   /**
    * Runs readBatch end-to-end and asserts null-bits, non-null values, and def levels.
-   * Each batch uses a fresh output vector since `state.valueOffset` resets to 0 per batch —
-   * mirrors production where `VectorizedColumnReader` hands in a batch-sized vector.
+   * Each batch uses a fresh output vector since `state.valueOffset` resets to 0 per batch,
+   * mirroring production where `VectorizedColumnReader` hands in a batch-sized vector.
    */
   // Non-trivial value formula: off-by-one mismatches won't coincidentally align.
   private def valueAt(idx: Int): Int = idx * 100 + 7


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace a non-ASCII em-dash (U+2014) in the `runAndAssert` docstring of `VectorizedRleValuesReaderSuite` with an ASCII comma, following `cloud-fan`'s post-merge review comment on PR #55386.

### Why are the changes needed?

Spark's convention is ASCII-only in code and comments.

### Does this PR introduce _any_ user-facing change?

No. 

### How was this patch tested?

Grep for non-ASCII in the file returns empty after the change.

### Was this patch authored or co-authored using generative AI tooling?

No

