### PR TITLE
[SPARK-40193][SQL][FOLLOWUP] Restrict cached-side If wrapping to original cached range

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PlanMerger.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PlanMerger.scala
@@ -397,12 +397,11 @@ class PlanMerger(
               }
           }
         case (np: Filter, cp) if filterPropagationSupported =>
+          // The recursion keeps `cp` unchanged and `cp` is not a Filter at this level, so no
+          // deeper case can expose a Filter on the cp side. cpFilter is therefore always None
+          // in the child result.
           tryMergePlans(np.child, cp, filterPropagationSupported).collect {
-            // If the cp side already propagated a filter from deeper recursion, the merge is
-            // effectively symmetric (both sides have a filter condition). Abort unless
-            // symmetricFilterPropagationEnabled.
-            case TryMergeResult(mergedChild, npMapping, cpMapping, npFilter, cpFilter)
-                if cpFilter.isEmpty || symmetricFilterPropagationEnabled =>
+            case TryMergeResult(mergedChild, npMapping, cpMapping, npFilter, None) =>
               val mappedNPCondition = mapAttributes(np.condition, npMapping)
               val newNPCondition = npFilter.fold(mappedNPCondition) {
                 case (f, _) => And(f, mappedNPCondition)
@@ -411,26 +410,25 @@ class PlanMerger(
                 Alias(newNPCondition, s"propagatedFilter_${PlanMerger.newId}")()
               val newNPFilter = newNPFilterAlias.toAttribute
               val project = Project(
-                mergedChild.output.toList ++ Seq(newNPFilterAlias) ++ cpFilter.toSeq,
+                mergedChild.output :+ newNPFilterAlias,
                 mergedChild)
-              TryMergeResult(project, npMapping, cpMapping, Some((newNPFilter, true)), cpFilter)
+              TryMergeResult(project, npMapping, cpMapping, Some((newNPFilter, true)), None)
           }
         case (np, cp: Filter) if filterPropagationSupported =>
+          // Symmetric to the previous case: `np` is unchanged and is not a Filter, so no
+          // deeper case can expose a Filter on the np side. npFilter is always None in the
+          // child result.
           tryMergePlans(np, cp.child, filterPropagationSupported).collect {
-            // If the np side already propagated a filter from deeper recursion, the merge is
-            // effectively symmetric (both sides have a filter condition). Abort unless
-            // symmetricFilterPropagationEnabled.
-            case TryMergeResult(mergedChild, npMapping, cpMapping, npFilter, cpFilter)
-                if npFilter.isEmpty || symmetricFilterPropagationEnabled =>
+            case TryMergeResult(mergedChild, npMapping, cpMapping, None, cpFilter) =>
               val mappedCPCondition = mapAttributes(cp.condition, cpMapping)
               val newCPCondition = cpFilter.fold(mappedCPCondition)(And(_, mappedCPCondition))
               val newCPFilterAlias =
                 Alias(newCPCondition, s"propagatedFilter_${PlanMerger.newId}")()
               val newCPFilter = newCPFilterAlias.toAttribute
               val project = Project(
-                mergedChild.output.toList ++ npFilter.map(_._1).toSeq ++ Seq(newCPFilterAlias),
+                mergedChild.output :+ newCPFilterAlias,
                 mergedChild)
-              TryMergeResult(project, npMapping, cpMapping, npFilter, Some(newCPFilter))
+              TryMergeResult(project, npMapping, cpMapping, None, Some(newCPFilter))
           }
 
         case (np: Join, cp: Join) if np.joinType == cp.joinType && np.hint == cp.hint =>
@@ -526,10 +524,15 @@ class PlanMerger(
     // Wrap unmatched cached expressions with the cached plan's filter so they are only computed
     // for rows that belong to the cached plan side. Plain attribute references are not wrapped.
     // Record each attr rewrite in the cached plan map so ancestor nodes can remap their stale
-    // references.
+    // references. Only iterate over the original cached range; new-plan expressions appended
+    // above were already wrapped with the new plan's filter and must not be double-wrapped.
+    val cachedPlanLength = cachedPlanExpressions.length
     val newCPMapping = AttributeMap(cachedPlanFilter.toSeq.flatMap { f =>
-      mergedExpressions.zipWithIndex.flatMap {
-        case (ce, i) if !matchedCachedIndices.contains(i) =>
+      (0 until cachedPlanLength).flatMap { i =>
+        if (matchedCachedIndices.contains(i)) {
+          None
+        } else {
+          val ce = mergedExpressions(i)
           val withoutAlias = ce match {
             case Alias(child, _) => child
             case e => e
@@ -541,7 +544,7 @@ class PlanMerger(
             mergedExpressions(i) = newAlias
             ce.toAttribute -> newAlias.toAttribute
           }
-        case _ => None
+        }
       }
     })
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PlanMerger.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PlanMerger.scala
@@ -397,11 +397,15 @@ class PlanMerger(
               }
           }
         case (np: Filter, cp) if filterPropagationSupported =>
-          // The recursion keeps `cp` unchanged and `cp` is not a Filter at this level, so no
-          // deeper case can expose a Filter on the cp side. cpFilter is therefore always None
-          // in the child result.
-          tryMergePlans(np.child, cp, filterPropagationSupported).collect {
-            case TryMergeResult(mergedChild, npMapping, cpMapping, npFilter, None) =>
+          // The recursion keeps `cp` unchanged and `cp` is not a Filter or Project at this level
+          // (earlier cases would have matched), and no case in the recursion unwraps a non-Filter
+          // non-Project `cp` to expose a deeper Filter. cpFilter is therefore always None in the
+          // child result; assert rather than silently drop so that a future case added above
+          // cannot quietly invalidate this invariant.
+          tryMergePlans(np.child, cp, filterPropagationSupported).map {
+            case TryMergeResult(mergedChild, npMapping, cpMapping, npFilter, cpFilter) =>
+              assert(cpFilter.isEmpty,
+                "cpFilter unexpectedly propagated from deeper recursion in (np: Filter, cp) case")
               val mappedNPCondition = mapAttributes(np.condition, npMapping)
               val newNPCondition = npFilter.fold(mappedNPCondition) {
                 case (f, _) => And(f, mappedNPCondition)
@@ -415,11 +419,13 @@ class PlanMerger(
               TryMergeResult(project, npMapping, cpMapping, Some((newNPFilter, true)), None)
           }
         case (np, cp: Filter) if filterPropagationSupported =>
-          // Symmetric to the previous case: `np` is unchanged and is not a Filter, so no
-          // deeper case can expose a Filter on the np side. npFilter is always None in the
-          // child result.
-          tryMergePlans(np, cp.child, filterPropagationSupported).collect {
-            case TryMergeResult(mergedChild, npMapping, cpMapping, None, cpFilter) =>
+          // Symmetric to the previous case: `np` is unchanged and is not a Filter or Project at
+          // this level, and no case in the recursion unwraps it to expose a deeper Filter.
+          // npFilter is always None in the child result; assert rather than silently drop.
+          tryMergePlans(np, cp.child, filterPropagationSupported).map {
+            case TryMergeResult(mergedChild, npMapping, cpMapping, npFilter, cpFilter) =>
+              assert(npFilter.isEmpty,
+                "npFilter unexpectedly propagated from deeper recursion in (np, cp: Filter) case")
               val mappedCPCondition = mapAttributes(cp.condition, cpMapping)
               val newCPCondition = cpFilter.fold(mappedCPCondition)(And(_, mappedCPCondition))
               val newCPFilterAlias =
@@ -526,9 +532,8 @@ class PlanMerger(
     // Record each attr rewrite in the cached plan map so ancestor nodes can remap their stale
     // references. Only iterate over the original cached range; new-plan expressions appended
     // above were already wrapped with the new plan's filter and must not be double-wrapped.
-    val cachedPlanLength = cachedPlanExpressions.length
     val newCPMapping = AttributeMap(cachedPlanFilter.toSeq.flatMap { f =>
-      (0 until cachedPlanLength).flatMap { i =>
+      cachedPlanExpressions.indices.flatMap { i =>
         if (matchedCachedIndices.contains(i)) {
           None
         } else {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/MergeSubplansSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/MergeSubplansSuite.scala
@@ -1456,6 +1456,65 @@ class MergeSubplansSuite extends PlanTest {
     comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
   }
 
+  test("SPARK-40193: Merge non-grouping subqueries with different filter conditions and " +
+      "non-attribute Project expressions on both sides") {
+    val subquery1 = ScalarSubquery(
+      testRelation.where($"a" > 1).select(($"a" * 2).as("x")).groupBy()(sum($"x").as("sum_x")))
+    val subquery2 = ScalarSubquery(
+      testRelation.where($"a" < 1).select(($"a" + 1).as("y")).groupBy()(max($"y").as("max_y")))
+    val originalQuery = testRelation.select(subquery1, subquery2)
+
+    // Merge steps:
+    // Inner Filter level - (np: Filter(a < 1), cp: Filter(a > 1)):
+    //   Different conditions -> symmetric first-time filter propagation.
+    //   f0 = Alias(a < 1, "propagatedFilter_0")  -- np
+    //   f1 = Alias(a > 1, "propagatedFilter_1")  -- cp
+    //   -> Project([a, b, c, f0Alias, f1Alias], testRelation)
+    //   -> Filter(OR(f0, f1), above)  [tagged]
+    //   propagates (Some(f0), Some(f1)) upward
+    //
+    // Outer Project level - (np: Project(a + 1 AS y), cp: Project(a * 2 AS x)):
+    //   Both sides have non-matching, non-attribute projections. Each side's projection is
+    //   wrapped with its own filter: np's a + 1 with f0, cp's a * 2 with f1. The cached-side
+    //   wrapping must touch only original cached entries; it must not double-wrap the np-
+    //   appended entry with f1.
+    //   -> Project([If(f1, a * 2, null) AS x, If(f0, a + 1, null) AS y, f0, f1], innerFilter)
+    //
+    // Aggregate consumes:
+    //   sum(x) FILTER f1  -- cp: rows where a > 1
+    //   max(y) FILTER f0  -- np: rows where a < 1
+    val f0Alias = Alias($"a" < 1, "propagatedFilter_0")()
+    val f1Alias = Alias($"a" > 1, "propagatedFilter_1")()
+    val f0 = f0Alias.toAttribute
+    val f1 = f1Alias.toAttribute
+    val intType = testRelation.output.head.dataType
+    val xAlias = Alias(If(f1, $"a" * 2, Literal(null, intType)), "x")()
+    val yAlias = Alias(If(f0, $"a" + 1, Literal(null, intType)), "y")()
+    val x = xAlias.toAttribute
+    val y = yAlias.toAttribute
+    val mergedSubquery = testRelation
+      .select(testRelation.output ++ Seq(f0Alias, f1Alias): _*)
+      .where(Or(f0, f1))
+      .select(xAlias, yAlias, f0, f1)
+      .groupBy()(
+        sum(x, Some(f1)).as("sum_x"),
+        max(y, Some(f0)).as("max_y"))
+      .select(CreateNamedStruct(Seq(
+        Literal("sum_x"), $"sum_x",
+        Literal("max_y"), $"max_y"
+      )).as("mergedValue"))
+    val analyzedMergedSubquery = mergedSubquery.analyze
+    val correctAnswer = WithCTE(
+      testRelation.select(
+        extractorExpression(0, analyzedMergedSubquery.output, 0),
+        extractorExpression(0, analyzedMergedSubquery.output, 1)),
+      Seq(definitionNode(analyzedMergedSubquery, 0)))
+
+    withSQLConf(SQLConf.MERGE_SUBPLANS_SYMMETRIC_FILTER_PROPAGATION_ENABLED.key -> "true") {
+      comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
+    }
+  }
+
   test("SPARK-40193: Merge non-grouping subqueries where one aggregate already carries a " +
       "FILTER clause") {
     val subquery1 = ScalarSubquery(testRelation.groupBy()(max($"a").as("max_a")))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to #55298 (SPARK-40193). Two related cleanups to `PlanMerger`'s filter propagation:

1. **Correctness fix in `mergeNamedExpressions`.** Wrapping of unmatched cached expressions with the cached plan's filter now iterates only over the original cached range `[0, cachedPlanExpressions.length)`, not over all of `mergedExpressions`. The previous loop also touched new-plan entries that were appended earlier in the same call and already wrapped with the new plan's filter.

2. **Tighten the `(np: Filter, cp)` / `(np, cp: Filter)` cases in `tryMergePlans`.** Drop the structurally unreachable branches that appended `cpFilter.toSeq` / `npFilter.map(_._1).toSeq` to the new `Project` and the corresponding `symmetricFilterPropagationEnabled` escape in the guard. In both cases the recursion keeps the non-Filter side unchanged, so no deeper case can expose a `Filter` on that side — the child result always has `cpFilter = None` / `npFilter = None`. Matching `None` explicitly makes the invariant explicit and removes dead code that would have produced a `Project` with duplicate attributes if ever reached.

### Why are the changes needed?

For (1): with symmetric filter propagation enabled (`spark.sql.optimizer.mergeSubplans.symmetricFilterPropagation.enabled = true`) and non-attribute `Project` expressions on both sides of the merge, the cached-side loop double-wrapped new-plan-appended expressions with `If(cpFilter, If(npFilter, expr, null), null)` and replaced the slot in `mergedExpressions` with a new `Alias` (fresh `exprId`). The `newNPMapping` built earlier in the same call still pointed at the single-wrap alias's attribute, so the parent `Aggregate` was rewritten to reference an attribute that was no longer in the merged `Project`'s output. The resulting plan failed analysis with `MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_APPEAR_IN_OPERATION`.

Minimal reproducer (fails on master before this PR):

```scala
withSQLConf(SQLConf.MERGE_SUBPLANS_SYMMETRIC_FILTER_PROPAGATION_ENABLED.key -> "true") {
  val subquery1 = ScalarSubquery(
    testRelation.where($"a" > 1).select(($"a" * 2).as("x")).groupBy()(sum($"x").as("sum_x")))
  val subquery2 = ScalarSubquery(
    testRelation.where($"a" < 1).select(($"a" + 1).as("y")).groupBy()(max($"y").as("max_y")))
  val df = testRelation.select(subquery1, subquery2).analyze
  MergeSubplans(df)  // analyzer error: Resolved attribute(s) "y" missing from "x", "y", ...
}
```

For (2): the branches in question are unreachable by case analysis and the appended `cpFilter.toSeq` / `npFilter.map(_._1).toSeq` would duplicate an attribute already present in `mergedChild.output`. Removing them makes the reachable contract explicit.

### Does this PR introduce _any_ user-facing change?

No. The bug was only observable as an analyzer failure, and only when `spark.sql.optimizer.mergeSubplans.symmetricFilterPropagation.enabled` (which defaults to `false`) was enabled together with subqueries whose merge path exercises non-attribute `Project` expressions on both sides. Behavior otherwise matches the released master.

### How was this patch tested?

- New unit test `MergeSubplansSuite`: `"SPARK-40193: Merge non-grouping subqueries with different filter conditions and non-attribute Project expressions on both sides"` — fails on master without the fix (analysis error), passes with the fix.
- Full `MergeSubplansSuite` (42 tests) and `PlanMergeSuite` (12 tests) continue to pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 4.5

This pull request and its description were written by Isaac.