### PR TITLE
[SPARK-56590][K8S] Add Java-friendly getters for driver resources of `KubernetesDriverSpec`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesDriverSpec.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesDriverSpec.scala
@@ -42,6 +42,16 @@ case class KubernetesDriverSpec(
   /** Get system properties as a Java-friendly map. */
   @Since("4.2.0")
   def getSystemPropertiesAsJavaMap: JMap[String, String] = systemProperties.asJava
+
+  /** Get driver pre Kubernetes resources as a Java-friendly list. */
+  @Since("4.2.0")
+  def getDriverPreKubernetesResourcesAsJavaList: JList[HasMetadata] =
+    driverPreKubernetesResources.asJava
+
+  /** Get driver Kubernetes resources as a Java-friendly list. */
+  @Since("4.2.0")
+  def getDriverKubernetesResourcesAsJavaList: JList[HasMetadata] =
+    driverKubernetesResources.asJava
 }
 
 @Unstable

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesDriverSpecSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesDriverSpecSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.deploy.k8s
 
-import java.util.{Arrays, HashMap, Map => JMap}
+import java.util.{Arrays, HashMap, List => JList, Map => JMap}
 
 import io.fabric8.kubernetes.api.model.{ContainerBuilder, HasMetadata, PodBuilder, SecretBuilder}
 
@@ -56,6 +56,16 @@ class KubernetesDriverSpecSuite extends SparkFunSuite {
     assert(javaProps.size() === 2)
     assert(javaProps.get("spark.key1") === "value1")
     assert(javaProps.get("spark.key2") === "value2")
+
+    val javaPreResources = spec.getDriverPreKubernetesResourcesAsJavaList
+    assert(javaPreResources.isInstanceOf[JList[_]])
+    assert(javaPreResources.size() === 1)
+    assert(javaPreResources.get(0) === secret)
+
+    val javaResources = spec.getDriverKubernetesResourcesAsJavaList
+    assert(javaResources.isInstanceOf[JList[_]])
+    assert(javaResources.size() === 1)
+    assert(javaResources.get(0) === secret)
   }
 
   test("create from empty Java collections") {
@@ -70,5 +80,7 @@ class KubernetesDriverSpecSuite extends SparkFunSuite {
     assert(spec.driverKubernetesResources.isEmpty)
     assert(spec.systemProperties.isEmpty)
     assert(spec.getSystemPropertiesAsJavaMap.isEmpty)
+    assert(spec.getDriverPreKubernetesResourcesAsJavaList.isEmpty)
+    assert(spec.getDriverKubernetesResourcesAsJavaList.isEmpty)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds Java-friendly APIs for `driverPreKubernetesResources` and `driverKubernetesResources` fields in `KubernetesDriverSpec`.

- `getDriverPreKubernetesResourcesAsJavaList`: returns `driverPreKubernetesResources` as `java.util.List[HasMetadata]`.
- `getDriverKubernetesResourcesAsJavaList`: returns `driverKubernetesResources` as `java.util.List[HasMetadata]`.

### Why are the changes needed?

`KubernetesDriverSpec` is a `@DeveloperApi` that is also intended for use by the Spark K8s operator. While `systemProperties` already exposes a Java-friendly accessor (`getSystemPropertiesAsJavaMap`), the `Seq[HasMetadata]` fields require Java callers to perform Scala-to-Java conversions manually. Providing symmetric Java-friendly accessors makes the API consistent and convenient for Java consumers.

### Does this PR introduce _any_ user-facing change?

No. This only adds new accessor methods to an `@Unstable` `@DeveloperApi`.

### How was this patch tested?

Pass the CIs with newly updated test cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code