### PR TITLE
[SPARK-56589][CORE] Use Virtual Threads for BlockManagerMasterEndpoint ask thread pool

### DIFF
--- a/core/benchmarks/BlockManagerMasterEndpointAskBenchmark-jdk21-results.txt
+++ b/core/benchmarks/BlockManagerMasterEndpointAskBenchmark-jdk21-results.txt
@@ -1,0 +1,26 @@
+================================================================================================
+Ask fan-out (20ms simulated RPC per endpoint)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11 on Mac OS X 26.4
+Apple M4 Pro
+Fan-out over 50 endpoints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Platform threads (cap=100)                           26             28           1          0.0      520361.7       1.0X
+Virtual threads                                      20             24           2          0.0      408295.8       1.3X
+
+OpenJDK 64-Bit Server VM 21.0.11 on Mac OS X 26.4
+Apple M4 Pro
+Fan-out over 500 endpoints:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Platform threads (cap=100)                          123            126           1          0.0      245398.6       1.0X
+Virtual threads                                      21             24           2          0.0       42824.5       5.7X
+
+OpenJDK 64-Bit Server VM 21.0.11 on Mac OS X 26.4
+Apple M4 Pro
+Fan-out over 5000 endpoints:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Platform threads (cap=100)                         1168           1170           3          0.0      233611.8       1.0X
+Virtual threads                                      31             34           2          0.2        6128.1      38.1X
+
+

--- a/core/benchmarks/BlockManagerMasterEndpointAskBenchmark-jdk21-results.txt
+++ b/core/benchmarks/BlockManagerMasterEndpointAskBenchmark-jdk21-results.txt
@@ -6,21 +6,21 @@ OpenJDK 64-Bit Server VM 21.0.11 on Mac OS X 26.4
 Apple M4 Pro
 Fan-out over 50 endpoints:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Platform threads (cap=100)                           26             28           1          0.0      520361.7       1.0X
-Virtual threads                                      20             24           2          0.0      408295.8       1.3X
+Platform threads (cap=100)                           25             27           1          0.0      508253.3       1.0X
+Virtual threads                                      20             23           2          0.0      407845.8       1.2X
 
 OpenJDK 64-Bit Server VM 21.0.11 on Mac OS X 26.4
 Apple M4 Pro
 Fan-out over 500 endpoints:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Platform threads (cap=100)                          123            126           1          0.0      245398.6       1.0X
-Virtual threads                                      21             24           2          0.0       42824.5       5.7X
+Platform threads (cap=100)                          123            126           2          0.0      246260.9       1.0X
+Virtual threads                                      22             25           2          0.0       43250.8       5.7X
 
 OpenJDK 64-Bit Server VM 21.0.11 on Mac OS X 26.4
 Apple M4 Pro
 Fan-out over 5000 endpoints:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Platform threads (cap=100)                         1168           1170           3          0.0      233611.8       1.0X
-Virtual threads                                      31             34           2          0.2        6128.1      38.1X
+Platform threads (cap=100)                         1162           1165           3          0.0      232387.6       1.0X
+Virtual threads                                      32             35           2          0.2        6301.4      36.9X
 
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -688,6 +688,17 @@ package object config {
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
 
+  private[spark] val STORAGE_BLOCK_MANAGER_MASTER_VIRTUAL_THREADS =
+    ConfigBuilder("spark.storage.blockManagerMaster.virtualThread.enabled")
+      .doc("If true and running on Java 21+, the BlockManagerMasterEndpoint uses virtual " +
+        "threads for its ask thread pool. This can reduce latency of fan-out operations " +
+        "such as removeRdd / removeShuffle / replication on clusters with many executors, " +
+        "where the existing platform-thread cap (100) serializes the Future.sequence " +
+        "fan-out. Has no effect on Java versions earlier than 21.")
+      .version("4.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val STORAGE_CLEANUP_FILES_AFTER_EXECUTOR_EXIT =
     ConfigBuilder("spark.storage.cleanupFilesAfterExecutorExit")
       .doc("Whether or not cleanup the files not served by the external shuffle service " +

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -19,7 +19,7 @@ package org.apache.spark.storage
 
 import java.io.IOException
 import java.util.{HashMap => JHashMap}
-import java.util.concurrent.{Executors, ExecutorService, TimeUnit}
+import java.util.concurrent.{Executors, ExecutorService, ThreadFactory, TimeUnit}
 
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future, TimeoutException}
@@ -1014,14 +1014,34 @@ private[storage] object BlockManagerMasterEndpoint {
 
   /**
    * Build the `ExecutorService` for the ask thread pool. Uses reflection to
-   * invoke `Executors.newVirtualThreadPerTaskExecutor()` so the source
-   * remains compatible with Java 17, same pattern as SPARK-50383.
+   * stay compatible with Java 17 (same pattern as SPARK-50383). On Java 21+
+   * with the config enabled, this is equivalent to:
+   * {{{
+   *   Executors.newThreadPerTaskExecutor(
+   *     Thread.ofVirtual().name("block-manager-ask-", 0).factory())
+   * }}}
+   * which produces virtual threads named `block-manager-ask-NN` so that
+   * thread dumps mirror the platform-thread pool naming.
    */
   private[storage] def createAskThreadPool(conf: SparkConf): ExecutorService = {
     if (shouldUseVirtualThreads(conf)) {
-      val newVirtualThreadPerTaskExecutor =
-        classOf[Executors].getMethod("newVirtualThreadPerTaskExecutor")
-      newVirtualThreadPerTaskExecutor.invoke(null).asInstanceOf[ExecutorService]
+      // Methods are resolved via the public `Thread.Builder` interface because
+      // `Thread.ofVirtual()` returns an instance of a JDK-internal concrete
+      // class (`java.lang.ThreadBuilders$VirtualThreadBuilder`) that is not
+      // accessible for reflective `invoke`.
+      val builderClass = Utils.classForName("java.lang.Thread$Builder")
+      val ofVirtual = classOf[Thread].getMethod("ofVirtual").invoke(null)
+      val namedBuilder = builderClass
+        .getMethod("name", classOf[String], java.lang.Long.TYPE)
+        .invoke(ofVirtual, "block-manager-ask-", java.lang.Long.valueOf(0L))
+      val factory = builderClass
+        .getMethod("factory")
+        .invoke(namedBuilder)
+        .asInstanceOf[ThreadFactory]
+      classOf[Executors]
+        .getMethod("newThreadPerTaskExecutor", classOf[ThreadFactory])
+        .invoke(null, factory)
+        .asInstanceOf[ExecutorService]
     } else {
       ThreadUtils.newDaemonCachedThreadPool("block-manager-ask-thread-pool", 100)
     }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -19,7 +19,7 @@ package org.apache.spark.storage
 
 import java.io.IOException
 import java.util.{HashMap => JHashMap}
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{Executors, ExecutorService, TimeUnit}
 
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future, TimeoutException}
@@ -99,8 +99,23 @@ class BlockManagerMasterEndpoint(
   // Maximum number of merger locations to cache
   private val maxRetainedMergerLocations = conf.get(config.SHUFFLE_MERGER_MAX_RETAINED_LOCATIONS)
 
-  private val askThreadPool =
-    ThreadUtils.newDaemonCachedThreadPool("block-manager-ask-thread-pool", 100)
+  // When enabled and running on Java 21+, use virtual threads for the ask pool
+  // to avoid the platform-thread cap (100) serializing Future.sequence fan-outs
+  // such as removeRdd / removeShuffle / replication on large clusters.
+  // Construction is delegated to the companion object so tests can exercise it
+  // directly. Same reflection-based pattern as SPARK-50383 (RestSubmissionServer)
+  // and SPARK-56297.
+  private val askThreadPool: ExecutorService = {
+    val vtRequested = conf.get(config.STORAGE_BLOCK_MANAGER_MASTER_VIRTUAL_THREADS)
+    if (vtRequested && !Utils.isJavaVersionAtLeast21) {
+      logWarning(log"${MDC(CONFIG, config.STORAGE_BLOCK_MANAGER_MASTER_VIRTUAL_THREADS.key)}" +
+        log" is enabled but requires Java 21+; falling back to a cached platform-thread pool.")
+    } else if (BlockManagerMasterEndpoint.shouldUseVirtualThreads(conf)) {
+      logInfo(log"Using virtual threads for block-manager-ask-thread-pool" +
+        log" (${MDC(CONFIG, config.STORAGE_BLOCK_MANAGER_MASTER_VIRTUAL_THREADS.key)}=true).")
+    }
+    BlockManagerMasterEndpoint.createAskThreadPool(conf)
+  }
   private implicit val askExecutionContext: ExecutionContextExecutorService =
     ExecutionContext.fromExecutorService(askThreadPool)
 
@@ -983,6 +998,33 @@ class BlockManagerMasterEndpoint(
 
   override def onStop(): Unit = {
     askThreadPool.shutdownNow()
+  }
+}
+
+private[storage] object BlockManagerMasterEndpoint {
+  /**
+   * Whether the ask thread pool should be backed by Java virtual threads.
+   * Requires both Java 21+ and
+   * [[config.STORAGE_BLOCK_MANAGER_MASTER_VIRTUAL_THREADS]] to be enabled.
+   */
+  private[storage] def shouldUseVirtualThreads(conf: SparkConf): Boolean = {
+    Utils.isJavaVersionAtLeast21 &&
+      conf.get(config.STORAGE_BLOCK_MANAGER_MASTER_VIRTUAL_THREADS)
+  }
+
+  /**
+   * Build the `ExecutorService` for the ask thread pool. Uses reflection to
+   * invoke `Executors.newVirtualThreadPerTaskExecutor()` so the source
+   * remains compatible with Java 17, same pattern as SPARK-50383.
+   */
+  private[storage] def createAskThreadPool(conf: SparkConf): ExecutorService = {
+    if (shouldUseVirtualThreads(conf)) {
+      val newVirtualThreadPerTaskExecutor =
+        classOf[Executors].getMethod("newVirtualThreadPerTaskExecutor")
+      newVirtualThreadPerTaskExecutor.invoke(null).asInstanceOf[ExecutorService]
+    } else {
+      ThreadUtils.newDaemonCachedThreadPool("block-manager-ask-thread-pool", 100)
+    }
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerMasterEndpointAskBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerMasterEndpointAskBenchmark.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage
+
+import java.util.concurrent.ExecutorService
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+
+import org.apache.spark.SparkConf
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+import org.apache.spark.internal.config.STORAGE_BLOCK_MANAGER_MASTER_VIRTUAL_THREADS
+import org.apache.spark.util.{ThreadUtils, Utils}
+
+/**
+ * Benchmark the fan-out behaviour of the `BlockManagerMasterEndpoint` ask
+ * thread pool under platform threads (current default, cap 100) and under
+ * virtual threads (SPARK-49807).
+ *
+ * The benchmark submits `N` concurrent tasks, each sleeping `sleepMillis` to
+ * simulate an RPC round-trip, and measures wall-clock time for the whole
+ * `Future.sequence`. With the 100-thread cap, N > 100 serialises into
+ * `ceil(N/100)` waves; virtual threads should complete in ~1 wave regardless
+ * of N.
+ *
+ * {{{
+ *   To run this benchmark:
+ *   1. build/sbt "core/Test/runMain \
+ *        org.apache.spark.storage.BlockManagerMasterEndpointAskBenchmark"
+ *   2. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt \
+ *        "core/Test/runMain org.apache.spark.storage.BlockManagerMasterEndpointAskBenchmark"
+ *      Results will be written to
+ *      "core/benchmarks/BlockManagerMasterEndpointAskBenchmark-results.txt".
+ *   Virtual-thread cases require Java 21+ and are skipped on earlier JDKs.
+ * }}}
+ */
+object BlockManagerMasterEndpointAskBenchmark extends BenchmarkBase {
+
+  /** Simulated RPC round-trip latency per task. */
+  private val sleepMillis = 20L
+
+  /** Number of benchmark iterations per case. */
+  private val iterations = 3
+
+  /** Upper bound for any individual fan-out run. */
+  private val awaitTimeout = 5.minutes
+
+  private val platformConf = new SparkConf()
+  private val virtualConf = new SparkConf()
+    .set(STORAGE_BLOCK_MANAGER_MASTER_VIRTUAL_THREADS, true)
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    runBenchmark(s"Ask fan-out (${sleepMillis}ms simulated RPC per endpoint)") {
+      Seq(50, 500, 5000).foreach { n =>
+        val benchmark = new Benchmark(
+          s"Fan-out over $n endpoints", n.toLong, iterations, output = output)
+
+        benchmark.addCase("Platform threads (cap=100)") { _ =>
+          val pool = BlockManagerMasterEndpoint.createAskThreadPool(platformConf)
+          try runFanout(pool, n) finally pool.shutdownNow()
+        }
+
+        if (Utils.isJavaVersionAtLeast21) {
+          benchmark.addCase("Virtual threads") { _ =>
+            val pool = BlockManagerMasterEndpoint.createAskThreadPool(virtualConf)
+            try runFanout(pool, n) finally pool.shutdownNow()
+          }
+        }
+
+        benchmark.run()
+      }
+    }
+  }
+
+  private def runFanout(pool: ExecutorService, n: Int): Unit = {
+    implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(pool)
+    val futures = (1 to n).map(_ => Future(Thread.sleep(sleepMillis)))
+    ThreadUtils.awaitResult(Future.sequence(futures), awaitTimeout)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerMasterEndpointVirtualThreadsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerMasterEndpointVirtualThreadsSuite.scala
@@ -51,6 +51,12 @@ class BlockManagerMasterEndpointVirtualThreadsSuite extends SparkFunSuite {
     ThreadUtils.awaitResult(Future { isVirtualThread(Thread.currentThread()) }(ec), 5.seconds)
   }
 
+  /** Submit a task to the pool and return the executing thread's name. */
+  private def threadNameFromPool(pool: ExecutorService): String = {
+    val ec = ExecutionContext.fromExecutor(pool)
+    ThreadUtils.awaitResult(Future { Thread.currentThread().getName }(ec), 5.seconds)
+  }
+
   private def shutdownQuietly(pool: ExecutorService): Unit = {
     pool.shutdownNow()
     pool.awaitTermination(5, TimeUnit.SECONDS)
@@ -92,6 +98,9 @@ class BlockManagerMasterEndpointVirtualThreadsSuite extends SparkFunSuite {
           s"got ${pool.getClass.getName}")
       assert(runOnPool(pool),
         "Enabled config on Java 21+ should run tasks on a virtual thread")
+      val name = threadNameFromPool(pool)
+      assert(name.startsWith("block-manager-ask-"),
+        s"Virtual thread name should start with 'block-manager-ask-', got '$name'")
     } finally {
       shutdownQuietly(pool)
     }

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerMasterEndpointVirtualThreadsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerMasterEndpointVirtualThreadsSuite.scala
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage
+
+import java.util.concurrent.{ExecutorService, ThreadPoolExecutor, TimeUnit}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.internal.config.STORAGE_BLOCK_MANAGER_MASTER_VIRTUAL_THREADS
+import org.apache.spark.util.{ThreadUtils, Utils}
+
+/**
+ * Unit tests for the virtual-thread-backed ask thread pool in
+ * [[BlockManagerMasterEndpoint]] (see SPARK-49807).
+ */
+class BlockManagerMasterEndpointVirtualThreadsSuite extends SparkFunSuite {
+
+  /**
+   * Returns whether the given Thread is a virtual thread, using reflection so
+   * this source compiles on Java 17 (the Thread.isVirtual method was added in
+   * Java 21).
+   */
+  private def isVirtualThread(t: Thread): Boolean = {
+    try {
+      t.getClass.getMethod("isVirtual").invoke(t).asInstanceOf[Boolean]
+    } catch {
+      case _: NoSuchMethodException => false
+    }
+  }
+
+  /** Submit a task to the pool and return whether it ran on a virtual thread. */
+  private def runOnPool(pool: ExecutorService): Boolean = {
+    val ec = ExecutionContext.fromExecutor(pool)
+    ThreadUtils.awaitResult(Future { isVirtualThread(Thread.currentThread()) }(ec), 5.seconds)
+  }
+
+  private def shutdownQuietly(pool: ExecutorService): Unit = {
+    pool.shutdownNow()
+    pool.awaitTermination(5, TimeUnit.SECONDS)
+  }
+
+  test("shouldUseVirtualThreads requires both Java 21+ and config enabled") {
+    val confOff = new SparkConf()
+    assert(!BlockManagerMasterEndpoint.shouldUseVirtualThreads(confOff),
+      "Default config should not enable virtual threads")
+
+    val confOn = new SparkConf().set(STORAGE_BLOCK_MANAGER_MASTER_VIRTUAL_THREADS, true)
+    assert(
+      BlockManagerMasterEndpoint.shouldUseVirtualThreads(confOn) ===
+        Utils.isJavaVersionAtLeast21,
+      "When config is enabled, virtual threads should be used iff Java is 21+")
+  }
+
+  test("default config returns a ThreadPoolExecutor fallback") {
+    val conf = new SparkConf()
+    val pool = BlockManagerMasterEndpoint.createAskThreadPool(conf)
+    try {
+      assert(pool.isInstanceOf[ThreadPoolExecutor],
+        s"Default config should produce a ThreadPoolExecutor, got ${pool.getClass.getName}")
+      assert(!runOnPool(pool),
+        "Default config should run tasks on a platform (non-virtual) thread")
+    } finally {
+      shutdownQuietly(pool)
+    }
+  }
+
+  test("config enabled on Java 21+ returns a virtual-thread executor") {
+    assume(Utils.isJavaVersionAtLeast21,
+      "Requires Java 21+ to use virtual threads")
+    val conf = new SparkConf().set(STORAGE_BLOCK_MANAGER_MASTER_VIRTUAL_THREADS, true)
+    val pool = BlockManagerMasterEndpoint.createAskThreadPool(conf)
+    try {
+      assert(!pool.isInstanceOf[ThreadPoolExecutor],
+        s"Virtual-thread executor should not be a ThreadPoolExecutor, " +
+          s"got ${pool.getClass.getName}")
+      assert(runOnPool(pool),
+        "Enabled config on Java 21+ should run tasks on a virtual thread")
+    } finally {
+      shutdownQuietly(pool)
+    }
+  }
+
+  test("config enabled on Java < 21 falls back to ThreadPoolExecutor") {
+    assume(!Utils.isJavaVersionAtLeast21,
+      "Only meaningful on Java < 21")
+    val conf = new SparkConf().set(STORAGE_BLOCK_MANAGER_MASTER_VIRTUAL_THREADS, true)
+    val pool = BlockManagerMasterEndpoint.createAskThreadPool(conf)
+    try {
+      assert(pool.isInstanceOf[ThreadPoolExecutor],
+        s"Java < 21 should always fall back to ThreadPoolExecutor, " +
+          s"got ${pool.getClass.getName}")
+      assert(!runOnPool(pool),
+        "Java < 21 fallback should run tasks on a platform thread")
+    } finally {
+      shutdownQuietly(pool)
+    }
+  }
+
+  test("pool supports concurrent submissions and shutdown") {
+    val conf = new SparkConf().set(STORAGE_BLOCK_MANAGER_MASTER_VIRTUAL_THREADS, true)
+    val pool = BlockManagerMasterEndpoint.createAskThreadPool(conf)
+    implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(pool)
+    try {
+      // Submit a modest fan-out; each task blocks briefly to exercise concurrency.
+      val futures = (1 to 50).map { i =>
+        Future {
+          Thread.sleep(20)
+          i
+        }
+      }
+      val sum = ThreadUtils.awaitResult(Future.sequence(futures), 30.seconds).sum
+      assert(sum === (1 to 50).sum)
+    } finally {
+      shutdownQuietly(pool)
+      assert(pool.isShutdown, "Pool should be shut down")
+    }
+  }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2221,6 +2221,18 @@ Apart from these, the following properties are also available, and may be useful
   <td>3.0.0</td>
 </tr>
 <tr>
+  <td><code>spark.storage.blockManagerMaster.virtualThread.enabled</code></td>
+  <td>false</td>
+  <td>
+    If true and running on Java 21+, the <code>BlockManagerMasterEndpoint</code> uses virtual threads for
+    its ask thread pool. This can reduce latency of fan-out operations such as <code>removeRdd</code>,
+    <code>removeShuffle</code>, and replication on clusters with many executors, where the default
+    platform-thread pool (capped at 100) serializes the <code>Future.sequence</code> fan-out.
+    Has no effect on Java versions earlier than 21.
+  </td>
+  <td>4.2.0</td>
+</tr>
+<tr>
   <td><code>spark.cleaner.periodicGC.interval</code></td>
   <td>30min</td>
   <td>

--- a/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
+++ b/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
@@ -1132,6 +1132,7 @@ spark.stage.maxConsecutiveAttempts
 spark.standalone.executorRemoveDelayOnDisconnection
 spark.standalone.submit.waitAppCompletion
 spark.storage.blockManagerHeartbeatTimeoutMs
+spark.storage.blockManagerMaster.virtualThread.enabled
 spark.storage.blockManagerMasterDriverHeartbeatTimeoutMs
 spark.storage.blockManagerTimeoutIntervalMs
 spark.storage.cachedPeersTtl


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add an opt-in config `spark.storage.blockManagerMaster.virtualThread.enabled` (default `false`). When enabled and running on Java 21+, `BlockManagerMasterEndpoint` constructs its ask thread pool as:

```
Executors.newThreadPerTaskExecutor(
    Thread.ofVirtual().name("block-manager-ask-", 0).factory())
```

(reached by reflection through the public `java.lang.Thread$Builder` interface so the source stays Java 17 compatible; the concrete builder class returned by `Thread.ofVirtual()` is a non-exported JDK internal). Otherwise the existing 100-thread cached platform-thread pool is used unchanged.

A warning is logged when the config is enabled on a JVM older than Java 21 (the flag is otherwise silently ignored), and an info log is emitted when virtual threads are in use. Virtual threads are named `block-manager-ask-NN` so thread dumps match the platform-thread pool naming.

The pool construction is extracted into a package-private companion helper (`BlockManagerMasterEndpoint.createAskThreadPool` / `shouldUseVirtualThreads`) so the unit tests and benchmark exercise the exact production code path.

The `askThreadPool` field's static type is narrowed from `ThreadPoolExecutor` to `ExecutorService` so that both backends fit; it is `private` and only used via `fromExecutorService(...)` and `shutdownNow()`, both supported on `ExecutorService`.

### Why are the changes needed?

This is a sub-task under [SPARK-49807](https://issues.apache.org/jira/browse/SPARK-49807) (Incorporate Java Virtual Threads). It extends the opt-in pattern established by [SPARK-50383](https://issues.apache.org/jira/browse/SPARK-50383) (REST Submission API) and [SPARK-56297](https://issues.apache.org/jira/browse/SPARK-56297) (reconciliation thread pool) to the driver's block-manager control plane.

`BlockManagerMasterEndpoint`'s ask pool serves outbound RPCs for `removeRdd` / `removeShuffle` / `removeBroadcast` / `removeBlock`, replication fan-out, and push-based shuffle merger bookkeeping. Each submitted task is purely blocked on the RPC round-trip. The pool is hard-capped at 100 platform threads, so on clusters with more than 100 executors a single `Future.sequence` fan-out (for example, `removeRdd` triggered by cache eviction) serialises into `ceil(N/100)` waves of blocking I/O even though the work is embarrassingly concurrent.

The default is `false` rather than `true` (unlike SPARK-50383) because this pool lives on the core driver runtime path rather than a dedicated REST server. A conservative opt-in gives operators time to validate virtual-thread behaviour against their deployment (Java version, JFR pipelines, thread-dump tooling) before enabling it.

#### Benchmark

A microbenchmark (`BlockManagerMasterEndpointAskBenchmark`, results file committed) that fans out N tasks over mock endpoints sleeping 20 ms to simulate an RPC round-trip (OpenJDK 21.0.11, 3 iterations):

| N | Platform (cap=100) | Virtual threads | Speedup |
|---|---|---|---|
| 50 | 25 ms | 20 ms | 1.2x |
| 500 | 123 ms | 22 ms | 5.7x |
| 5000 | 1162 ms | 32 ms | 36.9x |

`N` corresponds to the number of `BlockManagerStorageEndpoint` instances the driver fans out to in a single `Future.sequence` call — in practice, the executor count (multiplied by the block replica factor for `removeRdd`, and roughly the executor count for `removeBroadcast`).

#### Scope of the improvement

This change affects the driver's block-manager control plane (`removeRdd` / `removeShuffle` / `removeBroadcast` / replication fan-out) and does not touch the shuffle or task execution data paths. Query latency and shuffle throughput are unchanged. The visible benefit is in driver responsiveness during cache eviction, broadcast GC, and decommission events — primarily on clusters with more than ~100 executors where the current cap actually serialises fan-outs.

#### Follow-ups

The reflection-based construction duplicates the pattern in SPARK-50383 / SPARK-56297. Once multiple sites settle, hoisting it into a shared `ThreadUtils` helper would be a natural cleanup.

### Does this PR introduce _any_ user-facing change?

No. The new config defaults to `false`; public APIs are unchanged. Users on Java 21+ can opt in via `--conf spark.storage.blockManagerMaster.virtualThread.enabled=true`.

### How was this patch tested?

- New unit suite `BlockManagerMasterEndpointVirtualThreadsSuite` covering: config on/off, Java 21+ path (`assume(isJavaVersionAtLeast21)`), Java < 21 fallback (`assume(!isJavaVersionAtLeast21)`), virtual thread naming (`block-manager-ask-*` prefix), and concurrent submission + clean shutdown. Run on both Java 17.0.18 and Java 21.0.11 locally; each JDK reports 4 succeeded / 1 assume-skipped.
- Existing `BlockManagerMasterSuite` continues to pass unchanged with the default-off config.
- New benchmark `BlockManagerMasterEndpointAskBenchmark` producing `core/benchmarks/BlockManagerMasterEndpointAskBenchmark-jdk21-results.txt`. Results summarised above.
- The new config is added to `sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions` (same treatment as `spark.master.rest.virtualThread.enabled` from SPARK-50383) since it is an infrastructure config, not a SQL session config.
- `dev/lint-scala`: Scalastyle and Scalafmt both pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Anthropic)