### PR TITLE
[SPARK-56591][SQL][TESTS] Remove redundant QueryTest mixin from SharedSparkSession subclasses

### DIFF
--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
@@ -27,7 +27,7 @@ import org.apache.avro.generic.{GenericDatumReader, GenericDatumWriter, GenericR
 import org.apache.avro.io.{DecoderFactory, EncoderFactory}
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.avro.{functions => Fns}
 import org.apache.spark.sql.avro.functions.{from_avro, to_avro}
 import org.apache.spark.sql.execution.LocalTableScanExec
@@ -36,7 +36,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BinaryType, IntegerType, StructField, StructType}
 
-class AvroFunctionsSuite extends QueryTest with SharedSparkSession {
+class AvroFunctionsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("roundtrip in to_avro and from_avro - int and string") {

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeInitSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeInitSuite.scala
@@ -26,8 +26,7 @@ import org.apache.spark.sql.types.DecimalType
  * Tests here must run in isolation, otherwise some other test might
  * initialize variable and make this test flaky
  */
-abstract class AvroLogicalTypeInitSuite
-  extends SharedSparkSession {
+abstract class AvroLogicalTypeInitSuite extends SharedSparkSession {
 
   test("SPARK-47739: custom logical type registration test") {
     val avroTypeJson =

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeInitSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeInitSuite.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.avro
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.DecimalType
@@ -28,8 +27,7 @@ import org.apache.spark.sql.types.DecimalType
  * initialize variable and make this test flaky
  */
 abstract class AvroLogicalTypeInitSuite
-  extends QueryTest
-  with SharedSparkSession {
+  extends SharedSparkSession {
 
   test("SPARK-47739: custom logical type registration test") {
     val avroTypeJson =

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeSuite.scala
@@ -25,13 +25,13 @@ import org.apache.avro.file.DataFileWriter
 import org.apache.avro.generic.{GenericData, GenericDatumWriter, GenericRecord}
 
 import org.apache.spark.{SparkArithmeticException, SparkConf, SparkException}
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{DecimalType, LongType, StructField, StructType, TimestampNTZType, TimestampType}
 
-abstract class AvroLogicalTypeSuite extends QueryTest with SharedSparkSession {
+abstract class AvroLogicalTypeSuite extends SharedSparkSession {
   import testImplicits._
 
   val dateSchema = s"""

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeSuite.scala
@@ -25,7 +25,7 @@ import org.apache.avro.file.DataFileWriter
 import org.apache.avro.generic.{GenericData, GenericDatumWriter, GenericRecord}
 
 import org.apache.spark.{SparkArithmeticException, SparkConf, SparkException}
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroRowReaderSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroRowReaderSuite.scala
@@ -38,8 +38,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.v2.avro.AvroScan
 
 class AvroRowReaderSuite
-  extends QueryTest
-  with SharedSparkSession {
+  extends SharedSparkSession {
 
   import testImplicits._
 

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroRowReaderSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroRowReaderSuite.scala
@@ -36,8 +36,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.v2.avro.AvroScan
 
-class AvroRowReaderSuite
-  extends SharedSparkSession {
+class AvroRowReaderSuite extends SharedSparkSession {
 
   import testImplicits._
 

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroRowReaderSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroRowReaderSuite.scala
@@ -27,7 +27,6 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.{InternalRow, NoopFilters}
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -55,8 +55,7 @@ import org.apache.spark.sql.v2.avro.AvroScan
 import org.apache.spark.util.Utils
 
 abstract class AvroSuite
-  extends QueryTest
-  with SharedSparkSession
+  extends SharedSparkSession
   with CommonFileDataSourceSuite
   with NestedDataSourceSuiteBase {
 

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/DeprecatedAvroFunctionsSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/DeprecatedAvroFunctionsSuite.scala
@@ -23,14 +23,14 @@ import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericDatumWriter, GenericRecord, GenericRecordBuilder}
 import org.apache.avro.io.EncoderFactory
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.execution.LocalTableScanExec
 import org.apache.spark.sql.functions.{col, struct}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 @deprecated("This test suite will be removed.", "3.0.0")
-class DeprecatedAvroFunctionsSuite extends QueryTest with SharedSparkSession {
+class DeprecatedAvroFunctionsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("roundtrip in to_avro and from_avro - int and string") {

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/DeprecatedAvroFunctionsSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/DeprecatedAvroFunctionsSuite.scala
@@ -23,7 +23,7 @@ import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericDatumWriter, GenericRecord, GenericRecordBuilder}
 import org.apache.avro.io.EncoderFactory
 
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.LocalTableScanExec
 import org.apache.spark.sql.functions.{col, struct}
 import org.apache.spark.sql.internal.SQLConf

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -36,7 +36,6 @@ import org.scalatest.concurrent.{Eventually, PatienceConfiguration}
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.internal.LogKeys.{CLASS_NAME, CONTAINER, STATUS}
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.{DockerUtils, Utils}
 import org.apache.spark.util.Utils.timeStringAsSeconds
@@ -100,7 +99,7 @@ abstract class DatabaseOnDocker {
 }
 
 abstract class DockerJDBCIntegrationSuite
-  extends QueryTest with SharedSparkSession with Eventually with DockerIntegrationFunSuite {
+  extends SharedSparkSession with Eventually with DockerIntegrationFunSuite {
 
   protected val dockerIp = DockerUtils.getDockerIp()
   val db: DatabaseOnDocker

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderSuite.scala
@@ -29,14 +29,13 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, times, verify, when}
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.kafka010.KafkaOffsetRangeLimit.{EARLIEST, LATEST}
 import org.apache.spark.sql.kafka010.KafkaSourceProvider.StrategyOnNoMatchStartingOffset
 import org.apache.spark.sql.test.SharedSparkSession
 
-class KafkaOffsetReaderSuite extends QueryTest with SharedSparkSession with KafkaTest {
+class KafkaOffsetReaderSuite extends SharedSparkSession with KafkaTest {
 
   protected var testUtils: KafkaTestUtils = _
 

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
@@ -27,14 +27,14 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 
 import org.apache.spark.{SparkConf, TestUtils}
-import org.apache.spark.sql.{DataFrameReader, QueryTest}
+import org.apache.spark.sql.{DataFrameReader}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
-abstract class KafkaRelationSuiteBase extends QueryTest with SharedSparkSession with KafkaTest {
+abstract class KafkaRelationSuiteBase extends SharedSparkSession with KafkaTest {
 
   import testImplicits._
 

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
@@ -27,7 +27,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 
 import org.apache.spark.{SparkConf, TestUtils}
-import org.apache.spark.sql.{DataFrameReader}
+import org.apache.spark.sql.DataFrameReader
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.test.{SharedSparkSession, TestSparkSession}
 import org.apache.spark.sql.types.{BinaryType, DataType, IntegerType, StringType, StructField, StructType}
 import org.apache.spark.util.ArrayImplicits._
 
-abstract class KafkaSinkSuiteBase extends QueryTest with SharedSparkSession with KafkaTest {
+abstract class KafkaSinkSuiteBase extends SharedSparkSession with KafkaTest {
   protected var testUtils: KafkaTestUtils = _
 
   override def beforeAll(): Unit = {

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufExtensionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufExtensionsSuite.scala
@@ -20,7 +20,7 @@ import com.google.protobuf.DescriptorProtos.FileDescriptorSet
 import com.google.protobuf.DynamicMessage
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.internal.SQLConf.PROTOBUF_EXTENSIONS_SUPPORT_ENABLED
 import org.apache.spark.sql.protobuf.utils.ProtobufUtils
 import org.apache.spark.sql.test.SharedSparkSession
@@ -28,8 +28,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.{ProtobufUtils => CommonProtobufUtils}
 
 class ProtobufExtensionsSuite
-    extends QueryTest
-    with SharedSparkSession
+    extends SharedSparkSession
     with ProtobufTestBase
     with Serializable {
 

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -24,7 +24,7 @@ import scala.jdk.CollectionConverters._
 import com.google.protobuf.{Any => AnyProto, BoolValue, ByteString, BytesValue, DoubleValue, DynamicMessage, FloatValue, Int32Value, Int64Value, StringValue, UInt32Value, UInt64Value}
 import org.json4s.jackson.JsonMethods
 
-import org.apache.spark.sql.{AnalysisException, Column, DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Column, DataFrame, Row}
 import org.apache.spark.sql.functions.{array, lit, map, struct, typedLit}
 import org.apache.spark.sql.protobuf.protos.Proto2Messages.Proto2AllTypes
 import org.apache.spark.sql.protobuf.protos.SimpleMessageProtos._
@@ -35,7 +35,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.{ProtobufUtils => CommonProtobufUtils}
 
-class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with ProtobufTestBase
+class ProtobufFunctionsSuite extends SharedSparkSession with ProtobufTestBase
   with Serializable {
 
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/AddMetadataColumnsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/AddMetadataColumnsSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{Filter, Project}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class AddMetadataColumnsSuite extends QueryTest with SharedSparkSession {
+class AddMetadataColumnsSuite extends SharedSparkSession {
 
   test("Add only necessary metadata columns") {
     // For a query like:

--- a/sql/core/src/test/scala/org/apache/spark/sql/AlwaysPersistedConfigsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/AlwaysPersistedConfigsSuite.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.types.StructType
  * This suite tests if configs which values should always be stored are stored when creating a view
  * or a UDF.
  */
-class AlwaysPersistedConfigsSuite extends QueryTest with SharedSparkSession {
+class AlwaysPersistedConfigsSuite extends SharedSparkSession {
 
   override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(
     implicit pos: Position): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproxCountDistinctForIntervalsQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproxCountDistinctForIntervalsQuerySuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.plans.logical.Aggregate
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.test.SharedSparkSession
 
-class ApproxCountDistinctForIntervalsQuerySuite extends QueryTest with SharedSparkSession {
+class ApproxCountDistinctForIntervalsQuerySuite extends SharedSparkSession {
   import testImplicits._
 
   // ApproxCountDistinctForIntervals is used in equi-height histogram generation. An equi-height

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproxTopKSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, TimestampNTZType, TimestampType}
 
 
-class ApproxTopKSuite extends QueryTest with SharedSparkSession {
+class ApproxTopKSuite extends SharedSparkSession {
 
   val itemsWithTopK: Seq[(String, Seq[Row])] = Seq(
     ("0, 0, 1, 1, 2, 3, 4, 4",

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproximatePercentileQuerySuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.tags.SlowSQLTest
  * End-to-end tests for approximate percentile aggregate function.
  */
 @SlowSQLTest
-class ApproximatePercentileQuerySuite extends QueryTest with SharedSparkSession {
+class ApproximatePercentileQuerySuite extends SharedSparkSession {
   import testImplicits._
 
   private val table = "percentile_approx"

--- a/sql/core/src/test/scala/org/apache/spark/sql/BenchmarkQueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/BenchmarkQueryTest.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.execution.{SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
-abstract class BenchmarkQueryTest extends QueryTest with SharedSparkSession {
+abstract class BenchmarkQueryTest extends SharedSparkSession {
 
   // When Utils.isTesting is true, the RuleExecutor will issue an exception when hitting
   // the max iteration of analyzer/optimizer batches.

--- a/sql/core/src/test/scala/org/apache/spark/sql/BitmapExpressionsQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/BitmapExpressionsQuerySuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql
 import org.apache.spark.sql.functions.{bitmap_and_agg, bitmap_bit_position, bitmap_bucket_number, bitmap_construct_agg, bitmap_count, bitmap_or_agg, col, expr, hex, lit, substring, to_binary}
 import org.apache.spark.sql.test.SharedSparkSession
 
-class BitmapExpressionsQuerySuite extends QueryTest with SharedSparkSession {
+class BitmapExpressionsQuerySuite extends SharedSparkSession {
   import testImplicits._
 
   test("bitmap_construct_agg") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/BloomFilterAggregateQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/BloomFilterAggregateQuerySuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.tags.ExtendedSQLTest
  * Query tests for the Bloom filter aggregate and filter function.
  */
 @ExtendedSQLTest
-class BloomFilterAggregateQuerySuite extends QueryTest with SharedSparkSession {
+class BloomFilterAggregateQuerySuite extends SharedSparkSession {
   import testImplicits._
 
   // Registry requires 3-part identifiers (catalog.database.funcName) for session functions

--- a/sql/core/src/test/scala/org/apache/spark/sql/CTEHintSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CTEHintSuite.scala
@@ -22,7 +22,7 @@ import org.apache.logging.log4j.Level
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.test.SharedSparkSession
 
-class CTEHintSuite extends QueryTest with SharedSparkSession {
+class CTEHintSuite extends SharedSparkSession {
 
   def verifyCoalesceOrRepartitionHint(df: DataFrame): Unit = {
     def checkContainsRepartition(plan: LogicalPlan): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CTEInlineSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CTEInlineSuite.scala
@@ -27,8 +27,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 abstract class CTEInlineSuiteBase
-  extends QueryTest
-  with SharedSparkSession
+  extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
 
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/CacheTableInKryoSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CacheTableInKryoSuite.scala
@@ -27,8 +27,7 @@ import org.apache.spark.sql.execution.columnar.{DefaultCachedBatch, DefaultCache
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.storage.StorageLevel
 
-class CacheTableInKryoSuite extends QueryTest
-  with SharedSparkSession {
+class CacheTableInKryoSuite extends SharedSparkSession {
 
   override def sparkConf: SparkConf = {
     super.sparkConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -64,8 +64,7 @@ import org.apache.spark.util.{AccumulatorContext, Utils}
 private case class BigData(s: String)
 
 @SlowSQLTest
-class CachedTableSuite extends QueryTest
-  with SharedSparkSession
+class CachedTableSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -834,7 +834,7 @@ trait CharVarcharTestSuite extends QueryTest {
 }
 
 // Some basic char/varchar tests which doesn't rely on table implementation.
-class BasicCharVarcharTestSuite extends QueryTest with SharedSparkSession {
+class BasicCharVarcharTestSuite extends SharedSparkSession {
   import testImplicits._
 
   test("user-specified schema in cast") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.types.DayTimeIntervalType.DAY
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.ArrayImplicits._
 
-class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
+class ColumnExpressionSuite extends SharedSparkSession {
   import testImplicits._
 
   private lazy val booleanData = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ComplexTypesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ComplexTypesSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{ArrayType, IntegerType, MetadataBuilder, StringType, StructField, StructType}
 
-class ComplexTypesSuite extends QueryTest with SharedSparkSession {
+class ComplexTypesSuite extends SharedSparkSession {
   import testImplicits._
 
   override def beforeAll(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ConfigBehaviorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ConfigBehaviorSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 
-class ConfigBehaviorSuite extends QueryTest with SharedSparkSession {
+class ConfigBehaviorSuite extends SharedSparkSession {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CountMinSketchAggQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CountMinSketchAggQuerySuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.util.sketch.CountMinSketch
 /**
  * End-to-end test suite for count_min_sketch.
  */
-class CountMinSketchAggQuerySuite extends QueryTest with SharedSparkSession {
+class CountMinSketchAggQuerySuite extends SharedSparkSession {
 
   test("count-min sketch") {
     import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.types.DayTimeIntervalType.{DAY, HOUR, MINUTE, SECOND
 import org.apache.spark.sql.types.YearMonthIntervalType.{MONTH, YEAR}
 import org.apache.spark.unsafe.types._
 
-class CsvFunctionsSuite extends QueryTest with SharedSparkSession {
+class CsvFunctionsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("from_csv with empty options") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -46,8 +46,7 @@ import org.apache.spark.unsafe.types.CalendarInterval
 case class Fact(date: Int, hour: Int, minute: Int, room_name: String, temp: Double)
 
 @SlowSQLTest
-class DataFrameAggregateSuite extends QueryTest
-  with SharedSparkSession
+class DataFrameAggregateSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAsOfJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAsOfJoinSuite.scala
@@ -27,8 +27,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.tags.SlowSQLTest
 
 @SlowSQLTest
-class DataFrameAsOfJoinSuite extends QueryTest
-  with SharedSparkSession
+class DataFrameAsOfJoinSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
 
   def prepareForAsOfJoin(): (classic.DataFrame, classic.DataFrame) = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
@@ -35,7 +35,7 @@ import org.apache.spark.unsafe.types.CalendarInterval
 /**
  * A test suite to test DataFrame/SQL functionalities with complex types (i.e. array, struct, map).
  */
-class DataFrameComplexTypeSuite extends QueryTest with SharedSparkSession {
+class DataFrameComplexTypeSuite extends SharedSparkSession {
   import testImplicits._
 
   test("ArrayTransform with scan input") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -41,7 +41,7 @@ import org.apache.spark.tags.ExtendedSQLTest
  * Test suite for functions in [[org.apache.spark.sql.functions]].
  */
 @ExtendedSQLTest
-class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
+class DataFrameFunctionsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("DataFrame function and SQL function parity") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameImplicitsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameImplicitsSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 
 import org.apache.spark.sql.test.SharedSparkSession
 
-class DataFrameImplicitsSuite extends QueryTest with SharedSparkSession {
+class DataFrameImplicitsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("RDD of tuples") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -35,8 +35,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class DataFrameJoinSuite extends QueryTest
-  with SharedSparkSession
+class DataFrameJoinSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructType}
 
-class DataFrameNaFunctionsSuite extends QueryTest with SharedSparkSession {
+class DataFrameNaFunctionsSuite extends SharedSparkSession {
   import testImplicits._
 
   def createDF(): DataFrame = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class DataFramePivotSuite extends QueryTest with SharedSparkSession {
+class DataFramePivotSuite extends SharedSparkSession {
   import testImplicits._
 
   test("pivot courses") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameRangeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameRangeSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 
-class DataFrameRangeSuite extends QueryTest with SharedSparkSession with Eventually {
+class DataFrameRangeSuite extends SharedSparkSession with Eventually {
 
   test("SPARK-7150 range api") {
     // numSlice is greater than length

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSelfJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSelfJoinSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.test.SQLTestData.TestData
 import org.apache.spark.sql.types.{IntegerType, LongType, StructField, StructType}
 
-class DataFrameSelfJoinSuite extends QueryTest with SharedSparkSession {
+class DataFrameSelfJoinSuite extends SharedSparkSession {
   import testImplicits._
 
   test("join - join using self join") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSessionWindowingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSessionWindowingSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class DataFrameSessionWindowingSuite extends QueryTest with SharedSparkSession {
+class DataFrameSessionWindowingSuite extends SharedSparkSession {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -34,8 +34,7 @@ import org.apache.spark.sql.test.SQLTestData.NullStrings
 import org.apache.spark.sql.types._
 import org.apache.spark.util.ArrayImplicits._
 
-class DataFrameSetOperationsSuite extends QueryTest
-  with SharedSparkSession with AdaptiveSparkPlanHelper {
+class DataFrameSetOperationsSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
   import testImplicits._
 
   test("except") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameShowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameShowSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.functions.rand
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class DataFrameShowSuite extends QueryTest with SharedSparkSession {
+class DataFrameShowSuite extends SharedSparkSession {
   import testImplicits._
 
   ignore("show") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{ArrayType, DoubleType, StringType, StructField, StructType}
 
-class DataFrameStatSuite extends QueryTest with SharedSparkSession {
+class DataFrameStatSuite extends SharedSparkSession {
   import testImplicits._
 
   private def toLetter(i: Int): String = (i + 97).toChar.toString
@@ -608,7 +608,7 @@ class DataFrameStatSuite extends QueryTest with SharedSparkSession {
 }
 
 
-class DataFrameStatPerfSuite extends QueryTest with SharedSparkSession with Logging {
+class DataFrameStatPerfSuite extends SharedSparkSession with Logging {
 
   // Turn on this test if you want to test the performance of approximate quantiles.
   ignore("computing quantiles should not take much longer than describe()") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSubquerySuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.SparkRuntimeException
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 
-class DataFrameSubquerySuite extends QueryTest with SharedSparkSession {
+class DataFrameSubquerySuite extends SharedSparkSession {
   import testImplicits._
 
   setupTestData()

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -52,8 +52,7 @@ import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.ArrayImplicits._
 
 @SlowSQLTest
-class DataFrameSuite extends QueryTest
-  with SharedSparkSession
+class DataFrameSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTableValuedFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTableValuedFunctionsSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class DataFrameTableValuedFunctionsSuite extends QueryTest with SharedSparkSession {
+class DataFrameTableValuedFunctionsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("explode") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTimeWindowingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTimeWindowingSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class DataFrameTimeWindowingSuite extends QueryTest with SharedSparkSession {
+class DataFrameTimeWindowingSuite extends SharedSparkSession {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameToSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameToSchemaSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class DataFrameToSchemaSuite extends QueryTest with SharedSparkSession {
+class DataFrameToSchemaSuite extends SharedSparkSession {
   import testImplicits._
 
   test("reorder columns by name") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
+class DataFrameTransposeSuite extends SharedSparkSession {
   import testImplicits._
 
   //

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTungstenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTungstenSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.types._
  * This is here for now so I can make sure Tungsten project is tested without refactoring existing
  * end-to-end test infra. In the long run this should just go away.
  */
-class DataFrameTungstenSuite extends QueryTest with SharedSparkSession {
+class DataFrameTungstenSuite extends SharedSparkSession {
   import testImplicits._
 
   test("test simple types") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFramesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFramesSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types.CalendarIntervalType
 /**
  * Window frame testing for DataFrame API.
  */
-class DataFrameWindowFramesSuite extends QueryTest with SharedSparkSession {
+class DataFrameWindowFramesSuite extends SharedSparkSession {
   import testImplicits._
 
   test("reuse window partitionBy") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
@@ -38,8 +38,7 @@ import org.apache.spark.tags.SlowSQLTest
  * Window function testing for DataFrame API.
  */
 @SlowSQLTest
-class DataFrameWindowFunctionsSuite extends QueryTest
-  with SharedSparkSession
+class DataFrameWindowFunctionsSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
 
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
@@ -42,7 +42,7 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
 
-class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with BeforeAndAfter {
+class DataFrameWriterV2Suite extends SharedSparkSession with BeforeAndAfter {
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
   import org.apache.spark.sql.functions._
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
@@ -228,7 +228,7 @@ case class FooAgg(s: Int) extends Aggregator[Row, Int, Int] {
   def outputEncoder: Encoder[Int] = Encoders.scalaInt
 }
 
-class DatasetAggregatorSuite extends QueryTest with SharedSparkSession {
+class DatasetAggregatorSuite extends SharedSparkSession {
   import testImplicits._
 
   private implicit val ordering: Ordering[AggData] = Ordering.by((c: AggData) => c.a -> c.b)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetCacheSuite.scala
@@ -33,8 +33,7 @@ import org.apache.spark.storage.StorageLevel
 import org.apache.spark.tags.SlowSQLTest
 
 @SlowSQLTest
-class DatasetCacheSuite extends QueryTest
-  with SharedSparkSession
+class DatasetCacheSuite extends SharedSparkSession
   with TimeLimits
   with AdaptiveSparkPlanHelper {
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetOptimizationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetOptimizationSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 
-class DatasetOptimizationSuite extends QueryTest with SharedSparkSession {
+class DatasetOptimizationSuite extends SharedSparkSession {
   import testImplicits._
 
   test("SPARK-26619: Prune the unused serializers from SerializeFromObject") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetPrimitiveSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetPrimitiveSuite.scala
@@ -46,7 +46,7 @@ package object packageobject {
   case class PackageClass(value: Int)
 }
 
-class DatasetPrimitiveSuite extends QueryTest with SharedSparkSession {
+class DatasetPrimitiveSuite extends SharedSparkSession {
   import testImplicits._
 
   test("toDS") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSerializerRegistratorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSerializerRegistratorSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 /**
  * Test suite to test Kryo custom registrators.
  */
-class DatasetSerializerRegistratorSuite extends QueryTest with SharedSparkSession {
+class DatasetSerializerRegistratorSuite extends SharedSparkSession {
   import testImplicits._
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -71,8 +71,7 @@ object TestForTypeAlias {
   def aliasedArrayInTuple: (Int, IntArray) = (1, Array(1))
 }
 
-class DatasetSuite extends QueryTest
-  with SharedSparkSession
+class DatasetSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
   import testImplicits._
 
@@ -3074,8 +3073,7 @@ object CustomPathEncoder {
   )
 }
 
-class DatasetLargeResultCollectingSuite extends QueryTest
-  with SharedSparkSession {
+class DatasetLargeResultCollectingSuite extends SharedSparkSession {
 
   override protected def sparkConf: SparkConf = super.sparkConf.set(MAX_RESULT_SIZE.key, "4g")
   // SPARK-41193: Ignore this suite because it cannot run successfully with Spark

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetUnpivotSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetUnpivotSuite.scala
@@ -25,8 +25,7 @@ import org.apache.spark.util.ArrayImplicits._
 /**
  * Comprehensive tests for Dataset.unpivot.
  */
-class DatasetUnpivotSuite extends QueryTest
-  with SharedSparkSession {
+class DatasetUnpivotSuite extends SharedSparkSession {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.unsafe.types.CalendarInterval
 
-class DateFunctionsSuite extends QueryTest with SharedSparkSession {
+class DateFunctionsSuite extends SharedSparkSession {
   import testImplicits._
 
   // The test cases which throw exceptions under ANSI mode are covered by date.sql and

--- a/sql/core/src/test/scala/org/apache/spark/sql/DeprecatedAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DeprecatedAPISuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
-class DeprecatedAPISuite extends QueryTest with SharedSparkSession {
+class DeprecatedAPISuite extends SharedSparkSession {
   import MathFunctionsTestData.DoubleData
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DeprecatedDatasetAggregatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DeprecatedDatasetAggregatorSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 
 @deprecated("This test suite will be removed.", "3.0.0")
-class DeprecatedDatasetAggregatorSuite extends QueryTest with SharedSparkSession {
+class DeprecatedDatasetAggregatorSuite extends SharedSparkSession {
   import testImplicits._
 
   test("typed aggregation: TypedAggregator") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/EmptyInSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/EmptyInSuite.scala
@@ -22,8 +22,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class EmptyInSuite extends QueryTest
-with SharedSparkSession {
+class EmptyInSuite extends SharedSparkSession {
   import testImplicits._
 
   val row = identity[(java.lang.Integer, java.lang.Double)](_)

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.sources.TestOptionsSource
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
-trait ExplainSuiteHelper extends QueryTest with SharedSparkSession {
+trait ExplainSuiteHelper extends SharedSparkSession {
 
   protected def getNormalizedExplain(df: DataFrame, mode: ExplainMode): String = {
     val output = new java.io.ByteArrayOutputStream()

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExpressionsSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExpressionsSchemaSuite.scala
@@ -66,7 +66,7 @@ import org.apache.spark.util.Utils
  */
 // scalastyle:on line.size.limit
 @ExtendedSQLTest
-class ExpressionsSchemaSuite extends QueryTest with SharedSparkSession {
+class ExpressionsSchemaSuite extends SharedSparkSession {
 
   private val baseResourcePath = {
     // We use a path based on Spark home for 2 reasons:

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExtraStrategiesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExtraStrategiesSuite.scala
@@ -46,7 +46,7 @@ object TestStrategy extends Strategy {
   }
 }
 
-class ExtraStrategiesSuite extends QueryTest with SharedSparkSession {
+class ExtraStrategiesSuite extends SharedSparkSession {
   import testImplicits._
 
   test("insert an extraStrategy") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -45,8 +45,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class FileBasedDataSourceSuite extends QueryTest
-  with SharedSparkSession
+class FileBasedDataSourceSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/FunctionQualificationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FunctionQualificationSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types.IntegerType
  * This tests the system.builtin, system.session, and system.extension namespaces.
  *
  */
-class FunctionQualificationSuite extends QueryTest with SharedSparkSession {
+class FunctionQualificationSuite extends SharedSparkSession {
 
   override protected def sparkConf = {
     super.sparkConf.set("spark.sql.extensions", classOf[TestExtensions].getName)

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructType}
 
-class GeneratorFunctionSuite extends QueryTest with SharedSparkSession {
+class GeneratorFunctionSuite extends SharedSparkSession {
   import testImplicits._
 
   test("stack") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeographyDataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeographyDataFrameSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class GeographyDataFrameSuite extends QueryTest with SharedSparkSession {
+class GeographyDataFrameSuite extends SharedSparkSession {
 
   val point1 = "010100000000000000000031400000000000001C40"
     .grouped(2).map(Integer.parseInt(_, 16).toByte).toArray

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeometryDataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeometryDataFrameSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class GeometryDataFrameSuite extends QueryTest with SharedSparkSession {
+class GeometryDataFrameSuite extends SharedSparkSession {
 
   val point1 = "010100000000000000000031400000000000001C40"
     .grouped(2).map(Integer.parseInt(_, 16).toByte).toArray

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructType}
 
-class InjectRuntimeFilterSuite extends QueryTest with SharedSparkSession
+class InjectRuntimeFilterSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
 
   protected override def beforeAll(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/InlineTableParsingImprovementsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InlineTableParsingImprovementsSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, 
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class InlineTableParsingImprovementsSuite extends QueryTest with SharedSparkSession {
+class InlineTableParsingImprovementsSuite extends SharedSparkSession {
 
   /**
    * SQL parser.

--- a/sql/core/src/test/scala/org/apache/spark/sql/IntervalFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/IntervalFunctionsSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{DayTimeIntervalType => DT, YearMonthIntervalType => YM}
 import org.apache.spark.sql.types.DataTypeTestUtils._
 
-class IntervalFunctionsSuite extends QueryTest with SharedSparkSession {
+class IntervalFunctionsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("SPARK-36022: Respect interval fields in extract") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.tags.SlowSQLTest
 
 @SlowSQLTest
-class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlanHelper
+class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
   with JoinSelectionHelper {
   import testImplicits._
 
@@ -1819,8 +1819,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
 }
 
 class ThreadLeakInSortMergeJoinSuite
-  extends QueryTest
-    with SharedSparkSession
+  extends SharedSparkSession
     with AdaptiveSparkPlanHelper {
 
   setupTestData()

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.DayTimeIntervalType.{DAY, HOUR, MINUTE, SECOND}
 import org.apache.spark.sql.types.YearMonthIntervalType.{MONTH, YEAR}
 
-class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
+class JsonFunctionsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("function get_json_object") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/LateralColumnAliasSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/LateralColumnAliasSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  * Lateral column alias base suite with LCA off, extended by LateralColumnAliasSuite with LCA on.
  * Should test behaviors remaining the same no matter LCA conf is on or off.
  */
-class LateralColumnAliasSuiteBase extends QueryTest with SharedSparkSession {
+class LateralColumnAliasSuiteBase extends SharedSparkSession {
   // by default the tests in this suites run with LCA off
   val lcaEnabled: Boolean = false
   override protected def test(testName: String, testTags: Tag*)(testFun: => Any)

--- a/sql/core/src/test/scala/org/apache/spark/sql/LegacyParameterSubstitutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/LegacyParameterSubstitutionSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  * Test suite for the legacy parameter substitution configuration.
  * Tests the behavior when spark.sql.legacy.parameterSubstitution.constantsOnly is enabled.
  */
-class LegacyParameterSubstitutionSuite extends QueryTest with SharedSparkSession {
+class LegacyParameterSubstitutionSuite extends SharedSparkSession {
 
   test("parameter substitution works everywhere when legacy config is disabled (default)") {
     withSQLConf("spark.sql.legacy.parameterSubstitution.constantsOnly" -> "false") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/LogQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/LogQuerySuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.util.LogUtils.SPARK_LOG_SCHEMA
 /**
  * Test suite for querying Spark logs using SQL.
  */
-class LogQuerySuite extends QueryTest with SharedSparkSession with Logging {
+class LogQuerySuite extends SharedSparkSession with Logging {
 
   val logFile: File = {
     val pwd = new File(".").getCanonicalPath

--- a/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
@@ -33,7 +33,7 @@ private object MathFunctionsTestData {
   case class NullDoubles(a: java.lang.Double)
 }
 
-class MathFunctionsSuite extends QueryTest with SharedSparkSession {
+class MathFunctionsSuite extends SharedSparkSession {
   import MathFunctionsTestData._
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/MetadataCacheSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MetadataCacheSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 /**
  * Test suite to handle metadata cache related.
  */
-abstract class MetadataCacheSuite extends QueryTest with SharedSparkSession {
+abstract class MetadataCacheSuite extends SharedSparkSession {
 
   /** Removes one data file in the given directory. */
   protected def deleteOneFileInDirectory(dir: File): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BinaryType, StringType}
 
-class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
+class MiscFunctionsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("reflect and java_method") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/NestedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/NestedDataSourceSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{LongType, StructType}
 
 // Datasource tests for nested schemas
-trait NestedDataSourceSuiteBase extends QueryTest with SharedSparkSession {
+trait NestedDataSourceSuiteBase extends SharedSparkSession {
   protected val nestedDataSources: Seq[String] = Seq("orc", "parquet", "json")
   protected def readOptions(schema: StructType): Map[String, String] = Map.empty
   protected def save(selectExpr: Seq[String], format: String, path: String): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/OptimizeExpandQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/OptimizeExpandQuerySuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 class OptimizeExpandQuerySuite
-    extends QueryTest with SharedSparkSession {
+    extends SharedSparkSession {
 
   private def checkOptimizationCorrectness(
       sqlText: String): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/OptimizeExpandQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/OptimizeExpandQuerySuite.scala
@@ -21,8 +21,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Expand}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class OptimizeExpandQuerySuite
-    extends SharedSparkSession {
+class OptimizeExpandQuerySuite extends SharedSparkSession {
 
   private def checkOptimizationCorrectness(
       sqlText: String): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{CharType, DataType, DecimalType, StructField, VarcharType}
 
-class ParametersSuite extends QueryTest with SharedSparkSession {
+class ParametersSuite extends SharedSparkSession {
 
   // Helper function to check CHAR/VARCHAR types (similar to CharVarcharTestSuite)
   private def checkColType(f: StructField, dt: DataType): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/PercentileQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PercentileQuerySuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 /**
  * End-to-end tests for percentile aggregate function.
  */
-class PercentileQuerySuite extends QueryTest with SharedSparkSession {
+class PercentileQuerySuite extends SharedSparkSession {
   import testImplicits._
 
   private val table = "percentile_test"

--- a/sql/core/src/test/scala/org/apache/spark/sql/PlanMergeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PlanMergeSuite.scala
@@ -22,8 +22,7 @@ import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class PlanMergeSuite extends QueryTest
-  with SharedSparkSession
+class PlanMergeSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ProductAggSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ProductAggSuite.scala
@@ -23,8 +23,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{ByteType, DoubleType, FloatType, IntegerType, ShortType}
 
 
-class ProductAggSuite extends QueryTest
-  with SharedSparkSession {
+class ProductAggSuite extends SharedSparkSession {
 
   // Sequence of integers small enough that factorial is representable exactly as DoubleType:
   private lazy val data16 = spark.range(1, 17).toDF("x")

--- a/sql/core/src/test/scala/org/apache/spark/sql/PushDownJoinThroughUnionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PushDownJoinThroughUnionSuite.scala
@@ -24,8 +24,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 class PushDownJoinThroughUnionSuite
-    extends QueryTest
-    with SharedSparkSession
+    extends SharedSparkSession
     with AdaptiveSparkPlanHelper {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -1189,7 +1189,7 @@ object QueryTest extends Assertions {
 
 }
 
-class QueryTestSuite extends QueryTest with test.SharedSparkSession {
+class QueryTestSuite extends test.SharedSparkSession {
   test("SPARK-16940: checkAnswer should raise TestFailedException for wrong results") {
     intercept[org.scalatest.exceptions.TestFailedException] {
       checkAnswer(sql("SELECT 1"), Row(2) :: Nil)

--- a/sql/core/src/test/scala/org/apache/spark/sql/RelationQualificationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RelationQualificationSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  * (spark.sql.functionResolution.sessionOrder for unqualified names;
  * spark.sql.legacy.persistentCatalogFirst for two-part session.name vs persistent schema session).
  */
-class RelationQualificationSuite extends QueryTest with SharedSparkSession {
+class RelationQualificationSuite extends SharedSparkSession {
 
   test("SECTION 1: Basic qualification - SELECT from session.v and system.session.v") {
     sql("CREATE TEMPORARY VIEW v1 AS SELECT 1 AS c")

--- a/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsDataframeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsDataframeSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class ReplaceIntegerLiteralsWithOrdinalsDataframeSuite extends QueryTest with SharedSparkSession {
+class ReplaceIntegerLiteralsWithOrdinalsDataframeSuite extends SharedSparkSession {
   import testImplicits._
 
   test("Group by ordinal - Dataframe") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsSqlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ReplaceIntegerLiteralsWithOrdinalsSqlSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class ReplaceIntegerLiteralsWithOrdinalsSqlSuite extends QueryTest with SharedSparkSession {
+class ReplaceIntegerLiteralsWithOrdinalsSqlSuite extends SharedSparkSession {
 
   test("Group by ordinal - SQL") {
     val correctSqlText = "SELECT col1, max(col2) FROM VALUES(1,2),(1,3),(2,4) GROUP BY 1"

--- a/sql/core/src/test/scala/org/apache/spark/sql/ReplaceNullWithFalseInPredicateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ReplaceNullWithFalseInPredicateEndToEndSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.BooleanType
 
-class ReplaceNullWithFalseInPredicateEndToEndSuite extends QueryTest with SharedSparkSession {
+class ReplaceNullWithFalseInPredicateEndToEndSuite extends SharedSparkSession {
   import testImplicits._
 
   private def checkPlanIsEmptyLocalScan(df: DataFrame): Unit =

--- a/sql/core/src/test/scala/org/apache/spark/sql/ResolveDefaultColumnsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ResolveDefaultColumnsSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql
 import org.apache.spark.SparkRuntimeException
 import org.apache.spark.sql.test.SharedSparkSession
 
-class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {
+class ResolveDefaultColumnsSuite extends SharedSparkSession {
   test("column without default value defined (null as default)") {
     withTable("t") {
       sql("create table t(c1 timestamp, c2 timestamp) using parquet")

--- a/sql/core/src/test/scala/org/apache/spark/sql/RuntimeNullChecksV2Writes.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RuntimeNullChecksV2Writes.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, StructType}
 
-class RuntimeNullChecksV2Writes extends QueryTest with SharedSparkSession {
+class RuntimeNullChecksV2Writes extends SharedSparkSession {
 
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -62,7 +62,7 @@ import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 import org.apache.spark.util.{ResetSystemProperties, SparkTestUtils, Utils}
 
 @ExtendedSQLTest
-class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlanHelper
+class SQLQuerySuite extends SharedSparkSession with AdaptiveSparkPlanHelper
     with ResetSystemProperties {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -153,7 +153,7 @@ import org.apache.spark.util.Utils
  */
 // scalastyle:on line.size.limit
 @ExtendedSQLTest
-class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
+class SQLQueryTestSuite extends SharedSparkSession with SQLHelper
     with SQLQueryTestHelper with TPCDSSchema {
 
   import IntegratedUDFTestUtils._

--- a/sql/core/src/test/scala/org/apache/spark/sql/STExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/STExpressionsSuite.scala
@@ -25,8 +25,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
 class STExpressionsSuite
-  extends QueryTest
-  with SharedSparkSession
+  extends SharedSparkSession
   with ExpressionEvalHelper {
 
   // Private common constants used across several tests.

--- a/sql/core/src/test/scala/org/apache/spark/sql/STFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/STFunctionsSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class STFunctionsSuite extends QueryTest with SharedSparkSession {
+class STFunctionsSuite extends SharedSparkSession {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetCommandSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, TestSQLContext}
 import org.apache.spark.util.ResetSystemProperties
 
-class SetCommandSuite extends QueryTest with SharedSparkSession with ResetSystemProperties  {
+class SetCommandSuite extends SharedSparkSession with ResetSystemProperties  {
   test("SET commands semantics using sql()") {
     spark.sessionState.conf.clear()
     val testKey = "test.key.0"

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  * Resolution-level tests (tables/functions resolving via the stored path)
  * belong in a separate suite once the resolution engine is wired.
  */
-class SetPathSuite extends QueryTest with SharedSparkSession {
+class SetPathSuite extends SharedSparkSession {
 
   private def withPathEnabled(f: => Unit): Unit = {
     withSQLConf(SQLConf.PATH_ENABLED.key -> "true")(f)

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class StringFunctionsSuite extends QueryTest with SharedSparkSession {
+class StringFunctionsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("string concat") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringLiteralCoalescingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringLiteralCoalescingSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  * This feature works in all contexts where string literals are accepted,
  * not just in expressions.
  */
-class StringLiteralCoalescingSuite extends QueryTest with SharedSparkSession {
+class StringLiteralCoalescingSuite extends SharedSparkSession {
 
   // ========================================================================
   // Basic String Literal Coalescing Tests

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubqueryHintPropagationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubqueryHintPropagationSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{BROADCAST, HintInfo, Join, J
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.test.SharedSparkSession
 
-class SubqueryHintPropagationSuite extends QueryTest with SharedSparkSession {
+class SubqueryHintPropagationSuite extends SharedSparkSession {
 
   setupTestData()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -31,8 +31,7 @@ import org.apache.spark.sql.execution.joins.{BaseJoinExec, BroadcastHashJoinExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class SubquerySuite extends QueryTest
-  with SharedSparkSession
+class SubquerySuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/TableOptionsConstantFoldingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TableOptionsConstantFoldingSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 /** These tests exercise passing constant but non-literal OPTIONS lists, and folding them. */
-class TableOptionsConstantFoldingSuite extends QueryTest with SharedSparkSession {
+class TableOptionsConstantFoldingSuite extends SharedSparkSession {
   val prefix = "create table t (col int) using json options "
 
   /** Helper method to create a table with a OPTIONS list and then check the resulting value. */

--- a/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TimeFunctionsSuiteBase.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-abstract class TimeFunctionsSuiteBase extends QueryTest with SharedSparkSession {
+abstract class TimeFunctionsSuiteBase extends SharedSparkSession {
   import testImplicits._
 
   // Helper method to assert that two DataFrames with TimeType values are approximately equal.

--- a/sql/core/src/test/scala/org/apache/spark/sql/TypedImperativeAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TypedImperativeAggregateSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class TypedImperativeAggregateSuite extends QueryTest with SharedSparkSession {
+class TypedImperativeAggregateSuite extends SharedSparkSession {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -64,7 +64,7 @@ private case class KryoBufAggregator() extends Aggregator[Long, KryoEncodedBuf, 
   override def outputEncoder: Encoder[Long] = Encoders.scalaLong
 }
 
-class UDFSuite extends QueryTest with SharedSparkSession {
+class UDFSuite extends SharedSparkSession {
   import testImplicits._
 
   test("udf") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/UnwrapCastInComparisonEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UnwrapCastInComparisonEndToEndSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.IntegralLiteralTestUtils.{negat
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.Decimal
 
-class UnwrapCastInComparisonEndToEndSuite extends QueryTest with SharedSparkSession {
+class UnwrapCastInComparisonEndToEndSuite extends SharedSparkSession {
   import testImplicits._
 
   val t = "test_table"

--- a/sql/core/src/test/scala/org/apache/spark/sql/UrlFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UrlFunctionsSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class UrlFunctionsSuite extends QueryTest with SharedSparkSession {
+class UrlFunctionsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("url parse_url function") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/UserDefinedTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UserDefinedTypeSuite.scala
@@ -52,7 +52,7 @@ private[sql] class YearUDT extends UserDefinedType[Year] {
   private[spark] override def asNullable: YearUDT = this
 }
 
-class UserDefinedTypeSuite extends QueryTest with SharedSparkSession with ParquetTest
+class UserDefinedTypeSuite extends SharedSparkSession with ParquetTest
     with ExpressionEvalHelper {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/VariantEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/VariantEndToEndSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.types.variant.VariantBuilder
 import org.apache.spark.types.variant.VariantUtil._
 import org.apache.spark.unsafe.types.{UTF8String, VariantVal}
 
-class VariantEndToEndSuite extends QueryTest with SharedSparkSession {
+class VariantEndToEndSuite extends SharedSparkSession {
   import testImplicits._
 
   test("parse_json/to_json round-trip") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/VariantShreddingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/VariantShreddingSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.types.variant._
 import org.apache.spark.unsafe.types.{UTF8String, VariantVal}
 
-class VariantShreddingSuite extends QueryTest with SharedSparkSession with ParquetTest {
+class VariantShreddingSuite extends SharedSparkSession with ParquetTest {
   def parseJson(s: String): VariantVal = {
     val v = VariantBuilder.parseJson(s, false)
     new VariantVal(v.getValue, v.getMetadata)

--- a/sql/core/src/test/scala/org/apache/spark/sql/VariantSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/VariantSuite.scala
@@ -39,7 +39,7 @@ import org.apache.spark.types.variant.VariantUtil._
 import org.apache.spark.unsafe.types.{UTF8String, VariantVal}
 import org.apache.spark.util.ArrayImplicits._
 
-class VariantSuite extends QueryTest with SharedSparkSession with ExpressionEvalHelper {
+class VariantSuite extends SharedSparkSession with ExpressionEvalHelper {
   import testImplicits._
 
   test("basic tests") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/XPathFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/XPathFunctionsSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 /**
  * End-to-end tests for xpath expressions.
  */
-class XPathFunctionsSuite extends QueryTest with SharedSparkSession {
+class XPathFunctionsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("xpath_boolean") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/XmlFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/XmlFunctionsSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class XmlFunctionsSuite extends QueryTest with SharedSparkSession {
+class XmlFunctionsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("from_xml") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/AggregateExpressionResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/AggregateExpressionResolverSuite.scala
@@ -17,14 +17,14 @@
 
 package org.apache.spark.sql.analysis.resolver
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.analysis.resolver.Resolver
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.test.SharedSparkSession
 
-class AggregateExpressionResolverSuite extends QueryTest with SharedSparkSession {
+class AggregateExpressionResolverSuite extends SharedSparkSession {
   private val table = LocalRelation.fromExternalRows(
     Seq("a".attr.int),
     Seq(Row(1))

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/AggregateResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/AggregateResolverSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.analysis.resolver
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.analysis.resolver.{
   Resolver,
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.AnyValue
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.test.SharedSparkSession
 
-class AggregateResolverSuite extends QueryTest with SharedSparkSession {
+class AggregateResolverSuite extends SharedSparkSession {
   private val table = LocalRelation.fromExternalRows(
     Seq("a".attr.int, "b".attr.int),
     Seq(Row(1), Row(1))

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/AliasResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/AliasResolverSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.analysis.resolver
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.analysis.resolver.{
   Resolver,
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.plans.NormalizePlan
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.test.SharedSparkSession
 
-class AliasResolverSuite extends QueryTest with SharedSparkSession {
+class AliasResolverSuite extends SharedSparkSession {
   private val table = LocalRelation.fromExternalRows(
     Seq("a".attr.int),
     Seq(Row(1))

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/AliasResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/AliasResolverSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.analysis.resolver
 
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.analysis.resolver.{
   Resolver,

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/DataFrameAnalyzerTestGapsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/DataFrameAnalyzerTestGapsSuite.scala
@@ -17,14 +17,14 @@
 
 package org.apache.spark.sql.analysis.resolver
 
-import org.apache.spark.sql.{Column, QueryTest, Row}
+import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.test.SharedSparkSession
 
 /**
  * Test cases that cover dataframe analyzer test gaps discovered during single-pass analyzer
  * development.
  */
-class DataFrameAnalyzerTestGapsSuite extends QueryTest with SharedSparkSession {
+class DataFrameAnalyzerTestGapsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("Implicit alias resolution") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/DeepResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/DeepResolutionSuite.scala
@@ -18,12 +18,10 @@
 package org.apache.spark.sql.analysis.resolver
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.SharedSparkSession
 
 class DeepResolutionSuite
-    extends QueryTest
-    with SharedSparkSession
+    extends SharedSparkSession
     with SinglePassAnalyzerTestUtils {
   protected override def sparkConf: SparkConf = setTentativeMode(super.sparkConf)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ExplicitlyUnsupportedResolverFeatureSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ExplicitlyUnsupportedResolverFeatureSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.analysis.resolver
 
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.analysis.resolver.{
   ExplicitlyUnsupportedResolverFeature,
   Resolver
@@ -25,7 +24,7 @@ import org.apache.spark.sql.catalyst.analysis.resolver.{
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.test.SharedSparkSession
 
-class ExplicitlyUnsupportedResolverFeatureSuite extends QueryTest with SharedSparkSession {
+class ExplicitlyUnsupportedResolverFeatureSuite extends SharedSparkSession {
   test("Unsupported table types") {
     withTable("csv_table") {
       spark.sql("CREATE TABLE csv_table (col1 INT) USING CSV;").collect()

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ExpressionIdAssignerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ExpressionIdAssignerSuite.scala
@@ -22,7 +22,7 @@ import java.util.IdentityHashMap
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.analysis.resolver.{ExpressionIdAssigner, Resolver}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
@@ -34,7 +34,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class ExpressionIdAssignerSuite extends QueryTest with SharedSparkSession {
+class ExpressionIdAssignerSuite extends SharedSparkSession {
   private val col1Integer = AttributeReference(name = "col1", dataType = IntegerType)()
   private val col1IntegerAlias = Alias(col1Integer, "a")()
   private val col2Integer = AttributeReference(name = "col2", dataType = IntegerType)()

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/HybridAnalyzerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/HybridAnalyzerSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.analysis.resolver
 import org.scalactic.source.Position
 import org.scalatest.Tag
 
-import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.{AnalysisException}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, QueryPlanningTracker}
 import org.apache.spark.sql.catalyst.analysis.{
   AnalysisContext,
@@ -41,7 +41,7 @@ import org.apache.spark.sql.types.{IntegerType, MetadataBuilder}
 /**
  * Base trait for HybridAnalyzer test suites containing common test utilities and helper classes.
  */
-trait HybridAnalyzerSuiteBase extends QueryTest with SharedSparkSession {
+trait HybridAnalyzerSuiteBase extends SharedSparkSession {
   protected val col1Integer = AttributeReference("col1", IntegerType)()
   protected val col2Integer = AttributeReference("col2", IntegerType)()
   protected val col2IntegerWithMetadata = AttributeReference(

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/HybridAnalyzerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/HybridAnalyzerSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.analysis.resolver
 import org.scalactic.source.Position
 import org.scalatest.Tag
 
-import org.apache.spark.sql.{AnalysisException}
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, QueryPlanningTracker}
 import org.apache.spark.sql.catalyst.analysis.{
   AnalysisContext,

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/IdentifierAndCteSubstitutorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/IdentifierAndCteSubstitutorSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.analysis.resolver
 
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.analysis.resolver.{
   IdentifierAndCteSubstitutor,
@@ -27,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.test.SharedSparkSession
 
-class IdentifierAndCteSubstitutorSuite extends QueryTest with SharedSparkSession {
+class IdentifierAndCteSubstitutorSuite extends SharedSparkSession {
   test("Plan is unchanged") {
     val substitutor = new IdentifierAndCteSubstitutor
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/MetadataResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/MetadataResolverSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.analysis.resolver
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.{AliasIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{
   AnalysisContext,
@@ -34,8 +33,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class MetadataResolverSuite
-    extends QueryTest
-    with SharedSparkSession {
+    extends SharedSparkSession {
   private val catalogName = "spark_catalog"
 
   private val keyValueTableSchema = StructType(

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/MetadataResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/MetadataResolverSuite.scala
@@ -32,8 +32,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-class MetadataResolverSuite
-    extends SharedSparkSession {
+class MetadataResolverSuite extends SharedSparkSession {
   private val catalogName = "spark_catalog"
 
   private val keyValueTableSchema = StructType(

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/NameScopeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/NameScopeSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.analysis.resolver
 import java.util.HashMap
 
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.analysis.UnresolvedStar
 import org.apache.spark.sql.catalyst.analysis.resolver.{
   NameResolutionParameters,
@@ -44,7 +43,7 @@ import org.apache.spark.sql.catalyst.expressions.{
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class NameScopeSuite extends QueryTest with SharedSparkSession {
+class NameScopeSuite extends SharedSparkSession {
   private val col1Integer = AttributeReference(name = "col1", dataType = IntegerType)()
   private val col1IntegerOther = AttributeReference(name = "col1", dataType = IntegerType)()
   private val col2Integer = AttributeReference(name = "col2", dataType = IntegerType)()

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ResolverGuardSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ResolverGuardSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.analysis.resolver
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.analysis.resolver.{
   AnalyzerBridgeState,
   ExplicitlyUnsupportedResolverFeature,
@@ -397,7 +396,7 @@ class ResolverGuardSuite extends ResolverGuardSuiteBase {
 
 }
 
-trait ResolverGuardSuiteBase extends QueryTest with SharedSparkSession {
+trait ResolverGuardSuiteBase extends SharedSparkSession {
   protected def checkResolverGuard(
       query: String,
       unsupportedReason: Option[String] = None): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ResolverSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.analysis.resolver
 
-import org.apache.spark.sql.{AnalysisException}
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.analysis.resolver.{
   LogicalPlanResolver,

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ResolverSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.analysis.resolver
 
-import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.{AnalysisException}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.analysis.resolver.{
   LogicalPlanResolver,
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan, Proje
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.IntegerType
 
-class ResolverSuite extends QueryTest with SharedSparkSession {
+class ResolverSuite extends SharedSparkSession {
   private val col1Integer = AttributeReference("col1", IntegerType)()
 
   test("Node matched the extension") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ViewResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ViewResolverSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.analysis.resolver
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.analysis.resolver.{
@@ -33,7 +33,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-class ViewResolverSuite extends QueryTest with SharedSparkSession {
+class ViewResolverSuite extends SharedSparkSession {
   private val catalogName = "spark_catalog"
   private val col1Integer = "col1".attr.int.withNullability(false)
   private val col2String = "col2".attr.string.withNullability(false)

--- a/sql/core/src/test/scala/org/apache/spark/sql/catalyst/expressions/ValidateExternalTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/catalyst/expressions/ValidateExternalTypeSuite.scala
@@ -18,11 +18,11 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkRuntimeException
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructType}
 
-class ValidateExternalTypeSuite extends QueryTest with SharedSparkSession {
+class ValidateExternalTypeSuite extends SharedSparkSession {
   test("SPARK-49044 ValidateExternalType should be user visible") {
     checkError(
       exception = intercept[SparkRuntimeException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/catalyst/expressions/ValidateExternalTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/catalyst/expressions/ValidateExternalTypeSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkRuntimeException
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructType}
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollatedFilterPushDownToParquetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollatedFilterPushDownToParquetSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.collation
 import org.apache.parquet.schema.MessageType
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollatedFilterPushDownToParquetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollatedFilterPushDownToParquetSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.collation
 import org.apache.parquet.schema.MessageType
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.{DataFrame}
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
@@ -32,8 +32,7 @@ import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.sources.{EqualTo, Filter, IsNotNull}
 import org.apache.spark.sql.test.SharedSparkSession
 
-abstract class CollatedFilterPushDownToParquetSuite extends QueryTest
-  with SharedSparkSession
+abstract class CollatedFilterPushDownToParquetSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
 
   val dataSource = "parquet"

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
@@ -17,14 +17,13 @@
 
 package org.apache.spark.sql.collation
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.test.SharedSparkSession
 
 class CollationAggregationSuite
-  extends QueryTest
-  with SharedSparkSession
+  extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
 
   test("group by collated column doesn't work with obj hash aggregate") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.collation
 
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.test.SharedSparkSession

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSQLFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSQLFunctionsSuite.scala
@@ -17,12 +17,12 @@
 
 package org.apache.spark.sql.collation
 
-import org.apache.spark.sql.{Column, Dataset, QueryTest}
+import org.apache.spark.sql.{Column, Dataset}
 import org.apache.spark.sql.functions.{from_json, from_xml}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class CollationSQLFunctionsSuite extends QueryTest with SharedSparkSession {
+class CollationSQLFunctionsSuite extends SharedSparkSession {
 
   test("SPARK-50214: from_json and from_xml work correctly with session collation") {
     import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSQLRegexpSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationSQLRegexpSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.collation
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.Project
 import org.apache.spark.sql.test.SharedSparkSession
@@ -25,8 +25,7 @@ import org.apache.spark.sql.types.{ArrayType, BooleanType, IntegerType, StringTy
 
 // scalastyle:off nonascii
 class CollationSQLRegexpSuite
-  extends QueryTest
-  with SharedSparkSession
+  extends SharedSparkSession
   with ExpressionEvalHelper {
 
   test("Support Like string expression with collation") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationTypePrecedenceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationTypePrecedenceSuite.scala
@@ -18,12 +18,12 @@
 package org.apache.spark.sql.collation
 
 import org.apache.spark.SparkThrowable
-import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class CollationTypePrecedenceSuite extends QueryTest with SharedSparkSession {
+class CollationTypePrecedenceSuite extends SharedSparkSession {
 
   val dataSource: String = "parquet"
   val UNICODE_COLLATION_NAME = "SYSTEM.BUILTIN.UNICODE"

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.collation
 
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog.DEFAULT_DATABASE
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.Project
@@ -28,7 +28,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BooleanType, StringType, StructType}
 
-abstract class DefaultCollationTestSuite extends QueryTest with SharedSparkSession {
+abstract class DefaultCollationTestSuite extends SharedSparkSession {
 
   protected def resetCatalog: Boolean = false
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/IndeterminateCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/IndeterminateCollationTestSuite.scala
@@ -18,12 +18,12 @@
 package org.apache.spark.sql.collation
 
 import org.apache.spark.{SparkRuntimeException, SparkThrowable}
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 
-class IndeterminateCollationTestSuite extends QueryTest with SharedSparkSession {
+class IndeterminateCollationTestSuite extends SharedSparkSession {
 
   val testTableName = "tst_table"
   val dataSource = "parquet"

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.connector
 import java.sql.Timestamp
 import java.util
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.NamedStreamingRelation
 import org.apache.spark.sql.catalyst.streaming.UserProvided
@@ -34,7 +34,7 @@ import org.apache.spark.unsafe.types.UTF8String
  * End-to-end tests for Change Data Capture (CDC) queries using
  * [[InMemoryChangelogCatalog]].
  */
-class ChangelogEndToEndSuite extends QueryTest with SharedSparkSession {
+class ChangelogEndToEndSuite extends SharedSparkSession {
 
   private val catalogName = "cdc_e2e"
   private val testTableName = "test_table"

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogResolutionSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.connector
 
 import java.util
 
-import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.{AnalysisException}
 import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types.{LongType, StringType}
  * Tests for the CDC (Change Data Capture) analyzer resolution path:
  * RelationChanges -> resolveChangelog -> DataSourceV2Relation(ChangelogTable).
  */
-class ChangelogResolutionSuite extends QueryTest with SharedSparkSession {
+class ChangelogResolutionSuite extends SharedSparkSession {
 
   private val cdcCatalogName = "cdc_catalog"
   private val noCdcCatalogName = "no_cdc_catalog"

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogResolutionSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.connector
 
 import java.util
 
-import org.apache.spark.sql.{AnalysisException}
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSessionCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSessionCatalogSuite.scala
@@ -21,7 +21,7 @@ import java.util.Locale
 
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, SaveMode}
+import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import org.apache.spark.sql.connector.catalog._
@@ -180,8 +180,7 @@ object InMemoryTableSessionCatalog {
 }
 
 private [connector] trait SessionCatalogTest[T <: Table, Catalog <: TestV2SessionCatalogBase[T]]
-  extends QueryTest
-  with SharedSparkSession
+  extends SharedSparkSession
   with BeforeAndAfter {
 
   protected def catalog(name: String): CatalogPlugin = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedDeleteFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedDeleteFilterSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.connector.catalog.InMemoryPartitionPredicateDeleteCatalog
 import org.apache.spark.sql.connector.expressions.PartitionFieldReference
 import org.apache.spark.sql.connector.expressions.filter.PartitionPredicate
@@ -33,7 +33,7 @@ import org.apache.spark.sql.util.QueryExecutionListener
  * PartitionPredicate (see SPARK-55596).
  */
 class DataSourceV2EnhancedDeleteFilterSuite
-  extends QueryTest with SharedSparkSession {
+  extends SharedSparkSession {
 
   private val v2Source = classOf[FakeV2ProviderWithCustomSchema].getName
   private val catalogName = "ppd_cat"

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedDeleteFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedDeleteFilterSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.connector.catalog.InMemoryPartitionPredicateDeleteCatalog
 import org.apache.spark.sql.connector.expressions.PartitionFieldReference
 import org.apache.spark.sql.connector.expressions.filter.PartitionPredicate
@@ -32,8 +32,7 @@ import org.apache.spark.sql.util.QueryExecutionListener
  * Tests for metadata-only delete optimization using second-pass
  * PartitionPredicate (see SPARK-55596).
  */
-class DataSourceV2EnhancedDeleteFilterSuite
-  extends SharedSparkSession {
+class DataSourceV2EnhancedDeleteFilterSuite extends SharedSparkSession {
 
   private val v2Source = classOf[FakeV2ProviderWithCustomSchema].getName
   private val catalogName = "ppd_cat"

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedPartitionFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedPartitionFilterSuite.scala
@@ -21,7 +21,7 @@ import java.util.Locale
 
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.expressions.{Expression, In, PredicateHelper, ScalaUDF}
 import org.apache.spark.sql.connector.catalog.BufferedRows
 import org.apache.spark.sql.connector.catalog.InMemoryEnhancedPartitionFilterTable
@@ -51,7 +51,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  * 8. Untranslatable, Partition Filter, 2nd Pass Accepted -> Pushed Down
  */
 class DataSourceV2EnhancedPartitionFilterSuite
-  extends QueryTest with SharedSparkSession with BeforeAndAfter with PredicateHelper {
+  extends SharedSparkSession with BeforeAndAfter with PredicateHelper {
 
   protected val v2Source = classOf[FakeV2ProviderWithCustomSchema].getName
   protected val partFilterTableName = "testpartfilter.t"

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedRuntimePartitionFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2EnhancedRuntimePartitionFilterSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.connector
 
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.expressions.{DynamicPruning, DynamicPruningExpression}
 import org.apache.spark.sql.connector.catalog.{BufferedRows, InMemoryEnhancedRuntimePartitionFilterTable, InMemoryTableEnhancedRuntimePartitionFilterCatalog}
 import org.apache.spark.sql.connector.expressions.PartitionFieldReference
@@ -54,7 +54,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  * 12. Partition col not in filterAttributes -> no PartitionPredicate
  */
 class DataSourceV2EnhancedRuntimePartitionFilterSuite
-  extends QueryTest with SharedSparkSession with BeforeAndAfter {
+  extends SharedSparkSession with BeforeAndAfter {
 
   protected val v2Source = classOf[FakeV2ProviderWithCustomSchema].getName
   protected val catalogName = "testruntimepartfilter"

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
@@ -26,7 +26,7 @@ import scala.jdk.CollectionConverters._
 import test.org.apache.spark.sql.connector._
 
 import org.apache.spark.SparkUnsupportedOperationException
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GreaterThan => CatalystGreaterThan, Literal => CatalystLiteral, ScalarSubquery}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Project}
@@ -53,7 +53,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.ArrayImplicits._
 
-class DataSourceV2Suite extends QueryTest with SharedSparkSession with AdaptiveSparkPlanHelper {
+class DataSourceV2Suite extends SharedSparkSession with AdaptiveSparkPlanHelper {
   import testImplicits._
 
   private def getBatch(query: DataFrame): AdvancedBatch = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DatasourceV2SQLBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DatasourceV2SQLBase.scala
@@ -19,14 +19,13 @@ package org.apache.spark.sql.connector
 
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.connector.catalog.{CatalogPlugin, InMemoryCatalog, InMemoryPartitionTableCatalog, InMemoryTableWithV2FilterCatalog, StagingInMemoryTableCatalog}
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 trait DatasourceV2SQLBase
-  extends QueryTest with SharedSparkSession with BeforeAndAfter {
+  extends SharedSparkSession with BeforeAndAfter {
 
   protected def registerCatalog[T <: CatalogPlugin](name: String, clazz: Class[T]): Unit = {
     spark.conf.set(s"spark.sql.catalog.$name", clazz.getName)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DatasourceV2SQLBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DatasourceV2SQLBase.scala
@@ -24,8 +24,7 @@ import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAM
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-trait DatasourceV2SQLBase
-  extends SharedSparkSession with BeforeAndAfter {
+trait DatasourceV2SQLBase extends SharedSparkSession with BeforeAndAfter {
 
   protected def registerCatalog[T <: CatalogPlugin](name: String, clazz: Class[T]): Unit = {
     spark.conf.set(s"spark.sql.catalog.$name", clazz.getName)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DistributionAndOrderingSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DistributionAndOrderingSuiteBase.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.connector
 
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
@@ -31,7 +30,7 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.test.SharedSparkSession
 
 abstract class DistributionAndOrderingSuiteBase
-    extends QueryTest with SharedSparkSession with BeforeAndAfter with AdaptiveSparkPlanHelper {
+    extends SharedSparkSession with BeforeAndAfter with AdaptiveSparkPlanHelper {
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 
   override def beforeAll(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/FileDataSourceV2FallBackSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/FileDataSourceV2FallBackSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.connector
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.{SparkConf, SparkException}
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
 import org.apache.spark.sql.connector.read.ScanBuilder
@@ -81,7 +80,7 @@ class DummyWriteOnlyFileTable extends Table with SupportsWrite {
     java.util.EnumSet.of(TableCapability.BATCH_WRITE, TableCapability.ACCEPT_ANY_SCHEMA)
 }
 
-class FileDataSourceV2FallBackSuite extends QueryTest with SharedSparkSession {
+class FileDataSourceV2FallBackSuite extends SharedSparkSession {
 
   private val dummyReadOnlyFileSourceV2 = classOf[DummyReadOnlyFileDataSourceV2].getName
   private val dummyWriteOnlyFileSourceV2 = classOf[DummyWriteOnlyFileDataSourceV2].getName

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/InsertIntoTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/InsertIntoTests.scala
@@ -202,8 +202,7 @@ abstract class InsertIntoTests(
 }
 
 trait InsertIntoSQLOnlyTests
-  extends QueryTest
-  with SharedSparkSession
+  extends SharedSparkSession
   with BeforeAndAfter {
 
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/LocalScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/LocalScanSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector
 
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.catalog.{BasicInMemoryTableCatalog, Identifier, SupportsRead, Table, TableCapability, TableInfo}
 import org.apache.spark.sql.connector.read.{LocalScan, Scan, ScanBuilder}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/LocalScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/LocalScanSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.catalog.{BasicInMemoryTableCatalog, Identifier, SupportsRead, Table, TableCapability, TableInfo}
 import org.apache.spark.sql.connector.read.{LocalScan, Scan, ScanBuilder}
@@ -27,7 +27,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-class LocalScanSuite extends QueryTest with SharedSparkSession {
+class LocalScanSuite extends SharedSparkSession {
   override def beforeAll(): Unit = {
     super.beforeAll()
     spark.conf.set(SQLConf.DEFAULT_CATALOG.key, "testcat")

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ProcedureSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ProcedureSuite.scala
@@ -22,7 +22,7 @@ import java.util.Collections
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.{SPARK_DOC_ROOT, SparkException, SparkNumberFormatException}
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLId
 import org.apache.spark.sql.connector.catalog.{BasicInMemoryTableCatalog, DefaultValue, Identifier, InMemoryCatalog}
@@ -38,7 +38,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{DataType, DataTypes, IntegerType, StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 
-class ProcedureSuite extends QueryTest with SharedSparkSession with BeforeAndAfter {
+class ProcedureSuite extends SharedSparkSession with BeforeAndAfter {
 
   before {
     spark.conf.set(s"spark.sql.catalog.cat", classOf[InMemoryCatalog].getName)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/PushablePredicateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/PushablePredicateSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.connector
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.expressions.{Cast, Literal}
 import org.apache.spark.sql.connector.expressions.filter.{AlwaysTrue, Predicate => V2Predicate}
 import org.apache.spark.sql.execution.datasources.v2.PushablePredicate
@@ -26,7 +25,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BooleanType, TimestampType}
 
-class PushablePredicateSuite extends QueryTest with SharedSparkSession {
+class PushablePredicateSuite extends SharedSparkSession {
 
   override def sparkConf: SparkConf = super.sparkConf.set(SQLConf.ANSI_ENABLED, true)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/RowLevelOperationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/RowLevelOperationSuiteBase.scala
@@ -21,7 +21,7 @@ import java.util.Collections
 
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.sql.{DataFrame, Encoders, QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, Encoders, Row}
 import org.apache.spark.sql.QueryTest.{sameRows, withQueryExecutionsCaptured}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions.{DynamicPruningExpression, Expression, GenericRowWithSchema}
@@ -42,7 +42,7 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.ArrayImplicits._
 
 abstract class RowLevelOperationSuiteBase
-  extends QueryTest with SharedSparkSession with BeforeAndAfter with AdaptiveSparkPlanHelper {
+  extends SharedSparkSession with BeforeAndAfter with AdaptiveSparkPlanHelper {
 
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/SupportsCatalogOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/SupportsCatalogOptionsSuite.scala
@@ -26,7 +26,7 @@ import scala.util.Try
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, QueryTest, SaveMode}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, SaveMode}
 import org.apache.spark.sql.catalyst.analysis.{AsOfTimestamp, AsOfVersion, NoSuchTableException, TableAlreadyExistsException, TimeTravelSpec}
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, LogicalPlan, OverwriteByExpression}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -41,7 +41,7 @@ import org.apache.spark.sql.types.LongType
 import org.apache.spark.sql.util.{CaseInsensitiveStringMap, QueryExecutionListener}
 import org.apache.spark.unsafe.types.UTF8String
 
-class SupportsCatalogOptionsSuite extends QueryTest with SharedSparkSession with BeforeAndAfter {
+class SupportsCatalogOptionsSuite extends SharedSparkSession with BeforeAndAfter {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/V1ReadFallbackSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/V1ReadFallbackSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.connector
 
 import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, QueryTest, Row, SparkSession, SQLContext}
+import org.apache.spark.sql.{DataFrame, Row, SparkSession, SQLContext}
 import org.apache.spark.sql.connector.catalog.{BasicInMemoryTableCatalog, CatalogV2Util, Column, Identifier, SupportsRead, Table, TableCapability, TableInfo}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns, V1Scan}
@@ -30,7 +30,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-abstract class V1ReadFallbackSuite extends QueryTest with SharedSparkSession {
+abstract class V1ReadFallbackSuite extends SharedSparkSession {
   protected def baseTableScan(): DataFrame
 
   test("full scan") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/V1WriteFallbackSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/V1WriteFallbackSuite.scala
@@ -23,7 +23,7 @@ import scala.jdk.CollectionConverters._
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SaveMode, SparkSession, SQLContext}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SaveMode, SparkSession, SQLContext}
 import org.apache.spark.sql.QueryTest.withQueryExecutionsCaptured
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
@@ -46,7 +46,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.ArrayImplicits._
 
-class V1WriteFallbackSuite extends QueryTest with SharedSparkSession with BeforeAndAfter {
+class V1WriteFallbackSuite extends SharedSparkSession with BeforeAndAfter {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryContextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryContextSuite.scala
@@ -34,7 +34,7 @@ class QueryContextSuite extends SharedSparkSession {
       assert(e.getQueryContext.head.summary() ==
         """== DataFrame ==
           |"div" was called from
-          |org.apache.spark.sql.errors.QueryContextSuite.$anonfun$new$3(QueryContextSuite.scala:33)
+          |org.apache.spark.sql.errors.QueryContextSuite.$anonfun$new$3(QueryContextSuite.scala:32)
           |org.scalatest.Assertions.intercept(Assertions.scala:749)
           |""".stripMargin)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryContextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryContextSuite.scala
@@ -17,12 +17,11 @@
 package org.apache.spark.sql.errors
 
 import org.apache.spark.{SparkArithmeticException, SparkConf}
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class QueryContextSuite extends QueryTest with SharedSparkSession {
+class QueryContextSuite extends SharedSparkSession {
   override def sparkConf: SparkConf = super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "true")
 
   private val ansiConf = "\"" + SQLConf.ANSI_ENABLED.key + "\""

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.errors
 import org.apache.spark._
 import org.apache.spark.SparkBuildInfo
 import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskStart}
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.expressions.{CaseWhen, Cast, CheckOverflowInTableInsert, ExpressionProxy, Literal, SubExprEvaluationRuntime}
 import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation
 import org.apache.spark.sql.classic.SparkSession
@@ -29,8 +28,7 @@ import org.apache.spark.sql.test.{SharedSparkSession, TestSparkSession}
 import org.apache.spark.sql.types.ByteType
 
 // Test suite for all the execution errors that requires enable ANSI SQL mode.
-class QueryExecutionAnsiErrorsSuite extends QueryTest
-  with SharedSparkSession {
+class QueryExecutionAnsiErrorsSuite extends SharedSparkSession {
   import testImplicits._
 
   override def sparkConf: SparkConf = super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "true")

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.errors
 
 import org.apache.spark.SparkThrowable
-import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.{AnalysisException}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLId
@@ -26,7 +26,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 
 // Turn of the length check because most of the tests check entire error messages
 // scalastyle:off line.size.limit
-class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession with SQLHelper {
+class QueryParsingErrorsSuite extends SharedSparkSession with SQLHelper {
 
   private def parseException(sqlText: String): SparkThrowable = {
     intercept[ParseException](sql(sqlText).collect())

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.errors
 
 import org.apache.spark.SparkThrowable
-import org.apache.spark.sql.{AnalysisException}
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLId

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
@@ -23,7 +23,7 @@ import scala.util.Random
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.{DataFrame}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.internal.SQLConf
@@ -32,7 +32,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 /**
  * Test suite base for testing the redaction of DataSourceScanExec/BatchScanExec.
  */
-abstract class DataSourceScanRedactionTest extends QueryTest with SharedSparkSession {
+abstract class DataSourceScanRedactionTest extends SharedSparkSession {
 
   override protected def sparkConf: SparkConf = super.sparkConf
     .set("spark.redaction.string.regex", "file:/[^\\]\\s]+")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/DataSourceScanExecRedactionSuite.scala
@@ -23,7 +23,7 @@ import scala.util.Random
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.internal.SQLConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/DeprecatedWholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/DeprecatedWholeStageCodegenSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecutionSuite
 import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.expressions.scalalang.typed
@@ -25,8 +24,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 
 // Disable AQE because the WholeStageCodegenExec is added when running QueryStageExec
 @deprecated("This test suite will be removed.", "3.0.0")
-class DeprecatedWholeStageCodegenSuite extends QueryTest
-  with SharedSparkSession
+class DeprecatedWholeStageCodegenSuite extends SharedSparkSession
   with DisableAdaptiveExecutionSuite {
 
   test("simple typed UDAF should be included in WholeStageCodegen") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -16,10 +16,10 @@
  */
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.test.SharedSparkSession
 
-class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
+class ExecuteImmediateEndToEndSuite extends SharedSparkSession {
 
   test("SPARK-47033: EXECUTE IMMEDIATE USING does not recognize session variable names") {
     try {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalog.Table
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.plans.logical.{BROADCAST, HintInfo, Join, JoinHint}
@@ -25,7 +25,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 
-class GlobalTempViewSuite extends QueryTest with SharedSparkSession {
+class GlobalTempViewSuite extends SharedSparkSession {
   import testImplicits._
 
   override protected def beforeAll(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffsetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffsetSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{Dataset, QueryTest}
+import org.apache.spark.sql.{Dataset}
 import org.apache.spark.sql.IntegratedUDFTestUtils._
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.rand
@@ -25,8 +25,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.IntegerType
 
-class InsertSortForLimitAndOffsetSuite extends QueryTest
-  with SharedSparkSession
+class InsertSortForLimitAndOffsetSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffsetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffsetSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{Dataset}
+import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.IntegratedUDFTestUtils._
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.rand

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuerySuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.tags.SlowSQLTest
 
 @SlowSQLTest
-class OptimizeMetadataOnlyQuerySuite extends QueryTest with SharedSparkSession {
+class OptimizeMetadataOnlyQuerySuite extends SharedSparkSession {
   import testImplicits._
 
   override def beforeAll(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.connector.SimpleWritableDataSource
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
 import org.apache.spark.sql.internal.SQLConf
@@ -26,8 +26,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
 
 abstract class RemoveRedundantProjectsSuiteBase
-  extends QueryTest
-    with SharedSparkSession
+  extends SharedSparkSession
     with AdaptiveSparkPlanHelper {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantSortsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantSortsSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{DataFrame}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.plans.physical.{RangePartitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
 import org.apache.spark.sql.execution.joins.ShuffledJoin

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantSortsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantSortsSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.{DataFrame}
 import org.apache.spark.sql.catalyst.plans.physical.{RangePartitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
 import org.apache.spark.sql.execution.joins.ShuffledJoin
@@ -26,8 +26,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 
 
 abstract class RemoveRedundantSortsSuiteBase
-    extends QueryTest
-    with SharedSparkSession
+    extends SharedSparkSession
     with AdaptiveSparkPlanHelper {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantWindowGroupLimitsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantWindowGroupLimitsSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{DataFrame}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
 import org.apache.spark.sql.execution.window.WindowGroupLimitExec
 import org.apache.spark.sql.functions.lit

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantWindowGroupLimitsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantWindowGroupLimitsSuite.scala
@@ -17,15 +17,14 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.{DataFrame}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
 import org.apache.spark.sql.execution.window.WindowGroupLimitExec
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.test.SharedSparkSession
 
 abstract class RemoveRedundantWindowGroupLimitsSuiteBase
-    extends QueryTest
-    with SharedSparkSession
+    extends SharedSparkSession
     with AdaptiveSparkPlanHelper {
 
   private def checkNumWindowGroupLimits(df: DataFrame, count: Int): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAggSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAggSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{DataFrame}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.internal.SQLConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAggSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAggSuite.scala
@@ -17,15 +17,14 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.{DataFrame}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 abstract class ReplaceHashWithSortAggSuiteBase
-    extends QueryTest
-    with SharedSparkSession
+    extends SharedSparkSession
     with AdaptiveSparkPlanHelper {
 
   private def checkNumAggs(df: DataFrame, hashAggCount: Int, sortAggCount: Int): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
@@ -17,13 +17,13 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.test.SharedSparkSession
 
 /**
  * Test suite for SQL user-defined functions (UDFs).
  */
-class SQLFunctionSuite extends QueryTest with SharedSparkSession {
+class SQLFunctionSuite extends SharedSparkSession {
   import testImplicits._
 
   protected override def beforeAll(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLWindowFunctionSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.TestUtils.assertSpilled
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.internal.SQLConf.{WINDOW_EXEC_BUFFER_IN_MEMORY_THRESHOLD, WINDOW_EXEC_BUFFER_SPILL_THRESHOLD}
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -28,7 +28,7 @@ case class WindowData(month: Int, area: String, product: Int)
 /**
  * Test suite for SQL window functions.
  */
-class SQLWindowFunctionSuite extends QueryTest with SharedSparkSession {
+class SQLWindowFunctionSuite extends SharedSparkSession {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SameResultSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SameResultSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{DataFrame}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, Project}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SameResultSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SameResultSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.{DataFrame}
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, Project}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
@@ -29,7 +29,7 @@ import org.apache.spark.sql.types.IntegerType
 /**
  * Tests for the sameResult function for [[SparkPlan]]s.
  */
-class SameResultSuite extends QueryTest with SharedSparkSession {
+class SameResultSuite extends SharedSparkSession {
   import testImplicits._
 
   test("FileSourceScanExec: different orders of data filters and partition filters") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution
 
 import org.apache.spark.{SparkEnv, SparkException, SparkUnsupportedOperationException}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.Deduplicate
@@ -29,7 +28,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class SparkPlanSuite extends QueryTest with SharedSparkSession {
+class SparkPlanSuite extends SharedSparkSession {
 
   test("SPARK-21619 execution of a canonicalized plan should fail") {
     val plan = spark.range(10).queryExecution.executedPlan.canonicalized

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -22,7 +22,7 @@ import java.time.Duration
 
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.MapPartitionsWithEvaluatorRDD
-import org.apache.spark.sql.{Dataset, QueryTest, Row, SaveMode}
+import org.apache.spark.sql.{Dataset, Row, SaveMode}
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.catalyst.expressions.codegen.{ByteCodeStats, CodeAndComment, CodeGenerator}
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecutionSuite
@@ -36,7 +36,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{DayTimeIntervalType, DecimalType, IntegerType, StringType, StructField, StructType}
 
 // Disable AQE because the WholeStageCodegenExec is added when running QueryStageExec
-class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
+class WholeStageCodegenSuite extends SharedSparkSession
   with DisableAdaptiveExecutionSuite {
 
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobStart}
 import org.apache.spark.shuffle.sort.SortShuffleManager
-import org.apache.spark.sql.{DataFrame, Dataset, QueryTest, Row, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
@@ -60,8 +60,7 @@ import org.apache.spark.util.Utils
 
 @SlowSQLTest
 class AdaptiveQueryExecSuite
-  extends QueryTest
-  with SharedSparkSession
+  extends SharedSparkSession
   with AdaptiveSparkPlanHelper
   with PrivateMethodTester {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowFileReadWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowFileReadWriteSuite.scala
@@ -18,12 +18,11 @@ package org.apache.spark.sql.execution.arrow
 
 import java.io.File
 
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
-class ArrowFileReadWriteSuite extends QueryTest with SharedSparkSession {
+class ArrowFileReadWriteSuite extends SharedSparkSession {
 
   private var tempDataPath: String = _
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/CachedBatchSerializerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/CachedBatchSerializerSuite.scala
@@ -21,7 +21,7 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, UnsafeProjection}
 import org.apache.spark.sql.columnar.{CachedBatch, CachedBatchSerializer}
@@ -141,8 +141,7 @@ class DefaultCachedBatchSerializerNoUnwrap extends DefaultCachedBatchSerializer 
   }
 }
 
-class CachedBatchSerializerSuite extends QueryTest
-  with SharedSparkSession with AdaptiveSparkPlanHelper {
+class CachedBatchSerializerSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
   import testImplicits._
 
   override protected def sparkConf: SparkConf = {
@@ -201,8 +200,7 @@ class CachedBatchSerializerSuite extends QueryTest
 }
 
 
-class CachedBatchSerializerNoUnwrapSuite extends QueryTest
-  with SharedSparkSession with AdaptiveSparkPlanHelper {
+class CachedBatchSerializerNoUnwrapSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/CachedBatchSerializerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/CachedBatchSerializerSuite.scala
@@ -21,7 +21,7 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, UnsafeProjection}
 import org.apache.spark.sql.columnar.{CachedBatch, CachedBatchSerializer}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -22,7 +22,7 @@ import java.sql.{Date, Timestamp}
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet, In}
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
@@ -50,8 +50,7 @@ class TestCachedBatchSerializer(
   }
 }
 
-class InMemoryColumnarQuerySuite extends QueryTest
-  with SharedSparkSession with AdaptiveSparkPlanHelper {
+class InMemoryColumnarQuerySuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
   import testImplicits._
 
   setupTestData()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -22,7 +22,7 @@ import java.sql.{Date, Timestamp}
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet, In}
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/RefCountedTestCachedBatchSerializerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/RefCountedTestCachedBatchSerializerSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.columnar
 
 import org.apache.spark.SparkConf
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.columnar.{CachedBatch, SimpleMetricsCachedBatch}
@@ -97,7 +96,7 @@ class RefCountedTestCachedBatchSerializer extends DefaultCachedBatchSerializer {
   override def supportsColumnarInput(schema: Seq[Attribute]): Boolean = false
 }
 
-class RefCountedTestCachedBatchSerializerSuite extends QueryTest with SharedSparkSession {
+class RefCountedTestCachedBatchSerializerSuite extends SharedSparkSession {
   import testImplicits._
 
   override protected def sparkConf: SparkConf = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceResolverSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.analysis.resolver.{
   MetadataResolver,
@@ -29,7 +28,7 @@ import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
-class DataSourceResolverSuite extends QueryTest with SharedSparkSession {
+class DataSourceResolverSuite extends SharedSparkSession {
   private val keyValueTableSchema = StructType(
     Seq(
       StructField("key", IntegerType, true),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileFormatWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileFormatWriterSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.plans.CodegenInterpretedPlanTest
 import org.apache.spark.sql.test.SharedSparkSession
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileFormatWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileFormatWriterSuite.scala
@@ -17,13 +17,12 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.catalyst.plans.CodegenInterpretedPlanTest
 import org.apache.spark.sql.test.SharedSparkSession
 
 class FileFormatWriterSuite
-  extends QueryTest
-  with SharedSparkSession
+  extends SharedSparkSession
   with CodegenInterpretedPlanTest {
 
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
@@ -23,7 +23,7 @@ import java.text.SimpleDateFormat
 
 import org.apache.spark.TestUtils
 import org.apache.spark.paths.SparkPath
-import org.apache.spark.sql.{AnalysisException, Column, DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Column, DataFrame, Row}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.execution.FileSourceScanExec
@@ -33,7 +33,7 @@ import org.apache.spark.sql.streaming.Trigger
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, LongType, MetadataBuilder, StringType, StructField, StructType}
 
-class FileMetadataStructSuite extends QueryTest with SharedSparkSession {
+class FileMetadataStructSuite extends SharedSparkSession {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileResolverSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileResolverSuite.scala
@@ -17,14 +17,13 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.analysis.resolver.ProhibitedResolver
 import org.apache.spark.sql.catalyst.plans.logical.Project
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{LongType, StringType, StructType}
 
-class FileResolverSuite extends QueryTest with SharedSparkSession {
+class FileResolverSuite extends SharedSparkSession {
   private val tableSchema = new StructType().add("id", LongType)
   private val csvTableSchema = new StructType().add("_c0", StringType)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceCodecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceCodecSuite.scala
@@ -19,13 +19,12 @@ package org.apache.spark.sql.execution.datasources
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.execution.datasources.orc.OrcCompressionCodec
 import org.apache.spark.sql.execution.datasources.parquet.ParquetCompressionCodec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-trait FileSourceCodecSuite extends QueryTest with SharedSparkSession {
+trait FileSourceCodecSuite extends SharedSparkSession {
 
   protected def format: String
   protected val codecConfigName: String

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceCustomMetadataStructSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceCustomMetadataStructSuite.scala
@@ -21,7 +21,7 @@ import java.io.File
 
 import org.apache.hadoop.fs.{FileStatus, Path}
 
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, FileSourceConstantMetadataStructField, FileSourceGeneratedMetadataStructField, Literal}
 import org.apache.spark.sql.classic.{DataFrame, Dataset}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceCustomMetadataStructSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceCustomMetadataStructSuite.scala
@@ -21,7 +21,7 @@ import java.io.File
 
 import org.apache.hadoop.fs.{FileStatus, Path}
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, FileSourceConstantMetadataStructField, FileSourceGeneratedMetadataStructField, Literal}
 import org.apache.spark.sql.classic.{DataFrame, Dataset}
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types.{IntegerType, LongType, StringType, StructFiel
 import org.apache.spark.unsafe.types.UTF8String
 
 /** Verifies the ability for a FileFormat to define custom metadata types */
-class FileSourceCustomMetadataStructSuite extends QueryTest with SharedSparkSession {
+class FileSourceCustomMetadataStructSuite extends SharedSparkSession {
   import FileSourceCustomMetadataStructSuite._
 
   val extraConstantMetadataFields = Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -28,7 +28,7 @@ import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.SparkException
 import org.apache.spark.internal.config
 import org.apache.spark.paths.SparkPath.{fromUrlString => sp}
-import org.apache.spark.sql.{execution, DataFrame, QueryTest, Row, SparkSession}
+import org.apache.spark.sql.{execution, DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionSet}
@@ -43,7 +43,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, LongType, StructField, StructType}
 import org.apache.spark.util.Utils
 
-class FileSourceStrategySuite extends QueryTest with SharedSparkSession {
+class FileSourceStrategySuite extends SharedSparkSession {
   import testImplicits._
 
   protected override def sparkConf = super.sparkConf.set(config.DEFAULT_PARALLELISM.key, "1")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/InMemoryTableMetricSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/InMemoryTableMetricSuite.scala
@@ -26,8 +26,7 @@ import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.IntegerType
 
-class InMemoryTableMetricSuite
-  extends SharedSparkSession with BeforeAndAfter {
+class InMemoryTableMetricSuite extends SharedSparkSession with BeforeAndAfter {
   import testImplicits._
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/InMemoryTableMetricSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/InMemoryTableMetricSuite.scala
@@ -20,7 +20,6 @@ import java.util.Collections
 
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.connector.catalog.{Column, Identifier, InMemoryTable, InMemoryTableCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.functions.lit
@@ -28,7 +27,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.IntegerType
 
 class InMemoryTableMetricSuite
-  extends QueryTest with SharedSparkSession with BeforeAndAfter {
+  extends SharedSparkSession with BeforeAndAfter {
   import testImplicits._
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PathFilterStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PathFilterStrategySuite.scala
@@ -17,11 +17,10 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.test.SharedSparkSession
 
-class PathFilterStrategySuite extends QueryTest with SharedSparkSession {
+class PathFilterStrategySuite extends SharedSparkSession {
 
   test("SPARK-31962: PathFilterStrategies - modifiedAfter option") {
     val options =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PathFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PathFilterSuite.scala
@@ -23,12 +23,12 @@ import java.time.format.DateTimeFormatter
 
 import scala.util.Random
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.util.{stringToFile, DateTimeUtils}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 
-class PathFilterSuite extends QueryTest with SharedSparkSession {
+class PathFilterSuite extends SharedSparkSession {
   import testImplicits._
 
   test("SPARK-31962: modifiedBefore specified" +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadSchemaTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadSchemaTest.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources
 
 import java.io.File
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -67,7 +67,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  *     -> ToDecimalTypeTest
  */
 
-trait ReadSchemaTest extends QueryTest with SharedSparkSession {
+trait ReadSchemaTest extends SharedSparkSession {
   val format: String
   val options: Map[String, String] = Map.empty[String, String]
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadSchemaTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadSchemaTest.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources
 
 import java.io.File
 
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
@@ -18,12 +18,12 @@
 package org.apache.spark.sql.execution.datasources
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SaveMode, SparkSession, SQLContext}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SaveMode, SparkSession, SQLContext}
 import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, RelationProvider, TableScan}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
 
-class SaveIntoDataSourceCommandSuite extends QueryTest with SharedSparkSession {
+class SaveIntoDataSourceCommandSuite extends SharedSparkSession {
 
   test("simpleString is redacted") {
     val URL = "connection.url"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TableLocationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TableLocationSuite.scala
@@ -19,11 +19,11 @@ package org.apache.spark.sql.execution.datasources
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.{AnalysisException}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class TableLocationSuite extends QueryTest with SharedSparkSession {
+class TableLocationSuite extends SharedSparkSession {
 
   test("SPARK-44185: relative LOCATION in CTAS should be qualified with warehouse") {
     withSQLConf(SQLConf.ALLOW_NON_EMPTY_LOCATION_IN_CTAS.key -> "false") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TableLocationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TableLocationSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.sql.{AnalysisException}
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
@@ -126,7 +126,7 @@ trait V1WriteCommandSuiteBase extends QueryTest with AdaptiveSparkPlanHelper {
 }
 
 @SlowSQLTest
-class V1WriteCommandSuite extends QueryTest with SharedSparkSession with V1WriteCommandSuiteBase {
+class V1WriteCommandSuite extends SharedSparkSession with V1WriteCommandSuiteBase {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -28,7 +28,7 @@ import org.apache.hadoop.fs.{FileStatus, FileSystem, GlobFilter, Path}
 import org.mockito.Mockito.{mock, when}
 
 import org.apache.spark.{SparkException, SparkUnsupportedOperationException}
-import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.functions.col
@@ -38,7 +38,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
-class BinaryFileFormatSuite extends QueryTest with SharedSparkSession {
+class BinaryFileFormatSuite extends SharedSparkSession {
   import BinaryFileFormat._
 
   private var testDir: String = _

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVParsingOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVParsingOptionsSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.csv
 
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.SharedSparkSession
 
 class CSVParsingOptionsSuite extends SharedSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVParsingOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVParsingOptionsSuite.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.sql.execution.datasources.csv
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.test.SharedSparkSession
 
-class CSVParsingOptionsSuite extends QueryTest with SharedSparkSession {
+class CSVParsingOptionsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("SPARK-49955: null string value does not mean corrupted file") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -50,8 +50,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
 abstract class CSVSuite
-  extends QueryTest
-  with SharedSparkSession
+  extends SharedSparkSession
   with TestCsvData
   with CommonFileDataSourceSuite {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
@@ -18,14 +18,14 @@
 package org.apache.spark.sql.execution.datasources.json
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructType}
 
 /**
  * Test cases for various [[org.apache.spark.sql.catalyst.json.JSONOptions]].
  */
-class JsonParsingOptionsSuite extends QueryTest with SharedSparkSession {
+class JsonParsingOptionsSuite extends SharedSparkSession {
   import testImplicits._
 
   test("allowComments off") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonParsingOptionsSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.datasources.json
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructType}
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -59,8 +59,7 @@ class TestFileFilter extends PathFilter {
 }
 
 abstract class JsonSuite
-  extends QueryTest
-  with SharedSparkSession
+  extends SharedSparkSession
   with TestJsonData
   with CommonFileDataSourceSuite {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReaderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReaderSuite.scala
@@ -27,7 +27,6 @@ import org.apache.orc.TypeDescription
 
 import org.apache.spark.TestUtils
 import org.apache.spark.memory.MemoryMode
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -37,7 +36,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.unsafe.types.UTF8String.fromString
 
-class OrcColumnarBatchReaderSuite extends QueryTest with SharedSparkSession {
+class OrcColumnarBatchReaderSuite extends SharedSparkSession {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetColumnIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetColumnIndexSuite.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.{DataFrame}
 import org.apache.spark.sql.test.SharedSparkSession
 
-class ParquetColumnIndexSuite extends QueryTest with ParquetTest with SharedSparkSession {
+class ParquetColumnIndexSuite extends ParquetTest with SharedSparkSession {
   import testImplicits._
 
   private val actions: Seq[DataFrame => DataFrame] = Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetColumnIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetColumnIndexSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.spark.sql.{DataFrame}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.test.SharedSparkSession
 
 class ParquetColumnIndexSuite extends ParquetTest with SharedSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdIOSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources.parquet
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdIOSuite.scala
@@ -20,12 +20,12 @@ package org.apache.spark.sql.execution.datasources.parquet
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class ParquetFieldIdIOSuite extends QueryTest with ParquetTest with SharedSparkSession  {
+class ParquetFieldIdIOSuite extends ParquetTest with SharedSparkSession  {
 
   private def withId(id: Int): Metadata =
     new MetadataBuilder().putLong(ParquetUtils.FIELD_ID_METADATA_KEY, id).build()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileMetadataStructRowIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileMetadataStructRowIndexSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest}
+import org.apache.spark.sql.{AnalysisException, DataFrame}
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.internal.SQLConf
@@ -24,7 +24,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
 import org.apache.spark.util.ArrayImplicits._
 
-class ParquetFileMetadataStructRowIndexSuite extends QueryTest with SharedSparkSession {
+class ParquetFileMetadataStructRowIndexSuite extends SharedSparkSession {
   import testImplicits._
   import ParquetFileFormat.{ROW_INDEX, ROW_INDEX_TEMPORARY_COLUMN_NAME}
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -76,7 +76,7 @@ import org.apache.spark.util.ArrayImplicits._
  * dependent on this configuration, don't forget you better explicitly set this configuration
  * within the test.
  */
-abstract class ParquetFilterSuite extends QueryTest with ParquetTest with SharedSparkSession {
+abstract class ParquetFilterSuite extends ParquetTest with SharedSparkSession {
   import testImplicits.toRichColumn
 
   protected def createParquetFilters(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -56,7 +56,7 @@ import org.apache.spark.unsafe.types.UTF8String
 /**
  * A test suite that tests basic Parquet I/O.
  */
-class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession {
+class ParquetIOSuite extends ParquetTest with SharedSparkSession {
   import testImplicits._
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
@@ -50,7 +50,7 @@ case class ParquetData(intField: Int, stringField: String)
 case class ParquetDataWithKey(intField: Int, pi: Int, stringField: String, ps: String)
 
 abstract class ParquetPartitionDiscoverySuite
-  extends QueryTest with ParquetTest with SharedSparkSession {
+  extends ParquetTest with SharedSparkSession {
   import PartitioningUtils._
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -44,7 +44,7 @@ import org.apache.spark.util.Utils
 /**
  * A test suite that tests various Parquet queries.
  */
-abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedSparkSession {
+abstract class ParquetQuerySuite extends ParquetTest with SharedSparkSession {
   import testImplicits._
 
   test("simple select queries") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
@@ -28,7 +28,6 @@ import org.apache.parquet.hadoop.ParquetWriter.DEFAULT_BLOCK_SIZE
 import org.apache.parquet.hadoop.util.HadoopInputFile
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
@@ -41,7 +40,7 @@ import org.apache.spark.tags.SlowSQLTest
 import org.apache.spark.util.ArrayImplicits._
 
 @SlowSQLTest
-class ParquetRowIndexSuite extends QueryTest with SharedSparkSession {
+class ParquetRowIndexSuite extends SharedSparkSession {
   import testImplicits._
 
   private def readRowGroupRowCounts(path: String): Seq[Long] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVariantShreddingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVariantShreddingSuite.scala
@@ -29,7 +29,7 @@ import org.apache.parquet.schema.{LogicalTypeAnnotation, PrimitiveType, Type}
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType
 import org.apache.spark.sql.test.SharedSparkSession
@@ -38,7 +38,7 @@ import org.apache.spark.unsafe.types.VariantVal
 /**
  * Test shredding Variant values in the Parquet reader/writer.
  */
-class ParquetVariantShreddingSuite extends QueryTest with ParquetTest with SharedSparkSession {
+class ParquetVariantShreddingSuite extends ParquetTest with SharedSparkSession {
 
   private def testWithTempDir(name: String)(block: File => Unit): Unit = test(name) {
     withTempDir { dir =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorizedSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorizedSuite.scala
@@ -32,7 +32,7 @@ import org.apache.parquet.schema.{MessageType, MessageTypeParser}
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 
 import org.apache.spark.memory.MemoryMode
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{RowOrdering, SpecificInternalRow}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorizedSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorizedSuite.scala
@@ -32,7 +32,7 @@ import org.apache.parquet.schema.{MessageType, MessageTypeParser}
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 
 import org.apache.spark.memory.MemoryMode
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{RowOrdering, SpecificInternalRow}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -47,7 +47,7 @@ import org.apache.spark.util.collection.Utils.createArray
  * A test suite on the vectorized Parquet reader. Unlike `ParquetIOSuite`, this focuses on
  * low-level decoding logic covering column index, dictionary, different batch and page sizes, etc.
  */
-class ParquetVectorizedSuite extends QueryTest with ParquetTest with SharedSparkSession {
+class ParquetVectorizedSuite extends ParquetTest with SharedSparkSession {
   private val VALUES: Seq[String] = ('a' to 'z').map(_.toString)
   private val NUM_VALUES: Int = VALUES.length
   private val BATCH_SIZE_CONFIGS: Seq[Int] = Seq(1, 3, 5, 7, 10, 20, 40)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VariantInferShreddingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VariantInferShreddingSuite.scala
@@ -23,7 +23,7 @@ import java.io.File
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.classic.Dataset
@@ -36,7 +36,7 @@ import org.apache.spark.types.variant._
 import org.apache.spark.unsafe.types.VariantVal
 
 // Unit tests for variant shredding inference.
-class VariantInferShreddingSuite extends QueryTest with SharedSparkSession with ParquetTest {
+class VariantInferShreddingSuite extends SharedSparkSession with ParquetTest {
   override def sparkConf: SparkConf = {
     super.sparkConf.set(SQLConf.PUSH_VARIANT_INTO_SCAN.key, "true")
       .set(SQLConf.VARIANT_WRITE_SHREDDING_ENABLED.key, "true")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
@@ -26,7 +26,7 @@ import org.apache.hadoop.io.compress.{CompressionCodecFactory, GzipCodec}
 
 import org.apache.spark.{SparkConf, SparkIllegalArgumentException, TestUtils}
 import org.apache.spark.io.ZStdCompressionCodec
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SaveMode}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SaveMode}
 import org.apache.spark.sql.catalyst.util.HadoopCompressionCodec
 import org.apache.spark.sql.catalyst.util.HadoopCompressionCodec.{BZIP2, DEFLATE, GZIP, LZ4, NONE, SNAPPY}
 import org.apache.spark.sql.execution.datasources.CommonFileDataSourceSuite
@@ -35,7 +35,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.util.Utils
 
-abstract class TextSuite extends QueryTest with SharedSparkSession with CommonFileDataSourceSuite {
+abstract class TextSuite extends SharedSparkSession with CommonFileDataSourceSuite {
   import testImplicits._
 
   override protected def dataSourceFormat = "text"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/WholeTextFileSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/WholeTextFileSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources.text
 import java.io.File
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.util.HadoopCompressionCodec.GZIP
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/WholeTextFileSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/WholeTextFileSuite.scala
@@ -20,13 +20,13 @@ package org.apache.spark.sql.execution.datasources.text
 import java.io.File
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.catalyst.util.HadoopCompressionCodec.GZIP
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructType}
 
-abstract class WholeTextFileSuite extends QueryTest with SharedSparkSession {
+abstract class WholeTextFileSuite extends SharedSparkSession {
 
   // Hadoop's FileSystem caching does not use the Configuration as part of its cache key, which
   // can cause Filesystem.get(Configuration) to return a cached instance created with a different

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/FileTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/FileTableSuite.scala
@@ -22,7 +22,7 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.hadoop.fs.FileStatus
 
-import org.apache.spark.sql.{QueryTest, SparkSession}
+import org.apache.spark.sql.{SparkSession}
 import org.apache.spark.sql.connector.read.ScanBuilder
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, LogicalWriteInfoImpl, WriteBuilder}
 import org.apache.spark.sql.execution.datasources.DataSource
@@ -60,7 +60,7 @@ class DummyFileTable(
   override def fallbackFileFormat: Class[_ <: FileFormat] = classOf[TextFileFormat]
 }
 
-class FileTableSuite extends QueryTest with SharedSparkSession {
+class FileTableSuite extends SharedSparkSession {
 
   private val allFileBasedDataSources = Seq("orc", "parquet", "csv", "json", "text")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/FileTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/FileTableSuite.scala
@@ -22,7 +22,7 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.hadoop.fs.FileStatus
 
-import org.apache.spark.sql.{SparkSession}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.read.ScanBuilder
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, LogicalWriteInfoImpl, WriteBuilder}
 import org.apache.spark.sql.execution.datasources.DataSource

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DerbyTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DerbyTableCatalogSuite.scala
@@ -17,12 +17,12 @@
 package org.apache.spark.sql.execution.datasources.v2.jdbc
 
 import org.apache.spark.{SparkConf, SparkUnsupportedOperationException}
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.MetadataBuilder
 import org.apache.spark.util.Utils
 
-class DerbyTableCatalogSuite extends QueryTest with SharedSparkSession {
+class DerbyTableCatalogSuite extends SharedSparkSession {
 
   val tempDir = Utils.createTempDir()
   val url = s"jdbc:derby:memory:${tempDir.getCanonicalPath};create=true"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DerbyTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/DerbyTableCatalogSuite.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution.datasources.v2.jdbc
 
 import org.apache.spark.{SparkConf, SparkUnsupportedOperationException}
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.MetadataBuilder
 import org.apache.spark.util.Utils

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -24,7 +24,7 @@ import scala.jdk.CollectionConverters._
 import org.apache.logging.log4j.Level
 
 import org.apache.spark.{SparkConf, SparkIllegalArgumentException, SparkRuntimeException}
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.analysis.{NoSuchNamespaceException, TableAlreadyExistsException}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
@@ -37,7 +37,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.Utils
 
-class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
+class JDBCTableCatalogSuite extends SharedSparkSession {
 
   val tempDir = Utils.createTempDir()
   val url = s"jdbc:h2:${tempDir.getCanonicalPath};user=testUser;password=testPass"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlInferSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlInferSchemaSuite.scala
@@ -38,8 +38,7 @@ import org.apache.spark.sql.types.{
 }
 
 class XmlInferSchemaSuite
-    extends QueryTest
-    with SharedSparkSession
+    extends SharedSparkSession
     with TestXmlData
     with XmlSchemaInferenceCaseSensitivityTests {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -37,7 +37,7 @@ import org.apache.hadoop.io.compress.{CompressionCodecFactory, GzipCodec}
 
 import org.apache.spark.{DebugFilesystem, SparkConf, SparkException}
 import org.apache.spark.io.ZStdCompressionCodec
-import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, Encoders, QueryTest, Row, SaveMode, YearUDT}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, Encoders, Row, SaveMode, YearUDT}
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.UDTEncoder
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.TypeUtils.ordinalNumber
@@ -54,8 +54,7 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.Utils
 
 class XmlSuite
-    extends QueryTest
-    with SharedSparkSession
+    extends SharedSparkSession
     with CommonFileDataSourceSuite
     with TestXmlData {
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlVariantSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlVariantSuite.scala
@@ -20,7 +20,7 @@ import java.io.CharArrayWriter
 import java.time.ZoneOffset
 
 import org.apache.spark.{SparkConf, SparkException}
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.catalyst.xml.{StaxXmlGenerator, StaxXmlParser, XmlOptions}
 import org.apache.spark.sql.functions.{col, variant_get}
 import org.apache.spark.sql.internal.SQLConf
@@ -29,7 +29,7 @@ import org.apache.spark.sql.types.VariantType
 import org.apache.spark.types.variant.{Variant, VariantBuilder}
 import org.apache.spark.unsafe.types.VariantVal
 
-class XmlVariantSuite extends QueryTest with SharedSparkSession with TestXmlData {
+class XmlVariantSuite extends SharedSparkSession with TestXmlData {
 
   protected val legacyParserEnabled: Boolean = false
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.python
 
-import org.apache.spark.sql.{IntegratedUDFTestUtils, QueryTest}
+import org.apache.spark.sql.{IntegratedUDFTestUtils}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types.StringType
  * ArrowEvalPythonExec uses the columnar path (no ColumnarToRowExec) and
  * produces correct results.
  */
-class ArrowColumnarPythonUDFSuite extends QueryTest with SharedSparkSession {
+class ArrowColumnarPythonUDFSuite extends SharedSparkSession {
 
   import IntegratedUDFTestUtils._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/ArrowColumnarPythonUDFSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.python
 
-import org.apache.spark.sql.{IntegratedUDFTestUtils}
+import org.apache.spark.sql.IntegratedUDFTestUtils
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -21,7 +21,7 @@ import java.io.{File, FileWriter}
 
 import org.apache.spark.api.python.PythonException
 import org.apache.spark.api.python.PythonUtils
-import org.apache.spark.sql.{AnalysisException, IntegratedUDFTestUtils, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, IntegratedUDFTestUtils, Row}
 import org.apache.spark.sql.execution.FilterExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.datasources.DataSourceManager
@@ -33,8 +33,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
 
 abstract class PythonDataSourceSuiteBase
-    extends QueryTest
-    with SharedSparkSession
+    extends SharedSparkSession
     with AdaptiveSparkPlanHelper {
 
   protected val simpleDataSourceReaderScript: String =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
@@ -17,13 +17,13 @@
 
 package org.apache.spark.sql.execution.python
 
-import org.apache.spark.sql.{AnalysisException, IntegratedUDFTestUtils, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, IntegratedUDFTestUtils, Row}
 import org.apache.spark.sql.functions.{array, avg, col, count, transform}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.LongType
 
-class PythonUDFSuite extends QueryTest with SharedSparkSession {
+class PythonUDFSuite extends SharedSparkSession {
   import testImplicits._
 
   import IntegratedUDFTestUtils._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.python
 
 import org.apache.spark.api.python.PythonEvalType
-import org.apache.spark.sql.{IntegratedUDFTestUtils, QueryTest, Row}
+import org.apache.spark.sql.{IntegratedUDFTestUtils, Row}
 import org.apache.spark.sql.catalyst.expressions.{Add, Alias, Expression, FunctionTableSubqueryArgumentExpression, Literal}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, OneRowRelation, Project, Repartition, RepartitionByExpression, Sort, SubqueryAlias}
@@ -27,7 +27,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 
-class PythonUDTFSuite extends QueryTest with SharedSparkSession {
+class PythonUDTFSuite extends SharedSparkSession {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonWorkerLogsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonWorkerLogsSuite.scala
@@ -20,14 +20,14 @@ package org.apache.spark.sql.execution.python
 import java.util.UUID
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.{PythonWorkerLogBlockId, PythonWorkerLogBlockIdGenerator, PythonWorkerLogLine}
 import org.apache.spark.util.LogUtils
 
-class PythonWorkerLogsSuite extends QueryTest with SharedSparkSession {
+class PythonWorkerLogsSuite extends SharedSparkSession {
   import testImplicits._
 
   override def sparkConf: SparkConf =

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.Level
 
 import org.apache.spark.{SPARK_DOC_ROOT, SparkIllegalArgumentException, SparkNoSuchElementException}
 import org.apache.spark.network.util.ByteUnit
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.MIT
 import org.apache.spark.sql.classic.{SparkSession, SQLContext}
@@ -34,7 +34,7 @@ import org.apache.spark.sql.internal.StaticSQLConf._
 import org.apache.spark.sql.test.{SharedSparkSession, TestSQLContext}
 import org.apache.spark.util.Utils
 
-class SQLConfSuite extends QueryTest with SharedSparkSession {
+class SQLConfSuite extends SharedSparkSession {
 
   private val testKey = "test.key.0"
   private val testVal = "test.val.0"

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCMetricsSuite.scala
@@ -21,13 +21,12 @@ import java.sql.{Connection, DriverManager, Statement}
 import java.util.Properties
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
-class JDBCMetricsSuite extends QueryTest with SharedSparkSession {
+class JDBCMetricsSuite extends SharedSparkSession {
 
   val tempDir = Utils.createTempDir()
   val url = s"jdbc:h2:${tempDir.getCanonicalPath};user=testUser;password=testPass"

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -30,7 +30,7 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 
 import org.apache.spark.{SparkException, SparkIllegalArgumentException, SparkSQLException}
-import org.apache.spark.sql.{AnalysisException, DataFrame, Observation, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Observation, Row}
 import org.apache.spark.sql.catalyst.{analysis, TableIdentifier}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.plans.logical.ShowCreateTable
@@ -47,7 +47,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
-class JDBCSuite extends QueryTest with SharedSparkSession {
+class JDBCSuite extends SharedSparkSession {
   import testImplicits._
 
   val url = "jdbc:h2:mem:testdb0"

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -25,7 +25,7 @@ import scala.util.control.NonFatal
 import test.org.apache.spark.sql.connector.catalog.functions.JavaStrLen.JavaStrLenStaticMagic
 
 import org.apache.spark.{SparkConf, SparkException, SparkIllegalArgumentException}
-import org.apache.spark.sql.{AnalysisException, DataFrame, ExplainSuiteHelper, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, DataFrame, ExplainSuiteHelper, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{CannotReplaceMissingTableException, IndexAlreadyExistsException, NoSuchIndexException}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, GlobalLimit, LocalLimit, Offset, Sort}
@@ -45,7 +45,7 @@ import org.apache.spark.sql.types.{DataType, IntegerType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.Utils
 
-class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHelper {
+class JDBCV2Suite extends SharedSparkSession with ExplainSuiteHelper {
   import testImplicits._
 
   val tempDir = Utils.createTempDir()

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
@@ -21,7 +21,7 @@ import java.sql.{Connection, DriverManager}
 import java.util.Properties
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.connector.DataSourcePushdownTestUtils
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
@@ -32,8 +32,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{DataType, DataTypes, StructField, StructType}
 
 trait JDBCV2JoinPushdownIntegrationSuiteBase
-  extends QueryTest
-  with SharedSparkSession
+  extends SharedSparkSession
   with DataSourcePushdownTestUtils {
   val catalogName: String = "join_pushdown_catalog"
   val namespace: String = "join_schema"

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownIntegrationSuiteBase.scala
@@ -21,7 +21,7 @@ import java.sql.{Connection, DriverManager}
 import java.util.Properties
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.connector.DataSourcePushdownTestUtils
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.jdbc.v2
 import java.util.Locale
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{ExplainSuiteHelper}
+import org.apache.spark.sql.ExplainSuiteHelper
 import org.apache.spark.sql.connector.DataSourcePushdownTestUtils
 import org.apache.spark.sql.jdbc.{H2Dialect, JdbcDialect, JdbcDialects}
 import org.apache.spark.sql.test.SharedSparkSession

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/v2/JDBCV2JoinPushdownSuite.scala
@@ -20,15 +20,14 @@ package org.apache.spark.sql.jdbc.v2
 import java.util.Locale
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{ExplainSuiteHelper, QueryTest}
+import org.apache.spark.sql.{ExplainSuiteHelper}
 import org.apache.spark.sql.connector.DataSourcePushdownTestUtils
 import org.apache.spark.sql.jdbc.{H2Dialect, JdbcDialect, JdbcDialects}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
 class JDBCV2JoinPushdownSuite
-  extends QueryTest
-  with SharedSparkSession
+  extends SharedSparkSession
   with ExplainSuiteHelper
   with DataSourcePushdownTestUtils
   with JDBCV2JoinPushdownIntegrationSuiteBase {

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingCursorE2eSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingCursorE2eSuite.scala
@@ -19,7 +19,7 @@
 package org.apache.spark.sql.scripting
 
 import org.apache.spark.{SparkArithmeticException, SparkConf}
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.exceptions.SqlScriptingException
 import org.apache.spark.sql.internal.SQLConf
@@ -29,7 +29,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  * End-to-end tests for SQL Cursors.
  * Complete transcription of cursors.sql - all 87 tests with inline expected results.
  */
-class SqlScriptingCursorE2eSuite extends QueryTest with SharedSparkSession {
+class SqlScriptingCursorE2eSuite extends SharedSparkSession {
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.scripting
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
 import org.apache.spark.sql.catalyst.util.QuotingUtils.toSQLConf
 import org.apache.spark.sql.exceptions.SqlScriptingException
@@ -34,7 +34,7 @@ import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
  *  results are returned in expected manner, config flags are applied properly, etc.
  * For full functionality tests, see SqlScriptingParserSuite and SqlScriptingInterpreterSuite.
  */
-class SqlScriptingE2eSuite extends QueryTest with SharedSparkSession {
+class SqlScriptingE2eSuite extends SharedSparkSession {
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.scripting
 import scala.collection.mutable.ListBuffer
 
 import org.apache.spark.{SparkArithmeticException, SparkConf}
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLId
@@ -34,7 +34,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  * Output from the interpreter (iterator over executable statements) is then checked - statements
  *   are executed and output DataFrames are compared with expected outputs.
  */
-class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
+class SqlScriptingExecutionSuite extends SharedSparkSession {
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.scripting
 
 import org.apache.spark.{SparkException, SparkNumberFormatException}
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
@@ -34,8 +34,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  *   are executed and output DataFrames are compared with expected outputs.
  */
 class SqlScriptingInterpreterSuite
-    extends QueryTest
-    with SharedSparkSession
+    extends SharedSparkSession
     with SqlScriptingTestUtils {
 
   protected override def beforeAll(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/ExternalCommandRunnerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/ExternalCommandRunnerSuite.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.sql.sources
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{Row}
 import org.apache.spark.sql.test.SharedSparkSession
 
-class ExternalCommandRunnerSuite extends QueryTest with SharedSparkSession {
+class ExternalCommandRunnerSuite extends SharedSparkSession {
   test("execute command") {
     try {
       System.setProperty("command", "hello")

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/ExternalCommandRunnerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/ExternalCommandRunnerSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.sources
 
-import org.apache.spark.sql.{Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.SharedSparkSession
 
 class ExternalCommandRunnerSuite extends SharedSparkSession {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -26,7 +26,7 @@ import org.apache.hadoop.mapreduce.{JobContext, TaskAttemptContext}
 import org.apache.spark.TestUtils
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.io.FileNameSpec
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.datasources.SQLHadoopMapReduceCommitProtocol
@@ -48,7 +48,7 @@ private class OnlyDetectCustomPathFileCommitProtocol(jobId: String, path: String
   }
 }
 
-class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
+class PartitionedWriteSuite extends SharedSparkSession {
   import testImplicits._
 
   test("write many partitions") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
@@ -73,7 +73,7 @@ import org.apache.spark.util.{Clock, SystemClock, Utils}
  * avoid hanging forever in the case of failures. However, individual suites can change this
  * by overriding `streamingTimeout`.
  */
-trait StreamTest extends QueryTest with SharedSparkSession with TimeLimits {
+trait StreamTest extends SharedSparkSession with TimeLimits {
 
   // Necessary to make ScalaTest 3.x interrupt a thread on the JVM like ScalaTest 2.2.x
   implicit val defaultSignaler: Signaler = ThreadSignaler

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -142,7 +142,7 @@ class MessageCapturingCommitProtocol(jobId: String, path: String)
 }
 
 
-class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with BeforeAndAfter {
+class DataFrameReaderWriterSuite extends SharedSparkSession with BeforeAndAfter {
   import testImplicits._
 
   private val userSchema = new StructType().add("s", StringType)

--- a/sql/core/src/test/scala/org/apache/spark/sql/util/DataFrameCallbackSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/util/DataFrameCallbackSuite.scala
@@ -26,7 +26,7 @@ import scala.jdk.CollectionConverters._
 import org.apache.spark._
 import org.apache.spark.internal.config.EXECUTOR_HEARTBEAT_INTERVAL
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerExecutorMetricsUpdate}
-import org.apache.spark.sql.{functions, Encoder, Encoders, QueryTest, Row}
+import org.apache.spark.sql.{functions, Encoder, Encoders, Row}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan, Project}
 import org.apache.spark.sql.classic.Dataset
@@ -41,8 +41,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StringType
 
-class DataFrameCallbackSuite extends QueryTest
-  with SharedSparkSession
+class DataFrameCallbackSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
   import testImplicits._
   import functions._


### PR DESCRIPTION
### What changes were proposed in this pull request?

Since `SharedSparkSession` already extends `QueryTest` (`trait SharedSparkSession extends QueryTest with SharedSparkSessionBase`), mixing `QueryTest` in again alongside `SharedSparkSession` in the `extends` list is a no-op. Linearization:

```
SharedSparkSession  ->  QueryTest  ->  PlanTest -> PlanTestBase
                                    \> QueryTestBase
                                    \> SparkFunSuite
                    \>  SharedSparkSessionBase
```

Mechanical cleanup across 242 test files in `sql-core`, `sql-hive`, `sql-hive-thriftserver`, `sql-connect`, `sql-kafka-0-10`, `avro`, `protobuf`, and `docker-integration-tests`:

- `extends QueryTest with SharedSparkSession` -> `extends SharedSparkSession`
- `extends QueryTest with ParquetTest with SharedSparkSession` -> `extends ParquetTest with SharedSparkSession` (`ParquetTest -> FileBasedDataSourceTest -> QueryTest`, so `QueryTest` is already brought in twice)
- `extends QueryTest with test.SharedSparkSession` -> `extends test.SharedSparkSession` (`QueryTestSuite` in `QueryTest.scala`)
- multi-line variants (`extends QueryTest\n  with SharedSparkSession`) handled the same way
- removed the now-unused `QueryTest` imports where the file no longer referenced it; kept the import when the file still uses `QueryTest.checkAnswer` / `QueryTest.compare` / `QueryTest.sameRows` statically

Intentionally left untouched:

- `SharedSparkSession` itself (its own definition)
- traits that extend `QueryTest` but not `SharedSparkSession` (e.g. `CharVarcharTestSuite`, `V1WriteCommandSuiteBase`)

### Why are the changes needed?

Removes a redundant trait mixin and the resulting dead `QueryTest` imports, so the `extends` lists faithfully describe the class hierarchy and scalastyle's unused-import check stays clean.

### Does this PR introduce _any_ user-facing change?

No. Test-only class-declaration cleanup.

### How was this patch tested?

Existing tests. The affected modules compile cleanly:

    build/sbt sql/Test/compile connect/Test/compile hive/Test/compile \
              avro/Test/compile protobuf/Test/compile \
              sql-kafka-0-10/Test/compile docker-integration-tests/Test/compile
    build/sbt -Phive-thriftserver hive-thriftserver/Test/compile

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (model: claude-opus-4-7)