### PR TITLE
[SPARK-56032][SQL][FOLLOWUP] Defer throw-capable notNullPreds past guard otherPreds in FilterExec CSE codegen

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -254,34 +254,44 @@ case class FilterExec(condition: Expression, child: SparkPlan)
   override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
     val numOutput = metricTerm(ctx, "numOutputRows")
 
-    // Apply CSE to otherPreds. Two invariants we must preserve:
-    //   (a) Short-circuit order: otherPreds are evaluated sequentially and each may
-    //       `continue;` out of the row. A precomputation hoisted ahead of an earlier
-    //       otherPred would run for rows an earlier otherPred would have filtered out,
-    //       turning a filtered-out row into a thrown exception for any expression that
-    //       can throw (overflow, error class, etc.). SPARK-56032's original placement of
-    //       subExprsCode at the top of the `do { }` block broke this.
-    //   (b) Null guards: IsNotNull predicates must short-circuit before CSE
-    //       precomputation sees a null-bearing row. Otherwise CSE's
-    //       `value_X = isNull ? default : <compute>` materializes `null` into `value_X`
-    //       for non-primitive types, which downstream accessors (e.g.
-    //       `value_X.isNullAt(0)`) may NPE on without consulting `isNull_X`.
+    // Apply CSE to otherPreds. Three invariants we must preserve:
+    //   (a) Short-circuit order between otherPreds: each may `continue;` out of the row.
+    //       A precomputation hoisted ahead of an earlier otherPred would run for rows
+    //       an earlier otherPred would have filtered out, turning a filtered-out row
+    //       into a thrown exception for any expression that can throw (overflow, error
+    //       class, etc.). SPARK-56032's original placement of subExprsCode at the top
+    //       of the `do { }` block broke this.
+    //   (b) Short-circuit order between notNullPreds and otherPreds: `notNullPreds` may
+    //       include `IsNotNull(expensive_or_throwing)` inferred by
+    //       `InferFiltersFromConstraints`. Emitting all notNullPreds up front would
+    //       evaluate the inner expression on rows that an earlier-ordered otherPred
+    //       would have rejected -- same class of bug as (a) but across the
+    //       notNullPreds / otherPreds boundary. Mirror the non-CSE branch: emit just
+    //       the IsNotNull checks each otherPred needs before evaluating it, and defer
+    //       any leftover notNullPreds to after all otherPreds.
+    //   (c) Null guards for CSE state materialization: IsNotNull predicates on an
+    //       otherPred's references must short-circuit before CSE precomputation sees
+    //       a null-bearing row. Otherwise CSE's `value_X = isNull ? default : compute`
+    //       materializes `null` into `value_X` for non-primitive types, which
+    //       downstream accessors (e.g. `value_X.isNullAt(0)`) may NPE on without
+    //       consulting `isNull_X`.
     //
     // The fix for (a): emit each common subexpression's precompute *just before* the
     // first otherPred that references it, not all at the top of the `do { }` block.
     // A later otherPred still reuses the cached value -- it just doesn't pay the cost
     // for rows that an earlier otherPred rejected.
     //
-    // The fix for (b): emit all IsNotNull short-circuits upfront and bind otherPreds
-    // (and the CSE analysis) against the tightened `output`. `notNullAttributes` are
-    // guaranteed non-null by the time any otherPred (or any CSE precompute) runs, so
-    // the tightened-nullability optimization inside the predicate bodies is restored.
-    // This also supersedes the child.output binding workaround from SPARK-56431.
+    // The fix for (b): per-otherPred, emit the matching IsNotNull(ref) checks from
+    // `notNullPreds` (for each of that otherPred's references) before the otherPred's
+    // CSE precompute and body. Remaining notNullPreds emit after all otherPreds.
+    //
+    // The fix for (c): the IsNotNull interleaving above runs before any CSE precompute
+    // that is keyed off the same reference, so the precompute sees only non-null rows.
+    // Binding the otherPreds (and the CSE analysis) against `output` (with
+    // `notNullAttributes` tightened to non-nullable) restores the nullability-tightened
+    // optimization inside the predicate bodies.
     val (prologueCode, predicateCode) =
       if (conf.subexpressionEliminationEnabled && otherPreds.nonEmpty) {
-        val notNullShortCircuitCode = generatePredicateCode(
-          ctx, child.output, input, output, notNullPreds, Seq.empty, notNullAttributes)
-
         // Pre-evaluate input variables before CSE analysis: CSE clears
         // ctx.currentVars[i].code as a side effect; without this pre-evaluation, Janino
         // fails when otherPreds reference the same input columns that CSE already
@@ -303,25 +313,59 @@ case class FilterExec(condition: Expression, child: SparkPlan)
             boundOtherPreds.indexWhere(_.exists(e => ExpressionEquals(e) == exprEq))
           }.map { case (idx, kvs) => idx -> kvs.map(_._2) }
 
+        // Emit an IsNotNull check, binding against child.output so the inner expression
+        // is evaluated with its original nullability (the tightened-nullability `output`
+        // is only appropriate inside otherPreds, where the required checks have fired).
+        def genNotNull(pred: Expression): String = {
+          val bound = BindReferences.bindReference(pred, child.output)
+          val evaluated = evaluateRequiredVariables(child.output, input, pred.references)
+          val ev = ExpressionCanonicalizer.execute(bound).genCode(ctx)
+          s"""
+             |$evaluated
+             |${ev.code}
+             |if (${ev.isNull} || !${ev.value}) continue;
+           """.stripMargin
+        }
+
+        val generatedIsNotNullChecks = new Array[Boolean](notNullPreds.length)
+
         val predCode: String = {
           val parts = new StringBuilder
           ctx.withSubExprEliminationExprs(subExprs.states) {
-            boundOtherPreds.zipWithIndex.foreach { case (bound, idx) =>
-              statesByFirstUse.get(idx).foreach { states =>
-                parts.append(ctx.evaluateSubExprEliminationState(states))
-                parts.append('\n')
-              }
-              val ev = ExpressionCanonicalizer.execute(bound).genCode(ctx)
-              val nullCheck = if (bound.nullable) s"${ev.isNull} || " else ""
-              parts.append(ev.code.toString)
-              parts.append(s"\nif (${nullCheck}!${ev.value}) continue;\n")
+            otherPreds.iterator.zip(boundOtherPreds.iterator).zipWithIndex.foreach {
+              case ((orig, bound), idx) =>
+                orig.references.foreach { r =>
+                  val ni = notNullPreds.indexWhere {
+                    case IsNotNull(c) => c.semanticEquals(r)
+                    case _ => false
+                  }
+                  if (ni != -1 && !generatedIsNotNullChecks(ni)) {
+                    generatedIsNotNullChecks(ni) = true
+                    parts.append(genNotNull(notNullPreds(ni)))
+                    parts.append('\n')
+                  }
+                }
+                statesByFirstUse.get(idx).foreach { states =>
+                  parts.append(ctx.evaluateSubExprEliminationState(states))
+                  parts.append('\n')
+                }
+                val ev = ExpressionCanonicalizer.execute(bound).genCode(ctx)
+                val nullCheck = if (bound.nullable) s"${ev.isNull} || " else ""
+                parts.append(ev.code.toString)
+                parts.append(s"\nif (${nullCheck}!${ev.value}) continue;\n")
             }
             Seq.empty
           }
           parts.toString
         }
 
-        (notNullShortCircuitCode + "\n" + inputVarsEvalCode, predCode)
+        // Leftover notNullPreds: any IsNotNull that no otherPred's reference matched.
+        // These run after all otherPreds to match the non-CSE ordering.
+        val leftoverNotNull = notNullPreds.zipWithIndex.collect {
+          case (p, i) if !generatedIsNotNullChecks(i) => genNotNull(p)
+        }.mkString("\n")
+
+        (inputVarsEvalCode, predCode + "\n" + leftoverNotNull)
       } else {
         ("", generatePredicateCode(
           ctx, child.output, input, output, notNullPreds, otherPreds, notNullAttributes))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -266,9 +266,10 @@ case class FilterExec(condition: Expression, child: SparkPlan)
     //       `InferFiltersFromConstraints`. Emitting all notNullPreds up front would
     //       evaluate the inner expression on rows that an earlier-ordered otherPred
     //       would have rejected -- same class of bug as (a) but across the
-    //       notNullPreds / otherPreds boundary. Mirror the non-CSE branch: emit just
-    //       the IsNotNull checks each otherPred needs before evaluating it, and defer
-    //       any leftover notNullPreds to after all otherPreds.
+    //       notNullPreds / otherPreds boundary. Mirror the non-CSE branch: for each
+    //       reference of each otherPred, emit the matching IsNotNull check (direct or
+    //       synthetic) before the otherPred, and defer any leftover notNullPreds to
+    //       after all otherPreds.
     //   (c) Null guards for CSE state materialization: IsNotNull predicates on an
     //       otherPred's references must short-circuit before CSE precomputation sees
     //       a null-bearing row. Otherwise CSE's `value_X = isNull ? default : compute`
@@ -281,9 +282,13 @@ case class FilterExec(condition: Expression, child: SparkPlan)
     // A later otherPred still reuses the cached value -- it just doesn't pay the cost
     // for rows that an earlier otherPred rejected.
     //
-    // The fix for (b): per-otherPred, emit the matching IsNotNull(ref) checks from
-    // `notNullPreds` (for each of that otherPred's references) before the otherPred's
-    // CSE precompute and body. Remaining notNullPreds emit after all otherPreds.
+    // The fix for (b): per-otherPred, for each reference `r`: if `notNullPreds` has a
+    // direct `IsNotNull(r)`, emit it; else if `r` is covered by `notNullAttributes`
+    // through some complex `IsNotNull(expr(r))` in `notNullPreds`, emit a synthetic
+    // `IsNotNull(r)` so the tightened-output binding below is safe without evaluating
+    // the throw-capable inner expression. Then the otherPred's CSE precompute and
+    // body. Remaining notNullPreds (including any complex-child forms whose refs got
+    // synthetic coverage) emit after all otherPreds.
     //
     // The fix for (c): the IsNotNull interleaving above runs before any CSE precompute
     // that is keyed off the same reference, so the precompute sees only non-null rows.
@@ -328,6 +333,7 @@ case class FilterExec(condition: Expression, child: SparkPlan)
         }
 
         val generatedIsNotNullChecks = new Array[Boolean](notNullPreds.length)
+        val extraIsNotNullAttrs = mutable.Set[Attribute]()
 
         val predCode: String = {
           val parts = new StringBuilder
@@ -342,6 +348,11 @@ case class FilterExec(condition: Expression, child: SparkPlan)
                   if (ni != -1 && !generatedIsNotNullChecks(ni)) {
                     generatedIsNotNullChecks(ni) = true
                     parts.append(genNotNull(notNullPreds(ni)))
+                    parts.append('\n')
+                  } else if (notNullAttributes.contains(r.exprId) &&
+                      !extraIsNotNullAttrs.contains(r)) {
+                    extraIsNotNullAttrs += r
+                    parts.append(genNotNull(IsNotNull(r)))
                     parts.append('\n')
                   }
                 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -254,47 +254,32 @@ case class FilterExec(condition: Expression, child: SparkPlan)
   override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
     val numOutput = metricTerm(ctx, "numOutputRows")
 
-    // Apply CSE to otherPreds. Three invariants we must preserve:
-    //   (a) Short-circuit order between otherPreds: each may `continue;` out of the row.
-    //       A precomputation hoisted ahead of an earlier otherPred would run for rows
-    //       an earlier otherPred would have filtered out, turning a filtered-out row
-    //       into a thrown exception for any expression that can throw (overflow, error
-    //       class, etc.). SPARK-56032's original placement of subExprsCode at the top
-    //       of the `do { }` block broke this.
-    //   (b) Short-circuit order between notNullPreds and otherPreds: `notNullPreds` may
-    //       include `IsNotNull(expensive_or_throwing)` inferred by
-    //       `InferFiltersFromConstraints`. Emitting all notNullPreds up front would
-    //       evaluate the inner expression on rows that an earlier-ordered otherPred
-    //       would have rejected -- same class of bug as (a) but across the
-    //       notNullPreds / otherPreds boundary. Mirror the non-CSE branch: for each
-    //       reference of each otherPred, emit the matching IsNotNull check (direct or
-    //       synthetic) before the otherPred, and defer any leftover notNullPreds to
-    //       after all otherPreds.
-    //   (c) Null guards for CSE state materialization: IsNotNull predicates on an
-    //       otherPred's references must short-circuit before CSE precomputation sees
-    //       a null-bearing row. Otherwise CSE's `value_X = isNull ? default : compute`
-    //       materializes `null` into `value_X` for non-primitive types, which
-    //       downstream accessors (e.g. `value_X.isNullAt(0)`) may NPE on without
-    //       consulting `isNull_X`.
-    //
-    // The fix for (a): emit each common subexpression's precompute *just before* the
-    // first otherPred that references it, not all at the top of the `do { }` block.
-    // A later otherPred still reuses the cached value -- it just doesn't pay the cost
-    // for rows that an earlier otherPred rejected.
-    //
-    // The fix for (b): per-otherPred, for each reference `r`: if `notNullPreds` has a
-    // direct `IsNotNull(r)`, emit it; else if `r` is covered by `notNullAttributes`
-    // through some complex `IsNotNull(expr(r))` in `notNullPreds`, emit a synthetic
-    // `IsNotNull(r)` so the tightened-output binding below is safe without evaluating
-    // the throw-capable inner expression. Then emit the otherPred's CSE precompute and
-    // body. Remaining notNullPreds (including any complex-child forms whose refs got
-    // synthetic coverage) emit after all otherPreds.
-    //
-    // The fix for (c): the IsNotNull interleaving above runs before any CSE precompute
-    // that is keyed off the same reference, so the precompute sees only non-null rows.
-    // Binding the otherPreds (and the CSE analysis) against `output` (with
-    // `notNullAttributes` tightened to non-nullable) restores the nullability-tightened
-    // optimization inside the predicate bodies.
+    // Apply CSE to otherPreds, mirroring the non-CSE branch's ordering so we preserve
+    // short-circuit semantics. Three invariants:
+    //   (a) Between otherPreds: emit each common subexpression's precompute *just
+    //       before* the first otherPred that references it, not at the top of the
+    //       `do { }` block. A later otherPred still reuses the cached value -- it just
+    //       doesn't pay the cost for rows an earlier otherPred rejected. See #55471.
+    //   (b) Between notNullPreds and otherPreds: `notNullPreds` may include
+    //       `IsNotNull(expensive_or_throwing)` inferred by `InferFiltersFromConstraints`,
+    //       so emitting all notNullPreds up front would evaluate the inner expression
+    //       on rows an earlier-ordered otherPred would have rejected -- same class of
+    //       bug as (a) but across the notNullPreds / otherPreds boundary. Per-otherPred,
+    //       for each reference `r`: if `notNullPreds` has a direct `IsNotNull(r)`, emit
+    //       it; else if `r` is covered by `notNullAttributes` through some complex
+    //       `IsNotNull(expr(r))` in `notNullPreds`, emit a synthetic `IsNotNull(r)` so
+    //       the tightened-output binding below is safe without evaluating the
+    //       throw-capable inner expression. Then emit the otherPred's CSE precompute
+    //       and body. Remaining notNullPreds (including complex-child forms whose refs
+    //       got synthetic coverage) emit after all otherPreds.
+    //   (c) CSE state materialization: binding otherPreds (and the CSE analysis)
+    //       against `output` (with `notNullAttributes` tightened to non-nullable)
+    //       requires that the matching IsNotNull has already short-circuited -- else
+    //       CSE's `value_X = isNull ? default : compute` materializes `null` into
+    //       `value_X` for non-primitive types, which downstream accessors may NPE on
+    //       without consulting `isNull_X`. The (b) interleaving gives us that ordering
+    //       for free, since the IsNotNull check fires before the CSE precompute keyed
+    //       off the same reference.
     val (prologueCode, predicateCode) =
       if (conf.subexpressionEliminationEnabled && otherPreds.nonEmpty) {
         // Pre-evaluate input variables before CSE analysis: CSE clears

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -286,7 +286,7 @@ case class FilterExec(condition: Expression, child: SparkPlan)
     // direct `IsNotNull(r)`, emit it; else if `r` is covered by `notNullAttributes`
     // through some complex `IsNotNull(expr(r))` in `notNullPreds`, emit a synthetic
     // `IsNotNull(r)` so the tightened-output binding below is safe without evaluating
-    // the throw-capable inner expression. Then the otherPred's CSE precompute and
+    // the throw-capable inner expression. Then emit the otherPred's CSE precompute and
     // body. Remaining notNullPreds (including any complex-child forms whose refs got
     // synthetic coverage) emit after all otherPreds.
     //

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -336,7 +336,7 @@ case class FilterExec(condition: Expression, child: SparkPlan)
         val predCode: String = {
           val parts = new StringBuilder
           ctx.withSubExprEliminationExprs(subExprs.states) {
-            otherPreds.iterator.zip(boundOtherPreds.iterator).zipWithIndex.foreach {
+            otherPreds.zip(boundOtherPreds).zipWithIndex.foreach {
               case ((orig, bound), idx) =>
                 orig.references.foreach { r =>
                   val ni = notNullPreds.indexWhere {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -180,6 +180,9 @@ trait GeneratePredicateHelper extends PredicateHelper {
     // This has the property of not doing redundant IsNotNull checks and taking better advantage of
     // short-circuiting, not loading attributes until they are needed.
     // This is very perf sensitive.
+    // NOTE: `FilterExec.doConsume`'s CSE branch inlines the same interleaving so it can
+    // emit CSE state precomputes between the IsNotNull checks and each otherPred body.
+    // Any change to this algorithm must be mirrored there (and vice versa).
     // TODO: revisit this. We can consider reordering predicates as well.
     val generatedIsNotNullChecks = new Array[Boolean](notNullPreds.length)
     val extraIsNotNullAttrs = mutable.Set[Attribute]()
@@ -255,7 +258,10 @@ case class FilterExec(condition: Expression, child: SparkPlan)
     val numOutput = metricTerm(ctx, "numOutputRows")
 
     // Apply CSE to otherPreds, mirroring the non-CSE branch's ordering so we preserve
-    // short-circuit semantics. Three invariants:
+    // short-circuit semantics. The non-CSE branch lives in `generatePredicateCode`
+    // above; any future change to that algorithm should be reflected here (and vice
+    // versa) -- the two paths must stay in lockstep on notNullPreds/otherPreds
+    // interleaving. Three invariants:
     //   (a) Between otherPreds: emit each common subexpression's precompute *just
     //       before* the first otherPred that references it, not at the top of the
     //       `do { }` block. A later otherPred still reuses the cached value -- it just
@@ -306,6 +312,9 @@ case class FilterExec(condition: Expression, child: SparkPlan)
         // Emit an IsNotNull check, binding against child.output so the inner expression
         // is evaluated with its original nullability (the tightened-nullability `output`
         // is only appropriate inside otherPreds, where the required checks have fired).
+        // The `bound.nullable` gate below is defensive -- `IsNotNull` always produces a
+        // non-nullable Boolean, so this branch is structurally unreachable today; it
+        // mirrors the non-CSE helper's shape to keep future refactors safe.
         def genNotNull(pred: Expression): String = {
           val bound = BindReferences.bindReference(pred, child.output)
           val evaluated = evaluateRequiredVariables(child.output, input, pred.references)
@@ -356,8 +365,13 @@ case class FilterExec(condition: Expression, child: SparkPlan)
           parts.toString
         }
 
-        // Leftover notNullPreds: any IsNotNull that no otherPred's reference matched.
-        // These run after all otherPreds to match the non-CSE ordering.
+        // Leftover notNullPreds: any IsNotNull that no otherPred's reference matched by
+        // `semanticEquals`. These run after all otherPreds to match the non-CSE ordering.
+        // Note: a complex `IsNotNull(expr(r))` can still land here even when the (b) path
+        // already emitted a synthetic `IsNotNull(r)` ahead of some otherPred -- the
+        // synthetic check only guards the tightened-output binding; the inner expression
+        // itself may still need its null check (e.g. under non-ANSI `cast(s as int)` can
+        // return null for unparseable strings, so we must filter the resulting row).
         val leftoverNotNull = notNullPreds.zipWithIndex.collect {
           case (p, i) if !generatedIsNotNullChecks(i) => genNotNull(p)
         }.mkString("\n")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -325,10 +325,11 @@ case class FilterExec(condition: Expression, child: SparkPlan)
           val bound = BindReferences.bindReference(pred, child.output)
           val evaluated = evaluateRequiredVariables(child.output, input, pred.references)
           val ev = ExpressionCanonicalizer.execute(bound).genCode(ctx)
+          val nullCheck = if (bound.nullable) s"${ev.isNull} || " else ""
           s"""
              |$evaluated
              |${ev.code}
-             |if (${ev.isNull} || !${ev.value}) continue;
+             |if (${nullCheck}!${ev.value}) continue;
            """.stripMargin
         }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -188,7 +188,10 @@ trait GeneratePredicateHelper extends PredicateHelper {
     val extraIsNotNullAttrs = mutable.Set[Attribute]()
     val generated = otherPreds.map { c =>
       val nullChecks = c.references.map { r =>
-        val idx = notNullPreds.indexWhere { n => n.asInstanceOf[IsNotNull].child.semanticEquals(r)}
+        val idx = notNullPreds.indexWhere {
+          case IsNotNull(n) => n.semanticEquals(r)
+          case _ => false
+        }
         if (idx != -1 && !generatedIsNotNullChecks(idx)) {
           generatedIsNotNullChecks(idx) = true
           // Use the child's output. The nullability is what the child produced.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -22,7 +22,7 @@ import java.time.Duration
 
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.MapPartitionsWithEvaluatorRDD
-import org.apache.spark.sql.{Dataset, QueryTest, Row, SaveMode}
+import org.apache.spark.sql.{Dataset, Row, SaveMode}
 import org.apache.spark.sql.catalyst.expressions.{And, Cast, CodegenObjectFactoryMode, Expression, IsNotNull}
 import org.apache.spark.sql.catalyst.expressions.codegen.{ByteCodeStats, CodeAndComment, CodeGenerator}
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecutionSuite

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -1030,6 +1030,42 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     }
   }
 
+  test("SPARK-56032: FilterExec CSE emits all notNullPreds before guard otherPred") {
+    // The CSE branch in FilterExec.doConsume emits every notNullPred upfront,
+    // before any otherPred. When `InferFiltersFromConstraints` adds a notNull
+    // check on a throw-capable expression (`IsNotNull(cast(s as int))`) derived
+    // from a downstream join, that upfront evaluation fires on rows that the
+    // guard otherPred (`kind = 'numeric'`) would have rejected.
+    //
+    // Shape:
+    //   WITH guarded AS (SELECT s FROM t WHERE kind = 'numeric'),
+    //        derived AS (SELECT s, CAST(s AS INT) AS n FROM guarded),
+    //        pairs   AS (SELECT s, i FROM derived, idx WHERE i <= n)
+    //   SELECT s, i FROM pairs
+    // Optimized filter:
+    //   Filter(isnotnull(kind) AND kind = 'numeric' AND isnotnull(cast(s as int)))
+    // The non-CSE path defers leftover notNullPreds to after the otherPreds,
+    // so the guard short-circuits before the cast runs.
+    val t = Seq(("3", "numeric"), ("abc", "text")).toDF("s", "kind")
+    val idx = Seq(1, 2).toDF("i")
+    withSQLConf(
+      SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "true",
+      SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.ANSI_ENABLED.key -> "true") {
+      t.createOrReplaceTempView("t")
+      idx.createOrReplaceTempView("idx")
+      val df = spark.sql(
+        """
+          |WITH guarded AS (SELECT s FROM t WHERE kind = 'numeric'),
+          |     derived AS (SELECT s, CAST(s AS INT) AS n FROM guarded),
+          |     pairs   AS (SELECT s, i FROM derived, idx WHERE i <= n)
+          |SELECT s, i FROM pairs
+          |""".stripMargin)
+      checkAnswer(df, Seq(Row("3", 1), Row("3", 2)))
+    }
+  }
+
   test("SPARK-56032: FilterExec CSE preserves short-circuit across predicates") {
     // A CSE'd subexpression must not be hoisted above an earlier otherPred's short-circuit,
     // otherwise rows an earlier otherPred would have rejected still pay the cost of the

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -1076,17 +1076,13 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     }
   }
 
-  test("SPARK-56032: FilterExec CSE synthetic IsNotNull for shared otherPred refs") {
+  test("SPARK-56032: FilterExec CSE handles shared otherPred refs with guard") {
     // Filter shape: kind = 'numeric' AND cast(s as int) > 0 AND cast(s as int) < 100.
-    // The two cast otherPreds both reference `s`, so the first emits the direct
-    // `IsNotNull(s)` from notNullPreds and the second falls into the else-if that
-    // emits a synthetic `IsNotNull(s)`. This exercises the synthetic-emit branch in
-    // the CSE path and ensures the tightened-output binding of cast(s as int) never
-    // sees a null-s row.
-    //
-    // Also exercises invariant (b): the guard `kind = 'numeric'` must short-circuit
-    // before either cast otherPred runs, so the 'abc'/'text' row never triggers
-    // `CAST_INVALID_INPUT` under ANSI.
+    // Exercises invariant (b) on a shape with two cast otherPreds sharing a ref:
+    // the guard `kind = 'numeric'` must short-circuit before either cast runs, so
+    // the 'abc'/'text' row never triggers `CAST_INVALID_INPUT` under ANSI, and the
+    // null-s row is filtered by the IsNotNull check emitted ahead of the cast
+    // otherPreds rather than reaching the tightened-output binding.
     val schema = StructType(Seq(
       StructField("s", StringType, nullable = true),
       StructField("kind", StringType, nullable = true)))
@@ -1106,6 +1102,13 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       val plan = df.queryExecution.executedPlan
       assert(plan.exists(_.isInstanceOf[WholeStageCodegenExec]),
         "Filter should be in whole-stage codegen")
+      // Guard against optimizer drift: require the rolled-up filter to still carry
+      // both `cast(s as int)` conjuncts so the shared-ref path is exercised.
+      val castCount = plan.collectFirst { case f: FilterExec =>
+        f.condition.collect { case c: Cast => c }.size
+      }.getOrElse(0)
+      assert(castCount >= 2,
+        s"expected a FilterExec condition with at least 2 Cast expressions, got $castCount")
       checkAnswer(df, Seq(Row("3", "numeric"), Row("7", "numeric")))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -1053,13 +1053,13 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
       SQLConf.ANSI_ENABLED.key -> "true") {
-      t.createOrReplaceTempView("t")
-      idx.createOrReplaceTempView("idx")
+      t.createOrReplaceTempView("spark_56032_t")
+      idx.createOrReplaceTempView("spark_56032_idx")
       val df = spark.sql(
         """
-          |WITH guarded AS (SELECT s FROM t WHERE kind = 'numeric'),
+          |WITH guarded AS (SELECT s FROM spark_56032_t WHERE kind = 'numeric'),
           |     derived AS (SELECT s, CAST(s AS INT) AS n FROM guarded),
-          |     pairs   AS (SELECT s, i FROM derived, idx WHERE i <= n)
+          |     pairs   AS (SELECT s, i FROM derived, spark_56032_idx WHERE i <= n)
           |SELECT s, i FROM pairs
           |""".stripMargin)
       // Guard against optimizer drift: this test only exercises the bug when the
@@ -1073,6 +1073,40 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
         } => f
       }.nonEmpty, "expected a FilterExec with IsNotNull(Cast(...)) in its condition")
       checkAnswer(df, Seq(Row("3", 1), Row("3", 2)))
+    }
+  }
+
+  test("SPARK-56032: FilterExec CSE synthetic IsNotNull for shared otherPred refs") {
+    // Filter shape: kind = 'numeric' AND cast(s as int) > 0 AND cast(s as int) < 100.
+    // The two cast otherPreds both reference `s`, so the first emits the direct
+    // `IsNotNull(s)` from notNullPreds and the second falls into the else-if that
+    // emits a synthetic `IsNotNull(s)`. This exercises the synthetic-emit branch in
+    // the CSE path and ensures the tightened-output binding of cast(s as int) never
+    // sees a null-s row.
+    //
+    // Also exercises invariant (b): the guard `kind = 'numeric'` must short-circuit
+    // before either cast otherPred runs, so the 'abc'/'text' row never triggers
+    // `CAST_INVALID_INPUT` under ANSI.
+    val schema = StructType(Seq(
+      StructField("s", StringType, nullable = true),
+      StructField("kind", StringType, nullable = true)))
+    val data = spark.sparkContext.parallelize(Seq(
+      Row("3", "numeric"),
+      Row("7", "numeric"),
+      Row(null, "numeric"),
+      Row("abc", "text")))
+
+    withSQLConf(
+      SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "true",
+      SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.ANSI_ENABLED.key -> "true") {
+      val df = spark.createDataFrame(data, schema).where(
+        "kind = 'numeric' AND cast(s as int) > 0 AND cast(s as int) < 100")
+      val plan = df.queryExecution.executedPlan
+      assert(plan.exists(_.isInstanceOf[WholeStageCodegenExec]),
+        "Filter should be in whole-stage codegen")
+      checkAnswer(df, Seq(Row("3", "numeric"), Row("7", "numeric")))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -1035,10 +1035,11 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     // alongside an earlier guard otherPred (`kind = 'numeric'`). The non-CSE path
     // defers leftover notNullPreds to after the otherPreds so the guard short-circuits
     // before the cast runs; the CSE branch must preserve that ordering.
+    // AQE is disabled here and in the sibling test below so each FilterExec is directly
+    // visible for the plan-shape assertions, rather than wrapped inside an
+    // AdaptiveSparkPlan.
     val t = Seq(("3", "numeric"), ("abc", "text")).toDF("s", "kind")
     val idx = Seq(1, 2).toDF("i")
-    // AQE is disabled so the FilterExec is directly visible for the plan-shape
-    // assertion below, rather than wrapped inside an AdaptiveSparkPlan.
     withSQLConf(
       SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "true",
       SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
@@ -1054,12 +1055,10 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
             |     pairs   AS (SELECT s, i FROM derived, spark_56032_idx WHERE i <= n)
             |SELECT s, i FROM pairs
             |""".stripMargin)
-        // Guard against optimizer drift: this test only exercises the bug when a
-        // single rolled-up FilterExec contains both `IsNotNull(Cast(s AS INT))`
-        // (throw-capable notNullPred) and an earlier guard otherPred (a non-IsNotNull
-        // conjunct such as `kind = 'numeric'`). If a future optimizer change splits
-        // these into separate FilterExecs or drops the guard, `checkAnswer` alone
-        // would silently pass even without the fix.
+        // Guard against optimizer drift: require a single rolled-up FilterExec carrying
+        // both `IsNotNull(Cast(s AS INT))` and a non-IsNotNull guard conjunct -- without
+        // this, `checkAnswer` alone would silently pass even if the buggy ordering
+        // returned.
         def conjuncts(e: Expression): Seq[Expression] = e match {
           case And(l, r) => conjuncts(l) ++ conjuncts(r)
           case other => Seq(other)
@@ -1087,11 +1086,11 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
 
   test("SPARK-56032: FilterExec CSE handles shared otherPred refs with guard") {
     // Filter shape: kind = 'numeric' AND cast(s as int) > 0 AND cast(s as int) < 100.
-    // Exercises invariant (b) on a shape with two cast otherPreds sharing a ref:
-    // the guard `kind = 'numeric'` must short-circuit before either cast runs, so
-    // the 'abc'/'text' row never triggers `CAST_INVALID_INPUT` under ANSI, and the
-    // null-s row is filtered by the IsNotNull check emitted ahead of the cast
-    // otherPreds rather than reaching the tightened-output binding.
+    // Exercises invariant (b) on a shape where two cast otherPreds share a ref: the
+    // guard must short-circuit before either cast runs (so the 'abc'/'text' row never
+    // throws under ANSI), and the null-s row must be filtered by the IsNotNull check
+    // emitted ahead of the cast otherPreds rather than reaching the tightened-output
+    // binding. See the sibling test above for the AQE-off rationale.
     val schema = StructType(Seq(
       StructField("s", StringType, nullable = true),
       StructField("kind", StringType, nullable = true)))
@@ -1101,8 +1100,6 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       Row(null, "numeric"),
       Row("abc", "text")))
 
-    // AQE is disabled so the FilterExec is directly visible for plan-shape assertions
-    // below, rather than wrapped inside an AdaptiveSparkPlan.
     withSQLConf(
       SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "true",
       SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -23,7 +23,7 @@ import java.time.Duration
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.MapPartitionsWithEvaluatorRDD
 import org.apache.spark.sql.{Dataset, QueryTest, Row, SaveMode}
-import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
+import org.apache.spark.sql.catalyst.expressions.{Cast, CodegenObjectFactoryMode, IsNotNull}
 import org.apache.spark.sql.catalyst.expressions.codegen.{ByteCodeStats, CodeAndComment, CodeGenerator}
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecutionSuite
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, SortAggregateExec}
@@ -1062,6 +1062,16 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
           |     pairs   AS (SELECT s, i FROM derived, idx WHERE i <= n)
           |SELECT s, i FROM pairs
           |""".stripMargin)
+      // Guard against optimizer drift: this test only exercises the bug when the
+      // rolled-up filter contains `IsNotNull(Cast(s AS INT))` alongside an earlier
+      // guard otherPred. If a future optimizer change stops producing that shape,
+      // `checkAnswer` alone would silently pass even without the fix.
+      assert(df.queryExecution.executedPlan.collectFirst {
+        case f: FilterExec if f.condition.exists {
+          case IsNotNull(_: Cast) => true
+          case _ => false
+        } => f
+      }.nonEmpty, "expected a FilterExec with IsNotNull(Cast(...)) in its condition")
       checkAnswer(df, Seq(Row("3", 1), Row("3", 2)))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -1030,7 +1030,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     }
   }
 
-  test("SPARK-56032: FilterExec CSE emits all notNullPreds before guard otherPred") {
+  test("SPARK-56032: FilterExec CSE defers throw-capable notNullPred past guard otherPred") {
     // `InferFiltersFromConstraints` can add a throw-capable `IsNotNull(cast(s as int))`
     // alongside an earlier guard otherPred (`kind = 'numeric'`). The non-CSE path
     // defers leftover notNullPreds to after the otherPreds so the guard short-circuits

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -1048,13 +1048,17 @@ class WholeStageCodegenSuite extends SharedSparkSession
       withTempView("spark_56032_t", "spark_56032_idx") {
         t.createOrReplaceTempView("spark_56032_t")
         idx.createOrReplaceTempView("spark_56032_idx")
-        val df = spark.sql(
+        val query =
           """
             |WITH guarded AS (SELECT s FROM spark_56032_t WHERE kind = 'numeric'),
             |     derived AS (SELECT s, CAST(s AS INT) AS n FROM guarded),
             |     pairs   AS (SELECT s, i FROM derived, spark_56032_idx WHERE i <= n)
             |SELECT s, i FROM pairs
-            |""".stripMargin)
+            |""".stripMargin
+        val df = spark.sql(query)
+        val plan = df.queryExecution.executedPlan
+        assert(plan.exists(_.isInstanceOf[WholeStageCodegenExec]),
+          "Filter should be in whole-stage codegen")
         // Guard against optimizer drift: require a single rolled-up FilterExec carrying
         // both `IsNotNull(Cast(s AS INT))` and a non-IsNotNull guard conjunct -- without
         // this, `checkAnswer` alone would silently pass even if the buggy ordering
@@ -1063,7 +1067,7 @@ class WholeStageCodegenSuite extends SharedSparkSession
           case And(l, r) => conjuncts(l) ++ conjuncts(r)
           case other => Seq(other)
         }
-        val matchingFilter = df.queryExecution.executedPlan.collect {
+        val matchingFilter = plan.collect {
           case f: FilterExec =>
             val cs = conjuncts(f.condition)
             val hasThrowingIsNotNull = cs.exists {
@@ -1080,6 +1084,10 @@ class WholeStageCodegenSuite extends SharedSparkSession
           "expected a FilterExec whose condition carries both IsNotNull(Cast(...)) " +
             "and a non-IsNotNull guard conjunct")
         checkAnswer(df, Seq(Row("3", 1), Row("3", 2)))
+        // Cross-check the codegen path against the interpreted path.
+        withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false") {
+          checkAnswer(spark.sql(query), Seq(Row("3", 1), Row("3", 2)))
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -23,7 +23,7 @@ import java.time.Duration
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.MapPartitionsWithEvaluatorRDD
 import org.apache.spark.sql.{Dataset, QueryTest, Row, SaveMode}
-import org.apache.spark.sql.catalyst.expressions.{Cast, CodegenObjectFactoryMode, IsNotNull}
+import org.apache.spark.sql.catalyst.expressions.{And, Cast, CodegenObjectFactoryMode, Expression, IsNotNull}
 import org.apache.spark.sql.catalyst.expressions.codegen.{ByteCodeStats, CodeAndComment, CodeGenerator}
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecutionSuite
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, SortAggregateExec}
@@ -1037,6 +1037,8 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     // before the cast runs; the CSE branch must preserve that ordering.
     val t = Seq(("3", "numeric"), ("abc", "text")).toDF("s", "kind")
     val idx = Seq(1, 2).toDF("i")
+    // AQE is disabled so the FilterExec is directly visible for the plan-shape
+    // assertion below, rather than wrapped inside an AdaptiveSparkPlan.
     withSQLConf(
       SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "true",
       SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
@@ -1052,16 +1054,32 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
             |     pairs   AS (SELECT s, i FROM derived, spark_56032_idx WHERE i <= n)
             |SELECT s, i FROM pairs
             |""".stripMargin)
-        // Guard against optimizer drift: this test only exercises the bug when the
-        // rolled-up filter contains `IsNotNull(Cast(s AS INT))` alongside an earlier
-        // guard otherPred. If a future optimizer change stops producing that shape,
-        // `checkAnswer` alone would silently pass even without the fix.
-        assert(df.queryExecution.executedPlan.collectFirst {
-          case f: FilterExec if f.condition.exists {
-            case IsNotNull(_: Cast) => true
-            case _ => false
-          } => f
-        }.nonEmpty, "expected a FilterExec with IsNotNull(Cast(...)) in its condition")
+        // Guard against optimizer drift: this test only exercises the bug when a
+        // single rolled-up FilterExec contains both `IsNotNull(Cast(s AS INT))`
+        // (throw-capable notNullPred) and an earlier guard otherPred (a non-IsNotNull
+        // conjunct such as `kind = 'numeric'`). If a future optimizer change splits
+        // these into separate FilterExecs or drops the guard, `checkAnswer` alone
+        // would silently pass even without the fix.
+        def conjuncts(e: Expression): Seq[Expression] = e match {
+          case And(l, r) => conjuncts(l) ++ conjuncts(r)
+          case other => Seq(other)
+        }
+        val matchingFilter = df.queryExecution.executedPlan.collect {
+          case f: FilterExec =>
+            val cs = conjuncts(f.condition)
+            val hasThrowingIsNotNull = cs.exists {
+              case IsNotNull(_: Cast) => true
+              case _ => false
+            }
+            val hasGuardOtherPred = cs.exists {
+              case _: IsNotNull => false
+              case _ => true
+            }
+            hasThrowingIsNotNull && hasGuardOtherPred
+        }.exists(identity)
+        assert(matchingFilter,
+          "expected a FilterExec whose condition carries both IsNotNull(Cast(...)) " +
+            "and a non-IsNotNull guard conjunct")
         checkAnswer(df, Seq(Row("3", 1), Row("3", 2)))
       }
     }
@@ -1083,6 +1101,8 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       Row(null, "numeric"),
       Row("abc", "text")))
 
+    // AQE is disabled so the FilterExec is directly visible for plan-shape assertions
+    // below, rather than wrapped inside an AdaptiveSparkPlan.
     withSQLConf(
       SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "true",
       SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -1031,21 +1031,10 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
   }
 
   test("SPARK-56032: FilterExec CSE emits all notNullPreds before guard otherPred") {
-    // The CSE branch in FilterExec.doConsume emits every notNullPred upfront,
-    // before any otherPred. When `InferFiltersFromConstraints` adds a notNull
-    // check on a throw-capable expression (`IsNotNull(cast(s as int))`) derived
-    // from a downstream join, that upfront evaluation fires on rows that the
-    // guard otherPred (`kind = 'numeric'`) would have rejected.
-    //
-    // Shape:
-    //   WITH guarded AS (SELECT s FROM t WHERE kind = 'numeric'),
-    //        derived AS (SELECT s, CAST(s AS INT) AS n FROM guarded),
-    //        pairs   AS (SELECT s, i FROM derived, idx WHERE i <= n)
-    //   SELECT s, i FROM pairs
-    // Optimized filter:
-    //   Filter(isnotnull(kind) AND kind = 'numeric' AND isnotnull(cast(s as int)))
-    // The non-CSE path defers leftover notNullPreds to after the otherPreds,
-    // so the guard short-circuits before the cast runs.
+    // `InferFiltersFromConstraints` can add a throw-capable `IsNotNull(cast(s as int))`
+    // alongside an earlier guard otherPred (`kind = 'numeric'`). The non-CSE path
+    // defers leftover notNullPreds to after the otherPreds so the guard short-circuits
+    // before the cast runs; the CSE branch must preserve that ordering.
     val t = Seq(("3", "numeric"), ("abc", "text")).toDF("s", "kind")
     val idx = Seq(1, 2).toDF("i")
     withSQLConf(
@@ -1053,26 +1042,28 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
       SQLConf.ANSI_ENABLED.key -> "true") {
-      t.createOrReplaceTempView("spark_56032_t")
-      idx.createOrReplaceTempView("spark_56032_idx")
-      val df = spark.sql(
-        """
-          |WITH guarded AS (SELECT s FROM spark_56032_t WHERE kind = 'numeric'),
-          |     derived AS (SELECT s, CAST(s AS INT) AS n FROM guarded),
-          |     pairs   AS (SELECT s, i FROM derived, spark_56032_idx WHERE i <= n)
-          |SELECT s, i FROM pairs
-          |""".stripMargin)
-      // Guard against optimizer drift: this test only exercises the bug when the
-      // rolled-up filter contains `IsNotNull(Cast(s AS INT))` alongside an earlier
-      // guard otherPred. If a future optimizer change stops producing that shape,
-      // `checkAnswer` alone would silently pass even without the fix.
-      assert(df.queryExecution.executedPlan.collectFirst {
-        case f: FilterExec if f.condition.exists {
-          case IsNotNull(_: Cast) => true
-          case _ => false
-        } => f
-      }.nonEmpty, "expected a FilterExec with IsNotNull(Cast(...)) in its condition")
-      checkAnswer(df, Seq(Row("3", 1), Row("3", 2)))
+      withTempView("spark_56032_t", "spark_56032_idx") {
+        t.createOrReplaceTempView("spark_56032_t")
+        idx.createOrReplaceTempView("spark_56032_idx")
+        val df = spark.sql(
+          """
+            |WITH guarded AS (SELECT s FROM spark_56032_t WHERE kind = 'numeric'),
+            |     derived AS (SELECT s, CAST(s AS INT) AS n FROM guarded),
+            |     pairs   AS (SELECT s, i FROM derived, spark_56032_idx WHERE i <= n)
+            |SELECT s, i FROM pairs
+            |""".stripMargin)
+        // Guard against optimizer drift: this test only exercises the bug when the
+        // rolled-up filter contains `IsNotNull(Cast(s AS INT))` alongside an earlier
+        // guard otherPred. If a future optimizer change stops producing that shape,
+        // `checkAnswer` alone would silently pass even without the fix.
+        assert(df.queryExecution.executedPlan.collectFirst {
+          case f: FilterExec if f.condition.exists {
+            case IsNotNull(_: Cast) => true
+            case _ => false
+          } => f
+        }.nonEmpty, "expected a FilterExec with IsNotNull(Cast(...)) in its condition")
+        checkAnswer(df, Seq(Row("3", 1), Row("3", 2)))
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to #54862 and #55471.

In `FilterExec.doConsume`'s CSE branch, emit each `IsNotNull(ref)` from `notNullPreds` just before the first `otherPred` that references `ref`, and defer any remaining `notNullPreds` to after all `otherPreds`. This mirrors the non-CSE path's ordering. Previously (since #54862, refined in #55471) the CSE branch emitted the full block of `notNullPreds` up front, before any `otherPred`.

### Why are the changes needed?

`InferFiltersFromConstraints` can add an `IsNotNull(expr)` whose inner expression can throw on valid non-null inputs -- e.g. `IsNotNull(cast(s as int))` derived from a downstream join that expects the cast to be non-null. That `IsNotNull` lands in `notNullPreds`. The CSE branch was emitting it up front, so on any row where an earlier-ordered guard `otherPred` (e.g. `kind = 'numeric'`) would have short-circuited, the upfront `IsNotNull` still evaluated `cast(s as int)` and threw `CAST_INVALID_INPUT`. The non-CSE branch interleaves by-reference and defers leftovers, so the same query succeeds there.

Repro (added as a new test): a CTE chain where an inner guard filter bounds the input to a type that the outer projection then casts; `CombineFilters` + `PushPredicateThroughProject` + `InferFiltersFromConstraints` fold everything into a single

```
Filter(isnotnull(kind) AND kind = 'numeric' AND isnotnull(cast(s as int)))
```

With CSE enabled the cast throws on non-numeric rows; with CSE disabled it succeeds on the same physical plan. Same class of bug as (a) in #55471 -- short-circuit preservation -- but across the `notNullPreds` / `otherPreds` boundary rather than between adjacent `otherPreds`.

### Does this PR introduce _any_ user-facing change?

No user-facing API change. Fixes a regression introduced in #54862 where `FilterExec` CSE codegen could throw on rows an earlier-ordered guard predicate would have rejected.

### How was this patch tested?

Added \`SPARK-56032: FilterExec CSE emits all notNullPreds before guard otherPred\` to \`WholeStageCodegenSuite\`. Without the fix it throws \`SparkNumberFormatException\`; with the fix it matches the non-CSE result. All existing \`WholeStageCodegenSuite\` and \`DataFrameSuite\` tests continue to pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7