### PR TITLE
[SPARK-56600][K8S] Promote `SparkPod` to `Stable`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkPod.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkPod.scala
@@ -18,15 +18,16 @@ package org.apache.spark.deploy.k8s
 
 import io.fabric8.kubernetes.api.model.{Container, ContainerBuilder, Pod, PodBuilder}
 
-import org.apache.spark.annotation.{DeveloperApi, Unstable}
+import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
 
 /**
  * :: DeveloperApi ::
  *
  * Represents a SparkPod consisting of pod and the container within the pod.
  */
-@Unstable
+@Stable
 @DeveloperApi
+@Since("2.4.0")
 case class SparkPod(pod: Pod, container: Container) {
 
   /**
@@ -47,6 +48,7 @@ case class SparkPod(pod: Pod, container: Container) {
    * it can do matching without needing to exhaust all the possibilities. If the function
    * is not applied, then the original pod will be kept.
    */
+  @Since("3.0.0")
   def transform(fn: PartialFunction[SparkPod, SparkPod]): SparkPod = fn.lift(this).getOrElse(this)
 
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to promote the `SparkPod` case class to `@Stable` from Apache Spark 4.2.0.

### Why are the changes needed?

- The case class `SparkPod` has been served without any modification since Spark 2.4.0 and a new method was added at 3.0.0.
  - https://github.com/apache/spark/pull/20910
  - https://github.com/apache/spark/pull/22911
- Since Apache Spark 3.2.0 promoted it as a developer API, it has been serving until now stably.
  - https://github.com/apache/spark/pull/30206
- We had better promote it to `Stable` from Apache Spark 4.2.0.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7