### PR TITLE
[SPARK-56601][K8S] Promote `KubernetesClientUtils` to `Stable`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -29,7 +29,7 @@ import scala.jdk.CollectionConverters._
 import io.fabric8.kubernetes.api.model.{ConfigMap, ConfigMapBuilder, KeyToPath}
 
 import org.apache.spark.SparkConf
-import org.apache.spark.annotation.{DeveloperApi, Since, Unstable}
+import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
 import org.apache.spark.deploy.k8s.{Config, Constants, KubernetesUtils}
 import org.apache.spark.deploy.k8s.Config.{KUBERNETES_DNS_SUBDOMAIN_NAME_MAX_LENGTH, KUBERNETES_NAMESPACE}
 import org.apache.spark.deploy.k8s.Constants.ENV_SPARK_CONF_DIR
@@ -42,8 +42,9 @@ import org.apache.spark.util.ArrayImplicits._
  *
  * A utility class used for K8s operations internally and Spark K8s operator.
  */
-@Unstable
+@Stable
 @DeveloperApi
+@Since("3.1.0")
 object KubernetesClientUtils extends Logging {
 
   // Config map name can be KUBERNETES_DNS_SUBDOMAIN_NAME_MAX_LENGTH chars at max.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to promote `KubernetesClientUtils` from `@Unstable` to `@Stable` API.

### Why are the changes needed?

`KubernetesClientUtils` is a `@DeveloperApi` utility used by both Spark's
internal K8s submission path and the Spark K8s Operator. It was introduced in
Apache Spark 3.1.0 (SPARK-30985) and becomes `DeveloperAPI` at Spark 4.1.0.

- https://github.com/apache/spark/pull/27735
- https://github.com/apache/spark/pull/46327

Since 3.1.0,  its public surface has remained stable for multiple releases. Promoting it to `@Stable` signals this stability to downstream users like the Spark K8s Operator.

### Does this PR introduce _any_ user-facing change?

No, this is an annotation-only change (API stability signaling). No behavior
change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7