### PR TITLE
[SPARK-56602][K8S] Promote `KubernetesVolumeUtils` to `Stable`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesVolumeUtils.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.k8s
 import java.lang.Long.parseLong
 
 import org.apache.spark.SparkConf
-import org.apache.spark.annotation.{DeveloperApi, Since, Unstable}
+import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
 import org.apache.spark.deploy.k8s.Config._
 
 /**
@@ -27,8 +27,9 @@ import org.apache.spark.deploy.k8s.Config._
  *
  * A utility class used for K8s operations internally and Spark K8s operator.
  */
-@Unstable
+@Stable
 @DeveloperApi
+@Since("2.4.0")
 object KubernetesVolumeUtils {
   /**
    * Extract Spark volume configuration properties with a given name prefix.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR promotes `KubernetesVolumeUtils` to `Stable` for Apache Spark 4.2.0.

### Why are the changes needed?

`KubernetesVolumeUtils` was added at Apache Spark 2.4.0 and the last API signiture change happens at Apache Spark 3.0.0. It has been maintained stable and was promoted to `DeveloperAPI` at 4.0.0.
- https://github.com/apache/spark/pull/21260
- https://github.com/apache/spark/pull/22959
- https://github.com/apache/spark/pull/46326

We had better promote this to next step as `Stable` API.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)