### PR TITLE
[SPARK-56604][K8S] Promote `KubernetesDriverBuilder` to `Stable`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
@@ -19,7 +19,7 @@ package org.apache.spark.deploy.k8s.submit
 import io.fabric8.kubernetes.client.KubernetesClient
 
 import org.apache.spark.SparkException
-import org.apache.spark.annotation.{DeveloperApi, Since, Unstable}
+import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
 import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.features._
 import org.apache.spark.util.Utils
@@ -30,8 +30,9 @@ import org.apache.spark.util.Utils
  * KubernetesDriverBuilder builds k8s spec for driver, used for K8s operations internally
  * and Spark K8s operator.
  */
-@Unstable
+@Stable
 @DeveloperApi
+@Since("3.0.0")
 class KubernetesDriverBuilder {
 
   @Since("3.0.0")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to promote `KubernetesDriverBuilder` to `Stable` from Apache Spark 4.2.0.

### Why are the changes needed?

- The AS-IS `KubernetesDriverBuilder` was introduced at Apache Spark 3.0.0.
  - https://github.com/apache/spark/pull/23220
- Since Apache Spark 4.0.0 promoted it as a developer API, it has been serving until now stably.
  - https://github.com/apache/spark/pull/46357
- We had better promote it to `Stable` from Apache Spark 4.2.0.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7