### PR TITLE
[SPARK-58111][SQL] Scan and write schema narrowing for column-level UPDATE in DSv2

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6733,6 +6733,12 @@
     ],
     "sqlState" : "42000"
   },
+  "REQUIRED_DATA_ATTRIBUTES_OVERLAP_SCAN_ONLY_ATTRIBUTES" : {
+    "message" : [
+      "Connector <connector> declares the same column(s) in both `requiredDataAttributes()` and `scanOnlyDataAttributes()`: <overlappingColumns>. A column must be declared in exactly one of the two methods."
+    ],
+    "sqlState" : "42000"
+  },
   "REQUIRED_PARAMETER_NOT_FOUND" : {
     "message" : [
       "Cannot invoke routine <routineName> because the parameter named <parameterName> is required, but the routine call did not supply a value. Please update the routine call to supply an argument value (either positionally at index <index> or by name) and retry the query again."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6727,6 +6727,12 @@
     ],
     "sqlState" : "42614"
   },
+  "REQUIRED_DATA_ATTRIBUTES_MISSING_PARTITION_COLUMNS" : {
+    "message" : [
+      "Connector <connector> mixes in `SupportsColumnUpdates` but its `requiredDataAttributes()` and `scanOnlyDataAttributes()` do not cover every partition column: <missingColumns>. Spark does not implicitly add partition columns to the narrow scan; a connector that needs them for partitioning resolution or write-side clustering must declare them in one of the two methods."
+    ],
+    "sqlState" : "42000"
+  },
   "REQUIRED_DATA_ATTRIBUTES_MISSING_UPDATED_COLUMNS" : {
     "message" : [
       "Connector <connector> mixes in `SupportsColumnUpdates` but its `requiredDataAttributes()` does not cover every column being updated. Missing columns: <missingColumns>. Connectors must include every column reported by `RowLevelOperationInfo.updatedColumns()` in `requiredDataAttributes()`."
@@ -6997,6 +7003,12 @@
       "Error while calling spill() on <consumerToSpill> : <message>"
     ],
     "sqlState" : "82003"
+  },
+  "SPLIT_UPDATE_ROW_ID_NOT_DECLARED" : {
+    "message" : [
+      "Data source <connector> represents UPDATE as delete + insert but its `requiredDataAttributes()` does not include row ID column(s) <rowIds>. The REINSERT payload is projected down to `requiredDataAttributes()`, so an undeclared row ID column leaves the reinserted row with no identity for the connector to place it by. Include the row ID column(s) in `requiredDataAttributes()`."
+    ],
+    "sqlState" : "42000"
   },
   "SPLIT_UPDATE_ROW_ID_REASSIGNMENT" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2238,6 +2238,12 @@
     ],
     "sqlState" : "42K03"
   },
+  "DATA_SOURCE_WRITE_UPDATE_NOT_IMPLEMENTED" : {
+    "message" : [
+      "<class> mixes in `SupportsColumnUpdates` but does not implement `writeUpdate`. Connectors that opt into narrow column-level updates must override `writeUpdate` to handle rows in the `LogicalWriteInfo.updateSchema()` layout; the default implementation would forward narrow rows to `write`, which expects the full `LogicalWriteInfo.schema()` layout."
+    ],
+    "sqlState" : "0A000"
+  },
   "DATETIME_FIELD_OUT_OF_BOUNDS" : {
     "message" : [
       "<rangeMessage>."
@@ -6985,6 +6991,12 @@
       "Error while calling spill() on <consumerToSpill> : <message>"
     ],
     "sqlState" : "82003"
+  },
+  "SPLIT_UPDATE_ROW_ID_REASSIGNMENT" : {
+    "message" : [
+      "Cannot reassign row ID column(s) <rowIds> in a column-level UPDATE when data source <connector> represents UPDATE as delete + insert. The REINSERT path has no row-ID channel to reconstruct columns outside `requiredDataAttributes()`, so undeclared columns would become NULL. Either avoid reassigning row ID columns, or include every table column in `requiredDataAttributes()`."
+    ],
+    "sqlState" : "42000"
   },
   "SQL_CONF_NOT_FOUND" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6721,17 +6721,17 @@
     ],
     "sqlState" : "42614"
   },
-  "REQUIRED_PARAMETER_NOT_FOUND" : {
-    "message" : [
-      "Cannot invoke routine <routineName> because the parameter named <parameterName> is required, but the routine call did not supply a value. Please update the routine call to supply an argument value (either positionally at index <index> or by name) and retry the query again."
-    ],
-    "sqlState" : "4274K"
-  },
   "REQUIRED_DATA_ATTRIBUTES_MISSING_UPDATED_COLUMNS" : {
     "message" : [
       "Connector <connector> mixes in `SupportsColumnUpdates` but its `requiredDataAttributes()` does not cover every column being updated. Missing columns: <missingColumns>. Connectors must include every column reported by `RowLevelOperationInfo.updatedColumns()` in `requiredDataAttributes()`."
     ],
     "sqlState" : "42000"
+  },
+  "REQUIRED_PARAMETER_NOT_FOUND" : {
+    "message" : [
+      "Cannot invoke routine <routineName> because the parameter named <parameterName> is required, but the routine call did not supply a value. Please update the routine call to supply an argument value (either positionally at index <index> or by name) and retry the query again."
+    ],
+    "sqlState" : "4274K"
   },
   "REQUIRES_EXPLICIT_NAME_IN_WATERMARK_CLAUSE" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2461,6 +2461,12 @@
     ],
     "sqlState" : "KD009"
   },
+  "EMPTY_REQUIRED_DATA_ATTRIBUTES" : {
+    "message" : [
+      "Connector <connector> mixes in `SupportsColumnUpdates` but returned an empty array from `requiredDataAttributes()`. Connectors that opt into column-level updates must declare at least one required data attribute."
+    ],
+    "sqlState" : "42000"
+  },
   "EMPTY_SCHEMA_NOT_SUPPORTED_FOR_DATASOURCE" : {
     "message" : [
       "The <format> datasource does not support writing empty or nested empty schemas. Please make sure the data schema has at least one or more column(s)."
@@ -6720,6 +6726,12 @@
       "Cannot invoke routine <routineName> because the parameter named <parameterName> is required, but the routine call did not supply a value. Please update the routine call to supply an argument value (either positionally at index <index> or by name) and retry the query again."
     ],
     "sqlState" : "4274K"
+  },
+  "REQUIRED_DATA_ATTRIBUTES_MISSING_UPDATED_COLUMNS" : {
+    "message" : [
+      "Connector <connector> mixes in `SupportsColumnUpdates` but its `requiredDataAttributes()` does not cover every column being updated. Missing columns: <missingColumns>. Connectors must include every column reported by `RowLevelOperationInfo.updatedColumns()` in `requiredDataAttributes()`."
+    ],
+    "sqlState" : "42000"
   },
   "REQUIRES_EXPLICIT_NAME_IN_WATERMARK_CLAUSE" : {
     "message" : [

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -61,7 +61,7 @@ object MimaExcludes {
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.status.api.v1.sql.Node.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.status.api.v1.sql.Node.copy"),
     ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.status.api.v1.sql.Node$"),
-    // [SPARK-56599] Add scan and write schema narrowing for column-level UPDATEs in DSv2
+    // [SPARK-58111] Add scan and write schema narrowing for column-level UPDATEs in DSv2
     ProblemFilters.exclude[ReversedMissingMethodProblem](
       "org.apache.spark.sql.connector.write.RowLevelOperationInfo.updatedColumns")
   )

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -60,7 +60,10 @@ object MimaExcludes {
     // [SPARK-57987] Add desc field to the SQL REST API Node case class
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.status.api.v1.sql.Node.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.status.api.v1.sql.Node.copy"),
-    ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.status.api.v1.sql.Node$")
+    ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.status.api.v1.sql.Node$"),
+    // [SPARK-56599] Add scan and write schema narrowing for column-level UPDATEs in DSv2
+    ProblemFilters.exclude[ReversedMissingMethodProblem](
+      "org.apache.spark.sql.connector.write.RowLevelOperationInfo.updatedColumns")
   )
 
   // Exclude rules for 4.2.x from 4.1.0

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DataWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DataWriter.java
@@ -83,6 +83,42 @@ public interface DataWriter<T> extends Closeable {
   }
 
   /**
+   * Writes one updated, copied, or reinserted record with metadata.
+   * <p>
+   * Connectors that mix in {@link SupportsColumnUpdates} receive records here in the schema
+   * declared by {@link LogicalWriteInfo#updateSchema()}. Implementations must
+   * override this method when mixing in {@link SupportsColumnUpdates}; the default delegates
+   * to {@link #write(Object, Object)} so existing connectors are unaffected.
+   * <p>
+   * If this method fails (by throwing an exception), {@link #abort()} will be called and this
+   * data writer is considered to have been failed.
+   *
+   * @throws IOException if failure happens during disk/network IO like writing files.
+   *
+   * @since 4.3.0
+   */
+  default void writeUpdate(T metadata, T record) throws IOException {
+    write(metadata, record);
+  }
+
+  /**
+   * Writes one updated, copied, or reinserted record without metadata.
+   * <p>
+   * Equivalent to {@link #writeUpdate(Object, Object)} for writers that do not require metadata.
+   * The default delegates to {@link #write(Object)}.
+   * <p>
+   * If this method fails (by throwing an exception), {@link #abort()} will be called and this
+   * data writer is considered to have been failed.
+   *
+   * @throws IOException if failure happens during disk/network IO like writing files.
+   *
+   * @since 4.3.0
+   */
+  default void writeUpdate(T record) throws IOException {
+    write(record);
+  }
+
+  /**
    * Writes one record.
    * <p>
    * If this method fails (by throwing an exception), {@link #abort()} will be called and this

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DataWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DataWriter.java
@@ -20,7 +20,9 @@ package org.apache.spark.sql.connector.write;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.Map;
 
+import org.apache.spark.SparkUnsupportedOperationException;
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.metric.CustomTaskMetric;
 
@@ -86,36 +88,45 @@ public interface DataWriter<T> extends Closeable {
    * Writes one updated, copied, or reinserted record with metadata.
    * <p>
    * Connectors that mix in {@link SupportsColumnUpdates} receive records here in the schema
-   * declared by {@link LogicalWriteInfo#updateSchema()}. Implementations must
-   * override this method when mixing in {@link SupportsColumnUpdates}; the default delegates
-   * to {@link #write(Object, Object)} so existing connectors are unaffected.
+   * declared by {@link LogicalWriteInfo#updateSchema()}. Implementations must override this
+   * method when mixing in {@link SupportsColumnUpdates}.
    * <p>
    * If this method fails (by throwing an exception), {@link #abort()} will be called and this
    * data writer is considered to have been failed.
    *
    * @throws IOException if failure happens during disk/network IO like writing files.
+   * @throws SparkUnsupportedOperationException if the connector mixes in
+   *         {@link SupportsColumnUpdates} but does not override this method.
    *
    * @since 4.3.0
    */
   default void writeUpdate(T metadata, T record) throws IOException {
-    write(metadata, record);
+    throw new SparkUnsupportedOperationException(
+      "DATA_SOURCE_WRITE_UPDATE_NOT_IMPLEMENTED",
+      Map.of("class", getClass().getName()));
   }
 
   /**
    * Writes one updated, copied, or reinserted record without metadata.
    * <p>
    * Equivalent to {@link #writeUpdate(Object, Object)} for writers that do not require metadata.
-   * The default delegates to {@link #write(Object)}.
+   * Connectors that mix in {@link SupportsColumnUpdates} receive records here in the schema
+   * declared by {@link LogicalWriteInfo#updateSchema()}. Implementations must override this
+   * method when mixing in {@link SupportsColumnUpdates}.
    * <p>
    * If this method fails (by throwing an exception), {@link #abort()} will be called and this
    * data writer is considered to have been failed.
    *
    * @throws IOException if failure happens during disk/network IO like writing files.
+   * @throws SparkUnsupportedOperationException if the connector mixes in
+   * {@link SupportsColumnUpdates} but does not override this method.
    *
    * @since 4.3.0
    */
   default void writeUpdate(T record) throws IOException {
-    write(record);
+    throw new SparkUnsupportedOperationException(
+      "DATA_SOURCE_WRITE_UPDATE_NOT_IMPLEMENTED",
+      Map.of("class", getClass().getName()));
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DeltaWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DeltaWriter.java
@@ -40,6 +40,11 @@ public interface DeltaWriter<T> extends DataWriter<T> {
 
   /**
    * Updates a row.
+   * <p>
+   * When the associated {@link RowLevelOperation} mixes in {@link SupportsColumnUpdates}, the
+   * {@code row} follows the narrow layout declared by {@link LogicalWriteInfo#updateSchema()}
+   * rather than the full table schema from {@link LogicalWriteInfo#schema()}.
+   * Otherwise {@code row} follows the full table schema.
    *
    * @param metadata values for metadata columns that were projected but are not part of the row ID
    * @param id a row ID to update
@@ -52,6 +57,10 @@ public interface DeltaWriter<T> extends DataWriter<T> {
    * Reinserts a row with metadata.
    * <p>
    * This method handles the insert portion of updated rows split into deletes and inserts.
+   * <p>
+   * When the associated {@link RowLevelOperation} mixes in {@link SupportsColumnUpdates}, the
+   * {@code row} follows the narrow layout declared by {@link LogicalWriteInfo#updateSchema()}
+   * rather than the full table schema from {@link LogicalWriteInfo#schema()}.
    *
    * @param metadata values for metadata columns
    * @param row a row to reinsert

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DeltaWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DeltaWriter.java
@@ -41,10 +41,10 @@ public interface DeltaWriter<T> extends DataWriter<T> {
   /**
    * Updates a row.
    * <p>
-   * When the associated {@link RowLevelOperation} mixes in {@link SupportsColumnUpdates}, the
-   * {@code row} follows the narrow layout declared by {@link LogicalWriteInfo#updateSchema()}
-   * rather than the full table schema from {@link LogicalWriteInfo#schema()}.
-   * Otherwise {@code row} follows the full table schema.
+   * When {@link LogicalWriteInfo#updateSchema()} is present, the {@code row} follows the narrow
+   * layout it declares rather than the full table schema from {@link LogicalWriteInfo#schema()}.
+   * It is present only for UPDATE on an operation that mixes in {@link SupportsColumnUpdates};
+   * otherwise {@code row} follows the full table schema.
    *
    * @param metadata values for metadata columns that were projected but are not part of the row ID
    * @param id a row ID to update
@@ -58,9 +58,10 @@ public interface DeltaWriter<T> extends DataWriter<T> {
    * <p>
    * This method handles the insert portion of updated rows split into deletes and inserts.
    * <p>
-   * When the associated {@link RowLevelOperation} mixes in {@link SupportsColumnUpdates}, the
-   * {@code row} follows the narrow layout declared by {@link LogicalWriteInfo#updateSchema()}
-   * rather than the full table schema from {@link LogicalWriteInfo#schema()}.
+   * When {@link LogicalWriteInfo#updateSchema()} is present, the {@code row} follows the narrow
+   * layout it declares rather than the full table schema from {@link LogicalWriteInfo#schema()}.
+   * It is present only for UPDATE on an operation that mixes in {@link SupportsColumnUpdates};
+   * otherwise {@code row} follows the full table schema.
    *
    * @param metadata values for metadata columns
    * @param row a row to reinsert

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/LogicalWriteInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/LogicalWriteInfo.java
@@ -65,4 +65,14 @@ public interface LogicalWriteInfo {
     throw new SparkUnsupportedOperationException(
       "DATA_SOURCE_METADATA_SCHEMA_NOT_IMPLEMENTED", Map.of("class", getClass().getName()));
   }
+
+  /**
+   * the narrow schema for updates. Present only when the connector mixes in
+   * {@link SupportsColumnUpdates}.
+   *
+   * @since 4.3.0
+   */
+  default Optional<StructType> updateSchema() {
+    return Optional.empty();
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RowLevelOperation.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RowLevelOperation.java
@@ -105,4 +105,45 @@ public interface RowLevelOperation {
   default NamedReference[] requiredMetadataAttributes() {
     return new NamedReference[0];
   }
+
+
+  /**
+   * Controls whether to send only the required data columns to the connector rather than the
+   * full row.
+   * <p>
+   * When true, Spark narrows the data column schema ({@link LogicalWriteInfo#schema()}) to only
+   * the columns declared via {@link #requiredDataAttributes()}. Metadata columns (from
+   * {@link #requiredMetadataAttributes()}) and row ID columns (from
+   * {@link SupportsDelta#rowId()}) are unaffected and always projected separately.
+   * <p>
+   * If {@link #requiredDataAttributes()} returns a non-empty array, the write schema is exactly
+   * those columns in declared order. The connector must include all columns it wants to receive,
+   * including the columns being updated. If {@link #requiredDataAttributes()} returns an empty
+   * array, Spark sends only the non-identity assigned columns (heuristic path).
+   *
+   * @since 4.2.0
+   */
+  default boolean supportsColumnUpdates() {
+    return false;
+  }
+
+  /**
+   * Returns data column references required to perform this row-level operation.
+   * <p>
+   * This method is only consulted by Spark when {@link #supportsColumnUpdates()} returns
+   * {@code true}. If {@code supportsColumnUpdates()} returns {@code false}, the returned array
+   * is ignored and the full table row is sent (the default behavior).
+   * <p>
+   * When non-empty, the returned columns become the write schema in declared order.
+   * The connector must declare all columns it wants to receive, including the columns being
+   * updated. Use {@link RowLevelOperationInfo#updatedColumns()} to learn which columns are being
+   * assigned, then add any extra columns needed for row lookup or routing (e.g., primary key).
+   * <p>
+   * When empty (the default), Spark falls back to sending only the non-identity assigned columns.
+   *
+   * @since 4.2.0
+   */
+  default NamedReference[] requiredDataAttributes() {
+    return new NamedReference[0];
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RowLevelOperation.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RowLevelOperation.java
@@ -106,7 +106,6 @@ public interface RowLevelOperation {
     return new NamedReference[0];
   }
 
-
   /**
    * Controls whether to send only the required data columns to the connector rather than the
    * full row.
@@ -120,8 +119,10 @@ public interface RowLevelOperation {
    * those columns in declared order. The connector must include all columns it wants to receive,
    * including the columns being updated. If {@link #requiredDataAttributes()} returns an empty
    * array, Spark sends only the non-identity assigned columns (heuristic path).
+   * <p>
+   * Currently only consulted for UPDATE operations.
    *
-   * @since 4.2.0
+   * @since 4.3.0
    */
   default boolean supportsColumnUpdates() {
     return false;
@@ -140,8 +141,10 @@ public interface RowLevelOperation {
    * assigned, then add any extra columns needed for row lookup or routing (e.g., primary key).
    * <p>
    * When empty (the default), Spark falls back to sending only the non-identity assigned columns.
+   * <p>
+   * Currently only consulted for UPDATE operations.
    *
-   * @since 4.2.0
+   * @since 4.3.0
    */
   default NamedReference[] requiredDataAttributes() {
     return new NamedReference[0];

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RowLevelOperationInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RowLevelOperationInfo.java
@@ -40,7 +40,9 @@ public interface RowLevelOperationInfo {
   Command command();
 
   /**
-   * Returns the columns being updated by this operation.
+   * Returns the columns being updated by this operation. Currently populated only for UPDATE;
+   * DELETE and MERGE report an empty array.
+   * <p>
    * Nested struct field updates are reported at root-column granularity
    * (e.g. {@code SET s.c1 = -1} returns {@code s}).
    *

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RowLevelOperationInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RowLevelOperationInfo.java
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.connector.write;
 
 import org.apache.spark.annotation.Experimental;
+import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
@@ -37,4 +38,13 @@ public interface RowLevelOperationInfo {
    * Returns the row-level SQL command (e.g. DELETE, UPDATE, MERGE).
    */
   Command command();
+
+  /**
+   * Returns the columns being updated by this operation.
+   * Nested struct field updates are reported at root-column granularity
+   * (e.g. {@code SET s.c1 = -1} returns {@code s}).
+   *
+   * @since 4.3.0
+   */
+  NamedReference[] updatedColumns();
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RowLevelOperationInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RowLevelOperationInfo.java
@@ -49,7 +49,7 @@ public interface RowLevelOperationInfo {
    * whether pk is already in the updated columns list and, if not, add it to
    * requiredDataAttributes().
    *
-   * @since 4.2.0
+   * @since 4.3.0
    */
   default NamedReference[] updatedColumns() {
     return new NamedReference[0];

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RowLevelOperationInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RowLevelOperationInfo.java
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.connector.write;
 
 import org.apache.spark.annotation.Experimental;
+import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
@@ -37,4 +38,20 @@ public interface RowLevelOperationInfo {
    * Returns the row-level SQL command (e.g. DELETE, UPDATE, MERGE).
    */
   Command command();
+
+  /**
+   * Returns the columns being updated in an UPDATE statement, as non-identity assignments.
+   *
+   * <p>For DELETE and MERGE, returns an empty array.
+   *
+   * <p>Connectors can use this to decide what {@link RowLevelOperation#requiredDataAttributes()}
+   * to declare. For instance, a connector that needs its primary key for row lookup can check
+   * whether pk is already in the updated columns list and, if not, add it to
+   * requiredDataAttributes().
+   *
+   * @since 4.2.0
+   */
+  default NamedReference[] updatedColumns() {
+    return new NamedReference[0];
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/SupportsColumnUpdates.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/SupportsColumnUpdates.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.write;
+
+import org.apache.spark.annotation.Experimental;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+
+/**
+ * A mix-in interface for {@link RowLevelOperation}. Data sources can implement this interface to
+ * receive a narrow row containing only the columns declared via {@link #requiredDataAttributes()}
+ * for updated, copied, and reinserted records, instead of the full table row.
+ *
+ * @since 4.3.0
+ */
+@Experimental
+public interface SupportsColumnUpdates extends RowLevelOperation {
+  /**
+   * Returns the data column references required to perform this row-level operation.
+   * <p>
+   * The returned columns become the schema of updated, copied, and reinserted rows, in declared
+   * order. Implementations must include every column they want to receive (typically the columns
+   * reported by {@link RowLevelOperationInfo#updatedColumns()} plus any columns needed for row
+   * lookup or routing, e.g. a primary key).
+   * <p>
+   * If any of the columns from {@link RowLevelOperationInfo#updatedColumns()}) is
+   * missing, an analysis exception is thrown.
+   * <p>
+   * For updates on nested fields such as {@code SET t.s.c1 = -1} the connector should declare the
+   * root struct column {@code s} rather than any nested field.
+   */
+  NamedReference[] requiredDataAttributes();
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/SupportsColumnUpdates.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/SupportsColumnUpdates.java
@@ -37,7 +37,7 @@ public interface SupportsColumnUpdates extends RowLevelOperation {
    * reported by {@link RowLevelOperationInfo#updatedColumns()} plus any columns needed for row
    * lookup or routing, e.g. a primary key).
    * <p>
-   * If any of the columns from {@link RowLevelOperationInfo#updatedColumns()}) is
+   * If any of the columns from {@link RowLevelOperationInfo#updatedColumns()} are
    * missing, an analysis exception is thrown.
    * <p>
    * For updates on nested fields such as {@code SET t.s.c1 = -1} the connector should declare the

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/SupportsColumnUpdates.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/SupportsColumnUpdates.java
@@ -47,4 +47,22 @@ public interface SupportsColumnUpdates extends RowLevelOperation {
    * root struct column {@code s} rather than any nested field.
    */
   NamedReference[] requiredDataAttributes();
+
+  /**
+   * Returns additional data column references that must be present in the narrow scan but are
+   * NOT delivered to the writer.
+   * <p>
+   * Use this for columns needed only for planning -- e.g. resolving the table's partitioning
+   * expressions against the scan output, or as clustering keys returned from
+   * {@link RequiresDistributionAndOrdering#requiredDistribution()} -- where the column itself
+   * should not appear in the row passed to
+   * {@link DataWriter#writeUpdate(Object, Object)} / {@link DeltaWriter#update} /
+   * {@link DeltaWriter#reinsert}. Columns returned here are not reflected in
+   * {@link LogicalWriteInfo#updateSchema()}.
+   * <p>
+   * Must not overlap with {@link #requiredDataAttributes()}; defaults to an empty array.
+   */
+  default NamedReference[] scanOnlyDataAttributes() {
+    return new NamedReference[0];
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/SupportsColumnUpdates.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/SupportsColumnUpdates.java
@@ -24,6 +24,9 @@ import org.apache.spark.sql.connector.expressions.NamedReference;
  * A mix-in interface for {@link RowLevelOperation}. Data sources can implement this interface to
  * receive a narrow row containing only the columns declared via {@link #requiredDataAttributes()}
  * for updated, copied, and reinserted records, instead of the full table row.
+ * <p>
+ * Currently honored only for UPDATE. DELETE and MERGE ignore this interface: those operations
+ * receive full-width rows and {@link LogicalWriteInfo#updateSchema()} is absent for them.
  *
  * @since 4.3.0
  */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
@@ -28,8 +28,8 @@ import org.apache.spark.sql.catalyst.util.{GeneratedColumn, ReplaceDataProjectio
   WriteDeltaProjections}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils._
 import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
-import org.apache.spark.sql.connector.expressions.FieldReference
-import org.apache.spark.sql.connector.write.{RowLevelOperation, RowLevelOperationInfoImpl, RowLevelOperationTable, SupportsDelta}
+import org.apache.spark.sql.connector.expressions.{FieldReference, NamedReference}
+import org.apache.spark.sql.connector.write.{RowLevelOperation, RowLevelOperationInfoImpl, RowLevelOperationTable, SupportsColumnUpdates, SupportsDelta}
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -72,8 +72,9 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
   protected def buildOperationTable(
       table: SupportsRowLevelOperations,
       command: Command,
-      options: CaseInsensitiveStringMap): RowLevelOperationTable = {
-    val info = RowLevelOperationInfoImpl(command, options)
+      options: CaseInsensitiveStringMap,
+      updatedColumns: Seq[NamedReference] = Nil): RowLevelOperationTable = {
+    val info = RowLevelOperationInfoImpl(command, options, updatedColumns)
     val operation = table.newRowLevelOperationBuilder(info).build()
     RowLevelOperationTable(table, operation)
   }
@@ -83,8 +84,17 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       table: RowLevelOperationTable,
       metadataAttrs: Seq[AttributeReference],
       rowIdAttrs: Seq[AttributeReference] = Nil): DataSourceV2Relation = {
-
     val attrs = dedupAttrs(relation.output ++ rowIdAttrs ++ metadataAttrs)
+    relation.copy(table = table, output = attrs)
+  }
+
+  protected def buildNarrowRelationWithAttrs(
+      relation: DataSourceV2Relation,
+      table: RowLevelOperationTable,
+      dataAttrs: Seq[AttributeReference],
+      metadataAttrs: Seq[AttributeReference],
+      rowIdAttrs: Seq[AttributeReference] = Nil): DataSourceV2Relation = {
+    val attrs = dedupAttrs(dataAttrs ++ rowIdAttrs ++ metadataAttrs)
     relation.copy(table = table, output = attrs)
   }
 
@@ -109,6 +119,22 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       relation)
   }
 
+  /**
+   * Resolves the connector-declared required data attributes for column-update writes against
+   * the given relation. Non-existent columns are rejected with an `AnalysisException`.
+   */
+  protected def resolveRequiredDataAttrs(
+      relation: DataSourceV2Relation,
+      operation: SupportsColumnUpdates): Seq[AttributeReference] = {
+    val refs = operation.requiredDataAttributes
+    if (refs.isEmpty) {
+      throw QueryCompilationErrors.emptyRequiredDataAttributesError(operation.getClass.getName)
+    }
+    V2ExpressionUtils.resolveRefs[AttributeReference](
+      refs.toImmutableArraySeq,
+      relation)
+  }
+
   protected def resolveRowIdAttrs(
       relation: DataSourceV2Relation,
       operation: SupportsDelta): Seq[AttributeReference] = {
@@ -127,6 +153,17 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
 
   protected def resolveAttrRef(name: String, plan: LogicalPlan): AttributeReference = {
     V2ExpressionUtils.resolveRef[AttributeReference](FieldReference(name), plan)
+  }
+
+  protected def isIdentityAssignment(key: Attribute, value: Expression): Boolean = {
+    val unwrapped = value match {
+      case Alias(child, _) => child
+      case other => other
+    }
+    unwrapped match {
+      case attr: Attribute => AttributeSet(Seq(key)).contains(attr)
+      case _ => false
+    }
   }
 
   protected def deltaDeleteOutput(
@@ -210,11 +247,25 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
   protected def buildReplaceDataProjections(
       plan: LogicalPlan,
       rowAttrs: Seq[Attribute],
-      metadataAttrs: Seq[Attribute]): ReplaceDataProjections = {
+      metadataAttrs: Seq[Attribute],
+      updateRowAttrs: Seq[Attribute] = Nil): ReplaceDataProjections = {
     val outputs = extractOutputs(plan)
 
-    val outputsWithRow = filterOutputs(outputs, OPERATIONS_WITH_ROW)
-    val rowProjection = newLazyProjection(plan, outputsWithRow, rowAttrs)
+    val rowProjection = if (updateRowAttrs.nonEmpty) {
+      val outputsForInsert = filterOutputs(outputs,
+        OPERATIONS_WITH_ROW -- Set(UPDATE_OPERATION, COPY_OPERATION))
+      newLazyProjection(plan, outputsForInsert, rowAttrs)
+    } else {
+      val outputsWithRow = filterOutputs(outputs, OPERATIONS_WITH_ROW)
+      newLazyProjection(plan, outputsWithRow, rowAttrs)
+    }
+
+    val updateRowProjection = if (updateRowAttrs.nonEmpty) {
+      val outputsForUpdate = filterOutputs(outputs, Set(UPDATE_OPERATION, COPY_OPERATION))
+      Some(newLazyProjection(plan, outputsForUpdate, updateRowAttrs))
+    } else {
+      None
+    }
 
     val metadataProjection = if (metadataAttrs.nonEmpty) {
       val outputsWithMetadata = filterOutputs(outputs, OPERATIONS_WITH_METADATA)
@@ -223,19 +274,39 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       None
     }
 
-    ReplaceDataProjections(rowProjection, metadataProjection)
+    ReplaceDataProjections(rowProjection, updateRowProjection, metadataProjection)
   }
 
   protected def buildWriteDeltaProjections(
       plan: LogicalPlan,
       rowAttrs: Seq[Attribute],
       rowIdAttrs: Seq[Attribute],
-      metadataAttrs: Seq[Attribute]): WriteDeltaProjections = {
+      metadataAttrs: Seq[Attribute],
+      updateRowAttrs: Seq[Attribute] = Nil): WriteDeltaProjections = {
     val outputs = extractOutputs(plan)
 
-    val rowProjection = if (rowAttrs.nonEmpty) {
+    // Always produce Some(rowProjection) even for empty rowAttrs (identity-only column updates).
+    // When updateRowAttrs is non-empty, the row projection covers INSERT-shaped rows only and a
+    // separate updateRowProjection handles UPDATE/COPY/REINSERT-shaped rows.
+    val rowProjection = if (updateRowAttrs.nonEmpty) {
+      val outputsForInsert = filterOutputs(outputs,
+        OPERATIONS_WITH_ROW -- Set(UPDATE_OPERATION, COPY_OPERATION, REINSERT_OPERATION))
+      if (outputsForInsert.isEmpty) {
+        Some(ProjectingInternalRow(StructType(Nil), Nil))
+      } else {
+        Some(newLazyProjection(plan, outputsForInsert, rowAttrs))
+      }
+    } else if (rowAttrs.nonEmpty) {
       val outputsWithRow = filterOutputs(outputs, OPERATIONS_WITH_ROW)
       Some(newLazyProjection(plan, outputsWithRow, rowAttrs))
+    } else {
+      Some(ProjectingInternalRow(StructType(Nil), Nil))
+    }
+
+    val updateRowProjection = if (updateRowAttrs.nonEmpty) {
+      val outputsForUpdate = filterOutputs(outputs,
+        Set(UPDATE_OPERATION, COPY_OPERATION, REINSERT_OPERATION))
+      Some(newLazyProjection(plan, outputsForUpdate, updateRowAttrs))
     } else {
       None
     }
@@ -250,7 +321,7 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       None
     }
 
-    WriteDeltaProjections(rowProjection, rowIdProjection, metadataProjection)
+    WriteDeltaProjections(rowProjection, updateRowProjection, rowIdProjection, metadataProjection)
   }
 
   private def extractOutputs(plan: LogicalPlan): Seq[Seq[Expression]] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
@@ -84,6 +84,7 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       table: RowLevelOperationTable,
       metadataAttrs: Seq[AttributeReference],
       rowIdAttrs: Seq[AttributeReference] = Nil): DataSourceV2Relation = {
+
     val attrs = dedupAttrs(relation.output ++ rowIdAttrs ++ metadataAttrs)
     relation.copy(table = table, output = attrs)
   }
@@ -254,7 +255,11 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
     val rowProjection = if (updateRowAttrs.nonEmpty) {
       val outputsForInsert = filterOutputs(outputs,
         OPERATIONS_WITH_ROW -- Set(UPDATE_OPERATION, COPY_OPERATION))
-      newLazyProjection(plan, outputsForInsert, rowAttrs)
+      if (outputsForInsert.isEmpty) {
+        ProjectingInternalRow(StructType(Nil), Nil)
+      } else {
+        newLazyProjection(plan, outputsForInsert, rowAttrs)
+      }
     } else {
       val outputsWithRow = filterOutputs(outputs, OPERATIONS_WITH_ROW)
       newLazyProjection(plan, outputsWithRow, rowAttrs)
@@ -285,7 +290,6 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       updateRowAttrs: Seq[Attribute] = Nil): WriteDeltaProjections = {
     val outputs = extractOutputs(plan)
 
-    // Always produce Some(rowProjection) even for empty rowAttrs (identity-only column updates).
     // When updateRowAttrs is non-empty, the row projection covers INSERT-shaped rows only and a
     // separate updateRowProjection handles UPDATE/COPY/REINSERT-shaped rows.
     val rowProjection = if (updateRowAttrs.nonEmpty) {
@@ -300,7 +304,7 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       val outputsWithRow = filterOutputs(outputs, OPERATIONS_WITH_ROW)
       Some(newLazyProjection(plan, outputsWithRow, rowAttrs))
     } else {
-      Some(ProjectingInternalRow(StructType(Nil), Nil))
+      None
     }
 
     val updateRowProjection = if (updateRowAttrs.nonEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
@@ -22,12 +22,13 @@ import scala.collection.mutable
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.ProjectingInternalRow
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, AttributeSet, Expression, ExprId, If, Literal, MetadataAttribute, NamedExpression, V2ExpressionUtils}
+import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.logical.{Assignment, Expand, LogicalPlan, MergeRows, Project, Union}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.{ReplaceDataProjections, WriteDeltaProjections}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils._
 import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
-import org.apache.spark.sql.connector.expressions.FieldReference
+import org.apache.spark.sql.connector.expressions.{FieldReference, NamedReference}
 import org.apache.spark.sql.connector.write.{RowLevelOperation, RowLevelOperationInfoImpl, RowLevelOperationTable, SupportsDelta}
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -50,20 +51,35 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
   protected def buildOperationTable(
       table: SupportsRowLevelOperations,
       command: Command,
-      options: CaseInsensitiveStringMap): RowLevelOperationTable = {
-    val info = RowLevelOperationInfoImpl(command, options)
+      options: CaseInsensitiveStringMap,
+      updatedColumns: Seq[NamedReference] = Nil): RowLevelOperationTable = {
+    val info = RowLevelOperationInfoImpl(command, options, updatedColumns)
     val operation = table.newRowLevelOperationBuilder(info).build()
     RowLevelOperationTable(table, operation)
   }
 
+  // Builds a DataSourceV2Relation for a row-level operation, optionally narrowing its output.
+  //
+  // When dataAttrs is non-empty, the relation output is narrowed to include only columns
+  // required for a column-update write. When dataAttrs is empty, the full relation.output is
+  // preserved.
   protected def buildRelationWithAttrs(
       relation: DataSourceV2Relation,
       table: RowLevelOperationTable,
       metadataAttrs: Seq[AttributeReference],
-      rowIdAttrs: Seq[AttributeReference] = Nil): DataSourceV2Relation = {
+      rowIdAttrs: Seq[AttributeReference] = Nil,
+      dataAttrs: Seq[AttributeReference] = Nil,
+      cond: Expression = TrueLiteral): DataSourceV2Relation = {
 
-    val attrs = dedupAttrs(relation.output ++ rowIdAttrs ++ metadataAttrs)
-    relation.copy(table = table, output = attrs)
+    if (dataAttrs.nonEmpty) {
+      val required =
+        AttributeSet(dataAttrs) ++ AttributeSet(Seq(cond)) ++ AttributeSet(rowIdAttrs)
+      val narrowOutput = relation.output.filter(required.contains)
+      relation.copy(table = table, output = dedupAttrs(narrowOutput ++ rowIdAttrs ++ metadataAttrs))
+    } else {
+      val attrs = dedupAttrs(relation.output ++ rowIdAttrs ++ metadataAttrs)
+      relation.copy(table = table, output = attrs)
+    }
   }
 
   protected def dedupAttrs(attrs: Seq[AttributeReference]): Seq[AttributeReference] = {
@@ -84,6 +100,14 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
 
     V2ExpressionUtils.resolveRefs[AttributeReference](
       operation.requiredMetadataAttributes.toImmutableArraySeq,
+      relation)
+  }
+
+  protected def resolveRequiredDataAttrs(
+      relation: DataSourceV2Relation,
+      operation: RowLevelOperation): Seq[AttributeReference] = {
+    V2ExpressionUtils.resolveRefs[AttributeReference](
+      operation.requiredDataAttributes.toImmutableArraySeq,
       relation)
   }
 
@@ -211,11 +235,13 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       metadataAttrs: Seq[Attribute]): WriteDeltaProjections = {
     val outputs = extractOutputs(plan)
 
+    // Always produce Some(rowProjection) even for empty rowAttrs (identity-only column updates).
+    // Physical execution calls rowProjection.project(row) unconditionally; None causes NPE.
     val rowProjection = if (rowAttrs.nonEmpty) {
       val outputsWithRow = filterOutputs(outputs, OPERATIONS_WITH_ROW)
       Some(newLazyProjection(plan, outputsWithRow, rowAttrs))
     } else {
-      None
+      Some(ProjectingInternalRow(StructType(Nil), Nil))
     }
 
     val outputsWithRowId = filterOutputs(outputs, OPERATIONS_WITH_ROW_ID)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
@@ -72,9 +72,8 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       cond: Expression = TrueLiteral): DataSourceV2Relation = {
 
     if (dataAttrs.nonEmpty) {
-      val required =
-        AttributeSet(dataAttrs) ++ AttributeSet(Seq(cond)) ++ AttributeSet(rowIdAttrs)
-      val narrowOutput = relation.output.filter(required.contains)
+      val required = (dataAttrs ++ cond.references.toSeq).map(_.exprId).toSet
+      val narrowOutput = relation.output.filter(a => required.contains(a.exprId))
       relation.copy(table = table, output = dedupAttrs(narrowOutput ++ rowIdAttrs ++ metadataAttrs))
     } else {
       val attrs = dedupAttrs(relation.output ++ rowIdAttrs ++ metadataAttrs)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
@@ -58,11 +58,13 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
     RowLevelOperationTable(table, operation)
   }
 
-  // Builds a DataSourceV2Relation for a row-level operation, optionally narrowing its output.
-  //
-  // When dataAttrs is non-empty, the relation output is narrowed to include only columns
-  // required for a column-update write. When dataAttrs is empty, the full relation.output is
-  // preserved.
+  /**
+   * Builds a DataSourceV2Relation for a row-level operation, optionally narrowing its output.
+   *
+   * When dataAttrs is non-empty, the relation output is narrowed to include only columns
+   * required for a column-update write. When dataAttrs is empty, the full relation.output is
+   * preserved.
+   */
   protected def buildRelationWithAttrs(
       relation: DataSourceV2Relation,
       table: RowLevelOperationTable,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
@@ -17,15 +17,18 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, EqualNullSafe, Expression, If, Literal, MetadataAttribute, Not, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeReference, AttributeSet, EqualNullSafe, Expression, If, Literal, MetadataAttribute, Not, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.logical.{Assignment, Expand, Filter, LogicalPlan, Project, ReplaceData, Union, UpdateTable, WriteDelta}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils._
 import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
-import org.apache.spark.sql.connector.write.{RowLevelOperationTable, SupportsDelta}
+import org.apache.spark.sql.connector.expressions.FieldReference
+import org.apache.spark.sql.connector.write.{RowLevelOperation, RowLevelOperationTable, SupportsColumnUpdates, SupportsDelta}
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command.UPDATE
+import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, ExtractV2Table}
 import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.util.ArrayImplicits._
 
 /**
  * A rule that rewrites UPDATE operations using plans that operate on individual or groups of rows.
@@ -41,7 +44,11 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       EliminateSubqueryAliases(aliasedTable) match {
         case r @ ExtractV2Table(tbl: SupportsRowLevelOperations) =>
           checkNoGeneratedColumns(r, UPDATE)
-          val table = buildOperationTable(tbl, UPDATE, r.options)
+          val updatedCols = assignments.collect {
+            case Assignment(key: AttributeReference, value) if !isIdentityAssignment(key, value) =>
+              FieldReference(key.name)
+          }
+          val table = buildOperationTable(tbl, UPDATE, r.options, updatedCols)
           val updateCond = cond.getOrElse(TrueLiteral)
           table.operation match {
             case _: SupportsDelta =>
@@ -67,16 +74,29 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
     // resolve all required metadata attrs that may be used for grouping data on write
     val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
+    val connectorDataAttrs = resolveConnectorDataAttrs(relation, operationTable.operation)
+    val supportsColumnUpdate = connectorDataAttrs.nonEmpty
+
+    if (supportsColumnUpdate) {
+      validateUpdatedColumnsSubset(operationTable.operation, assignments, connectorDataAttrs)
+    }
 
     // construct a read relation and include all required metadata columns
-    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+    val readRelation = if (supportsColumnUpdate) {
+      val narrowDataAttrs =
+        computeNarrowReadAttrs(relation, connectorDataAttrs, assignments, cond)
+      buildNarrowRelationWithAttrs(relation, operationTable, narrowDataAttrs, metadataAttrs)
+    } else {
+      buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+    }
 
     // build a plan with updated and copied over records
     val query = buildReplaceDataUpdateProjection(readRelation, assignments, cond)
 
     // build a plan to replace read groups in the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildReplaceDataProjections(query, relation.output, metadataAttrs)
+    val projections = buildReplaceDataProjections(query, relation.output, metadataAttrs,
+      connectorDataAttrs)
     val groupFilterCond = if (groupFilterEnabled) Some(cond) else None
     ReplaceData(writeRelation, cond, query, relation, projections, groupFilterCond)
   }
@@ -91,11 +111,23 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
     // resolve all required metadata attrs that may be used for grouping data on write
     val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
+    val connectorDataAttrs = resolveConnectorDataAttrs(relation, operationTable.operation)
+    val supportsColumnUpdate = connectorDataAttrs.nonEmpty
+
+    if (supportsColumnUpdate) {
+      validateUpdatedColumnsSubset(operationTable.operation, assignments, connectorDataAttrs)
+    }
 
     // construct a read relation and include all required metadata columns
     // the same read relation will be used to read records that must be updated and copied over
     // the analyzer will take care of duplicated attr IDs
-    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+    val readRelation = if (supportsColumnUpdate) {
+      val narrowDataAttrs =
+        computeNarrowReadAttrs(relation, connectorDataAttrs, assignments, cond)
+      buildNarrowRelationWithAttrs(relation, operationTable, narrowDataAttrs, metadataAttrs)
+    } else {
+      buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+    }
 
     // build a plan for updated records that match the condition
     val matchedRowsPlan = Filter(cond, readRelation)
@@ -111,32 +143,40 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
     // build a plan to replace read groups in the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildReplaceDataProjections(query, relation.output, metadataAttrs)
+    val projections = buildReplaceDataProjections(query, relation.output, metadataAttrs,
+      connectorDataAttrs)
     val groupFilterCond = if (groupFilterEnabled) Some(cond) else None
     ReplaceData(writeRelation, cond, query, relation, projections, groupFilterCond)
   }
 
-  // this method assumes the assignments have been already aligned before
+  /**
+   * Builds the update projection for ReplaceData plans. Assumes assignments are already aligned.
+   */
   private def buildReplaceDataUpdateProjection(
       plan: LogicalPlan,
       assignments: Seq[Assignment],
       cond: Expression = TrueLiteral): LogicalPlan = {
 
-    // the plan output may include metadata columns at the end
-    // that's why the number of assignments may not match the number of plan output columns
-    val assignedValues = assignments.map(_.value)
-    val updatedValues = plan.output.zipWithIndex.map { case (attr, index) =>
-      if (index < assignments.size) {
-        val assignedExpr = assignedValues(index)
-        val updatedValue = If(cond, assignedExpr, attr)
-        Alias(updatedValue, attr.name)()
-      } else {
-        assert(MetadataAttribute.isValid(attr.metadata))
+    val assignmentMap = AttributeMap(assignments.collect {
+      case Assignment(key: Attribute, value) => key -> value
+    })
+
+    val updatedValues = plan.output.map { attr =>
+      if (MetadataAttribute.isValid(attr.metadata)) {
         if (MetadataAttribute.isPreservedOnUpdate(attr)) {
           attr
         } else {
           val updatedValue = If(cond, Literal(null, attr.dataType), attr)
           Alias(updatedValue, attr.name)(explicitMetadata = Some(attr.metadata))
+        }
+      } else {
+        assignmentMap.get(attr) match {
+          case Some(assignedExpr) =>
+            Alias(If(cond, assignedExpr, attr), attr.name)()
+          case None =>
+            // Column present in the narrow read relation but not assigned -- pass through so
+            // COPY-tagged rows keep their current value.
+            attr
         }
       }
     }
@@ -155,27 +195,101 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
     val operation = operationTable.operation.asInstanceOf[SupportsDelta]
 
-    // resolve all needed attrs (e.g. row ID and any required metadata attrs)
+    // resolve all needed attrs (e.g. row ID, any required metadata attrs and optionally connector
+    // declared attrs)
     val rowAttrs = relation.output
+    val connectorDataAttrs = resolveConnectorDataAttrs(relation, operation)
+    val supportsColumnUpdate = connectorDataAttrs.nonEmpty
+
+    if (supportsColumnUpdate) {
+      validateUpdatedColumnsSubset(operation, assignments, connectorDataAttrs)
+    }
+
+
     val rowIdAttrs = resolveRowIdAttrs(relation, operation)
     val metadataAttrs = resolveRequiredMetadataAttrs(relation, operation)
 
-    // construct a read relation and include all required metadata columns
-    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs, rowIdAttrs)
+    val narrowDataAttrs = if (supportsColumnUpdate) {
+      computeNarrowReadAttrs(relation, connectorDataAttrs, assignments, cond)
+    } else {
+      relation.output
+    }
+
+    val readRelation = if (supportsColumnUpdate) {
+      buildNarrowRelationWithAttrs(relation, operationTable, narrowDataAttrs, metadataAttrs,
+        rowIdAttrs)
+    } else {
+      buildRelationWithAttrs(relation, operationTable, metadataAttrs, rowIdAttrs)
+    }
 
     // build a plan for updated records that match the condition
     val matchedRowsPlan = Filter(cond, readRelation)
-    val rowDeltaPlan = if (operation.representUpdateAsDeleteAndInsert) {
-      buildDeletesAndInserts(matchedRowsPlan, assignments, rowIdAttrs)
+    val rowDeltaPlan = if (supportsColumnUpdate) {
+      if (operation.representUpdateAsDeleteAndInsert) {
+        buildNarrowDeletesAndInserts(matchedRowsPlan, assignments, rowIdAttrs)
+      } else {
+        buildColumnUpdateProjection(
+          matchedRowsPlan, assignments, rowIdAttrs, metadataAttrs, connectorDataAttrs)
+      }
     } else {
-      buildWriteDeltaUpdateProjection(matchedRowsPlan, assignments, rowIdAttrs)
+      if (operation.representUpdateAsDeleteAndInsert) {
+        buildDeletesAndInserts(matchedRowsPlan, assignments, rowIdAttrs)
+      } else {
+        buildWriteDeltaUpdateProjection(matchedRowsPlan, assignments, rowIdAttrs)
+      }
     }
 
     // build a plan to write the row delta to the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildWriteDeltaProjections(rowDeltaPlan, rowAttrs, rowIdAttrs, metadataAttrs)
+    val projections = buildWriteDeltaProjections(
+      rowDeltaPlan, rowAttrs, rowIdAttrs, metadataAttrs, connectorDataAttrs)
     val groupFilterCond = if (groupFilterEnabled) Some(cond) else None
     WriteDelta(writeRelation, cond, rowDeltaPlan, relation, projections, groupFilterCond)
+  }
+
+  /**
+   * Builds the WriteDelta projection for the column-update path.
+   */
+  private def buildColumnUpdateProjection(
+      plan: LogicalPlan,
+      assignments: Seq[Assignment],
+      rowIdAttrs: Seq[Attribute],
+      metadataAttrs: Seq[Attribute],
+      connectorDataAttrs: Seq[AttributeReference]): LogicalPlan = {
+
+    val assignedValues = assignments.collect {
+      case Assignment(key: Attribute, value) if !isIdentityAssignment(key, value) =>
+        Alias(value, key.name)()
+    }
+
+    // Connector-required columns whose value isn't being changed by the UPDATE: pass through the
+    // current value so the connector receives a complete write row.
+    val assignedKeyIds = assignments.collect {
+      case Assignment(key: AttributeReference, value) if !isIdentityAssignment(key, value) =>
+        key.exprId
+    }.toSet
+    val connectorPassThroughValues = connectorDataAttrs.filterNot(a => assignedKeyIds.contains(
+      a.exprId))
+
+    val metadataAttrSet = AttributeSet(metadataAttrs)
+    val metadataValues = plan.output.filter(metadataAttrSet.contains).map { attr =>
+      if (MetadataAttribute.isPreservedOnUpdate(attr)) {
+        attr
+      } else {
+        Alias(Literal(null, attr.dataType), attr.name)(explicitMetadata = Some(attr.metadata))
+      }
+    }
+
+    val rowIdAttrSet = AttributeSet(rowIdAttrs)
+    val rowIdValues = plan.output.filter(rowIdAttrSet.contains)
+
+    val originalRowIdValues = buildOriginalRowIdValues(rowIdAttrs, assignments)
+    val operationType = Alias(Literal(UPDATE_OPERATION), OPERATION_COLUMN)()
+
+    Project(
+      Seq(operationType) ++ assignedValues ++ connectorPassThroughValues ++
+        metadataValues ++ rowIdValues ++ originalRowIdValues,
+      plan)
   }
 
   // this method assumes the assignments have been already aligned before
@@ -225,5 +339,99 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     val attrs = operationTypeAttr +: matchedRowsPlan.output
     val expandOutput = generateExpandOutput(attrs, outputs)
     Expand(outputs, expandOutput, matchedRowsPlan)
+  }
+
+  /**
+   * Variant of `buildDeletesAndInserts` for the `SupportsColumnUpdates` narrow-scan path.
+   * This variant realigns the assignments to one value per surviving rowAttr padding unassigned
+   * rowAttrs with identity, so the reinsert output arity matches the delete output arity in
+   * the resulting Expand.
+   */
+  private def buildNarrowDeletesAndInserts(
+      matchedRowsPlan: LogicalPlan,
+      assignments: Seq[Assignment],
+      rowIdAttrs: Seq[Attribute]): Expand = {
+
+    val (metadataAttrs, rowAttrs) = matchedRowsPlan.output.partition { attr =>
+      MetadataAttribute.isValid(attr.metadata)
+    }
+    val assignmentMap = AttributeMap(assignments.collect {
+      case a @ Assignment(key: Attribute, _) => key -> a
+    })
+    val reinsertAssignments = rowAttrs.map { attr =>
+      assignmentMap.get(attr) match {
+        case Some(a) => a
+        case None => Assignment(attr, attr)
+      }
+    }
+    val deleteOutput = deltaDeleteOutput(rowAttrs, rowIdAttrs, metadataAttrs)
+    val insertOutput = deltaReinsertOutput(reinsertAssignments, metadataAttrs)
+    val outputs = Seq(deleteOutput, insertOutput)
+    val operationTypeAttr = AttributeReference(OPERATION_COLUMN, IntegerType, nullable = false)()
+    val attrs = operationTypeAttr +: matchedRowsPlan.output
+    val expandOutput = generateExpandOutput(attrs, outputs)
+    Expand(outputs, expandOutput, matchedRowsPlan)
+  }
+
+  /**
+   * Resolves the connector's `requiredDataAttributes()` if the operation opts into column
+   * updates. Returns `Nil` when the operation does not mix in `SupportsColumnUpdates`.
+   */
+  private def resolveConnectorDataAttrs(
+      relation: DataSourceV2Relation,
+      operation: RowLevelOperation): Seq[AttributeReference] = operation match {
+    case scu: SupportsColumnUpdates => resolveRequiredDataAttrs(relation, scu)
+    case _ => Nil
+  }
+
+  /**
+   * Computes the narrow set of data columns that must be present in the scan for a column-update
+   * write: connector-declared attrs, unioned with any table columns referenced by non-identity
+   * assignment RHS expressions, the operation condition, and the table's partition expressions.
+   * Partition-column refs are always kept so downstream rules (V2ScanPartitioningAndOrdering,
+   * GroupBasedRowLevelOperationScanPlanning) can resolve the table's partitioning expressions
+   * against the scan output.
+   */
+  private def computeNarrowReadAttrs(
+      relation: DataSourceV2Relation,
+      connectorDataAttrs: Seq[AttributeReference],
+      assignments: Seq[Assignment],
+      cond: Expression): Seq[AttributeReference] = {
+    val relationSet = relation.outputSet
+    val nonIdentityRhsRefs = assignments.iterator
+      .filterNot(a => a.key.isInstanceOf[Attribute] &&
+        isIdentityAssignment(a.key.asInstanceOf[Attribute], a.value))
+      .flatMap(_.value.references.toSeq)
+      .toSeq
+    val extraRefs = (cond.references.toSeq ++ nonIdentityRhsRefs)
+      .collect { case a: AttributeReference => a }
+      .filter(relationSet.contains)
+    val partitionRefNames = relation.table.partitioning().toImmutableArraySeq
+      .flatMap(_.references.toImmutableArraySeq)
+      .map(_.fieldNames.head)
+      .toSet
+    val partitionAttrs = relation.output
+      .filter(a => partitionRefNames.exists(name => conf.resolver(name, a.name)))
+    dedupAttrs(connectorDataAttrs ++ partitionAttrs ++ extraRefs)
+  }
+
+  /**
+   * Enforces that every column being assigned (non-identity) is present in the connector-declared
+   * `requiredDataAttributes()`. Comparison is at root-column granularity
+   */
+  private def validateUpdatedColumnsSubset(
+      operation: RowLevelOperation,
+      assignments: Seq[Assignment],
+      connectorDataAttrs: Seq[AttributeReference]): Unit = {
+    val declaredIds = connectorDataAttrs.map(_.exprId).toSet
+    val missing = assignments.collect {
+      case Assignment(key: AttributeReference, value)
+          if !isIdentityAssignment(key, value) && !declaredIds.contains(key.exprId) =>
+        key.name
+    }.distinct
+    if (missing.nonEmpty) {
+      throw QueryCompilationErrors.requiredDataAttributesMissingUpdatedColumnsError(
+        operation.getClass.getName, missing)
+    }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
@@ -91,7 +91,11 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     }
 
     // build a plan with updated and copied over records
-    val query = buildReplaceDataUpdateProjection(readRelation, assignments, cond)
+    val query = if (supportsColumnUpdate) {
+      buildNarrowReplaceDataUpdateProjection(readRelation, assignments, cond)
+    } else {
+      buildReplaceDataUpdateProjection(readRelation, assignments, cond)
+    }
 
     // build a plan to replace read groups in the table
     val writeRelation = relation.copy(table = operationTable)
@@ -131,7 +135,11 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
     // build a plan for updated records that match the condition
     val matchedRowsPlan = Filter(cond, readRelation)
-    val updatedRowsPlan = buildReplaceDataUpdateProjection(matchedRowsPlan, assignments)
+    val updatedRowsPlan = if (supportsColumnUpdate) {
+      buildNarrowReplaceDataUpdateProjection(matchedRowsPlan, assignments)
+    } else {
+      buildReplaceDataUpdateProjection(matchedRowsPlan, assignments)
+    }
 
     // build a plan that contains unmatched rows in matched groups that must be copied over
     val remainingRowFilter = Not(EqualNullSafe(cond, Literal.TrueLiteral))
@@ -149,10 +157,44 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     ReplaceData(writeRelation, cond, query, relation, projections, groupFilterCond)
   }
 
-  /**
-   * Builds the update projection for ReplaceData plans. Assumes assignments are already aligned.
-   */
+  // this method assumes the assignments have been already aligned before
   private def buildReplaceDataUpdateProjection(
+      plan: LogicalPlan,
+      assignments: Seq[Assignment],
+      cond: Expression = TrueLiteral): LogicalPlan = {
+
+    // the plan output may include metadata columns at the end
+    // that's why the number of assignments may not match the number of plan output columns
+    val assignedValues = assignments.map(_.value)
+    val updatedValues = plan.output.zipWithIndex.map { case (attr, index) =>
+      if (index < assignments.size) {
+        val assignedExpr = assignedValues(index)
+        val updatedValue = If(cond, assignedExpr, attr)
+        Alias(updatedValue, attr.name)()
+      } else {
+        assert(MetadataAttribute.isValid(attr.metadata))
+        if (MetadataAttribute.isPreservedOnUpdate(attr)) {
+          attr
+        } else {
+          val updatedValue = If(cond, Literal(null, attr.dataType), attr)
+          Alias(updatedValue, attr.name)(explicitMetadata = Some(attr.metadata))
+        }
+      }
+    }
+
+    val writeOp = If(cond, Literal(UPDATE_OPERATION), Literal(COPY_OPERATION))
+    val operationCol = Alias(writeOp, OPERATION_COLUMN)()
+    Project(operationCol +: updatedValues, plan)
+  }
+
+  /**
+   * Variant of `buildReplaceDataUpdateProjection` for the `SupportsColumnUpdates` narrow-scan
+   * path.
+   * For narrow attributes, looks up assignments by `ExprId` via `AttributeMap`and passes through
+   * carry-along data columns (partition refs, cond refs, non-identity RHS refs) that landed in the
+   * narrow scan but weren't user-assigned.
+   */
+  private def buildNarrowReplaceDataUpdateProjection(
       plan: LogicalPlan,
       assignments: Seq[Assignment],
       cond: Expression = TrueLiteral): LogicalPlan = {
@@ -174,8 +216,9 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
           case Some(assignedExpr) =>
             Alias(If(cond, assignedExpr, attr), attr.name)()
           case None =>
-            // Column present in the narrow read relation but not assigned -- pass through so
-            // COPY-tagged rows keep their current value.
+            // Column present in the narrow read relation but not assigned (partition ref,
+            // condition ref, or RHS ref carried in by `computeNarrowReadAttrs`) -- pass
+            // through so COPY-tagged rows keep their current value.
             attr
         }
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
@@ -46,7 +46,7 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
           checkNoGeneratedColumns(r, UPDATE)
           val updatedCols = assignments.collect {
             case Assignment(key: AttributeReference, value) if !isIdentityAssignment(key, value) =>
-              FieldReference(key.name)
+              FieldReference(Seq(key.name))
           }
           val table = buildOperationTable(tbl, UPDATE, r.options, updatedCols)
           val updateCond = cond.getOrElse(TrueLiteral)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
@@ -74,8 +74,10 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
     // resolve all required metadata attrs that may be used for grouping data on write
     val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
-    val connectorDataAttrs = resolveConnectorDataAttrs(relation, operationTable.operation)
-    val supportsColumnUpdate = connectorDataAttrs.nonEmpty
+    val supportsColumnUpdate = operationTable.operation.isInstanceOf[SupportsColumnUpdates]
+    val connectorDataAttrs = if (supportsColumnUpdate) {
+      resolveConnectorDataAttrs(relation, operationTable.operation)
+    } else Nil
 
     if (supportsColumnUpdate) {
       validateUpdatedColumnsSubset(operationTable.operation, assignments, connectorDataAttrs)
@@ -115,8 +117,10 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
     // resolve all required metadata attrs that may be used for grouping data on write
     val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
-    val connectorDataAttrs = resolveConnectorDataAttrs(relation, operationTable.operation)
-    val supportsColumnUpdate = connectorDataAttrs.nonEmpty
+    val supportsColumnUpdate = operationTable.operation.isInstanceOf[SupportsColumnUpdates]
+    val connectorDataAttrs = if (supportsColumnUpdate) {
+      resolveConnectorDataAttrs(relation, operationTable.operation)
+    } else Nil
 
     if (supportsColumnUpdate) {
       validateUpdatedColumnsSubset(operationTable.operation, assignments, connectorDataAttrs)
@@ -241,8 +245,10 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     // resolve all needed attrs (e.g. row ID, any required metadata attrs and optionally connector
     // declared attrs)
     val rowAttrs = relation.output
-    val connectorDataAttrs = resolveConnectorDataAttrs(relation, operation)
-    val supportsColumnUpdate = connectorDataAttrs.nonEmpty
+    val supportsColumnUpdate = operation.isInstanceOf[SupportsColumnUpdates]
+    val connectorDataAttrs = if (supportsColumnUpdate) {
+      resolveConnectorDataAttrs(relation, operation)
+    } else Nil
 
     if (supportsColumnUpdate) {
       validateUpdatedColumnsSubset(operation, assignments, connectorDataAttrs)
@@ -418,7 +424,7 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
   /**
    * Resolves the connector's `requiredDataAttributes()` if the operation opts into column
-   * updates. Returns `Nil` when the operation does not mix in `SupportsColumnUpdates`.
+   * updates. Returns `Nil` otherwise.
    */
   private def resolveConnectorDataAttrs(
       relation: DataSourceV2Relation,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeReference, AttributeSet, EqualNullSafe, Expression, If, Literal, MetadataAttribute, Not, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeReference, AttributeSet, EqualNullSafe, Expression, If, Literal, MetadataAttribute, Not, SubqueryExpression, V2ExpressionUtils}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.logical.{Assignment, Expand, Filter, LogicalPlan, Project, ReplaceData, Union, UpdateTable, WriteDelta}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils._
@@ -78,15 +78,19 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     val connectorDataAttrs = if (supportsColumnUpdate) {
       resolveConnectorDataAttrs(relation, operationTable.operation)
     } else Nil
+    val scanOnlyDataAttrs = if (supportsColumnUpdate) {
+      resolveScanOnlyDataAttrs(relation, operationTable.operation)
+    } else Nil
 
     if (supportsColumnUpdate) {
       validateUpdatedColumnsSubset(operationTable.operation, assignments, connectorDataAttrs)
+      validateNoOverlap(operationTable.operation, connectorDataAttrs, scanOnlyDataAttrs)
     }
 
     // construct a read relation and include all required metadata columns
     val readRelation = if (supportsColumnUpdate) {
       val narrowDataAttrs =
-        computeNarrowReadAttrs(relation, connectorDataAttrs, assignments, cond)
+        computeNarrowReadAttrs(relation, connectorDataAttrs, scanOnlyDataAttrs, assignments, cond)
       buildNarrowRelationWithAttrs(relation, operationTable, narrowDataAttrs, metadataAttrs)
     } else {
       buildRelationWithAttrs(relation, operationTable, metadataAttrs)
@@ -121,9 +125,13 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     val connectorDataAttrs = if (supportsColumnUpdate) {
       resolveConnectorDataAttrs(relation, operationTable.operation)
     } else Nil
+    val scanOnlyDataAttrs = if (supportsColumnUpdate) {
+      resolveScanOnlyDataAttrs(relation, operationTable.operation)
+    } else Nil
 
     if (supportsColumnUpdate) {
       validateUpdatedColumnsSubset(operationTable.operation, assignments, connectorDataAttrs)
+      validateNoOverlap(operationTable.operation, connectorDataAttrs, scanOnlyDataAttrs)
     }
 
     // construct a read relation and include all required metadata columns
@@ -131,7 +139,7 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     // the analyzer will take care of duplicated attr IDs
     val readRelation = if (supportsColumnUpdate) {
       val narrowDataAttrs =
-        computeNarrowReadAttrs(relation, connectorDataAttrs, assignments, cond)
+        computeNarrowReadAttrs(relation, connectorDataAttrs, scanOnlyDataAttrs, assignments, cond)
       buildNarrowRelationWithAttrs(relation, operationTable, narrowDataAttrs, metadataAttrs)
     } else {
       buildRelationWithAttrs(relation, operationTable, metadataAttrs)
@@ -249,9 +257,13 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     val connectorDataAttrs = if (supportsColumnUpdate) {
       resolveConnectorDataAttrs(relation, operation)
     } else Nil
+    val scanOnlyDataAttrs = if (supportsColumnUpdate) {
+      resolveScanOnlyDataAttrs(relation, operation)
+    } else Nil
 
     if (supportsColumnUpdate) {
       validateUpdatedColumnsSubset(operation, assignments, connectorDataAttrs)
+      validateNoOverlap(operation, connectorDataAttrs, scanOnlyDataAttrs)
     }
 
 
@@ -263,7 +275,7 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     }
 
     val narrowDataAttrs = if (supportsColumnUpdate) {
-      computeNarrowReadAttrs(relation, connectorDataAttrs, assignments, cond)
+      computeNarrowReadAttrs(relation, connectorDataAttrs, scanOnlyDataAttrs, assignments, cond)
     } else {
       relation.output
     }
@@ -282,7 +294,8 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
         buildNarrowDeletesAndInserts(matchedRowsPlan, assignments, rowIdAttrs)
       } else {
         buildColumnUpdateProjection(
-          matchedRowsPlan, assignments, rowIdAttrs, metadataAttrs, connectorDataAttrs)
+          matchedRowsPlan, assignments, rowIdAttrs, metadataAttrs, connectorDataAttrs,
+          scanOnlyDataAttrs)
       }
     } else {
       if (operation.representUpdateAsDeleteAndInsert) {
@@ -308,7 +321,8 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       assignments: Seq[Assignment],
       rowIdAttrs: Seq[Attribute],
       metadataAttrs: Seq[Attribute],
-      connectorDataAttrs: Seq[AttributeReference]): LogicalPlan = {
+      connectorDataAttrs: Seq[AttributeReference],
+      scanOnlyDataAttrs: Seq[AttributeReference]): LogicalPlan = {
 
     val assignedValues = assignments.collect {
       case Assignment(key: Attribute, value) if !isIdentityAssignment(key, value) =>
@@ -316,13 +330,22 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     }
 
     // Connector-required columns whose value isn't being changed by the UPDATE: pass through the
-    // current value so the connector receives a complete write row.
+    // current value so the connector receives a complete write row. Row-ID columns are excluded
+    // here even when also connector-required (e.g. a primary key used for both row lookup and
+    // write payload) they are emitted once, below, via rowIdValues.
     val assignedKeyIds = assignments.collect {
       case Assignment(key: AttributeReference, value) if !isIdentityAssignment(key, value) =>
         key.exprId
     }.toSet
-    val connectorPassThroughValues = connectorDataAttrs.filterNot(a => assignedKeyIds.contains(
-      a.exprId))
+    val rowIdAttrSet = AttributeSet(rowIdAttrs)
+    val connectorPassThroughValues = connectorDataAttrs.filterNot(a =>
+      assignedKeyIds.contains(a.exprId) || rowIdAttrSet.contains(a))
+
+    // scanOnlyDataAttrs are never assigned carry them through the write query so
+    // scan-side / write-side planning (e.g. RequiresDistributionAndOrdering clustering keys)
+    // can resolve them, but they are intentionally excluded from the write payload.
+    val scanOnlyPassThroughValues = scanOnlyDataAttrs.filterNot(a =>
+      assignedKeyIds.contains(a.exprId) || rowIdAttrSet.contains(a))
 
     val metadataAttrSet = AttributeSet(metadataAttrs)
     val metadataValues = plan.output.filter(metadataAttrSet.contains).map { attr =>
@@ -333,7 +356,6 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       }
     }
 
-    val rowIdAttrSet = AttributeSet(rowIdAttrs)
     val rowIdValues = plan.output.filter(rowIdAttrSet.contains)
 
     val originalRowIdValues = buildOriginalRowIdValues(rowIdAttrs, assignments)
@@ -341,7 +363,7 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
     Project(
       Seq(operationType) ++ assignedValues ++ connectorPassThroughValues ++
-        metadataValues ++ rowIdValues ++ originalRowIdValues,
+        scanOnlyPassThroughValues ++ metadataValues ++ rowIdValues ++ originalRowIdValues,
       plan)
   }
 
@@ -438,16 +460,28 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
   }
 
   /**
+   * Resolves the connector's `scanOnlyDataAttributes()` if the operation opts into column
+   * updates. Returns `Nil` otherwise.
+   */
+  private def resolveScanOnlyDataAttrs(
+      relation: DataSourceV2Relation,
+      operation: RowLevelOperation): Seq[AttributeReference] = operation match {
+    case scu: SupportsColumnUpdates =>
+      V2ExpressionUtils.resolveRefs[AttributeReference](
+        scu.scanOnlyDataAttributes.toImmutableArraySeq, relation)
+    case _ => Nil
+  }
+
+  /**
    * Computes the narrow set of data columns that must be present in the scan for a column-update
-   * write: connector-declared attrs, unioned with any table columns referenced by non-identity
-   * assignment RHS expressions, the operation condition, and the table's partition expressions.
-   * Partition-column refs are always kept so downstream rules (V2ScanPartitioningAndOrdering,
-   * GroupBasedRowLevelOperationScanPlanning) can resolve the table's partitioning expressions
-   * against the scan output.
+   * write: connector-declared attrs (both `requiredDataAttributes()` and
+   * `scanOnlyDataAttributes()`), unioned with any table columns referenced by non-identity
+   * assignment RHS expressions and the operation condition.
    */
   private def computeNarrowReadAttrs(
       relation: DataSourceV2Relation,
       connectorDataAttrs: Seq[AttributeReference],
+      scanOnlyDataAttrs: Seq[AttributeReference],
       assignments: Seq[Assignment],
       cond: Expression): Seq[AttributeReference] = {
     val relationSet = relation.outputSet
@@ -459,13 +493,7 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     val extraRefs = (cond.references.toSeq ++ nonIdentityRhsRefs)
       .collect { case a: AttributeReference => a }
       .filter(relationSet.contains)
-    val partitionRefNames = relation.table.partitioning().toImmutableArraySeq
-      .flatMap(_.references.toImmutableArraySeq)
-      .map(_.fieldNames.head)
-      .toSet
-    val partitionAttrs = relation.output
-      .filter(a => partitionRefNames.exists(name => conf.resolver(name, a.name)))
-    dedupAttrs(connectorDataAttrs ++ partitionAttrs ++ extraRefs)
+    dedupAttrs(connectorDataAttrs ++ scanOnlyDataAttrs ++ extraRefs)
   }
 
   /**
@@ -485,6 +513,23 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     if (missing.nonEmpty) {
       throw QueryCompilationErrors.requiredDataAttributesMissingUpdatedColumnsError(
         operation.getClass.getName, missing)
+    }
+  }
+
+  /**
+   * Enforces that `requiredDataAttributes()` and `scanOnlyDataAttributes()` are disjoint.
+   */
+  private def validateNoOverlap(
+      operation: RowLevelOperation,
+      connectorDataAttrs: Seq[AttributeReference],
+      scanOnlyDataAttrs: Seq[AttributeReference]): Unit = {
+    val requiredIds = connectorDataAttrs.map(_.exprId).toSet
+    val overlapping = scanOnlyDataAttrs.collect {
+      case attr if requiredIds.contains(attr.exprId) => attr.name
+    }.distinct
+    if (overlapping.nonEmpty) {
+      throw QueryCompilationErrors.requiredDataAttributesOverlapScanOnlyAttributesError(
+        operation.getClass.getName, overlapping)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
@@ -85,6 +85,8 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     if (supportsColumnUpdate) {
       validateUpdatedColumnsSubset(operationTable.operation, assignments, connectorDataAttrs)
       validateNoOverlap(operationTable.operation, connectorDataAttrs, scanOnlyDataAttrs)
+      validatePartitionAttrsDeclared(
+        operationTable.operation, relation, connectorDataAttrs, scanOnlyDataAttrs)
     }
 
     // construct a read relation and include all required metadata columns
@@ -132,6 +134,8 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     if (supportsColumnUpdate) {
       validateUpdatedColumnsSubset(operationTable.operation, assignments, connectorDataAttrs)
       validateNoOverlap(operationTable.operation, connectorDataAttrs, scanOnlyDataAttrs)
+      validatePartitionAttrsDeclared(
+        operationTable.operation, relation, connectorDataAttrs, scanOnlyDataAttrs)
     }
 
     // construct a read relation and include all required metadata columns
@@ -264,6 +268,7 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     if (supportsColumnUpdate) {
       validateUpdatedColumnsSubset(operation, assignments, connectorDataAttrs)
       validateNoOverlap(operation, connectorDataAttrs, scanOnlyDataAttrs)
+      validatePartitionAttrsDeclared(operation, relation, connectorDataAttrs, scanOnlyDataAttrs)
     }
 
 
@@ -272,6 +277,7 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
     if (supportsColumnUpdate && operation.representUpdateAsDeleteAndInsert) {
       validateNoRowIdReassignment(operation, assignments, rowIdAttrs)
+      validateRowIdDeclared(operation, connectorDataAttrs, rowIdAttrs)
     }
 
     val narrowDataAttrs = if (supportsColumnUpdate) {
@@ -534,6 +540,31 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
   }
 
   /**
+   * Enforces that every partition-source column is declared in either `requiredDataAttributes()`
+   * or `scanOnlyDataAttributes()`. Spark no longer adds partition refs to the narrow scan
+   * implicitly, so a connector that needs them for partitioning resolution or write-side
+   * clustering must declare them in one of the two methods.
+   */
+  private def validatePartitionAttrsDeclared(
+      operation: RowLevelOperation,
+      relation: DataSourceV2Relation,
+      connectorDataAttrs: Seq[AttributeReference],
+      scanOnlyDataAttrs: Seq[AttributeReference]): Unit = {
+    val partitionRefNames = relation.table.partitioning().toImmutableArraySeq
+      .flatMap(_.references.toImmutableArraySeq)
+      .map(_.fieldNames.head)
+      .toSet
+    val declared = AttributeSet(connectorDataAttrs ++ scanOnlyDataAttrs)
+    val undeclared = relation.output
+      .filter(a => partitionRefNames.exists(name => conf.resolver(name, a.name)))
+      .filterNot(declared.contains).map(_.name)
+    if (undeclared.nonEmpty) {
+      throw QueryCompilationErrors.requiredDataAttributesMissingPartitionColumnsError(
+        operation.getClass.getName, undeclared)
+    }
+  }
+
+  /**
    * For connectors that opt into narrow column updates AND represent UPDATE as delete + insert,
    * reject reassignment of any row-ID column as the REINSERT path has no row-ID channel to
    * reconstruct columns outside `requiredDataAttributes()`.
@@ -551,6 +582,25 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     if (reassigned.nonEmpty) {
       throw QueryCompilationErrors.splitUpdateRowIdReassignmentError(
         operation.getClass.getName, reassigned)
+    }
+  }
+
+  /**
+   * For connectors that opt into narrow column updates AND represent UPDATE as delete + insert,
+   * requires every row-ID column to be declared in `requiredDataAttributes()`. The REINSERT
+   * payload is narrow and only contains `requiredDataAttributes()`, so an undeclared row-ID column
+   * would leave the reinserted row with no identity for the connector to place it by.
+   */
+  private def validateRowIdDeclared(
+      operation: RowLevelOperation,
+      connectorDataAttrs: Seq[AttributeReference],
+      rowIdAttrs: Seq[Attribute]): Unit = {
+    val declaredIds = connectorDataAttrs.map(_.exprId).toSet
+    val undeclared = rowIdAttrs.filterNot(a => declaredIds.contains(a.exprId))
+      .map(_.name).distinct
+    if (undeclared.nonEmpty) {
+      throw QueryCompilationErrors.splitUpdateRowIdNotDeclaredError(
+        operation.getClass.getName, undeclared)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
@@ -258,6 +258,10 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     val rowIdAttrs = resolveRowIdAttrs(relation, operation)
     val metadataAttrs = resolveRequiredMetadataAttrs(relation, operation)
 
+    if (supportsColumnUpdate && operation.representUpdateAsDeleteAndInsert) {
+      validateNoRowIdReassignment(operation, assignments, rowIdAttrs)
+    }
+
     val narrowDataAttrs = if (supportsColumnUpdate) {
       computeNarrowReadAttrs(relation, connectorDataAttrs, assignments, cond)
     } else {
@@ -481,6 +485,27 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     if (missing.nonEmpty) {
       throw QueryCompilationErrors.requiredDataAttributesMissingUpdatedColumnsError(
         operation.getClass.getName, missing)
+    }
+  }
+
+  /**
+   * For connectors that opt into narrow column updates AND represent UPDATE as delete + insert,
+   * reject reassignment of any row-ID column as the REINSERT path has no row-ID channel to
+   * reconstruct columns outside `requiredDataAttributes()`.
+   */
+  private def validateNoRowIdReassignment(
+      operation: RowLevelOperation,
+      assignments: Seq[Assignment],
+      rowIdAttrs: Seq[Attribute]): Unit = {
+    val rowIdAttrSet = AttributeSet(rowIdAttrs)
+    val reassigned = assignments.collect {
+      case Assignment(key: AttributeReference, value)
+          if rowIdAttrSet.contains(key) && !isIdentityAssignment(key, value) =>
+        key.name
+    }.distinct
+    if (reassigned.nonEmpty) {
+      throw QueryCompilationErrors.splitUpdateRowIdReassignmentError(
+        operation.getClass.getName, reassigned)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeReference, AttributeSet, Cast, EqualNullSafe, Expression, If, Literal, MetadataAttribute, Not, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeReference, AttributeSet, EqualNullSafe, Expression, If, Literal, MetadataAttribute, Not, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.logical.{Assignment, Expand, Filter, LogicalPlan, Project, ReplaceData, Union, UpdateTable, WriteDelta}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils._
@@ -328,8 +328,6 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
   }
 
   // Returns the table attributes that are genuinely updated (non-identity) in this UPDATE.
-  // Strips Alias/Cast wrappers introduced during assignment alignment before doing the
-  // AttributeSet membership check (which uses exprId equality internally).
   private def computeAssignedAttrs(assignments: Seq[Assignment]): Seq[AttributeReference] = {
     assignments.collect {
       case Assignment(key: AttributeReference, value) if !isIdentityAssignment(key, value) => key
@@ -337,17 +335,14 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
   }
 
   private def isIdentityAssignment(key: Attribute, value: Expression): Boolean = {
-    stripAliasesAndCasts(value) match {
+    val unwrapped = value match {
+      case Alias(child, _) => child
+      case other => other
+    }
+    unwrapped match {
       case attr: Attribute => AttributeSet(Seq(key)).contains(attr)
       case _ => false
     }
-  }
-
-  // Recursively strips Alias and Cast wrappers introduced during assignment alignment.
-  private def stripAliasesAndCasts(expr: Expression): Expression = expr match {
-    case Alias(child, _) => stripAliasesAndCasts(child)
-    case Cast(child, _, _, _) => stripAliasesAndCasts(child)
-    case other => other
   }
 
   // this method assumes the assignments have been already aligned before

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
@@ -17,11 +17,12 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, EqualNullSafe, Expression, If, Literal, MetadataAttribute, Not, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeReference, AttributeSet, Cast, EqualNullSafe, Expression, If, Literal, MetadataAttribute, Not, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.logical.{Assignment, Expand, Filter, LogicalPlan, Project, ReplaceData, Union, UpdateTable, WriteDelta}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils._
 import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
+import org.apache.spark.sql.connector.expressions.FieldReference
 import org.apache.spark.sql.connector.write.{RowLevelOperationTable, SupportsDelta}
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command.UPDATE
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, ExtractV2Table}
@@ -41,7 +42,13 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
 
       EliminateSubqueryAliases(aliasedTable) match {
         case r @ ExtractV2Table(tbl: SupportsRowLevelOperations) =>
-          val table = buildOperationTable(tbl, UPDATE, CaseInsensitiveStringMap.empty())
+          val updatedCols = assignments.collect {
+            case Assignment(key: AttributeReference, value)
+                if !isIdentityAssignment(key, value) =>
+              FieldReference(key.name)
+          }
+          val table = buildOperationTable(tbl, UPDATE, CaseInsensitiveStringMap.empty(),
+            updatedCols)
           val updateCond = cond.getOrElse(TrueLiteral)
           table.operation match {
             case _: SupportsDelta =>
@@ -65,18 +72,15 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       assignments: Seq[Assignment],
       cond: Expression): ReplaceData = {
 
-    // resolve all required metadata attrs that may be used for grouping data on write
-    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
+    val (readRelation, rowAttrs) = buildCoWReadSetup(relation, operationTable, assignments, cond)
 
-    // construct a read relation and include all required metadata columns
-    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+    val updatedAndRemainingRowsPlan = buildReplaceDataUpdateProjection(
+      readRelation, assignments, cond)
 
-    // build a plan with updated and copied over records
-    val query = buildReplaceDataUpdateProjection(readRelation, assignments, cond)
-
-    // build a plan to replace read groups in the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildReplaceDataProjections(query, relation.output, metadataAttrs)
+    val query = updatedAndRemainingRowsPlan
+    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
+    val projections = buildReplaceDataProjections(query, rowAttrs, metadataAttrs)
     val groupFilterCond = if (groupFilterEnabled) Some(cond) else None
     ReplaceData(writeRelation, cond, query, relation, projections, groupFilterCond)
   }
@@ -89,13 +93,7 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       assignments: Seq[Assignment],
       cond: Expression): ReplaceData = {
 
-    // resolve all required metadata attrs that may be used for grouping data on write
-    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
-
-    // construct a read relation and include all required metadata columns
-    // the same read relation will be used to read records that must be updated and copied over
-    // the analyzer will take care of duplicated attr IDs
-    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+    val (readRelation, rowAttrs) = buildCoWReadSetup(relation, operationTable, assignments, cond)
 
     // build a plan for updated records that match the condition
     val matchedRowsPlan = Filter(cond, readRelation)
@@ -106,37 +104,91 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     val remainingRowsPlan = addOperationColumn(COPY_OPERATION,
       Filter(remainingRowFilter, readRelation))
 
-    // the new state is a union of updated and copied over records
-    val query = Union(updatedRowsPlan, remainingRowsPlan)
+    val updatedAndRemainingRowsPlan = Union(updatedRowsPlan, remainingRowsPlan)
 
-    // build a plan to replace read groups in the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildReplaceDataProjections(query, relation.output, metadataAttrs)
+    val query = updatedAndRemainingRowsPlan
+    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
+    val projections = buildReplaceDataProjections(query, rowAttrs, metadataAttrs)
     val groupFilterCond = if (groupFilterEnabled) Some(cond) else None
     ReplaceData(writeRelation, cond, query, relation, projections, groupFilterCond)
   }
 
+  // Common read-relation setup shared by both CoW plan builders.
+  //
+  // When the connector supports column updates and declares required data attributes,
+  // the read relation is narrowed at analysis time so that
+  // GroupBasedRowLevelOperationScanPlanning uses only the needed columns for the scan.
+  // Otherwise the full relation output is used.
+  private def buildCoWReadSetup(
+      relation: DataSourceV2Relation,
+      operationTable: RowLevelOperationTable,
+      assignments: Seq[Assignment],
+      cond: Expression): (DataSourceV2Relation, Seq[Attribute]) = {
+
+    val operation = operationTable.operation
+    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operation)
+    val connectorDataAttrs = resolveRequiredDataAttrs(relation, operation)
+    val isNarrow = operation.supportsColumnUpdates() && connectorDataAttrs.nonEmpty
+
+    // CoW scan narrowing must be done manually at analysis time.
+    // GroupBasedRowLevelOperationScanPlanning (an optimizer rule that fires after analysis)
+    // always reads relation.output directly when building the physical scan -- it does not
+    // observe Project nodes above the relation, so optimizer-driven column pruning has no
+    // effect on CoW scans.  We narrow DataSourceV2Relation.output here so that rule picks
+    // up the narrow set.
+    val readRelation = if (isNarrow) {
+      val allRequired = (connectorDataAttrs ++ computeAssignedAttrs(assignments)).distinct
+      buildRelationWithAttrs(relation, operationTable, metadataAttrs, dataAttrs = allRequired,
+        cond = cond)
+    } else {
+      buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+    }
+
+    // CoW write schema (two paths only, no heuristic for CoW):
+    // - Narrow path (connectorDataAttrs declared): exactly connector-declared cols in declared
+    //   order.  The connector must declare ALL columns it wants to receive.
+    // - Full path (connectorDataAttrs empty OR supportsColumnUpdates=false): full table output.
+    //   Unlike MOR, CoW does not have a heuristic assigned-only path because
+    //   GroupBasedRowLevelOperationScanPlanning needs explicit column declarations to narrow.
+    val rowAttrs: Seq[Attribute] = if (isNarrow) connectorDataAttrs else relation.output
+
+    (readRelation, rowAttrs)
+  }
+
   // this method assumes the assignments have been already aligned before
+  //
+  // Works for both the full-scan and narrow-scan CoW paths.  In the narrow case,
+  // readRelation.output is already restricted by buildCoWReadSetup, so projecting
+  // all plan.output gives the correct narrow write schema.
   private def buildReplaceDataUpdateProjection(
       plan: LogicalPlan,
       assignments: Seq[Assignment],
       cond: Expression = TrueLiteral): LogicalPlan = {
 
-    // the plan output may include metadata columns at the end
-    // that's why the number of assignments may not match the number of plan output columns
-    val assignedValues = assignments.map(_.value)
-    val updatedValues = plan.output.zipWithIndex.map { case (attr, index) =>
-      if (index < assignments.size) {
-        val assignedExpr = assignedValues(index)
-        val updatedValue = If(cond, assignedExpr, attr)
-        Alias(updatedValue, attr.name)()
-      } else {
-        assert(MetadataAttribute.isValid(attr.metadata))
+    // Build a name-keyed map via AttributeMap (compares by exprId internally) so we can look
+    // up each plan column's assignment without relying on positional ordering.  This is more
+    // robust than position-based indexing and works correctly for any plan output layout.
+    val assignmentMap = AttributeMap(assignments.collect {
+      case Assignment(key: Attribute, value) => key -> value
+    })
+
+    val updatedValues = plan.output.map { attr =>
+      if (MetadataAttribute.isValid(attr.metadata)) {
         if (MetadataAttribute.isPreservedOnUpdate(attr)) {
           attr
         } else {
           val updatedValue = If(cond, Literal(null, attr.dataType), attr)
           Alias(updatedValue, attr.name)(explicitMetadata = Some(attr.metadata))
+        }
+      } else {
+        assignmentMap.get(attr) match {
+          case Some(assignedExpr) =>
+            Alias(If(cond, assignedExpr, attr), attr.name)()
+          case None =>
+            // Column is present in the scan but has no assignment -- pass through unchanged.
+            // In the narrow CoW path these are connector-declared columns not being updated.
+            attr
         }
       }
     }
@@ -154,28 +206,148 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       cond: Expression): WriteDelta = {
 
     val operation = operationTable.operation.asInstanceOf[SupportsDelta]
+    // Column-update support applies to the standard delta path and the delete+reinsert path.
+    // When representUpdateAsDeleteAndInsert is true, the REINSERT leg of the Expand already
+    // uses only assigned values, so the narrow effectiveRowAttrs applies correctly.
+    val supportsColumnUpdate = operation.supportsColumnUpdates()
 
     // resolve all needed attrs (e.g. row ID and any required metadata attrs)
-    val rowAttrs = relation.output
     val rowIdAttrs = resolveRowIdAttrs(relation, operation)
     val metadataAttrs = resolveRequiredMetadataAttrs(relation, operation)
 
-    // construct a read relation and include all required metadata columns
+    // Connector-declared data attrs used to determine pass-through columns in the write plan.
+    val connectorDataAttrs = if (supportsColumnUpdate) {
+      resolveRequiredDataAttrs(relation, operation)
+    } else Nil
+
+    // MOR uses a full-schema scan; ColumnPruning narrows it via Project references.
     val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs, rowIdAttrs)
+
+    // Connector-required attrs that are NOT being assigned are added as pass-throughs in the
+    // plan so that ColumnPruning keeps them in the physical scan AND the connector receives
+    // their current values via DeltaWriter.update's row argument.
+    val assignedAttrs = if (supportsColumnUpdate) computeAssignedAttrs(assignments)
+                        else relation.output
+    val connectorExtraAttrs: Seq[AttributeReference] = if (connectorDataAttrs.nonEmpty) {
+      val assignedAttrSet = AttributeSet(assignedAttrs)
+      connectorDataAttrs.filterNot(assignedAttrSet.contains)
+    } else Nil
 
     // build a plan for updated records that match the condition
     val matchedRowsPlan = Filter(cond, readRelation)
     val rowDeltaPlan = if (operation.representUpdateAsDeleteAndInsert) {
       buildDeletesAndInserts(matchedRowsPlan, assignments, rowIdAttrs)
+    } else if (supportsColumnUpdate) {
+      buildColumnUpdateProjection(
+        matchedRowsPlan, assignments, rowIdAttrs, metadataAttrs, connectorExtraAttrs)
     } else {
       buildWriteDeltaUpdateProjection(matchedRowsPlan, assignments, rowIdAttrs)
     }
 
+    // Effective row write schema:
+    // - Narrow path (connectorDataAttrs declared): exactly connector-declared cols in declared
+    //   order.  The connector must declare ALL columns it wants to receive (including updated
+    //   ones).  This mirrors the metadata pattern and enables strict areCompatible validation.
+    // - Heuristic path (connectorDataAttrs empty): only the assigned (changed) columns.
+    // - Full path (no column-update support): full table output.
+    val effectiveRowAttrs = if (supportsColumnUpdate && connectorDataAttrs.nonEmpty) {
+      connectorDataAttrs
+    } else if (supportsColumnUpdate) {
+      assignedAttrs
+    } else {
+      relation.output
+    }
+
     // build a plan to write the row delta to the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildWriteDeltaProjections(rowDeltaPlan, rowAttrs, rowIdAttrs, metadataAttrs)
+    val projections = buildWriteDeltaProjections(
+      rowDeltaPlan, effectiveRowAttrs, rowIdAttrs, metadataAttrs)
     val groupFilterCond = if (groupFilterEnabled) Some(cond) else None
     WriteDelta(writeRelation, cond, rowDeltaPlan, relation, projections, groupFilterCond)
+  }
+
+  // Builds the row delta projection for the column update path.
+  //
+  // The resulting Project references only:
+  //   - assigned column values (new values being written)
+  //   - connector pass-through values (connector declared but not assigned)
+  //   - metadata columns (nulled or preserved)
+  //   - row ID columns (for delta identification)
+  //   - original row ID values (only when a row ID column is being reassigned)
+  //
+  // ColumnPruning observes exactly these references and narrows the physical scan accordingly.
+  // Connectors that need additional columns in the scan (e.g., partition columns for
+  // distribution) should declare them in requiredDataAttributes().
+  //
+  // Note: AlignUpdateAssignments guarantees all assignment keys are top-level
+  // AttributeReferences even for nested field updates (e.g., SET col1.field = 'x' becomes
+  // Assignment(col1: AttributeReference, CreateNamedStruct(...))), so isIdentityAssignment
+  // correctly identifies non-updating assignments.
+  private def buildColumnUpdateProjection(
+      plan: LogicalPlan,
+      assignments: Seq[Assignment],
+      rowIdAttrs: Seq[Attribute],
+      metadataAttrs: Seq[Attribute],
+      connectorExtraAttrs: Seq[AttributeReference] = Nil): LogicalPlan = {
+
+    // only emit values for non-identity assignments (the narrow write schema)
+    val assignedValues = assignments.collect {
+      case Assignment(key: Attribute, value) if !isIdentityAssignment(key, value) =>
+        Alias(value, key.name)()
+    }
+
+    // Connector-required data attrs that are not being assigned are passed through as-is
+    // so that (a) ColumnPruning keeps them in the physical scan, and (b) the connector
+    // receives their current values via DeltaWriter.update's row argument.
+    val connectorExtraAttrSet = AttributeSet(connectorExtraAttrs)
+    val connectorPassThroughValues = plan.output.filter { a =>
+      connectorExtraAttrSet.contains(a) && !MetadataAttribute.isValid(a.metadata)
+    }
+
+    // pass through or null out metadata columns present in the scan
+    val metadataAttrSet = AttributeSet(metadataAttrs)
+    val metadataValues = plan.output.filter(metadataAttrSet.contains).map { attr =>
+      if (MetadataAttribute.isPreservedOnUpdate(attr)) {
+        attr
+      } else {
+        Alias(Literal(null, attr.dataType), attr.name)(explicitMetadata = Some(attr.metadata))
+      }
+    }
+
+    // pass through row ID columns from the scan
+    val rowIdAttrSet = AttributeSet(rowIdAttrs)
+    val rowIdValues = plan.output.filter(rowIdAttrSet.contains)
+
+    val originalRowIdValues = buildOriginalRowIdValues(rowIdAttrs, assignments)
+    val operationType = Alias(Literal(UPDATE_OPERATION), OPERATION_COLUMN)()
+
+    Project(
+      Seq(operationType) ++ assignedValues ++ connectorPassThroughValues ++
+        metadataValues ++ rowIdValues ++ originalRowIdValues,
+      plan)
+  }
+
+  // Returns the table attributes that are genuinely updated (non-identity) in this UPDATE.
+  // Strips Alias/Cast wrappers introduced during assignment alignment before doing the
+  // AttributeSet membership check (which uses exprId equality internally).
+  private def computeAssignedAttrs(assignments: Seq[Assignment]): Seq[AttributeReference] = {
+    assignments.collect {
+      case Assignment(key: AttributeReference, value) if !isIdentityAssignment(key, value) => key
+    }
+  }
+
+  private def isIdentityAssignment(key: Attribute, value: Expression): Boolean = {
+    stripAliasesAndCasts(value) match {
+      case attr: Attribute => AttributeSet(Seq(key)).contains(attr)
+      case _ => false
+    }
+  }
+
+  // Recursively strips Alias and Cast wrappers introduced during assignment alignment.
+  private def stripAliasesAndCasts(expr: Expression): Expression = expr match {
+    case Alias(child, _) => stripAliasesAndCasts(child)
+    case Cast(child, _, _, _) => stripAliasesAndCasts(child)
+    case other => other
   }
 
   // this method assumes the assignments have been already aligned before

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
@@ -43,8 +43,7 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       EliminateSubqueryAliases(aliasedTable) match {
         case r @ ExtractV2Table(tbl: SupportsRowLevelOperations) =>
           val updatedCols = assignments.collect {
-            case Assignment(key: AttributeReference, value)
-                if !isIdentityAssignment(key, value) =>
+            case Assignment(key: AttributeReference, value) if !isIdentityAssignment(key, value) =>
               FieldReference(key.name)
           }
           val table = buildOperationTable(tbl, UPDATE, CaseInsensitiveStringMap.empty(),
@@ -72,17 +71,18 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       assignments: Seq[Assignment],
       cond: Expression): ReplaceData = {
 
-    val (readRelation, rowAttrs) = buildCoWReadSetup(relation, operationTable, assignments, cond)
+    val (readRelation, rowAttrs, metadataAttrs) =
+      buildReplaceDataReadRelation(relation, operationTable, assignments, cond)
 
     val updatedAndRemainingRowsPlan = buildReplaceDataUpdateProjection(
       readRelation, assignments, cond)
 
     val writeRelation = relation.copy(table = operationTable)
-    val query = updatedAndRemainingRowsPlan
-    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
-    val projections = buildReplaceDataProjections(query, rowAttrs, metadataAttrs)
+    val projections = buildReplaceDataProjections(updatedAndRemainingRowsPlan, rowAttrs,
+      metadataAttrs)
     val groupFilterCond = if (groupFilterEnabled) Some(cond) else None
-    ReplaceData(writeRelation, cond, query, relation, projections, groupFilterCond)
+    ReplaceData(writeRelation, cond, updatedAndRemainingRowsPlan, relation, projections,
+      groupFilterCond)
   }
 
   // build a rewrite plan for sources that support replacing groups of data (e.g. files, partitions)
@@ -93,7 +93,8 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       assignments: Seq[Assignment],
       cond: Expression): ReplaceData = {
 
-    val (readRelation, rowAttrs) = buildCoWReadSetup(relation, operationTable, assignments, cond)
+    val (readRelation, rowAttrs, metadataAttrs) =
+      buildReplaceDataReadRelation(relation, operationTable, assignments, cond)
 
     // build a plan for updated records that match the condition
     val matchedRowsPlan = Filter(cond, readRelation)
@@ -107,36 +108,29 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     val updatedAndRemainingRowsPlan = Union(updatedRowsPlan, remainingRowsPlan)
 
     val writeRelation = relation.copy(table = operationTable)
-    val query = updatedAndRemainingRowsPlan
-    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
-    val projections = buildReplaceDataProjections(query, rowAttrs, metadataAttrs)
+    val projections = buildReplaceDataProjections(updatedAndRemainingRowsPlan, rowAttrs,
+      metadataAttrs)
     val groupFilterCond = if (groupFilterEnabled) Some(cond) else None
-    ReplaceData(writeRelation, cond, query, relation, projections, groupFilterCond)
+    ReplaceData(writeRelation, cond, updatedAndRemainingRowsPlan, relation, projections,
+      groupFilterCond)
   }
 
-  // Common read-relation setup shared by both CoW plan builders.
-  //
-  // When the connector supports column updates and declares required data attributes,
-  // the read relation is narrowed at analysis time so that
-  // GroupBasedRowLevelOperationScanPlanning uses only the needed columns for the scan.
-  // Otherwise the full relation output is used.
-  private def buildCoWReadSetup(
+  /**
+   * When the connector supports column updates and declares required data attributes,
+   * the read relation is narrowed at analysis time so that GroupBasedRowLevelOperationScanPlanning
+   * uses only the needed columns for the scan. Otherwise, the full relation output is used.
+   */
+  private def buildReplaceDataReadRelation(
       relation: DataSourceV2Relation,
       operationTable: RowLevelOperationTable,
       assignments: Seq[Assignment],
-      cond: Expression): (DataSourceV2Relation, Seq[Attribute]) = {
+      cond: Expression): (DataSourceV2Relation, Seq[Attribute], Seq[AttributeReference]) = {
 
     val operation = operationTable.operation
     val metadataAttrs = resolveRequiredMetadataAttrs(relation, operation)
     val connectorDataAttrs = resolveRequiredDataAttrs(relation, operation)
     val isNarrow = operation.supportsColumnUpdates() && connectorDataAttrs.nonEmpty
 
-    // CoW scan narrowing must be done manually at analysis time.
-    // GroupBasedRowLevelOperationScanPlanning (an optimizer rule that fires after analysis)
-    // always reads relation.output directly when building the physical scan -- it does not
-    // observe Project nodes above the relation, so optimizer-driven column pruning has no
-    // effect on CoW scans.  We narrow DataSourceV2Relation.output here so that rule picks
-    // up the narrow set.
     val readRelation = if (isNarrow) {
       val allRequired = (connectorDataAttrs ++ computeAssignedAttrs(assignments)).distinct
       buildRelationWithAttrs(relation, operationTable, metadataAttrs, dataAttrs = allRequired,
@@ -145,30 +139,24 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       buildRelationWithAttrs(relation, operationTable, metadataAttrs)
     }
 
-    // CoW write schema (two paths only, no heuristic for CoW):
-    // - Narrow path (connectorDataAttrs declared): exactly connector-declared cols in declared
-    //   order.  The connector must declare ALL columns it wants to receive.
-    // - Full path (connectorDataAttrs empty OR supportsColumnUpdates=false): full table output.
-    //   Unlike MOR, CoW does not have a heuristic assigned-only path because
-    //   GroupBasedRowLevelOperationScanPlanning needs explicit column declarations to narrow.
     val rowAttrs: Seq[Attribute] = if (isNarrow) connectorDataAttrs else relation.output
 
-    (readRelation, rowAttrs)
+    (readRelation, rowAttrs, metadataAttrs)
   }
 
-  // this method assumes the assignments have been already aligned before
-  //
-  // Works for both the full-scan and narrow-scan CoW paths.  In the narrow case,
-  // readRelation.output is already restricted by buildCoWReadSetup, so projecting
-  // all plan.output gives the correct narrow write schema.
+  /**
+   * Builds the update projection for ReplaceData plans. Assumes assignments are already aligned.
+   *
+   * plan.output may be narrowed by buildReplaceDataReadRelation, so only columns present in the
+   * plan are projected.
+   */
   private def buildReplaceDataUpdateProjection(
       plan: LogicalPlan,
       assignments: Seq[Assignment],
       cond: Expression = TrueLiteral): LogicalPlan = {
 
-    // Build a name-keyed map via AttributeMap (compares by exprId internally) so we can look
-    // up each plan column's assignment without relying on positional ordering.  This is more
-    // robust than position-based indexing and works correctly for any plan output layout.
+    // plan.output may be narrowed (fewer columns than assignments) or reordered,
+    // so assignments are matched by exprId.
     val assignmentMap = AttributeMap(assignments.collect {
       case Assignment(key: Attribute, value) => key -> value
     })
@@ -186,8 +174,7 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
           case Some(assignedExpr) =>
             Alias(If(cond, assignedExpr, attr), attr.name)()
           case None =>
-            // Column is present in the scan but has no assignment -- pass through unchanged.
-            // In the narrow CoW path these are connector-declared columns not being updated.
+            // Column in relation.output with no matching assignment; pass through unchanged.
             attr
         }
       }
@@ -206,26 +193,19 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       cond: Expression): WriteDelta = {
 
     val operation = operationTable.operation.asInstanceOf[SupportsDelta]
-    // Column-update support applies to the standard delta path and the delete+reinsert path.
-    // When representUpdateAsDeleteAndInsert is true, the REINSERT leg of the Expand already
-    // uses only assigned values, so the narrow effectiveRowAttrs applies correctly.
     val supportsColumnUpdate = operation.supportsColumnUpdates()
 
-    // resolve all needed attrs (e.g. row ID and any required metadata attrs)
     val rowIdAttrs = resolveRowIdAttrs(relation, operation)
     val metadataAttrs = resolveRequiredMetadataAttrs(relation, operation)
 
-    // Connector-declared data attrs used to determine pass-through columns in the write plan.
     val connectorDataAttrs = if (supportsColumnUpdate) {
       resolveRequiredDataAttrs(relation, operation)
     } else Nil
 
-    // MOR uses a full-schema scan; ColumnPruning narrows it via Project references.
     val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs, rowIdAttrs)
 
-    // Connector-required attrs that are NOT being assigned are added as pass-throughs in the
-    // plan so that ColumnPruning keeps them in the physical scan AND the connector receives
-    // their current values via DeltaWriter.update's row argument.
+    // Connector-declared attrs not being assigned are passed through so ColumnPruning
+    // keeps them in the scan and the connector receives their current values.
     val assignedAttrs = if (supportsColumnUpdate) computeAssignedAttrs(assignments)
                         else relation.output
     val connectorExtraAttrs: Seq[AttributeReference] = if (connectorDataAttrs.nonEmpty) {
@@ -244,12 +224,6 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       buildWriteDeltaUpdateProjection(matchedRowsPlan, assignments, rowIdAttrs)
     }
 
-    // Effective row write schema:
-    // - Narrow path (connectorDataAttrs declared): exactly connector-declared cols in declared
-    //   order.  The connector must declare ALL columns it wants to receive (including updated
-    //   ones).  This mirrors the metadata pattern and enables strict areCompatible validation.
-    // - Heuristic path (connectorDataAttrs empty): only the assigned (changed) columns.
-    // - Full path (no column-update support): full table output.
     val effectiveRowAttrs = if (supportsColumnUpdate && connectorDataAttrs.nonEmpty) {
       connectorDataAttrs
     } else if (supportsColumnUpdate) {
@@ -266,23 +240,11 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     WriteDelta(writeRelation, cond, rowDeltaPlan, relation, projections, groupFilterCond)
   }
 
-  // Builds the row delta projection for the column update path.
-  //
-  // The resulting Project references only:
-  //   - assigned column values (new values being written)
-  //   - connector pass-through values (connector declared but not assigned)
-  //   - metadata columns (nulled or preserved)
-  //   - row ID columns (for delta identification)
-  //   - original row ID values (only when a row ID column is being reassigned)
-  //
-  // ColumnPruning observes exactly these references and narrows the physical scan accordingly.
-  // Connectors that need additional columns in the scan (e.g., partition columns for
-  // distribution) should declare them in requiredDataAttributes().
-  //
-  // Note: AlignUpdateAssignments guarantees all assignment keys are top-level
-  // AttributeReferences even for nested field updates (e.g., SET col1.field = 'x' becomes
-  // Assignment(col1: AttributeReference, CreateNamedStruct(...))), so isIdentityAssignment
-  // correctly identifies non-updating assignments.
+  /**
+   * Builds the WriteDelta projection for the column update path. The resulting Project
+   * references only the columns needed for the write, so ColumnPruning narrows the scan
+   * to match.
+   */
   private def buildColumnUpdateProjection(
       plan: LogicalPlan,
       assignments: Seq[Assignment],
@@ -290,21 +252,16 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       metadataAttrs: Seq[Attribute],
       connectorExtraAttrs: Seq[AttributeReference] = Nil): LogicalPlan = {
 
-    // only emit values for non-identity assignments (the narrow write schema)
     val assignedValues = assignments.collect {
       case Assignment(key: Attribute, value) if !isIdentityAssignment(key, value) =>
         Alias(value, key.name)()
     }
 
-    // Connector-required data attrs that are not being assigned are passed through as-is
-    // so that (a) ColumnPruning keeps them in the physical scan, and (b) the connector
-    // receives their current values via DeltaWriter.update's row argument.
     val connectorExtraAttrSet = AttributeSet(connectorExtraAttrs)
     val connectorPassThroughValues = plan.output.filter { a =>
       connectorExtraAttrSet.contains(a) && !MetadataAttribute.isValid(a.metadata)
     }
 
-    // pass through or null out metadata columns present in the scan
     val metadataAttrSet = AttributeSet(metadataAttrs)
     val metadataValues = plan.output.filter(metadataAttrSet.contains).map { attr =>
       if (MetadataAttribute.isPreservedOnUpdate(attr)) {
@@ -314,7 +271,6 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
       }
     }
 
-    // pass through row ID columns from the scan
     val rowIdAttrSet = AttributeSet(rowIdAttrs)
     val rowIdValues = plan.output.filter(rowIdAttrSet.contains)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -366,10 +366,12 @@ trait RowLevelWrite extends V2WriteCommand with SupportsSubquery {
       originalTable)
   }
 
-  // Resolves the connector-declared data attributes against the original table.
-  // Symmetric with projectedMetadataAttrs; used to validate the narrow updateRowProjection
-  // when the connector mixes in SupportsColumnUpdates. The write relation stays wide, so
-  // the narrow projection cannot be validated against `table.output` directly.
+  /**
+   * Resolves the connector-declared data attributes against the original table.
+   * Symmetric with projectedMetadataAttrs; used to validate the narrow updateRowProjection
+   * when the connector mixes in SupportsColumnUpdates. The write relation stays wide, so
+   * the narrow projection cannot be validated against `table.output` directly.
+   */
   protected def projectedDataAttrs: Seq[Attribute] = operation match {
     case scu: SupportsColumnUpdates =>
       V2ExpressionUtils.resolveRefs[AttributeReference](

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.connector.catalog.constraints.Constraint
 import org.apache.spark.sql.connector.catalog.procedures.BoundProcedure
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.expressions.filter.Predicate
-import org.apache.spark.sql.connector.write.{DeltaWrite, RowLevelOperation, RowLevelOperationTable, SupportsDelta, Write}
+import org.apache.spark.sql.connector.write.{DeltaWrite, RowLevelOperation, RowLevelOperationTable, SupportsColumnUpdates, SupportsDelta, Write}
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command.{DELETE, MERGE, UPDATE}
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLType
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -365,6 +365,18 @@ trait RowLevelWrite extends V2WriteCommand with SupportsSubquery {
       operation.requiredMetadataAttributes.toImmutableArraySeq,
       originalTable)
   }
+
+  // Resolves the connector-declared data attributes against the original table.
+  // Symmetric with projectedMetadataAttrs; used to validate the narrow updateRowProjection
+  // when the connector mixes in SupportsColumnUpdates. The write relation stays wide, so
+  // the narrow projection cannot be validated against `table.output` directly.
+  protected def projectedDataAttrs: Seq[Attribute] = operation match {
+    case scu: SupportsColumnUpdates =>
+      V2ExpressionUtils.resolveRefs[AttributeReference](
+        scu.requiredDataAttributes.toImmutableArraySeq,
+        originalTable)
+    case _ => Nil
+  }
 }
 
 /**
@@ -418,7 +430,29 @@ case class ReplaceData(
   // validates row projection output is compatible with table attributes
   private def rowAttrsResolved: Boolean = {
     val inRowAttrs = DataTypeUtils.toAttributes(projections.rowProjection.schema)
-    table.skipSchemaResolution || areCompatible(inRowAttrs, table.output)
+    val inUpdateAttrs = projections.updateRowProjection match {
+      case Some(projection) => DataTypeUtils.toAttributes(projection.schema)
+      case None => Nil
+    }
+    // `rowProjection` (INSERT-tagged rows) validates against `table.output` -- the full table
+    // shape. `updateRowProjection` (UPDATE/COPY-tagged rows) is narrow for column-update
+    // connectors, so it validates against `projectedDataAttrs` (the connector-declared narrow
+    // set) instead. When the connector does not mix in `SupportsColumnUpdates`,
+    // `updateRowProjection` is absent and `updateResolved` is trivially true.
+    val insertResolved = table.skipSchemaResolution || inRowAttrs.isEmpty ||
+      areCompatible(inRowAttrs, table.output)
+    val updateResolved = inUpdateAttrs.isEmpty || dataAttrsResolved(inUpdateAttrs)
+    insertResolved && updateResolved
+  }
+
+  /**
+   * Validates the narrow-write-schema row projection output for a column-update connector.
+   * The write schema must exactly match the columns declared via
+   * `SupportsColumnUpdates.requiredDataAttributes()` (same columns, same order).
+   */
+  private def dataAttrsResolved(inRowAttrs: Seq[Attribute]): Boolean = {
+    operation.isInstanceOf[SupportsColumnUpdates] &&
+      areCompatible(inRowAttrs, projectedDataAttrs)
   }
 
   // validates metadata projection output is compatible with metadata attributes
@@ -510,7 +544,29 @@ case class WriteDelta(
       case Some(projection) => DataTypeUtils.toAttributes(projection.schema)
       case None => Nil
     }
-    table.skipSchemaResolution || areCompatible(inRowAttrs, outRowAttrs)
+    val inUpdateAttrs = projections.updateRowProjection match {
+      case Some(projection) => DataTypeUtils.toAttributes(projection.schema)
+      case None => Nil
+    }
+    // `rowProjection` (INSERT-tagged rows) validates against `outRowAttrs`. For column-update
+    // connectors, `updateRowProjection` (UPDATE/COPY/REINSERT-tagged rows) is narrow and
+    // validates against `projectedDataAttrs` (the connector-declared narrow set) instead.
+    // When the connector does not mix in `SupportsColumnUpdates`, `updateRowProjection` is
+    // absent and `updateResolved` is trivially true.
+    val insertResolved = table.skipSchemaResolution || inRowAttrs.isEmpty ||
+      areCompatible(inRowAttrs, outRowAttrs)
+    val updateResolved = inUpdateAttrs.isEmpty || dataAttrsResolved(inUpdateAttrs)
+    insertResolved && updateResolved
+  }
+
+  /**
+   * Validates the narrow-write-schema row projection output for a column-update connector.
+   * The write schema must exactly match the columns declared via
+   * `SupportsColumnUpdates.requiredDataAttributes()` (same columns, same order).
+   */
+  private def dataAttrsResolved(inRowAttrs: Seq[Attribute]): Boolean = {
+    operation.isInstanceOf[SupportsColumnUpdates] &&
+      areCompatible(inRowAttrs, projectedDataAttrs)
   }
 
   // validates row ID projection output is compatible with row ID attributes

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -436,14 +436,16 @@ case class ReplaceData(
       case Some(projection) => DataTypeUtils.toAttributes(projection.schema)
       case None => Nil
     }
-    // `rowProjection` (INSERT-tagged rows) validates against `table.output` -- the full table
-    // shape. `updateRowProjection` (UPDATE/COPY-tagged rows) is narrow for column-update
-    // connectors, so it validates against `projectedDataAttrs` (the connector-declared narrow
-    // set) instead. When the connector does not mix in `SupportsColumnUpdates`,
+    // `rowProjection` (INSERT-tagged rows) validates against full table column set.
+    // `updateRowProjection` (UPDATE/COPY-tagged rows) is narrow for column-update
+    // connectors, so it validates against the connector-declared narrow
+    // set instead. When the connector does not mix in `SupportsColumnUpdates`,
     // `updateRowProjection` is absent and `updateResolved` is trivially true.
-    val insertResolved = table.skipSchemaResolution || inRowAttrs.isEmpty ||
+    val insertResolved = table.skipSchemaResolution ||
+      (inUpdateAttrs.nonEmpty && inRowAttrs.isEmpty) ||
       areCompatible(inRowAttrs, table.output)
-    val updateResolved = inUpdateAttrs.isEmpty || dataAttrsResolved(inUpdateAttrs)
+    val updateResolved = table.skipSchemaResolution ||
+      inUpdateAttrs.isEmpty || dataAttrsResolved(inUpdateAttrs)
     insertResolved && updateResolved
   }
 
@@ -551,13 +553,15 @@ case class WriteDelta(
       case None => Nil
     }
     // `rowProjection` (INSERT-tagged rows) validates against `outRowAttrs`. For column-update
-    // connectors, `updateRowProjection` (UPDATE/COPY/REINSERT-tagged rows) is narrow and
-    // validates against `projectedDataAttrs` (the connector-declared narrow set) instead.
-    // When the connector does not mix in `SupportsColumnUpdates`, `updateRowProjection` is
-    // absent and `updateResolved` is trivially true.
-    val insertResolved = table.skipSchemaResolution || inRowAttrs.isEmpty ||
+    // connectors, `updateRowProjection` is narrow and validates against `projectedDataAttrs`
+    // (the connector-declared narrow set) instead. When the connector does not mix in
+    // `SupportsColumnUpdates`, `updateRowProjection` is absent and `updateResolved` is trivially
+    // true.
+    val insertResolved = table.skipSchemaResolution ||
+      (inUpdateAttrs.nonEmpty && inRowAttrs.isEmpty) ||
       areCompatible(inRowAttrs, outRowAttrs)
-    val updateResolved = inUpdateAttrs.isEmpty || dataAttrsResolved(inUpdateAttrs)
+    val updateResolved = table.skipSchemaResolution ||
+      inUpdateAttrs.isEmpty || dataAttrsResolved(inUpdateAttrs)
     insertResolved && updateResolved
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -386,19 +386,19 @@ case class ReplaceData(
   // validates row projection output is compatible with table attributes
   private def rowAttrsResolved: Boolean = {
     val inRowAttrs = DataTypeUtils.toAttributes(projections.rowProjection.schema)
-    table.skipSchemaResolution ||
-      areCompatible(inRowAttrs, table.output) ||
+    table.skipSchemaResolution || areCompatible(inRowAttrs, table.output) ||
       dataAttrsResolved(inRowAttrs)
   }
 
-  // Validates the narrow-write-schema row projection output.
-  //
-  // When the connector declares specific data attributes via requiredDataAttributes(), the
-  // write schema must exactly match projectedDataAttrs (same columns, same order).  This is
-  // symmetric with metadataAttrsResolved: the connector's declared attrs define the write schema.
-  //
-  // When requiredDataAttributes() is empty (heuristic path), the write schema contains only
-  // the assigned columns.  We validate each one exists in the table with a compatible type.
+  /**
+   * Validates the narrow-write-schema row projection output.
+   *
+   * When the connector declares specific data attributes via requiredDataAttributes(), the
+   * write schema must exactly match projectedDataAttrs (same columns, same order).
+   *
+   * When requiredDataAttributes() is empty, the write schema contains only
+   * the assigned columns. We validate each one exists in the table with a compatible type.
+   */
   private def dataAttrsResolved(inRowAttrs: Seq[Attribute]): Boolean = {
     if (!operation.supportsColumnUpdates()) { return false }
     val outDataAttrs = projectedDataAttrs
@@ -506,12 +506,19 @@ case class WriteDelta(
       case Some(projection) => DataTypeUtils.toAttributes(projection.schema)
       case None => Nil
     }
-    table.skipSchemaResolution ||
-      areCompatible(inRowAttrs, outRowAttrs) ||
+    table.skipSchemaResolution || areCompatible(inRowAttrs, outRowAttrs) ||
       dataAttrsResolved(inRowAttrs)
   }
 
-  // Validates the narrow-write-schema row projection.  Symmetric with ReplaceData.
+  /**
+   * Validates the narrow-write-schema row projection output.
+   *
+   * When the connector declares specific data attributes via requiredDataAttributes(), the
+   * write schema must exactly match projectedDataAttrs (same columns, same order).
+   *
+   * When requiredDataAttributes() is empty, the write schema contains only
+   * the assigned columns. We validate each one exists in the table with a compatible type.
+   */
   private def dataAttrsResolved(inRowAttrs: Seq[Attribute]): Boolean = {
     if (!operation.supportsColumnUpdates()) { return false }
     val outDataAttrs = projectedDataAttrs

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -325,6 +325,14 @@ trait RowLevelWrite extends V2WriteCommand with SupportsSubquery {
       operation.requiredMetadataAttributes.toImmutableArraySeq,
       originalTable)
   }
+
+  // Resolves the connector-declared data attributes against the original table.
+  // Symmetric with projectedMetadataAttrs; used in narrow-schema validation.
+  protected def projectedDataAttrs: Seq[Attribute] = {
+    V2ExpressionUtils.resolveRefs[AttributeReference](
+      operation.requiredDataAttributes.toImmutableArraySeq,
+      originalTable)
+  }
 }
 
 /**
@@ -378,7 +386,35 @@ case class ReplaceData(
   // validates row projection output is compatible with table attributes
   private def rowAttrsResolved: Boolean = {
     val inRowAttrs = DataTypeUtils.toAttributes(projections.rowProjection.schema)
-    table.skipSchemaResolution || areCompatible(inRowAttrs, table.output)
+    table.skipSchemaResolution ||
+      areCompatible(inRowAttrs, table.output) ||
+      dataAttrsResolved(inRowAttrs)
+  }
+
+  // Validates the narrow-write-schema row projection output.
+  //
+  // When the connector declares specific data attributes via requiredDataAttributes(), the
+  // write schema must exactly match projectedDataAttrs (same columns, same order).  This is
+  // symmetric with metadataAttrsResolved: the connector's declared attrs define the write schema.
+  //
+  // When requiredDataAttributes() is empty (heuristic path), the write schema contains only
+  // the assigned columns.  We validate each one exists in the table with a compatible type.
+  private def dataAttrsResolved(inRowAttrs: Seq[Attribute]): Boolean = {
+    if (!operation.supportsColumnUpdates()) { return false }
+    val outDataAttrs = projectedDataAttrs
+    if (outDataAttrs.nonEmpty) {
+      areCompatible(inRowAttrs, outDataAttrs)
+    } else {
+      inRowAttrs.forall { inAttr =>
+        table.output.exists { outAttr =>
+          val inType = CharVarcharUtils.getRawType(inAttr.metadata).getOrElse(inAttr.dataType)
+          val outType = CharVarcharUtils.getRawType(outAttr.metadata).getOrElse(outAttr.dataType)
+          inAttr.name == outAttr.name &&
+            DataType.equalsIgnoreCompatibleNullability(inType, outType) &&
+            (outAttr.nullable || !inAttr.nullable)
+        }
+      }
+    }
   }
 
   // validates metadata projection output is compatible with metadata attributes
@@ -470,7 +506,28 @@ case class WriteDelta(
       case Some(projection) => DataTypeUtils.toAttributes(projection.schema)
       case None => Nil
     }
-    table.skipSchemaResolution || areCompatible(inRowAttrs, outRowAttrs)
+    table.skipSchemaResolution ||
+      areCompatible(inRowAttrs, outRowAttrs) ||
+      dataAttrsResolved(inRowAttrs)
+  }
+
+  // Validates the narrow-write-schema row projection.  Symmetric with ReplaceData.
+  private def dataAttrsResolved(inRowAttrs: Seq[Attribute]): Boolean = {
+    if (!operation.supportsColumnUpdates()) { return false }
+    val outDataAttrs = projectedDataAttrs
+    if (outDataAttrs.nonEmpty) {
+      areCompatible(inRowAttrs, outDataAttrs)
+    } else {
+      inRowAttrs.forall { inAttr =>
+        table.output.exists { outAttr =>
+          val inType = CharVarcharUtils.getRawType(inAttr.metadata).getOrElse(inAttr.dataType)
+          val outType = CharVarcharUtils.getRawType(outAttr.metadata).getOrElse(outAttr.dataType)
+          inAttr.name == outAttr.name &&
+            DataType.equalsIgnoreCompatibleNullability(inType, outType) &&
+            (outAttr.nullable || !inAttr.nullable)
+        }
+      }
+    }
   }
 
   // validates row ID projection output is compatible with row ID attributes

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ReplaceDataProjections.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ReplaceDataProjections.scala
@@ -21,4 +21,5 @@ import org.apache.spark.sql.catalyst.ProjectingInternalRow
 
 case class ReplaceDataProjections(
     rowProjection: ProjectingInternalRow,
+    updateRowProjection: Option[ProjectingInternalRow],
     metadataProjection: Option[ProjectingInternalRow])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/WriteDeltaProjections.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/WriteDeltaProjections.scala
@@ -21,5 +21,6 @@ import org.apache.spark.sql.catalyst.ProjectingInternalRow
 
 case class WriteDeltaProjections(
     rowProjection: Option[ProjectingInternalRow],
+    updateRowProjection: Option[ProjectingInternalRow],
     rowIdProjection: ProjectingInternalRow,
     metadataProjection: Option[ProjectingInternalRow])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/LogicalWriteInfoImpl.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/LogicalWriteInfoImpl.scala
@@ -29,7 +29,8 @@ private[sql] case class LogicalWriteInfoImpl(
     schema: StructType,
     options: CaseInsensitiveStringMap,
     override val rowIdSchema: Optional[StructType] = Optional.empty[StructType],
-    override val metadataSchema: Optional[StructType] = Optional.empty[StructType])
+    override val metadataSchema: Optional[StructType] = Optional.empty[StructType],
+    override val updateSchema: Optional[StructType] = Optional.empty[StructType])
   extends LogicalWriteInfo
 
 object LogicalWriteInfoImpl {
@@ -38,12 +39,14 @@ object LogicalWriteInfoImpl {
       schema: StructType,
       options: CaseInsensitiveStringMap,
       rowIdSchema: Option[StructType],
-      metadataSchema: Option[StructType]): LogicalWriteInfoImpl = {
+      metadataSchema: Option[StructType],
+      updateSchema: Option[StructType]): LogicalWriteInfoImpl = {
     LogicalWriteInfoImpl(
       queryId,
       schema,
       options,
       rowIdSchema.toJava,
-      metadataSchema.toJava)
+      metadataSchema.toJava,
+      updateSchema.toJava)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/RowLevelOperationInfoImpl.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/RowLevelOperationInfoImpl.scala
@@ -17,9 +17,15 @@
 
 package org.apache.spark.sql.connector.write
 
+import org.apache.spark.sql.connector.expressions.NamedReference
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 private[sql] case class RowLevelOperationInfoImpl(
     command: Command,
-    options: CaseInsensitiveStringMap) extends RowLevelOperationInfo
+    options: CaseInsensitiveStringMap,
+    private val updatedCols: Seq[NamedReference])
+    extends RowLevelOperationInfo {
+
+  override def updatedColumns(): Array[NamedReference] = updatedCols.toArray
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/RowLevelOperationInfoImpl.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/RowLevelOperationInfoImpl.scala
@@ -17,9 +17,15 @@
 
 package org.apache.spark.sql.connector.write
 
+import org.apache.spark.sql.connector.expressions.NamedReference
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 private[sql] case class RowLevelOperationInfoImpl(
     command: Command,
-    options: CaseInsensitiveStringMap) extends RowLevelOperationInfo
+    options: CaseInsensitiveStringMap,
+    private val updatedCols: Seq[NamedReference] = Nil)
+    extends RowLevelOperationInfo {
+
+  override def updatedColumns(): Array[NamedReference] = updatedCols.toArray
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -4557,6 +4557,16 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "missingColumns" -> missingColumns.mkString("[", ", ", "]")))
   }
 
+  def splitUpdateRowIdReassignmentError(
+      connectorClass: String,
+      rowIds: Seq[String]): Throwable = {
+    new AnalysisException(
+      errorClass = "SPLIT_UPDATE_ROW_ID_REASSIGNMENT",
+      messageParameters = Map(
+        "connector" -> connectorClass,
+        "rowIds" -> rowIds.mkString("[", ", ", "]")))
+  }
+
   def cannotRenameTableAcrossSchemaError(): Throwable = {
     new SparkUnsupportedOperationException(
       errorClass = "CANNOT_RENAME_ACROSS_SCHEMA", messageParameters = Map("type" -> "table")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -4547,6 +4547,16 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("connector" -> connectorClass))
   }
 
+  def requiredDataAttributesMissingPartitionColumnsError(
+      connectorClass: String,
+      missingColumns: Seq[String]): Throwable = {
+    new AnalysisException(
+      errorClass = "REQUIRED_DATA_ATTRIBUTES_MISSING_PARTITION_COLUMNS",
+      messageParameters = Map(
+        "connector" -> connectorClass,
+        "missingColumns" -> missingColumns.mkString("[", ", ", "]")))
+  }
+
   def requiredDataAttributesMissingUpdatedColumnsError(
       connectorClass: String,
       missingColumns: Seq[String]): Throwable = {
@@ -4565,6 +4575,16 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map(
         "connector" -> connectorClass,
         "overlappingColumns" -> overlappingColumns.mkString("[", ", ", "]")))
+  }
+
+  def splitUpdateRowIdNotDeclaredError(
+      connectorClass: String,
+      rowIds: Seq[String]): Throwable = {
+    new AnalysisException(
+      errorClass = "SPLIT_UPDATE_ROW_ID_NOT_DECLARED",
+      messageParameters = Map(
+        "connector" -> connectorClass,
+        "rowIds" -> rowIds.mkString("[", ", ", "]")))
   }
 
   def splitUpdateRowIdReassignmentError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -4541,6 +4541,22 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("nullableRowIdAttrs" -> nullableRowIdAttrs.mkString(", ")))
   }
 
+  def emptyRequiredDataAttributesError(connectorClass: String): Throwable = {
+    new AnalysisException(
+      errorClass = "EMPTY_REQUIRED_DATA_ATTRIBUTES",
+      messageParameters = Map("connector" -> connectorClass))
+  }
+
+  def requiredDataAttributesMissingUpdatedColumnsError(
+      connectorClass: String,
+      missingColumns: Seq[String]): Throwable = {
+    new AnalysisException(
+      errorClass = "REQUIRED_DATA_ATTRIBUTES_MISSING_UPDATED_COLUMNS",
+      messageParameters = Map(
+        "connector" -> connectorClass,
+        "missingColumns" -> missingColumns.mkString("[", ", ", "]")))
+  }
+
   def cannotRenameTableAcrossSchemaError(): Throwable = {
     new SparkUnsupportedOperationException(
       errorClass = "CANNOT_RENAME_ACROSS_SCHEMA", messageParameters = Map("type" -> "table")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -4557,6 +4557,16 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "missingColumns" -> missingColumns.mkString("[", ", ", "]")))
   }
 
+  def requiredDataAttributesOverlapScanOnlyAttributesError(
+      connectorClass: String,
+      overlappingColumns: Seq[String]): Throwable = {
+    new AnalysisException(
+      errorClass = "REQUIRED_DATA_ATTRIBUTES_OVERLAP_SCAN_ONLY_ATTRIBUTES",
+      messageParameters = Map(
+        "connector" -> connectorClass,
+        "overlappingColumns" -> overlappingColumns.mkString("[", ", ", "]")))
+  }
+
   def splitUpdateRowIdReassignmentError(
       connectorClass: String,
       rowIds: Seq[String]): Throwable = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -1292,6 +1292,7 @@ private class BufferedRowsWriterFactory(schema: StructType)
 private class BufferWriter(schema: StructType) extends DataWriter[InternalRow] {
 
   private final val WRITE = UTF8String.fromString(Write.toString)
+  private final val WRITE_UPDATE = UTF8String.fromString(WriteUpdate.toString)
 
   protected val buffer = new BufferedRows(Seq.empty, schema)
 
@@ -1304,6 +1305,21 @@ private class BufferWriter(schema: StructType) extends DataWriter[InternalRow] {
   override def write(row: InternalRow): Unit = {
     buffer.rows.append(row.copy())
     val logEntry = new GenericInternalRow(Array[Any](WRITE, null, null, row.copy()))
+    buffer.log.append(logEntry)
+  }
+
+  // Tag UPDATE/COPY rows distinctly so tests can verify that Spark dispatches
+  // through writeUpdate (the SupportsColumnUpdates path) rather than write.
+  override def writeUpdate(metadata: InternalRow, row: InternalRow): Unit = {
+    buffer.rows.append(row.copy())
+    val logEntry = new GenericInternalRow(
+      Array[Any](WRITE_UPDATE, null, metadata.copy(), row.copy()))
+    buffer.log.append(logEntry)
+  }
+
+  override def writeUpdate(row: InternalRow): Unit = {
+    buffer.rows.append(row.copy())
+    val logEntry = new GenericInternalRow(Array[Any](WRITE_UPDATE, null, null, row.copy()))
     buffer.log.append(logEntry)
   }
 
@@ -1350,6 +1366,7 @@ case class Commit(id: Long, writeSummary: Option[WriteSummary] = None)
 
 sealed trait Operation
 case object Write extends Operation
+case object WriteUpdate extends Operation
 case object Delete extends Operation
 case object Update extends Operation
 case object Reinsert extends Operation

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
@@ -87,6 +87,8 @@ class InMemoryRowLevelOperationTable private (
   private final val COLUMN_UPDATE_EMPTY_REQ_ATTRS = "column-update-empty-req-attrs"
   private final val COLUMN_UPDATE_SCAN_ONLY = "column-update-scan-only"
   private final val COLUMN_UPDATE_OVERLAP = "column-update-overlap"
+  private final val COLUMN_UPDATE_MISSING_PARTITION = "column-update-missing-partition"
+  private final val COLUMN_UPDATE_SPLIT_MISSING_ROW_ID = "column-update-split-missing-row-id"
 
   // used in row-level operation tests to verify replaced partitions
   var replacedPartitions: Seq[Seq[Any]] = Seq.empty
@@ -156,10 +158,16 @@ class InMemoryRowLevelOperationTable private (
       () => new PartitionBasedColumnUpdateOperation(info.command, info.updatedColumns().toSeq)
     } else if (properties.getOrDefault(COLUMN_UPDATE_SPLIT, "false") == "true") {
       () => new DeltaBasedColumnUpdateSplitOperation(info.command, info.updatedColumns().toSeq)
+    } else if (properties.getOrDefault(COLUMN_UPDATE_SPLIT_MISSING_ROW_ID, "false") == "true") {
+      () => new DeltaBasedColumnUpdateSplitMissingRowIdOperation(
+        info.command, info.updatedColumns().toSeq)
     } else if (properties.getOrDefault(COLUMN_UPDATE_SCAN_ONLY, "false") == "true") {
       () => new DeltaBasedColumnUpdateScanOnlyOperation(info.command, info.updatedColumns().toSeq)
     } else if (properties.getOrDefault(COLUMN_UPDATE_OVERLAP, "false") == "true") {
       () => new DeltaBasedColumnUpdateOverlapOperation(info.command, info.updatedColumns().toSeq)
+    } else if (properties.getOrDefault(COLUMN_UPDATE_MISSING_PARTITION, "false") == "true") {
+      () => new DeltaBasedColumnUpdateMissingPartitionOperation(
+        info.command, info.updatedColumns().toSeq)
     } else if (properties.getOrDefault(SUPPORTS_DELTAS, "false") == "true") {
       () => DeltaBasedOperation(info.command, info.options)
     } else {
@@ -448,6 +456,15 @@ class InMemoryRowLevelOperationTable private (
     override def scanOnlyDataAttributes(): Array[NamedReference] = Array(DEP_COLUMN_REF)
   }
 
+  // Test-only: declares `dep` (the partition column) in neither `requiredDataAttributes()` nor
+  // `scanOnlyDataAttributes()`, to exercise the guard that rejects an undeclared partition column.
+  class DeltaBasedColumnUpdateMissingPartitionOperation(
+      command: Command,
+      updatedCols: Seq[NamedReference] = Nil)
+      extends DeltaBasedColumnUpdateOperation(command, updatedCols) {
+    override def scanOnlyDataAttributes(): Array[NamedReference] = Array.empty
+  }
+
   class DeltaBasedColumnUpdateSplitOperation(
       command: Command,
       updatedCols: Seq[NamedReference] = Nil)
@@ -530,6 +547,15 @@ class InMemoryRowLevelOperationTable private (
           }
       }
     }
+  }
+
+  // Test-only: a split-update fixture whose requiredDataAttributes() excludes the row-ID
+  // column, to exercise the guard that rejects an undeclared row ID for the REINSERT path.
+  class DeltaBasedColumnUpdateSplitMissingRowIdOperation(
+      command: Command,
+      updatedCols: Seq[NamedReference] = Nil)
+      extends DeltaBasedColumnUpdateSplitOperation(command, updatedCols) {
+    override def requiredDataAttributes(): Array[NamedReference] = updatedCols.toArray
   }
 
   class PartitionBasedColumnUpdateOperation(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
@@ -686,7 +686,8 @@ object InMemoryRowLevelOperationTable {
   private[catalog] val lastScanSchemaRef: java.util.concurrent.atomic.AtomicReference[StructType] =
     new java.util.concurrent.atomic.AtomicReference[StructType]()
 
-  /** Called by test-only scan builders on every scan build. Overwrites; tests reset between cases. */
+  /** Called by test-only scan builders on every scan build. Overwrites; tests reset between
+   * cases. */
   private[catalog] def recordLastScanSchema(schema: StructType): Unit = {
     lastScanSchemaRef.set(schema)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.connector.distributions.{Distribution, Distributions
 import org.apache.spark.sql.connector.expressions.{FieldReference, LogicalExpressions, NamedReference, SortDirection, SortOrder, Transform}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder}
-import org.apache.spark.sql.connector.write.{BatchWrite, DeltaBatchWrite, DeltaWrite, DeltaWriteBuilder, DeltaWriter, DeltaWriterFactory, LogicalWriteInfo, PhysicalWriteInfo, RequiresDistributionAndOrdering, RowLevelOperation, RowLevelOperationBuilder, RowLevelOperationInfo, SupportsDelta, Write, WriteBuilder, WriterCommitMessage}
+import org.apache.spark.sql.connector.write.{BatchWrite, DeltaBatchWrite, DeltaWrite, DeltaWriteBuilder, DeltaWriter, DeltaWriterFactory, LogicalWriteInfo, PhysicalWriteInfo, RequiresDistributionAndOrdering, RowLevelOperation, RowLevelOperationBuilder, RowLevelOperationInfo, SupportsColumnUpdates, SupportsDelta, Write, WriteBuilder, WriterCommitMessage}
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -79,11 +79,26 @@ class InMemoryRowLevelOperationTable private (
   private final val SPLIT_UPDATES = "split-updates"
   private final val NO_METADATA = "no-metadata"
   private final val noMetadata = properties.getOrDefault(NO_METADATA, "false") == "true"
+  private final val COLUMN_UPDATE = "column-update"
+  private final val COLUMN_UPDATE_REQ_ATTRS = "column-update-req-attrs"
+  private final val COLUMN_UPDATE_COW = "column-update-cow"
+  private final val COLUMN_UPDATE_FROM_INFO = "column-update-from-info"
+  private final val COLUMN_UPDATE_SPLIT = "column-update-split"
+  private final val COLUMN_UPDATE_EMPTY_REQ_ATTRS = "column-update-empty-req-attrs"
 
   // used in row-level operation tests to verify replaced partitions
   var replacedPartitions: Seq[Seq[Any]] = Seq.empty
   // used in row-level operation tests to verify reported write schema
   var lastWriteInfo: LogicalWriteInfo = _
+  // used in column-update tests to verify that Spark passed the correct updated column list
+  // to the connector via RowLevelOperationInfo.updatedColumns()
+  var lastUpdatedColumns: Array[NamedReference] = Array.empty
+  // used in scan-narrowing tests to verify the schema Spark asked the connector to read.
+  // Routed through the companion object (see InMemoryRowLevelOperationTable.lastScanSchema)
+  // because Spark's planner and the test harness can hold references to different table
+  // instances for the same identifier -- a per-instance field would only be visible to one.
+  def lastScanSchema: StructType =
+    InMemoryRowLevelOperationTable.lastScanSchemaRef.get()
   // used in row-level operation tests to verify passed records
   // (operation, id, metadata, row)
   var lastWriteLog: Seq[InternalRow] = Seq.empty
@@ -124,7 +139,22 @@ class InMemoryRowLevelOperationTable private (
 
   override def newRowLevelOperationBuilder(
       info: RowLevelOperationInfo): RowLevelOperationBuilder = {
-    if (properties.getOrDefault(SUPPORTS_DELTAS, "false") == "true") {
+    lastUpdatedColumns = info.updatedColumns()
+    if (properties.getOrDefault(COLUMN_UPDATE, "false") == "true") {
+      () => new DeltaBasedColumnUpdateOperation(info.command, info.updatedColumns().toSeq)
+    } else if (properties.containsKey(COLUMN_UPDATE_REQ_ATTRS)) {
+      val reqCols = properties.get(COLUMN_UPDATE_REQ_ATTRS).split(",").map(_.trim)
+      () => new DeltaBasedColumnUpdateOperationWithReqAttrs(info.command, reqCols)
+    } else if (properties.getOrDefault(COLUMN_UPDATE_EMPTY_REQ_ATTRS, "false") == "true") {
+      // Test-only: returns an empty requiredDataAttributes() so we can verify Spark rejects it.
+      () => new DeltaBasedColumnUpdateOperationWithReqAttrs(info.command, Array.empty)
+    } else if (properties.getOrDefault(COLUMN_UPDATE_FROM_INFO, "false") == "true") {
+      () => new DeltaBasedColumnUpdateOperationFromInfo(info.command, info.updatedColumns().toSeq)
+    } else if (properties.getOrDefault(COLUMN_UPDATE_COW, "false") == "true") {
+      () => new PartitionBasedColumnUpdateOperation(info.command, info.updatedColumns().toSeq)
+    } else if (properties.getOrDefault(COLUMN_UPDATE_SPLIT, "false") == "true") {
+      () => new DeltaBasedColumnUpdateSplitOperation(info.command, info.updatedColumns().toSeq)
+    } else if (properties.getOrDefault(SUPPORTS_DELTAS, "false") == "true") {
       () => DeltaBasedOperation(info.command, info.options)
     } else {
       () => PartitionBasedOperation(info.command, info.options)
@@ -147,6 +177,7 @@ class InMemoryRowLevelOperationTable private (
       new InMemoryScanBuilder(schema, options) {
         override def build: Scan = {
           val scan = super.build()
+          InMemoryRowLevelOperationTable.recordLastScanSchema(scan.readSchema())
           configuredScan = scan.asInstanceOf[InMemoryBatchScan]
           scan
         }
@@ -216,7 +247,13 @@ class InMemoryRowLevelOperationTable private (
     override def rowId(): Array[NamedReference] = Array(PK_COLUMN_REF)
 
     override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
-      new InMemoryScanBuilder(schema, options)
+      new InMemoryScanBuilder(schema, options) {
+        override def build: Scan = {
+          val scan = super.build()
+          InMemoryRowLevelOperationTable.recordLastScanSchema(scan.readSchema())
+          scan
+        }
+      }
     }
 
     override def newWriteBuilder(info: LogicalWriteInfo): DeltaWriteBuilder = {
@@ -250,6 +287,327 @@ class InMemoryRowLevelOperationTable private (
 
     override def representUpdateAsDeleteAndInsert(): Boolean = {
       properties.getOrDefault(SPLIT_UPDATES, "false").toBoolean
+    }
+  }
+
+  // A delta-based operation that supports column-level updates: Spark sends only the
+  // declared + assigned columns in the row projection instead of the full row schema. The base
+  // class composes its required-attrs set as `pk` (the row-lookup key) plus whatever columns
+  // Spark reports as being assigned via `RowLevelOperationInfo#updatedColumns()`.
+  class DeltaBasedColumnUpdateOperation(
+      command: Command,
+      updatedCols: Seq[NamedReference] = Nil)
+      extends DeltaBasedOperation(command, CaseInsensitiveStringMap.empty())
+        with SupportsColumnUpdates {
+    override def representUpdateAsDeleteAndInsert(): Boolean = false
+    override def requiredDataAttributes(): Array[NamedReference] = {
+      val pk: NamedReference = FieldReference("pk")
+      val updatedNames = updatedCols.map(_.describe()).toSet
+      if (updatedNames.contains("pk")) updatedCols.toArray
+      else (pk +: updatedCols).toArray
+    }
+
+    override def newWriteBuilder(info: LogicalWriteInfo): DeltaWriteBuilder = {
+      lastWriteInfo = info
+      // Capture info into a local val so nested writer/commit closures see a stable schema
+      // even if a subsequent newWriteBuilder call mutates lastWriteInfo.
+      val capturedInfo = info
+      val capturedWriteSchema = if (capturedInfo.updateSchema().isPresent) {
+        capturedInfo.updateSchema().get()
+      } else {
+        capturedInfo.schema()
+      }
+      new DeltaWriteBuilder {
+        override def build(): DeltaWrite =
+          new DeltaWrite with RequiresDistributionAndOrdering {
+
+            override def requiredDistribution(): Distribution = {
+              Distributions.clustered(Array(PARTITION_COLUMN_REF))
+            }
+
+            override def requiredOrdering(): Array[SortOrder] = {
+              Array[SortOrder](
+                LogicalExpressions.sort(
+                  PARTITION_COLUMN_REF,
+                  SortDirection.ASCENDING,
+                  SortDirection.ASCENDING.defaultNullOrdering())
+              )
+            }
+
+            override def toBatch: DeltaBatchWrite =
+              new TestBatchWrite with DeltaBatchWrite {
+                override def createBatchWriterFactory(
+                    info: PhysicalWriteInfo): DeltaWriterFactory = {
+                  // Use the narrow update schema for UPDATE/COPY/REINSERT rows when present.
+                  new DeltaBufferedRowsWriterFactory(capturedWriteSchema)
+                }
+
+                // For column-update writes, rows contain only the assigned columns
+                // (narrow schema from LogicalWriteInfo). We expand each row to the full table
+                // schema by overlaying write-schema columns on the base row found by pk.
+                override protected def doCommit(messages: Array[WriterCommitMessage]): Unit =
+                  dataMap.synchronized {
+                    val newData = messages.map(_.asInstanceOf[BufferedRows])
+                    val writeSchema = capturedWriteSchema
+                    val writeFieldIdx = writeSchema.fieldNames.zipWithIndex.toMap
+
+                    val mergedData = newData.map { buf =>
+                      val merged = new BufferedRows(buf.key, schema)
+                      val updateOpName = UTF8String.fromString(Update.toString)
+                      val insertOpName = UTF8String.fromString(Insert.toString)
+                      buf.log.foreach { logRow =>
+                        val opName = logRow.getUTF8String(0)
+                        if (opName == updateOpName) {
+                          val pk = logRow.getInt(1)
+                          val narrowRow = logRow.get(3, writeSchema).asInstanceOf[InternalRow]
+                          val baseRow = dataMap.values.iterator.flatten
+                            .flatMap(_.rows)
+                            .find(r => r.getInt(schema.fieldIndex("pk")) == pk)
+                          val fullRow = new GenericInternalRow(schema.length)
+                          baseRow.foreach { base =>
+                            for (i <- schema.fields.indices) {
+                              fullRow.update(i, base.get(i, schema.fields(i).dataType))
+                            }
+                          }
+                          schema.fields.zipWithIndex.foreach { case (field, i) =>
+                            writeFieldIdx.get(field.name).foreach { j =>
+                              fullRow.update(i, narrowRow.get(j, field.dataType))
+                            }
+                          }
+                          merged.rows.append(fullRow)
+                        } else if (opName == insertOpName) {
+                          // INSERT rows arrive with the full table schema via writer.insert()
+                          val insertRow = logRow.get(3, schema).asInstanceOf[InternalRow]
+                          merged.rows.append(insertRow.copy())
+                        }
+                      }
+                      merged
+                    }
+
+                    withDeletes(newData)
+                    withData(mergedData)
+                    lastWriteLog = newData.flatMap(buffer => buffer.log).toIndexedSeq
+                  }
+
+                override def abort(messages: Array[WriterCommitMessage]): Unit = {}
+              }
+          }
+      }
+    }
+  }
+
+  class DeltaBasedColumnUpdateOperationWithReqAttrs(command: Command, reqCols: Array[String])
+      extends DeltaBasedColumnUpdateOperation(command) {
+    override def requiredDataAttributes(): Array[NamedReference] = reqCols.map(FieldReference(_))
+  }
+
+  class DeltaBasedColumnUpdateOperationFromInfo(
+      command: Command,
+      updatedCols: Seq[NamedReference])
+      extends DeltaBasedColumnUpdateOperation(command, updatedCols) {
+  }
+
+  class DeltaBasedColumnUpdateSplitOperation(
+      command: Command,
+      updatedCols: Seq[NamedReference] = Nil)
+      extends DeltaBasedColumnUpdateOperation(command, updatedCols) {
+    override def representUpdateAsDeleteAndInsert(): Boolean = true
+
+    override def newWriteBuilder(info: LogicalWriteInfo): DeltaWriteBuilder = {
+      lastWriteInfo = info
+      // Capture info into a local val so nested writer/commit closures see a stable schema
+      // even if a subsequent newWriteBuilder call mutates lastWriteInfo.
+      val capturedInfo = info
+      val capturedWriteSchema = if (capturedInfo.updateSchema().isPresent) {
+        capturedInfo.updateSchema().get()
+      } else {
+        capturedInfo.schema()
+      }
+      new DeltaWriteBuilder {
+        override def build(): DeltaWrite =
+          new DeltaWrite with RequiresDistributionAndOrdering {
+            override def requiredDistribution(): Distribution =
+              Distributions.clustered(Array(PARTITION_COLUMN_REF))
+            override def requiredOrdering(): Array[SortOrder] = Array[SortOrder](
+              LogicalExpressions.sort(
+                PARTITION_COLUMN_REF,
+                SortDirection.ASCENDING,
+                SortDirection.ASCENDING.defaultNullOrdering()))
+            override def toBatch: DeltaBatchWrite =
+              new TestBatchWrite with DeltaBatchWrite {
+                override def createBatchWriterFactory(
+                    info: PhysicalWriteInfo): DeltaWriterFactory = {
+                  new DeltaBufferedRowsWriterFactory(capturedWriteSchema)
+                }
+
+                // For delete+reinsert with narrow writes, the REINSERT row has only the
+                // connector-declared columns (requiredDataAttributes order).
+                // pk is the first field in the write schema (declared before updatedCols).
+                // Reconstruct the full row by overlaying the narrow row onto the original.
+                override protected def doCommit(messages: Array[WriterCommitMessage]): Unit =
+                  dataMap.synchronized {
+                    val newData = messages.map(_.asInstanceOf[BufferedRows])
+                    val writeSchema = capturedWriteSchema
+                    val writeFieldIdx = writeSchema.fieldNames.zipWithIndex.toMap
+                    val reinsertOpName = UTF8String.fromString(Reinsert.toString)
+                    val pkIdx = writeFieldIdx("pk")
+
+                    val expandedData = newData.map { buf =>
+                      val expanded = new BufferedRows(buf.key, schema)
+                      buf.log.foreach { logRow =>
+                        val opName = logRow.getUTF8String(0)
+                        if (opName == reinsertOpName) {
+                          val narrowRow = logRow.get(3, writeSchema).asInstanceOf[InternalRow]
+                          val pk = narrowRow.getInt(pkIdx)
+                          val baseRow = dataMap.values.iterator.flatten
+                            .flatMap(_.rows)
+                            .find(r => r.getInt(schema.fieldIndex("pk")) == pk)
+                          val fullRow = new GenericInternalRow(schema.length)
+                          baseRow.foreach { base =>
+                            for (i <- schema.fields.indices) {
+                              fullRow.update(i, base.get(i, schema.fields(i).dataType))
+                            }
+                          }
+                          schema.fields.zipWithIndex.foreach { case (field, i) =>
+                            writeFieldIdx.get(field.name).foreach { j =>
+                              fullRow.update(i, narrowRow.get(j, field.dataType))
+                            }
+                          }
+                          expanded.rows.append(fullRow)
+                        }
+                      }
+                      expanded
+                    }
+
+                    withDeletes(newData)
+                    withData(expandedData)
+                    lastWriteLog = newData.flatMap(buffer => buffer.log).toIndexedSeq
+                  }
+
+                override def abort(messages: Array[WriterCommitMessage]): Unit = {}
+              }
+          }
+      }
+    }
+  }
+
+  class PartitionBasedColumnUpdateOperation(
+      command: Command,
+      updatedCols: Seq[NamedReference] = Nil)
+      extends RowLevelOperation with SupportsColumnUpdates {
+    var configuredScan: InMemoryBatchScan = _
+
+    override def command(): Command = command
+
+    override def requiredDataAttributes(): Array[NamedReference] = {
+      val base = Seq(FieldReference("pk"), FieldReference("dep"))
+      val baseNames = base.map(_.describe()).toSet
+      (base ++ updatedCols.filterNot(r => baseNames.contains(r.describe()))).toArray
+    }
+
+    override def requiredMetadataAttributes(): Array[NamedReference] =
+      Array(PARTITION_COLUMN_REF, INDEX_COLUMN_REF)
+
+    override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+      new InMemoryScanBuilder(schema, options) {
+        override def build(): Scan = {
+          val scan = super.build()
+          InMemoryRowLevelOperationTable.recordLastScanSchema(scan.readSchema())
+          configuredScan = scan.asInstanceOf[InMemoryBatchScan]
+          scan
+        }
+      }
+    }
+
+    override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
+      lastWriteInfo = info
+      new WriteBuilder {
+        override def build(): Write = new Write with RequiresDistributionAndOrdering {
+          override def requiredDistribution: Distribution =
+            Distributions.clustered(Array(PARTITION_COLUMN_REF))
+
+          override def requiredOrdering: Array[SortOrder] = Array[SortOrder](
+            LogicalExpressions.sort(
+              PARTITION_COLUMN_REF,
+              SortDirection.ASCENDING,
+              SortDirection.ASCENDING.defaultNullOrdering()))
+
+          override def toBatch: BatchWrite = {
+            val narrowSchema = if (info.updateSchema().isPresent) {
+              info.updateSchema().get()
+            } else {
+              info.schema()
+            }
+            PartitionBasedNarrowReplaceData(configuredScan, narrowSchema, info.schema())
+          }
+
+          override def description: String = "InMemoryNarrowCoWWrite"
+        }
+      }
+    }
+
+    override def description(): String = "InMemoryPartitionColumnUpdateOperation"
+  }
+
+  // CoW write handler for narrow column-update writes.
+  // Narrow rows (UPDATE/COPY) are sent via writeUpdate, wide rows (INSERT) via write.
+  // Both arrive in the same buffer; rows are routed by the operation tag in the log entry,
+  // which lets tests assert that Spark dispatched through the correct writer method.
+  private case class PartitionBasedNarrowReplaceData(
+      scan: InMemoryBatchScan,
+      writeSchema: StructType,
+      fullSchema: StructType) extends TestBatchWrite {
+
+    override protected def doCommit(
+        messages: Array[WriterCommitMessage]): Unit = dataMap.synchronized {
+      val newData = messages.map(_.asInstanceOf[BufferedRows])
+      val readRows = scan.data.flatMap(_.asInstanceOf[BufferedRows].rows)
+      val readPartitions = readRows.map(r => getKey(r, schema)).distinct
+      dataMap --= readPartitions
+      replacedPartitions = readPartitions
+
+      val writeFieldIdx = writeSchema.fieldNames.zipWithIndex.toMap
+      val pkIdxInWrite = writeFieldIdx("pk")
+      val pkIdxInFull = schema.fieldIndex("pk")
+      val writeUpdateOpName = UTF8String.fromString(WriteUpdate.toString)
+
+      val expandedData = newData.map { buf =>
+        val expanded = new BufferedRows(buf.key, schema)
+        // Walk the log so we can route on the operation tag (Write vs WriteUpdate).
+        // buf.rows contains rows in the same order as the log; iterate together.
+        buf.log.zip(buf.rows).foreach { case (logEntry, row) =>
+          val opName = logEntry.getUTF8String(0)
+          if (opName == writeUpdateOpName) {
+            // UPDATE/COPY narrow row: look up base row by pk, overlay narrow values
+            val pk = row.getInt(pkIdxInWrite)
+            val origRow = readRows.find(r => r.getInt(pkIdxInFull) == pk)
+            val fullRow = new GenericInternalRow(schema.length)
+            origRow.foreach { base =>
+              for (i <- schema.fields.indices) {
+                fullRow.update(i, base.get(i, schema.fields(i).dataType))
+              }
+            }
+            schema.fields.zipWithIndex.foreach { case (field, i) =>
+              writeFieldIdx.get(field.name).foreach { j =>
+                fullRow.update(i, row.get(j, field.dataType))
+              }
+            }
+            expanded.rows.append(fullRow)
+          } else {
+            // INSERT row: full schema, append directly aligned to table schema
+            val fullRow = new GenericInternalRow(schema.length)
+            schema.fields.zipWithIndex.foreach { case (field, i) =>
+              val srcIdx = fullSchema.fieldIndex(field.name)
+              fullRow.update(i, row.get(srcIdx, field.dataType))
+            }
+            expanded.rows.append(fullRow)
+          }
+        }
+        expanded
+      }
+
+      withData(expandedData, schema)
+      lastWriteLog = newData.flatMap(buffer => buffer.log).toImmutableArraySeq
     }
   }
 
@@ -321,6 +679,21 @@ private class DeltaBufferWriter(schema: StructType) extends BufferWriter(schema)
 }
 
 object InMemoryRowLevelOperationTable {
+  // Global holder for the scan schema of the last row-level operation. See the class-level
+  // `lastScanSchema` def for why this is a companion-object field rather than a per-instance one.
+  // Tests that assert on scan narrowing should reset this before running the operation under test
+  // (see `RowLevelOperationSuiteBase.beforeEach`).
+  private[catalog] val lastScanSchemaRef: java.util.concurrent.atomic.AtomicReference[StructType] =
+    new java.util.concurrent.atomic.AtomicReference[StructType]()
+
+  /** Called by test-only scan builders on every scan build. Overwrites; tests reset between cases. */
+  private[catalog] def recordLastScanSchema(schema: StructType): Unit = {
+    lastScanSchemaRef.set(schema)
+  }
+
+  /** Called by test setup to clear the last recorded scan schema between test cases. */
+  def resetLastScanSchema(): Unit = lastScanSchemaRef.set(null)
+
   def withColumns(
       name: String,
       columns: Array[Column],

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
@@ -85,6 +85,8 @@ class InMemoryRowLevelOperationTable private (
   private final val COLUMN_UPDATE_FROM_INFO = "column-update-from-info"
   private final val COLUMN_UPDATE_SPLIT = "column-update-split"
   private final val COLUMN_UPDATE_EMPTY_REQ_ATTRS = "column-update-empty-req-attrs"
+  private final val COLUMN_UPDATE_SCAN_ONLY = "column-update-scan-only"
+  private final val COLUMN_UPDATE_OVERLAP = "column-update-overlap"
 
   // used in row-level operation tests to verify replaced partitions
   var replacedPartitions: Seq[Seq[Any]] = Seq.empty
@@ -154,6 +156,10 @@ class InMemoryRowLevelOperationTable private (
       () => new PartitionBasedColumnUpdateOperation(info.command, info.updatedColumns().toSeq)
     } else if (properties.getOrDefault(COLUMN_UPDATE_SPLIT, "false") == "true") {
       () => new DeltaBasedColumnUpdateSplitOperation(info.command, info.updatedColumns().toSeq)
+    } else if (properties.getOrDefault(COLUMN_UPDATE_SCAN_ONLY, "false") == "true") {
+      () => new DeltaBasedColumnUpdateScanOnlyOperation(info.command, info.updatedColumns().toSeq)
+    } else if (properties.getOrDefault(COLUMN_UPDATE_OVERLAP, "false") == "true") {
+      () => new DeltaBasedColumnUpdateOverlapOperation(info.command, info.updatedColumns().toSeq)
     } else if (properties.getOrDefault(SUPPORTS_DELTAS, "false") == "true") {
       () => DeltaBasedOperation(info.command, info.options)
     } else {
@@ -307,6 +313,13 @@ class InMemoryRowLevelOperationTable private (
       else (pk +: updatedCols).toArray
     }
 
+    override def scanOnlyDataAttributes(): Array[NamedReference] = {
+      val required = requiredDataAttributes().map(_.describe()).toSet
+      if (required.contains("dep")) Array.empty else Array(FieldReference("dep"))
+    }
+
+    protected def clusterColumnRef: NamedReference = PARTITION_COLUMN_REF
+
     override def newWriteBuilder(info: LogicalWriteInfo): DeltaWriteBuilder = {
       lastWriteInfo = info
       // Capture info into a local val so nested writer/commit closures see a stable schema
@@ -322,13 +335,13 @@ class InMemoryRowLevelOperationTable private (
           new DeltaWrite with RequiresDistributionAndOrdering {
 
             override def requiredDistribution(): Distribution = {
-              Distributions.clustered(Array(PARTITION_COLUMN_REF))
+              Distributions.clustered(Array(clusterColumnRef))
             }
 
             override def requiredOrdering(): Array[SortOrder] = {
               Array[SortOrder](
                 LogicalExpressions.sort(
-                  PARTITION_COLUMN_REF,
+                  clusterColumnRef,
                   SortDirection.ASCENDING,
                   SortDirection.ASCENDING.defaultNullOrdering())
               )
@@ -405,6 +418,34 @@ class InMemoryRowLevelOperationTable private (
       command: Command,
       updatedCols: Seq[NamedReference])
       extends DeltaBasedColumnUpdateOperation(command, updatedCols) {
+  }
+
+  // Declares `dep` as the write-side clustering key via `scanOnlyDataAttributes()`. `dep` must be
+  // present in the narrow scan / write query for `RequiresDistributionAndOrdering` to resolve it,
+  // but is excluded from `requiredDataAttributes()` so it never reaches the writer.
+  class DeltaBasedColumnUpdateScanOnlyOperation(
+      command: Command,
+      updatedCols: Seq[NamedReference] = Nil)
+      extends DeltaBasedColumnUpdateOperation(command, updatedCols) {
+    private final val DEP_COLUMN_REF = FieldReference("dep")
+
+    override def scanOnlyDataAttributes(): Array[NamedReference] = Array(DEP_COLUMN_REF)
+
+    override protected def clusterColumnRef: NamedReference = DEP_COLUMN_REF
+  }
+
+  // Test-only: declares `dep` in both `requiredDataAttributes()` and
+  // `scanOnlyDataAttributes()` so we can verify Spark rejects the overlapping contract.
+  class DeltaBasedColumnUpdateOverlapOperation(
+      command: Command,
+      updatedCols: Seq[NamedReference] = Nil)
+      extends DeltaBasedColumnUpdateOperation(command, updatedCols) {
+    private final val DEP_COLUMN_REF = FieldReference("dep")
+
+    override def requiredDataAttributes(): Array[NamedReference] =
+      super.requiredDataAttributes() :+ DEP_COLUMN_REF
+
+    override def scanOnlyDataAttributes(): Array[NamedReference] = Array(DEP_COLUMN_REF)
   }
 
   class DeltaBasedColumnUpdateSplitOperation(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
@@ -538,7 +538,9 @@ class InMemoryRowLevelOperationTable private (
             } else {
               info.schema()
             }
-            PartitionBasedNarrowReplaceData(configuredScan, narrowSchema, info.schema())
+            // info.schema() is empty for column-update UPDATE writes (no INSERT rows);
+            // use the table schema to align any INSERT-tagged rows.
+            PartitionBasedNarrowReplaceData(configuredScan, narrowSchema, schema)
           }
 
           override def description: String = "InMemoryNarrowCoWWrite"

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
@@ -73,17 +73,8 @@ class InMemoryRowLevelOperationTable private (
   private final val noMetadata = properties.getOrDefault(NO_METADATA, "false") == "true"
   private final val COLUMN_UPDATE = "column-update"
   private final val COLUMN_UPDATE_REQ_ATTRS = "column-update-req-attrs"
-  // Selects PartitionBasedColumnUpdateOperation: CoW connector with supportsColumnUpdates=true
-  // and requiredDataAttributes=[pk,dep].
   private final val COLUMN_UPDATE_COW = "column-update-cow"
-  // Selects DeltaBasedColumnUpdateOperationFromInfo: connector that derives
-  // requiredDataAttributes() dynamically from RowLevelOperationInfo.updatedColumns().
-  // Always adds "pk" for row lookup plus whatever Spark reports as updated.
   private final val COLUMN_UPDATE_FROM_INFO = "column-update-from-info"
-  // Selects DeltaBasedColumnUpdateSplitOperation: delta connector with
-  // representUpdateAsDeleteAndInsert=true AND supportsColumnUpdates=true.
-  // Used to verify Point 7: the restriction on column updates for the delete+reinsert path
-  // has been lifted.
   private final val COLUMN_UPDATE_SPLIT = "column-update-split"
 
   // used in row-level operation tests to verify replaced partitions
@@ -341,23 +332,11 @@ class InMemoryRowLevelOperationTable private (
     }
   }
 
-  // A variant of DeltaBasedColumnUpdateOperation that overrides requiredDataAttributes()
-  // to declare a fixed set of data columns the connector needs in the scan.  This exercises
-  // the connector-driven scan-narrowing path (as opposed to the heuristic path).
   class DeltaBasedColumnUpdateOperationWithReqAttrs(command: Command, reqCols: Array[String])
       extends DeltaBasedColumnUpdateOperation(command) {
     override def requiredDataAttributes(): Array[NamedReference] = reqCols.map(FieldReference(_))
   }
 
-  // A delta-based column-update connector that derives requiredDataAttributes() dynamically
-  // from RowLevelOperationInfo.updatedColumns().
-  //
-  // This models the common connector pattern:
-  //   1. Spark tells the connector which columns are being updated via updatedColumns().
-  //   2. The connector adds any extra columns it always needs (here: "pk" for row lookup).
-  //   3. The combined set is returned from requiredDataAttributes() so Spark narrows the scan.
-  //
-  // If "pk" is already in updatedColumns (the user is updating pk itself), it is not duplicated.
   class DeltaBasedColumnUpdateOperationFromInfo(
       command: Command,
       updatedCols: Seq[NamedReference])
@@ -375,13 +354,6 @@ class InMemoryRowLevelOperationTable private (
     }
   }
 
-  // A delta-based operation that combines representUpdateAsDeleteAndInsert=true with
-  // supportsColumnUpdates()=true.  This verifies that the restriction which previously
-  // blocked column-level updates on the delete+reinsert path has been lifted.
-  //
-  // The connector declares "pk" plus any columns being updated (via updatedCols).
-  // The write schema = requiredDataAttributes() in declared order.
-  // The REINSERT leg receives the narrow write row; the DELETE leg uses row ID only.
   class DeltaBasedColumnUpdateSplitOperation(
       command: Command,
       updatedCols: Seq[NamedReference] = Nil)
@@ -464,11 +436,6 @@ class InMemoryRowLevelOperationTable private (
     }
   }
 
-  // A CoW operation that supports column-level updates.  The connector declares it needs
-  // "pk" and "dep" for partition routing, plus any columns the user is updating (via
-  // updatedCols from RowLevelOperationInfo).  supportsColumnUpdates()=true so Spark narrows
-  // the scan and write schema to exactly requiredDataAttributes().
-  // The commit logic reconstructs full rows from the original scan data using pk as a key.
   class PartitionBasedColumnUpdateOperation(
       command: Command,
       updatedCols: Seq[NamedReference] = Nil) extends RowLevelOperation {
@@ -479,8 +446,6 @@ class InMemoryRowLevelOperationTable private (
     override def supportsColumnUpdates(): Boolean = true
 
     override def requiredDataAttributes(): Array[NamedReference] = {
-      // Always need pk (for row lookup) and dep (partition key).
-      // Also include any columns being updated so Spark sends their new values.
       val base = Seq(FieldReference("pk"), FieldReference("dep"))
       val baseNames = base.map(_.describe()).toSet
       (base ++ updatedCols.filterNot(r => baseNames.contains(r.describe()))).toArray

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
@@ -71,18 +71,49 @@ class InMemoryRowLevelOperationTable private (
   private final val SPLIT_UPDATES = "split-updates"
   private final val NO_METADATA = "no-metadata"
   private final val noMetadata = properties.getOrDefault(NO_METADATA, "false") == "true"
+  private final val COLUMN_UPDATE = "column-update"
+  private final val COLUMN_UPDATE_REQ_ATTRS = "column-update-req-attrs"
+  // Selects PartitionBasedColumnUpdateOperation: CoW connector with supportsColumnUpdates=true
+  // and requiredDataAttributes=[pk,dep].
+  private final val COLUMN_UPDATE_COW = "column-update-cow"
+  // Selects DeltaBasedColumnUpdateOperationFromInfo: connector that derives
+  // requiredDataAttributes() dynamically from RowLevelOperationInfo.updatedColumns().
+  // Always adds "pk" for row lookup plus whatever Spark reports as updated.
+  private final val COLUMN_UPDATE_FROM_INFO = "column-update-from-info"
+  // Selects DeltaBasedColumnUpdateSplitOperation: delta connector with
+  // representUpdateAsDeleteAndInsert=true AND supportsColumnUpdates=true.
+  // Used to verify Point 7: the restriction on column updates for the delete+reinsert path
+  // has been lifted.
+  private final val COLUMN_UPDATE_SPLIT = "column-update-split"
 
   // used in row-level operation tests to verify replaced partitions
   var replacedPartitions: Seq[Seq[Any]] = Seq.empty
   // used in row-level operation tests to verify reported write schema
   var lastWriteInfo: LogicalWriteInfo = _
+  // used in column-update tests to verify the scan projection was narrowed correctly
+  var lastScanSchema: StructType = _
+  // used in column-update tests to verify that Spark passed the correct updated column list
+  // to the connector via RowLevelOperationInfo.updatedColumns()
+  var lastUpdatedColumns: Array[NamedReference] = Array.empty
   // used in row-level operation tests to verify passed records
   // (operation, id, metadata, row)
   var lastWriteLog: Seq[InternalRow] = Seq.empty
 
   override def newRowLevelOperationBuilder(
       info: RowLevelOperationInfo): RowLevelOperationBuilder = {
-    if (properties.getOrDefault(SUPPORTS_DELTAS, "false") == "true") {
+    lastUpdatedColumns = info.updatedColumns()
+    if (properties.getOrDefault(COLUMN_UPDATE, "false") == "true") {
+      () => new DeltaBasedColumnUpdateOperation(info.command)
+    } else if (properties.containsKey(COLUMN_UPDATE_REQ_ATTRS)) {
+      val reqCols = properties.get(COLUMN_UPDATE_REQ_ATTRS).split(",").map(_.trim)
+      () => new DeltaBasedColumnUpdateOperationWithReqAttrs(info.command, reqCols)
+    } else if (properties.getOrDefault(COLUMN_UPDATE_FROM_INFO, "false") == "true") {
+      () => new DeltaBasedColumnUpdateOperationFromInfo(info.command, info.updatedColumns().toSeq)
+    } else if (properties.getOrDefault(COLUMN_UPDATE_COW, "false") == "true") {
+      () => new PartitionBasedColumnUpdateOperation(info.command, info.updatedColumns().toSeq)
+    } else if (properties.getOrDefault(COLUMN_UPDATE_SPLIT, "false") == "true") {
+      () => new DeltaBasedColumnUpdateSplitOperation(info.command, info.updatedColumns().toSeq)
+    } else if (properties.getOrDefault(SUPPORTS_DELTAS, "false") == "true") {
       () => DeltaBasedOperation(info.command)
     } else {
       () => PartitionBasedOperation(info.command)
@@ -213,6 +244,327 @@ class InMemoryRowLevelOperationTable private (
 
     override def representUpdateAsDeleteAndInsert(): Boolean = {
       properties.getOrDefault(SPLIT_UPDATES, "false").toBoolean
+    }
+  }
+
+  // A delta-based operation that supports column-level updates: Spark sends only the
+  // assigned/changed columns in the row projection instead of the full row schema.
+  class DeltaBasedColumnUpdateOperation(command: Command)
+      extends DeltaBasedOperation(command) {
+    override def representUpdateAsDeleteAndInsert(): Boolean = false
+    override def supportsColumnUpdates(): Boolean = true
+
+    // Override newScanBuilder to record the schema that Spark actually requests from the
+    // connector after column pruning, so tests can assert on scan narrowing.
+    override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+      new InMemoryScanBuilder(schema, options) {
+        override def build(): Scan = {
+          val scan = super.build()
+          lastScanSchema = scan.readSchema()
+          scan
+        }
+      }
+    }
+
+    override def newWriteBuilder(info: LogicalWriteInfo): DeltaWriteBuilder = {
+      lastWriteInfo = info
+      new DeltaWriteBuilder {
+        override def build(): DeltaWrite =
+          new DeltaWrite with RequiresDistributionAndOrdering {
+
+            override def requiredDistribution(): Distribution = {
+              Distributions.clustered(Array(PARTITION_COLUMN_REF))
+            }
+
+            override def requiredOrdering(): Array[SortOrder] = {
+              Array[SortOrder](
+                LogicalExpressions.sort(
+                  PARTITION_COLUMN_REF,
+                  SortDirection.ASCENDING,
+                  SortDirection.ASCENDING.defaultNullOrdering())
+              )
+            }
+
+            override def toBatch: DeltaBatchWrite =
+              new RowLevelOperationBatchWrite with DeltaBatchWrite {
+                override def createBatchWriterFactory(
+                    info: PhysicalWriteInfo): DeltaWriterFactory = {
+                  new DeltaBufferedRowsWriterFactory(lastWriteInfo.schema())
+                }
+
+                // For column-update writes, rows contain only the assigned columns
+                // (narrow schema from LogicalWriteInfo). We expand each row to the full table
+                // schema by overlaying write-schema columns on the base row found by pk.
+                override def commit(messages: Array[WriterCommitMessage]): Unit =
+                  dataMap.synchronized {
+                    val newData = messages.map(_.asInstanceOf[BufferedRows])
+                    val writeSchema = lastWriteInfo.schema()
+                    val writeFieldIdx = writeSchema.fieldNames.zipWithIndex.toMap
+
+                    val mergedData = newData.map { buf =>
+                      val merged = new BufferedRows(buf.key, schema)
+                      val updateOpName = UTF8String.fromString(Update.toString)
+                      buf.log.foreach { logRow =>
+                        val opName = logRow.getUTF8String(0)
+                        if (opName == updateOpName) {
+                          val pk = logRow.getInt(1)
+                          val narrowRow = logRow.get(3, writeSchema).asInstanceOf[InternalRow]
+                          val baseRow = dataMap.values.iterator.flatten
+                            .flatMap(_.rows)
+                            .find(r => r.getInt(schema.fieldIndex("pk")) == pk)
+                          val fullRow = new GenericInternalRow(schema.length)
+                          baseRow.foreach { base =>
+                            for (i <- schema.fields.indices) {
+                              fullRow.update(i, base.get(i, schema(i).dataType))
+                            }
+                          }
+                          schema.fields.zipWithIndex.foreach { case (field, i) =>
+                            writeFieldIdx.get(field.name).foreach { j =>
+                              fullRow.update(i, narrowRow.get(j, field.dataType))
+                            }
+                          }
+                          merged.rows.append(fullRow)
+                        }
+                      }
+                      merged
+                    }
+
+                    withDeletes(newData)
+                    withData(mergedData)
+                    lastWriteLog = newData.flatMap(buffer => buffer.log).toIndexedSeq
+                  }
+
+                override def abort(messages: Array[WriterCommitMessage]): Unit = {}
+              }
+          }
+      }
+    }
+  }
+
+  // A variant of DeltaBasedColumnUpdateOperation that overrides requiredDataAttributes()
+  // to declare a fixed set of data columns the connector needs in the scan.  This exercises
+  // the connector-driven scan-narrowing path (as opposed to the heuristic path).
+  class DeltaBasedColumnUpdateOperationWithReqAttrs(command: Command, reqCols: Array[String])
+      extends DeltaBasedColumnUpdateOperation(command) {
+    override def requiredDataAttributes(): Array[NamedReference] = reqCols.map(FieldReference(_))
+  }
+
+  // A delta-based column-update connector that derives requiredDataAttributes() dynamically
+  // from RowLevelOperationInfo.updatedColumns().
+  //
+  // This models the common connector pattern:
+  //   1. Spark tells the connector which columns are being updated via updatedColumns().
+  //   2. The connector adds any extra columns it always needs (here: "pk" for row lookup).
+  //   3. The combined set is returned from requiredDataAttributes() so Spark narrows the scan.
+  //
+  // If "pk" is already in updatedColumns (the user is updating pk itself), it is not duplicated.
+  class DeltaBasedColumnUpdateOperationFromInfo(
+      command: Command,
+      updatedCols: Seq[NamedReference])
+      extends DeltaBasedColumnUpdateOperation(command) {
+
+    private val PK_REF: NamedReference = FieldReference("pk")
+
+    override def requiredDataAttributes(): Array[NamedReference] = {
+      val updatedNames = updatedCols.map(_.describe()).toSet
+      if (updatedNames.contains("pk")) {
+        updatedCols.toArray
+      } else {
+        (Array(PK_REF) ++ updatedCols).toArray
+      }
+    }
+  }
+
+  // A delta-based operation that combines representUpdateAsDeleteAndInsert=true with
+  // supportsColumnUpdates()=true.  This verifies that the restriction which previously
+  // blocked column-level updates on the delete+reinsert path has been lifted.
+  //
+  // The connector declares "pk" plus any columns being updated (via updatedCols).
+  // The write schema = requiredDataAttributes() in declared order.
+  // The REINSERT leg receives the narrow write row; the DELETE leg uses row ID only.
+  class DeltaBasedColumnUpdateSplitOperation(
+      command: Command,
+      updatedCols: Seq[NamedReference] = Nil)
+      extends DeltaBasedColumnUpdateOperation(command) {
+    override def representUpdateAsDeleteAndInsert(): Boolean = true
+
+    private val PK_REF: NamedReference = FieldReference("pk")
+    override def requiredDataAttributes(): Array[NamedReference] = {
+      val updatedNames = updatedCols.map(_.describe()).toSet
+      if (updatedNames.contains("pk")) updatedCols.toArray
+      else (Array(PK_REF) ++ updatedCols).toArray
+    }
+
+    override def newWriteBuilder(info: LogicalWriteInfo): DeltaWriteBuilder = {
+      lastWriteInfo = info
+      new DeltaWriteBuilder {
+        override def build(): DeltaWrite =
+          new DeltaWrite with RequiresDistributionAndOrdering {
+            override def requiredDistribution(): Distribution =
+              Distributions.clustered(Array(PARTITION_COLUMN_REF))
+            override def requiredOrdering(): Array[SortOrder] = Array[SortOrder](
+              LogicalExpressions.sort(
+                PARTITION_COLUMN_REF,
+                SortDirection.ASCENDING,
+                SortDirection.ASCENDING.defaultNullOrdering()))
+            override def toBatch: DeltaBatchWrite =
+              new RowLevelOperationBatchWrite with DeltaBatchWrite {
+                override def createBatchWriterFactory(
+                    info: PhysicalWriteInfo): DeltaWriterFactory =
+                  new DeltaBufferedRowsWriterFactory(lastWriteInfo.schema())
+
+                // For delete+reinsert with narrow writes, the REINSERT row has only the
+                // connector-declared columns (requiredDataAttributes order).
+                // pk is the first field in the write schema (declared before updatedCols).
+                // Reconstruct the full row by overlaying the narrow row onto the original.
+                override def commit(messages: Array[WriterCommitMessage]): Unit =
+                  dataMap.synchronized {
+                    val newData = messages.map(_.asInstanceOf[BufferedRows])
+                    val writeSchema = lastWriteInfo.schema()
+                    val writeFieldIdx = writeSchema.fieldNames.zipWithIndex.toMap
+                    val reinsertOpName = UTF8String.fromString(Reinsert.toString)
+                    val pkIdx = writeFieldIdx("pk")
+
+                    val expandedData = newData.map { buf =>
+                      val expanded = new BufferedRows(buf.key, schema)
+                      buf.log.foreach { logRow =>
+                        val opName = logRow.getUTF8String(0)
+                        if (opName == reinsertOpName) {
+                          val narrowRow = logRow.get(3, writeSchema).asInstanceOf[InternalRow]
+                          val pk = narrowRow.getInt(pkIdx)
+                          val baseRow = dataMap.values.iterator.flatten
+                            .flatMap(_.rows)
+                            .find(r => r.getInt(schema.fieldIndex("pk")) == pk)
+                          val fullRow = new GenericInternalRow(schema.length)
+                          baseRow.foreach { base =>
+                            for (i <- schema.fields.indices) {
+                              fullRow.update(i, base.get(i, schema(i).dataType))
+                            }
+                          }
+                          schema.fields.zipWithIndex.foreach { case (field, i) =>
+                            writeFieldIdx.get(field.name).foreach { j =>
+                              fullRow.update(i, narrowRow.get(j, field.dataType))
+                            }
+                          }
+                          expanded.rows.append(fullRow)
+                        }
+                      }
+                      expanded
+                    }
+
+                    withDeletes(newData)
+                    withData(expandedData)
+                    lastWriteLog = newData.flatMap(buffer => buffer.log).toIndexedSeq
+                  }
+
+                override def abort(messages: Array[WriterCommitMessage]): Unit = {}
+              }
+          }
+      }
+    }
+  }
+
+  // A CoW operation that supports column-level updates.  The connector declares it needs
+  // "pk" and "dep" for partition routing, plus any columns the user is updating (via
+  // updatedCols from RowLevelOperationInfo).  supportsColumnUpdates()=true so Spark narrows
+  // the scan and write schema to exactly requiredDataAttributes().
+  // The commit logic reconstructs full rows from the original scan data using pk as a key.
+  class PartitionBasedColumnUpdateOperation(
+      command: Command,
+      updatedCols: Seq[NamedReference] = Nil) extends RowLevelOperation {
+    var configuredScan: InMemoryBatchScan = _
+
+    override def command(): Command = command
+
+    override def supportsColumnUpdates(): Boolean = true
+
+    override def requiredDataAttributes(): Array[NamedReference] = {
+      // Always need pk (for row lookup) and dep (partition key).
+      // Also include any columns being updated so Spark sends their new values.
+      val base = Seq(FieldReference("pk"), FieldReference("dep"))
+      val baseNames = base.map(_.describe()).toSet
+      (base ++ updatedCols.filterNot(r => baseNames.contains(r.describe()))).toArray
+    }
+
+    override def requiredMetadataAttributes(): Array[NamedReference] =
+      Array(PARTITION_COLUMN_REF, INDEX_COLUMN_REF)
+
+    override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+      new InMemoryScanBuilder(schema, options) {
+        override def build(): Scan = {
+          val scan = super.build()
+          configuredScan = scan.asInstanceOf[InMemoryBatchScan]
+          lastScanSchema = scan.readSchema()
+          scan
+        }
+      }
+    }
+
+    override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
+      lastWriteInfo = info
+      new WriteBuilder {
+        override def build(): Write = new Write with RequiresDistributionAndOrdering {
+          override def requiredDistribution: Distribution =
+            Distributions.clustered(Array(PARTITION_COLUMN_REF))
+
+          override def requiredOrdering: Array[SortOrder] = Array[SortOrder](
+            LogicalExpressions.sort(
+              PARTITION_COLUMN_REF,
+              SortDirection.ASCENDING,
+              SortDirection.ASCENDING.defaultNullOrdering()))
+
+          override def toBatch: BatchWrite =
+            PartitionBasedNarrowReplaceData(configuredScan, info.schema())
+
+          override def description: String = "InMemoryNarrowCoWWrite"
+        }
+      }
+    }
+
+    override def description(): String = "InMemoryPartitionColumnUpdateOperation"
+  }
+
+  // CoW write handler for narrow column-update writes.
+  // Receives rows with only the connector-declared + assigned columns.
+  // Reconstructs full rows by looking up the original row by pk and overlaying received columns.
+  private case class PartitionBasedNarrowReplaceData(
+      scan: InMemoryBatchScan,
+      writeSchema: StructType) extends RowLevelOperationBatchWrite {
+
+    override def commit(messages: Array[WriterCommitMessage]): Unit = dataMap.synchronized {
+      val newData = messages.map(_.asInstanceOf[BufferedRows])
+      val readRows = scan.data.flatMap(_.asInstanceOf[BufferedRows].rows)
+      val readPartitions = readRows.map(r => getKey(r, schema)).distinct
+      dataMap --= readPartitions
+      replacedPartitions = readPartitions
+
+      val writeFieldIdx = writeSchema.fieldNames.zipWithIndex.toMap
+      val pkIdxInWrite = writeFieldIdx("pk")
+      val pkIdxInFull = schema.fieldIndex("pk")
+
+      val expandedData = newData.map { buf =>
+        val expanded = new BufferedRows(buf.key, schema)
+        buf.rows.foreach { narrowRow =>
+          val pk = narrowRow.getInt(pkIdxInWrite)
+          val origRow = readRows.find(r => r.getInt(pkIdxInFull) == pk)
+          val fullRow = new GenericInternalRow(schema.length)
+          origRow.foreach { base =>
+            for (i <- schema.fields.indices) {
+              fullRow.update(i, base.get(i, schema(i).dataType))
+            }
+          }
+          schema.fields.zipWithIndex.foreach { case (field, i) =>
+            writeFieldIdx.get(field.name).foreach { j =>
+              fullRow.update(i, narrowRow.get(j, field.dataType))
+            }
+          }
+          expanded.rows.append(fullRow)
+        }
+        expanded
+      }
+
+      withData(expandedData, schema)
+      lastWriteLog = newData.flatMap(buffer => buffer.log).toImmutableArraySeq
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
@@ -315,7 +315,7 @@ class InMemoryRowLevelOperationTable private (
                           val fullRow = new GenericInternalRow(schema.length)
                           baseRow.foreach { base =>
                             for (i <- schema.fields.indices) {
-                              fullRow.update(i, base.get(i, schema(i).dataType))
+                              fullRow.update(i, base.get(i, schema.fields(i).dataType))
                             }
                           }
                           schema.fields.zipWithIndex.foreach { case (field, i) =>
@@ -438,7 +438,7 @@ class InMemoryRowLevelOperationTable private (
                           val fullRow = new GenericInternalRow(schema.length)
                           baseRow.foreach { base =>
                             for (i <- schema.fields.indices) {
-                              fullRow.update(i, base.get(i, schema(i).dataType))
+                              fullRow.update(i, base.get(i, schema.fields(i).dataType))
                             }
                           }
                           schema.fields.zipWithIndex.foreach { case (field, i) =>
@@ -550,7 +550,7 @@ class InMemoryRowLevelOperationTable private (
           val fullRow = new GenericInternalRow(schema.length)
           origRow.foreach { base =>
             for (i <- schema.fields.indices) {
-              fullRow.update(i, base.get(i, schema(i).dataType))
+              fullRow.update(i, base.get(i, schema.fields(i).dataType))
             }
           }
           schema.fields.zipWithIndex.foreach { case (field, i) =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/txns.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/txns.scala
@@ -142,6 +142,7 @@ class TxnTable(
   override def newRowLevelOperationBuilder(
       info: RowLevelOperationInfo): RowLevelOperationBuilder = {
     catalog.writeTarget = this
+    delegate.lastUpdatedColumns = info.updatedColumns()
     super.newRowLevelOperationBuilder(info)
   }
 
@@ -158,6 +159,7 @@ class TxnTable(
     delegate.replacedPartitions = replacedPartitions
     delegate.lastWriteInfo = lastWriteInfo
     delegate.lastWriteLog = lastWriteLog
+    delegate.lastUpdatedColumns = lastUpdatedColumns
     delegate.commits ++= commits
     delegate.increaseVersion()
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/txns.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/txns.scala
@@ -112,6 +112,7 @@ class TxnTable(
   override def newRowLevelOperationBuilder(
       info: RowLevelOperationInfo): RowLevelOperationBuilder = {
     catalog.writeTarget = this
+    delegate.lastUpdatedColumns = info.updatedColumns()
     super.newRowLevelOperationBuilder(info)
   }
 
@@ -128,6 +129,8 @@ class TxnTable(
     delegate.replacedPartitions = replacedPartitions
     delegate.lastWriteInfo = lastWriteInfo
     delegate.lastWriteLog = lastWriteLog
+    delegate.lastUpdatedColumns = lastUpdatedColumns
+    delegate.lastScanSchema = lastScanSchema
     delegate.commits ++= commits
     delegate.increaseVersion()
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
@@ -176,7 +176,8 @@ abstract class FileTable(
       writeInfo.schema(),
       mergedOptions(writeInfo.options()),
       writeInfo.rowIdSchema(),
-      writeInfo.metadataSchema())
+      writeInfo.metadataSchema(),
+      writeInfo.updateSchema())
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2Writes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2Writes.scala
@@ -111,8 +111,10 @@ object V2Writes extends Rule[LogicalPlan] with PredicateHelper {
     case rd @ ReplaceData(r: DataSourceV2Relation, _, query, _, projections, _, None) =>
       val rowSchema = projections.rowProjection.schema
       val metadataSchema = projections.metadataProjection.map(_.schema)
+      val updateSchema = projections.updateRowProjection.map(_.schema)
       val writeOptions = mergeOptions(Map.empty, r.options.asCaseSensitiveMap.asScala.toMap)
-      val writeBuilder = newWriteBuilder(r.table, writeOptions, rowSchema, metadataSchema)
+      val writeBuilder = newWriteBuilder(r.table, writeOptions, rowSchema, metadataSchema,
+        updateSchema)
       val write = writeBuilder.build()
       val newQuery = DistributionAndOrderingUtils.prepareQuery(write, query, r.funCatalog)
       rd.copy(write = Some(write), query = newQuery)
@@ -164,6 +166,7 @@ object V2Writes extends Rule[LogicalPlan] with PredicateHelper {
       writeOptions: Map[String, String],
       rowSchema: StructType,
       metadataSchema: Option[StructType] = None,
+      updateSchema: Option[StructType] = None,
       queryId: String = UUID.randomUUID().toString): WriteBuilder = {
 
     val info = LogicalWriteInfoImpl(
@@ -171,7 +174,8 @@ object V2Writes extends Rule[LogicalPlan] with PredicateHelper {
       rowSchema,
       writeOptions.asOptions,
       rowIdSchema = None,
-      metadataSchema)
+      metadataSchema,
+      updateSchema)
     table.asWritable.newWriteBuilder(info)
   }
 
@@ -184,13 +188,15 @@ object V2Writes extends Rule[LogicalPlan] with PredicateHelper {
     val rowSchema = projections.rowProjection.map(_.schema).getOrElse(StructType(Nil))
     val rowIdSchema = Some(projections.rowIdProjection.schema)
     val metadataSchema = projections.metadataProjection.map(_.schema)
+    val updateSchema = projections.updateRowProjection.map(_.schema)
 
     val info = LogicalWriteInfoImpl(
       queryId,
       rowSchema,
       writeOptions.asOptions,
       rowIdSchema,
-      metadataSchema)
+      metadataSchema,
+      updateSchema)
 
     val writeBuilder = table.asWritable.newWriteBuilder(info)
     assert(writeBuilder.isInstanceOf[DeltaWriteBuilder], s"$writeBuilder must be DeltaWriteBuilder")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
@@ -385,9 +385,15 @@ case class ReplaceDataExec(
   override def writingTask: WritingSparkTask[_] = {
     projections.metadataProjection match {
       case Some(metadataProj) =>
-        DataAndMetadataWritingSparkTask(projections.rowProjection, metadataProj, sparkMetrics)
+        DataAndMetadataWritingSparkTask(
+          projections.rowProjection,
+          projections.updateRowProjection.orNull,
+          metadataProj, sparkMetrics)
       case None =>
-        DataWithProjectionWritingSparkTask(projections.rowProjection, sparkMetrics)
+        DataWithProjectionWritingSparkTask(
+          projections.rowProjection,
+          projections.updateRowProjection.orNull,
+          sparkMetrics)
     }
   }
 
@@ -771,6 +777,7 @@ trait WritingSparkTask[W <: DataWriter[InternalRow]] extends Logging with Serial
 
 case class DataAndMetadataWritingSparkTask(
     dataProj: ProjectingInternalRow,
+    updateDataProj: ProjectingInternalRow,
     metadataProj: ProjectingInternalRow,
     sparkMetrics: Map[String, SQLMetric])
   extends WritingSparkTask[DataWriter[InternalRow]] {
@@ -779,6 +786,8 @@ case class DataAndMetadataWritingSparkTask(
       writer: DataWriter[InternalRow], iter: java.util.Iterator[InternalRow]): Unit = {
     var numUpdatedRows = 0L
     var numCopiedRows = 0L
+    val proj = if (updateDataProj != null) updateDataProj else dataProj
+    val useWriteUpdate = updateDataProj != null
 
     while (iter.hasNext) {
       val row = iter.next()
@@ -787,15 +796,17 @@ case class DataAndMetadataWritingSparkTask(
       operation match {
         case UPDATE_OPERATION =>
           numUpdatedRows += 1L
-          dataProj.project(row)
+          proj.project(row)
           metadataProj.project(row)
-          writer.write(metadataProj, dataProj)
+          if (useWriteUpdate) writer.writeUpdate(metadataProj, proj)
+          else writer.write(metadataProj, proj)
 
         case COPY_OPERATION =>
           numCopiedRows += 1L
-          dataProj.project(row)
+          proj.project(row)
           metadataProj.project(row)
-          writer.write(metadataProj, dataProj)
+          if (useWriteUpdate) writer.writeUpdate(metadataProj, proj)
+          else writer.write(metadataProj, proj)
 
         case INSERT_OPERATION =>
           dataProj.project(row)
@@ -813,6 +824,7 @@ case class DataAndMetadataWritingSparkTask(
 
 case class DataWithProjectionWritingSparkTask(
     dataProj: ProjectingInternalRow,
+    updateDataProj: ProjectingInternalRow,
     sparkMetrics: Map[String, SQLMetric])
   extends WritingSparkTask[DataWriter[InternalRow]] {
 
@@ -820,6 +832,8 @@ case class DataWithProjectionWritingSparkTask(
       writer: DataWriter[InternalRow], iter: java.util.Iterator[InternalRow]): Unit = {
     var numUpdatedRows = 0L
     var numCopiedRows = 0L
+    val proj = if (updateDataProj != null) updateDataProj else dataProj
+    val useWriteUpdate = updateDataProj != null
 
     while (iter.hasNext) {
       val row = iter.next()
@@ -828,13 +842,15 @@ case class DataWithProjectionWritingSparkTask(
       operation match {
         case UPDATE_OPERATION =>
           numUpdatedRows += 1L
-          dataProj.project(row)
-          writer.write(dataProj)
+          proj.project(row)
+          if (useWriteUpdate) writer.writeUpdate(proj)
+          else writer.write(proj)
 
         case COPY_OPERATION =>
           numCopiedRows += 1L
-          dataProj.project(row)
-          writer.write(dataProj)
+          proj.project(row)
+          if (useWriteUpdate) writer.writeUpdate(proj)
+          else writer.write(proj)
 
         case INSERT_OPERATION =>
           dataProj.project(row)
@@ -863,12 +879,16 @@ case class DeltaWritingSparkTask(
   extends WritingSparkTask[DeltaWriter[InternalRow]] {
 
   private lazy val rowProjection = projections.rowProjection.orNull
+  private lazy val updateRowProjection = projections.updateRowProjection.orNull
   private lazy val rowIdProjection = projections.rowIdProjection
 
   override protected def write(
       writer: DeltaWriter[InternalRow], iter: java.util.Iterator[InternalRow]): Unit = {
     var numUpdatedRows = 0L
     var numDeletedRows = 0L
+    // UPDATE/COPY/REINSERT rows use the narrow update projection when the connector implements
+    // SupportsColumnUpdates; otherwise fall back to the full row projection.
+    val updateProj = if (updateRowProjection != null) updateRowProjection else rowProjection
 
     while (iter.hasNext) {
       val row = iter.next()
@@ -882,16 +902,16 @@ case class DeltaWritingSparkTask(
 
         case UPDATE_OPERATION =>
           numUpdatedRows += 1L
-          rowProjection.project(row)
+          updateProj.project(row)
           rowIdProjection.project(row)
-          writer.update(null, rowIdProjection, rowProjection)
+          writer.update(null, rowIdProjection, updateProj)
 
         case REINSERT_OPERATION =>
           // When representUpdateAsDeleteAndInsert is true, each logical update is split
           // into a DELETE and a REINSERT. Count the REINSERT as one updated row.
           numUpdatedRows += 1L
-          rowProjection.project(row)
-          writer.reinsert(null, rowProjection)
+          updateProj.project(row)
+          writer.reinsert(null, updateProj)
 
         case INSERT_OPERATION =>
           rowProjection.project(row)
@@ -913,6 +933,7 @@ case class DeltaWithMetadataWritingSparkTask(
   extends WritingSparkTask[DeltaWriter[InternalRow]] {
 
   private lazy val rowProjection = projections.rowProjection.orNull
+  private lazy val updateRowProjection = projections.updateRowProjection.orNull
   private lazy val rowIdProjection = projections.rowIdProjection
   private lazy val metadataProjection = projections.metadataProjection.orNull
 
@@ -920,6 +941,9 @@ case class DeltaWithMetadataWritingSparkTask(
       writer: DeltaWriter[InternalRow], iter: java.util.Iterator[InternalRow]): Unit = {
     var numUpdatedRows = 0L
     var numDeletedRows = 0L
+    // UPDATE/COPY/REINSERT rows use the narrow update projection when the connector implements
+    // SupportsColumnUpdates; otherwise fall back to the full row projection.
+    val updateProj = if (updateRowProjection != null) updateRowProjection else rowProjection
 
     while (iter.hasNext) {
       val row = iter.next()
@@ -934,18 +958,18 @@ case class DeltaWithMetadataWritingSparkTask(
 
         case UPDATE_OPERATION =>
           numUpdatedRows += 1L
-          rowProjection.project(row)
+          updateProj.project(row)
           rowIdProjection.project(row)
           metadataProjection.project(row)
-          writer.update(metadataProjection, rowIdProjection, rowProjection)
+          writer.update(metadataProjection, rowIdProjection, updateProj)
 
         case REINSERT_OPERATION =>
           // When representUpdateAsDeleteAndInsert is true, each logical update is split
           // into a DELETE and a REINSERT. Count the REINSERT as one updated row.
           numUpdatedRows += 1L
-          rowProjection.project(row)
+          updateProj.project(row)
           metadataProjection.project(row)
-          writer.reinsert(metadataProjection, rowProjection)
+          writer.reinsert(metadataProjection, updateProj)
 
         case INSERT_OPERATION =>
           rowProjection.project(row)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.sql.execution.dynamicpruning
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, DynamicPruningExpression, Expression, InSubquery, ListQuery, PredicateHelper, V2ExpressionUtils}
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, AttributeSet, DynamicPruningExpression, Expression, InSubquery, ListQuery, PredicateHelper, V2ExpressionUtils}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.optimizer.RewritePredicateSubquery
 import org.apache.spark.sql.catalyst.planning.{DeltaBasedRowLevelOperation, GroupBasedRowLevelOperation}
@@ -25,6 +26,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, LogicalPl
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.read.SupportsRuntimeV2Filtering
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command.{DELETE, MERGE, UPDATE}
+import org.apache.spark.sql.connector.write.SupportsColumnUpdates
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Implicits, DataSourceV2Relation, DataSourceV2ScanRelation, ExtractV2Scan}
 import org.apache.spark.util.ArrayImplicits._
 
@@ -103,7 +105,11 @@ class RowLevelOperationRuntimeGroupFiltering(optimizeSubqueries: Rule[LogicalPla
         // and must transform the runtime filter condition to use correct expr IDs for each relation
         // note this only applies to group-based row-level operations (i.e. ReplaceData)
         // see RewriteUpdateTable for more details
-        val attrMap = buildTableToScanAttrMap(write.table.output, relation.output)
+        val attrMap = if (write.operation.isInstanceOf[SupportsColumnUpdates]) {
+          buildNarrowTableToScanAttrMap(write.table.output, relation.output, cond.references)
+        } else {
+          buildTableToScanAttrMap(write.table.output, relation.output)
+        }
         val transformedCond = cond transform {
           case attr: AttributeReference if attrMap.contains(attr) => attrMap(attr)
         }
@@ -138,14 +144,41 @@ class RowLevelOperationRuntimeGroupFiltering(optimizeSubqueries: Rule[LogicalPla
       tableAttrs: Seq[Attribute],
       scanAttrs: Seq[Attribute]): AttributeMap[Attribute] = {
 
-    // Only map tableAttrs that have a matching scan attribute. Callers consume this map via
-    // `attrMap.contains(attr)`, so an entry is only useful when it actually exists; missing
-    // entries are legitimately absent from the (potentially narrowed) column-update scan and
-    // do not need to be mapped.
-    val attrMapping = tableAttrs.flatMap { tableAttr =>
+    val attrMapping = tableAttrs.map { tableAttr =>
       scanAttrs
         .find(scanAttr => conf.resolver(scanAttr.name, tableAttr.name))
         .map(scanAttr => tableAttr -> scanAttr)
+        .getOrElse {
+          throw new AnalysisException(
+            errorClass = "_LEGACY_ERROR_TEMP_3075",
+            messageParameters = Map(
+              "tableAttr" -> tableAttr.toString,
+              "scanAttrs" -> scanAttrs.mkString(",")))
+        }
+    }
+    AttributeMap(attrMapping)
+  }
+
+  /**
+   * Variant of `buildTableToScanAttrMap` for the `SupportsColumnUpdates` narrow-scan path.
+   * Table columns dropped from the narrow scan are legitimately absent and silently skipped.
+   * Only attributes referenced by the group-filter condition are required to resolve.
+   */
+  private def buildNarrowTableToScanAttrMap(
+      tableAttrs: Seq[Attribute],
+      scanAttrs: Seq[Attribute],
+      condRefs: AttributeSet): AttributeMap[Attribute] = {
+
+    val attrMapping = tableAttrs.flatMap { tableAttr =>
+      val matched = scanAttrs.find(scanAttr => conf.resolver(scanAttr.name, tableAttr.name))
+      if (matched.isEmpty && condRefs.contains(tableAttr)) {
+        throw new AnalysisException(
+          errorClass = "_LEGACY_ERROR_TEMP_3075",
+          messageParameters = Map(
+            "tableAttr" -> tableAttr.toString,
+            "scanAttrs" -> scanAttrs.mkString(",")))
+      }
+      matched.map(scanAttr => tableAttr -> scanAttr)
     }
     AttributeMap(attrMapping)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.dynamicpruning
 
-import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, DynamicPruningExpression, Expression, InSubquery, ListQuery, PredicateHelper, V2ExpressionUtils}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.optimizer.RewritePredicateSubquery
@@ -139,17 +138,14 @@ class RowLevelOperationRuntimeGroupFiltering(optimizeSubqueries: Rule[LogicalPla
       tableAttrs: Seq[Attribute],
       scanAttrs: Seq[Attribute]): AttributeMap[Attribute] = {
 
-    val attrMapping = tableAttrs.map { tableAttr =>
+    // Only map tableAttrs that have a matching scan attribute. Callers consume this map via
+    // `attrMap.contains(attr)`, so an entry is only useful when it actually exists; missing
+    // entries are legitimately absent from the (potentially narrowed) column-update scan and
+    // do not need to be mapped.
+    val attrMapping = tableAttrs.flatMap { tableAttr =>
       scanAttrs
         .find(scanAttr => conf.resolver(scanAttr.name, tableAttr.name))
         .map(scanAttr => tableAttr -> scanAttr)
-        .getOrElse {
-          throw new AnalysisException(
-            errorClass = "_LEGACY_ERROR_TEMP_3075",
-            messageParameters = Map(
-              "tableAttr" -> tableAttr.toString,
-              "scanAttrs" -> scanAttrs.mkString(",")))
-        }
     }
     AttributeMap(attrMapping)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.dynamicpruning
 
-import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, DynamicPruningExpression, Expression, InSubquery, ListQuery, PredicateHelper, V2ExpressionUtils}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.optimizer.RewritePredicateSubquery
@@ -139,17 +138,13 @@ class RowLevelOperationRuntimeGroupFiltering(optimizeSubqueries: Rule[LogicalPla
       tableAttrs: Seq[Attribute],
       scanAttrs: Seq[Attribute]): AttributeMap[Attribute] = {
 
-    val attrMapping = tableAttrs.map { tableAttr =>
+    // For column-level updates, the scan may be narrowed to exclude columns that the
+    // connector does not need.  Skip table attributes that are absent from the scan
+    // instead of throwing -- they cannot appear in the condition if they were pruned.
+    val attrMapping = tableAttrs.flatMap { tableAttr =>
       scanAttrs
         .find(scanAttr => conf.resolver(scanAttr.name, tableAttr.name))
         .map(scanAttr => tableAttr -> scanAttr)
-        .getOrElse {
-          throw new AnalysisException(
-            errorClass = "_LEGACY_ERROR_TEMP_3075",
-            messageParameters = Map(
-              "tableAttr" -> tableAttr.toString,
-              "scanAttrs" -> scanAttrs.mkString(",")))
-        }
     }
     AttributeMap(attrMapping)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
@@ -138,9 +138,9 @@ class RowLevelOperationRuntimeGroupFiltering(optimizeSubqueries: Rule[LogicalPla
       tableAttrs: Seq[Attribute],
       scanAttrs: Seq[Attribute]): AttributeMap[Attribute] = {
 
-    // For column-level updates, the scan may be narrowed to exclude columns that the
-    // connector does not need.  Skip table attributes that are absent from the scan
-    // instead of throwing -- they cannot appear in the condition if they were pruned.
+    // The scan may be narrowed to exclude columns not needed by the connector.
+    // Attributes absent from the scan are skipped here; the caller must ensure
+    // that any attribute referenced in the condition is present in the scan.
     val attrMapping = tableAttrs.flatMap { tableAttr =>
       scanAttrs
         .find(scanAttr => conf.resolver(scanAttr.name, tableAttr.name))

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
@@ -525,7 +525,8 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
 
   test("column-update: analysis fails when assignment key is outside requiredDataAttributes") {
     // Connector declares only [pk] but the user assigns to `id`. We enforce
-    // updatedColumns ⊆ requiredDataAttributes at analysis time (root-column granularity).
+    // updatedColumns is a subset of requiredDataAttributes at analysis time
+    // (root-column granularity).
     createAndInitTableWithReqAttrs("pk", "pk INT NOT NULL, id INT, dep STRING",
       """{ "pk": 1, "id": 1, "dep": "hr" }""".stripMargin)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
@@ -182,6 +182,23 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
       s"dep must not be in update schema: $updateSchema")
   }
 
+  test("column-update: nested field identity update reports root struct as updated") {
+    createAndInitTable("pk INT NOT NULL, s STRUCT<c1: INT, c2: INT>, dep STRING",
+      """{ "pk": 1, "s": { "c1": 1, "c2": 2 }, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET s.c1 = s.c1 WHERE pk = 1")
+
+    val updatedNames = table.lastUpdatedColumns.map(_.describe()).toSet
+    assert(updatedNames == Set("s"),
+      s"nested identity is reported as an update at root-column granularity: $updatedNames")
+
+    // Data correctness: the struct is rewritten but with equal values, so rows are unchanged.
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Row(1, Row(1, 2), "hr") :: Nil)
+  }
+
   test("column-update: updatedColumns contains non-identity assigned columns") {
     createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
       """{ "pk": 1, "id": 1, "dep": "hr" }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
@@ -1,0 +1,523 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, TableInfo}
+import org.apache.spark.sql.connector.expressions.LogicalExpressions.{identity, reference}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+/**
+ * Tests for UPDATE statements targeting connectors that return true from
+ * [[org.apache.spark.sql.connector.write.RowLevelOperation#supportsColumnUpdates]].
+ *
+ * When a connector supports column updates, Spark narrows the row projection
+ * (LogicalWriteInfo.schema()) to contain only the assigned/changed columns rather than
+ * the full table row.
+ */
+class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
+
+  override protected lazy val extraTableProps: java.util.Map[String, String] = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update", "true")
+    props
+  }
+
+  test("column-update: rowSchema contains only the single assigned column") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+
+    // info.schema() is empty: UPDATE-only column-update writes have no INSERT-shaped rows,
+    // so nothing flows through the writer's write() path. The narrow update-row layout is
+    // carried by info.updateSchema().
+    checkLastWriteInfo(
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))),
+      expectedUpdateSchema = Some(StructType(Seq(
+        PK_FIELD,
+        StructField("id", IntegerType, nullable = false)
+      ))))
+  }
+
+  test("column-update: rowSchema contains multiple assigned columns") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1, dep = 'engineering' WHERE pk = 1")
+
+    checkLastWriteInfo(
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))),
+      expectedUpdateSchema = Some(StructType(Seq(
+        PK_FIELD,
+        StructField("id", IntegerType, nullable = false),
+        StructField("dep", StringType, nullable = false)
+      ))))
+  }
+
+  test("column-update: rowSchema is empty for a full identity update") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = id, dep = dep WHERE pk = 1")
+
+    // All assignments are identity, so updatedColumns is empty -- the connector still declares
+    // pk for row lookup, so the narrow update schema is just [pk].
+    checkLastWriteInfo(
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))),
+      expectedUpdateSchema = Some(StructType(Array(PK_FIELD))))
+  }
+
+  test("column-update: row filter condition is orthogonal to column narrowing") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET dep = 'engineering' WHERE pk IN (1, 3)")
+
+    checkLastWriteInfo(
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))),
+      expectedUpdateSchema = Some(StructType(Seq(
+        PK_FIELD,
+        StructField("dep", StringType, nullable = false)
+      ))))
+  }
+
+  test("column-update: update all rows (no WHERE clause)") {
+    createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = salary * 2")
+
+    checkLastWriteInfo(
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))),
+      expectedUpdateSchema = Some(StructType(Seq(
+        PK_FIELD,
+        StructField("salary", IntegerType, nullable = true)
+      ))))
+  }
+
+  test("column-update: rowSchema excludes identity assignments in a mixed UPDATE") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = id, dep = 'engineering' WHERE pk = 1")
+
+    checkLastWriteInfo(
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))),
+      expectedUpdateSchema = Some(StructType(Seq(
+        PK_FIELD,
+        StructField("dep", StringType, nullable = false)
+      ))))
+  }
+
+  test("column-update: cross-column assignment is not treated as identity") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET dep = dep, id = -1 WHERE pk = 1")
+
+    checkLastWriteInfo(
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))),
+      expectedUpdateSchema = Some(StructType(Seq(
+        PK_FIELD,
+        StructField("id", IntegerType, nullable = false)
+      ))))
+  }
+
+  test("column-update: nested struct field update narrows to the root struct column") {
+    createAndInitTable("pk INT NOT NULL, s STRUCT<c1: INT, c2: INT>, dep STRING",
+      """{ "pk": 1, "s": { "c1": 1, "c2": 2 }, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET s.c1 = -1 WHERE pk = 1")
+
+    val updatedNames = table.lastUpdatedColumns.map(_.describe()).toSet
+    assert(updatedNames == Set("s"),
+      s"expected [s] in updatedColumns (root struct) but got: $updatedNames")
+
+    // info.updateSchema() carries the narrow row layout; info.schema() is the full table.
+    val updateSchema = table.lastWriteInfo.updateSchema().get()
+    assert(updateSchema.fieldNames.contains("s"),
+      s"s must be in update schema: $updateSchema")
+    assert(!updateSchema.fieldNames.contains("dep"),
+      s"dep must not be in update schema: $updateSchema")
+  }
+
+  test("column-update: updatedColumns contains non-identity assigned columns") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1, dep = 'eng' WHERE pk = 1")
+
+    val updatedNames = table.lastUpdatedColumns.map(_.describe()).toSet
+    assert(updatedNames == Set("id", "dep"),
+      s"expected [id, dep] in updatedColumns but got: $updatedNames")
+  }
+
+  test("column-update: updatedColumns excludes identity assignments") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1, dep = dep WHERE pk = 1")
+
+    val updatedNames = table.lastUpdatedColumns.map(_.describe()).toSet
+    assert(updatedNames == Set("id"),
+      s"expected only [id] in updatedColumns but got: $updatedNames")
+  }
+
+  test("column-update: updatedColumns is empty for a full identity update") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = id, dep = dep WHERE pk = 1")
+
+    assert(table.lastUpdatedColumns.isEmpty,
+      s"expected empty updatedColumns but got: ${table.lastUpdatedColumns.mkString(", ")}")
+  }
+
+  test("column-update: updatedColumns is empty for DELETE (Javadoc contract)") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"DELETE FROM $tableNameAsString WHERE dep = 'hr'")
+
+    assert(table.lastUpdatedColumns.isEmpty,
+      s"DELETE must pass empty updatedColumns but got: ${table.lastUpdatedColumns.mkString(", ")}")
+  }
+
+  test("column-update: data correctness -- single column update") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
+    // 1 row matched WHERE pk = 1 -> 1 update. MoR emits no COPY rows.
+    checkUpdateMetrics(numUpdatedRows = 1, numCopiedRows = 0, deltaUpdate = true)
+  }
+
+  test("column-update: data correctness -- update all rows") {
+    createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = salary * 2")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, 200, "hr") :: Row(2, 400, "software") :: Row(3, 600, "hr") :: Nil)
+    checkUpdateMetrics(numUpdatedRows = 3, numCopiedRows = 0, deltaUpdate = true)
+  }
+
+  test("column-update: data correctness -- mixed identity and real assignments") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = id, dep = 'engineering' WHERE pk = 1")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, 1, "engineering") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
+    checkUpdateMetrics(numUpdatedRows = 1, numCopiedRows = 0, deltaUpdate = true)
+  }
+
+  private def createAndInitTableWithReqAttrs(
+      reqAttrs: String,
+      schemaString: String,
+      jsonData: String): Unit = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update-req-attrs", reqAttrs)
+    val columns = CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schemaString))
+    val transforms = Array[Transform](identity(reference(Seq("dep"))))
+    val tableInfo = new TableInfo.Builder()
+      .withColumns(columns)
+      .withPartitions(transforms)
+      .withProperties(props)
+      .build()
+    catalog.createTable(ident, tableInfo)
+    append(schemaString, jsonData)
+  }
+
+  test("column-update: requiredDataAttributes - data correctness") {
+    createAndInitTableWithReqAttrs("dep,id", "pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
+  }
+
+  test("column-update: empty requiredDataAttributes throws AnalysisException") {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update-empty-req-attrs", "true")
+    val columns = CatalogV2Util.structTypeToV2Columns(
+      StructType.fromDDL("pk INT NOT NULL, id INT, dep STRING"))
+    val transforms = Array[Transform](identity(reference(Seq("dep"))))
+    val tableInfo = new TableInfo.Builder()
+      .withColumns(columns)
+      .withPartitions(transforms)
+      .withProperties(props)
+      .build()
+    catalog.createTable(ident, tableInfo)
+    append("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }""".stripMargin)
+
+    // A connector that mixes in SupportsColumnUpdates but returns an empty
+    // requiredDataAttributes() violates the mix-in contract -- analysis must reject the
+    // operation rather than silently falling through to the wide write path.
+    val ex = intercept[org.apache.spark.sql.AnalysisException] {
+      sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+    }
+    assert(ex.getCondition == "EMPTY_REQUIRED_DATA_ATTRIBUTES",
+      s"expected EMPTY_REQUIRED_DATA_ATTRIBUTES but got: ${ex.getCondition}")
+  }
+
+  test("column-update: requiredDataAttributes throws AnalysisException for invalid column") {
+    createAndInitTableWithReqAttrs("nonexistent_col", "pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    val ex = intercept[org.apache.spark.sql.AnalysisException] {
+      sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+    }
+    assert(ex.getMessage.contains("nonexistent_col"),
+      s"Expected error about unresolvable column but got: ${ex.getMessage}")
+  }
+
+  private def createAndInitTableFromInfo(schemaString: String, jsonData: String): Unit = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update-from-info", "true")
+    val columns = CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schemaString))
+    val transforms = Array[Transform](identity(reference(Seq("dep"))))
+    val tableInfo = new TableInfo.Builder()
+      .withColumns(columns)
+      .withPartitions(transforms)
+      .withProperties(props)
+      .build()
+    catalog.createTable(ident, tableInfo)
+    append(schemaString, jsonData)
+  }
+
+  test("column-update from-info: write schema is updatedColumns + pk pass-through") {
+    createAndInitTableFromInfo("pk INT NOT NULL, salary INT, id INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "id": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "id": 20, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE pk = 1")
+
+    val updateSchema = table.lastWriteInfo.updateSchema().get()
+    assert(updateSchema.fieldNames.contains("salary"),
+      s"salary must be in update schema: $updateSchema")
+    assert(updateSchema.fieldNames.contains("pk"),
+      s"pk must be in update schema: $updateSchema")
+    assert(!updateSchema.fieldNames.contains("id"),
+      s"id must not be in update schema: $updateSchema")
+    assert(!updateSchema.fieldNames.contains("dep"),
+      s"dep must not be in update schema: $updateSchema")
+  }
+
+  test("column-update from-info: pk already in updatedColumns is not duplicated") {
+    createAndInitTableFromInfo("pk INT NOT NULL, salary INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET pk = pk + 10, salary = -1 WHERE dep = 'hr'")
+
+    val updateSchema = table.lastWriteInfo.updateSchema().get()
+    val pkCount = updateSchema.fieldNames.count(_ == "pk")
+    assert(pkCount == 1, s"pk must appear exactly once in update schema: $updateSchema")
+  }
+
+  test("column-update from-info: data correctness") {
+    createAndInitTableFromInfo("pk INT NOT NULL, salary INT, id INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "id": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "id": 20, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "id": 30, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, -1, 10, "hr") ::
+      Row(2, 200, 20, "software") ::
+      Row(3, -1, 30, "hr") :: Nil)
+  }
+
+  private def createAndInitTableSplit(schemaString: String, jsonData: String): Unit = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update-split", "true")
+    val columns = CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schemaString))
+    val transforms = Array[Transform](identity(reference(Seq("dep"))))
+    val tableInfo = new TableInfo.Builder()
+      .withColumns(columns)
+      .withPartitions(transforms)
+      .withProperties(props)
+      .build()
+    catalog.createTable(ident, tableInfo)
+    append(schemaString, jsonData)
+  }
+
+  test("column-update split: write schema is narrow (assigned + pk pass-through)") {
+    createAndInitTableSplit("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+
+    // For representUpdateAsDeleteAndInsert connectors, reinsert-tagged rows still route through
+    // writeUpdate() (info.updateSchema() = narrow), not write(). info.schema() stays empty.
+    checkLastWriteInfo(
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))),
+      expectedUpdateSchema = Some(StructType(Seq(
+        PK_FIELD,
+        StructField("id", IntegerType, nullable = false)
+      ))))
+  }
+
+  test("column-update split: data correctness") {
+    createAndInitTableSplit("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE dep = 'hr'")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, -1, "hr") :: Nil)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scan-narrowing tests: verify that when the connector opts into column updates,
+  // the physical scan reads only the columns actually needed by the operation.
+  //
+  // Assertions use `checkLastScanExcludes` (proves narrowing) and `checkLastScanIncludes`
+  // (proves transparent widening) rather than exact-set matches -- ColumnPruning is
+  // free to further tighten the scan beyond our analysis-time narrow set (e.g. when an
+  // assignment RHS is a literal, the assigned column doesn't need to be read).
+  // ---------------------------------------------------------------------------
+
+  test("column-update: scan excludes columns outside connector-declared + cond + RHS refs") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    // requiredDataAttributes = [pk, id]; cond refs [pk] only; RHS is a literal.
+    // `dep` is neither declared nor referenced -- it must not appear in the scan.
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+
+    checkLastScanExcludes("dep")
+  }
+
+  test("column-update: scan transparently widens for cond-referenced columns") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    // requiredDataAttributes = [pk, id]; cond refs [dep].
+    // `dep` must appear even though the connector didn't declare it.
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE dep = 'hr'")
+
+    checkLastScanIncludes("dep")
+  }
+
+  test("column-update: scan transparently widens for assignment RHS references") {
+    createAndInitTable("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "hr" }
+        |""".stripMargin)
+
+    // requiredDataAttributes = [pk, salary]; RHS `salary + bonus` references `bonus`.
+    // `bonus` must appear in the scan even though it's not declared as required.
+    sql(s"UPDATE $tableNameAsString SET salary = salary + bonus WHERE pk = 1")
+
+    checkLastScanIncludes("bonus", "salary")
+    checkLastScanExcludes("dep")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, 110, 10, "hr") :: Row(2, 200, 20, "hr") :: Nil)
+  }
+
+  test("column-update: analysis fails when assignment key is outside requiredDataAttributes") {
+    // Connector declares only [pk] but the user assigns to `id`. We enforce
+    // updatedColumns ⊆ requiredDataAttributes at analysis time (root-column granularity).
+    createAndInitTableWithReqAttrs("pk", "pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }""".stripMargin)
+
+    val ex = intercept[org.apache.spark.sql.AnalysisException] {
+      sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+    }
+    assert(ex.getCondition == "REQUIRED_DATA_ATTRIBUTES_MISSING_UPDATED_COLUMNS",
+      s"expected REQUIRED_DATA_ATTRIBUTES_MISSING_UPDATED_COLUMNS but got: ${ex.getCondition}")
+    assert(ex.getMessage.contains("id"),
+      s"error message must name the missing column `id`: ${ex.getMessage}")
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
@@ -482,6 +482,70 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
       s"expected SPLIT_UPDATE_ROW_ID_REASSIGNMENT but got: ${ex.getCondition}")
   }
 
+  private def createAndInitTableScanOnly(schemaString: String, jsonData: String): Unit = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update-scan-only", "true")
+    val columns = CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schemaString))
+    val transforms = Array[Transform](identity(reference(Seq("dep"))))
+    val tableInfo = new TableInfo.Builder()
+      .withColumns(columns)
+      .withPartitions(transforms)
+      .withProperties(props)
+      .build()
+    catalog.createTable(ident, tableInfo)
+    append(schemaString, jsonData)
+  }
+
+  test("column-update: scanOnlyDataAttributes resolves write-side clustering on a data " +
+    "column without leaking it into the write payload") {
+    createAndInitTableScanOnly("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+
+    // `dep` must not appear in the narrow write payload -- it was declared scan-only, not
+    // required -- even though it drove write clustering.
+    checkLastWriteInfo(
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))),
+      expectedUpdateSchema = Some(StructType(Seq(
+        PK_FIELD,
+        StructField("id", IntegerType, nullable = false)
+      ))))
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
+  }
+
+  test("column-update: requiredDataAttributes and scanOnlyDataAttributes overlap is rejected") {
+    createAndInitTableOverlap("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }""".stripMargin)
+
+    val ex = intercept[org.apache.spark.sql.AnalysisException] {
+      sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+    }
+    assert(ex.getCondition == "REQUIRED_DATA_ATTRIBUTES_OVERLAP_SCAN_ONLY_ATTRIBUTES",
+      s"expected REQUIRED_DATA_ATTRIBUTES_OVERLAP_SCAN_ONLY_ATTRIBUTES but got: ${ex.getCondition}")
+  }
+
+  private def createAndInitTableOverlap(schemaString: String, jsonData: String): Unit = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update-overlap", "true")
+    val columns = CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schemaString))
+    val transforms = Array[Transform](identity(reference(Seq("dep"))))
+    val tableInfo = new TableInfo.Builder()
+      .withColumns(columns)
+      .withPartitions(transforms)
+      .withProperties(props)
+      .build()
+    catalog.createTable(ident, tableInfo)
+    append(schemaString, jsonData)
+  }
+
   // ---------------------------------------------------------------------------
   // Scan-narrowing tests: verify that when the connector opts into column updates,
   // the physical scan reads only the columns actually needed by the operation.
@@ -493,16 +557,18 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
   // ---------------------------------------------------------------------------
 
   test("column-update: scan excludes columns outside connector-declared + cond + RHS refs") {
-    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
-      """{ "pk": 1, "id": 1, "dep": "hr" }
-        |{ "pk": 2, "id": 2, "dep": "software" }
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING, extra STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr", "extra": "x" }
+        |{ "pk": 2, "id": 2, "dep": "software", "extra": "y" }
         |""".stripMargin)
 
     // requiredDataAttributes = [pk, id]; cond refs [pk] only; RHS is a literal.
-    // `dep` is neither declared nor referenced -- it must not appear in the scan.
+    // `dep` is scan-only declared (needed for scan-side partitioning resolution) so it must
+    // appear; `extra` is neither declared, scan-only, nor referenced, so it must not.
     sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
 
-    checkLastScanExcludes("dep")
+    checkLastScanIncludes("dep")
+    checkLastScanExcludes("extra")
   }
 
   test("column-update: scan transparently widens for cond-referenced columns") {
@@ -519,21 +585,23 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
   }
 
   test("column-update: scan transparently widens for assignment RHS references") {
-    createAndInitTable("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
-      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
-        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "hr" }
+    createAndInitTable("pk INT NOT NULL, salary INT, bonus INT, dep STRING, extra STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr", "extra": "x" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "hr", "extra": "y" }
         |""".stripMargin)
 
     // requiredDataAttributes = [pk, salary]; RHS `salary + bonus` references `bonus`.
-    // `bonus` must appear in the scan even though it's not declared as required.
+    // `bonus` must appear in the scan even though it's not declared as required. `dep` is
+    // scan-only declared (needed for scan-side partitioning resolution) so it also appears;
+    // `extra` is neither declared, scan-only, nor referenced, so it must not.
     sql(s"UPDATE $tableNameAsString SET salary = salary + bonus WHERE pk = 1")
 
-    checkLastScanIncludes("bonus", "salary")
-    checkLastScanExcludes("dep")
+    checkLastScanIncludes("bonus", "salary", "dep")
+    checkLastScanExcludes("extra")
 
     checkAnswer(
       sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
-      Row(1, 110, 10, "hr") :: Row(2, 200, 20, "hr") :: Nil)
+      Row(1, 110, 10, "hr", "x") :: Row(2, 200, 20, "hr", "y") :: Nil)
   }
 
   test("column-update: analysis fails when assignment key is outside requiredDataAttributes") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
@@ -24,11 +24,11 @@ import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 /**
- * Tests for UPDATE statements targeting connectors that return true from
- * [[org.apache.spark.sql.connector.write.RowLevelOperation#supportsColumnUpdates]].
+ * Tests for UPDATE statements targeting connectors that mix in
+ * [[org.apache.spark.sql.connector.write.SupportsColumnUpdates]].
  *
- * When a connector supports column updates, Spark narrows the row projection
- * (LogicalWriteInfo.schema()) to contain only the assigned/changed columns rather than
+ * When a connector supports column updates, Spark narrows the update-row projection
+ * (LogicalWriteInfo.updateSchema()) to contain only the declared columns rather than
  * the full table row.
  */
 class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
@@ -467,6 +467,19 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
     checkAnswer(
       sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
       Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, -1, "hr") :: Nil)
+  }
+
+  test("column-update split: row-ID reassignment on narrow write is rejected") {
+    createAndInitTableSplit("pk INT NOT NULL, salary INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "dep": "software" }
+        |""".stripMargin)
+
+    val ex = intercept[org.apache.spark.sql.AnalysisException] {
+      sql(s"UPDATE $tableNameAsString SET pk = pk + 10, salary = -1 WHERE dep = 'hr'")
+    }
+    assert(ex.getCondition == "SPLIT_UPDATE_ROW_ID_REASSIGNMENT",
+      s"expected SPLIT_UPDATE_ROW_ID_REASSIGNMENT but got: ${ex.getCondition}")
   }
 
   // ---------------------------------------------------------------------------

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
@@ -482,6 +482,40 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
       s"expected SPLIT_UPDATE_ROW_ID_REASSIGNMENT but got: ${ex.getCondition}")
   }
 
+  test("column-update split: undeclared row-ID column on narrow write is rejected") {
+    // The connector's requiredDataAttributes() excludes `pk` (the row ID). The REINSERT
+    // payload for the split-update path is projected down to requiredDataAttributes(), so
+    // without `pk` there the reinserted row would have no identity for the connector to
+    // place it by. This must be rejected at analysis time, not discovered at write time.
+    createAndInitTableSplitMissingRowId("pk INT NOT NULL, salary INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "dep": "software" }
+        |""".stripMargin)
+
+    val ex = intercept[org.apache.spark.sql.AnalysisException] {
+      sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
+    }
+    assert(ex.getCondition == "SPLIT_UPDATE_ROW_ID_NOT_DECLARED",
+      s"expected SPLIT_UPDATE_ROW_ID_NOT_DECLARED but got: ${ex.getCondition}")
+    assert(ex.getMessage.contains("pk"),
+      s"error message must name the undeclared row ID column `pk`: ${ex.getMessage}")
+  }
+
+  private def createAndInitTableSplitMissingRowId(
+      schemaString: String, jsonData: String): Unit = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update-split-missing-row-id", "true")
+    val columns = CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schemaString))
+    val transforms = Array[Transform](identity(reference(Seq("dep"))))
+    val tableInfo = new TableInfo.Builder()
+      .withColumns(columns)
+      .withPartitions(transforms)
+      .withProperties(props)
+      .build()
+    catalog.createTable(ident, tableInfo)
+    append(schemaString, jsonData)
+  }
+
   private def createAndInitTableScanOnly(schemaString: String, jsonData: String): Unit = {
     val props = new java.util.HashMap[String, String]()
     props.put("column-update-scan-only", "true")
@@ -535,6 +569,33 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
   private def createAndInitTableOverlap(schemaString: String, jsonData: String): Unit = {
     val props = new java.util.HashMap[String, String]()
     props.put("column-update-overlap", "true")
+    val columns = CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schemaString))
+    val transforms = Array[Transform](identity(reference(Seq("dep"))))
+    val tableInfo = new TableInfo.Builder()
+      .withColumns(columns)
+      .withPartitions(transforms)
+      .withProperties(props)
+      .build()
+    catalog.createTable(ident, tableInfo)
+    append(schemaString, jsonData)
+  }
+
+  test("column-update: undeclared partition column on narrow write is rejected") {
+    createAndInitTableMissingPartition("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }""".stripMargin)
+
+    val ex = intercept[org.apache.spark.sql.AnalysisException] {
+      sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+    }
+    assert(ex.getCondition == "REQUIRED_DATA_ATTRIBUTES_MISSING_PARTITION_COLUMNS",
+      s"expected REQUIRED_DATA_ATTRIBUTES_MISSING_PARTITION_COLUMNS but got: ${ex.getCondition}")
+    assert(ex.getMessage.contains("dep"),
+      s"error message must name the undeclared partition column `dep`: ${ex.getMessage}")
+  }
+
+  private def createAndInitTableMissingPartition(schemaString: String, jsonData: String): Unit = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update-missing-partition", "true")
     val columns = CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schemaString))
     val transforms = Array[Transform](identity(reference(Seq("dep"))))
     val tableInfo = new TableInfo.Builder()

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
@@ -428,9 +428,12 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
     sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE pk = 1")
 
     val writeSchema = table.lastWriteInfo.schema()
-    assert(writeSchema.fieldNames.contains("salary"), s"salary must be in write schema: $writeSchema")
-    assert(writeSchema.fieldNames.contains("pk"), s"pk must be in write schema: $writeSchema")
-    assert(!writeSchema.fieldNames.contains("id"), s"id must not be in write schema: $writeSchema")
+    assert(writeSchema.fieldNames.contains("salary"),
+      s"salary must be in write schema: $writeSchema")
+    assert(writeSchema.fieldNames.contains("pk"),
+      s"pk must be in write schema: $writeSchema")
+    assert(!writeSchema.fieldNames.contains("id"),
+      s"id must not be in write schema: $writeSchema")
     assert(!writeSchema.fieldNames.contains("dep"),
       s"dep must not be in write schema: $writeSchema")
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
@@ -39,8 +39,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
     props
   }
 
-  // --- Schema narrowing: verify LogicalWriteInfo.schema() is narrow ---
-
   test("column-update: rowSchema contains only the single assigned column") {
     createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
       """{ "pk": 1, "id": 1, "dep": "hr" }
@@ -50,7 +48,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
 
     sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
 
-    // Only the assigned column (id) should appear in the row schema -- not pk or dep
     checkLastWriteInfo(
       expectedRowSchema = StructType(Seq(
         StructField("id", IntegerType, nullable = false)
@@ -67,7 +64,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
 
     sql(s"UPDATE $tableNameAsString SET id = -1, dep = 'engineering' WHERE pk = 1")
 
-    // Both assigned columns (id, dep) should appear -- but NOT pk (unassigned)
     checkLastWriteInfo(
       expectedRowSchema = StructType(Seq(
         StructField("id", IntegerType, nullable = false),
@@ -124,16 +120,12 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
       expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
   }
 
-  // --- Identity assignment filtering ---
-
   test("column-update: rowSchema excludes identity assignments in a mixed UPDATE") {
     createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
       """{ "pk": 1, "id": 1, "dep": "hr" }
         |{ "pk": 2, "id": 2, "dep": "software" }
         |""".stripMargin)
 
-    // id = id is identity -- should be excluded from rowSchema
-    // dep = 'engineering' is a real assignment -- should be included
     sql(s"UPDATE $tableNameAsString SET id = id, dep = 'engineering' WHERE pk = 1")
 
     checkLastWriteInfo(
@@ -150,7 +142,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
         |{ "pk": 2, "id": 2, "dep": "software" }
         |""".stripMargin)
 
-    // dep = dep is identity; id = -1 is a real assignment -- only id should appear
     sql(s"UPDATE $tableNameAsString SET dep = dep, id = -1 WHERE pk = 1")
 
     checkLastWriteInfo(
@@ -161,7 +152,23 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
       expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
   }
 
-  // --- updatedColumns in RowLevelOperationInfo ---
+  test("column-update: nested struct field update narrows to the root struct column") {
+    createAndInitTable("pk INT NOT NULL, s STRUCT<c1: INT, c2: INT>, dep STRING",
+      """{ "pk": 1, "s": { "c1": 1, "c2": 2 }, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET s.c1 = -1 WHERE pk = 1")
+
+    val updatedNames = table.lastUpdatedColumns.map(_.describe()).toSet
+    assert(updatedNames == Set("s"),
+      s"expected [s] in updatedColumns (root struct) but got: $updatedNames")
+
+    val writeSchema = table.lastWriteInfo.schema()
+    assert(writeSchema.fieldNames.contains("s"),
+      s"s must be in write schema: $writeSchema")
+    assert(!writeSchema.fieldNames.contains("dep"),
+      s"dep must not be in write schema: $writeSchema")
+  }
 
   test("column-update: updatedColumns contains non-identity assigned columns") {
     createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
@@ -180,7 +187,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
       """{ "pk": 1, "id": 1, "dep": "hr" }
         |""".stripMargin)
 
-    // dep = dep is identity; only id should appear in updatedColumns
     sql(s"UPDATE $tableNameAsString SET id = -1, dep = dep WHERE pk = 1")
 
     val updatedNames = table.lastUpdatedColumns.map(_.describe()).toSet
@@ -200,9 +206,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
   }
 
   test("column-update: updatedColumns is empty for DELETE (Javadoc contract)") {
-    // DELETE never has updated columns -- verify that the default empty array is passed
-    // through RowLevelOperationInfo even when a column-update connector handles the DELETE.
-    // Use a partition-column condition so the InMemory table can process the filter.
     createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
       """{ "pk": 1, "id": 1, "dep": "hr" }
         |{ "pk": 2, "id": 2, "dep": "software" }
@@ -213,8 +216,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
     assert(table.lastUpdatedColumns.isEmpty,
       s"DELETE must pass empty updatedColumns but got: ${table.lastUpdatedColumns.mkString(", ")}")
   }
-
-  // --- Data correctness ---
 
   test("column-update: data correctness -- single column update") {
     createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
@@ -251,7 +252,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
         |{ "pk": 3, "id": 3, "dep": "hr" }
         |""".stripMargin)
 
-    // Only dep changes; id stays as-is even though id = id is in the SET list.
     sql(s"UPDATE $tableNameAsString SET id = id, dep = 'engineering' WHERE pk = 1")
 
     checkAnswer(
@@ -259,16 +259,12 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
       Row(1, 1, "engineering") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
   }
 
-  // --- Scan narrowing: verify the connector only receives the columns it needs ---
-
   test("column-update: scan excludes the assigned column when SET to a literal") {
     createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
       """{ "pk": 1, "id": 1, "dep": "hr" }
         |{ "pk": 2, "id": 2, "dep": "software" }
         |""".stripMargin)
 
-    // id is the target of a literal assignment -- its current value is not needed.
-    // pk is needed for the WHERE condition and as rowId.
     sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
 
     val scanSchema = table.lastScanSchema
@@ -282,8 +278,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
         |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
         |""".stripMargin)
 
-    // salary appears on the RHS (salary * 2) so it must be scanned.
-    // bonus is not referenced anywhere -- excluded.
     sql(s"UPDATE $tableNameAsString SET salary = salary * 2")
 
     val scanSchema = table.lastScanSchema
@@ -297,7 +291,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
         |{ "pk": 2, "id": 2, "salary": 200, "dep": "software" }
         |""".stripMargin)
 
-    // dep is a literal assignment; id and salary are not referenced -- only pk needed.
     sql(s"UPDATE $tableNameAsString SET dep = 'engineering' WHERE pk = 1")
 
     val scanSchema = table.lastScanSchema
@@ -312,9 +305,7 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
         |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
         |""".stripMargin)
 
-    // dep appears in the WHERE clause -- must be scanned even though it is not assigned.
-    // bonus is neither assigned nor in the condition -- excluded.
-    // salary is set to a literal -- current value not needed.
+    // dep is in WHERE but not assigned -- must still be scanned
     sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
 
     val scanSchema = table.lastScanSchema
@@ -325,12 +316,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
       s"salary should be excluded (literal assignment): $scanSchema")
   }
 
-  // ---------------------------------------------------------------------------
-  // Connector-driven scan narrowing via requiredDataAttributes()
-  // ---------------------------------------------------------------------------
-
-  // Creates a table backed by DeltaBasedColumnUpdateOperationWithReqAttrs, which overrides
-  // requiredDataAttributes() to return the given comma-separated column names.
   private def createAndInitTableWithReqAttrs(
       reqAttrs: String,
       schemaString: String,
@@ -349,10 +334,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
   }
 
   test("column-update: requiredDataAttributes forces connector-declared column into scan") {
-    // Connector declares it always needs "dep".
-    // SQL assigns "id" (literal) with condition on "pk".
-    // Connector-driven scan = {pk, dep} (dep from connector declaration; pk from condition).
-    // id is NOT in scan: literal assignment + not declared by connector.
     createAndInitTableWithReqAttrs("dep", "pk INT NOT NULL, id INT, dep STRING",
       """{ "pk": 1, "id": 1, "dep": "hr" }
         |{ "pk": 2, "id": 2, "dep": "software" }
@@ -365,12 +346,10 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
       s"dep must be in scan (connector required): $scanSchema")
     assert(scanSchema.fieldNames.contains("pk"), s"pk must be in scan: $scanSchema")
     assert(!scanSchema.fieldNames.contains("id"),
-      s"id should be excluded (literal assignment, not declared): $scanSchema")
+      s"id should be excluded (literal, not declared): $scanSchema")
   }
 
   test("column-update: requiredDataAttributes - data correctness") {
-    // Connector declares "dep,id" so it receives both the new id value and dep for routing.
-    // The write schema is exactly requiredDataAttributes = {dep, id} (declared order).
     createAndInitTableWithReqAttrs("dep,id", "pk INT NOT NULL, id INT, dep STRING",
       """{ "pk": 1, "id": 1, "dep": "hr" }
         |{ "pk": 2, "id": 2, "dep": "software" }
@@ -385,13 +364,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
   }
 
   test("column-update: empty requiredDataAttributes falls back to heuristic") {
-    // "column-update" uses DeltaBasedColumnUpdateOperation whose requiredDataAttributes()
-    // returns the default empty array.
-    // With the optimizer-driven approach for MOR, the scan is narrowed by V2ScanRelationPushDown
-    // which observes what columns the write plan actually references.
-    // SET id = -1 (literal assignment): id is not referenced from the scan, so it is pruned.
-    // dep is the partitioning column; since it is not declared in requiredDataAttributes()
-    // and is not referenced by the WHERE condition (pk = 1), it may be pruned from the scan.
     createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
       """{ "pk": 1, "id": 1, "dep": "hr" }
         |{ "pk": 2, "id": 2, "dep": "software" }
@@ -401,16 +373,21 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
 
     val scanSchema = table.lastScanSchema
     assert(!scanSchema.fieldNames.contains("id"),
-      s"id must NOT be in scan (literal assignment, no scan reference): $scanSchema")
+      s"id must NOT be in scan (literal assignment): $scanSchema")
     assert(scanSchema.fieldNames.contains("pk"), s"pk must be in scan (condition): $scanSchema")
   }
 
-  // ---------------------------------------------------------------------------
-  // Connector uses RowLevelOperationInfo.updatedColumns() to derive its own
-  // requiredDataAttributes() dynamically.
-  // DeltaBasedColumnUpdateOperationFromInfo always adds "pk" (for row lookup) to
-  // whatever Spark reports as updated columns.
-  // ---------------------------------------------------------------------------
+  test("column-update: requiredDataAttributes throws AnalysisException for invalid column") {
+    createAndInitTableWithReqAttrs("nonexistent_col", "pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    val ex = intercept[org.apache.spark.sql.AnalysisException] {
+      sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+    }
+    assert(ex.getMessage.contains("nonexistent_col"),
+      s"Expected error about unresolvable column but got: ${ex.getMessage}")
+  }
 
   private def createAndInitTableFromInfo(schemaString: String, jsonData: String): Unit = {
     val props = new java.util.HashMap[String, String]()
@@ -427,16 +404,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
   }
 
   test("column-update from-info: connector adds pk to updatedColumns for requiredDataAttributes") {
-    // Connector receives updatedColumns=[salary], adds pk for row lookup.
-    // requiredDataAttributes() = [pk, salary].
-    //
-    // salary = -1 is a LITERAL assignment: the write plan references Literal(-1) not the
-    // scan's salary column.  Since salary is in assignedAttrs, it is not a connectorExtraAttr
-    // pass-through either.  V2ScanRelationPushDown therefore does not see salary referenced
-    // and prunes it from the scan.
-    //
-    // The scan contains: pk (connector pass-through), dep (partitioning + WHERE condition).
-    // The scan excludes: salary (literal assignment), id and bonus (not declared, not in cond).
     createAndInitTableFromInfo("pk INT NOT NULL, salary INT, id INT, bonus INT, dep STRING",
       """{ "pk": 1, "salary": 100, "id": 10, "bonus": 5, "dep": "hr" }
         |{ "pk": 2, "salary": 200, "id": 20, "bonus": 6, "dep": "software" }
@@ -446,19 +413,13 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
     sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
 
     val scanSchema = table.lastScanSchema
-    assert(scanSchema.fieldNames.contains("pk"),
-      s"pk must be in scan (connector pass-through via connectorExtraAttrs): $scanSchema")
-    assert(scanSchema.fieldNames.contains("dep"),
-      s"dep must be in scan (partitioning + WHERE): $scanSchema")
-    assert(!scanSchema.fieldNames.contains("id"),
-      s"id must be excluded (not declared, not assigned, not in condition): $scanSchema")
-    assert(!scanSchema.fieldNames.contains("bonus"),
-      s"bonus must be excluded (not declared, not assigned, not in condition): $scanSchema")
+    assert(scanSchema.fieldNames.contains("pk"), s"pk must be in scan: $scanSchema")
+    assert(scanSchema.fieldNames.contains("dep"), s"dep must be in scan (WHERE): $scanSchema")
+    assert(!scanSchema.fieldNames.contains("id"), s"id must be excluded: $scanSchema")
+    assert(!scanSchema.fieldNames.contains("bonus"), s"bonus must be excluded: $scanSchema")
   }
 
   test("column-update from-info: write schema is updatedColumns + pk pass-through") {
-    // requiredDataAttributes = [pk, salary] (pk always added; salary because it's assigned).
-    // Write schema = requiredDataAttributes in declared order = {pk, salary}.
     createAndInitTableFromInfo("pk INT NOT NULL, salary INT, id INT, dep STRING",
       """{ "pk": 1, "salary": 100, "id": 10, "dep": "hr" }
         |{ "pk": 2, "salary": 200, "id": 20, "dep": "software" }
@@ -467,20 +428,14 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
     sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE pk = 1")
 
     val writeSchema = table.lastWriteInfo.schema()
-    assert(writeSchema.fieldNames.contains("salary"),
-      s"salary must be in write schema (assigned): $writeSchema")
-    assert(writeSchema.fieldNames.contains("pk"),
-      s"pk must be in write schema " +
-        s"(connector pass-through via requiredDataAttributes): $writeSchema")
-    assert(!writeSchema.fieldNames.contains("id"),
-      s"id must not be in write schema: $writeSchema")
+    assert(writeSchema.fieldNames.contains("salary"), s"salary must be in write schema: $writeSchema")
+    assert(writeSchema.fieldNames.contains("pk"), s"pk must be in write schema: $writeSchema")
+    assert(!writeSchema.fieldNames.contains("id"), s"id must not be in write schema: $writeSchema")
     assert(!writeSchema.fieldNames.contains("dep"),
-      s"dep must not be in write schema (partitioning, not a data column to write): $writeSchema")
+      s"dep must not be in write schema: $writeSchema")
   }
 
   test("column-update from-info: pk already in updatedColumns is not duplicated") {
-    // When the user updates pk itself, updatedColumns=[pk, salary].
-    // Connector sees pk already present -> requiredDataAttributes=[pk, salary] (no dup).
     createAndInitTableFromInfo("pk INT NOT NULL, salary INT, dep STRING",
       """{ "pk": 1, "salary": 100, "dep": "hr" }
         |{ "pk": 2, "salary": 200, "dep": "software" }
@@ -502,125 +457,12 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
 
     sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
 
-    // salary updated for hr rows; id preserved (not in write schema, connector uses pk lookup)
     checkAnswer(
       sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
       Row(1, -1, 10, "hr") ::
       Row(2, 200, 20, "software") ::
       Row(3, -1, 30, "hr") :: Nil)
   }
-
-  // ---------------------------------------------------------------------------
-  // CoW connector with supportsColumnUpdates() on RowLevelOperation.
-  // PartitionBasedColumnUpdateOperation declares requiredDataAttributes() = [pk, dep] and
-  // supportsColumnUpdates() = true.  Spark narrows the scan to connector-declared + assigned
-  // columns; bonus is excluded.  The connector reconstructs full rows via pk lookup.
-  // ---------------------------------------------------------------------------
-
-  private def createAndInitTableCoW(schemaString: String, jsonData: String): Unit = {
-    val props = new java.util.HashMap[String, String]()
-    props.put("column-update-cow", "true")
-    val columns = CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schemaString))
-    val transforms = Array[Transform](identity(reference(Seq("dep"))))
-    val tableInfo = new TableInfo.Builder()
-      .withColumns(columns)
-      .withPartitions(transforms)
-      .withProperties(props)
-      .build()
-    catalog.createTable(ident, tableInfo)
-    append(schemaString, jsonData)
-  }
-
-  test("column-update CoW: scan excludes columns not declared and not assigned") {
-    // Connector declares [pk, dep].  SET salary = -1.
-    // Narrow scan = pk (declared) + dep (declared + condition + partitioning)
-    // + salary (assigned LHS).  bonus is neither declared nor assigned -> excluded.
-    createAndInitTableCoW("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
-      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
-        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
-        |{ "pk": 3, "salary": 300, "bonus": 30, "dep": "hr" }
-        |""".stripMargin)
-
-    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
-
-    val scanSchema = table.lastScanSchema
-    assert(scanSchema.fieldNames.contains("pk"), s"pk must be in scan: $scanSchema")
-    assert(scanSchema.fieldNames.contains("dep"), s"dep must be in scan: $scanSchema")
-    assert(scanSchema.fieldNames.contains("salary"),
-      s"salary must be in scan (assigned LHS): $scanSchema")
-    assert(!scanSchema.fieldNames.contains("bonus"), s"bonus must be excluded: $scanSchema")
-  }
-
-  test("column-update CoW: write schema contains only declared + assigned columns") {
-    createAndInitTableCoW("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
-      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
-        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
-        |""".stripMargin)
-
-    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
-
-    val writeSchema = table.lastWriteInfo.schema()
-    assert(writeSchema.fieldNames.contains("pk"), s"pk must be in write schema: $writeSchema")
-    assert(writeSchema.fieldNames.contains("dep"), s"dep must be in write schema: $writeSchema")
-    assert(writeSchema.fieldNames.contains("salary"),
-      s"salary must be in write schema: $writeSchema")
-    assert(!writeSchema.fieldNames.contains("bonus"),
-      s"bonus must not be in write schema: $writeSchema")
-  }
-
-  test("column-update CoW: data correctness -- bonus preserved, salary updated") {
-    // bonus is not in the write schema; the connector must preserve it from the original row.
-    createAndInitTableCoW("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
-      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
-        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
-        |{ "pk": 3, "salary": 300, "bonus": 30, "dep": "hr" }
-        |""".stripMargin)
-
-    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
-
-    checkAnswer(
-      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
-      Row(1, -1, 10, "hr") ::
-      Row(2, 200, 20, "software") ::
-      Row(3, -1, 30, "hr") :: Nil)
-  }
-
-  test("column-update CoW: narrow scan + subquery WHERE condition") {
-    // Exercises buildReplaceDataWithUnionPlan + narrow scan + the flatMap change in
-    // RowLevelOperationRuntimeGroupFiltering.buildTableToScanAttrMap.
-    // The subquery forces the UNION path (updated rows + remaining rows).
-    // bonus is not declared and not assigned, must be excluded from scan and write
-    // but the subquery-based filter must still work correctly with the narrow scan.
-    createAndInitTableCoW("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
-      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
-        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
-        |{ "pk": 3, "salary": 300, "bonus": 30, "dep": "hr" }
-        |""".stripMargin)
-
-    import testImplicits._
-    val subqueryDF = Seq("hr").toDF()
-    subqueryDF.createOrReplaceTempView("target_deps")
-
-    sql(
-      s"""UPDATE $tableNameAsString
-         |SET salary = -1
-         |WHERE dep IN (SELECT * FROM target_deps)
-         |""".stripMargin)
-
-    checkAnswer(
-      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
-      Row(1, -1, 10, "hr") ::
-      Row(2, 200, 20, "software") ::
-      Row(3, -1, 30, "hr") :: Nil)
-  }
-
-  // ---------------------------------------------------------------------------
-  // Delta connector with representUpdateAsDeleteAndInsert=true AND supportsColumnUpdates=true.
-  //
-  // Point 7: The restriction that blocked column-level updates on the delete+reinsert path
-  // has been removed.  The REINSERT leg of the Expand uses only assigned values (the narrow
-  // write schema from effectiveRowAttrs), and the DELETE leg uses row ID only.
-  // ---------------------------------------------------------------------------
 
   private def createAndInitTableSplit(schemaString: String, jsonData: String): Unit = {
     val props = new java.util.HashMap[String, String]()
@@ -637,10 +479,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
   }
 
   test("column-update split: write schema is narrow (assigned + pk pass-through)") {
-    // representUpdateAsDeleteAndInsert=true + supportsColumnUpdates=true.
-    // requiredDataAttributes() = [pk, id] (pk always declared; id because it's being updated).
-    // The write schema = requiredDataAttributes() in declared order = {pk, id}.
-    // dep is NOT in the write schema (not declared, not assigned).
     createAndInitTableSplit("pk INT NOT NULL, id INT, dep STRING",
       """{ "pk": 1, "id": 1, "dep": "hr" }
         |{ "pk": 2, "id": 2, "dep": "software" }
@@ -648,7 +486,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
 
     sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
 
-    // Write schema is exactly requiredDataAttributes = {pk, id} in declared order.
     checkLastWriteInfo(
       expectedRowSchema = StructType(Seq(
         StructField("pk", IntegerType, nullable = false),
@@ -659,8 +496,6 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
   }
 
   test("column-update split: data correctness") {
-    // representUpdateAsDeleteAndInsert=true + supportsColumnUpdates=true.
-    // The connector receives narrow REINSERT rows and must reconstruct full rows.
     createAndInitTableSplit("pk INT NOT NULL, id INT, dep STRING",
       """{ "pk": 1, "id": 1, "dep": "hr" }
         |{ "pk": 2, "id": 2, "dep": "software" }
@@ -674,4 +509,3 @@ class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
       Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, -1, "hr") :: Nil)
   }
 }
-

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedColumnUpdateTableSuite.scala
@@ -1,0 +1,677 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, TableInfo}
+import org.apache.spark.sql.connector.expressions.LogicalExpressions.{identity, reference}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+/**
+ * Tests for UPDATE statements targeting connectors that return true from
+ * [[org.apache.spark.sql.connector.write.RowLevelOperation#supportsColumnUpdates]].
+ *
+ * When a connector supports column updates, Spark narrows the row projection
+ * (LogicalWriteInfo.schema()) to contain only the assigned/changed columns rather than
+ * the full table row.
+ */
+class DeltaBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
+
+  override protected lazy val extraTableProps: java.util.Map[String, String] = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update", "true")
+    props
+  }
+
+  // --- Schema narrowing: verify LogicalWriteInfo.schema() is narrow ---
+
+  test("column-update: rowSchema contains only the single assigned column") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+
+    // Only the assigned column (id) should appear in the row schema -- not pk or dep
+    checkLastWriteInfo(
+      expectedRowSchema = StructType(Seq(
+        StructField("id", IntegerType, nullable = false)
+      )),
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
+  }
+
+  test("column-update: rowSchema contains multiple assigned columns") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1, dep = 'engineering' WHERE pk = 1")
+
+    // Both assigned columns (id, dep) should appear -- but NOT pk (unassigned)
+    checkLastWriteInfo(
+      expectedRowSchema = StructType(Seq(
+        StructField("id", IntegerType, nullable = false),
+        StructField("dep", StringType, nullable = false)
+      )),
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
+  }
+
+  test("column-update: rowSchema is empty for a full identity update") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = id, dep = dep WHERE pk = 1")
+
+    checkLastWriteInfo(
+      expectedRowSchema = new StructType(),
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
+  }
+
+  test("column-update: row filter condition is orthogonal to column narrowing") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET dep = 'engineering' WHERE pk IN (1, 3)")
+
+    checkLastWriteInfo(
+      expectedRowSchema = StructType(Seq(
+        StructField("dep", StringType, nullable = false)
+      )),
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
+  }
+
+  test("column-update: update all rows (no WHERE clause)") {
+    createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = salary * 2")
+
+    checkLastWriteInfo(
+      expectedRowSchema = StructType(Seq(
+        StructField("salary", IntegerType, nullable = true)
+      )),
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
+  }
+
+  // --- Identity assignment filtering ---
+
+  test("column-update: rowSchema excludes identity assignments in a mixed UPDATE") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    // id = id is identity -- should be excluded from rowSchema
+    // dep = 'engineering' is a real assignment -- should be included
+    sql(s"UPDATE $tableNameAsString SET id = id, dep = 'engineering' WHERE pk = 1")
+
+    checkLastWriteInfo(
+      expectedRowSchema = StructType(Seq(
+        StructField("dep", StringType, nullable = false)
+      )),
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
+  }
+
+  test("column-update: cross-column assignment is not treated as identity") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    // dep = dep is identity; id = -1 is a real assignment -- only id should appear
+    sql(s"UPDATE $tableNameAsString SET dep = dep, id = -1 WHERE pk = 1")
+
+    checkLastWriteInfo(
+      expectedRowSchema = StructType(Seq(
+        StructField("id", IntegerType, nullable = false)
+      )),
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
+  }
+
+  // --- updatedColumns in RowLevelOperationInfo ---
+
+  test("column-update: updatedColumns contains non-identity assigned columns") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1, dep = 'eng' WHERE pk = 1")
+
+    val updatedNames = table.lastUpdatedColumns.map(_.describe()).toSet
+    assert(updatedNames == Set("id", "dep"),
+      s"expected [id, dep] in updatedColumns but got: $updatedNames")
+  }
+
+  test("column-update: updatedColumns excludes identity assignments") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    // dep = dep is identity; only id should appear in updatedColumns
+    sql(s"UPDATE $tableNameAsString SET id = -1, dep = dep WHERE pk = 1")
+
+    val updatedNames = table.lastUpdatedColumns.map(_.describe()).toSet
+    assert(updatedNames == Set("id"),
+      s"expected only [id] in updatedColumns but got: $updatedNames")
+  }
+
+  test("column-update: updatedColumns is empty for a full identity update") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = id, dep = dep WHERE pk = 1")
+
+    assert(table.lastUpdatedColumns.isEmpty,
+      s"expected empty updatedColumns but got: ${table.lastUpdatedColumns.mkString(", ")}")
+  }
+
+  test("column-update: updatedColumns is empty for DELETE (Javadoc contract)") {
+    // DELETE never has updated columns -- verify that the default empty array is passed
+    // through RowLevelOperationInfo even when a column-update connector handles the DELETE.
+    // Use a partition-column condition so the InMemory table can process the filter.
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"DELETE FROM $tableNameAsString WHERE dep = 'hr'")
+
+    assert(table.lastUpdatedColumns.isEmpty,
+      s"DELETE must pass empty updatedColumns but got: ${table.lastUpdatedColumns.mkString(", ")}")
+  }
+
+  // --- Data correctness ---
+
+  test("column-update: data correctness -- single column update") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
+  }
+
+  test("column-update: data correctness -- update all rows") {
+    createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = salary * 2")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, 200, "hr") :: Row(2, 400, "software") :: Row(3, 600, "hr") :: Nil)
+  }
+
+  test("column-update: data correctness -- mixed identity and real assignments") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    // Only dep changes; id stays as-is even though id = id is in the SET list.
+    sql(s"UPDATE $tableNameAsString SET id = id, dep = 'engineering' WHERE pk = 1")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, 1, "engineering") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
+  }
+
+  // --- Scan narrowing: verify the connector only receives the columns it needs ---
+
+  test("column-update: scan excludes the assigned column when SET to a literal") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    // id is the target of a literal assignment -- its current value is not needed.
+    // pk is needed for the WHERE condition and as rowId.
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+
+    val scanSchema = table.lastScanSchema
+    assert(!scanSchema.fieldNames.contains("id"), s"id should be excluded from scan: $scanSchema")
+    assert(scanSchema.fieldNames.contains("pk"), s"pk must be in scan: $scanSchema")
+  }
+
+  test("column-update: scan includes the assigned column when its current value is the RHS") {
+    createAndInitTable("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
+        |""".stripMargin)
+
+    // salary appears on the RHS (salary * 2) so it must be scanned.
+    // bonus is not referenced anywhere -- excluded.
+    sql(s"UPDATE $tableNameAsString SET salary = salary * 2")
+
+    val scanSchema = table.lastScanSchema
+    assert(scanSchema.fieldNames.contains("salary"), s"salary must be in scan: $scanSchema")
+    assert(!scanSchema.fieldNames.contains("bonus"), s"bonus should be excluded: $scanSchema")
+  }
+
+  test("column-update: scan excludes non-referenced columns for literal assignment") {
+    createAndInitTable("pk INT NOT NULL, id INT, salary INT, dep STRING",
+      """{ "pk": 1, "id": 1, "salary": 100, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "salary": 200, "dep": "software" }
+        |""".stripMargin)
+
+    // dep is a literal assignment; id and salary are not referenced -- only pk needed.
+    sql(s"UPDATE $tableNameAsString SET dep = 'engineering' WHERE pk = 1")
+
+    val scanSchema = table.lastScanSchema
+    assert(scanSchema.fieldNames.contains("pk"), s"pk must be in scan: $scanSchema")
+    assert(!scanSchema.fieldNames.contains("id"), s"id should be excluded: $scanSchema")
+    assert(!scanSchema.fieldNames.contains("salary"), s"salary should be excluded: $scanSchema")
+  }
+
+  test("column-update: scan includes condition columns even when not assigned") {
+    createAndInitTable("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
+        |""".stripMargin)
+
+    // dep appears in the WHERE clause -- must be scanned even though it is not assigned.
+    // bonus is neither assigned nor in the condition -- excluded.
+    // salary is set to a literal -- current value not needed.
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
+
+    val scanSchema = table.lastScanSchema
+    assert(scanSchema.fieldNames.contains("dep"),
+      s"dep must be in scan (WHERE clause): $scanSchema")
+    assert(!scanSchema.fieldNames.contains("bonus"), s"bonus should be excluded: $scanSchema")
+    assert(!scanSchema.fieldNames.contains("salary"),
+      s"salary should be excluded (literal assignment): $scanSchema")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Connector-driven scan narrowing via requiredDataAttributes()
+  // ---------------------------------------------------------------------------
+
+  // Creates a table backed by DeltaBasedColumnUpdateOperationWithReqAttrs, which overrides
+  // requiredDataAttributes() to return the given comma-separated column names.
+  private def createAndInitTableWithReqAttrs(
+      reqAttrs: String,
+      schemaString: String,
+      jsonData: String): Unit = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update-req-attrs", reqAttrs)
+    val columns = CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schemaString))
+    val transforms = Array[Transform](identity(reference(Seq("dep"))))
+    val tableInfo = new TableInfo.Builder()
+      .withColumns(columns)
+      .withPartitions(transforms)
+      .withProperties(props)
+      .build()
+    catalog.createTable(ident, tableInfo)
+    append(schemaString, jsonData)
+  }
+
+  test("column-update: requiredDataAttributes forces connector-declared column into scan") {
+    // Connector declares it always needs "dep".
+    // SQL assigns "id" (literal) with condition on "pk".
+    // Connector-driven scan = {pk, dep} (dep from connector declaration; pk from condition).
+    // id is NOT in scan: literal assignment + not declared by connector.
+    createAndInitTableWithReqAttrs("dep", "pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+
+    val scanSchema = table.lastScanSchema
+    assert(scanSchema.fieldNames.contains("dep"),
+      s"dep must be in scan (connector required): $scanSchema")
+    assert(scanSchema.fieldNames.contains("pk"), s"pk must be in scan: $scanSchema")
+    assert(!scanSchema.fieldNames.contains("id"),
+      s"id should be excluded (literal assignment, not declared): $scanSchema")
+  }
+
+  test("column-update: requiredDataAttributes - data correctness") {
+    // Connector declares "dep,id" so it receives both the new id value and dep for routing.
+    // The write schema is exactly requiredDataAttributes = {dep, id} (declared order).
+    createAndInitTableWithReqAttrs("dep,id", "pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
+  }
+
+  test("column-update: empty requiredDataAttributes falls back to heuristic") {
+    // "column-update" uses DeltaBasedColumnUpdateOperation whose requiredDataAttributes()
+    // returns the default empty array.
+    // With the optimizer-driven approach for MOR, the scan is narrowed by V2ScanRelationPushDown
+    // which observes what columns the write plan actually references.
+    // SET id = -1 (literal assignment): id is not referenced from the scan, so it is pruned.
+    // dep is the partitioning column; since it is not declared in requiredDataAttributes()
+    // and is not referenced by the WHERE condition (pk = 1), it may be pruned from the scan.
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+
+    val scanSchema = table.lastScanSchema
+    assert(!scanSchema.fieldNames.contains("id"),
+      s"id must NOT be in scan (literal assignment, no scan reference): $scanSchema")
+    assert(scanSchema.fieldNames.contains("pk"), s"pk must be in scan (condition): $scanSchema")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Connector uses RowLevelOperationInfo.updatedColumns() to derive its own
+  // requiredDataAttributes() dynamically.
+  // DeltaBasedColumnUpdateOperationFromInfo always adds "pk" (for row lookup) to
+  // whatever Spark reports as updated columns.
+  // ---------------------------------------------------------------------------
+
+  private def createAndInitTableFromInfo(schemaString: String, jsonData: String): Unit = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update-from-info", "true")
+    val columns = CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schemaString))
+    val transforms = Array[Transform](identity(reference(Seq("dep"))))
+    val tableInfo = new TableInfo.Builder()
+      .withColumns(columns)
+      .withPartitions(transforms)
+      .withProperties(props)
+      .build()
+    catalog.createTable(ident, tableInfo)
+    append(schemaString, jsonData)
+  }
+
+  test("column-update from-info: connector adds pk to updatedColumns for requiredDataAttributes") {
+    // Connector receives updatedColumns=[salary], adds pk for row lookup.
+    // requiredDataAttributes() = [pk, salary].
+    //
+    // salary = -1 is a LITERAL assignment: the write plan references Literal(-1) not the
+    // scan's salary column.  Since salary is in assignedAttrs, it is not a connectorExtraAttr
+    // pass-through either.  V2ScanRelationPushDown therefore does not see salary referenced
+    // and prunes it from the scan.
+    //
+    // The scan contains: pk (connector pass-through), dep (partitioning + WHERE condition).
+    // The scan excludes: salary (literal assignment), id and bonus (not declared, not in cond).
+    createAndInitTableFromInfo("pk INT NOT NULL, salary INT, id INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "id": 10, "bonus": 5, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "id": 20, "bonus": 6, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "id": 30, "bonus": 7, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
+
+    val scanSchema = table.lastScanSchema
+    assert(scanSchema.fieldNames.contains("pk"),
+      s"pk must be in scan (connector pass-through via connectorExtraAttrs): $scanSchema")
+    assert(scanSchema.fieldNames.contains("dep"),
+      s"dep must be in scan (partitioning + WHERE): $scanSchema")
+    assert(!scanSchema.fieldNames.contains("id"),
+      s"id must be excluded (not declared, not assigned, not in condition): $scanSchema")
+    assert(!scanSchema.fieldNames.contains("bonus"),
+      s"bonus must be excluded (not declared, not assigned, not in condition): $scanSchema")
+  }
+
+  test("column-update from-info: write schema is updatedColumns + pk pass-through") {
+    // requiredDataAttributes = [pk, salary] (pk always added; salary because it's assigned).
+    // Write schema = requiredDataAttributes in declared order = {pk, salary}.
+    createAndInitTableFromInfo("pk INT NOT NULL, salary INT, id INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "id": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "id": 20, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE pk = 1")
+
+    val writeSchema = table.lastWriteInfo.schema()
+    assert(writeSchema.fieldNames.contains("salary"),
+      s"salary must be in write schema (assigned): $writeSchema")
+    assert(writeSchema.fieldNames.contains("pk"),
+      s"pk must be in write schema " +
+        s"(connector pass-through via requiredDataAttributes): $writeSchema")
+    assert(!writeSchema.fieldNames.contains("id"),
+      s"id must not be in write schema: $writeSchema")
+    assert(!writeSchema.fieldNames.contains("dep"),
+      s"dep must not be in write schema (partitioning, not a data column to write): $writeSchema")
+  }
+
+  test("column-update from-info: pk already in updatedColumns is not duplicated") {
+    // When the user updates pk itself, updatedColumns=[pk, salary].
+    // Connector sees pk already present -> requiredDataAttributes=[pk, salary] (no dup).
+    createAndInitTableFromInfo("pk INT NOT NULL, salary INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET pk = pk + 10, salary = -1 WHERE dep = 'hr'")
+
+    val writeSchema = table.lastWriteInfo.schema()
+    val pkCount = writeSchema.fieldNames.count(_ == "pk")
+    assert(pkCount == 1, s"pk must appear exactly once in write schema: $writeSchema")
+  }
+
+  test("column-update from-info: data correctness") {
+    createAndInitTableFromInfo("pk INT NOT NULL, salary INT, id INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "id": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "id": 20, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "id": 30, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
+
+    // salary updated for hr rows; id preserved (not in write schema, connector uses pk lookup)
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, -1, 10, "hr") ::
+      Row(2, 200, 20, "software") ::
+      Row(3, -1, 30, "hr") :: Nil)
+  }
+
+  // ---------------------------------------------------------------------------
+  // CoW connector with supportsColumnUpdates() on RowLevelOperation.
+  // PartitionBasedColumnUpdateOperation declares requiredDataAttributes() = [pk, dep] and
+  // supportsColumnUpdates() = true.  Spark narrows the scan to connector-declared + assigned
+  // columns; bonus is excluded.  The connector reconstructs full rows via pk lookup.
+  // ---------------------------------------------------------------------------
+
+  private def createAndInitTableCoW(schemaString: String, jsonData: String): Unit = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update-cow", "true")
+    val columns = CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schemaString))
+    val transforms = Array[Transform](identity(reference(Seq("dep"))))
+    val tableInfo = new TableInfo.Builder()
+      .withColumns(columns)
+      .withPartitions(transforms)
+      .withProperties(props)
+      .build()
+    catalog.createTable(ident, tableInfo)
+    append(schemaString, jsonData)
+  }
+
+  test("column-update CoW: scan excludes columns not declared and not assigned") {
+    // Connector declares [pk, dep].  SET salary = -1.
+    // Narrow scan = pk (declared) + dep (declared + condition + partitioning)
+    // + salary (assigned LHS).  bonus is neither declared nor assigned -> excluded.
+    createAndInitTableCoW("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "bonus": 30, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
+
+    val scanSchema = table.lastScanSchema
+    assert(scanSchema.fieldNames.contains("pk"), s"pk must be in scan: $scanSchema")
+    assert(scanSchema.fieldNames.contains("dep"), s"dep must be in scan: $scanSchema")
+    assert(scanSchema.fieldNames.contains("salary"),
+      s"salary must be in scan (assigned LHS): $scanSchema")
+    assert(!scanSchema.fieldNames.contains("bonus"), s"bonus must be excluded: $scanSchema")
+  }
+
+  test("column-update CoW: write schema contains only declared + assigned columns") {
+    createAndInitTableCoW("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
+
+    val writeSchema = table.lastWriteInfo.schema()
+    assert(writeSchema.fieldNames.contains("pk"), s"pk must be in write schema: $writeSchema")
+    assert(writeSchema.fieldNames.contains("dep"), s"dep must be in write schema: $writeSchema")
+    assert(writeSchema.fieldNames.contains("salary"),
+      s"salary must be in write schema: $writeSchema")
+    assert(!writeSchema.fieldNames.contains("bonus"),
+      s"bonus must not be in write schema: $writeSchema")
+  }
+
+  test("column-update CoW: data correctness -- bonus preserved, salary updated") {
+    // bonus is not in the write schema; the connector must preserve it from the original row.
+    createAndInitTableCoW("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "bonus": 30, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, -1, 10, "hr") ::
+      Row(2, 200, 20, "software") ::
+      Row(3, -1, 30, "hr") :: Nil)
+  }
+
+  test("column-update CoW: narrow scan + subquery WHERE condition") {
+    // Exercises buildReplaceDataWithUnionPlan + narrow scan + the flatMap change in
+    // RowLevelOperationRuntimeGroupFiltering.buildTableToScanAttrMap.
+    // The subquery forces the UNION path (updated rows + remaining rows).
+    // bonus is not declared and not assigned, must be excluded from scan and write
+    // but the subquery-based filter must still work correctly with the narrow scan.
+    createAndInitTableCoW("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "bonus": 30, "dep": "hr" }
+        |""".stripMargin)
+
+    import testImplicits._
+    val subqueryDF = Seq("hr").toDF()
+    subqueryDF.createOrReplaceTempView("target_deps")
+
+    sql(
+      s"""UPDATE $tableNameAsString
+         |SET salary = -1
+         |WHERE dep IN (SELECT * FROM target_deps)
+         |""".stripMargin)
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, -1, 10, "hr") ::
+      Row(2, 200, 20, "software") ::
+      Row(3, -1, 30, "hr") :: Nil)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Delta connector with representUpdateAsDeleteAndInsert=true AND supportsColumnUpdates=true.
+  //
+  // Point 7: The restriction that blocked column-level updates on the delete+reinsert path
+  // has been removed.  The REINSERT leg of the Expand uses only assigned values (the narrow
+  // write schema from effectiveRowAttrs), and the DELETE leg uses row ID only.
+  // ---------------------------------------------------------------------------
+
+  private def createAndInitTableSplit(schemaString: String, jsonData: String): Unit = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update-split", "true")
+    val columns = CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schemaString))
+    val transforms = Array[Transform](identity(reference(Seq("dep"))))
+    val tableInfo = new TableInfo.Builder()
+      .withColumns(columns)
+      .withPartitions(transforms)
+      .withProperties(props)
+      .build()
+    catalog.createTable(ident, tableInfo)
+    append(schemaString, jsonData)
+  }
+
+  test("column-update split: write schema is narrow (assigned + pk pass-through)") {
+    // representUpdateAsDeleteAndInsert=true + supportsColumnUpdates=true.
+    // requiredDataAttributes() = [pk, id] (pk always declared; id because it's being updated).
+    // The write schema = requiredDataAttributes() in declared order = {pk, id}.
+    // dep is NOT in the write schema (not declared, not assigned).
+    createAndInitTableSplit("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+
+    // Write schema is exactly requiredDataAttributes = {pk, id} in declared order.
+    checkLastWriteInfo(
+      expectedRowSchema = StructType(Seq(
+        StructField("pk", IntegerType, nullable = false),
+        StructField("id", IntegerType, nullable = false)
+      )),
+      expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+      expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
+  }
+
+  test("column-update split: data correctness") {
+    // representUpdateAsDeleteAndInsert=true + supportsColumnUpdates=true.
+    // The connector receives narrow REINSERT rows and must reconstruct full rows.
+    createAndInitTableSplit("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE dep = 'hr'")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, -1, "hr") :: Nil)
+  }
+}
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.connector
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.InSubquery
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 class DeltaBasedUpdateTableSuite extends DeltaBasedUpdateTableSuiteBase {
 
@@ -45,11 +45,13 @@ class DeltaBasedUpdateTableSuite extends DeltaBasedUpdateTableSuiteBase {
       sql(s"SELECT * FROM $tableNameAsString"),
       Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
 
+    // info.schema() reflects the row projection: `id` is non-nullable because the assignment
+    // supplies a non-null literal, matching master's projection-derived write schema semantics.
     checkLastWriteInfo(
-      expectedRowSchema = StructType(table.schema.map {
-        case attr if attr.name == "id" => attr.copy(nullable = false) // input is a constant
-        case attr => attr
-      }),
+      expectedRowSchema = StructType(Seq(
+        PK_FIELD,
+        StructField("id", IntegerType, nullable = false),
+        StructField("dep", StringType, nullable = true))),
       expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
       expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
 
@@ -82,10 +84,10 @@ class DeltaBasedUpdateTableSuite extends DeltaBasedUpdateTableSuiteBase {
         Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
 
       checkLastWriteInfo(
-        expectedRowSchema = StructType(table.schema.map {
-          case attr if attr.name == "id" => attr.copy(nullable = false) // input is a constant
-          case attr => attr
-        }),
+        expectedRowSchema = StructType(Seq(
+          PK_FIELD,
+          StructField("id", IntegerType, nullable = false),
+          StructField("dep", StringType, nullable = true))),
         expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
         expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.connector
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.InSubquery
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.StructType
 
 class DeltaBasedUpdateTableSuite extends DeltaBasedUpdateTableSuiteBase {
 
@@ -45,13 +45,11 @@ class DeltaBasedUpdateTableSuite extends DeltaBasedUpdateTableSuiteBase {
       sql(s"SELECT * FROM $tableNameAsString"),
       Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
 
-    // info.schema() reflects the row projection: `id` is non-nullable because the assignment
-    // supplies a non-null literal, matching master's projection-derived write schema semantics.
     checkLastWriteInfo(
-      expectedRowSchema = StructType(Seq(
-        PK_FIELD,
-        StructField("id", IntegerType, nullable = false),
-        StructField("dep", StringType, nullable = true))),
+      expectedRowSchema = StructType(table.schema.map {
+        case attr if attr.name == "id" => attr.copy(nullable = false) // input is a constant
+        case attr => attr
+      }),
       expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
       expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
 
@@ -84,10 +82,10 @@ class DeltaBasedUpdateTableSuite extends DeltaBasedUpdateTableSuiteBase {
         Row(1, -1, "hr") :: Row(2, 2, "software") :: Row(3, 3, "hr") :: Nil)
 
       checkLastWriteInfo(
-        expectedRowSchema = StructType(Seq(
-          PK_FIELD,
-          StructField("id", IntegerType, nullable = false),
-          StructField("dep", StringType, nullable = true))),
+        expectedRowSchema = StructType(table.schema.map {
+          case attr if attr.name == "id" => attr.copy(nullable = false) // input is a constant
+          case attr => attr
+        }),
         expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
         expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuiteBase.scala
@@ -23,6 +23,68 @@ abstract class DeltaBasedUpdateTableSuiteBase extends UpdateTableSuiteBase {
 
   override protected def deltaUpdate: Boolean = true
 
+  test("updatedColumns: single non-identity assignment") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+
+    checkLastUpdatedColumns("id")
+  }
+
+  test("updatedColumns: multiple non-identity assignments") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1, dep = 'eng' WHERE pk = 1")
+
+    checkLastUpdatedColumns("id", "dep")
+  }
+
+  test("updatedColumns: identity assignments are excluded") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1, dep = dep WHERE pk = 1")
+
+    checkLastUpdatedColumns("id")
+  }
+
+  test("updatedColumns: empty when all assignments are identity") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = id, dep = dep WHERE pk = 1")
+
+    checkLastUpdatedColumns() // expects empty
+  }
+
+  test("updatedColumns: no WHERE clause still reports assigned columns") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET dep = 'eng'")
+
+    checkLastUpdatedColumns("dep")
+  }
+
+  test("updatedColumns: cross-column assignment is not treated as identity") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    // SET id = dep assigns a different column's value -- not identity
+    sql(s"UPDATE $tableNameAsString SET id = 0, dep = dep WHERE pk = 1")
+
+    checkLastUpdatedColumns("id")
+  }
+
   test("nullable row ID attrs") {
     createAndInitTable("pk INT, salary INT, dep STRING",
       """{ "pk": 1, "salary": 300, "dep": 'hr' }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuiteBase.scala
@@ -23,11 +23,6 @@ abstract class DeltaBasedUpdateTableSuiteBase extends UpdateTableSuiteBase {
 
   override protected def deltaUpdate: Boolean = true
 
-  // ---------------------------------------------------------------------------
-  // RowLevelOperationInfo.updatedColumns() -- Spark informs the connector which
-  // columns are genuinely being updated (non-identity assignments only).
-  // ---------------------------------------------------------------------------
-
   test("updatedColumns: single non-identity assignment") {
     createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
       """{ "pk": 1, "id": 1, "dep": "hr" }
@@ -53,7 +48,6 @@ abstract class DeltaBasedUpdateTableSuiteBase extends UpdateTableSuiteBase {
       """{ "pk": 1, "id": 1, "dep": "hr" }
         |""".stripMargin)
 
-    // dep = dep is an identity assignment and must NOT appear in updatedColumns
     sql(s"UPDATE $tableNameAsString SET id = -1, dep = dep WHERE pk = 1")
 
     checkLastUpdatedColumns("id")
@@ -85,7 +79,7 @@ abstract class DeltaBasedUpdateTableSuiteBase extends UpdateTableSuiteBase {
       """{ "pk": 1, "id": 1, "dep": "hr" }
         |""".stripMargin)
 
-    // SET id = dep assigns a different column's value to id -- not identity
+    // SET id = dep assigns a different column's value -- not identity
     sql(s"UPDATE $tableNameAsString SET id = 0, dep = dep WHERE pk = 1")
 
     checkLastUpdatedColumns("id")

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateTableSuiteBase.scala
@@ -23,6 +23,74 @@ abstract class DeltaBasedUpdateTableSuiteBase extends UpdateTableSuiteBase {
 
   override protected def deltaUpdate: Boolean = true
 
+  // ---------------------------------------------------------------------------
+  // RowLevelOperationInfo.updatedColumns() -- Spark informs the connector which
+  // columns are genuinely being updated (non-identity assignments only).
+  // ---------------------------------------------------------------------------
+
+  test("updatedColumns: single non-identity assignment") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1 WHERE pk = 1")
+
+    checkLastUpdatedColumns("id")
+  }
+
+  test("updatedColumns: multiple non-identity assignments") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = -1, dep = 'eng' WHERE pk = 1")
+
+    checkLastUpdatedColumns("id", "dep")
+  }
+
+  test("updatedColumns: identity assignments are excluded") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    // dep = dep is an identity assignment and must NOT appear in updatedColumns
+    sql(s"UPDATE $tableNameAsString SET id = -1, dep = dep WHERE pk = 1")
+
+    checkLastUpdatedColumns("id")
+  }
+
+  test("updatedColumns: empty when all assignments are identity") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET id = id, dep = dep WHERE pk = 1")
+
+    checkLastUpdatedColumns() // expects empty
+  }
+
+  test("updatedColumns: no WHERE clause still reports assigned columns") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET dep = 'eng'")
+
+    checkLastUpdatedColumns("dep")
+  }
+
+  test("updatedColumns: cross-column assignment is not treated as identity") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    // SET id = dep assigns a different column's value to id -- not identity
+    sql(s"UPDATE $tableNameAsString SET id = 0, dep = dep WHERE pk = 1")
+
+    checkLastUpdatedColumns("id")
+  }
+
   test("nullable row ID attrs") {
     createAndInitTable("pk INT, salary INT, dep STRING",
       """{ "pk": 1, "salary": 300, "dep": 'hr' }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedColumnUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedColumnUpdateTableSuite.scala
@@ -212,4 +212,29 @@ class GroupBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
       sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
       Row(1, Row(-1, 2), "hr") :: Row(2, Row(3, 4), "hr") :: Nil)
   }
+
+  test("column-update ReplaceData: nested field identity update reports root struct as updated") {
+    createAndInitTableReplaceData("pk INT NOT NULL, s STRUCT<c1: INT, c2: INT>, dep STRING",
+      """{ "pk": 1, "s": { "c1": 1, "c2": 2 }, "dep": "hr" }
+        |""".stripMargin)
+
+    // `SET s.c1 = s.c1` is semantically a no-op on the nested field, but the analyzer's
+    // AssignmentUtils rewrites nested field assignments into whole-struct rebuilds:
+    //     Assignment(s, named_struct("c1", s.c1, "c2", s.c2))
+    // `isIdentityAssignment` operates at root-column granularity and does NOT recognize the
+    // rebuilt struct as identity (its value is a `named_struct(...)`, not a plain Attribute
+    // matching the key). So `s` is reported in updatedColumns even though the values don't
+    // change. This documents the root-column granularity of `RowLevelOperationInfo` for the
+    // CoW path.
+    sql(s"UPDATE $tableNameAsString SET s.c1 = s.c1 WHERE pk = 1")
+
+    val updatedNames = table.lastUpdatedColumns.map(_.describe()).toSet
+    assert(updatedNames == Set("s"),
+      s"nested identity is reported as an update at root-column granularity: $updatedNames")
+
+    // Data correctness: the struct is rewritten but with equal values, so rows are unchanged.
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Row(1, Row(1, 2), "hr") :: Nil)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedColumnUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedColumnUpdateTableSuite.scala
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, TableInfo, WriteUpdate}
+import org.apache.spark.sql.connector.expressions.LogicalExpressions.{identity, reference}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.types.StructType
+
+class GroupBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
+
+  private def createAndInitTableReplaceData(schemaString: String, jsonData: String): Unit = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update-cow", "true")
+    val columns = CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schemaString))
+    val transforms = Array[Transform](identity(reference(Seq("dep"))))
+    val tableInfo = new TableInfo.Builder()
+      .withColumns(columns)
+      .withPartitions(transforms)
+      .withProperties(props)
+      .build()
+    catalog.createTable(ident, tableInfo)
+    append(schemaString, jsonData)
+  }
+
+  test("column-update ReplaceData: write schema contains only declared + assigned columns") {
+    createAndInitTableReplaceData("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
+
+    val updateSchema = table.lastWriteInfo.updateSchema().get()
+    assert(updateSchema.fieldNames.contains("pk"), s"pk must be in update schema: $updateSchema")
+    assert(updateSchema.fieldNames.contains("dep"), s"dep must be in update schema: $updateSchema")
+    assert(updateSchema.fieldNames.contains("salary"),
+      s"salary must be in update schema: $updateSchema")
+    assert(!updateSchema.fieldNames.contains("bonus"),
+      s"bonus must not be in update schema: $updateSchema")
+  }
+
+  test("column-update ReplaceData: data correctness -- bonus preserved, salary updated") {
+    createAndInitTableReplaceData("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "bonus": 30, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, -1, 10, "hr") ::
+      Row(2, 200, 20, "software") ::
+      Row(3, -1, 30, "hr") :: Nil)
+    // CoW: pk=1 and pk=3 match (2 updates); the 'hr' partition has no other rows so no copies.
+    checkUpdateMetrics(numUpdatedRows = 2, numCopiedRows = 0)
+  }
+
+  test("column-update ReplaceData: subquery WHERE condition data correctness") {
+    createAndInitTableReplaceData("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "bonus": 30, "dep": "hr" }
+        |""".stripMargin)
+
+    import testImplicits._
+    val subqueryDF = Seq("hr").toDF()
+    subqueryDF.createOrReplaceTempView("target_deps")
+
+    sql(
+      s"""UPDATE $tableNameAsString
+         |SET salary = -1
+         |WHERE dep IN (SELECT * FROM target_deps)
+         |""".stripMargin)
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, -1, 10, "hr") ::
+      Row(2, 200, 20, "software") ::
+      Row(3, -1, 30, "hr") :: Nil)
+    checkUpdateMetrics(numUpdatedRows = 2, numCopiedRows = 0)
+  }
+
+  test("column-update ReplaceData: runtime group filtering data correctness") {
+    Seq(true, false).foreach { dppEnabled =>
+      Seq(true, false).foreach { aqeEnabled =>
+        withSQLConf(
+            org.apache.spark.sql.internal.SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key ->
+              dppEnabled.toString,
+            org.apache.spark.sql.internal.SQLConf.ADAPTIVE_EXECUTION_ENABLED.key ->
+              aqeEnabled.toString) {
+          withTable(tableNameAsString) {
+            withTempView("matched_pk") {
+              createAndInitTableReplaceData("pk INT, salary INT, bonus INT, dep STRING",
+                """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+                  |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
+                  |{ "pk": 3, "salary": 300, "bonus": 30, "dep": "hr" }
+                  |""".stripMargin)
+
+              import testImplicits._
+              val matchedPkDF = Seq(Some(1), None).toDF()
+              matchedPkDF.createOrReplaceTempView("matched_pk")
+
+              sql(s"UPDATE $tableNameAsString SET salary = -1 " +
+                s"WHERE pk IN (SELECT * FROM matched_pk)")
+
+              checkAnswer(
+                sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+                Row(1, -1, 10, "hr") ::
+                Row(2, 200, 20, "software") ::
+                Row(3, 300, 30, "hr") :: Nil)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("column-update ReplaceData: dispatch verification -- UPDATE/COPY rows use writeUpdate") {
+    // Validates the runtime contract: when SupportsColumnUpdates is in play, UPDATE and COPY
+    // rows flow through DataWriter.writeUpdate(...) rather than DataWriter.write(...). The
+    // test connector tags log entries by which writer method was called, so we can assert
+    // every row in the write log went through the narrow path.
+    createAndInitTableReplaceData("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "hr" }
+        |{ "pk": 3, "salary": 300, "bonus": 30, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE pk = 1")
+
+    // The matched 'hr' partition rewrites two rows: pk=1 (UPDATE) and pk=2 (COPY). Both
+    // must be tagged as writeUpdate; no plain write entries.
+    val ops = table.lastWriteLog.map(_.getUTF8String(0).toString).toSet
+    assert(ops == Set(WriteUpdate.toString),
+      s"all CoW column-update log entries must use writeUpdate, got: $ops")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scan-narrowing tests: verify that the physical scan reads only the columns
+  // required by the connector, the assignment RHS, and the operation condition.
+  // ---------------------------------------------------------------------------
+
+  test("column-update ReplaceData: scan excludes columns outside required + cond") {
+    createAndInitTableReplaceData("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
+        |""".stripMargin)
+
+    // Connector-declared requiredDataAttributes = [pk, dep, salary]; cond refs `dep` (already
+    // declared). `bonus` is neither declared nor referenced -- it must not appear in the scan.
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
+
+    checkLastScanExcludes("bonus")
+  }
+
+  test("column-update ReplaceData: scan transparently widens for RHS references") {
+    createAndInitTableReplaceData("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "hr" }
+        |""".stripMargin)
+
+    // Connector-declared = [pk, dep, salary]; RHS `salary + bonus` references `bonus`.
+    // Narrow scan must include `bonus` even though it's not declared as required.
+    sql(s"UPDATE $tableNameAsString SET salary = salary + bonus WHERE dep = 'hr'")
+
+    checkLastScanIncludes("bonus", "salary")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, 110, 10, "hr") :: Row(2, 220, 20, "hr") :: Nil)
+  }
+
+  test("column-update ReplaceData: nested struct field update narrows to root struct column") {
+    createAndInitTableReplaceData("pk INT NOT NULL, s STRUCT<c1: INT, c2: INT>, dep STRING",
+      """{ "pk": 1, "s": { "c1": 1, "c2": 2 }, "dep": "hr" }
+        |{ "pk": 2, "s": { "c1": 3, "c2": 4 }, "dep": "hr" }
+        |""".stripMargin)
+
+    // `SET s.c1 = -1` is aligned into a whole-struct assignment, so updatedColumns is [s]
+    // at root granularity. The narrow write / scan schema covers the root struct column.
+    sql(s"UPDATE $tableNameAsString SET s.c1 = -1 WHERE pk = 1")
+
+    val updatedNames = table.lastUpdatedColumns.map(_.describe()).toSet
+    assert(updatedNames == Set("s"),
+      s"expected [s] in updatedColumns (root struct) but got: $updatedNames")
+
+    val updateSchema = table.lastWriteInfo.updateSchema().get()
+    assert(updateSchema.fieldNames.contains("s"),
+      s"s must be in update schema: $updateSchema")
+
+    // Data correctness: matched row's c1 updated, c2 preserved; unmatched row untouched.
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, Row(-1, 2), "hr") :: Row(2, Row(3, 4), "hr") :: Nil)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedColumnUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedColumnUpdateTableSuite.scala
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, TableInfo}
+import org.apache.spark.sql.connector.expressions.LogicalExpressions.{identity, reference}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.types.StructType
+
+class GroupBasedColumnUpdateTableSuite extends RowLevelOperationSuiteBase {
+
+  private def createAndInitTableReplaceData(schemaString: String, jsonData: String): Unit = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("column-update-cow", "true")
+    val columns = CatalogV2Util.structTypeToV2Columns(StructType.fromDDL(schemaString))
+    val transforms = Array[Transform](identity(reference(Seq("dep"))))
+    val tableInfo = new TableInfo.Builder()
+      .withColumns(columns)
+      .withPartitions(transforms)
+      .withProperties(props)
+      .build()
+    catalog.createTable(ident, tableInfo)
+    append(schemaString, jsonData)
+  }
+
+  test("column-update ReplaceData: scan excludes columns not declared and not assigned") {
+    createAndInitTableReplaceData("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "bonus": 30, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
+
+    val scanSchema = table.lastScanSchema
+    assert(scanSchema.fieldNames.contains("pk"), s"pk must be in scan: $scanSchema")
+    assert(scanSchema.fieldNames.contains("dep"), s"dep must be in scan: $scanSchema")
+    assert(scanSchema.fieldNames.contains("salary"),
+      s"salary must be in scan (assigned): $scanSchema")
+    assert(!scanSchema.fieldNames.contains("bonus"), s"bonus must be excluded: $scanSchema")
+  }
+
+  test("column-update ReplaceData: write schema contains only declared + assigned columns") {
+    createAndInitTableReplaceData("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
+
+    val writeSchema = table.lastWriteInfo.schema()
+    assert(writeSchema.fieldNames.contains("pk"), s"pk must be in write schema: $writeSchema")
+    assert(writeSchema.fieldNames.contains("dep"), s"dep must be in write schema: $writeSchema")
+    assert(writeSchema.fieldNames.contains("salary"),
+      s"salary must be in write schema: $writeSchema")
+    assert(!writeSchema.fieldNames.contains("bonus"),
+      s"bonus must not be in write schema: $writeSchema")
+  }
+
+  test("column-update ReplaceData: data correctness -- bonus preserved, salary updated") {
+    createAndInitTableReplaceData("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "bonus": 30, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE dep = 'hr'")
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, -1, 10, "hr") ::
+      Row(2, 200, 20, "software") ::
+      Row(3, -1, 30, "hr") :: Nil)
+  }
+
+  test("column-update ReplaceData: narrow scan + subquery WHERE condition") {
+    createAndInitTableReplaceData("pk INT NOT NULL, salary INT, bonus INT, dep STRING",
+      """{ "pk": 1, "salary": 100, "bonus": 10, "dep": "hr" }
+        |{ "pk": 2, "salary": 200, "bonus": 20, "dep": "software" }
+        |{ "pk": 3, "salary": 300, "bonus": 30, "dep": "hr" }
+        |""".stripMargin)
+
+    import testImplicits._
+    val subqueryDF = Seq("hr").toDF()
+    subqueryDF.createOrReplaceTempView("target_deps")
+
+    sql(
+      s"""UPDATE $tableNameAsString
+         |SET salary = -1
+         |WHERE dep IN (SELECT * FROM target_deps)
+         |""".stripMargin)
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+      Row(1, -1, 10, "hr") ::
+      Row(2, 200, 20, "software") ::
+      Row(3, -1, 30, "hr") :: Nil)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/RowLevelOperationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/RowLevelOperationSuiteBase.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.{DynamicPruningExpression, Expr
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, ReplaceData, WriteDelta}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.METADATA_COL_ATTR_KEY
-import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Column, Delete, Identifier, InMemoryRowLevelOperationTable, InMemoryRowLevelOperationTableCatalog, Insert, MetadataColumn, Operation, Reinsert, RowLevelOperationWithOptions, Table, TableInfo, Txn, TxnTable, Update, Write}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Column, Delete, Identifier, InMemoryRowLevelOperationTable, InMemoryRowLevelOperationTableCatalog, InMemoryTable, Insert, MetadataColumn, Operation, Reinsert, RowLevelOperationWithOptions, Table, TableInfo, Txn, TxnTable, Update, Write, WriteUpdate}
 import org.apache.spark.sql.connector.expressions.LogicalExpressions.{identity, reference}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.write.RowLevelOperationTable
@@ -48,6 +48,7 @@ abstract class RowLevelOperationSuiteBase
 
   before {
     spark.conf.set("spark.sql.catalog.cat", classOf[InMemoryRowLevelOperationTableCatalog].getName)
+    InMemoryRowLevelOperationTable.resetLastScanSchema()
   }
 
   after {
@@ -267,13 +268,102 @@ abstract class RowLevelOperationSuiteBase
   protected def checkLastWriteInfo(
       expectedRowSchema: StructType = new StructType(),
       expectedRowIdSchema: Option[StructType] = None,
-      expectedMetadataSchema: Option[StructType] = None): Unit = {
+      expectedMetadataSchema: Option[StructType] = None,
+      expectedUpdateSchema: Option[StructType] = None): Unit = {
     val info = table.lastWriteInfo
     assert(info.schema == expectedRowSchema, "row schema must match")
     val actualRowIdSchema = Option(info.rowIdSchema.orElse(null))
     assert(actualRowIdSchema == expectedRowIdSchema, "row ID schema must match")
     val actualMetadataSchema = Option(info.metadataSchema.orElse(null))
     assert(actualMetadataSchema == expectedMetadataSchema, "metadata schema must match")
+    val actualUpdateSchema = Option(info.updateSchema.orElse(null))
+    assert(actualUpdateSchema == expectedUpdateSchema, "update schema must match")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Write-summary metrics helpers (UPDATE and MERGE). Hoisted from the peer
+  // suites so column-update suites can assert on metrics without duplication.
+  // ---------------------------------------------------------------------------
+
+  protected def getUpdateSummary(): org.apache.spark.sql.connector.write.UpdateSummary = {
+    catalog.loadTable(ident).asInstanceOf[InMemoryTable]
+      .commits.last.writeSummary.get
+      .asInstanceOf[org.apache.spark.sql.connector.write.UpdateSummary]
+  }
+
+  /**
+   * Asserts the last UPDATE's write summary metrics. `deltaUpdate` controls the expected
+   * COPY count: MoR connectors emit only deltas (no COPY rows) so `numCopiedRows` is forced
+   * to 0; CoW connectors emit COPY rows for unchanged rows in matched groups.
+   */
+  protected def checkUpdateMetrics(
+      numUpdatedRows: Long,
+      numCopiedRows: Long,
+      deltaUpdate: Boolean = false): Unit = {
+    val summary = getUpdateSummary()
+    assert(summary.numUpdatedRows() === numUpdatedRows,
+      s"Expected numUpdatedRows=$numUpdatedRows, got ${summary.numUpdatedRows()}")
+    val expectedCopied = if (deltaUpdate) 0L else numCopiedRows
+    assert(summary.numCopiedRows() === expectedCopied,
+      s"Expected numCopiedRows=$expectedCopied, got ${summary.numCopiedRows()}")
+  }
+
+  /**
+   * Asserts that the column names in RowLevelOperationInfo.updatedColumns() received by the
+   * last operation match exactly the expected set.  Order is ignored.
+   */
+  protected def checkLastUpdatedColumns(expectedNames: String*): Unit = {
+    val actual = table.lastUpdatedColumns.map(_.describe()).toSet
+    val expected = expectedNames.toSet
+    assert(actual == expected,
+      s"updatedColumns mismatch: expected ${expected.mkString("[", ", ", "]")} " +
+        s"but got ${actual.mkString("[", ", ", "]")}")
+  }
+
+  /**
+   * Asserts the set of top-level column names present in the last connector scan schema.
+   * Metadata columns are filtered out so tests can focus on data-column narrowing without
+   * having to enumerate `_partition` / `index` on every assertion.
+   */
+  protected def checkLastScanDataColumns(expectedNames: String*): Unit = {
+    val schema = Option(table.lastScanSchema).getOrElse(StructType(Nil))
+    val actual = schema.fieldNames
+      .filterNot(name => name == "_partition" || name == "index")
+      .toSet
+    val expected = expectedNames.toSet
+    assert(actual == expected,
+      s"scan data-column mismatch: expected ${expected.mkString("[", ", ", "]")} " +
+        s"but got ${actual.mkString("[", ", ", "]")} " +
+        s"(full lastScanSchema=${schema.fieldNames.mkString("[", ", ", "]")})")
+  }
+
+  /**
+   * Asserts that the last connector scan schema does NOT contain any of the given columns.
+   * Useful for negative narrowing assertions -- proves that a column outside the analysis-time
+   * narrow set was pruned by the scan, without over-specifying what else is present (which
+   * ColumnPruning may further tighten in ways unrelated to the narrowing contract).
+   */
+  protected def checkLastScanExcludes(excludedNames: String*): Unit = {
+    val schema = Option(table.lastScanSchema).getOrElse(StructType(Nil))
+    val actual = schema.fieldNames.toSet
+    val leaked = excludedNames.toSet.intersect(actual)
+    assert(leaked.isEmpty,
+      s"scan should not include ${leaked.mkString("[", ", ", "]")} " +
+        s"but lastScanSchema=${schema.fieldNames.mkString("[", ", ", "]")}")
+  }
+
+  /**
+   * Asserts that the last connector scan schema DOES contain all of the given columns.
+   * Positive narrowing assertion -- proves that a column referenced by the operation (via
+   * assignment RHS, condition, etc.) survived analysis-time narrowing and appeared in the scan.
+   */
+  protected def checkLastScanIncludes(includedNames: String*): Unit = {
+    val schema = Option(table.lastScanSchema).getOrElse(StructType(Nil))
+    val actual = schema.fieldNames.toSet
+    val missing = includedNames.toSet.diff(actual)
+    assert(missing.isEmpty,
+      s"scan must include ${missing.mkString("[", ", ", "]")} " +
+        s"but lastScanSchema=${schema.fieldNames.mkString("[", ", ", "]")}")
   }
 
   protected def checkLastWriteLog(expectedEntries: WriteLogEntry*): Unit = {
@@ -313,6 +403,15 @@ abstract class RowLevelOperationSuiteBase
 
   protected def writeWithMetadataLogEntry(metadata: Row, data: Row): WriteLogEntry = {
     WriteLogEntry(operation = Write, metadata = Some(metadata), data = Some(data))
+  }
+
+  // SupportsColumnUpdates CoW path: UPDATE/COPY rows arrive via writer.writeUpdate(...).
+  protected def writeUpdateLogEntry(data: Row): WriteLogEntry = {
+    WriteLogEntry(operation = WriteUpdate, data = Some(data))
+  }
+
+  protected def writeUpdateWithMetadataLogEntry(metadata: Row, data: Row): WriteLogEntry = {
+    WriteLogEntry(operation = WriteUpdate, metadata = Some(metadata), data = Some(data))
   }
 
   protected def deleteWriteLogEntry(id: Int, metadata: Row): WriteLogEntry = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/RowLevelOperationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/RowLevelOperationSuiteBase.scala
@@ -280,11 +280,6 @@ abstract class RowLevelOperationSuiteBase
     assert(actualUpdateSchema == expectedUpdateSchema, "update schema must match")
   }
 
-  // ---------------------------------------------------------------------------
-  // Write-summary metrics helpers (UPDATE and MERGE). Hoisted from the peer
-  // suites so column-update suites can assert on metrics without duplication.
-  // ---------------------------------------------------------------------------
-
   protected def getUpdateSummary(): org.apache.spark.sql.connector.write.UpdateSummary = {
     catalog.loadTable(ident).asInstanceOf[InMemoryTable]
       .commits.last.writeSummary.get

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/RowLevelOperationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/RowLevelOperationSuiteBase.scala
@@ -316,23 +316,6 @@ abstract class RowLevelOperationSuiteBase
   }
 
   /**
-   * Asserts the set of top-level column names present in the last connector scan schema.
-   * Metadata columns are filtered out so tests can focus on data-column narrowing without
-   * having to enumerate `_partition` / `index` on every assertion.
-   */
-  protected def checkLastScanDataColumns(expectedNames: String*): Unit = {
-    val schema = Option(table.lastScanSchema).getOrElse(StructType(Nil))
-    val actual = schema.fieldNames
-      .filterNot(name => name == "_partition" || name == "index")
-      .toSet
-    val expected = expectedNames.toSet
-    assert(actual == expected,
-      s"scan data-column mismatch: expected ${expected.mkString("[", ", ", "]")} " +
-        s"but got ${actual.mkString("[", ", ", "]")} " +
-        s"(full lastScanSchema=${schema.fieldNames.mkString("[", ", ", "]")})")
-  }
-
-  /**
    * Asserts that the last connector scan schema does NOT contain any of the given columns.
    * Useful for negative narrowing assertions -- proves that a column outside the analysis-time
    * narrow set was pruned by the scan, without over-specifying what else is present (which

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/RowLevelOperationSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/RowLevelOperationSuiteBase.scala
@@ -245,6 +245,18 @@ abstract class RowLevelOperationSuiteBase
     assert(actualMetadataSchema == expectedMetadataSchema, "metadata schema must match")
   }
 
+  /**
+   * Asserts that the column names in RowLevelOperationInfo.updatedColumns() received by the
+   * last operation match exactly the expected set.  Order is ignored.
+   */
+  protected def checkLastUpdatedColumns(expectedNames: String*): Unit = {
+    val actual = table.lastUpdatedColumns.map(_.describe()).toSet
+    val expected = expectedNames.toSet
+    assert(actual == expected,
+      s"updatedColumns mismatch: expected ${expected.mkString("[", ", ", "]")} " +
+        s"but got ${actual.mkString("[", ", ", "]")}")
+  }
+
   protected def checkLastWriteLog(expectedEntries: WriteLogEntry*): Unit = {
     val entryType = new StructType()
       .add(StructField("operation", StringType))

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableSuiteBase.scala
@@ -34,9 +34,7 @@ abstract class UpdateTableSuiteBase extends RowLevelOperationSuiteBase {
 
   protected def deltaUpdate: Boolean = false
 
-  // getUpdateSummary and checkUpdateMetrics are inherited from RowLevelOperationSuiteBase
-  // so all row-level suites (including the column-update variants) share the same helpers.
-  // Forward to the base method with `deltaUpdate` resolved here.
+  // Convenience overload that forwards `deltaUpdate` from the current suite to the base helper.
   protected def checkUpdateMetrics(numUpdatedRows: Long, numCopiedRows: Long): Unit = {
     super.checkUpdateMetrics(numUpdatedRows, numCopiedRows, deltaUpdate)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableSuiteBase.scala
@@ -22,9 +22,8 @@ import org.apache.spark.internal.config
 import org.apache.spark.sql.{sources, AnalysisException, Row}
 import org.apache.spark.sql.QueryTest.withQueryExecutionsCaptured
 import org.apache.spark.sql.catalyst.plans.logical.{ReplaceData, WriteDelta}
-import org.apache.spark.sql.connector.catalog.{Aborted, Column, ColumnDefaultValue, Committed, InMemoryTable, TableChange, TableInfo}
+import org.apache.spark.sql.connector.catalog.{Aborted, Column, ColumnDefaultValue, Committed, TableChange, TableInfo}
 import org.apache.spark.sql.connector.expressions.{GeneralScalarExpression, LiteralValue}
-import org.apache.spark.sql.connector.write.UpdateSummary
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanRelation}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StringType}
@@ -35,20 +34,11 @@ abstract class UpdateTableSuiteBase extends RowLevelOperationSuiteBase {
 
   protected def deltaUpdate: Boolean = false
 
-  protected def getUpdateSummary(): UpdateSummary = {
-    val t = catalog.loadTable(ident).asInstanceOf[InMemoryTable]
-    t.commits.last.writeSummary.get.asInstanceOf[UpdateSummary]
-  }
-
-  protected def checkUpdateMetrics(
-      numUpdatedRows: Long,
-      numCopiedRows: Long): Unit = {
-    val summary = getUpdateSummary()
-    assert(summary.numUpdatedRows() === numUpdatedRows,
-      s"Expected numUpdatedRows=$numUpdatedRows, got ${summary.numUpdatedRows()}")
-    val expectedCopied = if (deltaUpdate) 0L else numCopiedRows
-    assert(summary.numCopiedRows() === expectedCopied,
-      s"Expected numCopiedRows=$expectedCopied, got ${summary.numCopiedRows()}")
+  // getUpdateSummary and checkUpdateMetrics are inherited from RowLevelOperationSuiteBase
+  // so all row-level suites (including the column-update variants) share the same helpers.
+  // Forward to the base method with `deltaUpdate` resolved here.
+  protected def checkUpdateMetrics(numUpdatedRows: Long, numCopiedRows: Long): Unit = {
+    super.checkUpdateMetrics(numUpdatedRows, numCopiedRows, deltaUpdate)
   }
 
   test("update table containing added column with default value") {


### PR DESCRIPTION
 **What changes were proposed in this pull request?**      

For SPIP: [SPARK-56599](https://issues.apache.org/jira/browse/SPARK-56599)                                                                                                  
                                                                                                                                                          
This PR adds an opt-in DSv2 mix-in for connectors to receive narrow rows on column-level UPDATE, so connectors can avoid reading and writing full-table rows when only a subset of columns is being updated.
  
 Public API additions (since 4.3.0):

- SupportsColumnUpdates (`@Experimental`) — a new mix-in on RowLevelOperation. Connectors implement `requiredDataAttributes(): NamedReference[]` to declare the columns they need in the write payload, and optionally `scanOnlyDataAttributes(): NamedReference[]` to declare additional columns needed only for scan/write-side planning (e.g. resolving partitioning expressions or write clustering keys) but excluded from the write payload; must not overlap with requiredDataAttributes(), defaults to an empty array.
- `RowLevelOperationInfo.updatedColumns(): NamedReference[] (`@Experimental`)` — non-identity assignment column names (root-column granularity for nested field updates), populated by Spark before the connector's operation builder runs, so the connector can size `requiredDataAttributes()` accordingly.
- `LogicalWriteInfo.updateSchema(): Optional<StructType> (`@Evolving`)` — narrow row schema for writeUpdate()-bound rows; schema() is empty when there are no INSERT-shaped rows (the common UPDATE-only case), and otherwise still carries the full table shape for INSERT-tagged rows.
- `DataWriter.writeUpdate(record)` and `writeUpdate(metadata, record) (`@Evolving`)` — narrow write channel; default implementations delegate to write(...) so existing connectors are unaffected.

When a connector mixes in SupportsColumnUpdates, Spark's UPDATE (RewriteUpdateTable) narrows both sides of the plan: 

- Scan side: the physical scan is narrowed to requiredDataAttributes() plus scanOnlyDataAttributes(), plus any columns referenced by the UPDATE condition or non-identity assignment expressions.
- Write side: the row handed to writeUpdate()/DeltaWriter is narrowed to requiredDataAttributes() only; scanOnlyDataAttributes() columns stay in the scan for planning but are excluded from the write payload.


  
## Why are the changes needed?
  
Schema narrowing helps connectors request for only updated columns enabling efficient column-level updates of wide tables.
  
## Does this PR introduce any user-facing change?
  
Yes, new public DSv2 connector APIs:

- RowLevelOperation gains a new mix-in SupportsColumnUpdates (requiredDataAttributes(), scanOnlyDataAttributes())
- RowLevelOperationInfo.updatedColumns()
- LogicalWriteInfo.updateSchema()
- DataWriter.writeUpdate(...)
  
## How was this patch tested?
  
  New tests in:
  - DeltaBasedColumnUpdateTableSuite 
  - GroupBasedColumnUpdateTableSuite 
  

## Was this patch authored or co-authored using generative AI tooling?
I used Claude Code (Opus 5)  to generate code and tests and manually reviewed the generated code.
