### PR TITLE
[SPARK-56605][SQL] Improve error context in CheckAnalysis for view body resolution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -73,7 +73,8 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
    * Contains system.session and the current catalog namespace only. Not from SQLConf.
    */
   private def ddlSearchPathForError(catalogPath: Seq[String]): Seq[String] = {
-    Seq(toSQLId(Seq("system", "session")), toSQLId(catalogPath))
+    Seq(toSQLId(Seq(CatalogManager.SYSTEM_CATALOG_NAME, CatalogManager.SESSION_NAMESPACE)),
+      toSQLId(catalogPath))
   }
 
   /**
@@ -84,9 +85,16 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
     SQLConf.get.resolutionSearchPath(catalogPath).map(toSQLId)
   }
 
-  /** Current catalog name and namespace as a path, used when computing search path for errors. */
+  /**
+   * Current catalog name and namespace as a path, used when computing search path for errors.
+   * When resolving inside a view body, uses the view's defining catalog/namespace
+   * (from AnalysisContext) so the error message reflects the view's resolution context
+   * rather than the caller's current schema.
+   */
   private def catalogPathForError: Seq[String] = {
-    (currentCatalog.name +: catalogManager.currentNamespace).toSeq
+    val ctx = AnalysisContext.get.catalogAndNamespace
+    if (ctx.nonEmpty) ctx
+    else (currentCatalog.name +: catalogManager.currentNamespace).toSeq
   }
 
   /**
@@ -94,7 +102,7 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
    * (e.g. DROP TEMPORARY VIEW). Contains system.session only.
    */
   private def tempViewOnlySearchPathForError(): Seq[String] = {
-    Seq(toSQLId(Seq("system", "session")))
+    Seq(toSQLId(Seq(CatalogManager.SYSTEM_CATALOG_NAME, CatalogManager.SESSION_NAMESPACE)))
   }
 
   /**
@@ -595,7 +603,9 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
               searchPathForUnresolvedRelation(u.multipartIdentifier))
 
           case RelationChanges(u: UnresolvedRelation, _) =>
-            u.tableNotFound(u.multipartIdentifier)
+            u.tableNotFound(
+              u.multipartIdentifier,
+              searchPathForUnresolvedRelation(u.multipartIdentifier))
 
           case etw: EventTimeWatermark =>
             etw.eventTime.dataType match {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make `TABLE_OR_VIEW_NOT_FOUND` and `UNRESOLVED_ROUTINE` error messages context-aware when fired inside a view body:

- `catalogPathForError` now consults `AnalysisContext.catalogAndNamespace` when resolving inside a view body, so error messages report the view's defining catalog/namespace rather than the caller's current schema.
- Use `CatalogManager.SYSTEM_CATALOG_NAME` / `SESSION_NAMESPACE` constants instead of string literals in `ddlSearchPathForError` and `tempViewOnlySearchPathForError`.
- Add `searchPath` to `RelationChanges` error (was missing, producing "not available").

### Why are the changes needed?

When an unresolved relation error fires inside a view body, the current error message shows the caller's current schema, not the view's defining schema. This is confusing -- the user sees a search path that doesn't match where the view was actually trying to resolve.

These are prerequisite cleanups for the SQL PATH resolution wiring ([SPARK-54810](https://issues.apache.org/jira/browse/SPARK-54810)).

### Does this PR introduce _any_ user-facing change?

Yes. Error messages for `TABLE_OR_VIEW_NOT_FOUND` inside view bodies now show the view's defining catalog/namespace instead of the caller's current schema. `RelationChanges` errors now include the search path.

### How was this patch tested?

CI (1 file, 15-line change to `CheckAnalysis.scala`).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.6