### PR TITLE
[SPARK-54090][PYTHON] Fix cascading diff in assertDataFrameEqual when row counts differ

### DIFF
--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1084,6 +1084,76 @@ class UtilsTestsMixin:
             messageParameters={"error_msg": error_msg},
         )
 
+    def test_different_row_count_middle_missing_no_cascading_diff(self):
+        # SPARK-54090: When checkRowOrder=False and expected is missing a row in
+        # the middle of the sorted order, only the truly missing/extra row should
+        # be reported -- not every row after the first mismatch.
+        actual = [Row(id="1"), Row(id="2"), Row(id="3"), Row(id="4"), Row(id="5")]
+        expected = [Row(id="1"), Row(id="2"), Row(id="4"), Row(id="5")]
+
+        with self.assertRaises(PySparkAssertionError) as pe:
+            assertDataFrameEqual(actual, expected)
+
+        error_msg = pe.exception.getMessageParameters()["error_msg"]
+        # Only Row(id='3') is extra in actual: 1 / max(5, 4) = 20%
+        self.assertIn("20.00000 %", error_msg)
+
+    def test_different_row_count_multiple_missing(self):
+        # SPARK-54090: Multiple rows missing from expected should be counted
+        # individually, not cascade across every subsequent row.
+        actual = [Row(v=i) for i in range(1, 7)]
+        expected = [Row(v=i) for i in (1, 3, 5)]
+
+        with self.assertRaises(PySparkAssertionError) as pe:
+            assertDataFrameEqual(actual, expected)
+
+        error_msg = pe.exception.getMessageParameters()["error_msg"]
+        # 3 extras (2, 4, 6) in actual; max(6, 3) = 6 -> 50%
+        self.assertIn("50.00000 %", error_msg)
+
+    def test_different_row_count_includeDiffRows(self):
+        # SPARK-54090: includeDiffRows should contain only truly differing rows.
+        actual = [Row(id="1"), Row(id="2"), Row(id="3"), Row(id="4"), Row(id="5")]
+        expected = [Row(id="1"), Row(id="2"), Row(id="4"), Row(id="5")]
+
+        with self.assertRaises(PySparkAssertionError) as pe:
+            assertDataFrameEqual(actual, expected, includeDiffRows=True)
+
+        # Only one actual row (id='3') has no match in expected.
+        self.assertEqual(pe.exception.data, [(Row(id="3"), None)])
+
+    def test_different_row_count_mixed_extra_and_missing(self):
+        # SPARK-54090: both extras in actual and missing in actual must be
+        # reported without cascading.
+        actual = [Row(v="A"), Row(v="B"), Row(v="D"), Row(v="X")]
+        expected = [Row(v="A"), Row(v="B"), Row(v="C"), Row(v="D"), Row(v="E")]
+
+        with self.assertRaises(PySparkAssertionError) as pe:
+            assertDataFrameEqual(actual, expected, includeDiffRows=True)
+
+        # X is extra in actual; C and E are missing from actual.  Merge-walk
+        # visits them in sorted order: C missing, E missing, X extra.
+        self.assertEqual(
+            pe.exception.data,
+            [(None, Row(v="C")), (None, Row(v="E")), (Row(v="X"), None)],
+        )
+        error_msg = pe.exception.getMessageParameters()["error_msg"]
+        # 3 total diffs / max(4, 5) = 60%
+        self.assertIn("60.00000 %", error_msg)
+
+    def test_different_row_count_extras_at_end(self):
+        # Extras only at end -- both zip_longest and merge-walk should agree.
+        actual = [Row(v=1), Row(v=2), Row(v=3), Row(v=4), Row(v=5)]
+        expected = [Row(v=1), Row(v=2), Row(v=3)]
+
+        with self.assertRaises(PySparkAssertionError) as pe:
+            assertDataFrameEqual(actual, expected, includeDiffRows=True)
+
+        self.assertEqual(pe.exception.data, [(Row(v=4), None), (Row(v=5), None)])
+        error_msg = pe.exception.getMessageParameters()["error_msg"]
+        # 2 extras / max(5, 3) = 40%
+        self.assertIn("40.00000 %", error_msg)
+
     def test_remove_non_word_characters_long(self):
         def remove_non_word_characters(col):
             return F.regexp_replace(col, "[^\\w\\s]+", "")

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -1091,7 +1091,6 @@ def assertDataFrameEqual(
         rows1: List[Row], rows2: List[Row], maxErrors: int = None, showOnlyDiff: bool = False
     ):
         __tracebackhide__ = True
-        zipped = list(zip_longest(rows1, rows2))
         diff_rows_cnt = 0
         diff_rows = []
         has_diff_rows = False
@@ -1099,28 +1098,86 @@ def assertDataFrameEqual(
         rows_str1 = ""
         rows_str2 = ""
 
-        # count different rows
-        for r1, r2 in zipped:
-            if not compare_rows(r1, r2):
-                diff_rows_cnt += 1
-                has_diff_rows = True
-                if includeDiffRows:
-                    diff_rows.append((r1, r2))
-                rows_str1 += str(r1) + "\n"
-                rows_str2 += str(r2) + "\n"
+        def record_diff(r1, r2):
+            nonlocal diff_rows_cnt, has_diff_rows
+            diff_rows_cnt += 1
+            has_diff_rows = True
+            if includeDiffRows:
+                diff_rows.append((r1, r2))
+
+        # SPARK-54090: For checkRowOrder=False, the input lists have already
+        # been sorted by str(x).  When their lengths differ, the original
+        # zip_longest pairing causes a single missing/extra row to cascade
+        # into a mismatch on every subsequent row -- inflating both the diff
+        # count and the reported percentage.  Walk sorted lists of different
+        # lengths as a merge so only truly missing/extra rows contribute.
+        # When the lengths match, zip_longest aligns positions correctly and
+        # is preserved to keep field-level diffs reported as paired rows.
+        use_merge_walk = not checkRowOrder and len(rows1) != len(rows2)
+
+        if not use_merge_walk:
+            zipped = list(zip_longest(rows1, rows2))
+            for r1, r2 in zipped:
+                if not compare_rows(r1, r2):
+                    record_diff(r1, r2)
+                    rows_str1 += str(r1) + "\n"
+                    rows_str2 += str(r2) + "\n"
+                    if maxErrors is not None and diff_rows_cnt >= maxErrors:
+                        break
+                elif not showOnlyDiff:
+                    rows_str1 += str(r1) + "\n"
+                    rows_str2 += str(r2) + "\n"
+            total = len(zipped)
+        else:
+            i = j = 0
+            len1, len2 = len(rows1), len(rows2)
+            while i < len1 or j < len2:
+                if i < len1 and j < len2:
+                    r1, r2 = rows1[i], rows2[j]
+                    if compare_rows(r1, r2):
+                        if not showOnlyDiff:
+                            rows_str1 += str(r1) + "\n"
+                            rows_str2 += str(r2) + "\n"
+                        i += 1
+                        j += 1
+                        continue
+                    s1, s2 = str(r1), str(r2)
+                    if s1 < s2:
+                        record_diff(r1, None)
+                        rows_str1 += str(r1) + "\n"
+                        i += 1
+                    elif s1 > s2:
+                        record_diff(None, r2)
+                        rows_str2 += str(r2) + "\n"
+                        j += 1
+                    else:
+                        # Equal str() but compare_rows said they differ (e.g.
+                        # float values outside tolerance that still str-sort
+                        # identically).  Treat as a paired mismatch.
+                        record_diff(r1, r2)
+                        rows_str1 += str(r1) + "\n"
+                        rows_str2 += str(r2) + "\n"
+                        i += 1
+                        j += 1
+                elif i < len1:
+                    record_diff(rows1[i], None)
+                    rows_str1 += str(rows1[i]) + "\n"
+                    i += 1
+                else:
+                    record_diff(None, rows2[j])
+                    rows_str2 += str(rows2[j]) + "\n"
+                    j += 1
                 if maxErrors is not None and diff_rows_cnt >= maxErrors:
                     break
-            elif not showOnlyDiff:
-                rows_str1 += str(r1) + "\n"
-                rows_str2 += str(r2) + "\n"
+            total = max(len1, len2)
 
         generated_diff = _context_diff(
-            actual=rows_str1.splitlines(), expected=rows_str2.splitlines(), n=len(zipped)
+            actual=rows_str1.splitlines(), expected=rows_str2.splitlines(), n=total
         )
 
         if has_diff_rows:
             error_msg = "Results do not match: "
-            percent_diff = (diff_rows_cnt / len(zipped)) * 100
+            percent_diff = (diff_rows_cnt / total) * 100 if total else 0
             error_msg += "( %.5f %% )" % percent_diff
             error_msg += "\n" + "\n".join(generated_diff)
             data = diff_rows if includeDiffRows else None


### PR DESCRIPTION
### What changes were proposed in this pull request?

When `assertDataFrameEqual` is called with `checkRowOrder=False` (the default) and the two inputs have **different row counts**, a single missing/extra row cascades into a mismatch on every subsequent row. This inflates both the diff count and the reported mismatch percentage.

Root cause: after sorting both lists by `str(row)`, `assert_rows_equal` pairs rows with `zip_longest`. When one side is shorter, the pairing shifts past every row following the hole.

Fix: switch to a merge-walk over the sorted lists **only when their lengths differ**. Equal lengths keep `zip_longest` so that field-level diffs continue to be reported as paired rows (preserving existing docstrings and tests that rely on "B vs X" style pairing).

The merge-walk uses `compare_rows` for equality (honoring `rtol`/`atol`) and `str(r)` for ordering decisions (consistent with how the lists were sorted).

### Why are the changes needed?

Reproducer:

```python
from pyspark.testing.utils import assertDataFrameEqual
from pyspark.sql import Row

actual   = [Row(id='1'), Row(id='2'), Row(id='3'), Row(id='4'), Row(id='5')]
expected = [Row(id='1'), Row(id='2'),              Row(id='4'), Row(id='5')]
assertDataFrameEqual(actual, expected)
```

Before this fix: `Results do not match: ( 60.00000 % )` (3 of 5 rows reported as different).
After this fix:  `Results do not match: ( 20.00000 % )` (only `Row(id='3')` is reported).

A larger example from the JIRA: rows1 has 5 rows, rows2 has 3 of them missing in the middle -- the old code reports 80% mismatch; the new code reports 40%, matching what a user would expect from a sorted-set comparison.

### Does this PR introduce _any_ user-facing change?

Yes, but only in the error message / reported data when `assertDataFrameEqual(checkRowOrder=False)` is given inputs whose row counts differ:
- The reported mismatch percentage is no longer inflated by positional shifting.
- `includeDiffRows=True` now returns `(row, None)` tuples for extras and `(None, row)` tuples for missing rows, rather than shifted `(row, row)` pairs.

Behavior when row counts are equal (including all existing docstring examples) is unchanged.

### How was this patch tested?

- Added five targeted tests in `python/pyspark/sql/tests/test_utils.py`:
  - `test_different_row_count_middle_missing_no_cascading_diff`
  - `test_different_row_count_multiple_missing`
  - `test_different_row_count_includeDiffRows`
  - `test_different_row_count_mixed_extra_and_missing`
  - `test_different_row_count_extras_at_end`

### Was this patch authored or co-authored using generative AI tooling?

No.