### PR TITLE
[SPARK-56607][PYTHON] Remove unnecessary __new__ and __init__

### DIFF
--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -104,11 +104,12 @@ if TYPE_CHECKING:
 class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def __new__(
         cls,
-        jdf: "JavaObject",
-        sql_ctx: Union["SQLContext", "SparkSession"],
+        *args,
+        **kwargs,
     ) -> "DataFrame":
-        self = object.__new__(cls)
-        return self
+        # ParentDataFrame by default calls DataFrame.__new__ for backward compatibility.
+        # We have to do an explicit object.__new__ to avoid infinite recursion.
+        return object.__new__(cls)
 
     def __init__(
         self,

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -108,7 +108,6 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         sql_ctx: Union["SQLContext", "SparkSession"],
     ) -> "DataFrame":
         self = object.__new__(cls)
-        self.__init__(jdf, sql_ctx)  # type: ignore[misc]
         return self
 
     def __init__(

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -104,8 +104,8 @@ if TYPE_CHECKING:
 class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def __new__(
         cls,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> "DataFrame":
         # ParentDataFrame by default calls DataFrame.__new__ for backward compatibility.
         # We have to do an explicit object.__new__ to avoid infinite recursion.

--- a/python/pyspark/sql/classic/window.py
+++ b/python/pyspark/sql/classic/window.py
@@ -93,11 +93,6 @@ class Window(ParentWindow):
 
 
 class WindowSpec(ParentWindowSpec):
-    def __new__(cls, jspec: "JavaObject") -> "WindowSpec":
-        self = object.__new__(cls)
-        self.__init__(jspec)  # type: ignore[misc]
-        return self
-
     def __init__(self, jspec: "JavaObject") -> None:
         self._jspec = jspec
 

--- a/python/pyspark/sql/classic/window.py
+++ b/python/pyspark/sql/classic/window.py
@@ -93,6 +93,10 @@ class Window(ParentWindow):
 
 
 class WindowSpec(ParentWindowSpec):
+    def __new__(cls, jspec: "JavaObject") -> "WindowSpec":
+        self = object.__new__(cls)
+        return self
+
     def __init__(self, jspec: "JavaObject") -> None:
         self._jspec = jspec
 

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -112,8 +112,8 @@ if TYPE_CHECKING:
 class DataFrame(ParentDataFrame):
     def __new__(
         cls,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> "DataFrame":
         # ParentDataFrame by default creates classic DataFrame for backward compatibility.
         # We have to do an explicit object.__new__ to avoid that.

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -116,7 +116,6 @@ class DataFrame(ParentDataFrame):
         session: "SparkSession",
     ) -> "DataFrame":
         self = object.__new__(cls)
-        self.__init__(plan, session)  # type: ignore[misc]
         return self
 
     def __init__(

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -112,11 +112,12 @@ if TYPE_CHECKING:
 class DataFrame(ParentDataFrame):
     def __new__(
         cls,
-        plan: plan.LogicalPlan,
-        session: "SparkSession",
+        *args,
+        **kwargs,
     ) -> "DataFrame":
-        self = object.__new__(cls)
-        return self
+        # ParentDataFrame by default creates classic DataFrame for backward compatibility.
+        # We have to do an explicit object.__new__ to avoid that.
+        return object.__new__(cls)
 
     def __init__(
         self,

--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -55,16 +55,6 @@ class WindowFrame:
 
 
 class WindowSpec(ParentWindowSpec):
-    def __new__(
-        cls,
-        partitionSpec: Sequence[Expression],
-        orderSpec: Sequence[SortOrder],
-        frame: Optional[WindowFrame],
-    ) -> "WindowSpec":
-        self = object.__new__(cls)
-        self.__init__(partitionSpec, orderSpec, frame)  # type: ignore[misc]
-        return self
-
     def __getnewargs__(self) -> Tuple[Any, ...]:
         return (self._partitionSpec, self._orderSpec, self._frame)
 

--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -55,6 +55,15 @@ class WindowFrame:
 
 
 class WindowSpec(ParentWindowSpec):
+    def __new__(
+        cls,
+        partitionSpec: Sequence[Expression],
+        orderSpec: Sequence[SortOrder],
+        frame: Optional[WindowFrame],
+    ) -> "WindowSpec":
+        self = object.__new__(cls)
+        return self
+
     def __getnewargs__(self) -> Tuple[Any, ...]:
         return (self._partitionSpec, self._orderSpec, self._frame)
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -147,7 +147,7 @@ class DataFrame:
     ) -> "DataFrame":
         from pyspark.sql.classic.dataframe import DataFrame
 
-        return DataFrame.__new__(DataFrame, jdf, sql_ctx)
+        return DataFrame(jdf, sql_ctx)
 
     @property
     def sparkSession(self) -> "SparkSession":

--- a/python/pyspark/sql/tests/connect/test_connect_plan.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan.py
@@ -345,7 +345,6 @@ class SparkConnectPlanTests(PlanOnlyTestFixture):
         class MockDF(DataFrame):
             def __new__(cls, df: DataFrame) -> "DataFrame":
                 self = object.__new__(cls)
-                self.__init__(df)  # type: ignore[misc]
                 return self
 
             def __init__(self, df: DataFrame):

--- a/python/pyspark/sql/tests/connect/test_connect_plan.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan.py
@@ -343,10 +343,6 @@ class SparkConnectPlanTests(PlanOnlyTestFixture):
         from pyspark.sql.connect.observation import Observation
 
         class MockDF(DataFrame):
-            def __new__(cls, df: DataFrame) -> "DataFrame":
-                self = object.__new__(cls)
-                return self
-
             def __init__(self, df: DataFrame):
                 super().__init__(df._plan, df._session)
 

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -340,7 +340,7 @@ class WindowSpec:
     """
 
     def __new__(cls, jspec: "JavaObject") -> "WindowSpec":
-        from pyspark.sql.classic.WindowSpec import WindowSpec  # type: ignore[import-not-found]
+        from pyspark.sql.classic.window import WindowSpec
 
         return WindowSpec.__new__(WindowSpec, jspec)
 

--- a/python/pyspark/testing/mlutils.py
+++ b/python/pyspark/testing/mlutils.py
@@ -25,7 +25,8 @@ from pyspark.ml.param.shared import HasMaxIter, HasRegParam
 from pyspark.ml.classification import Classifier, ClassificationModel
 from pyspark.ml.util import DefaultParamsReadable, DefaultParamsWritable
 from pyspark.ml.wrapper import _java2py
-from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import SparkSession
+from pyspark.sql.classic.dataframe import DataFrame
 from pyspark.sql.types import DoubleType
 from pyspark.testing.utils import ReusedPySparkTestCase as PySparkTestCase
 

--- a/python/pyspark/testing/mlutils.py
+++ b/python/pyspark/testing/mlutils.py
@@ -99,11 +99,6 @@ class SparkSessionTestCase(PySparkTestCase):
 
 
 class MockDataset(DataFrame):
-    def __new__(cls) -> "DataFrame":
-        self = object.__new__(cls)
-        self.__init__()
-        return self
-
     def __init__(self):
         self.index = 0
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

* Removed `__init__` call in `__new__` because it's unnecessary and could be unsound.
* Removed unnecessary `__new__` method when it just does the default thing.
* Kept the weird behavior of `DataFrame` where the base class calls the derived class `__new__` method, but made it cleaner.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Remove some unnecessary and potentially buggy code. Also less mypy ignores.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

CI.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.