### PR TITLE
[SPARK-55726][PYTHON][TEST][FOLLOW-UP] Write grouped benchmark data as one Arrow IPC stream per DataFrame

### DIFF
--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -77,16 +77,15 @@ class MockProtocolWriter:
     @classmethod
     def write_grouped_data_payload(
         cls,
-        groups: list[tuple[list[pa.RecordBatch], ...]],
+        groups: list[list[list[pa.RecordBatch]]],
         buf: io.BufferedIOBase,
     ) -> None:
         """Write grouped Arrow data in the wire protocol expected by _load_group_dataframes.
 
-        Each group is a tuple of DataFrames; each DataFrame is a list of Arrow
-        RecordBatches written as one Arrow IPC stream (so batches of the same
-        DataFrame stay in one stream, matching the real wire protocol where
-        large groups may be split across multiple batches by
-        ``spark.sql.execution.arrow.maxRecordsPerBatch``).
+        Shape: ``groups[g][df]`` is the list of RecordBatches for DataFrame ``df``
+        of group ``g``. Each DataFrame's batches are written as one Arrow IPC
+        stream, matching the real wire protocol where a group may be split across
+        multiple batches by ``spark.sql.execution.arrow.maxRecordsPerBatch``.
         """
         for group in groups:
             write_int(len(group), buf)  # num_dfs in this group
@@ -272,13 +271,12 @@ class MockDataFactory:
         num_cols: int,
         batch_size: int = MAX_RECORDS_PER_BATCH,
         spark_type_pool: list[tuple[Callable, Any]],
-    ) -> tuple[list[tuple[list[pa.RecordBatch]]], StructType]:
+    ) -> tuple[list[list[list[pa.RecordBatch]]], StructType]:
         """Create groups, each containing a single DataFrame.
 
-        Each group is a 1-tuple ``(batches,)`` where ``batches`` is the list of
-        Arrow RecordBatches for that group's DataFrame (``num_rows`` rows split
-        into batches of ``batch_size``). All batches of a group are written as
-        one Arrow IPC stream by ``write_grouped_data_payload``.
+        Each group is ``[batches]`` where ``batches`` is the list of Arrow
+        RecordBatches for that group's DataFrame (``num_rows`` rows split into
+        batches of ``batch_size``).
         """
         groups = []
         for _ in range(num_groups):
@@ -288,7 +286,7 @@ class MockDataFactory:
                 batch_size=batch_size,
                 spark_type_pool=spark_type_pool,
             )
-            groups.append((list(batches),))
+            groups.append([list(batches)])
 
         schema = StructType(
             [
@@ -307,12 +305,12 @@ class MockDataFactory:
         num_cols: int,
         batch_size: int = MAX_RECORDS_PER_BATCH,
         spark_type_pool: list[tuple[Callable, Any]],
-    ) -> tuple[list[tuple[list[pa.RecordBatch], list[pa.RecordBatch]]], StructType]:
+    ) -> tuple[list[list[list[pa.RecordBatch]]], StructType]:
         """Create cogroups, each containing two DataFrames (left, right).
 
-        Each cogroup is a 2-tuple ``(left_batches, right_batches)``. The two
-        DataFrames share the same schema but have independent data, each with
-        ``num_rows`` rows and ``num_cols`` flat columns.
+        Each cogroup is ``[left_batches, right_batches]``. The two DataFrames
+        share the same schema but have independent data, each with ``num_rows``
+        rows and ``num_cols`` flat columns.
         """
         left_groups, schema = cls.make_grouped_batches(
             num_groups=num_groups,
@@ -328,7 +326,7 @@ class MockDataFactory:
             batch_size=batch_size,
             spark_type_pool=spark_type_pool,
         )
-        cogroups = [(left_groups[i][0], right_groups[i][0]) for i in range(num_groups)]
+        cogroups = [[left_groups[i][0], right_groups[i][0]] for i in range(num_groups)]
         return cogroups, schema
 
 
@@ -933,7 +931,7 @@ class _GroupedMapPandasBenchMixin:
                 spark_type_pool=MockDataFactory.MIXED_TYPES,
                 batch_size=3,
             )
-            return ([([b],) for b in batches] * 200, schema)
+            return ([[[b]] for b in batches] * 200, schema)
         _kind, rows, n_cols, num_groups = cfg
         groups, schema = MockDataFactory.make_grouped_batches(
             num_groups=num_groups,

--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -77,15 +77,21 @@ class MockProtocolWriter:
     @classmethod
     def write_grouped_data_payload(
         cls,
-        groups: list[tuple[pa.RecordBatch, ...]],
-        num_dfs: int,
+        groups: list[tuple[list[pa.RecordBatch], ...]],
         buf: io.BufferedIOBase,
     ) -> None:
-        """Write grouped Arrow data in the wire protocol expected by _load_group_dataframes."""
+        """Write grouped Arrow data in the wire protocol expected by _load_group_dataframes.
+
+        Each group is a tuple of DataFrames; each DataFrame is a list of Arrow
+        RecordBatches written as one Arrow IPC stream (so batches of the same
+        DataFrame stay in one stream, matching the real wire protocol where
+        large groups may be split across multiple batches by
+        ``spark.sql.execution.arrow.maxRecordsPerBatch``).
+        """
         for group in groups:
-            write_int(num_dfs, buf)
-            for df_batch in group:
-                cls.write_data_payload(iter([df_batch]), buf)
+            write_int(len(group), buf)  # num_dfs in this group
+            for df_batches in group:
+                cls.write_data_payload(iter(df_batches), buf)
         write_int(0, buf)  # end of groups
 
     @classmethod
@@ -266,10 +272,13 @@ class MockDataFactory:
         num_cols: int,
         batch_size: int = MAX_RECORDS_PER_BATCH,
         spark_type_pool: list[tuple[Callable, Any]],
-    ) -> tuple[list[tuple[pa.RecordBatch, ...]], StructType]:
-        """Create groups of batches.
+    ) -> tuple[list[tuple[list[pa.RecordBatch]]], StructType]:
+        """Create groups, each containing a single DataFrame.
 
-        Each group has ``num_rows`` total rows, split into batches of ``batch_size``.
+        Each group is a 1-tuple ``(batches,)`` where ``batches`` is the list of
+        Arrow RecordBatches for that group's DataFrame (``num_rows`` rows split
+        into batches of ``batch_size``). All batches of a group are written as
+        one Arrow IPC stream by ``write_grouped_data_payload``.
         """
         groups = []
         for _ in range(num_groups):
@@ -279,7 +288,7 @@ class MockDataFactory:
                 batch_size=batch_size,
                 spark_type_pool=spark_type_pool,
             )
-            groups.append(tuple(batches))
+            groups.append((list(batches),))
 
         schema = StructType(
             [
@@ -298,11 +307,12 @@ class MockDataFactory:
         num_cols: int,
         batch_size: int = MAX_RECORDS_PER_BATCH,
         spark_type_pool: list[tuple[Callable, Any]],
-    ) -> tuple[list[tuple[pa.RecordBatch, pa.RecordBatch]], StructType]:
-        """Create cogroups of batch pairs (left, right).
+    ) -> tuple[list[tuple[list[pa.RecordBatch], list[pa.RecordBatch]]], StructType]:
+        """Create cogroups, each containing two DataFrames (left, right).
 
-        Each cogroup has two DataFrames with identical schema but independent
-        data, each with ``num_rows`` rows and ``num_cols`` flat columns.
+        Each cogroup is a 2-tuple ``(left_batches, right_batches)``. The two
+        DataFrames share the same schema but have independent data, each with
+        ``num_rows`` rows and ``num_cols`` flat columns.
         """
         left_groups, schema = cls.make_grouped_batches(
             num_groups=num_groups,
@@ -530,7 +540,7 @@ class _CogroupedMapArrowBenchMixin:
         MockProtocolWriter.write_worker_input(
             PythonEvalType.SQL_COGROUPED_MAP_ARROW_UDF,
             lambda b: MockProtocolWriter.write_udf_payload(udf_func, schema, arg_offsets, b),
-            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, num_dfs=2, buf=b),
+            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, buf=b),
             buf,
         )
 
@@ -608,7 +618,7 @@ class _GroupedAggArrowBenchMixin:
         MockProtocolWriter.write_worker_input(
             PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF,
             write_udf,
-            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, num_dfs=1, buf=b),
+            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, buf=b),
             buf,
         )
 
@@ -667,7 +677,7 @@ class _GroupedAggArrowIterBenchMixin(_GroupedAggArrowBenchMixin):
         MockProtocolWriter.write_worker_input(
             PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF,
             write_udf,
-            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, num_dfs=1, buf=b),
+            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, buf=b),
             buf,
         )
 
@@ -741,7 +751,7 @@ class _GroupedAggPandasBenchMixin:
         MockProtocolWriter.write_worker_input(
             PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
             write_udf,
-            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, num_dfs=1, buf=b),
+            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, buf=b),
             buf,
         )
 
@@ -818,14 +828,14 @@ class _GroupedMapArrowBenchMixin:
     def _write_scenario(self, scenario, udf_name, buf):
         groups, schema = self._build_scenario(scenario)
         udf_func = self._udfs[udf_name]
-        n_total = groups[0][0].column(0).type.num_fields
+        n_total = groups[0][0][0].column(0).type.num_fields
         n_values = len(schema.fields)
         num_key_cols = n_total - n_values
         arg_offsets = MockUDFFactory.make_grouped_arg_offsets(num_key_cols, n_values)
         MockProtocolWriter.write_worker_input(
             PythonEvalType.SQL_GROUPED_MAP_ARROW_UDF,
             lambda b: MockProtocolWriter.write_udf_payload(udf_func, schema, arg_offsets, b),
-            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, num_dfs=1, buf=b),
+            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, buf=b),
             buf,
         )
 
@@ -872,14 +882,14 @@ class _GroupedMapArrowIterBenchMixin(_GroupedMapArrowBenchMixin):
     def _write_scenario(self, scenario, udf_name, buf):
         groups, schema = self._build_scenario(scenario)
         udf_func = self._udfs[udf_name]
-        n_total = groups[0][0].column(0).type.num_fields
+        n_total = groups[0][0][0].column(0).type.num_fields
         n_values = len(schema.fields)
         num_key_cols = n_total - n_values
         arg_offsets = MockUDFFactory.make_grouped_arg_offsets(num_key_cols, n_values)
         MockProtocolWriter.write_worker_input(
             PythonEvalType.SQL_GROUPED_MAP_ARROW_ITER_UDF,
             lambda b: MockProtocolWriter.write_udf_payload(udf_func, schema, arg_offsets, b),
-            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, num_dfs=1, buf=b),
+            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, buf=b),
             buf,
         )
 
@@ -923,7 +933,7 @@ class _GroupedMapPandasBenchMixin:
                 spark_type_pool=MockDataFactory.MIXED_TYPES,
                 batch_size=3,
             )
-            return ([(b,) for b in batches] * 200, schema)
+            return ([([b],) for b in batches] * 200, schema)
         _kind, rows, n_cols, num_groups = cfg
         groups, schema = MockDataFactory.make_grouped_batches(
             num_groups=num_groups,
@@ -956,11 +966,7 @@ class _GroupedMapPandasBenchMixin:
         MockProtocolWriter.write_worker_input(
             PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF,
             lambda b: MockProtocolWriter.write_udf_payload(udf_func, ret_type, arg_offsets, b),
-            lambda b: MockProtocolWriter.write_grouped_data_payload(
-                groups,
-                num_dfs=1,
-                buf=b,
-            ),
+            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, buf=b),
             buf,
         )
 
@@ -1348,7 +1354,7 @@ class _WindowAggArrowBenchMixin:
         MockProtocolWriter.write_worker_input(
             PythonEvalType.SQL_WINDOW_AGG_ARROW_UDF,
             write_udf,
-            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, num_dfs=1, buf=b),
+            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, buf=b),
             buf,
             runner_conf={"window_bound_types": "unbounded"},
         )

--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -55,6 +55,13 @@ from pyspark.worker import main as worker_main
 # ---------------------------------------------------------------------------
 
 
+# ``GroupedBatches[i]`` is the list of Arrow RecordBatches making up the ``i``-th
+# DataFrame of a group: 1 DF for grouped scenarios, 2 (left, right) for cogrouped.
+# Analogous to ``GroupedBatch``/``CoGroupedBatch`` in ``pyspark.sql.pandas._typing``
+# but materialized as lists here since benchmarks pre-build the full payload.
+GroupedBatches = list[list[pa.RecordBatch]]
+
+
 class MockProtocolWriter:
     """Constructs the binary wire protocol that ``worker.py``'s ``main()`` expects."""
 
@@ -77,7 +84,7 @@ class MockProtocolWriter:
     @classmethod
     def write_grouped_data_payload(
         cls,
-        groups: list[list[list[pa.RecordBatch]]],
+        groups: list[GroupedBatches],
         buf: io.BufferedIOBase,
     ) -> None:
         """Write grouped Arrow data in the wire protocol expected by _load_group_dataframes.
@@ -271,7 +278,7 @@ class MockDataFactory:
         num_cols: int,
         batch_size: int = MAX_RECORDS_PER_BATCH,
         spark_type_pool: list[tuple[Callable, Any]],
-    ) -> tuple[list[list[list[pa.RecordBatch]]], StructType]:
+    ) -> tuple[list[GroupedBatches], StructType]:
         """Create groups, each containing a single DataFrame.
 
         Each group is ``[batches]`` where ``batches`` is the list of Arrow
@@ -305,7 +312,7 @@ class MockDataFactory:
         num_cols: int,
         batch_size: int = MAX_RECORDS_PER_BATCH,
         spark_type_pool: list[tuple[Callable, Any]],
-    ) -> tuple[list[list[list[pa.RecordBatch]]], StructType]:
+    ) -> tuple[list[GroupedBatches], StructType]:
         """Create cogroups, each containing two DataFrames (left, right).
 
         Each cogroup is ``[left_batches, right_batches]``. The two DataFrames


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `MockProtocolWriter.write_grouped_data_payload` in `python/benchmarks/bench_eval_type.py` to write each DataFrame as one Arrow IPC stream (multiple batches per stream), matching the real worker wire protocol. `num_dfs` is now inferred from the group tuple length. Grouped/cogrouped data factories return nested-list shapes accordingly.

### Why are the changes needed?

The old writer emitted one stream per RecordBatch, while declaring ``num_dfs=1`` upfront. When a group spanned more than one batch, the worker read the next stream's bytes as ``num_dfs`` for the next group. The ``lg_grp_few_col`` / ``lg_grp_many_col`` scenarios in ``GroupedMapPandasUDF{Time,Peakmem}Bench`` (100K rows/group with default ``MAX_RECORDS_PER_BATCH=10_000``) hit this:

```
pyspark.errors.exceptions.base.PySparkValueError:
  [INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP] Invalid number of dataframes in group 1208025088.
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran all 15 `_GroupedMapPandasBenchMixin` scenario x UDF combinations and one scenario per other grouped/cogrouped bench class locally. All pass. `lg_grp_*` fail on master before this patch and pass after.

### Was this patch authored or co-authored using generative AI tooling?

No.