### PR TITLE
[SPARK-56610][INFRA] Make JIRA connect timeout configurable in merge_spark_pr.py

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -57,6 +57,9 @@ JIRA_PASSWORD = os.environ.get("JIRA_PASSWORD", "")
 # Go to https://issues.apache.org/jira/secure/ViewProfile.jspa -> Personal Access Tokens for
 # your own token management.
 JIRA_ACCESS_TOKEN = os.environ.get("JIRA_ACCESS_TOKEN")
+# Connection timeout (in seconds) for the JIRA client. Raise this if the default is too
+# short for your network, e.g. when the TLS handshake goes through a slow proxy.
+JIRA_CONNECT_TIMEOUT = float(os.environ.get("JIRA_CONNECT_TIMEOUT", "3.05"))
 # OAuth key used for issuing requests against the GitHub API. If this is not defined, then requests
 # will be unauthenticated. You should only need to configure this if you find yourself regularly
 # exceeding your IP's unauthenticated request rate limit. You can create an OAuth key at
@@ -562,7 +565,9 @@ def initialize_jira():
         print_error("ERROR finding jira library. Run 'pip3 install jira' to install.")
         continue_maybe("Continue without jira?")
     elif JIRA_ACCESS_TOKEN:
-        client = jira.client.JIRA(jira_server, token_auth=JIRA_ACCESS_TOKEN, timeout=(3.05, 30))
+        client = jira.client.JIRA(
+            jira_server, token_auth=JIRA_ACCESS_TOKEN, timeout=(JIRA_CONNECT_TIMEOUT, 30)
+        )
         try:
             # Eagerly check if the token is valid to align with the behavior of username/password
             # authn
@@ -582,7 +587,9 @@ def initialize_jira():
         print("Visit https://issues.apache.org/jira/secure/ViewProfile.jspa ")
         print("and click 'Personal Access Tokens' menu to manage your own tokens.")
         asf_jira = jira.client.JIRA(
-            jira_server, basic_auth=(JIRA_USERNAME, JIRA_PASSWORD), timeout=(3.05, 30)
+            jira_server,
+            basic_auth=(JIRA_USERNAME, JIRA_PASSWORD),
+            timeout=(JIRA_CONNECT_TIMEOUT, 30),
         )
     else:
         print("Neither JIRA_ACCESS_TOKEN nor JIRA_USERNAME/JIRA_PASSWORD are set.")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a `JIRA_CONNECT_TIMEOUT` environment variable (default `3.05`) in `dev/merge_spark_pr.py`, and use it as the connect-timeout component of the `requests` timeout tuple at both `jira.client.JIRA(...)` call sites.

### Why are the changes needed?

The hardcoded 3.05-second connect timeout introduced in SPARK-55643 sits just past the standard TCP retransmission window — fine for a bare TCP connect on a direct connection, but too tight for a proxied TLS handshake (TCP connect to proxy + HTTPS `CONNECT` + TLS handshake to the target). When the script runs behind a slow HTTPS proxy, `initialize_jira()` fails almost immediately with:

```
requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='issues.apache.org', port=443): Read timed out. (read timeout=3.05)
```

`ResilientSession`'s internal retry loop does not recover from this, because it only catches `requests.exceptions.ConnectionError`, and `ReadTimeout` does not inherit from it.

In practice, this makes `dev/merge_spark_pr.py` unusable from any environment that routes traffic through an HTTPS proxy — I cannot merge a PR from my WSL2 setup, and have to switch to another macos just for merging PRs.

Exposing the timeout as an env var lets affected users raise the limit (e.g. `JIRA_CONNECT_TIMEOUT=30`) without editing the script.

### Does this PR introduce _any_ user-facing change?

No. `merge_spark_pr.py` is a developer tool, and the default timeout value is unchanged.

### How was this patch tested?

Manual test. Setting `JIRA_CONNECT_TIMEOUT=30` lets `dev/merge_spark_pr.py` get past `initialize_jira()` in an environment that previously failed with `ReadTimeout` after ~3 s.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Claude Code (Opus 4.7)`