### PR TITLE
[SPARK-56615][SQL] Clarify `KeyedPartitioning` `satisfies0()` and `nonGroupedSatisfies()`/`groupedSatisfies()` contract

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -380,24 +380,17 @@ case class CoalescedHashPartitioning(from: HashPartitioning, partitions: Seq[Coa
  *   unique partition keys, or (2) `GroupPartitionsExec` coalesces partitions with duplicate keys.
  *
  * == Distribution Satisfaction and Grouping ==
- * The `satisfies()` method returns true if this partitioning can satisfy a distribution,
- * regardless of whether the partitioning is actually grouped. The method delegates to:
- * - `nonGroupedSatisfies()`: Returns true for basic distributions (UnspecifiedDistribution,
- *   AllTuples when single partition)
- * - `groupedSatisfies()`: Returns true for distributions requiring grouped partitioning
- *   (ClusteredDistribution, OrderedDistribution)
+ * Besides the default `satisfies()`, `KeyedPartitioning` exposes two additional methods used by
+ * `EnsureRequirements` to handle grouped and non-grouped KPs separately:
  *
- * If `satisfies()` returns true but `isGrouped == false`, the partitioning does NOT actually
- * satisfy the distribution yet. The `EnsureRequirements` rule must insert `GroupPartitionsExec` to
- * coalesce duplicate partition keys before the distribution requirement is truly satisfied.
+ * - `nonGroupedSatisfies()`: called on non-grouped KPs to check as-is satisfaction (without
+ *   inserting `GroupPartitionsExec`).
+ * - `groupedSatisfies()`: called on non-grouped KPs to check whether inserting
+ *   `GroupPartitionsExec` would satisfy the distribution. When it returns true, the distribution
+ *   is NOT yet satisfied -- `EnsureRequirements` will insert `GroupPartitionsExec` to coalesce
+ *   duplicate partition keys.
  *
- * For example, an ungrouped KeyedPartitioning with keys `[1, 2, 2, 3]` will return
- * `satisfies(ClusteredDistribution(...)) == true` because it can satisfy the distribution after
- * grouping. However, `EnsureRequirements` must add `GroupPartitionsExec` to produce grouped keys
- * `[1, 2, 3]` before the distribution is actually satisfied.
- *
- * Similarly, for `OrderedDistribution`, even if `satisfies()` returns true, `GroupPartitionsExec`
- * must be added to both group the partitions AND sort the partition keys according to the
+ * For `OrderedDistribution`, `GroupPartitionsExec` must also sort the partition keys to meet the
  * ordering requirement.
  *
  * == Example ==
@@ -405,20 +398,21 @@ case class CoalescedHashPartitioning(from: HashPartitioning, partitions: Seq[Coa
  *
  * '''Before GroupPartitionsExec''' (ungrouped):
  * {{{
- *   expressions:           [years(ts_col)]
- *   partitionKeys:         [0, 1, 2, 2]    // partitions 2 and 3 have the same key
- *   numPartitions:         4
- *   isGrouped:             false
- *   satisfies(ClusteredDistribution(...)) == true   // CAN satisfy after grouping
+ *   expressions:                                 [years(ts_col)]
+ *   partitionKeys:                               [0, 1, 2, 2]  // partitions 2 and 3 share a key
+ *   numPartitions:                               4
+ *   isGrouped:                                   false
+ *   satisfies(ClusteredDistribution(...))        == false      // isGrouped guards groupedSatisfies
+ *   groupedSatisfies(ClusteredDistribution(...)) == true       // would satisfy after grouping
  * }}}
  *
  * '''After GroupPartitionsExec''' (grouped):
  * {{{
- *   expressions:           [years(ts_col)]
- *   partitionKeys:         [0, 1, 2]       // duplicates removed, partitions coalesced
- *   numPartitions:         3
- *   isGrouped:             true
- *   satisfies(ClusteredDistribution(...)) == true   // ACTUALLY satisfies now
+ *   expressions:                                [years(ts_col)]
+ *   partitionKeys:                              [0, 1, 2]      // duplicates removed
+ *   numPartitions:                              3
+ *   isGrouped:                                  true
+ *   satisfies(ClusteredDistribution(...))       == true        // satisfies now
  * }}}
  *
  * @param expressions Partition transform expressions (e.g., `years(col)`, `bucket(10, col)`).
@@ -472,7 +466,7 @@ case class KeyedPartitioning(
     KeyedPartitioning.reduceKeys(partitionKeys, expressionDataTypes, reducers)
 
   override def satisfies0(required: Distribution): Boolean = {
-    nonGroupedSatisfies(required) || groupedSatisfies(required)
+    nonGroupedSatisfies(required) || (isGrouped && groupedSatisfies(required))
   }
 
   def nonGroupedSatisfies(required: Distribution): Boolean = super.satisfies0(required)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst
 import org.apache.spark.SparkFunSuite
 /* Implicit conversions */
 import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.expressions.{CollationAwareMurmur3Hash, Expression, Literal, Pmod}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, CollationAwareMurmur3Hash, Expression, Literal, Pmod}
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.types.IntegerType
 
@@ -390,5 +390,24 @@ class DistributionSuite extends SparkFunSuite {
       UnknownPartitioning(10),
       StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
       false)
+  }
+
+  test("SPARK-56615: non-grouped KeyedPartitioning does not satisfy ClusteredDistribution") {
+    val x = AttributeReference("x", IntegerType)()
+
+    // Non-grouped: duplicate partition key (1 appears twice), so isGrouped=false.
+    val nonGroupedKP =
+      KeyedPartitioning(Seq(x), Seq(InternalRow(1), InternalRow(1), InternalRow(2)))
+    assert(!nonGroupedKP.isGrouped)
+    // satisfies() must return false: the partitions are not yet grouped.
+    checkSatisfied(nonGroupedKP, ClusteredDistribution(Seq(x)), false)
+    // groupedSatisfies() returns true: it CAN satisfy once GroupPartitionsExec groups them.
+    assert(nonGroupedKP.groupedSatisfies(ClusteredDistribution(Seq(x))))
+
+    // Grouped: all distinct keys, so isGrouped=true and satisfies() delegates to
+    // groupedSatisfies().
+    val groupedKP = KeyedPartitioning(Seq(x), Seq(InternalRow(1), InternalRow(2), InternalRow(3)))
+    assert(groupedKP.isGrouped)
+    checkSatisfied(groupedKP, ClusteredDistribution(Seq(x)), true)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`KeyedPartitioning.satisfies0` previously delegated unconditionally to both `nonGroupedSatisfies` and `groupedSatisfies`, meaning an ungrouped KP would incorrectly claim to satisfy `ClusteredDistribution` if called directly. The correct form is:

    nonGroupedSatisfies(required) || (isGrouped && groupedSatisfies(required))

`EnsureRequirements` never calls `satisfies()` on an ungrouped `KeyedPartitioning` (it uses `splitKeyedPartitionings` and calls the two helpers directly), so the missing guard has had no runtime effect. This PR adds the guard to make the semantics correct for any future direct caller.

Also adds documentation to `KeyedPartitioning` and `EnsureRequirements` explaining the intended call contract: `groupedSatisfies` answers "would this KP satisfy if it were grouped?", and `EnsureRequirements` calls it directly on non-grouped KPs to decide whether inserting `GroupPartitionsExec` would satisfy the distribution.

### Why are the changes needed?

The missing `isGrouped &&` guard in `satisfies0` is a latent correctness issue. The documentation clarifies a subtle and previously undocumented contract between `KeyedPartitioning` and `EnsureRequirements`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The fix aligns the implementation with the contract that `EnsureRequirements` already relies on. Existing `KeyGroupedPartitioningSuite` and related suites cover the behaviour, but added a new test as well.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 4.6
