### PR TITLE
[SPARK-56622][K8S][INFRA] Update K8s IT CI to use K8s 1.36

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1472,7 +1472,7 @@ jobs:
       - name: Start Minikube
         uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
         with:
-          kubernetes-version: "1.35.0"
+          kubernetes-version: "1.36.0"
           # GitHub Actions limit 4C/16G, limit to 2C/6G for better resource statistic
           # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
           cpus: 2


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update CI to test K8s 1.36.

### Why are the changes needed?

To ensure Apache Spark K8s Operator works with the latest Kubernetes 1.36 release.
- https://kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check the installed version manually in the log.

```
System Info:
  ...
  Kubelet Version:            v1.36.0
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7