### PR TITLE
[SPARK-56623][K8S] Promote `KubernetesDriverSpec` to `Stable`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesDriverSpec.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesDriverSpec.scala
@@ -22,7 +22,7 @@ import scala.jdk.CollectionConverters._
 
 import io.fabric8.kubernetes.api.model.HasMetadata
 
-import org.apache.spark.annotation.{DeveloperApi, Since, Unstable}
+import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
 
 /**
  * :: DeveloperApi ::
@@ -30,7 +30,7 @@ import org.apache.spark.annotation.{DeveloperApi, Since, Unstable}
  * Spec for driver pod and resources, used for K8s operations internally
  * and Spark K8s operator.
  */
-@Unstable
+@Stable
 @DeveloperApi
 @Since("3.3.0")
 case class KubernetesDriverSpec(
@@ -54,8 +54,9 @@ case class KubernetesDriverSpec(
     driverKubernetesResources.asJava
 }
 
-@Unstable
+@Stable
 @DeveloperApi
+@Since("4.2.0")
 object KubernetesDriverSpec {
   @Since("4.2.0")
   def create(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to promote `KubernetesDriverSpec` to `Stable` from Apache Spark 4.2.0.

### Why are the changes needed?

- The AS-IS `KubernetesDriverSpec` was introduced at Apache Spark 2.3.0 and established in this structure at 3.3.0.
  - https://github.com/apache/spark/pull/19717
  - https://github.com/apache/spark/pull/34599
- Since Apache Spark 4.0.0 promoted it as a developer API, it has been serving until now stably.
  - https://github.com/apache/spark/pull/46371
- We had better promote it to `Stable` from Apache Spark 4.2.0.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7