### PR TITLE
[SPARK-56624][K8S] Promote `KubernetesUtils` to `Stable`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -28,7 +28,7 @@ import io.fabric8.kubernetes.client.KubernetesClient
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{SparkConf, SparkException}
-import org.apache.spark.annotation.{DeveloperApi, Since, Unstable}
+import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.k8s.Config.KUBERNETES_FILE_UPLOAD_PATH
 import org.apache.spark.internal.Logging
@@ -44,8 +44,9 @@ import org.apache.spark.util.Utils.{getHadoopFileSystem, uploadFileToHadoopCompa
  *
  * A utility class used for K8s operations internally and for implementing ExternalClusterManagers.
  */
-@Unstable
+@Stable
 @DeveloperApi
+@Since("2.3.0")
 object KubernetesUtils extends Logging {
 
   private val systemClock = new SystemClock()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to promote `KubernetesUtils` to `Stable` from Apache Spark 4.2.0.

### Why are the changes needed?

- Apache Spark 2.3.0 introduced `KubernetesUtils`.
  - https://github.com/apache/spark/pull/20160
- Apache Spark 3.2.0 promoted it to the Developer API.
  - https://github.com/apache/spark/pull/32406
- Since then, it has been serving stably as a `@DeveloperApi` utility class used for K8s operations internally and for implementing `ExternalClusterManager`s. We had better promote it to `Stable` from Apache Spark 4.2.0.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7