### PR TITLE
[SPARK-56626][SQL] Introduce SupportsReportCatalogStatistics mixin for Table

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsReportCatalogStatistics.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsReportCatalogStatistics.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.read.Statistics;
+
+/**
+ * A mix-in interface for {@link Table}. Data sources can implement this interface to report
+ * table-level statistics to Spark.
+ * <p>
+ * The statistics returned here describe the table as a whole, independent of any {@code Scan}
+ * and independent of any pushed operators (filters, partition pruning, column pruning,
+ * aggregate pushdown). They are analogous to DSv1's {@code CatalogStatistics} exposed via
+ * {@code CatalogTable.stats}: a stable, pre-filter, pre-pruning property of the table.
+ * <p>
+ * This is distinct from
+ * {@link org.apache.spark.sql.connector.read.SupportsReportStatistics} on {@code Scan}, which
+ * reports <em>post-pushdown</em> statistics that reflect the data the scan will actually
+ * produce. A table may implement both: catalog statistics drive CBO decisions on the
+ * unfiltered relation (join reordering, broadcast thresholds), while scan statistics tighten
+ * estimates once pushdown has happened.
+ * <p>
+ * Implementations should return statistics without triggering expensive work such as file
+ * listing or remote metadata fetches beyond what is already cached on the {@code Table}
+ * instance. Consumers may call this method during optimization, potentially more than once
+ * per query, and expect a consistent result for a given {@code Table} instance.
+ *
+ * @since 4.2.0
+ */
+@Evolving
+public interface SupportsReportCatalogStatistics extends Table {
+
+  /**
+   * Returns table-level statistics for this table.
+   * <p>
+   * The returned statistics must describe the full table, not a filtered or pruned subset.
+   * When no statistics are available, return {@link Statistics#emptyStatistics} rather than
+   * {@code null}.
+   */
+  Statistics catalogStatistics();
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, ExposesMetadataC
 import org.apache.spark.sql.catalyst.streaming.{StreamingSourceIdentifyingName, Unassigned}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.{truncatedString, CharVarcharUtils}
-import org.apache.spark.sql.connector.catalog.{CatalogPlugin, FunctionCatalog, Identifier, SupportsMetadataColumns, SupportsReportCatalogStatistics, Table, TableCapability, TableCatalog, V2TableUtil}
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, FunctionCatalog, Identifier, SupportsMetadataColumns, Table, TableCapability, TableCatalog, V2TableUtil}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.CatalogHelper
 import org.apache.spark.sql.connector.expressions.{FieldReference, NamedReference}
 import org.apache.spark.sql.connector.read.{Scan, Statistics => V2Statistics, SupportsReportStatistics, SupportsRuntimeV2Filtering}
@@ -199,20 +199,6 @@ case class DataSourceV2ScanRelation(
   }
 
   override def computeStats(): Statistics = {
-    // If the table reports catalog-level (pre-filter, pre-pruning) statistics via
-    // SupportsReportCatalogStatistics and those stats carry a row count, prefer them:
-    // they describe the full table independent of any pushdown and are typically the
-    // strongest stats available to CBO. Otherwise fall through to the scan's own
-    // post-pushdown statistics as before.
-    relation.table match {
-      case t: SupportsReportCatalogStatistics =>
-        val catalogStats = t.catalogStatistics()
-        if (catalogStats.numRows().isPresent) {
-          return DataSourceV2Relation.transformV2Stats(
-            catalogStats, None, conf.defaultSizeInBytes, output)
-        }
-      case _ =>
-    }
     scan match {
       case r: SupportsReportStatistics =>
         val statistics = r.estimateStatistics()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, ExposesMetadataC
 import org.apache.spark.sql.catalyst.streaming.{StreamingSourceIdentifyingName, Unassigned}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.{truncatedString, CharVarcharUtils}
-import org.apache.spark.sql.connector.catalog.{CatalogPlugin, FunctionCatalog, Identifier, SupportsMetadataColumns, Table, TableCapability, TableCatalog, V2TableUtil}
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, FunctionCatalog, Identifier, SupportsMetadataColumns, SupportsReportCatalogStatistics, Table, TableCapability, TableCatalog, V2TableUtil}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.CatalogHelper
 import org.apache.spark.sql.connector.expressions.{FieldReference, NamedReference}
 import org.apache.spark.sql.connector.read.{Scan, Statistics => V2Statistics, SupportsReportStatistics, SupportsRuntimeV2Filtering}
@@ -199,6 +199,20 @@ case class DataSourceV2ScanRelation(
   }
 
   override def computeStats(): Statistics = {
+    // If the table reports catalog-level (pre-filter, pre-pruning) statistics via
+    // SupportsReportCatalogStatistics and those stats carry a row count, prefer them:
+    // they describe the full table independent of any pushdown and are typically the
+    // strongest stats available to CBO. Otherwise fall through to the scan's own
+    // post-pushdown statistics as before.
+    relation.table match {
+      case t: SupportsReportCatalogStatistics =>
+        val catalogStats = t.catalogStatistics()
+        if (catalogStats.numRows().isPresent) {
+          return DataSourceV2Relation.transformV2Stats(
+            catalogStats, None, conf.defaultSizeInBytes, output)
+        }
+      case _ =>
+    }
     scan match {
       case r: SupportsReportStatistics =>
         val statistics = r.estimateStatistics()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a new `@Evolving` mix-in on `org.apache.spark.sql.connector.catalog.Table`:

```java
public interface SupportsReportCatalogStatistics extends Table {
  Statistics catalogStatistics();
}
```

The returned stats describe the full table — pre-filter, pre-pruning, scan-independent — analogous to DSv1's `CatalogStatistics`. Distinct from `Scan`-level `SupportsReportStatistics`, which reports post-pushdown stats; a table may implement both.

Wires it into `DataSourceV2ScanRelation.computeStats` additively: if the table implements the mixin and `catalogStatistics().numRows()` is present, those stats are used via `transformV2Stats`; otherwise control falls through to the existing `Scan.estimateStatistics()` path unchanged. The `numRows`-present guard ensures the fallthrough when the mixin has nothing meaningful to report.

No built-in `Table` implements the mixin in this PR.

### Why are the changes needed?

DSv2 currently conflates catalog-level and scan-level statistics on `Scan.estimateStatistics()`, so reading table-wide stats requires building a `ScanBuilder` — which, depending on the connector, can trigger file listing, `planScanFiles`, or remote metadata round-trips. This mixin is a scan-independent accessor with a stable, pre-pushdown contract, suitable for CBO decisions on the unfiltered relation.

### Does this PR introduce _any_ user-facing change?

No. The interface is new; no built-in table implements it, so existing queries observe identical behavior.

### How was this patch tested?

No new tests. The `computeStats` change is a guarded prefix on the existing implementation — with no implementor it degenerates to the unchanged scan path, covered by existing DSv2 suites. A follow-up adding an in-tree implementor (e.g. `V1Table`) will add targeted coverage.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)