### PR TITLE
[SPARK-56611][SQL] Fix ALTER TABLE RENAME TO with catalog-qualified targets

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -454,19 +454,18 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       }
 
       // Strip catalog prefix if the identifier is catalog-qualified.
-      val newNameParts =
-        if (rawNewNameParts.length > 1 && rawNewNameParts.head == catalog.name()) {
-          rawNewNameParts.tail
-        } else {
-          rawNewNameParts
-        }
+      val newNameParts = if (rawNewNameParts.length > 1 &&
+          SQLConf.get.resolver(rawNewNameParts.head, catalog.name())) {
+        rawNewNameParts.tail
+      } else {
+        rawNewNameParts
+      }
 
-      val namespace =
-        if (newNameParts.length == 1) {
-          oldIdent.namespace()
-        } else {
-          newNameParts.dropRight(1).toArray
-        }
+      val namespace = if (newNameParts.length == 1) {
+        oldIdent.namespace()
+      } else {
+        newNameParts.init.toArray
+      }
 
       val newIdent = Identifier.of(namespace, newNameParts.last)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -461,13 +461,11 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
         rawNewNameParts
       }
 
-      val namespace = if (newNameParts.length == 1) {
-        oldIdent.namespace()
+      val newIdent = if (newNameParts.length == 1) {
+        Identifier.of(oldIdent.namespace(), newNameParts.last)
       } else {
-        newNameParts.init.toArray
+        newNameParts.asIdentifier
       }
-
-      val newIdent = Identifier.of(namespace, newNameParts.last)
 
       RenameTableExec(
         catalog,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -448,14 +448,32 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
     case _: NoopCommand =>
       LocalTableScanExec(Nil, Nil, None) :: Nil
 
-    case RenameTable(r @ ResolvedTable(catalog, oldIdent, _, _), newIdent, isView) =>
+    case RenameTable(r @ ResolvedTable(catalog, oldIdent, _, _), rawNewNameParts, isView) =>
       if (isView) {
         throw QueryCompilationErrors.cannotRenameTableWithAlterViewError()
       }
+
+      // Strip catalog prefix if the identifier is catalog-qualified.
+      val newNameParts =
+        if (rawNewNameParts.length > 1 && rawNewNameParts.head == catalog.name()) {
+          rawNewNameParts.tail
+        } else {
+          rawNewNameParts
+        }
+
+      val namespace =
+        if (newNameParts.length == 1) {
+          oldIdent.namespace()
+        } else {
+          newNameParts.dropRight(1).toArray
+        }
+
+      val newIdent = Identifier.of(namespace, newNameParts.last)
+
       RenameTableExec(
         catalog,
         oldIdent,
-        newIdent.asIdentifier,
+        newIdent,
         invalidateTableCache(r),
         session.sharedState.cacheManager.cacheQuery) :: Nil
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -455,17 +455,13 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
 
       // Strip catalog prefix if the identifier is catalog-qualified.
       val newNameParts = if (rawNewNameParts.length > 1 &&
-          SQLConf.get.resolver(rawNewNameParts.head, catalog.name())) {
+          session.sessionState.conf.resolver(rawNewNameParts.head, catalog.name())) {
         rawNewNameParts.tail
       } else {
         rawNewNameParts
       }
 
-      val newIdent = if (newNameParts.length == 1) {
-        Identifier.of(oldIdent.namespace(), newNameParts.last)
-      } else {
-        newNameParts.asIdentifier
-      }
+      val newIdent = newNameParts.asIdentifier
 
       RenameTableExec(
         catalog,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2486,6 +2486,36 @@ class DataSourceV2SQLSuiteV1Filter
       ExpectedContext("testcat.ns.tbl", 11, 10 + "testcat.ns.tbl".length))
   }
 
+  test("SPARK-56611: rename table with catalog-qualified identifier") {
+    withTable("testcat.ns.t1", "testcat.ns.t1_renamed") {
+      sql("CREATE TABLE testcat.ns.t1 USING foo AS SELECT id, data FROM source")
+      checkAnswer(sql("SHOW TABLES FROM testcat.ns"), Seq(Row("ns", "t1", false)))
+
+      // rename with just table name, inherits namespace from source
+      sql("ALTER TABLE testcat.ns.t1 RENAME TO t1_renamed")
+      checkAnswer(sql("SHOW TABLES FROM testcat.ns"), Seq(Row("ns", "t1_renamed", false)))
+
+      // rename with namespace-qualified name
+      sql("ALTER TABLE testcat.ns.t1_renamed RENAME TO ns.t1")
+      checkAnswer(sql("SHOW TABLES FROM testcat.ns"), Seq(Row("ns", "t1", false)))
+
+      // rename with catalog-qualified target identifier
+      sql("ALTER TABLE testcat.ns.t1 RENAME TO testcat.ns.t1_renamed")
+      checkAnswer(sql("SHOW TABLES FROM testcat.ns"), Seq(Row("ns", "t1_renamed", false)))
+    }
+  }
+
+  test("SPARK-56611: rename table across namespace should work for V2 catalogs") {
+    withTable("testcat.ns1.t1", "testcat.ns2.t1") {
+      sql("CREATE TABLE testcat.ns1.t1 USING foo AS SELECT id, data FROM source")
+      checkAnswer(sql("SHOW TABLES FROM testcat.ns1"), Seq(Row("ns1", "t1", false)))
+
+      sql("ALTER TABLE testcat.ns1.t1 RENAME TO ns2.t1")
+      checkAnswer(sql("SHOW TABLES FROM testcat.ns1"), Nil)
+      checkAnswer(sql("SHOW TABLES FROM testcat.ns2"), Seq(Row("ns2", "t1", false)))
+    }
+  }
+
   test("ANALYZE TABLE") {
     val t = "testcat.ns1.ns2.tbl"
     withTable(t) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2491,14 +2491,6 @@ class DataSourceV2SQLSuiteV1Filter
       sql("CREATE TABLE testcat.ns.t1 USING foo AS SELECT id, data FROM source")
       checkAnswer(sql("SHOW TABLES FROM testcat.ns"), Seq(Row("ns", "t1", false)))
 
-      // rename with just table name, inherits namespace from source
-      sql("ALTER TABLE testcat.ns.t1 RENAME TO t1_renamed")
-      checkAnswer(sql("SHOW TABLES FROM testcat.ns"), Seq(Row("ns", "t1_renamed", false)))
-
-      // rename with namespace-qualified name
-      sql("ALTER TABLE testcat.ns.t1_renamed RENAME TO ns.t1")
-      checkAnswer(sql("SHOW TABLES FROM testcat.ns"), Seq(Row("ns", "t1", false)))
-
       // rename with catalog-qualified target identifier
       sql("ALTER TABLE testcat.ns.t1 RENAME TO testcat.ns.t1_renamed")
       checkAnswer(sql("SHOW TABLES FROM testcat.ns"), Seq(Row("ns", "t1_renamed", false)))
@@ -2506,17 +2498,6 @@ class DataSourceV2SQLSuiteV1Filter
       // rename with case-insensitive catalog-qualified target identifier
       sql("ALTER TABLE testcat.ns.t1_renamed RENAME TO TesTcaT.ns.t1")
       checkAnswer(sql("SHOW TABLES FROM testcat.ns"), Seq(Row("ns", "t1", false)))
-    }
-  }
-
-  test("SPARK-56611: rename table across namespaces") {
-    withTable("testcat.ns1.t1", "testcat.ns2.t1") {
-      sql("CREATE TABLE testcat.ns1.t1 USING foo AS SELECT id, data FROM source")
-      checkAnswer(sql("SHOW TABLES FROM testcat.ns1"), Seq(Row("ns1", "t1", false)))
-
-      sql("ALTER TABLE testcat.ns1.t1 RENAME TO ns2.t1")
-      checkAnswer(sql("SHOW TABLES FROM testcat.ns1"), Nil)
-      checkAnswer(sql("SHOW TABLES FROM testcat.ns2"), Seq(Row("ns2", "t1", false)))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2520,6 +2520,19 @@ class DataSourceV2SQLSuiteV1Filter
     }
   }
 
+  test("SPARK-56611: rename target is resolved within source catalog") {
+    withTable("testcat.ns1.t1", "testcat.testcat2.ns2.t1") {
+      sql("CREATE TABLE testcat.ns1.t1 USING foo AS SELECT id, data FROM source")
+
+      // testcat2 is a valid catalog name, but in the rename target it is
+      // treated as a namespace within testcat (the source table's catalog).
+      sql("ALTER TABLE testcat.ns1.t1 RENAME TO testcat2.ns2.t1")
+      checkAnswer(sql("SHOW TABLES FROM testcat.ns1"), Nil)
+      checkAnswer(
+        sql("SHOW TABLES FROM testcat.testcat2.ns2"), Seq(Row("testcat2.ns2", "t1", false)))
+    }
+  }
+
   test("ANALYZE TABLE") {
     val t = "testcat.ns1.ns2.tbl"
     withTable(t) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2502,10 +2502,14 @@ class DataSourceV2SQLSuiteV1Filter
       // rename with catalog-qualified target identifier
       sql("ALTER TABLE testcat.ns.t1 RENAME TO testcat.ns.t1_renamed")
       checkAnswer(sql("SHOW TABLES FROM testcat.ns"), Seq(Row("ns", "t1_renamed", false)))
+
+      // rename with case-insensitive catalog-qualified target identifier
+      sql("ALTER TABLE testcat.ns.t1_renamed RENAME TO TesTcaT.ns.t1")
+      checkAnswer(sql("SHOW TABLES FROM testcat.ns"), Seq(Row("ns", "t1", false)))
     }
   }
 
-  test("SPARK-56611: rename table across namespace should work for V2 catalogs") {
+  test("SPARK-56611: rename table across namespaces") {
     withTable("testcat.ns1.t1", "testcat.ns2.t1") {
       sql("CREATE TABLE testcat.ns1.t1 USING foo AS SELECT id, data FROM source")
       checkAnswer(sql("SHOW TABLES FROM testcat.ns1"), Seq(Row("ns1", "t1", false)))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This fixes ALTER TABLE ... RENAME TO in V2 catalogs when the target name is catalog-qualified.

**Changes:**

* Strip the catalog prefix from the target when it matches the source catalog

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Right now, a catalog-qualified rename fails:

For example:

```sql
ALTER TABLE testcat.ns.t1 RENAME TO testcat.ns.t2;
```

this fails because `asIdentifier` treats everything except the last part as the namespace. That means the catalog name (`testcat`) incorrectly ends up inside the namespace:

```scala
Identifier.of(["testcat", "ns"], "t2")
```

instead of:

```scala
Identifier.of(["ns"], "t2")
```

**Steps to reproduce:**

```sql
CREATE TABLE testcat.ns.t1 USING foo AS SELECT 1 AS id;
ALTER TABLE testcat.ns.t1 RENAME TO testcat.ns.t2;
```

This fails with a namespace resolution error due to the catalog being treated as part of the namespace.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, Catalog-qualified renames like ALTER TABLE catalog.ns.t1 RENAME TO catalog.ns.t2 now work correctly

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added tests in DataSourceV2SQLSuite covering catalog-qualified renames and target resolution within the source catalog.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
