### PR TITLE
[SPARK-56630][INFRA] Surface javadoc crash culprit in unidoc failure output

### DIFF
--- a/docs/_plugins/build_api_docs.rb
+++ b/docs/_plugins/build_api_docs.rb
@@ -171,51 +171,63 @@ end
 # already shows what's wrong.
 def diagnose_unidoc_failure(log_file)
   return unless File.exist?(log_file)
-  lines = File.readlines(log_file)
+  begin
+    lines = File.readlines(log_file)
 
-  javadoc_exit_idx = lines.rindex { |l| l.include?("javadoc exited with exit code") }
-  last_generating = nil
-  if javadoc_exit_idx
-    # Strip ANSI color codes so the regex matches sbt-coloured output too.
-    ansi = /\e\[[0-9;]*[A-Za-z]/
-    lines[0...javadoc_exit_idx].reverse_each do |line|
-      if line.gsub(ansi, '') =~ %r{Generating .+/javaunidoc/(\S+?\.html)\.\.\.}
-        last_generating = $1
-        break
+    javadoc_exit_idx = lines.rindex { |l| l.include?("javadoc exited with exit code") }
+    last_generating = nil
+    if javadoc_exit_idx
+      # Strip ANSI color codes so the regex matches sbt-coloured output too.
+      ansi = /\e\[[0-9;]*[A-Za-z]/
+      lines[0...javadoc_exit_idx].reverse_each do |line|
+        if line.gsub(ansi, '') =~ %r{Generating .+/javaunidoc/(\S+?\.html)\.\.\.}
+          last_generating = $1
+          break
+        end
       end
     end
-  end
 
-  banner = "=" * 78
-  $stderr.puts ""
-  $stderr.puts banner
-  $stderr.puts "Unidoc failed -- diagnostic summary"
-  $stderr.puts banner
-  if last_generating
-    class_path = last_generating.sub(/\.html$/, '')
-    class_name = class_path.tr('/', '.')
+    banner = "=" * 78
     $stderr.puts ""
-    $stderr.puts "  Javadoc crashed while generating: #{last_generating}"
-    $stderr.puts "  Likely culprit: doc comment in #{class_name}"
+    $stderr.puts banner
+    $stderr.puts "Unidoc failed -- diagnostic summary"
+    $stderr.puts banner
+    if last_generating
+      class_path = last_generating.sub(/\.html$/, '')
+      class_name = class_path.tr('/', '.')
+      $stderr.puts ""
+      $stderr.puts "  Javadoc crashed while generating: #{last_generating}"
+      $stderr.puts "  Likely culprit: doc comment in #{class_name}"
+      $stderr.puts ""
+      $stderr.puts "  Javadoc can hard-exit (not just warn) on specific scaladoc"
+      $stderr.puts "  patterns once they have been passed through genjavadoc --"
+      $stderr.puts "  wiki-style `[[Class]]` / `[[method]]` links or inline-backticked"
+      $stderr.puts "  code refs in the Scala source for the class above are common"
+      $stderr.puts "  triggers. Start by auditing any recent doc-string changes in"
+      $stderr.puts "  that source file."
+      $stderr.puts ""
+      $stderr.puts "  NOTE: the '[error]' lines above on files under"
+      $stderr.puts "  target/java/... are benign genjavadoc stubs -- every PR"
+      $stderr.puts "  emits them and they do not cause the exit. Ignore them."
+    elsif javadoc_exit_idx
+      $stderr.puts ""
+      $stderr.puts "  Javadoc exited but no class HTML generation was in progress;"
+      $stderr.puts "  the crash predates HTML output -- likely a CLI / classpath /"
+      $stderr.puts "  setup issue. See the full sbt output above."
+    else
+      $stderr.puts ""
+      $stderr.puts "  Could not locate a 'javadoc exited with exit code' marker in"
+      $stderr.puts "  the log; the failure is likely outside the javaunidoc step"
+      $stderr.puts "  (scaladoc / sbt / build env). See the full sbt output above."
+    end
+    $stderr.puts banner
     $stderr.puts ""
-    $stderr.puts "  Javadoc can hard-exit (not just warn) on specific scaladoc"
-    $stderr.puts "  patterns once they have been passed through genjavadoc --"
-    $stderr.puts "  wiki-style `[[Class]]` / `[[method]]` links or inline-backticked"
-    $stderr.puts "  code refs in the Scala source for the class above are common"
-    $stderr.puts "  triggers. Start by auditing any recent doc-string changes in"
-    $stderr.puts "  that source file."
-    $stderr.puts ""
-    $stderr.puts "  NOTE: the 100 '[error]' lines above, all on files under"
-    $stderr.puts "  target/java/..., are benign genjavadoc stubs -- every PR"
-    $stderr.puts "  emits them and they do not cause the exit. Ignore them."
-  else
-    $stderr.puts ""
-    $stderr.puts "  Could not locate a 'javadoc exited with exit code' marker in"
-    $stderr.puts "  the log; the failure is likely outside the javaunidoc step"
-    $stderr.puts "  (scaladoc / sbt / build env). See the full sbt output above."
+  rescue => e
+    # Never let the diagnostic helper itself obscure the underlying unidoc
+    # failure: if anything here goes wrong (e.g. encoding error reading the
+    # log), report it briefly and let the caller raise the real error.
+    $stderr.puts "(diagnostic helper failed: #{e.class}: #{e.message})"
   end
-  $stderr.puts banner
-  $stderr.puts ""
 end
 
 def build_scala_and_java_docs

--- a/docs/_plugins/build_api_docs.rb
+++ b/docs/_plugins/build_api_docs.rb
@@ -133,7 +133,89 @@ def build_spark_scala_and_java_docs_if_necessary
 
   command = "build/sbt -Pkinesis-asl unidoc"
   puts "Running '#{command}'..."
-  system(command) || raise("Unidoc generation failed")
+  # Tee sbt output to a log file so we can diagnose failures. The most common
+  # unidoc failure is a javadoc crash mid-stream while generating HTML for a
+  # specific class, buried under ~100 benign errors on genjavadoc-generated
+  # Java stubs (e.g. target/java/org/apache/spark/ErrorInfo.java). Without the
+  # diagnostic below, the real culprit -- the source whose doc tripped javadoc
+  # -- is effectively invisible in the CI log.
+  log_file = File.join(SPARK_PROJECT_ROOT, "target", "unidoc-build.log")
+  mkdir_p(File.dirname(log_file))
+  success = stream_and_capture(command, log_file)
+  unless success
+    diagnose_unidoc_failure(log_file)
+    raise("Unidoc generation failed")
+  end
+end
+
+# Runs `command`, streaming every line to both stdout and `log_file`. Returns
+# true iff the command exited 0. Ruby-only; no shell pipefail reliance.
+def stream_and_capture(command, log_file)
+  File.open(log_file, 'w') do |f|
+    IO.popen("#{command} 2>&1", 'r') do |pipe|
+      pipe.each_line do |line|
+        $stdout.write(line)
+        $stdout.flush
+        f.write(line)
+      end
+    end
+  end
+  $?.success?
+end
+
+# Scans the captured unidoc log and prints a pointer to the most likely
+# culprit source file. The heuristic: when javadoc dies mid-HTML-generation,
+# the last "Generating .../X.html" line before "javadoc exited with exit code"
+# names the class that tripped it. Prints nothing actionable if the failure
+# mode doesn't match (e.g. a scaladoc error), in which case the full log above
+# already shows what's wrong.
+def diagnose_unidoc_failure(log_file)
+  return unless File.exist?(log_file)
+  lines = File.readlines(log_file)
+
+  javadoc_exit_idx = lines.rindex { |l| l.include?("javadoc exited with exit code") }
+  last_generating = nil
+  if javadoc_exit_idx
+    # Strip ANSI color codes so the regex matches sbt-coloured output too.
+    ansi = /\e\[[0-9;]*[A-Za-z]/
+    lines[0...javadoc_exit_idx].reverse_each do |line|
+      if line.gsub(ansi, '') =~ %r{Generating .+/javaunidoc/(\S+?\.html)\.\.\.}
+        last_generating = $1
+        break
+      end
+    end
+  end
+
+  banner = "=" * 78
+  $stderr.puts ""
+  $stderr.puts banner
+  $stderr.puts "Unidoc failed -- diagnostic summary"
+  $stderr.puts banner
+  if last_generating
+    class_path = last_generating.sub(/\.html$/, '')
+    class_name = class_path.tr('/', '.')
+    $stderr.puts ""
+    $stderr.puts "  Javadoc crashed while generating: #{last_generating}"
+    $stderr.puts "  Likely culprit: doc comment in #{class_name}"
+    $stderr.puts ""
+    $stderr.puts "  Javadoc can hard-exit (not just warn) on specific scaladoc"
+    $stderr.puts "  patterns once they have been passed through genjavadoc --"
+    $stderr.puts "  wiki-style `[[Class]]` / `[[method]]` links or inline-backticked"
+    $stderr.puts "  code refs in the Scala source for the class above are common"
+    $stderr.puts "  triggers. Start by auditing any recent doc-string changes in"
+    $stderr.puts "  that source file."
+    $stderr.puts ""
+    $stderr.puts "  NOTE: the 100 '[error]' lines above, all on files under"
+    $stderr.puts "  target/java/..., are benign genjavadoc stubs -- every PR"
+    $stderr.puts "  emits them and they do not cause the exit. Ignore them."
+  else
+    $stderr.puts ""
+    $stderr.puts "  Could not locate a 'javadoc exited with exit code' marker in"
+    $stderr.puts "  the log; the failure is likely outside the javaunidoc step"
+    $stderr.puts "  (scaladoc / sbt / build env). See the full sbt output above."
+  end
+  $stderr.puts banner
+  $stderr.puts ""
 end
 
 def build_scala_and_java_docs

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
@@ -172,11 +172,6 @@ private[sql] object CatalogV2Implicits {
     }
 
     /**
-     * DO NOT MERGE -- intentional javadoc-crash bait to verify CI diagnostic.
-     * Reproduces the exact doc pattern that hard-exited javadoc on PR #51419:
-     * a wiki-style link to [[TableIdentifier]], a forward ref to
-     * [[toQualifiedNameParts]], and an inline-backticked `Seq[String]`.
-     *
      * Tries to convert catalog identifier to the table identifier. Table identifier does not
      * support multiple namespaces (nested namespaces), so if identifier contains nested namespace,
      * conversion cannot be done

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
@@ -172,6 +172,11 @@ private[sql] object CatalogV2Implicits {
     }
 
     /**
+     * DO NOT MERGE -- intentional javadoc-crash bait to verify CI diagnostic.
+     * Reproduces the exact doc pattern that hard-exited javadoc on PR #51419:
+     * a wiki-style link to [[TableIdentifier]], a forward ref to
+     * [[toQualifiedNameParts]], and an inline-backticked `Seq[String]`.
+     *
      * Tries to convert catalog identifier to the table identifier. Table identifier does not
      * support multiple namespaces (nested namespaces), so if identifier contains nested namespace,
      * conversion cannot be done


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a diagnostic banner to the unidoc step in `docs/_plugins/build_api_docs.rb`. When `build/sbt unidoc` fails, the script now scans the captured sbt output and prints a framed summary naming the `<Class>.html` javadoc was generating when it died, the inferred source class to audit, and a one-paragraph hint about the usual scaladoc triggers.

Implementation:
- `stream_and_capture` tees sbt output to both stdout and `target/unidoc-build.log` (Ruby-only, no shell `pipefail` reliance).
- `diagnose_unidoc_failure` finds the last `Generating .../<Class>.html...` line before `javadoc exited with exit code N` and prints a culprit-pointer banner. ANSI colour codes are stripped before regex matching.
- When the failure mode doesn't match the mid-HTML-crash pattern (e.g. scaladoc failure, sbt env issue), the banner says so and points back to the full log.

### Why are the changes needed?

Today, when javadoc hard-exits during unidoc HTML generation -- typically because of a specific scaladoc construct (e.g. wiki-style `[[Class]]` links or backtick-inline code refs) in an exposed Scala source -- the failing PR's CI log shows ~100 `[error]` lines on `target/java/...` files. Those errors are benign: they're genjavadoc-emitted Java stubs (`static public abstract R apply(T1, T2, T3, T4)`) that every PR produces, and `javadoc` always complains about them but normally still finishes. They are not the cause of the failure.

The actual signal is the last `Generating .../<Class>.html...` line before `javadoc exited with exit code 1`, which a developer has to find by hand in a multi-thousand-line log. The error reporting does not differentiate the benign noise from the real crash, so the failure consistently looks like it's "in" `ErrorInfo.java` / `LexicalThreadLocal.java` / similar, when it's actually in a Scala source that none of those names point to.

A recent example: PR #51419 hit this exact misdirection -- the log was full of errors on `common/utils/target/java/...` stubs, but the real culprit was a doc comment in `CatalogV2Implicits.IdentifierHelper` that triggered a hard exit during HTML generation. The diagnostic in this PR would have named that class directly.

### Does this PR introduce _any_ user-facing change?

No. CI-only output change visible in the unidoc step of the doc-gen job.

### How was this patch tested?

- Dry-ran the parser logic against the captured failing log from PR #51419 -- it correctly extracts `org/apache/spark/sql/connector/catalog/CatalogV2Implicits.IdentifierHelper.html` as the crash class.
- The second commit on this branch (`DO NOT MERGE: break a docstring to validate the unidoc diagnostic`) intentionally reintroduces the same `[[...]]`+backtick-inline scaladoc pattern in `CatalogV2Implicits.IdentifierHelper.asTableIdentifierOpt` so that this PR's CI run actually exercises the new path. Once the banner fires and names that class on the failing CI run, that commit will be dropped from this PR.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude (Anthropic)