### PR TITLE
[SPARK-56561][DOCS] Document order preservation for array_distinct, array_intersect, array_union, array_except

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -19651,6 +19651,8 @@ def array_remove(col: "ColumnOrName", element: Any) -> Column:
 def array_distinct(col: "ColumnOrName") -> Column:
     """
     Array function: removes duplicate values from the array.
+    The order of elements in the result is the same as the order of their first occurrence
+    in the input.
 
     .. versionadded:: 2.4.0
 
@@ -19830,7 +19832,7 @@ def array_insert(arr: "ColumnOrName", pos: Union["ColumnOrName", int], value: An
 def array_intersect(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     """
     Array function: returns a new array containing the intersection of elements in col1 and col2,
-    without duplicates.
+    without duplicates. The result preserves the order of elements from the first array.
 
     .. versionadded:: 2.4.0
 
@@ -19923,7 +19925,8 @@ def array_intersect(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
 def array_union(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     """
     Array function: returns a new array containing the union of elements in col1 and col2,
-    without duplicates.
+    without duplicates. The result preserves the order of elements from the first array,
+    followed by elements from the second array that are not in the first.
 
     .. versionadded:: 2.4.0
 
@@ -20016,7 +20019,7 @@ def array_union(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
 def array_except(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     """
     Array function: returns a new array containing the elements present in col1 but not in col2,
-    without duplicates.
+    without duplicates. The result preserves the order of elements from the first array.
 
     .. versionadded:: 2.4.0
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -8845,7 +8845,8 @@ object functions {
     Column.fn("array_prepend", column, lit(element))
 
   /**
-   * Removes duplicate values from the array.
+   * Removes duplicate values from the array. The order of elements in the result is the same as
+   * the order of their first occurrence in the input.
    * @group array_funcs
    * @since 2.4.0
    */
@@ -8853,7 +8854,7 @@ object functions {
 
   /**
    * Returns an array of the elements in the intersection of the given two arrays, without
-   * duplicates.
+   * duplicates. The result preserves the order of elements from the first array.
    *
    * @group array_funcs
    * @since 2.4.0
@@ -8872,6 +8873,8 @@ object functions {
 
   /**
    * Returns an array of the elements in the union of the given two arrays, without duplicates.
+   * The result preserves the order of elements from the first array, followed by elements from
+   * the second array that are not in the first.
    *
    * @group array_funcs
    * @since 2.4.0
@@ -8881,7 +8884,7 @@ object functions {
 
   /**
    * Returns an array of the elements in the first array but not in the second array, without
-   * duplicates. The order of elements in the result is not determined
+   * duplicates. The result preserves the order of elements from the first array.
    *
    * @group array_funcs
    * @since 2.4.0

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -4200,9 +4200,13 @@ trait ArraySetLike {
 
 /**
  * Removes duplicate values from the array.
+ * The order of elements in the result is the same as the order of their first occurrence
+ * in the input.
  */
 @ExpressionDescription(
-  usage = "_FUNC_(array) - Removes duplicate values from the array.",
+  usage = """_FUNC_(array) - Removes duplicate values from the array.
+    The order of elements in the result is the same as the order of their first occurrence
+    in the input.""",
   examples = """
     Examples:
       > SELECT _FUNC_(array(1, 2, 3, null, 3));
@@ -4391,12 +4395,16 @@ trait ArrayBinaryLike
 }
 
 /**
- * Returns an array of the elements in the union of x and y, without duplicates
+ * Returns an array of the elements in the union of x and y, without duplicates.
+ * The result preserves the order of elements from the first array, followed by elements
+ * from the second array that are not in the first.
  */
 @ExpressionDescription(
   usage = """
     _FUNC_(array1, array2) - Returns an array of the elements in the union of array1 and array2,
       without duplicates.
+      The result preserves the order of elements from the first array, followed by elements
+      from the second array that are not in the first.
   """,
   examples = """
     Examples:
@@ -4568,12 +4576,14 @@ case class ArrayUnion(left: Expression, right: Expression) extends ArrayBinaryLi
 }
 
 /**
- * Returns an array of the elements in the intersect of x and y, without duplicates
+ * Returns an array of the elements in the intersect of x and y, without duplicates.
+ * The result preserves the order of elements from the first array.
  */
 @ExpressionDescription(
   usage = """
   _FUNC_(array1, array2) - Returns an array of the elements in the intersection of array1 and
     array2, without duplicates.
+    The result preserves the order of elements from the first array.
   """,
   examples = """
     Examples:
@@ -4800,12 +4810,14 @@ case class ArrayIntersect(left: Expression, right: Expression) extends ArrayBina
 }
 
 /**
- * Returns an array of the elements in the intersect of x and y, without duplicates
+ * Returns an array of the elements in array1 but not in array2, without duplicates.
+ * The result preserves the order of elements from the first array.
  */
 @ExpressionDescription(
   usage = """
   _FUNC_(array1, array2) - Returns an array of the elements in array1 but not in array2,
     without duplicates.
+    The result preserves the order of elements from the first array.
   """,
   examples = """
     Examples:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This change documents the order preservation behavior of `array_distinct`, `array_intersect`, `array_union`, and `array_except` in:
  - SQL function descriptions (`@ExpressionDescription`)
  - Scala API scaladoc (`functions.scala`)
  - PySpark docstrings (`builtin.py`)
                                                                                                                                                                                    
Also fixes an incorrect statement in `array_except`'s scaladoc which said "The order of elements in the result is not determined" - the implementation preserves order from the first array.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
With this change users will not have to read implementation code to know whether these functions preserve element order. This is useful for code reviews and helps AI coding agents understand the behavior.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No - It is just updating the documentation.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

1. Verified Unit Tests using SBT - Tests pass for `CollectionExpressionsSuite` and `DataFrameFunctionsSuite`
* `build/sbt 'catalyst/testOnly *CollectionExpressionsSuite -- -z "Array Distinct" -z "Array Union" -z "Array Except" -z "Array Intersect"'`
* `build/sbt 'sql/testOnly *DataFrameFunctionsSuite -- -z "array_distinct" -z "array_intersect" -z "array_union" -z "array_except"'`

2. Runtime verification using - `spark-shell`:

```
import org.apache.spark.sql.functions._
val df = spark.createDataFrame(Seq((Array(3,1,2,1,3), Array(2,4,3)))).toDF("a","b")
val r1 = df.select(array_distinct(col("a"))).collect()(0).getSeq[Int](0)
println(s"array_distinct([3,1,2,1,3]) = $r1")
```
Result - `array_distinct([3,1,2,1,3]) = ArraySeq(3, 1, 2)`

```
import org.apache.spark.sql.functions._
val df = spark.createDataFrame(Seq((Array(3,1,2,1,3), Array(2,4,3)))).toDF("a","b")
val r2 = df.select(array_union(col("a"), col("b"))).collect()(0).getSeq[Int](0)
println(s"array_union([3,1,2,1,3], [2,4,3]) = $r2")
```
Result - `array_union([3,1,2,1,3], [2,4,3]) = ArraySeq(3, 1, 2, 4)`

```
import org.apache.spark.sql.functions._
val df = spark.createDataFrame(Seq((Array(3,1,2,1,3), Array(2,4,3)))).toDF("a","b")
val r3 = df.select(array_intersect(col("a"), col("b"))).collect()(0).getSeq[Int](0)
println(s"array_intersect([3,1,2,1,3], [2,4,3]) = $r3")
```
Result - `array_intersect([3,1,2,1,3], [2,4,3]) = ArraySeq(3, 2)`

```
import org.apache.spark.sql.functions._
val df = spark.createDataFrame(Seq((Array(3,1,2,1,3), Array(2,4,3)))).toDF("a","b")
val r4 = df.select(array_except(col("a"), col("b"))).collect()(0).getSeq[Int](0)
println(s"array_except([3,1,2,1,3], [2,4,3]) = $r4")
```
Result - `array_except([3,1,2,1,3], [2,4,3]) = ArraySeq(1)`

### What changes were proposed in this pull request? 
Documentation update.                                                                                                                              

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.