### PR TITLE
[SPARK-47444][SQL] Validate numeric table stats in ALTER TABLE SET TBLPROPERTIES

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4657,6 +4657,12 @@
     },
     "sqlState" : "42823"
   },
+  "INVALID_TABLE_STATS_VALUE" : {
+    "message" : [
+      "The value <value> for table statistics property <key> is not a valid numeric value."
+    ],
+    "sqlState" : "22023"
+  },
   "INVALID_TEMP_OBJ_QUALIFIER" : {
     "message" : [
       "Temporary <objectType> <objectName> cannot be qualified with <qualifier>. Temporary objects can only be qualified with SESSION or SYSTEM.SESSION."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -1203,6 +1203,16 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
             }
           case _ =>
         }
+      // SPARK-47444: Validate that stats-related properties have numeric values.
+      case SetTableProperties(_, properties) =>
+        val numericStatsKeys = Set("numRows", "totalSize", "rawDataSize")
+        properties.foreach { case (key, value) =>
+          if (numericStatsKeys.contains(key) && scala.util.Try(BigInt(value)).isFailure) {
+            throw new AnalysisException(
+              errorClass = "INVALID_TABLE_STATS_VALUE",
+              messageParameters = Map("key" -> toSQLId(key), "value" -> s"'$value'"))
+          }
+        }
       case _ =>
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -30,7 +30,7 @@ import org.apache.hadoop.mapred.{FileInputFormat, JobConf}
 
 import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.internal.config.RDD_PARALLEL_LISTING_THRESHOLD
-import org.apache.spark.sql.{Row, SaveMode, SparkSession}
+import org.apache.spark.sql.{AnalysisException, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, Resolver}
 import org.apache.spark.sql.catalyst.catalog._
@@ -321,6 +321,15 @@ case class AlterTableSetPropertiesCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val table = catalog.getTableRawMetadata(tableName)
+    // SPARK-47444: Validate that stats-related properties have numeric values.
+    val numericStatsKeys = Set("numRows", "totalSize", "rawDataSize")
+    properties.foreach { case (key, value) =>
+      if (numericStatsKeys.contains(key) && scala.util.Try(BigInt(value)).isFailure) {
+        throw new AnalysisException(
+          errorClass = "INVALID_TABLE_STATS_VALUE",
+          messageParameters = Map("key" -> toSQLId(key), "value" -> s"'$value'"))
+      }
+    }
     // This overrides old properties and update the comment parameter of CatalogTable
     // with the newly added/modified comment since CatalogTable also holds comment as its
     // direct property.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableSetTblPropertiesSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableSetTblPropertiesSuiteBase.scala
@@ -126,4 +126,29 @@ trait AlterTableSetTblPropertiesSuiteBase extends QueryTest with DDLCommandTestU
       }
     }
   }
+
+  test("SPARK-47444: reject non-numeric values for table stats properties") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (col1 int) $defaultUsing")
+      Seq("numRows", "totalSize", "rawDataSize").foreach { key =>
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql(s"ALTER TABLE $t SET TBLPROPERTIES ('$key'='')")
+          },
+          condition = "INVALID_TABLE_STATS_VALUE",
+          parameters = Map("key" -> s"`$key`", "value" -> "''")
+        )
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql(s"ALTER TABLE $t SET TBLPROPERTIES ('$key'='abc')")
+          },
+          condition = "INVALID_TABLE_STATS_VALUE",
+          parameters = Map("key" -> s"`$key`", "value" -> "'abc'")
+        )
+      }
+      // Valid numeric values should succeed
+      sql(s"ALTER TABLE $t SET TBLPROPERTIES ('numRows'='100', 'totalSize'='5000')")
+    }
+  }
+
 }


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds validation for table statistics properties `(numRows, totalSize, rawDataSize)` in `ALTER TABLE SET TBLPROPERTIES` to reject non-numeric values.

The PR changes the below 4 files:
  1. `error-conditions.json` - Added a new error condition `INVALID_TABLE_STATS_VALUE (SQLSTATE 22023)` with the message: `"The value <value> for table statistics property <key> is not  a valid numeric value."`
  2. `CheckAnalysis.scala` - Added new case `SetTableProperties(_, properties)` match in `checkAnalysis0()` that validates stats property values can be parsed as `BigInt`. This catches invalid values at analysis time for the `v2 catalog` code path (e.g., `ALTER TABLE ... SET TBLPROPERTIES` resolved through `DataSourceV2`).
  3. `ddl.scala` - Added the same validation in `AlterTableSetPropertiesCommand.run()` before properties are written to the catalog. This catches invalid values at execution time for the `v1 catalog` code path (Hive/in-memory catalog).
  4. `AlterTableSetTblPropertiesSuiteBase.scala` - Added a new test that covers both invalid and valid inputs for all three stats properties.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As reported in [SPARK-47444](https://issues.apache.org/jira/browse/SPARK-47444), `ALTER TABLE SET TBLPROPERTIES` currently accepts empty strings and non-numeric values for `numRows, totalSize, and rawDataSize`. While [SPARK-30262](https://issues.apache.org/jira/browse/SPARK-30262) added a defensive filter when reading stats (to avoid `NumberFormatException`), invalid values can still be written to the catalog. Downstream tools and applications that consume these stats may break or produce incorrect results.

As mentioned in [SPARK-47444](https://issues.apache.org/jira/browse/SPARK-47444) - Hive and Beeline already validate these properties on write. Spark should do the same.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. `ALTER TABLE SET TBLPROPERTIES` now throws an `AnalysisException` with error condition `INVALID_TABLE_STATS_VALUE` if `numRows, totalSize, or rawDataSize` is set to a non-numeric value (including empty strings). Previously, these invalid values were silently accepted.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added a new test in `AlterTableSetTblPropertiesSuiteBase`

- <b>Empty string values</b> are rejected for all three stats properties `(numRows, totalSize, rawDataSize)`
- <b>Non-numeric string values</b> `(e.g., 'abc')` are rejected for all three stats properties
- <b>Valid numeric values</b> `(e.g., '100', '5000')` continue to be accepted without error

All assertions use `checkError` to verify the exact error condition `(INVALID_TABLE_STATS_VALUE)` and parameter values. The full `AlterTableSetTblPropertiesSuite` passes (4/4 tests including the new one)

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes.  All changes were reviewed and verified by the author.
