### PR TITLE
[SPARK-55553][GRAPHX] Unpersist sccWorkGraph in StronglyConnectedComponents

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/StronglyConnectedComponents.scala
@@ -46,6 +46,7 @@ object StronglyConnectedComponents {
 
     // helper variables to unpersist cached graphs
     var prevSccGraph = sccGraph
+    var prevSccWorkGraph = sccWorkGraph
 
     var numVertices = sccWorkGraph.numVertices
     var iter = 0
@@ -58,6 +59,12 @@ object StronglyConnectedComponents {
         }.outerJoinVertices(sccWorkGraph.inDegrees) {
           (vid, data, degreeOpt) => if (degreeOpt.isDefined) data else (vid, true)
         }.cache()
+        // materialize vertices and edges
+        sccWorkGraph.vertices.count()
+        sccWorkGraph.edges.count()
+        // sccWorkGraph materialized so, unpersist can be done on previous
+        prevSccWorkGraph.unpersist()
+        prevSccWorkGraph = sccWorkGraph
 
         // get all vertices to be removed
         val finalVertices = sccWorkGraph.vertices
@@ -77,6 +84,12 @@ object StronglyConnectedComponents {
 
         // only keep vertices that are not final
         sccWorkGraph = sccWorkGraph.subgraph(vpred = (vid, data) => !data._2).cache()
+        // materialize vertices and edges
+        sccWorkGraph.vertices.count()
+        sccWorkGraph.edges.count()
+        // sccWorkGraph materialized so, unpersist can be done on previous
+        prevSccWorkGraph.unpersist()
+        prevSccWorkGraph = sccWorkGraph
       } while (sccWorkGraph.numVertices < numVertices)
 
       // if iter < numIter at this point sccGraph that is returned


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes an asymmetric cache leak in `StronglyConnectedComponents.run`
(GraphX). Inside the inner `do { ... } while (...)` loop, `sccWorkGraph` is
reassigned twice (once via the `outerJoinVertices` chain, once via the
`subgraph` call) and `.cache()`'d each time, but the previous generation
was never `unpersist()`-ed.

The companion `sccGraph` is already tracked correctly via `prevSccGraph`
(introduced in SPARK-16478). This PR mirrors that lifecycle for
`sccWorkGraph`:

- Track the previous reference in a new `prevSccWorkGraph` variable.
- After each reassignment, materialize the new generation with
  `vertices.count()` / `edges.count()`.
- `prevSccWorkGraph.unpersist()` once the new generation is materialized,
  then advance `prevSccWorkGraph = sccWorkGraph`.

The algorithm and output are unchanged.

### Why are the changes needed?

On graphs that need many SCC iterations, the un-unpersisted `sccWorkGraph`
generations accumulate in the block manager and pin memory / disk blocks
until the job ends, causing eviction of other useful blocks and, on
larger graphs, OOMs or excessive spill. The fix restores symmetry with
the existing `sccGraph` cleanup that has been in place since SPARK-16478.

### Does this PR introduce _any_ user-facing change?

No. Pure internal cache-management fix; the public API and the returned
graph are identical.

### How was this patch tested?

Existing `StronglyConnectedComponentsSuite` unit tests pass locally
(`build/sbt 'graphx/testOnly *StronglyConnectedComponentsSuite'`).
The change is a strict subset of the cleanup pattern already applied to
`sccGraph` in the same loop, so existing coverage exercises the new
`unpersist` calls on every iteration.

### Was this patch authored or co-authored using generative AI tooling?

Cursor