### PR TITLE
[SPARK-56631][DOC] Update `addressable` gem version to 2.9.0

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
     bigdecimal (3.2.2)
     colorator (1.1.0)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Bump `addressable` (transitive dependency of `jekyll`) from 2.8.7 to 2.9.0 in `docs/Gemfile.lock`.

### Why are the changes needed?
`addressable` < 2.9.0 has a high-severity ReDoS vulnerability ([CVE-2026-35611](https://nvd.nist.gov/vuln/detail/CVE-2026-35611), [GHSA-h27x-rffw-24p4](https://github.com/sporkmonger/addressable/security/advisories/GHSA-h27x-rffw-24p4), CVSS 7.5) in `Addressable::Template#match`. 2.9.0 fully remediates the vulnerability and also widens the `public_suffix` upper bound to `< 8.0` (the resolved `public_suffix 6.0.2` continues to satisfy).

Release notes: https://github.com/sporkmonger/addressable/blob/main/CHANGELOG.md

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GitHub Actions.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code