### PR TITLE
[SPARK-56591][SQL][TESTS][FOLLOWUP] Remove redundant QueryTest mixin from SharedSparkSession subclasses

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -41,8 +41,7 @@ case class ComplexClass(a: Long, b: StringLongClass)
 case class ArrayClass(arr: Seq[StringIntClass])
 
 class QueryCompilationErrorsSuite
-  extends QueryTest
-  with QueryErrorsBase
+  extends QueryErrorsBase
   with SharedSparkSession {
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -41,8 +41,8 @@ case class ComplexClass(a: Long, b: StringLongClass)
 case class ArrayClass(arr: Seq[StringIntClass])
 
 class QueryCompilationErrorsSuite
-  extends QueryErrorsBase
-  with SharedSparkSession {
+  extends SharedSparkSession
+  with QueryErrorsBase {
   import testImplicits._
 
   test("CANNOT_UP_CAST_DATATYPE: invalid upcast data type") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -31,7 +31,7 @@ import org.mockito.Mockito.{mock, spy, when}
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark._
-import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, Encoder, KryoData, QueryTest, Row, SaveMode}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, Encoder, KryoData, Row, SaveMode}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NamedParameter, UnresolvedGenerator}
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
@@ -62,8 +62,7 @@ import org.apache.spark.util.Utils
 
 
 class QueryExecutionErrorsSuite
-  extends QueryTest
-  with ParquetTest
+  extends ParquetTest
   with OrcTest
   with SharedSparkSession
   with DataTypeErrorsBase {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceAggregatePushDownSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceAggregatePushDownSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources
 import java.sql.{Date, Timestamp}
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame, ExplainSuiteHelper, QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, ExplainSuiteHelper, Row}
 import org.apache.spark.sql.execution.datasources.orc.OrcTest
 import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
@@ -34,8 +34,7 @@ import org.apache.spark.tags.SlowSQLTest
  * A test suite that tests aggregate push down for Parquet and ORC.
  */
 trait FileSourceAggregatePushDownSuite
-  extends QueryTest
-  with FileBasedDataSourceTest
+  extends FileBasedDataSourceTest
   with SharedSparkSession
   with ExplainSuiteHelper {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -22,7 +22,7 @@ import java.io.File
 import org.scalactic.Equality
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.SchemaPruningTest
 import org.apache.spark.sql.catalyst.expressions.Concat
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
@@ -36,8 +36,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
 abstract class SchemaPruningSuite
-  extends QueryTest
-  with FileBasedDataSourceTest
+  extends FileBasedDataSourceTest
   with SchemaPruningTest
   with SharedSparkSession
   with AdaptiveSparkPlanHelper {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
@@ -25,7 +25,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path, RawLocalFileSystem}
 
 import org.apache.spark.{SparkConf, SparkException}
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.datasources.CommonFileDataSourceSuite
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -33,8 +33,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.util.HadoopFSUtils
 
 abstract class ParquetFileFormatSuite
-  extends QueryTest
-  with ParquetTest
+  extends ParquetTest
   with SharedSparkSession
   with CommonFileDataSourceSuite {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRebaseDatetimeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRebaseDatetimeSuite.scala
@@ -21,7 +21,7 @@ import java.nio.file.{Files, Paths, StandardCopyOption}
 import java.sql.{Date, Timestamp}
 
 import org.apache.spark.{SPARK_VERSION_SHORT, SparkConf, SparkException, SparkUpgradeException}
-import org.apache.spark.sql.{QueryTest, Row, SPARK_LEGACY_DATETIME_METADATA_KEY, SPARK_LEGACY_INT96_METADATA_KEY, SPARK_TIMEZONE_METADATA_KEY}
+import org.apache.spark.sql.{Row, SPARK_LEGACY_DATETIME_METADATA_KEY, SPARK_LEGACY_INT96_METADATA_KEY, SPARK_TIMEZONE_METADATA_KEY}
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.internal.LegacyBehaviorPolicy.{CORRECTED, EXCEPTION, LEGACY}
@@ -31,8 +31,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.tags.SlowSQLTest
 
 abstract class ParquetRebaseDatetimeSuite
-  extends QueryTest
-  with ParquetTest
+  extends ParquetTest
   with SharedSparkSession {
 
   import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTypeWideningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTypeWideningSuite.scala
@@ -25,7 +25,7 @@ import org.apache.parquet.hadoop.ParquetOutputFormat
 import org.apache.parquet.hadoop.util.HadoopInputFile
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.datasources.SchemaColumnConvertNotSupportedException
 import org.apache.spark.sql.functions.col
@@ -36,8 +36,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.DecimalType.{ByteDecimal, IntDecimal, LongDecimal, ShortDecimal}
 
 class ParquetTypeWideningSuite
-    extends QueryTest
-    with ParquetTest
+    extends ParquetTest
     with SharedSparkSession
     with AdaptiveSparkPlanHelper {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to SPARK-56591. Seven additional `sql-core` test suites still mix in `QueryTest` alongside `SharedSparkSession` (which already extends `QueryTest`), so the explicit mixin is redundant. This removes the redundant `with QueryTest` and the now-unused `QueryTest` imports:

- `SchemaPruningSuite`
- `ParquetRebaseDatetimeSuite`
- `ParquetTypeWideningSuite`
- `ParquetFileFormatSuite`
- `FileSourceAggregatePushDownSuite`
- `QueryCompilationErrorsSuite`
- `QueryExecutionErrorsSuite`

### Why are the changes needed?

SPARK-56591 missed these cases. Removes redundant trait mixins so the `extends` lists faithfully describe the class hierarchy.

### Does this PR introduce _any_ user-facing change?

No. Test-only class-declaration cleanup.

### How was this patch tested?

Existing tests. (Local `sql/Test/compile` was attempted but blocked by an unrelated dependency-resolution failure for `io.netty:netty-tcnative-boringssl-static`; GitHub Actions CI on this PR will compile the affected modules.)

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (model: claude-opus-4-7)