### PR TITLE
[SPARK-56633][SQL][TESTS] Add comprehensive Parquet vectorized-reader benchmark coverage

### DIFF
--- a/sql/core/benchmarks/ParquetVectorUpdaterBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/ParquetVectorUpdaterBenchmark-jdk21-results.txt
@@ -1,0 +1,84 @@
+================================================================================================
+Identity Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Identity Updaters:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+BooleanUpdater                                        0              0           0      16946.4           0.1       1.0X
+ByteUpdater (INT32 -> Byte)                           0              0           0       3743.2           0.3       0.2X
+ShortUpdater (INT32 -> Short)                         1              1           0       1676.4           0.6       0.1X
+IntegerUpdater                                        0              0           0      10258.9           0.1       0.6X
+LongUpdater                                           0              0           0       5140.3           0.2       0.3X
+FloatUpdater                                          0              0           0      10259.8           0.1       0.6X
+DoubleUpdater                                         0              0           0       5130.4           0.2       0.3X
+BinaryUpdater                                        15             15           0         70.4          14.2       0.0X
+
+
+================================================================================================
+Type-converting Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Type-converting Updaters:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+IntegerToLongUpdater                                     2              2           0        530.9           1.9       1.0X
+IntegerToDoubleUpdater                                   2              2           0        531.3           1.9       1.0X
+FloatToDoubleUpdater                                     2              2           0        489.7           2.0       0.9X
+DateToTimestampNTZUpdater                               29             29           0         36.2          27.6       0.1X
+DowncastLongUpdater (INT64 -> Decimal(9,2))              2              2           0        455.7           2.2       0.9X
+
+
+================================================================================================
+Rebase Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Rebase Updaters:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------
+IntegerWithRebaseUpdater (DATE legacy)                       0              0           0       3644.6           0.3       1.0X
+LongWithRebaseUpdater (TIMESTAMP_MICROS legacy)              0              0           0       2663.3           0.4       0.7X
+LongAsMicrosUpdater (TIMESTAMP_MILLIS)                       2              3           0        420.0           2.4       0.1X
+
+
+================================================================================================
+Unsigned Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Unsigned Updaters:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------
+UnsignedIntegerUpdater (UINT32 -> Long)                    0              0           0       5974.2           0.2       1.0X
+UnsignedLongUpdater (UINT64 -> Decimal(20,0))             17             18           0         60.3          16.6       0.0X
+
+
+================================================================================================
+Decimal Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Decimal Updaters:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+IntegerToDecimalUpdater                               0              0           0      10257.8           0.1       1.0X
+LongToDecimalUpdater                                  0              0           0       5133.7           0.2       0.5X
+FixedLenByteArrayToDecimalUpdater                    21             21           0         50.2          19.9       0.0X
+
+
+================================================================================================
+FixedLenByteArray Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+FixedLenByteArray Updaters:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------
+FixedLenByteArrayUpdater (len=16 -> Binary)                         20             21           1         51.5          19.4       1.0X
+FixedLenByteArrayAsIntUpdater (len=4 -> Decimal(9,2))                7              7           0        160.1           6.2       3.1X
+FixedLenByteArrayAsLongUpdater (len=8 -> Decimal(18,4))              8              8           0        133.2           7.5       2.6X
+
+

--- a/sql/core/benchmarks/ParquetVectorUpdaterBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/ParquetVectorUpdaterBenchmark-jdk25-results.txt
@@ -1,0 +1,84 @@
+================================================================================================
+Identity Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Identity Updaters:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+BooleanUpdater                                        0              0           0      17177.7           0.1       1.0X
+ByteUpdater (INT32 -> Byte)                           0              0           0       3680.4           0.3       0.2X
+ShortUpdater (INT32 -> Short)                         1              1           0       1664.2           0.6       0.1X
+IntegerUpdater                                        0              0           0      10311.6           0.1       0.6X
+LongUpdater                                           0              0           0       5153.5           0.2       0.3X
+FloatUpdater                                          0              0           0      10313.6           0.1       0.6X
+DoubleUpdater                                         0              0           0       5157.8           0.2       0.3X
+BinaryUpdater                                        16             16           0         67.6          14.8       0.0X
+
+
+================================================================================================
+Type-converting Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Type-converting Updaters:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+IntegerToLongUpdater                                     2              2           0        454.8           2.2       1.0X
+IntegerToDoubleUpdater                                   2              2           0        454.5           2.2       1.0X
+FloatToDoubleUpdater                                     2              2           0        483.4           2.1       1.1X
+DateToTimestampNTZUpdater                               29             29           0         36.6          27.3       0.1X
+DowncastLongUpdater (INT64 -> Decimal(9,2))              2              2           0        455.5           2.2       1.0X
+
+
+================================================================================================
+Rebase Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Rebase Updaters:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------
+IntegerWithRebaseUpdater (DATE legacy)                       0              0           0       3668.8           0.3       1.0X
+LongWithRebaseUpdater (TIMESTAMP_MICROS legacy)              0              0           0       2671.2           0.4       0.7X
+LongAsMicrosUpdater (TIMESTAMP_MILLIS)                       3              3           0        371.3           2.7       0.1X
+
+
+================================================================================================
+Unsigned Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Unsigned Updaters:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------
+UnsignedIntegerUpdater (UINT32 -> Long)                    0              0           0       6344.0           0.2       1.0X
+UnsignedLongUpdater (UINT64 -> Decimal(20,0))             18             18           0         59.3          16.9       0.0X
+
+
+================================================================================================
+Decimal Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Decimal Updaters:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+IntegerToDecimalUpdater                               0              0           0      10280.2           0.1       1.0X
+LongToDecimalUpdater                                  0              0           0       5153.3           0.2       0.5X
+FixedLenByteArrayToDecimalUpdater                    21             21           0         50.6          19.8       0.0X
+
+
+================================================================================================
+FixedLenByteArray Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+FixedLenByteArray Updaters:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------
+FixedLenByteArrayUpdater (len=16 -> Binary)                         21             21           1         50.5          19.8       1.0X
+FixedLenByteArrayAsIntUpdater (len=4 -> Decimal(9,2))                7              7           0        152.6           6.6       3.0X
+FixedLenByteArrayAsLongUpdater (len=8 -> Decimal(18,4))              8              8           0        127.7           7.8       2.5X
+
+

--- a/sql/core/benchmarks/ParquetVectorUpdaterBenchmark-results.txt
+++ b/sql/core/benchmarks/ParquetVectorUpdaterBenchmark-results.txt
@@ -1,0 +1,84 @@
+================================================================================================
+Identity Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Identity Updaters:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+BooleanUpdater                                        0              0           0      14625.7           0.1       1.0X
+ByteUpdater (INT32 -> Byte)                           0              0           0       3672.0           0.3       0.3X
+ShortUpdater (INT32 -> Short)                         1              1           0       2053.4           0.5       0.1X
+IntegerUpdater                                        0              0           0      10284.1           0.1       0.7X
+LongUpdater                                           0              0           0       5132.8           0.2       0.4X
+FloatUpdater                                          0              0           0      10257.9           0.1       0.7X
+DoubleUpdater                                         0              0           0       5097.0           0.2       0.3X
+BinaryUpdater                                        15             15           1         70.3          14.2       0.0X
+
+
+================================================================================================
+Type-converting Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Type-converting Updaters:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+IntegerToLongUpdater                                     2              2           0        454.5           2.2       1.0X
+IntegerToDoubleUpdater                                   2              2           0        478.3           2.1       1.1X
+FloatToDoubleUpdater                                     2              2           0        480.2           2.1       1.1X
+DateToTimestampNTZUpdater                               36             36           0         29.5          33.9       0.1X
+DowncastLongUpdater (INT64 -> Decimal(9,2))              2              2           0        455.3           2.2       1.0X
+
+
+================================================================================================
+Rebase Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Rebase Updaters:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------
+IntegerWithRebaseUpdater (DATE legacy)                       0              0           0       2651.7           0.4       1.0X
+LongWithRebaseUpdater (TIMESTAMP_MICROS legacy)              0              1           0       2101.9           0.5       0.8X
+LongAsMicrosUpdater (TIMESTAMP_MILLIS)                       2              2           0        454.6           2.2       0.2X
+
+
+================================================================================================
+Unsigned Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Unsigned Updaters:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------
+UnsignedIntegerUpdater (UINT32 -> Long)                    1              1           0       1093.3           0.9       1.0X
+UnsignedLongUpdater (UINT64 -> Decimal(20,0))             18             18           0         59.1          16.9       0.1X
+
+
+================================================================================================
+Decimal Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Decimal Updaters:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+IntegerToDecimalUpdater                               0              0           0      10263.1           0.1       1.0X
+LongToDecimalUpdater                                  0              0           0       5133.0           0.2       0.5X
+FixedLenByteArrayToDecimalUpdater                    21             21           0         51.0          19.6       0.0X
+
+
+================================================================================================
+FixedLenByteArray Updaters
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+FixedLenByteArray Updaters:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------
+FixedLenByteArrayUpdater (len=16 -> Binary)                         19             19           0         54.8          18.3       1.0X
+FixedLenByteArrayAsIntUpdater (len=4 -> Decimal(9,2))                7              7           0        160.2           6.2       2.9X
+FixedLenByteArrayAsLongUpdater (len=8 -> Decimal(18,4))              9              9           0        123.3           8.1       2.3X
+
+

--- a/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk21-results.txt
@@ -1,0 +1,93 @@
+================================================================================================
+DELTA_BINARY_PACKED INT32
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+DELTA_BINARY_PACKED INT32:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readIntegers, constant                                2              2           0        451.8           2.2       1.0X
+skipIntegers, constant                                3              3           0        415.1           2.4       0.9X
+readIntegers, monotonic                               3              3           0        369.7           2.7       0.8X
+skipIntegers, monotonic                               3              3           0        415.6           2.4       0.9X
+readIntegers, small-delta random                      3              3           0        308.6           3.2       0.7X
+skipIntegers, small-delta random                      3              3           0        358.6           2.8       0.8X
+readIntegers, wide random                             4              4           0        249.2           4.0       0.6X
+skipIntegers, wide random                             4              4           0        281.4           3.6       0.6X
+
+
+================================================================================================
+DELTA_BINARY_PACKED INT64
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+DELTA_BINARY_PACKED INT64:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readLongs, constant                                   5              6           0        195.2           5.1       1.0X
+skipLongs, constant                                   6              6           0        175.4           5.7       0.9X
+readLongs, monotonic                                  7              7           0        158.8           6.3       0.8X
+skipLongs, monotonic                                  6              6           0        175.6           5.7       0.9X
+readLongs, small-delta random                         8              8           0        139.4           7.2       0.7X
+skipLongs, small-delta random                         7              7           0        152.5           6.6       0.8X
+readLongs, wide random                               10             10           1        102.9           9.7       0.5X
+skipLongs, wide random                                6              9           2        185.5           5.4       1.0X
+
+
+================================================================================================
+DELTA_BYTE_ARRAY
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+DELTA_BYTE_ARRAY:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBinary, no overlap, len=16                       35             41           4         29.6          33.8       1.0X
+skipBinary, no overlap, len=16                       41             45           3         25.9          38.6       0.9X
+readBinary, half overlap, len=16                     41             44           3         25.4          39.3       0.9X
+skipBinary, half overlap, len=16                     47             50           5         22.3          44.8       0.8X
+readBinary, full overlap, len=16                     42             44           3         25.1          39.9       0.8X
+skipBinary, full overlap, len=16                     48             50           3         22.0          45.6       0.7X
+readBinary, half overlap, len=64                     42             42           1         25.2          39.6       0.9X
+skipBinary, half overlap, len=64                     47             50          14         22.4          44.6       0.8X
+
+
+================================================================================================
+DELTA_LENGTH_BYTE_ARRAY
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+DELTA_LENGTH_BYTE_ARRAY:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBinary, payloadLen=8                             20             21           0         51.7          19.3       1.0X
+skipBinary, payloadLen=8                             10             10           0        106.3           9.4       2.1X
+readBinary, payloadLen=32                            16             18           2         63.9          15.7       1.2X
+skipBinary, payloadLen=32                             6              6           0        175.9           5.7       3.4X
+readBinary, payloadLen=128                           19             19           0         56.0          17.8       1.1X
+skipBinary, payloadLen=128                            6              6           0        176.3           5.7       3.4X
+readBinary, payloadLen=512                           41             43           3         25.6          39.0       0.5X
+skipBinary, payloadLen=512                            6              6           1        176.4           5.7       3.4X
+
+
+================================================================================================
+Variant reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+Variant reads:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------
+readBytes (INT32)                                            7              7           0        142.3           7.0       1.0X
+readShorts (INT32)                                           7              8           0        143.0           7.0       1.0X
+readUnsignedIntegers (INT32 -> Long)                         7              7           0        147.1           6.8       1.0X
+readUnsignedLongs (INT64 -> Decimal(20,0))                 232            243          23          4.5         221.5       0.0X
+skipBytes                                                    4              4           0        285.4           3.5       2.0X
+skipShorts                                                   4              4           0        285.4           3.5       2.0X
+readByte (INT32 single-value)                               13             13           1         80.2          12.5       0.6X
+readShort (INT32 single-value)                              13             13           1         82.0          12.2       0.6X
+readInteger (INT32 single-value)                            13             13           0         80.2          12.5       0.6X
+readLong (INT64 single-value)                               14             14           0         74.9          13.3       0.5X
+readBinary(len) (DELTA_BYTE_ARRAY single-value)             64             67           3         16.5          60.6       0.1X
+
+

--- a/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk25-results.txt
@@ -3,17 +3,17 @@ DELTA_BINARY_PACKED INT32
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT32:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readIntegers, constant                                2              2           0        602.3           1.7       1.0X
-skipIntegers, constant                                2              2           0        461.6           2.2       0.8X
-readIntegers, monotonic                               3              3           0        387.8           2.6       0.6X
-skipIntegers, monotonic                               2              2           0        462.5           2.2       0.8X
-readIntegers, small-delta random                      4              4           0        295.1           3.4       0.5X
-skipIntegers, small-delta random                      3              3           0        335.4           3.0       0.6X
-readIntegers, wide random                             4              4           0        248.9           4.0       0.4X
-skipIntegers, wide random                             4              4           0        275.5           3.6       0.5X
+readIntegers, constant                                2              2           0        487.1           2.1       1.0X
+skipIntegers, constant                                3              3           0        364.8           2.7       0.7X
+readIntegers, monotonic                               3              4           0        303.1           3.3       0.6X
+skipIntegers, monotonic                               3              3           0        365.3           2.7       0.7X
+readIntegers, small-delta random                      4              4           0        241.3           4.1       0.5X
+skipIntegers, small-delta random                      4              4           0        278.7           3.6       0.6X
+readIntegers, wide random                             5              5           0        201.4           5.0       0.4X
+skipIntegers, wide random                             5              5           0        225.6           4.4       0.5X
 
 
 ================================================================================================
@@ -21,17 +21,17 @@ DELTA_BINARY_PACKED INT64
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT64:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readLongs, constant                                   5              5           0        202.3           4.9       1.0X
-skipLongs, constant                                   6              6           0        188.5           5.3       0.9X
-readLongs, monotonic                                  6              6           0        173.3           5.8       0.9X
-skipLongs, monotonic                                  6              6           0        188.1           5.3       0.9X
-readLongs, small-delta random                         7              7           0        153.3           6.5       0.8X
-skipLongs, small-delta random                         6              6           0        164.5           6.1       0.8X
-readLongs, wide random                                9              9           0        113.9           8.8       0.6X
-skipLongs, wide random                                9              9           0        120.1           8.3       0.6X
+readLongs, constant                                   6              7           1        163.0           6.1       1.0X
+skipLongs, constant                                   7              7           0        152.1           6.6       0.9X
+readLongs, monotonic                                  8              8           1        139.1           7.2       0.9X
+skipLongs, monotonic                                  7              7           0        152.0           6.6       0.9X
+readLongs, small-delta random                         9              9           0        122.7           8.2       0.8X
+skipLongs, small-delta random                         8              8           0        133.9           7.5       0.8X
+readLongs, wide random                               11             11           0         94.4          10.6       0.6X
+skipLongs, wide random                               10             10           0        100.9           9.9       0.6X
 
 
 ================================================================================================
@@ -39,17 +39,17 @@ DELTA_BYTE_ARRAY
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 DELTA_BYTE_ARRAY:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, no overlap, len=16                       30             31           2         34.6          28.9       1.0X
-skipBinary, no overlap, len=16                       32             34           2         32.8          30.5       0.9X
-readBinary, half overlap, len=16                     34             35           1         30.7          32.6       0.9X
-skipBinary, half overlap, len=16                     37             40           2         28.6          35.0       0.8X
-readBinary, full overlap, len=16                     34             35           1         30.4          32.9       0.9X
-skipBinary, full overlap, len=16                     37             40           2         28.6          35.0       0.8X
-readBinary, half overlap, len=64                     35             37           2         29.6          33.8       0.9X
-skipBinary, half overlap, len=64                     37             38           2         28.1          35.6       0.8X
+readBinary, no overlap, len=16                       37             38           2         28.2          35.5       1.0X
+skipBinary, no overlap, len=16                       42             43           2         25.2          39.7       0.9X
+readBinary, half overlap, len=16                     43             44           2         24.3          41.2       0.9X
+skipBinary, half overlap, len=16                     48             49           2         21.8          45.9       0.8X
+readBinary, full overlap, len=16                     44             47           4         24.0          41.7       0.9X
+skipBinary, full overlap, len=16                     48             50           2         21.6          46.3       0.8X
+readBinary, half overlap, len=64                     44             45           2         23.8          42.0       0.8X
+skipBinary, half overlap, len=64                     49             53           4         21.6          46.3       0.8X
 
 
 ================================================================================================
@@ -57,17 +57,17 @@ DELTA_LENGTH_BYTE_ARRAY
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 DELTA_LENGTH_BYTE_ARRAY:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, payloadLen=8                             17             17           0         61.3          16.3       1.0X
-skipBinary, payloadLen=8                              9              9           0        115.1           8.7       1.9X
-readBinary, payloadLen=32                            17             18           2         60.8          16.4       1.0X
-skipBinary, payloadLen=32                             9              9           0        115.1           8.7       1.9X
-readBinary, payloadLen=128                           19             19           0         54.5          18.4       0.9X
-skipBinary, payloadLen=128                            9              9           0        115.0           8.7       1.9X
-readBinary, payloadLen=512                           37             37           0         28.2          35.4       0.5X
-skipBinary, payloadLen=512                            9              9           1        115.2           8.7       1.9X
+readBinary, payloadLen=8                             22             22           0         48.7          20.5       1.0X
+skipBinary, payloadLen=8                             11             11           0         97.0          10.3       2.0X
+readBinary, payloadLen=32                            21             22           0         48.9          20.5       1.0X
+skipBinary, payloadLen=32                            11             11           0         97.0          10.3       2.0X
+readBinary, payloadLen=128                           24             24           1         43.7          22.9       0.9X
+skipBinary, payloadLen=128                           11             11           1         97.1          10.3       2.0X
+readBinary, payloadLen=512                           51             53           1         20.5          48.7       0.4X
+skipBinary, payloadLen=512                           11             11           0         97.1          10.3       2.0X
 
 
 ================================================================================================
@@ -75,19 +75,19 @@ Variant reads
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Variant reads:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-readBytes (INT32)                                            8              8           0        139.5           7.2       1.0X
-readShorts (INT32)                                           8              8           0        139.2           7.2       1.0X
-readUnsignedIntegers (INT32 -> Long)                         8              8           0        138.4           7.2       1.0X
-readUnsignedLongs (INT64 -> Decimal(20,0))                 167            174          15          6.3         159.2       0.0X
-skipBytes                                                    7              7           0        147.4           6.8       1.1X
-skipShorts                                                   7              7           0        147.6           6.8       1.1X
-readByte (INT32 single-value)                               11             11           1         98.7          10.1       0.7X
-readShort (INT32 single-value)                              11             11           0         95.4          10.5       0.7X
-readInteger (INT32 single-value)                            11             11           1         95.3          10.5       0.7X
-readLong (INT64 single-value)                               13             13           1         82.8          12.1       0.6X
-readBinary(len) (DELTA_BYTE_ARRAY single-value)             53             55           2         19.8          50.4       0.1X
+readBytes (INT32)                                            9             10           1        115.6           8.6       1.0X
+readShorts (INT32)                                           9             10           1        116.0           8.6       1.0X
+readUnsignedIntegers (INT32 -> Long)                         9              9           1        117.1           8.5       1.0X
+readUnsignedLongs (INT64 -> Decimal(20,0))                 211            223          27          5.0         201.5       0.0X
+skipBytes                                                    9              9           0        122.2           8.2       1.1X
+skipShorts                                                   9              9           0        122.3           8.2       1.1X
+readByte (INT32 single-value)                               13             13           0         80.1          12.5       0.7X
+readShort (INT32 single-value)                              14             15           1         72.7          13.7       0.6X
+readInteger (INT32 single-value)                            14             15           0         72.9          13.7       0.6X
+readLong (INT64 single-value)                               16             17           1         64.3          15.6       0.6X
+readBinary(len) (DELTA_BYTE_ARRAY single-value)             79             81           2         13.3          74.9       0.1X
 
 

--- a/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk25-results.txt
@@ -6,14 +6,14 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 9V74 80-Core Processor
 DELTA_BINARY_PACKED INT32:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readIntegers, constant                                4              4           0        291.5           3.4       1.0X
-skipIntegers, constant                                4              4           0        247.2           4.0       0.8X
-readIntegers, monotonic                               5              5           0        225.5           4.4       0.8X
-skipIntegers, monotonic                               4              4           0        247.5           4.0       0.8X
-readIntegers, small-delta random                      5              5           0        196.9           5.1       0.7X
-skipIntegers, small-delta random                      5              5           0        214.0           4.7       0.7X
-readIntegers, wide random                             6              6           0        164.9           6.1       0.6X
-skipIntegers, wide random                             6              6           0        176.5           5.7       0.6X
+readIntegers, constant                                2              2           0        602.3           1.7       1.0X
+skipIntegers, constant                                2              2           0        461.6           2.2       0.8X
+readIntegers, monotonic                               3              3           0        387.8           2.6       0.6X
+skipIntegers, monotonic                               2              2           0        462.5           2.2       0.8X
+readIntegers, small-delta random                      4              4           0        295.1           3.4       0.5X
+skipIntegers, small-delta random                      3              3           0        335.4           3.0       0.6X
+readIntegers, wide random                             4              4           0        248.9           4.0       0.4X
+skipIntegers, wide random                             4              4           0        275.5           3.6       0.5X
 
 
 ================================================================================================
@@ -24,14 +24,14 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 9V74 80-Core Processor
 DELTA_BINARY_PACKED INT64:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readLongs, constant                                   8              8           0        134.4           7.4       1.0X
-skipLongs, constant                                   8              8           0        127.4           7.9       0.9X
-readLongs, monotonic                                  9              9           0        118.9           8.4       0.9X
-skipLongs, monotonic                                  8              8           0        127.3           7.9       0.9X
-readLongs, small-delta random                         9             10           0        110.7           9.0       0.8X
-skipLongs, small-delta random                         9              9           0        118.0           8.5       0.9X
-readLongs, wide random                               12             13           0         84.1          11.9       0.6X
-skipLongs, wide random                               12             12           0         88.0          11.4       0.7X
+readLongs, constant                                   5              5           0        202.3           4.9       1.0X
+skipLongs, constant                                   6              6           0        188.5           5.3       0.9X
+readLongs, monotonic                                  6              6           0        173.3           5.8       0.9X
+skipLongs, monotonic                                  6              6           0        188.1           5.3       0.9X
+readLongs, small-delta random                         7              7           0        153.3           6.5       0.8X
+skipLongs, small-delta random                         6              6           0        164.5           6.1       0.8X
+readLongs, wide random                                9              9           0        113.9           8.8       0.6X
+skipLongs, wide random                                9              9           0        120.1           8.3       0.6X
 
 
 ================================================================================================
@@ -42,14 +42,14 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 9V74 80-Core Processor
 DELTA_BYTE_ARRAY:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, no overlap, len=16                       58             61           3         18.2          55.1       1.0X
-skipBinary, no overlap, len=16                       65             67           2         16.1          62.3       0.9X
-readBinary, half overlap, len=16                     65             68           2         16.1          62.2       0.9X
-skipBinary, half overlap, len=16                     69             71           3         15.3          65.4       0.8X
-readBinary, full overlap, len=16                     65             67           2         16.0          62.4       0.9X
-skipBinary, full overlap, len=16                     69             70           3         15.3          65.5       0.8X
-readBinary, half overlap, len=64                     66             67           1         15.9          62.8       0.9X
-skipBinary, half overlap, len=64                     68             69           1         15.3          65.3       0.8X
+readBinary, no overlap, len=16                       30             31           2         34.6          28.9       1.0X
+skipBinary, no overlap, len=16                       32             34           2         32.8          30.5       0.9X
+readBinary, half overlap, len=16                     34             35           1         30.7          32.6       0.9X
+skipBinary, half overlap, len=16                     37             40           2         28.6          35.0       0.8X
+readBinary, full overlap, len=16                     34             35           1         30.4          32.9       0.9X
+skipBinary, full overlap, len=16                     37             40           2         28.6          35.0       0.8X
+readBinary, half overlap, len=64                     35             37           2         29.6          33.8       0.9X
+skipBinary, half overlap, len=64                     37             38           2         28.1          35.6       0.8X
 
 
 ================================================================================================
@@ -60,14 +60,14 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 9V74 80-Core Processor
 DELTA_LENGTH_BYTE_ARRAY:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, payloadLen=8                             35             35           0         30.2          33.1       1.0X
-skipBinary, payloadLen=8                             13             13           0         82.0          12.2       2.7X
-readBinary, payloadLen=32                            35             36           1         29.8          33.5       1.0X
-skipBinary, payloadLen=32                            13             13           0         82.0          12.2       2.7X
-readBinary, payloadLen=128                           37             38           1         28.1          35.6       0.9X
-skipBinary, payloadLen=128                           13             13           1         82.1          12.2       2.7X
-readBinary, payloadLen=512                           52             52           1         20.3          49.2       0.7X
-skipBinary, payloadLen=512                           13             13           0         82.1          12.2       2.7X
+readBinary, payloadLen=8                             17             17           0         61.3          16.3       1.0X
+skipBinary, payloadLen=8                              9              9           0        115.1           8.7       1.9X
+readBinary, payloadLen=32                            17             18           2         60.8          16.4       1.0X
+skipBinary, payloadLen=32                             9              9           0        115.1           8.7       1.9X
+readBinary, payloadLen=128                           19             19           0         54.5          18.4       0.9X
+skipBinary, payloadLen=128                            9              9           0        115.0           8.7       1.9X
+readBinary, payloadLen=512                           37             37           0         28.2          35.4       0.5X
+skipBinary, payloadLen=512                            9              9           1        115.2           8.7       1.9X
 
 
 ================================================================================================
@@ -78,16 +78,16 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 9V74 80-Core Processor
 Variant reads:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-readBytes (INT32)                                           11             11           0         99.6          10.0       1.0X
-readShorts (INT32)                                          11             11           1         99.6          10.0       1.0X
-readUnsignedIntegers (INT32 -> Long)                        10             11           1         99.9          10.0       1.0X
-readUnsignedLongs (INT64 -> Decimal(20,0))                 216            227          24          4.9         205.6       0.0X
-skipBytes                                                   10             10           0        105.6           9.5       1.1X
-skipShorts                                                  10             10           0        105.6           9.5       1.1X
-readByte (INT32 single-value)                               15             15           1         69.5          14.4       0.7X
-readShort (INT32 single-value)                              16             16           0         66.2          15.1       0.7X
-readInteger (INT32 single-value)                            16             16           0         66.2          15.1       0.7X
-readLong (INT64 single-value)                               18             18           0         59.1          16.9       0.6X
-readBinary(len) (DELTA_BYTE_ARRAY single-value)             95             96           2         11.1          90.3       0.1X
+readBytes (INT32)                                            8              8           0        139.5           7.2       1.0X
+readShorts (INT32)                                           8              8           0        139.2           7.2       1.0X
+readUnsignedIntegers (INT32 -> Long)                         8              8           0        138.4           7.2       1.0X
+readUnsignedLongs (INT64 -> Decimal(20,0))                 167            174          15          6.3         159.2       0.0X
+skipBytes                                                    7              7           0        147.4           6.8       1.1X
+skipShorts                                                   7              7           0        147.6           6.8       1.1X
+readByte (INT32 single-value)                               11             11           1         98.7          10.1       0.7X
+readShort (INT32 single-value)                              11             11           0         95.4          10.5       0.7X
+readInteger (INT32 single-value)                            11             11           1         95.3          10.5       0.7X
+readLong (INT64 single-value)                               13             13           1         82.8          12.1       0.6X
+readBinary(len) (DELTA_BYTE_ARRAY single-value)             53             55           2         19.8          50.4       0.1X
 
 

--- a/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk25-results.txt
@@ -1,0 +1,93 @@
+================================================================================================
+DELTA_BINARY_PACKED INT32
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
+DELTA_BINARY_PACKED INT32:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readIntegers, constant                                4              4           0        291.5           3.4       1.0X
+skipIntegers, constant                                4              4           0        247.2           4.0       0.8X
+readIntegers, monotonic                               5              5           0        225.5           4.4       0.8X
+skipIntegers, monotonic                               4              4           0        247.5           4.0       0.8X
+readIntegers, small-delta random                      5              5           0        196.9           5.1       0.7X
+skipIntegers, small-delta random                      5              5           0        214.0           4.7       0.7X
+readIntegers, wide random                             6              6           0        164.9           6.1       0.6X
+skipIntegers, wide random                             6              6           0        176.5           5.7       0.6X
+
+
+================================================================================================
+DELTA_BINARY_PACKED INT64
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
+DELTA_BINARY_PACKED INT64:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readLongs, constant                                   8              8           0        134.4           7.4       1.0X
+skipLongs, constant                                   8              8           0        127.4           7.9       0.9X
+readLongs, monotonic                                  9              9           0        118.9           8.4       0.9X
+skipLongs, monotonic                                  8              8           0        127.3           7.9       0.9X
+readLongs, small-delta random                         9             10           0        110.7           9.0       0.8X
+skipLongs, small-delta random                         9              9           0        118.0           8.5       0.9X
+readLongs, wide random                               12             13           0         84.1          11.9       0.6X
+skipLongs, wide random                               12             12           0         88.0          11.4       0.7X
+
+
+================================================================================================
+DELTA_BYTE_ARRAY
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
+DELTA_BYTE_ARRAY:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBinary, no overlap, len=16                       58             61           3         18.2          55.1       1.0X
+skipBinary, no overlap, len=16                       65             67           2         16.1          62.3       0.9X
+readBinary, half overlap, len=16                     65             68           2         16.1          62.2       0.9X
+skipBinary, half overlap, len=16                     69             71           3         15.3          65.4       0.8X
+readBinary, full overlap, len=16                     65             67           2         16.0          62.4       0.9X
+skipBinary, full overlap, len=16                     69             70           3         15.3          65.5       0.8X
+readBinary, half overlap, len=64                     66             67           1         15.9          62.8       0.9X
+skipBinary, half overlap, len=64                     68             69           1         15.3          65.3       0.8X
+
+
+================================================================================================
+DELTA_LENGTH_BYTE_ARRAY
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
+DELTA_LENGTH_BYTE_ARRAY:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBinary, payloadLen=8                             35             35           0         30.2          33.1       1.0X
+skipBinary, payloadLen=8                             13             13           0         82.0          12.2       2.7X
+readBinary, payloadLen=32                            35             36           1         29.8          33.5       1.0X
+skipBinary, payloadLen=32                            13             13           0         82.0          12.2       2.7X
+readBinary, payloadLen=128                           37             38           1         28.1          35.6       0.9X
+skipBinary, payloadLen=128                           13             13           1         82.1          12.2       2.7X
+readBinary, payloadLen=512                           52             52           1         20.3          49.2       0.7X
+skipBinary, payloadLen=512                           13             13           0         82.1          12.2       2.7X
+
+
+================================================================================================
+Variant reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
+Variant reads:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------
+readBytes (INT32)                                           11             11           0         99.6          10.0       1.0X
+readShorts (INT32)                                          11             11           1         99.6          10.0       1.0X
+readUnsignedIntegers (INT32 -> Long)                        10             11           1         99.9          10.0       1.0X
+readUnsignedLongs (INT64 -> Decimal(20,0))                 216            227          24          4.9         205.6       0.0X
+skipBytes                                                   10             10           0        105.6           9.5       1.1X
+skipShorts                                                  10             10           0        105.6           9.5       1.1X
+readByte (INT32 single-value)                               15             15           1         69.5          14.4       0.7X
+readShort (INT32 single-value)                              16             16           0         66.2          15.1       0.7X
+readInteger (INT32 single-value)                            16             16           0         66.2          15.1       0.7X
+readLong (INT64 single-value)                               18             18           0         59.1          16.9       0.6X
+readBinary(len) (DELTA_BYTE_ARRAY single-value)             95             96           2         11.1          90.3       0.1X
+
+

--- a/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-results.txt
+++ b/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-results.txt
@@ -1,0 +1,93 @@
+================================================================================================
+DELTA_BINARY_PACKED INT32
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+DELTA_BINARY_PACKED INT32:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readIntegers, constant                                2              2           0        482.3           2.1       1.0X
+skipIntegers, constant                                3              3           0        335.4           3.0       0.7X
+readIntegers, monotonic                               3              3           0        314.9           3.2       0.7X
+skipIntegers, monotonic                               3              3           0        335.1           3.0       0.7X
+readIntegers, small-delta random                      4              4           0        257.5           3.9       0.5X
+skipIntegers, small-delta random                      4              4           0        269.5           3.7       0.6X
+readIntegers, wide random                             5              5           0        209.3           4.8       0.4X
+skipIntegers, wide random                             5              5           0        218.2           4.6       0.5X
+
+
+================================================================================================
+DELTA_BINARY_PACKED INT64
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+DELTA_BINARY_PACKED INT64:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readLongs, constant                                   5              6           1        191.0           5.2       1.0X
+skipLongs, constant                                   6              6           0        170.1           5.9       0.9X
+readLongs, monotonic                                  7              7           0        144.9           6.9       0.8X
+skipLongs, monotonic                                  6              6           0        170.1           5.9       0.9X
+readLongs, small-delta random                         8              8           0        134.8           7.4       0.7X
+skipLongs, small-delta random                         7              7           0        152.8           6.5       0.8X
+readLongs, wide random                               11             11           0         97.8          10.2       0.5X
+skipLongs, wide random                               10             10           0        106.4           9.4       0.6X
+
+
+================================================================================================
+DELTA_BYTE_ARRAY
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+DELTA_BYTE_ARRAY:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBinary, no overlap, len=16                       36             37           1         29.2          34.2       1.0X
+skipBinary, no overlap, len=16                       41             41           1         25.8          38.7       0.9X
+readBinary, half overlap, len=16                     42             43           1         25.0          39.9       0.9X
+skipBinary, half overlap, len=16                     48             50           2         21.6          46.2       0.7X
+readBinary, full overlap, len=16                     42             44           2         24.8          40.3       0.8X
+skipBinary, full overlap, len=16                     48             49           1         21.8          45.9       0.7X
+readBinary, half overlap, len=64                     42             44           1         24.8          40.4       0.8X
+skipBinary, half overlap, len=64                     47             49           1         22.2          45.1       0.8X
+
+
+================================================================================================
+DELTA_LENGTH_BYTE_ARRAY
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+DELTA_LENGTH_BYTE_ARRAY:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBinary, payloadLen=8                             22             25           2         48.1          20.8       1.0X
+skipBinary, payloadLen=8                             11             12           1         95.8          10.4       2.0X
+readBinary, payloadLen=32                            22             26           3         48.0          20.9       1.0X
+skipBinary, payloadLen=32                            11             12           1         97.6          10.2       2.0X
+readBinary, payloadLen=128                           26             29           2         40.0          25.0       0.8X
+skipBinary, payloadLen=128                           11             12           1         96.0          10.4       2.0X
+readBinary, payloadLen=512                           54             62           4         19.3          51.9       0.4X
+skipBinary, payloadLen=512                           11             13           2         95.7          10.4       2.0X
+
+
+================================================================================================
+Variant reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+Variant reads:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------
+readBytes (INT32)                                            7              7           0        145.8           6.9       1.0X
+readShorts (INT32)                                           7              8           1        140.7           7.1       1.0X
+readUnsignedIntegers (INT32 -> Long)                         7              7           0        143.3           7.0       1.0X
+readUnsignedLongs (INT64 -> Decimal(20,0))                 227            239          25          4.6         216.4       0.0X
+skipBytes                                                    8              8           0        136.8           7.3       0.9X
+skipShorts                                                   8              8           0        136.6           7.3       0.9X
+readByte (INT32 single-value)                               12             12           1         85.8          11.7       0.6X
+readShort (INT32 single-value)                              12             12           0         85.9          11.6       0.6X
+readInteger (INT32 single-value)                            12             12           0         86.1          11.6       0.6X
+readLong (INT64 single-value)                               14             15           1         73.4          13.6       0.5X
+readBinary(len) (DELTA_BYTE_ARRAY single-value)             71             77           5         14.7          68.2       0.1X
+
+

--- a/sql/core/benchmarks/VectorizedPlainValuesReaderBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/VectorizedPlainValuesReaderBenchmark-jdk21-results.txt
@@ -1,0 +1,86 @@
+================================================================================================
+Fixed-size bulk reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Fixed-size bulk reads:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBooleans                                          0              0           0      20570.4           0.0       1.0X
+readBytes                                             0              0           0       3671.3           0.3       0.2X
+readShorts                                            0              0           0       3317.6           0.3       0.2X
+readIntegers                                          0              0           0       7683.8           0.1       0.4X
+readLongs                                             0              0           0       3812.5           0.3       0.2X
+readFloats                                            0              0           0      10254.8           0.1       0.5X
+readDoubles                                           0              0           0       5122.9           0.2       0.2X
+
+
+================================================================================================
+Conversion bulk reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Conversion bulk reads:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readUnsignedIntegers                                  0              0           0       5940.6           0.2       1.0X
+readUnsignedLongs                                    17             17           0         61.3          16.3       0.0X
+readIntegersWithRebase, no rebase needed              0              0           0       3276.6           0.3       0.6X
+readLongsWithRebase, no rebase needed                 0              0           0       2279.6           0.4       0.4X
+
+
+================================================================================================
+Variable-length reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Variable-length reads:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBinary, payloadLen=8                             14             14           1         74.0          13.5       1.0X
+readBinary, payloadLen=32                            15             15           1         71.2          14.0       1.0X
+readBinary, payloadLen=128                           17             18           1         60.5          16.5       0.8X
+readBinary, payloadLen=512                           37             38           0         28.3          35.3       0.4X
+
+
+================================================================================================
+Single-value reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBoolean                                           0              0           0       2342.8           0.4       1.0X
+readByte                                              0              0           0       2681.3           0.4       1.1X
+readShort                                             0              0           0       2681.3           0.4       1.1X
+readInteger                                           0              0           0       2681.3           0.4       1.1X
+readLong                                              0              0           0       2681.3           0.4       1.1X
+readFloat                                             0              0           0       2681.3           0.4       1.1X
+readDouble                                            0              0           0       2683.1           0.4       1.1X
+
+
+================================================================================================
+Skip
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+skipBinary, payloadLen=8                             12             12           1         90.4          11.1       1.0X
+skipBinary, payloadLen=32                            12             12           1         90.3          11.1       1.0X
+skipBinary, payloadLen=128                           12             13           1         85.5          11.7       0.9X
+skipBinary, payloadLen=512                           12             13           1         85.1          11.7       0.9X
+skipFixedLenByteArray, len=4                          0              0           0   36157793.1           0.0  399858.2X
+skipFixedLenByteArray, len=16                         0              0           0   36157793.1           0.0  399858.2X
+skipFixedLenByteArray, len=64                         0              0           0   36157793.1           0.0  399858.2X
+skipBooleans                                          0              0           0   36157793.1           0.0  399858.2X
+skipBytes                                             0              0           0   36157793.1           0.0  399858.2X
+skipShorts                                            0              0           0   36157793.1           0.0  399858.2X
+skipIntegers                                          0              0           0   36157793.1           0.0  399858.2X
+skipLongs                                             0              0           0   36157793.1           0.0  399858.2X
+skipFloats                                            0              0           0   36157793.1           0.0  399858.2X
+skipDoubles                                           0              0           0   36157793.1           0.0  399858.2X
+
+

--- a/sql/core/benchmarks/VectorizedPlainValuesReaderBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/VectorizedPlainValuesReaderBenchmark-jdk25-results.txt
@@ -1,0 +1,86 @@
+================================================================================================
+Fixed-size bulk reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Fixed-size bulk reads:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBooleans                                          0              0           0      20232.6           0.0       1.0X
+readBytes                                             0              0           0       3747.3           0.3       0.2X
+readShorts                                            0              1           0       3321.0           0.3       0.2X
+readIntegers                                          0              0           0       7767.7           0.1       0.4X
+readLongs                                             0              0           0       3882.9           0.3       0.2X
+readFloats                                            0              0           0      10246.0           0.1       0.5X
+readDoubles                                           0              0           0       3881.0           0.3       0.2X
+
+
+================================================================================================
+Conversion bulk reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Conversion bulk reads:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readUnsignedIntegers                                  0              0           0       5093.5           0.2       1.0X
+readUnsignedLongs                                    18             19           1         59.2          16.9       0.0X
+readIntegersWithRebase, no rebase needed              0              0           0       3282.5           0.3       0.6X
+readLongsWithRebase, no rebase needed                 0              0           0       2287.3           0.4       0.4X
+
+
+================================================================================================
+Variable-length reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Variable-length reads:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBinary, payloadLen=8                             15             16           0         68.4          14.6       1.0X
+readBinary, payloadLen=32                            16             16           0         66.2          15.1       1.0X
+readBinary, payloadLen=128                           18             18           0         58.5          17.1       0.9X
+readBinary, payloadLen=512                           37             38           1         28.1          35.6       0.4X
+
+
+================================================================================================
+Single-value reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBoolean                                           0              0           0       2453.6           0.4       1.0X
+readByte                                              0              0           0       2659.6           0.4       1.1X
+readShort                                             0              0           0       2659.6           0.4       1.1X
+readInteger                                           0              0           0       2659.6           0.4       1.1X
+readLong                                              0              0           0       2659.6           0.4       1.1X
+readFloat                                             0              0           0       2659.7           0.4       1.1X
+readDouble                                            0              0           0       2659.6           0.4       1.1X
+
+
+================================================================================================
+Skip
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+skipBinary, payloadLen=8                              6              6           0        171.0           5.8       1.0X
+skipBinary, payloadLen=32                             6              6           0        169.5           5.9       1.0X
+skipBinary, payloadLen=128                            9              9           0        115.7           8.6       0.7X
+skipBinary, payloadLen=512                            9              9           0        117.1           8.5       0.7X
+skipFixedLenByteArray, len=4                          0              0           0   36157793.1           0.0  211494.7X
+skipFixedLenByteArray, len=16                         0              0           0   36157793.1           0.0  211494.7X
+skipFixedLenByteArray, len=64                         0              0           0   36157793.1           0.0  211494.7X
+skipBooleans                                          0              0           0   36157793.1           0.0  211494.7X
+skipBytes                                             0              0           0   36157793.1           0.0  211494.7X
+skipShorts                                            0              0           0   36157793.1           0.0  211494.7X
+skipIntegers                                          0              0           0   36157793.1           0.0  211494.7X
+skipLongs                                             0              0           0   36157793.1           0.0  211494.7X
+skipFloats                                            0              0           0   36157793.1           0.0  211494.7X
+skipDoubles                                           0              0           0   36157793.1           0.0  211494.7X
+
+

--- a/sql/core/benchmarks/VectorizedPlainValuesReaderBenchmark-results.txt
+++ b/sql/core/benchmarks/VectorizedPlainValuesReaderBenchmark-results.txt
@@ -3,16 +3,16 @@ Fixed-size bulk reads
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Fixed-size bulk reads:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBooleans                                          0              0           0      24348.7           0.0       1.0X
-readBytes                                             0              0           0       4656.2           0.2       0.2X
-readShorts                                            0              0           0       2486.0           0.4       0.1X
-readIntegers                                          0              0           0      11417.5           0.1       0.5X
-readLongs                                             0              0           0       5474.4           0.2       0.2X
-readFloats                                            0              0           0      11248.3           0.1       0.5X
-readDoubles                                           0              0           0       5546.1           0.2       0.2X
+readBooleans                                          0              0           0      20546.2           0.0       1.0X
+readBytes                                             0              0           0       3654.2           0.3       0.2X
+readShorts                                            0              1           0       2154.3           0.5       0.1X
+readIntegers                                          0              0           0      10214.0           0.1       0.5X
+readLongs                                             0              0           0       5137.3           0.2       0.3X
+readFloats                                            0              0           0      10239.9           0.1       0.5X
+readDoubles                                           0              0           0       5135.5           0.2       0.2X
 
 
 ================================================================================================
@@ -20,13 +20,13 @@ Conversion bulk reads
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Conversion bulk reads:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readUnsignedIntegers                                  1              1           0       1252.5           0.8       1.0X
-readUnsignedLongs                                    14             14           0         74.0          13.5       0.1X
-readIntegersWithRebase, no rebase needed              0              0           0       2841.9           0.4       2.3X
-readLongsWithRebase, no rebase needed                 0              0           0       2299.5           0.4       1.8X
+readUnsignedIntegers                                  1              1           0       1093.8           0.9       1.0X
+readUnsignedLongs                                    17             17           0         61.2          16.3       0.1X
+readIntegersWithRebase, no rebase needed              0              0           0       2675.3           0.4       2.4X
+readLongsWithRebase, no rebase needed                 1              1           0       2086.2           0.5       1.9X
 
 
 ================================================================================================
@@ -34,13 +34,13 @@ Variable-length reads
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Variable-length reads:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, payloadLen=8                             11             11           0         93.1          10.7       1.0X
-readBinary, payloadLen=32                            12             12           0         90.3          11.1       1.0X
-readBinary, payloadLen=128                           13             13           0         79.5          12.6       0.9X
-readBinary, payloadLen=512                           31             32           0         33.5          29.9       0.4X
+readBinary, payloadLen=8                             15             15           3         72.0          13.9       1.0X
+readBinary, payloadLen=32                            15             15           3         70.0          14.3       1.0X
+readBinary, payloadLen=128                           17             18           2         60.3          16.6       0.8X
+readBinary, payloadLen=512                           38             39           1         27.6          36.2       0.4X
 
 
 ================================================================================================
@@ -48,16 +48,16 @@ Single-value reads
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBoolean                                           0              0           0       2258.3           0.4       1.0X
-readByte                                              1              1           0       1139.7           0.9       0.5X
-readShort                                             1              1           0       1163.2           0.9       0.5X
-readInteger                                           1              1           0       1163.0           0.9       0.5X
-readLong                                              1              1           0       1163.2           0.9       0.5X
-readFloat                                             1              1           0       1163.2           0.9       0.5X
-readDouble                                            1              1           0       1163.2           0.9       0.5X
+readBoolean                                           1              1           0       1842.8           0.5       1.0X
+readByte                                              1              1           0        917.1           1.1       0.5X
+readShort                                             1              1           0        916.8           1.1       0.5X
+readInteger                                           1              1           0        917.1           1.1       0.5X
+readLong                                              1              1           0        917.1           1.1       0.5X
+readFloat                                             1              1           0        917.1           1.1       0.5X
+readDouble                                            1              1           0        917.0           1.1       0.5X
 
 
 ================================================================================================
@@ -65,22 +65,22 @@ Skip
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-skipBinary, payloadLen=8                              4              4           0        244.0           4.1       1.0X
-skipBinary, payloadLen=32                             4              4           0        242.9           4.1       1.0X
-skipBinary, payloadLen=128                           11             11           0         98.2          10.2       0.4X
-skipBinary, payloadLen=512                           11             11           0         95.6          10.5       0.4X
-skipFixedLenByteArray, len=4                          0              0           0   34952533.3           0.0  143276.2X
-skipFixedLenByteArray, len=16                         0              0           0   34952533.3           0.0  143276.2X
-skipFixedLenByteArray, len=64                         0              0           0   34952533.3           0.0  143276.2X
-skipBooleans                                          0              0           0   34952533.3           0.0  143276.2X
-skipBytes                                             0              0           0   34952533.3           0.0  143276.2X
-skipShorts                                            0              0           0   34952533.3           0.0  143276.2X
-skipIntegers                                          0              0           0   34952533.3           0.0  143276.2X
-skipLongs                                             0              0           0   34952533.3           0.0  143276.2X
-skipFloats                                            0              0           0   34952533.3           0.0  143276.2X
-skipDoubles                                           0              0           0   34952533.3           0.0  143276.2X
+skipBinary, payloadLen=8                              5              5           0        214.0           4.7       1.0X
+skipBinary, payloadLen=32                             5              5           0        210.8           4.7       1.0X
+skipBinary, payloadLen=128                            9              9           0        119.3           8.4       0.6X
+skipBinary, payloadLen=512                            8              9           1        124.0           8.1       0.6X
+skipFixedLenByteArray, len=4                          0              0           0   26214400.0           0.0  122511.1X
+skipFixedLenByteArray, len=16                         0              0           0   26214400.0           0.0  122511.1X
+skipFixedLenByteArray, len=64                         0              0           0   26214400.0           0.0  122511.1X
+skipBooleans                                          0              0           0   26214400.0           0.0  122511.1X
+skipBytes                                             0              0           0   26214400.0           0.0  122511.1X
+skipShorts                                            0              0           0   26214400.0           0.0  122511.1X
+skipIntegers                                          0              0           0   26214400.0           0.0  122511.1X
+skipLongs                                             0              0           0   26214400.0           0.0  122511.1X
+skipFloats                                            0              0           0   26214400.0           0.0  122511.1X
+skipDoubles                                           0              0           0   26214400.0           0.0  122511.1X
 
 

--- a/sql/core/benchmarks/VectorizedPlainValuesReaderBenchmark-results.txt
+++ b/sql/core/benchmarks/VectorizedPlainValuesReaderBenchmark-results.txt
@@ -1,0 +1,86 @@
+================================================================================================
+Fixed-size bulk reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
+Fixed-size bulk reads:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBooleans                                          0              0           0      24348.7           0.0       1.0X
+readBytes                                             0              0           0       4656.2           0.2       0.2X
+readShorts                                            0              0           0       2486.0           0.4       0.1X
+readIntegers                                          0              0           0      11417.5           0.1       0.5X
+readLongs                                             0              0           0       5474.4           0.2       0.2X
+readFloats                                            0              0           0      11248.3           0.1       0.5X
+readDoubles                                           0              0           0       5546.1           0.2       0.2X
+
+
+================================================================================================
+Conversion bulk reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
+Conversion bulk reads:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readUnsignedIntegers                                  1              1           0       1252.5           0.8       1.0X
+readUnsignedLongs                                    14             14           0         74.0          13.5       0.1X
+readIntegersWithRebase, no rebase needed              0              0           0       2841.9           0.4       2.3X
+readLongsWithRebase, no rebase needed                 0              0           0       2299.5           0.4       1.8X
+
+
+================================================================================================
+Variable-length reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
+Variable-length reads:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBinary, payloadLen=8                             11             11           0         93.1          10.7       1.0X
+readBinary, payloadLen=32                            12             12           0         90.3          11.1       1.0X
+readBinary, payloadLen=128                           13             13           0         79.5          12.6       0.9X
+readBinary, payloadLen=512                           31             32           0         33.5          29.9       0.4X
+
+
+================================================================================================
+Single-value reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
+Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBoolean                                           0              0           0       2258.3           0.4       1.0X
+readByte                                              1              1           0       1139.7           0.9       0.5X
+readShort                                             1              1           0       1163.2           0.9       0.5X
+readInteger                                           1              1           0       1163.0           0.9       0.5X
+readLong                                              1              1           0       1163.2           0.9       0.5X
+readFloat                                             1              1           0       1163.2           0.9       0.5X
+readDouble                                            1              1           0       1163.2           0.9       0.5X
+
+
+================================================================================================
+Skip
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
+Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+skipBinary, payloadLen=8                              4              4           0        244.0           4.1       1.0X
+skipBinary, payloadLen=32                             4              4           0        242.9           4.1       1.0X
+skipBinary, payloadLen=128                           11             11           0         98.2          10.2       0.4X
+skipBinary, payloadLen=512                           11             11           0         95.6          10.5       0.4X
+skipFixedLenByteArray, len=4                          0              0           0   34952533.3           0.0  143276.2X
+skipFixedLenByteArray, len=16                         0              0           0   34952533.3           0.0  143276.2X
+skipFixedLenByteArray, len=64                         0              0           0   34952533.3           0.0  143276.2X
+skipBooleans                                          0              0           0   34952533.3           0.0  143276.2X
+skipBytes                                             0              0           0   34952533.3           0.0  143276.2X
+skipShorts                                            0              0           0   34952533.3           0.0  143276.2X
+skipIntegers                                          0              0           0   34952533.3           0.0  143276.2X
+skipLongs                                             0              0           0   34952533.3           0.0  143276.2X
+skipFloats                                            0              0           0   34952533.3           0.0  143276.2X
+skipDoubles                                           0              0           0   34952533.3           0.0  143276.2X
+
+

--- a/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-jdk21-results.txt
@@ -3,19 +3,19 @@ Boolean decode
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 RLE readBooleans decode:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cold reader, trueRatio=0.0                            0              0           0     100873.1           0.0       1.0X
-reused reader, trueRatio=0.0                          0              0           0     102240.2           0.0       1.0X
-cold reader, trueRatio=0.1                            1              1           0        943.5           1.1       0.0X
-reused reader, trueRatio=0.1                          1              1           0        952.8           1.0       0.0X
-cold reader, trueRatio=0.5                            1              1           0       1067.3           0.9       0.0X
-reused reader, trueRatio=0.5                          1              1           0       1070.0           0.9       0.0X
-cold reader, trueRatio=0.9                            1              1           0        938.3           1.1       0.0X
-reused reader, trueRatio=0.9                          1              1           0        940.1           1.1       0.0X
-cold reader, trueRatio=1.0                            0              0           0     101448.9           0.0       1.0X
-reused reader, trueRatio=1.0                          0              0           0     102540.2           0.0       1.0X
+cold reader, trueRatio=0.0                            0              0           0      59466.7           0.0       1.0X
+reused reader, trueRatio=0.0                          0              0           0      82871.7           0.0       1.4X
+cold reader, trueRatio=0.1                            1              1           0        744.9           1.3       0.0X
+reused reader, trueRatio=0.1                          1              1           0        746.1           1.3       0.0X
+cold reader, trueRatio=0.5                            1              1           0        826.2           1.2       0.0X
+reused reader, trueRatio=0.5                          1              1           0        828.1           1.2       0.0X
+cold reader, trueRatio=0.9                            1              1           0        743.5           1.3       0.0X
+reused reader, trueRatio=0.9                          1              1           0        738.4           1.4       0.0X
+cold reader, trueRatio=1.0                            0              0           0      82409.3           0.0       1.4X
+reused reader, trueRatio=1.0                          0              0           0      82871.7           0.0       1.4X
 
 
 ================================================================================================
@@ -23,21 +23,21 @@ Integer decode
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 RLE readIntegers dictionary-id decode:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-PACKED cold, bitWidth=4                               2              2           0        543.7           1.8       1.0X
-PACKED reused, bitWidth=4                             2              2           0        537.5           1.9       1.0X
-RLE, bitWidth=4                                       0              0           0       6239.2           0.2      11.5X
-PACKED cold, bitWidth=8                               2              2           0        586.1           1.7       1.1X
-PACKED reused, bitWidth=8                             2              2           0        587.1           1.7       1.1X
-RLE, bitWidth=8                                       0              0           0       6238.4           0.2      11.5X
-PACKED cold, bitWidth=12                              2              2           0        486.4           2.1       0.9X
-PACKED reused, bitWidth=12                            2              2           0        484.4           2.1       0.9X
-RLE, bitWidth=12                                      0              0           0       6237.7           0.2      11.5X
-PACKED cold, bitWidth=20                              3              3           0        401.5           2.5       0.7X
-PACKED reused, bitWidth=20                            3              3           0        399.0           2.5       0.7X
-RLE, bitWidth=20                                      0              0           0       6240.3           0.2      11.5X
+PACKED cold, bitWidth=4                               2              2           0        489.7           2.0       1.0X
+PACKED reused, bitWidth=4                             2              2           0        487.7           2.1       1.0X
+RLE, bitWidth=4                                       0              0           0       4506.8           0.2       9.2X
+PACKED cold, bitWidth=8                               2              2           0        524.2           1.9       1.1X
+PACKED reused, bitWidth=8                             2              2           0        524.6           1.9       1.1X
+RLE, bitWidth=8                                       0              0           0       4507.0           0.2       9.2X
+PACKED cold, bitWidth=12                              3              3           0        417.6           2.4       0.9X
+PACKED reused, bitWidth=12                            3              3           0        415.4           2.4       0.8X
+RLE, bitWidth=12                                      0              0           0       4507.2           0.2       9.2X
+PACKED cold, bitWidth=20                              3              3           0        351.9           2.8       0.7X
+PACKED reused, bitWidth=20                            3              3           0        349.4           2.9       0.7X
+RLE, bitWidth=20                                      0              0           0       4499.6           0.2       9.2X
 
 
 ================================================================================================
@@ -45,19 +45,19 @@ Nullable batch decode with def-level materialization
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Nullable batch with def-levels:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       7968.6           0.1       1.0X
-nullRatio=0.1, random                                 7              7           0        141.4           7.1       0.0X
-nullRatio=0.1, clustered                              5              5           0        200.3           5.0       0.0X
-nullRatio=0.3, random                                11             11           0         97.3          10.3       0.0X
-nullRatio=0.3, clustered                              5              5           1        200.5           5.0       0.0X
-nullRatio=0.5, random                                12             12           0         88.0          11.4       0.0X
-nullRatio=0.5, clustered                              5              5           0        203.0           4.9       0.0X
-nullRatio=0.9, random                                 7              7           0        153.1           6.5       0.0X
-nullRatio=0.9, clustered                              5              5           0        216.6           4.6       0.0X
-nullRatio=1.0, random                                 0              0           0       5760.9           0.2       0.7X
+nullRatio=0.0, n/a                                    0              0           0       6695.3           0.1       1.0X
+nullRatio=0.1, random                                 9              9           0        123.2           8.1       0.0X
+nullRatio=0.1, clustered                              6              6           1        174.1           5.7       0.0X
+nullRatio=0.3, random                                12             12           0         85.3          11.7       0.0X
+nullRatio=0.3, clustered                              6              6           0        172.7           5.8       0.0X
+nullRatio=0.5, random                                14             14           0         76.5          13.1       0.0X
+nullRatio=0.5, clustered                              6              6           0        173.6           5.8       0.0X
+nullRatio=0.9, random                                 8              8           0        132.0           7.6       0.0X
+nullRatio=0.9, clustered                              6              6           0        182.4           5.5       0.0X
+nullRatio=1.0, random                                 0              0           0       5048.8           0.2       0.8X
 
 
 ================================================================================================
@@ -65,19 +65,19 @@ Nullable batch decode without def-level materialization
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Nullable batch without def-levels:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0      12890.8           0.1       1.0X
-nullRatio=0.1, random                                 6              6           1        174.7           5.7       0.0X
-nullRatio=0.1, clustered                              4              4           0        247.0           4.0       0.0X
-nullRatio=0.3, random                                 9              9           0        118.0           8.5       0.0X
-nullRatio=0.3, clustered                              4              4           0        245.5           4.1       0.0X
-nullRatio=0.5, random                                10             10           0        105.9           9.4       0.0X
-nullRatio=0.5, clustered                              4              4           0        247.8           4.0       0.0X
-nullRatio=0.9, random                                 6              6           0        190.5           5.2       0.0X
-nullRatio=0.9, clustered                              4              4           1        260.5           3.8       0.0X
-nullRatio=1.0, random                                 0              0           0      11767.9           0.1       0.9X
+nullRatio=0.0, n/a                                    0              0           0      12199.7           0.1       1.0X
+nullRatio=0.1, random                                 7              7           0        147.8           6.8       0.0X
+nullRatio=0.1, clustered                              5              5           0        204.6           4.9       0.0X
+nullRatio=0.3, random                                10             10           0        100.8           9.9       0.0X
+nullRatio=0.3, clustered                              5              5           0        200.6           5.0       0.0X
+nullRatio=0.5, random                                12             12           0         89.4          11.2       0.0X
+nullRatio=0.5, clustered                              5              5           0        199.3           5.0       0.0X
+nullRatio=0.9, random                                 7              7           0        153.3           6.5       0.0X
+nullRatio=0.9, clustered                              5              5           0        202.2           4.9       0.0X
+nullRatio=1.0, random                                 0              0           0      11887.9           0.1       1.0X
 
 
 ================================================================================================
@@ -85,15 +85,15 @@ Nullable batch decode with row-index filtering (with def-levels)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Nullable batch with def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                   1              1           0       1266.0           0.8       1.0X
-nullRatio=0.3, contiguous 50%                                   7              7           0        142.2           7.0       0.1X
-nullRatio=0.9, contiguous 50%                                   5              5           0        198.4           5.0       0.2X
-nullRatio=0.0, alt 1000-row windows                             2              2           0        459.0           2.2       0.4X
-nullRatio=0.3, alt 1000-row windows                             9              9           0        118.8           8.4       0.1X
-nullRatio=0.9, alt 1000-row windows                             7              7           0        152.9           6.5       0.1X
+nullRatio=0.0, contiguous 50%                                   1              1           0        757.3           1.3       1.0X
+nullRatio=0.3, contiguous 50%                                   9              9           0        119.6           8.4       0.2X
+nullRatio=0.9, contiguous 50%                                   7              7           0        158.9           6.3       0.2X
+nullRatio=0.0, alt 1000-row windows                             3              3           0        377.7           2.6       0.5X
+nullRatio=0.3, alt 1000-row windows                            10             10           0        102.3           9.8       0.1X
+nullRatio=0.9, alt 1000-row windows                             8              8           1        130.9           7.6       0.2X
 
 
 ================================================================================================
@@ -101,15 +101,15 @@ Nullable batch decode with row-index filtering (without def-levels)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Nullable batch without def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                      1              1           0       1062.0           0.9       1.0X
-nullRatio=0.3, contiguous 50%                                      7              7           0        152.1           6.6       0.1X
-nullRatio=0.9, contiguous 50%                                      5              5           0        207.5           4.8       0.2X
-nullRatio=0.0, alt 1000-row windows                                2              2           0        478.6           2.1       0.5X
-nullRatio=0.3, alt 1000-row windows                                8              8           0        129.6           7.7       0.1X
-nullRatio=0.9, alt 1000-row windows                                6              6           0        166.4           6.0       0.2X
+nullRatio=0.0, contiguous 50%                                      1              2           0        767.0           1.3       1.0X
+nullRatio=0.3, contiguous 50%                                      8              8           0        129.1           7.7       0.2X
+nullRatio=0.9, contiguous 50%                                      6              7           0        166.0           6.0       0.2X
+nullRatio=0.0, alt 1000-row windows                                3              3           0        377.2           2.7       0.5X
+nullRatio=0.3, alt 1000-row windows                               10             10           0        109.0           9.2       0.1X
+nullRatio=0.9, alt 1000-row windows                                8              8           0        137.5           7.3       0.2X
 
 
 ================================================================================================
@@ -117,18 +117,18 @@ Single-value reads
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBoolean                                           3              3           0        347.5           2.9       1.0X
-readInteger, bitWidth=4                               3              3           0        318.1           3.1       0.9X
-readValueDictionaryId, bitWidth=4                     3              3           0        318.2           3.1       0.9X
-readInteger, bitWidth=8                               3              3           0        335.1           3.0       1.0X
-readValueDictionaryId, bitWidth=8                     3              3           0        335.5           3.0       1.0X
-readInteger, bitWidth=12                              4              4           0        296.9           3.4       0.9X
-readValueDictionaryId, bitWidth=12                    4              4           0        299.4           3.3       0.9X
-readInteger, bitWidth=20                              4              4           0        263.8           3.8       0.8X
-readValueDictionaryId, bitWidth=20                    4              4           1        263.6           3.8       0.8X
+readBoolean                                           3              3           0        311.5           3.2       1.0X
+readInteger, bitWidth=4                               4              4           0        275.7           3.6       0.9X
+readValueDictionaryId, bitWidth=4                     4              4           0        276.2           3.6       0.9X
+readInteger, bitWidth=8                               4              4           0        289.2           3.5       0.9X
+readValueDictionaryId, bitWidth=8                     4              4           0        289.8           3.5       0.9X
+readInteger, bitWidth=12                              4              4           0        252.3           4.0       0.8X
+readValueDictionaryId, bitWidth=12                    4              4           0        252.1           4.0       0.8X
+readInteger, bitWidth=20                              5              5           0        227.7           4.4       0.7X
+readValueDictionaryId, bitWidth=20                    5              5           0        227.2           4.4       0.7X
 
 
 ================================================================================================
@@ -136,19 +136,19 @@ Skip
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-skipBooleans, trueRatio=0.0                           0              0           0   34952533.3           0.0       1.0X
-skipBooleans, trueRatio=0.5                           2              2           0        613.5           1.6       0.0X
-skipBooleans, trueRatio=1.0                           0              0           0   34952533.3           0.0       1.0X
-skipIntegers PACKED, bitWidth=4                       2              2           0        576.0           1.7       0.0X
-skipIntegers RLE, bitWidth=4                          0              0           0   34952533.3           0.0       1.0X
-skipIntegers PACKED, bitWidth=8                       2              2           0        645.1           1.6       0.0X
-skipIntegers RLE, bitWidth=8                          0              0           0   34952533.3           0.0       1.0X
-skipIntegers PACKED, bitWidth=12                      2              2           0        500.8           2.0       0.0X
-skipIntegers RLE, bitWidth=12                         0              0           0   34952533.3           0.0       1.0X
-skipIntegers PACKED, bitWidth=20                      3              3           0        417.0           2.4       0.0X
-skipIntegers RLE, bitWidth=20                         0              0           0   26214400.0           0.0       0.8X
+skipBooleans, trueRatio=0.0                           0              0           0   26214400.0           0.0       1.0X
+skipBooleans, trueRatio=0.5                           2              2           0        559.1           1.8       0.0X
+skipBooleans, trueRatio=1.0                           0              0           0   26214400.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=4                       2              2           0        502.4           2.0       0.0X
+skipIntegers RLE, bitWidth=4                          0              0           0   21399510.2           0.0       0.8X
+skipIntegers PACKED, bitWidth=8                       2              2           0        551.4           1.8       0.0X
+skipIntegers RLE, bitWidth=8                          0              0           0   21399510.2           0.0       0.8X
+skipIntegers PACKED, bitWidth=12                      2              2           0        431.5           2.3       0.0X
+skipIntegers RLE, bitWidth=12                         0              0           0   21399510.2           0.0       0.8X
+skipIntegers PACKED, bitWidth=20                      3              3           0        364.1           2.7       0.0X
+skipIntegers RLE, bitWidth=20                         0              0           0   21399510.2           0.0       0.8X
 
 

--- a/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-jdk21-results.txt
@@ -2,81 +2,153 @@
 Boolean decode
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 RLE readBooleans decode:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cold reader, trueRatio=0.0                            0              0           0      25171.1           0.0       1.0X
-reused reader, trueRatio=0.0                          0              0           0      25171.1           0.0       1.0X
-cold reader, trueRatio=0.1                            1              1           0        755.2           1.3       0.0X
-reused reader, trueRatio=0.1                          1              1           0        754.1           1.3       0.0X
-cold reader, trueRatio=0.5                            1              1           0        835.6           1.2       0.0X
-reused reader, trueRatio=0.5                          1              1           0        833.3           1.2       0.0X
-cold reader, trueRatio=0.9                            1              1           0        753.3           1.3       0.0X
-reused reader, trueRatio=0.9                          1              1           0        753.6           1.3       0.0X
-cold reader, trueRatio=1.0                            0              0           0      25165.0           0.0       1.0X
-reused reader, trueRatio=1.0                          0              0           0      25183.2           0.0       1.0X
+cold reader, trueRatio=0.0                            0              0           0     100873.1           0.0       1.0X
+reused reader, trueRatio=0.0                          0              0           0     102240.2           0.0       1.0X
+cold reader, trueRatio=0.1                            1              1           0        943.5           1.1       0.0X
+reused reader, trueRatio=0.1                          1              1           0        952.8           1.0       0.0X
+cold reader, trueRatio=0.5                            1              1           0       1067.3           0.9       0.0X
+reused reader, trueRatio=0.5                          1              1           0       1070.0           0.9       0.0X
+cold reader, trueRatio=0.9                            1              1           0        938.3           1.1       0.0X
+reused reader, trueRatio=0.9                          1              1           0        940.1           1.1       0.0X
+cold reader, trueRatio=1.0                            0              0           0     101448.9           0.0       1.0X
+reused reader, trueRatio=1.0                          0              0           0     102540.2           0.0       1.0X
 
 
 ================================================================================================
 Integer decode
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 RLE readIntegers dictionary-id decode:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-PACKED cold, bitWidth=4                               2              2           0        478.0           2.1       1.0X
-PACKED reused, bitWidth=4                             2              2           0        475.7           2.1       1.0X
-RLE, bitWidth=4                                       0              0           0       4508.2           0.2       9.4X
-PACKED cold, bitWidth=8                               2              2           0        518.0           1.9       1.1X
-PACKED reused, bitWidth=8                             2              2           0        515.7           1.9       1.1X
-RLE, bitWidth=8                                       0              0           0       4508.9           0.2       9.4X
-PACKED cold, bitWidth=12                              8              8           0        136.1           7.3       0.3X
-PACKED reused, bitWidth=12                            8              8           0        136.1           7.3       0.3X
-RLE, bitWidth=12                                      0              0           0       4503.7           0.2       9.4X
-PACKED cold, bitWidth=20                              3              3           0        353.3           2.8       0.7X
-PACKED reused, bitWidth=20                            3              3           0        352.1           2.8       0.7X
-RLE, bitWidth=20                                      0              0           0       4508.9           0.2       9.4X
+PACKED cold, bitWidth=4                               2              2           0        543.7           1.8       1.0X
+PACKED reused, bitWidth=4                             2              2           0        537.5           1.9       1.0X
+RLE, bitWidth=4                                       0              0           0       6239.2           0.2      11.5X
+PACKED cold, bitWidth=8                               2              2           0        586.1           1.7       1.1X
+PACKED reused, bitWidth=8                             2              2           0        587.1           1.7       1.1X
+RLE, bitWidth=8                                       0              0           0       6238.4           0.2      11.5X
+PACKED cold, bitWidth=12                              2              2           0        486.4           2.1       0.9X
+PACKED reused, bitWidth=12                            2              2           0        484.4           2.1       0.9X
+RLE, bitWidth=12                                      0              0           0       6237.7           0.2      11.5X
+PACKED cold, bitWidth=20                              3              3           0        401.5           2.5       0.7X
+PACKED reused, bitWidth=20                            3              3           0        399.0           2.5       0.7X
+RLE, bitWidth=20                                      0              0           0       6240.3           0.2      11.5X
 
 
 ================================================================================================
 Nullable batch decode with def-level materialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Nullable batch with def-levels:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       6502.7           0.2       1.0X
-nullRatio=0.1, random                                 8              9           0        123.7           8.1       0.0X
-nullRatio=0.1, clustered                              6              6           0        169.7           5.9       0.0X
-nullRatio=0.3, random                                12             12           0         87.3          11.5       0.0X
-nullRatio=0.3, clustered                              6              6           0        168.0           6.0       0.0X
-nullRatio=0.5, random                                13             13           0         79.8          12.5       0.0X
-nullRatio=0.5, clustered                              6              6           0        171.7           5.8       0.0X
-nullRatio=0.9, random                                 8              8           0        136.0           7.4       0.0X
-nullRatio=0.9, clustered                              6              6           0        181.6           5.5       0.0X
-nullRatio=1.0, random                                 0              0           0       5072.8           0.2       0.8X
+nullRatio=0.0, n/a                                    0              0           0       7968.6           0.1       1.0X
+nullRatio=0.1, random                                 7              7           0        141.4           7.1       0.0X
+nullRatio=0.1, clustered                              5              5           0        200.3           5.0       0.0X
+nullRatio=0.3, random                                11             11           0         97.3          10.3       0.0X
+nullRatio=0.3, clustered                              5              5           1        200.5           5.0       0.0X
+nullRatio=0.5, random                                12             12           0         88.0          11.4       0.0X
+nullRatio=0.5, clustered                              5              5           0        203.0           4.9       0.0X
+nullRatio=0.9, random                                 7              7           0        153.1           6.5       0.0X
+nullRatio=0.9, clustered                              5              5           0        216.6           4.6       0.0X
+nullRatio=1.0, random                                 0              0           0       5760.9           0.2       0.7X
 
 
 ================================================================================================
 Nullable batch decode without def-level materialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
 Nullable batch without def-levels:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0      11512.6           0.1       1.0X
-nullRatio=0.1, random                                 7              7           0        144.6           6.9       0.0X
-nullRatio=0.1, clustered                              5              5           0        197.2           5.1       0.0X
-nullRatio=0.3, random                                11             11           0         99.6          10.0       0.0X
-nullRatio=0.3, clustered                              6              6           0        189.8           5.3       0.0X
-nullRatio=0.5, random                                12             12           0         89.0          11.2       0.0X
-nullRatio=0.5, clustered                              5              5           0        194.7           5.1       0.0X
-nullRatio=0.9, random                                 7              7           0        151.9           6.6       0.0X
-nullRatio=0.9, clustered                              5              5           0        200.5           5.0       0.0X
-nullRatio=1.0, random                                 0              0           0      11945.0           0.1       1.0X
+nullRatio=0.0, n/a                                    0              0           0      12890.8           0.1       1.0X
+nullRatio=0.1, random                                 6              6           1        174.7           5.7       0.0X
+nullRatio=0.1, clustered                              4              4           0        247.0           4.0       0.0X
+nullRatio=0.3, random                                 9              9           0        118.0           8.5       0.0X
+nullRatio=0.3, clustered                              4              4           0        245.5           4.1       0.0X
+nullRatio=0.5, random                                10             10           0        105.9           9.4       0.0X
+nullRatio=0.5, clustered                              4              4           0        247.8           4.0       0.0X
+nullRatio=0.9, random                                 6              6           0        190.5           5.2       0.0X
+nullRatio=0.9, clustered                              4              4           1        260.5           3.8       0.0X
+nullRatio=1.0, random                                 0              0           0      11767.9           0.1       0.9X
+
+
+================================================================================================
+Nullable batch decode with row-index filtering (with def-levels)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
+Nullable batch with def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------------
+nullRatio=0.0, contiguous 50%                                   1              1           0       1266.0           0.8       1.0X
+nullRatio=0.3, contiguous 50%                                   7              7           0        142.2           7.0       0.1X
+nullRatio=0.9, contiguous 50%                                   5              5           0        198.4           5.0       0.2X
+nullRatio=0.0, alt 1000-row windows                             2              2           0        459.0           2.2       0.4X
+nullRatio=0.3, alt 1000-row windows                             9              9           0        118.8           8.4       0.1X
+nullRatio=0.9, alt 1000-row windows                             7              7           0        152.9           6.5       0.1X
+
+
+================================================================================================
+Nullable batch decode with row-index filtering (without def-levels)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
+Nullable batch without def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------
+nullRatio=0.0, contiguous 50%                                      1              1           0       1062.0           0.9       1.0X
+nullRatio=0.3, contiguous 50%                                      7              7           0        152.1           6.6       0.1X
+nullRatio=0.9, contiguous 50%                                      5              5           0        207.5           4.8       0.2X
+nullRatio=0.0, alt 1000-row windows                                2              2           0        478.6           2.1       0.5X
+nullRatio=0.3, alt 1000-row windows                                8              8           0        129.6           7.7       0.1X
+nullRatio=0.9, alt 1000-row windows                                6              6           0        166.4           6.0       0.2X
+
+
+================================================================================================
+Single-value reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
+Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBoolean                                           3              3           0        347.5           2.9       1.0X
+readInteger, bitWidth=4                               3              3           0        318.1           3.1       0.9X
+readValueDictionaryId, bitWidth=4                     3              3           0        318.2           3.1       0.9X
+readInteger, bitWidth=8                               3              3           0        335.1           3.0       1.0X
+readValueDictionaryId, bitWidth=8                     3              3           0        335.5           3.0       1.0X
+readInteger, bitWidth=12                              4              4           0        296.9           3.4       0.9X
+readValueDictionaryId, bitWidth=12                    4              4           0        299.4           3.3       0.9X
+readInteger, bitWidth=20                              4              4           0        263.8           3.8       0.8X
+readValueDictionaryId, bitWidth=20                    4              4           1        263.6           3.8       0.8X
+
+
+================================================================================================
+Skip
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 9V74 80-Core Processor
+Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+skipBooleans, trueRatio=0.0                           0              0           0   34952533.3           0.0       1.0X
+skipBooleans, trueRatio=0.5                           2              2           0        613.5           1.6       0.0X
+skipBooleans, trueRatio=1.0                           0              0           0   34952533.3           0.0       1.0X
+skipIntegers PACKED, bitWidth=4                       2              2           0        576.0           1.7       0.0X
+skipIntegers RLE, bitWidth=4                          0              0           0   34952533.3           0.0       1.0X
+skipIntegers PACKED, bitWidth=8                       2              2           0        645.1           1.6       0.0X
+skipIntegers RLE, bitWidth=8                          0              0           0   34952533.3           0.0       1.0X
+skipIntegers PACKED, bitWidth=12                      2              2           0        500.8           2.0       0.0X
+skipIntegers RLE, bitWidth=12                         0              0           0   34952533.3           0.0       1.0X
+skipIntegers PACKED, bitWidth=20                      3              3           0        417.0           2.4       0.0X
+skipIntegers RLE, bitWidth=20                         0              0           0   26214400.0           0.0       0.8X
 
 

--- a/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-jdk25-results.txt
@@ -2,81 +2,153 @@
 Boolean decode
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1011-azure
 AMD EPYC 7763 64-Core Processor
 RLE readBooleans decode:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cold reader, trueRatio=0.0                            0              0           0      60530.9           0.0       1.0X
-reused reader, trueRatio=0.0                          0              0           0      56821.1           0.0       0.9X
-cold reader, trueRatio=0.1                            1              1           0        709.0           1.4       0.0X
-reused reader, trueRatio=0.1                          1              1           0        708.2           1.4       0.0X
-cold reader, trueRatio=0.5                            1              1           0        747.9           1.3       0.0X
-reused reader, trueRatio=0.5                          1              1           0        746.5           1.3       0.0X
-cold reader, trueRatio=0.9                            1              1           0        709.0           1.4       0.0X
-reused reader, trueRatio=0.9                          1              2           0        705.6           1.4       0.0X
-cold reader, trueRatio=1.0                            0              0           0      59164.7           0.0       1.0X
-reused reader, trueRatio=1.0                          0              0           0      58832.7           0.0       1.0X
+cold reader, trueRatio=0.0                            0              0           0       5323.3           0.2       1.0X
+reused reader, trueRatio=0.0                          0              0           0       4464.5           0.2       0.8X
+cold reader, trueRatio=0.1                            2              2           0        669.3           1.5       0.1X
+reused reader, trueRatio=0.1                          2              2           0        672.6           1.5       0.1X
+cold reader, trueRatio=0.5                            1              1           0        722.5           1.4       0.1X
+reused reader, trueRatio=0.5                          1              1           0        724.3           1.4       0.1X
+cold reader, trueRatio=0.9                            2              2           0        669.6           1.5       0.1X
+reused reader, trueRatio=0.9                          2              2           0        674.0           1.5       0.1X
+cold reader, trueRatio=1.0                            0              0           0       4574.1           0.2       0.9X
+reused reader, trueRatio=1.0                          0              0           0       4460.9           0.2       0.8X
 
 
 ================================================================================================
 Integer decode
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1011-azure
 AMD EPYC 7763 64-Core Processor
 RLE readIntegers dictionary-id decode:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-PACKED cold, bitWidth=4                               2              2           0        517.0           1.9       1.0X
-PACKED reused, bitWidth=4                             2              2           0        518.3           1.9       1.0X
-RLE, bitWidth=4                                       0              0           0      18145.5           0.1      35.1X
+PACKED cold, bitWidth=4                               2              2           0        516.7           1.9       1.0X
+PACKED reused, bitWidth=4                             2              2           0        516.1           1.9       1.0X
+RLE, bitWidth=4                                       0              0           0      18696.2           0.1      36.2X
 PACKED cold, bitWidth=8                               2              2           0        570.0           1.8       1.1X
-PACKED reused, bitWidth=8                             2              2           0        556.9           1.8       1.1X
-RLE, bitWidth=8                                       0              0           0      18098.2           0.1      35.0X
-PACKED cold, bitWidth=12                              2              2           0        454.5           2.2       0.9X
-PACKED reused, bitWidth=12                            2              2           0        453.0           2.2       0.9X
-RLE, bitWidth=12                                      0              0           0      18164.4           0.1      35.1X
-PACKED cold, bitWidth=20                              3              3           0        374.6           2.7       0.7X
-PACKED reused, bitWidth=20                            3              3           0        374.2           2.7       0.7X
-RLE, bitWidth=20                                      0              0           0      18462.1           0.1      35.7X
+PACKED reused, bitWidth=8                             2              2           0        567.0           1.8       1.1X
+RLE, bitWidth=8                                       0              0           0      18583.5           0.1      36.0X
+PACKED cold, bitWidth=12                              2              2           0        454.6           2.2       0.9X
+PACKED reused, bitWidth=12                            2              2           0        452.6           2.2       0.9X
+RLE, bitWidth=12                                      0              0           0      18696.2           0.1      36.2X
+PACKED cold, bitWidth=20                              3              3           0        373.2           2.7       0.7X
+PACKED reused, bitWidth=20                            3              3           0        369.4           2.7       0.7X
+RLE, bitWidth=20                                      0              0           0      15516.8           0.1      30.0X
 
 
 ================================================================================================
 Nullable batch decode with def-level materialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1011-azure
 AMD EPYC 7763 64-Core Processor
 Nullable batch with def-levels:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       6625.9           0.2       1.0X
-nullRatio=0.1, random                                 9              9           0        121.8           8.2       0.0X
-nullRatio=0.1, clustered                              6              6           0        170.3           5.9       0.0X
-nullRatio=0.3, random                                13             13           0         83.8          11.9       0.0X
-nullRatio=0.3, clustered                              6              6           0        170.4           5.9       0.0X
-nullRatio=0.5, random                                14             14           0         75.8          13.2       0.0X
-nullRatio=0.5, clustered                              6              6           0        172.1           5.8       0.0X
-nullRatio=0.9, random                                 8              8           0        131.0           7.6       0.0X
-nullRatio=0.9, clustered                              6              6           0        181.7           5.5       0.0X
-nullRatio=1.0, random                                 0              0           0       8305.2           0.1       1.3X
+nullRatio=0.0, n/a                                    0              0           0       6608.2           0.2       1.0X
+nullRatio=0.1, random                                 9              9           0        119.1           8.4       0.0X
+nullRatio=0.1, clustered                              6              6           0        166.2           6.0       0.0X
+nullRatio=0.3, random                                13             13           0         81.2          12.3       0.0X
+nullRatio=0.3, clustered                              6              6           0        166.0           6.0       0.0X
+nullRatio=0.5, random                                15             15           1         71.3          14.0       0.0X
+nullRatio=0.5, clustered                              6              6           0        166.6           6.0       0.0X
+nullRatio=0.9, random                                 8              8           0        127.6           7.8       0.0X
+nullRatio=0.9, clustered                              6              6           0        175.5           5.7       0.0X
+nullRatio=1.0, random                                 0              0           0       8275.6           0.1       1.3X
 
 
 ================================================================================================
 Nullable batch decode without def-level materialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1011-azure
 AMD EPYC 7763 64-Core Processor
 Nullable batch without def-levels:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0      11869.8           0.1       1.0X
-nullRatio=0.1, random                                 7              7           0        149.1           6.7       0.0X
-nullRatio=0.1, clustered                              5              5           0        208.1           4.8       0.0X
-nullRatio=0.3, random                                10             10           0        101.1           9.9       0.0X
-nullRatio=0.3, clustered                              5              5           0        206.6           4.8       0.0X
-nullRatio=0.5, random                                12             12           0         90.7          11.0       0.0X
-nullRatio=0.5, clustered                              5              5           0        206.4           4.8       0.0X
-nullRatio=0.9, random                                 7              7           0        160.2           6.2       0.0X
-nullRatio=0.9, clustered                              5              5           0        213.5           4.7       0.0X
-nullRatio=1.0, random                                 0              0           0      11957.2           0.1       1.0X
+nullRatio=0.0, n/a                                    0              0           0      11464.6           0.1       1.0X
+nullRatio=0.1, random                                 7              7           0        148.7           6.7       0.0X
+nullRatio=0.1, clustered                              5              5           0        207.2           4.8       0.0X
+nullRatio=0.3, random                                10             10           0        100.6           9.9       0.0X
+nullRatio=0.3, clustered                              5              5           0        204.8           4.9       0.0X
+nullRatio=0.5, random                                12             12           0         90.6          11.0       0.0X
+nullRatio=0.5, clustered                              5              5           0        205.1           4.9       0.0X
+nullRatio=0.9, random                                 7              7           0        158.9           6.3       0.0X
+nullRatio=0.9, clustered                              5              5           0        212.4           4.7       0.0X
+nullRatio=1.0, random                                 0              0           0      11983.2           0.1       1.0X
+
+
+================================================================================================
+Nullable batch decode with row-index filtering (with def-levels)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+Nullable batch with def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------------
+nullRatio=0.0, contiguous 50%                                   1              1           0        762.9           1.3       1.0X
+nullRatio=0.3, contiguous 50%                                   9              9           0        116.5           8.6       0.2X
+nullRatio=0.9, contiguous 50%                                   7              7           0        156.2           6.4       0.2X
+nullRatio=0.0, alt 1000-row windows                             2              2           0        433.5           2.3       0.6X
+nullRatio=0.3, alt 1000-row windows                            10             10           0        103.5           9.7       0.1X
+nullRatio=0.9, alt 1000-row windows                             8              8           1        136.1           7.3       0.2X
+
+
+================================================================================================
+Nullable batch decode with row-index filtering (without def-levels)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+Nullable batch without def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------
+nullRatio=0.0, contiguous 50%                                      1              2           0        732.5           1.4       1.0X
+nullRatio=0.3, contiguous 50%                                      8              8           0        131.7           7.6       0.2X
+nullRatio=0.9, contiguous 50%                                      6              6           0        173.9           5.8       0.2X
+nullRatio=0.0, alt 1000-row windows                                2              2           0        423.8           2.4       0.6X
+nullRatio=0.3, alt 1000-row windows                                9              9           0        115.8           8.6       0.2X
+nullRatio=0.9, alt 1000-row windows                                7              7           0        147.6           6.8       0.2X
+
+
+================================================================================================
+Single-value reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBoolean                                           3              3           0        321.6           3.1       1.0X
+readInteger, bitWidth=4                               3              4           0        305.3           3.3       0.9X
+readValueDictionaryId, bitWidth=4                     3              4           0        305.0           3.3       0.9X
+readInteger, bitWidth=8                               3              3           0        322.7           3.1       1.0X
+readValueDictionaryId, bitWidth=8                     3              3           0        322.7           3.1       1.0X
+readInteger, bitWidth=12                              4              4           0        282.4           3.5       0.9X
+readValueDictionaryId, bitWidth=12                    4              4           0        282.4           3.5       0.9X
+readInteger, bitWidth=20                              4              4           0        248.5           4.0       0.8X
+readValueDictionaryId, bitWidth=20                    4              4           0        248.4           4.0       0.8X
+
+
+================================================================================================
+Skip
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1011-azure
+AMD EPYC 7763 64-Core Processor
+Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+skipBooleans, trueRatio=0.0                           0              0           0   26214400.0           0.0       1.0X
+skipBooleans, trueRatio=0.5                           2              2           0        621.6           1.6       0.0X
+skipBooleans, trueRatio=1.0                           0              0           0   26214400.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=4                       2              2           0        537.5           1.9       0.0X
+skipIntegers RLE, bitWidth=4                          0              0           0   26214400.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=8                       2              2           0        599.4           1.7       0.0X
+skipIntegers RLE, bitWidth=8                          0              0           0   26214400.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=12                      2              2           0        471.2           2.1       0.0X
+skipIntegers RLE, bitWidth=12                         0              0           0   21399510.2           0.0       0.8X
+skipIntegers PACKED, bitWidth=20                      3              3           0        384.7           2.6       0.0X
+skipIntegers RLE, bitWidth=20                         0              0           0   21399510.2           0.0       0.8X
 
 

--- a/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-results.txt
+++ b/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-results.txt
@@ -2,81 +2,153 @@
 Boolean decode
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 RLE readBooleans decode:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cold reader, trueRatio=0.0                            0              0           0      47464.1           0.0       1.0X
-reused reader, trueRatio=0.0                          0              0           0      47485.6           0.0       1.0X
-cold reader, trueRatio=0.1                            1              1           0        894.1           1.1       0.0X
-reused reader, trueRatio=0.1                          1              1           0        897.4           1.1       0.0X
-cold reader, trueRatio=0.5                            1              1           0       1027.8           1.0       0.0X
-reused reader, trueRatio=0.5                          1              1           0       1029.3           1.0       0.0X
-cold reader, trueRatio=0.9                            1              1           0        893.8           1.1       0.0X
-reused reader, trueRatio=0.9                          1              1           0        896.6           1.1       0.0X
-cold reader, trueRatio=1.0                            0              0           0      47421.1           0.0       1.0X
-reused reader, trueRatio=1.0                          0              0           0      47485.6           0.0       1.0X
+cold reader, trueRatio=0.0                            0              0           0      66239.8           0.0       1.0X
+reused reader, trueRatio=0.0                          0              0           0      57887.6           0.0       0.9X
+cold reader, trueRatio=0.1                            1              1           0        893.5           1.1       0.0X
+reused reader, trueRatio=0.1                          1              1           0        895.6           1.1       0.0X
+cold reader, trueRatio=0.5                            1              1           0       1018.7           1.0       0.0X
+reused reader, trueRatio=0.5                          1              1           0       1029.4           1.0       0.0X
+cold reader, trueRatio=0.9                            1              1           0        891.9           1.1       0.0X
+reused reader, trueRatio=0.9                          1              1           0        894.8           1.1       0.0X
+cold reader, trueRatio=1.0                            0              0           0      67001.7           0.0       1.0X
+reused reader, trueRatio=1.0                          0              0           0      72380.5           0.0       1.1X
 
 
 ================================================================================================
 Integer decode
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 RLE readIntegers dictionary-id decode:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-PACKED cold, bitWidth=4                               2              2           0        488.1           2.0       1.0X
-PACKED reused, bitWidth=4                             2              2           0        485.9           2.1       1.0X
-RLE, bitWidth=4                                       0              0           0      19116.1           0.1      39.2X
-PACKED cold, bitWidth=8                               2              2           0        482.1           2.1       1.0X
-PACKED reused, bitWidth=8                             2              2           0        479.7           2.1       1.0X
-RLE, bitWidth=8                                       0              0           0      18567.1           0.1      38.0X
-PACKED cold, bitWidth=12                              3              3           0        362.1           2.8       0.7X
-PACKED reused, bitWidth=12                            3              3           0        361.3           2.8       0.7X
-RLE, bitWidth=12                                      0              0           0      19126.9           0.1      39.2X
-PACKED cold, bitWidth=20                              3              3           0        308.6           3.2       0.6X
-PACKED reused, bitWidth=20                            3              3           0        306.5           3.3       0.6X
-RLE, bitWidth=20                                      0              0           0      19074.4           0.1      39.1X
+PACKED cold, bitWidth=4                               2              2           0        505.6           2.0       1.0X
+PACKED reused, bitWidth=4                             2              2           0        504.6           2.0       1.0X
+RLE, bitWidth=4                                       0              0           0      18249.1           0.1      36.1X
+PACKED cold, bitWidth=8                               2              2           0        497.6           2.0       1.0X
+PACKED reused, bitWidth=8                             2              2           0        496.2           2.0       1.0X
+RLE, bitWidth=8                                       0              0           0      18123.0           0.1      35.8X
+PACKED cold, bitWidth=12                              3              3           0        370.2           2.7       0.7X
+PACKED reused, bitWidth=12                            3              3           0        369.6           2.7       0.7X
+RLE, bitWidth=12                                      0              0           0      18573.3           0.1      36.7X
+PACKED cold, bitWidth=20                              3              3           0        315.1           3.2       0.6X
+PACKED reused, bitWidth=20                            3              3           0        316.2           3.2       0.6X
+RLE, bitWidth=20                                      0              0           0      18570.0           0.1      36.7X
 
 
 ================================================================================================
 Nullable batch decode with def-level materialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Nullable batch with def-levels:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       6441.9           0.2       1.0X
-nullRatio=0.1, random                                 9              9           0        113.0           8.9       0.0X
-nullRatio=0.1, clustered                              7              7           0        144.8           6.9       0.0X
-nullRatio=0.3, random                                13             13           0         78.9          12.7       0.0X
-nullRatio=0.3, clustered                              7              7           0        156.6           6.4       0.0X
-nullRatio=0.5, random                                15             15           0         71.9          13.9       0.0X
-nullRatio=0.5, clustered                              7              7           0        159.2           6.3       0.0X
-nullRatio=0.9, random                                 8              8           0        124.8           8.0       0.0X
-nullRatio=0.9, clustered                              6              6           0        171.3           5.8       0.0X
-nullRatio=1.0, random                                 0              0           0       8031.7           0.1       1.2X
+nullRatio=0.0, n/a                                    0              0           0       6431.5           0.2       1.0X
+nullRatio=0.1, random                                 9              9           0        114.6           8.7       0.0X
+nullRatio=0.1, clustered                              7              7           0        159.7           6.3       0.0X
+nullRatio=0.3, random                                13             13           0         80.1          12.5       0.0X
+nullRatio=0.3, clustered                              7              7           1        157.8           6.3       0.0X
+nullRatio=0.5, random                                14             15           0         72.7          13.7       0.0X
+nullRatio=0.5, clustered                              6              7           0        162.0           6.2       0.0X
+nullRatio=0.9, random                                 8              8           0        126.4           7.9       0.0X
+nullRatio=0.9, clustered                              6              6           0        174.0           5.7       0.0X
+nullRatio=1.0, random                                 0              0           0       8062.5           0.1       1.3X
 
 
 ================================================================================================
 Nullable batch decode without def-level materialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 Nullable batch without def-levels:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0      11037.9           0.1       1.0X
-nullRatio=0.1, random                                 8              8           0        139.2           7.2       0.0X
-nullRatio=0.1, clustered                              6              6           0        190.1           5.3       0.0X
-nullRatio=0.3, random                                11             11           0         96.7          10.3       0.0X
-nullRatio=0.3, clustered                              6              6           0        188.5           5.3       0.0X
-nullRatio=0.5, random                                12             12           0         86.9          11.5       0.0X
-nullRatio=0.5, clustered                              6              6           0        188.0           5.3       0.0X
-nullRatio=0.9, random                                 7              7           0        149.4           6.7       0.0X
-nullRatio=0.9, clustered                              5              5           0        197.9           5.1       0.0X
-nullRatio=1.0, random                                 0              0           0      11675.8           0.1       1.1X
+nullRatio=0.0, n/a                                    0              0           0      11054.0           0.1       1.0X
+nullRatio=0.1, random                                 7              8           0        140.6           7.1       0.0X
+nullRatio=0.1, clustered                              5              5           0        193.2           5.2       0.0X
+nullRatio=0.3, random                                11             11           0         97.4          10.3       0.0X
+nullRatio=0.3, clustered                              6              6           0        184.4           5.4       0.0X
+nullRatio=0.5, random                                12             12           0         87.7          11.4       0.0X
+nullRatio=0.5, clustered                              5              6           0        191.6           5.2       0.0X
+nullRatio=0.9, random                                 7              7           0        151.7           6.6       0.0X
+nullRatio=0.9, clustered                              5              5           0        200.8           5.0       0.0X
+nullRatio=1.0, random                                 0              0           0      11662.5           0.1       1.1X
+
+
+================================================================================================
+Nullable batch decode with row-index filtering (with def-levels)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Nullable batch with def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------------
+nullRatio=0.0, contiguous 50%                                   1              2           0        763.7           1.3       1.0X
+nullRatio=0.3, contiguous 50%                                   9              9           0        117.3           8.5       0.2X
+nullRatio=0.9, contiguous 50%                                   7              7           0        157.5           6.3       0.2X
+nullRatio=0.0, alt 1000-row windows                             3              3           0        418.8           2.4       0.5X
+nullRatio=0.3, alt 1000-row windows                            10             10           0        103.8           9.6       0.1X
+nullRatio=0.9, alt 1000-row windows                             8              8           0        134.7           7.4       0.2X
+
+
+================================================================================================
+Nullable batch decode with row-index filtering (without def-levels)
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Nullable batch without def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------
+nullRatio=0.0, contiguous 50%                                      1              1           0        865.4           1.2       1.0X
+nullRatio=0.3, contiguous 50%                                      8              8           0        128.8           7.8       0.1X
+nullRatio=0.9, contiguous 50%                                      6              6           0        173.4           5.8       0.2X
+nullRatio=0.0, alt 1000-row windows                                2              2           0        425.9           2.3       0.5X
+nullRatio=0.3, alt 1000-row windows                                9              9           0        111.3           9.0       0.1X
+nullRatio=0.9, alt 1000-row windows                                7              7           0        143.3           7.0       0.2X
+
+
+================================================================================================
+Single-value reads
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+readBoolean                                           4              4           0        287.0           3.5       1.0X
+readInteger, bitWidth=4                               4              4           0        275.7           3.6       1.0X
+readValueDictionaryId, bitWidth=4                     4              4           0        275.5           3.6       1.0X
+readInteger, bitWidth=8                               4              4           0        273.7           3.7       1.0X
+readValueDictionaryId, bitWidth=8                     4              4           0        273.4           3.7       1.0X
+readInteger, bitWidth=12                              5              5           1        230.1           4.3       0.8X
+readValueDictionaryId, bitWidth=12                    5              5           0        229.3           4.4       0.8X
+readInteger, bitWidth=20                              5              5           0        207.9           4.8       0.7X
+readValueDictionaryId, bitWidth=20                    5              5           0        207.3           4.8       0.7X
+
+
+================================================================================================
+Skip
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
+AMD EPYC 7763 64-Core Processor
+Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+skipBooleans, trueRatio=0.0                           0              0           0   20971520.0           0.0       1.0X
+skipBooleans, trueRatio=0.5                           2              2           0        569.4           1.8       0.0X
+skipBooleans, trueRatio=1.0                           0              0           0   21399510.2           0.0       1.0X
+skipIntegers PACKED, bitWidth=4                       2              2           0        522.7           1.9       0.0X
+skipIntegers RLE, bitWidth=4                          0              0           0   20971520.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=8                       2              2           0        516.6           1.9       0.0X
+skipIntegers RLE, bitWidth=8                          0              0           0   21399510.2           0.0       1.0X
+skipIntegers PACKED, bitWidth=12                      3              3           0        382.4           2.6       0.0X
+skipIntegers RLE, bitWidth=12                         0              0           0   17476266.7           0.0       0.8X
+skipIntegers PACKED, bitWidth=20                      3              3           0        323.0           3.1       0.0X
+skipIntegers RLE, bitWidth=20                         0              0           0   17476266.7           0.0       0.8X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTestAccess.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTestAccess.scala
@@ -18,24 +18,37 @@
 package org.apache.spark.sql.execution.datasources.parquet
 
 import java.lang.reflect.{InvocationTargetException, Method}
+import java.time.ZoneId
 import java.util.PrimitiveIterator
 
 import org.apache.parquet.column.ColumnDescriptor
+import org.apache.parquet.schema.LogicalTypeAnnotation
 
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector
 import org.apache.spark.util.SparkClassUtils
 
 /**
- * Reflective bridge to the package-private `ParquetReadState`. Under `spark-submit --jars`,
- * test and main classes load from different classloaders, blocking package-private access.
- * Reflection with `setAccessible` sidesteps the check without widening production visibility.
+ * Reflective bridge to package-private classes in
+ * `org.apache.spark.sql.execution.datasources.parquet`. Under `spark-submit --jars`, test
+ * and main classes load from different classloaders, blocking package-private access despite
+ * the matching package name. Reflection with `setAccessible(true)` sidesteps the check
+ * without widening production visibility.
+ *
+ * Currently bridges:
+ *   - `ParquetReadState` (constructor + `resetForNewBatch` + `resetForNewPage`)
+ *   - `VectorizedRleValuesReader.readBatch` (5-arg overload not exposed publicly)
+ *   - `ParquetVectorUpdaterFactory` (constructor)
+ *   - `VectorizedDeltaByteArrayReader` (no-arg constructor)
+ *   - `VectorizedDeltaLengthByteArrayReader` (no-arg constructor)
  */
-object ParquetReadStateTestAccess {
+object ParquetTestAccess {
+
+  // -------- ParquetReadState --------
 
   private val stateCls = SparkClassUtils.classForName[Any](
     "org.apache.spark.sql.execution.datasources.parquet.ParquetReadState")
 
-  private val ctor = {
+  private val stateCtor = {
     val c = stateCls.getDeclaredConstructor(
       classOf[ColumnDescriptor],
       java.lang.Boolean.TYPE,
@@ -71,7 +84,7 @@ object ParquetReadStateTestAccess {
       isRequired: Boolean,
       rowIndexes: PrimitiveIterator.OfLong = null): AnyRef = {
     try {
-      ctor.newInstance(
+      stateCtor.newInstance(
         descriptor,
         Boolean.box(isRequired),
         rowIndexes).asInstanceOf[AnyRef]
@@ -104,6 +117,63 @@ object ParquetReadStateTestAccess {
       readBatchMethod.invoke(
         reader, state, values, defLevels, valueReader, updater)
     } catch { case e: ReflectiveOperationException => throw rethrow(e) }
+
+  // -------- ParquetVectorUpdaterFactory --------
+
+  private val factoryCtor = {
+    val cls = SparkClassUtils.classForName[Any](
+      "org.apache.spark.sql.execution.datasources.parquet.ParquetVectorUpdaterFactory")
+    val c = cls.getDeclaredConstructor(
+      classOf[LogicalTypeAnnotation],
+      classOf[ZoneId],
+      classOf[String],
+      classOf[String],
+      classOf[String],
+      classOf[String])
+    c.setAccessible(true)
+    c
+  }
+
+  def newFactory(
+      logicalTypeAnnotation: LogicalTypeAnnotation,
+      convertTz: ZoneId,
+      datetimeRebaseMode: String,
+      datetimeRebaseTz: String,
+      int96RebaseMode: String,
+      int96RebaseTz: String): ParquetVectorUpdaterFactory = {
+    try {
+      factoryCtor.newInstance(
+        logicalTypeAnnotation, convertTz,
+        datetimeRebaseMode, datetimeRebaseTz,
+        int96RebaseMode, int96RebaseTz).asInstanceOf[ParquetVectorUpdaterFactory]
+    } catch {
+      case e: ReflectiveOperationException => throw rethrow(e)
+    }
+  }
+
+  // -------- VectorizedDeltaByteArrayReader / VectorizedDeltaLengthByteArrayReader --------
+
+  private val deltaByteArrayCtor = {
+    val c = classOf[VectorizedDeltaByteArrayReader].getDeclaredConstructor()
+    c.setAccessible(true)
+    c
+  }
+
+  private val deltaLengthByteArrayCtor = {
+    val c = classOf[VectorizedDeltaLengthByteArrayReader].getDeclaredConstructor()
+    c.setAccessible(true)
+    c
+  }
+
+  def newDeltaByteArrayReader(): VectorizedDeltaByteArrayReader =
+    try { deltaByteArrayCtor.newInstance() }
+    catch { case e: ReflectiveOperationException => throw rethrow(e) }
+
+  def newDeltaLengthByteArrayReader(): VectorizedDeltaLengthByteArrayReader =
+    try { deltaLengthByteArrayCtor.newInstance() }
+    catch { case e: ReflectiveOperationException => throw rethrow(e) }
+
+  // -------- shared helper --------
 
   private def rethrow(e: ReflectiveOperationException): RuntimeException = {
     val cause = e match {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterBenchmark.scala
@@ -1,0 +1,419 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import java.nio.{ByteBuffer, ByteOrder}
+import java.time.ZoneOffset
+
+import org.apache.parquet.bytes.ByteBufferInputStream
+import org.apache.parquet.column.ColumnDescriptor
+import org.apache.parquet.schema.{LogicalTypeAnnotation, Types}
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
+import org.apache.parquet.schema.Type.Repetition
+
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+import org.apache.spark.sql.execution.vectorized.{OnHeapColumnVector, WritableColumnVector}
+import org.apache.spark.sql.types._
+
+/**
+ * Low-level benchmark for `ParquetVectorUpdater` implementations in
+ * `ParquetVectorUpdaterFactory`. Measures the per-batch throughput of `readValues`,
+ * `readValue`, and `skipValues` for the family of Updaters Spark uses to populate a
+ * column vector from a `VectorizedValuesReader`.
+ *
+ * Coverage is intentionally broad - every Updater family is included even when no
+ * obvious optimization opportunity exists today, so the result file tracks the
+ * long-term baseline and future iteration does not have to add coverage first.
+ *
+ * Groups:
+ *   A. Identity Updaters -- direct copy from PLAIN values into target column type
+ *      (Boolean, Byte, Short, Integer, Long, Float, Double, Binary).
+ *   B. Type-converting Updaters -- per-row read+convert+write loops.
+ *      `IntegerToLong`, `IntegerToDouble`, `FloatToDouble`, `DateToTimestampNTZ`,
+ *      `DowncastLong`.
+ *   C. Rebase Updaters -- date/timestamp legacy-calendar rebase variants.
+ *      `IntegerWithRebase` (DATE), `LongWithRebase` (TIMESTAMP_MICROS),
+ *      `LongAsMicros`.
+ *   D. Unsigned Updaters -- `UnsignedInteger`, `UnsignedLong`.
+ *   E. Decimal Updaters -- `IntegerToDecimal`, `LongToDecimal`,
+ *      `BinaryToDecimal`, `FixedLenByteArrayToDecimal`.
+ *   F. FixedLenByteArray Updaters -- `FixedLenByteArray`, `FixedLenByteArrayAsInt`,
+ *      `FixedLenByteArrayAsLong`.
+ *
+ * Updater instances are obtained via `ParquetVectorUpdaterFactory.getUpdater`, the
+ * production entry point, so the benchmark exercises the full configuration matrix
+ * (logical-type annotation, rebase mode, timezone) the production decoder uses.
+ *
+ * Pre-warm: each case runs one full `readValues` against a fresh reader before
+ * `benchmark.addCase` to stabilize first-case JIT state.
+ *
+ * To run this benchmark:
+ * {{{
+ *   1. build/sbt "sql/Test/runMain <this class>"
+ *   2. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results in "benchmarks/ParquetVectorUpdaterBenchmark-results.txt".
+ *   3. GHA: `Run benchmarks` workflow, class = `*ParquetVectorUpdater*`.
+ * }}}
+ */
+object ParquetVectorUpdaterBenchmark extends BenchmarkBase {
+
+  private val NUM_ROWS = 1024 * 1024
+  private val NUM_ITERS = 5
+
+  // --------------- Helpers ---------------
+
+  private def descriptor(
+      name: PrimitiveTypeName,
+      logical: LogicalTypeAnnotation = null,
+      typeLength: Int = 0): ColumnDescriptor = {
+    var builder = Types.primitive(name, Repetition.OPTIONAL)
+    if (typeLength > 0) builder = builder.length(typeLength)
+    if (logical != null) builder = builder.as(logical)
+    new ColumnDescriptor(Array("col"), builder.named("col"), 0, 1)
+  }
+
+  // Production code (`VectorizedColumnReader`) constructs the Factory with the descriptor's
+  // own logical type annotation. The Factory's `isTimestampTypeMatched` and friends read
+  // that field rather than the descriptor, so the two must agree or the Factory throws.
+  private def factory(
+      desc: ColumnDescriptor,
+      datetimeRebaseMode: String = "CORRECTED",
+      int96RebaseMode: String = "CORRECTED"): ParquetVectorUpdaterFactory =
+    ParquetTestAccess.newFactory(
+      desc.getPrimitiveType.getLogicalTypeAnnotation,
+      ZoneOffset.UTC, datetimeRebaseMode, "UTC", int96RebaseMode, "UTC")
+
+  // ---- PLAIN-encoded value byte producers ----
+
+  private def plainIntBytes(count: Int)(f: Int => Int): Array[Byte] = {
+    val buf = ByteBuffer.allocate(count * 4).order(ByteOrder.LITTLE_ENDIAN)
+    var i = 0
+    while (i < count) { buf.putInt(f(i)); i += 1 }
+    buf.array()
+  }
+
+  private def plainLongBytes(count: Int)(f: Int => Long): Array[Byte] = {
+    val buf = ByteBuffer.allocate(count * 8).order(ByteOrder.LITTLE_ENDIAN)
+    var i = 0
+    while (i < count) { buf.putLong(f(i)); i += 1 }
+    buf.array()
+  }
+
+  private def plainFloatBytes(count: Int)(f: Int => Float): Array[Byte] = {
+    val buf = ByteBuffer.allocate(count * 4).order(ByteOrder.LITTLE_ENDIAN)
+    var i = 0
+    while (i < count) { buf.putFloat(f(i)); i += 1 }
+    buf.array()
+  }
+
+  private def plainDoubleBytes(count: Int)(f: Int => Double): Array[Byte] = {
+    val buf = ByteBuffer.allocate(count * 8).order(ByteOrder.LITTLE_ENDIAN)
+    var i = 0
+    while (i < count) { buf.putDouble(f(i)); i += 1 }
+    buf.array()
+  }
+
+  private def plainBooleanBytes(count: Int): Array[Byte] = {
+    val byteCount = (count + 7) / 8
+    val out = new Array[Byte](byteCount)
+    var i = 0
+    while (i < count) {
+      if ((i & 1) == 0) out(i / 8) = (out(i / 8) | (1 << (i % 8))).toByte
+      i += 1
+    }
+    out
+  }
+
+  /** Variable-length binary: 4-byte length prefix + payload, repeated. */
+  private def plainBinaryBytes(count: Int, payloadLen: Int): Array[Byte] = {
+    val recordLen = 4 + payloadLen
+    val buf = ByteBuffer.allocate(count * recordLen).order(ByteOrder.LITTLE_ENDIAN)
+    val payload = new Array[Byte](payloadLen)
+    var i = 0
+    while (i < count) {
+      buf.putInt(payloadLen)
+      buf.put(payload)
+      i += 1
+    }
+    buf.array()
+  }
+
+  /** Fixed-length byte array: just `count * len` bytes, all zero. */
+  private def plainFixedLenBytes(count: Int, len: Int): Array[Byte] =
+    new Array[Byte](count * len)
+
+  private def newPlainReader(bytes: Array[Byte]): VectorizedPlainValuesReader = {
+    val r = new VectorizedPlainValuesReader
+    r.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes)))
+    r
+  }
+
+  // --------------- Per-case runners ---------------
+
+  /**
+   * Pre-warms then registers a benchmark case that reads `NUM_ROWS` values via
+   * `updater.readValues`. The Factory is built from the descriptor inside the helper
+   * so its `logicalTypeAnnotation` field always matches the descriptor (production
+   * `VectorizedColumnReader` does the same). The Updater is obtained fresh from the
+   * Factory inside the case body to mirror production (one Updater per batch).
+   * `vector.reset()` clears arrayData for variable-length types so byte storage does
+   * not accumulate.
+   */
+  private def addReadValuesCase(
+      benchmark: Benchmark,
+      label: String,
+      sparkType: DataType,
+      desc: ColumnDescriptor,
+      vector: WritableColumnVector,
+      bytes: Array[Byte],
+      datetimeRebaseMode: String = "CORRECTED",
+      int96RebaseMode: String = "CORRECTED"): Unit = {
+    val fac = factory(desc, datetimeRebaseMode, int96RebaseMode)
+
+    // Pre-warm so the call site is C2-compiled before benchmark.run() measures.
+    vector.reset()
+    val warmUpdater = fac.getUpdater(desc, sparkType)
+    warmUpdater.readValues(NUM_ROWS, 0, vector, newPlainReader(bytes))
+
+    benchmark.addCase(label) { _ =>
+      vector.reset()
+      val u = fac.getUpdater(desc, sparkType)
+      u.readValues(NUM_ROWS, 0, vector, newPlainReader(bytes))
+    }
+  }
+
+  // --------------- Group A: identity Updaters ---------------
+
+  private def runIdentityBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "Identity Updaters", NUM_ROWS.toLong, NUM_ITERS, output = output)
+
+    val intVec = new OnHeapColumnVector(NUM_ROWS, IntegerType)
+    val longVec = new OnHeapColumnVector(NUM_ROWS, LongType)
+    val floatVec = new OnHeapColumnVector(NUM_ROWS, FloatType)
+    val doubleVec = new OnHeapColumnVector(NUM_ROWS, DoubleType)
+    val boolVec = new OnHeapColumnVector(NUM_ROWS, BooleanType)
+    val byteVec = new OnHeapColumnVector(NUM_ROWS, ByteType)
+    val shortVec = new OnHeapColumnVector(NUM_ROWS, ShortType)
+    val binaryVec = new OnHeapColumnVector(NUM_ROWS, BinaryType)
+
+    val intBytes = plainIntBytes(NUM_ROWS)(i => i)
+    val longBytes = plainLongBytes(NUM_ROWS)(_.toLong)
+    val floatBytes = plainFloatBytes(NUM_ROWS)(_.toFloat)
+    val doubleBytes = plainDoubleBytes(NUM_ROWS)(_.toDouble)
+    val boolBytes = plainBooleanBytes(NUM_ROWS)
+    val binaryBytes = plainBinaryBytes(NUM_ROWS, payloadLen = 16)
+
+    addReadValuesCase(benchmark, "BooleanUpdater",
+      BooleanType, descriptor(PrimitiveTypeName.BOOLEAN), boolVec, boolBytes)
+    addReadValuesCase(benchmark, "ByteUpdater (INT32 -> Byte)",
+      ByteType, descriptor(PrimitiveTypeName.INT32), byteVec, intBytes)
+    addReadValuesCase(benchmark, "ShortUpdater (INT32 -> Short)",
+      ShortType, descriptor(PrimitiveTypeName.INT32), shortVec, intBytes)
+    addReadValuesCase(benchmark, "IntegerUpdater",
+      IntegerType, descriptor(PrimitiveTypeName.INT32), intVec, intBytes)
+    addReadValuesCase(benchmark, "LongUpdater",
+      LongType, descriptor(PrimitiveTypeName.INT64), longVec, longBytes)
+    addReadValuesCase(benchmark, "FloatUpdater",
+      FloatType, descriptor(PrimitiveTypeName.FLOAT), floatVec, floatBytes)
+    addReadValuesCase(benchmark, "DoubleUpdater",
+      DoubleType, descriptor(PrimitiveTypeName.DOUBLE), doubleVec, doubleBytes)
+    addReadValuesCase(benchmark, "BinaryUpdater",
+      BinaryType, descriptor(PrimitiveTypeName.BINARY), binaryVec, binaryBytes)
+
+    benchmark.run()
+  }
+
+  // --------------- Group B: type-converting Updaters ---------------
+
+  private def runTypeConvertingBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "Type-converting Updaters", NUM_ROWS.toLong, NUM_ITERS, output = output)
+
+    val longVec = new OnHeapColumnVector(NUM_ROWS, LongType)
+    val doubleVec = new OnHeapColumnVector(NUM_ROWS, DoubleType)
+    val shortDecVec = new OnHeapColumnVector(NUM_ROWS, DecimalType(9, 2))
+
+    val intBytes = plainIntBytes(NUM_ROWS)(i => i)
+    val longBytes = plainLongBytes(NUM_ROWS)(_.toLong)
+    val floatBytes = plainFloatBytes(NUM_ROWS)(_.toFloat)
+
+    addReadValuesCase(benchmark, "IntegerToLongUpdater",
+      LongType, descriptor(PrimitiveTypeName.INT32), longVec, intBytes)
+    addReadValuesCase(benchmark, "IntegerToDoubleUpdater",
+      DoubleType, descriptor(PrimitiveTypeName.INT32), doubleVec, intBytes)
+    addReadValuesCase(benchmark, "FloatToDoubleUpdater",
+      DoubleType, descriptor(PrimitiveTypeName.FLOAT), doubleVec, floatBytes)
+    addReadValuesCase(benchmark, "DateToTimestampNTZUpdater",
+      TimestampNTZType,
+      descriptor(PrimitiveTypeName.INT32, LogicalTypeAnnotation.dateType()),
+      longVec, intBytes)
+    // 32-bit-decimal target with INT64 source routes via canReadAsLongDecimal +
+    // is32BitDecimalType, both TRUE here, hence DowncastLongUpdater.
+    addReadValuesCase(benchmark, "DowncastLongUpdater (INT64 -> Decimal(9,2))",
+      DecimalType(9, 2),
+      descriptor(PrimitiveTypeName.INT64, LogicalTypeAnnotation.decimalType(2, 9)),
+      shortDecVec, longBytes)
+
+    benchmark.run()
+  }
+
+  // --------------- Group C: rebase Updaters ---------------
+
+  private def runRebaseBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "Rebase Updaters", NUM_ROWS.toLong, NUM_ITERS, output = output)
+
+    val intVec = new OnHeapColumnVector(NUM_ROWS, IntegerType)
+    val longVec = new OnHeapColumnVector(NUM_ROWS, LongType)
+
+    // Post-1582 values measure the no-rebase fast path.
+    val intBytes = plainIntBytes(NUM_ROWS)(_ => 18000)
+    val longBytes = plainLongBytes(NUM_ROWS)(_ => 1577836800000000L)
+
+    addReadValuesCase(benchmark, "IntegerWithRebaseUpdater (DATE legacy)",
+      DateType,
+      descriptor(PrimitiveTypeName.INT32, LogicalTypeAnnotation.dateType()),
+      intVec, intBytes,
+      datetimeRebaseMode = "LEGACY")
+    addReadValuesCase(benchmark, "LongWithRebaseUpdater (TIMESTAMP_MICROS legacy)",
+      TimestampType,
+      descriptor(PrimitiveTypeName.INT64,
+        LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS)),
+      longVec, longBytes,
+      datetimeRebaseMode = "LEGACY")
+    addReadValuesCase(benchmark, "LongAsMicrosUpdater (TIMESTAMP_MILLIS)",
+      TimestampType,
+      descriptor(PrimitiveTypeName.INT64,
+        LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS)),
+      longVec, longBytes)
+
+    benchmark.run()
+  }
+
+  // --------------- Group D: unsigned Updaters ---------------
+
+  private def runUnsignedBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "Unsigned Updaters", NUM_ROWS.toLong, NUM_ITERS, output = output)
+
+    val longVec = new OnHeapColumnVector(NUM_ROWS, LongType)
+    val decimalVec = new OnHeapColumnVector(NUM_ROWS, DecimalType(20, 0))
+
+    val intBytes = plainIntBytes(NUM_ROWS)(i => i)
+    val longBytes = plainLongBytes(NUM_ROWS)(_.toLong)
+
+    addReadValuesCase(benchmark, "UnsignedIntegerUpdater (UINT32 -> Long)",
+      LongType,
+      descriptor(PrimitiveTypeName.INT32, LogicalTypeAnnotation.intType(32, false)),
+      longVec, intBytes)
+    addReadValuesCase(benchmark, "UnsignedLongUpdater (UINT64 -> Decimal(20,0))",
+      DecimalType(20, 0),
+      descriptor(PrimitiveTypeName.INT64, LogicalTypeAnnotation.intType(64, false)),
+      decimalVec, longBytes)
+
+    benchmark.run()
+  }
+
+  // --------------- Group E: decimal Updaters ---------------
+
+  private def runDecimalBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "Decimal Updaters", NUM_ROWS.toLong, NUM_ITERS, output = output)
+
+    val shortDecVec = new OnHeapColumnVector(NUM_ROWS, DecimalType(9, 2))
+    val longDecVec = new OnHeapColumnVector(NUM_ROWS, DecimalType(18, 4))
+    // FixedLenByteArrayToDecimal routes when:
+    //   1) scale mismatch (target=4 vs parquet=2) defeats canReadAsLong/Int/BinaryDecimal, and
+    //   2) target precision exceeds parquet precision by at least the scale increase, so
+    //      isDecimalTypeMatched succeeds and canReadAsDecimal is true.
+    // Hence target Decimal(18, 4) with parquet decimalType(scale=2, precision=16):
+    // precisionIncrease=2 >= scaleIncrease=2.
+    val flbaTargetVec = new OnHeapColumnVector(NUM_ROWS, DecimalType(18, 4))
+
+    val intBytes = plainIntBytes(NUM_ROWS)(i => i)
+    val longBytes = plainLongBytes(NUM_ROWS)(_.toLong)
+    val flbaBytes = plainFixedLenBytes(NUM_ROWS, len = 8)
+
+    addReadValuesCase(benchmark, "IntegerToDecimalUpdater",
+      DecimalType(9, 2),
+      descriptor(PrimitiveTypeName.INT32, LogicalTypeAnnotation.decimalType(2, 9)),
+      shortDecVec, intBytes)
+    addReadValuesCase(benchmark, "LongToDecimalUpdater",
+      DecimalType(18, 4),
+      descriptor(PrimitiveTypeName.INT64, LogicalTypeAnnotation.decimalType(4, 18)),
+      longDecVec, longBytes)
+    // BinaryToDecimalUpdater is intentionally not benchmarked. Its `readValue`
+    // implementation uses the target vector as scratch via `putByteArray`, which requires
+    // the vector's `arrayData` child. Targets routed to this Updater have precision <= 18
+    // (DecimalType not byte-array decimal), so the WritableColumnVector constructor does
+    // not allocate `arrayData` and the call NPEs. The path is exercised only when a
+    // BINARY-source column has decimal precision <= 18, which is uncommon enough that
+    // this latent issue has not been a blocker. Skipping until the Updater itself is
+    // fixed to use a separate scratch buffer.
+    addReadValuesCase(benchmark, "FixedLenByteArrayToDecimalUpdater",
+      DecimalType(18, 4),
+      descriptor(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+        LogicalTypeAnnotation.decimalType(2, 16), typeLength = 8),
+      flbaTargetVec, flbaBytes)
+
+    benchmark.run()
+  }
+
+  // --------------- Group F: FixedLenByteArray Updaters ---------------
+
+  private def runFixedLenByteArrayBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "FixedLenByteArray Updaters", NUM_ROWS.toLong, NUM_ITERS, output = output)
+
+    val binaryVec = new OnHeapColumnVector(NUM_ROWS, BinaryType)
+    val shortDecVec = new OnHeapColumnVector(NUM_ROWS, DecimalType(9, 2))
+    val longDecVec = new OnHeapColumnVector(NUM_ROWS, DecimalType(18, 4))
+
+    val flbaBytes16 = plainFixedLenBytes(NUM_ROWS, len = 16)
+    val flbaBytes4 = plainFixedLenBytes(NUM_ROWS, len = 4)
+    val flbaBytes8 = plainFixedLenBytes(NUM_ROWS, len = 8)
+
+    addReadValuesCase(benchmark, "FixedLenByteArrayUpdater (len=16 -> Binary)",
+      BinaryType,
+      descriptor(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, typeLength = 16),
+      binaryVec, flbaBytes16)
+    addReadValuesCase(benchmark, "FixedLenByteArrayAsIntUpdater (len=4 -> Decimal(9,2))",
+      DecimalType(9, 2),
+      descriptor(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+        LogicalTypeAnnotation.decimalType(2, 9), typeLength = 4),
+      shortDecVec, flbaBytes4)
+    addReadValuesCase(benchmark, "FixedLenByteArrayAsLongUpdater (len=8 -> Decimal(18,4))",
+      DecimalType(18, 4),
+      descriptor(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+        LogicalTypeAnnotation.decimalType(4, 18), typeLength = 8),
+      longDecVec, flbaBytes8)
+
+    benchmark.run()
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    runBenchmark("Identity Updaters") { runIdentityBenchmark() }
+    runBenchmark("Type-converting Updaters") { runTypeConvertingBenchmark() }
+    runBenchmark("Rebase Updaters") { runRebaseBenchmark() }
+    runBenchmark("Unsigned Updaters") { runUnsignedBenchmark() }
+    runBenchmark("Decimal Updaters") { runDecimalBenchmark() }
+    runBenchmark("FixedLenByteArray Updaters") { runFixedLenByteArrayBenchmark() }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaReaderBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaReaderBenchmark.scala
@@ -1,0 +1,367 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import java.nio.ByteBuffer
+
+import scala.util.Random
+
+import org.apache.parquet.bytes.{ByteBufferInputStream, DirectByteBufferAllocator}
+import org.apache.parquet.column.values.delta.{DeltaBinaryPackingValuesWriterForInteger, DeltaBinaryPackingValuesWriterForLong}
+import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter
+import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter
+import org.apache.parquet.io.api.Binary
+
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
+import org.apache.spark.sql.types.{BinaryType, ByteType, DecimalType, IntegerType, LongType, ShortType}
+
+/**
+ * Low-level benchmark for the three Parquet delta-encoding decoders:
+ *
+ *   - `VectorizedDeltaBinaryPackedReader` (DELTA_BINARY_PACKED) - default INT32/INT64
+ *     encoding for Parquet v2.
+ *   - `VectorizedDeltaByteArrayReader` (DELTA_BYTE_ARRAY) - prefix+suffix string encoding.
+ *   - `VectorizedDeltaLengthByteArrayReader` (DELTA_LENGTH_BYTE_ARRAY) - length-prefixed
+ *     binary encoding.
+ *
+ * Coverage is intentionally broad - all three readers and their primary read/skip paths
+ * are included so the benchmark suite catches regressions across the full delta-decode
+ * surface, not just paths with an active optimization candidate.
+ *
+ * Groups:
+ *   A. DELTA_BINARY_PACKED INT32 - readIntegers / skipIntegers across value distributions.
+ *   B. DELTA_BINARY_PACKED INT64 - readLongs / skipLongs across value distributions.
+ *   C. DELTA_BYTE_ARRAY - readBinary / skipBinary across prefix-overlap ratios.
+ *   D. DELTA_LENGTH_BYTE_ARRAY - readBinary / skipBinary across payload sizes.
+ *   E. Variant reads - byte/short/unsigned bulk variants of DELTA_BINARY_PACKED, single-
+ *      value reads on all three readers, and skipBytes / skipShorts.
+ *
+ * To run this benchmark:
+ * {{{
+ *   1. build/sbt "sql/Test/runMain <this class>"
+ *   2. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results in "benchmarks/VectorizedDeltaReaderBenchmark-results.txt".
+ *   3. GHA: `Run benchmarks` workflow, class = `*VectorizedDeltaReader*`.
+ * }}}
+ */
+object VectorizedDeltaReaderBenchmark extends BenchmarkBase {
+
+  private val NUM_ROWS = 1024 * 1024
+  private val NUM_ITERS = 5
+  private val BLOCK_SIZE = 128
+  private val MINI_BLOCK_NUM = 4
+  private val PAGE_SIZE = 64 * 1024
+
+  // --------------- Group A: DELTA_BINARY_PACKED INT32 ---------------
+
+  private def encodeDeltaInts(values: Array[Int]): Array[Byte] = {
+    val writer = new DeltaBinaryPackingValuesWriterForInteger(
+      BLOCK_SIZE, MINI_BLOCK_NUM, PAGE_SIZE, PAGE_SIZE, new DirectByteBufferAllocator)
+    var i = 0
+    while (i < values.length) { writer.writeInteger(values(i)); i += 1 }
+    val out = writer.getBytes.toByteArray
+    writer.close()
+    out
+  }
+
+  private def runDeltaIntBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "DELTA_BINARY_PACKED INT32", NUM_ROWS.toLong, NUM_ITERS, output = output)
+    val vec = new OnHeapColumnVector(NUM_ROWS, IntegerType)
+
+    val rng = new Random(42)
+    val distributions: Seq[(String, Array[Int])] = Seq(
+      "constant" -> Array.fill(NUM_ROWS)(0),
+      "monotonic" -> Array.tabulate(NUM_ROWS)(identity),
+      "small-delta random" -> Array.tabulate(NUM_ROWS)(_ => rng.nextInt(256)),
+      "wide random" -> Array.tabulate(NUM_ROWS)(_ => rng.nextInt())
+    )
+
+    distributions.foreach { case (tag, values) =>
+      val bytes = encodeDeltaInts(values)
+
+      // Pre-warm.
+      val warm = new VectorizedDeltaBinaryPackedReader
+      warm.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes)))
+      warm.readIntegers(NUM_ROWS, vec, 0)
+
+      benchmark.addCase(s"readIntegers, $tag") { _ =>
+        val r = new VectorizedDeltaBinaryPackedReader
+        r.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes)))
+        r.readIntegers(NUM_ROWS, vec, 0)
+      }
+
+      benchmark.addCase(s"skipIntegers, $tag") { _ =>
+        val r = new VectorizedDeltaBinaryPackedReader
+        r.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes)))
+        r.skipIntegers(NUM_ROWS)
+      }
+    }
+    benchmark.run()
+  }
+
+  // --------------- Group B: DELTA_BINARY_PACKED INT64 ---------------
+
+  private def encodeDeltaLongs(values: Array[Long]): Array[Byte] = {
+    val writer = new DeltaBinaryPackingValuesWriterForLong(
+      BLOCK_SIZE, MINI_BLOCK_NUM, PAGE_SIZE, PAGE_SIZE, new DirectByteBufferAllocator)
+    var i = 0
+    while (i < values.length) { writer.writeLong(values(i)); i += 1 }
+    val out = writer.getBytes.toByteArray
+    writer.close()
+    out
+  }
+
+  private def runDeltaLongBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "DELTA_BINARY_PACKED INT64", NUM_ROWS.toLong, NUM_ITERS, output = output)
+    val vec = new OnHeapColumnVector(NUM_ROWS, LongType)
+
+    val rng = new Random(42)
+    val distributions: Seq[(String, Array[Long])] = Seq(
+      "constant" -> Array.fill(NUM_ROWS)(0L),
+      "monotonic" -> Array.tabulate(NUM_ROWS)(_.toLong),
+      "small-delta random" -> Array.tabulate(NUM_ROWS)(_ => rng.nextInt(256).toLong),
+      "wide random" -> Array.tabulate(NUM_ROWS)(_ => rng.nextLong())
+    )
+
+    distributions.foreach { case (tag, values) =>
+      val bytes = encodeDeltaLongs(values)
+
+      val warm = new VectorizedDeltaBinaryPackedReader
+      warm.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes)))
+      warm.readLongs(NUM_ROWS, vec, 0)
+
+      benchmark.addCase(s"readLongs, $tag") { _ =>
+        val r = new VectorizedDeltaBinaryPackedReader
+        r.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes)))
+        r.readLongs(NUM_ROWS, vec, 0)
+      }
+
+      benchmark.addCase(s"skipLongs, $tag") { _ =>
+        val r = new VectorizedDeltaBinaryPackedReader
+        r.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes)))
+        r.skipLongs(NUM_ROWS)
+      }
+    }
+    benchmark.run()
+  }
+
+  // --------------- Group C: DELTA_BYTE_ARRAY ---------------
+
+  private def encodeDeltaByteArray(values: Array[Array[Byte]]): Array[Byte] = {
+    val writer = new DeltaByteArrayWriter(PAGE_SIZE, PAGE_SIZE, new DirectByteBufferAllocator)
+    var i = 0
+    while (i < values.length) { writer.writeBytes(Binary.fromConstantByteArray(values(i))); i += 1 }
+    val out = writer.getBytes.toByteArray
+    writer.close()
+    out
+  }
+
+  /**
+   * Generate string-like binaries with `prefixOverlap` chars shared with the previous value
+   * and a random `suffixLen` of new bytes appended. Produces realistic delta-encoder input.
+   */
+  private def generateDeltaByteArrayValues(
+      count: Int, prefixOverlap: Int, suffixLen: Int): Array[Array[Byte]] = {
+    val rng = new Random(42)
+    val values = new Array[Array[Byte]](count)
+    var prev: Array[Byte] = new Array[Byte](0)
+    var i = 0
+    while (i < count) {
+      val keep = math.min(prefixOverlap, prev.length)
+      val v = new Array[Byte](keep + suffixLen)
+      System.arraycopy(prev, 0, v, 0, keep)
+      var j = 0
+      while (j < suffixLen) { v(keep + j) = rng.nextInt().toByte; j += 1 }
+      values(i) = v
+      prev = v
+      i += 1
+    }
+    values
+  }
+
+  private def runDeltaByteArrayBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "DELTA_BYTE_ARRAY", NUM_ROWS.toLong, NUM_ITERS, output = output)
+    val vec = new OnHeapColumnVector(NUM_ROWS, BinaryType)
+
+    val shapes: Seq[(String, Int, Int)] = Seq(
+      ("no overlap, len=16", 0, 16),
+      ("half overlap, len=16", 8, 16),
+      ("full overlap, len=16", 16, 16),
+      ("half overlap, len=64", 32, 64)
+    )
+
+    shapes.foreach { case (tag, prefix, suffix) =>
+      val values = generateDeltaByteArrayValues(NUM_ROWS, prefix, suffix)
+      val bytes = encodeDeltaByteArray(values)
+
+      val warm = ParquetTestAccess.newDeltaByteArrayReader()
+      warm.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes)))
+      vec.reset()
+      warm.readBinary(NUM_ROWS, vec, 0)
+
+      benchmark.addCase(s"readBinary, $tag") { _ =>
+        val r = ParquetTestAccess.newDeltaByteArrayReader()
+        r.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes)))
+        vec.reset() // clear arrayData so payloads do not accumulate across iterations
+        r.readBinary(NUM_ROWS, vec, 0)
+      }
+
+      benchmark.addCase(s"skipBinary, $tag") { _ =>
+        val r = ParquetTestAccess.newDeltaByteArrayReader()
+        r.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes)))
+        r.skipBinary(NUM_ROWS)
+      }
+    }
+    benchmark.run()
+  }
+
+  // --------------- Group D: DELTA_LENGTH_BYTE_ARRAY ---------------
+
+  private def encodeDeltaLengthByteArray(values: Array[Array[Byte]]): Array[Byte] = {
+    val writer = new DeltaLengthByteArrayValuesWriter(
+      PAGE_SIZE, PAGE_SIZE, new DirectByteBufferAllocator)
+    var i = 0
+    while (i < values.length) { writer.writeBytes(Binary.fromConstantByteArray(values(i))); i += 1 }
+    val out = writer.getBytes.toByteArray
+    writer.close()
+    out
+  }
+
+  private def runDeltaLengthByteArrayBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "DELTA_LENGTH_BYTE_ARRAY", NUM_ROWS.toLong, NUM_ITERS, output = output)
+    val vec = new OnHeapColumnVector(NUM_ROWS, BinaryType)
+    val rng = new Random(42)
+
+    val payloadSizes = Seq(8, 32, 128, 512)
+
+    payloadSizes.foreach { len =>
+      val values = Array.tabulate(NUM_ROWS) { _ =>
+        val v = new Array[Byte](len)
+        rng.nextBytes(v)
+        v
+      }
+      val bytes = encodeDeltaLengthByteArray(values)
+
+      val warm = ParquetTestAccess.newDeltaLengthByteArrayReader()
+      warm.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes)))
+      vec.reset()
+      warm.readBinary(NUM_ROWS, vec, 0)
+
+      benchmark.addCase(s"readBinary, payloadLen=$len") { _ =>
+        val r = ParquetTestAccess.newDeltaLengthByteArrayReader()
+        r.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes)))
+        vec.reset()
+        r.readBinary(NUM_ROWS, vec, 0)
+      }
+
+      benchmark.addCase(s"skipBinary, payloadLen=$len") { _ =>
+        val r = ParquetTestAccess.newDeltaLengthByteArrayReader()
+        r.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes)))
+        r.skipBinary(NUM_ROWS)
+      }
+    }
+    benchmark.run()
+  }
+
+  // --------------- Group E: variant reads ---------------
+
+  private def runVariantReadsBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "Variant reads", NUM_ROWS.toLong, NUM_ITERS, output = output)
+
+    val rng = new Random(42)
+    val intValues = Array.tabulate(NUM_ROWS)(_ => rng.nextInt())
+    val longValues = Array.tabulate(NUM_ROWS)(_ => rng.nextLong())
+    val intBytes = encodeDeltaInts(intValues)
+    val longBytes = encodeDeltaLongs(longValues)
+
+    val byteVec = new OnHeapColumnVector(NUM_ROWS, ByteType)
+    val shortVec = new OnHeapColumnVector(NUM_ROWS, ShortType)
+    val longVec = new OnHeapColumnVector(NUM_ROWS, LongType)
+    val unsignedLongVec = new OnHeapColumnVector(NUM_ROWS, DecimalType(20, 0))
+
+    def newIntReader(): VectorizedDeltaBinaryPackedReader = {
+      val r = new VectorizedDeltaBinaryPackedReader
+      r.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(intBytes)))
+      r
+    }
+    def newLongReader(): VectorizedDeltaBinaryPackedReader = {
+      val r = new VectorizedDeltaBinaryPackedReader
+      r.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(longBytes)))
+      r
+    }
+
+    // Bulk byte/short downcasts and unsigned conversions of DELTA_BINARY_PACKED data.
+    benchmark.addCase("readBytes (INT32)") { _ => newIntReader().readBytes(NUM_ROWS, byteVec, 0) }
+    benchmark.addCase("readShorts (INT32)") { _ =>
+      newIntReader().readShorts(NUM_ROWS, shortVec, 0)
+    }
+    benchmark.addCase("readUnsignedIntegers (INT32 -> Long)") { _ =>
+      newIntReader().readUnsignedIntegers(NUM_ROWS, longVec, 0)
+    }
+    benchmark.addCase("readUnsignedLongs (INT64 -> Decimal(20,0))") { _ =>
+      newLongReader().readUnsignedLongs(NUM_ROWS, unsignedLongVec, 0)
+    }
+    benchmark.addCase("skipBytes") { _ => newIntReader().skipBytes(NUM_ROWS) }
+    benchmark.addCase("skipShorts") { _ => newIntReader().skipShorts(NUM_ROWS) }
+
+    // Per-call overhead of single-value reads.
+    benchmark.addCase("readByte (INT32 single-value)") { _ =>
+      val r = newIntReader()
+      var i = 0; while (i < NUM_ROWS) { r.readByte(); i += 1 }
+    }
+    benchmark.addCase("readShort (INT32 single-value)") { _ =>
+      val r = newIntReader()
+      var i = 0; while (i < NUM_ROWS) { r.readShort(); i += 1 }
+    }
+    benchmark.addCase("readInteger (INT32 single-value)") { _ =>
+      val r = newIntReader()
+      var i = 0; while (i < NUM_ROWS) { r.readInteger(); i += 1 }
+    }
+    benchmark.addCase("readLong (INT64 single-value)") { _ =>
+      val r = newLongReader()
+      var i = 0; while (i < NUM_ROWS) { r.readLong(); i += 1 }
+    }
+
+    // Single-value readBinary(len) on DeltaByteArrayReader. Each call returns the
+    // next decoded value reconstructed from prefix/suffix state.
+    val binValues = generateDeltaByteArrayValues(NUM_ROWS, prefixOverlap = 8, suffixLen = 16)
+    val binBytes = encodeDeltaByteArray(binValues)
+    val perRowLen = 8 + 16 // matches the values produced by generateDeltaByteArrayValues
+    benchmark.addCase("readBinary(len) (DELTA_BYTE_ARRAY single-value)") { _ =>
+      val r = ParquetTestAccess.newDeltaByteArrayReader()
+      r.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(binBytes)))
+      var i = 0; while (i < NUM_ROWS) { r.readBinary(perRowLen); i += 1 }
+    }
+    benchmark.run()
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    runBenchmark("DELTA_BINARY_PACKED INT32") { runDeltaIntBenchmark() }
+    runBenchmark("DELTA_BINARY_PACKED INT64") { runDeltaLongBenchmark() }
+    runBenchmark("DELTA_BYTE_ARRAY") { runDeltaByteArrayBenchmark() }
+    runBenchmark("DELTA_LENGTH_BYTE_ARRAY") { runDeltaLengthByteArrayBenchmark() }
+    runBenchmark("Variant reads") { runVariantReadsBenchmark() }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReaderBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReaderBenchmark.scala
@@ -1,0 +1,385 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import java.nio.{ByteBuffer, ByteOrder}
+
+import org.apache.parquet.bytes.ByteBufferInputStream
+
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
+import org.apache.spark.sql.types._
+
+/**
+ * Low-level benchmark for `VectorizedPlainValuesReader`. Measures every public
+ * read/skip method, including paths that are already memcpy-optimal, so the
+ * benchmark suite tracks the long-term performance baseline of the PLAIN decode
+ * surface and is ready for future iterative optimization without first having
+ * to add coverage.
+ *
+ * Groups:
+ *   A. Fixed-size bulk reads - readBooleans, readBytes, readShorts, readIntegers,
+ *      readLongs, readFloats, readDoubles. These are at memcpy speed today;
+ *      kept in the benchmark as regression tracking.
+ *   B. Conversion bulk reads - readUnsignedIntegers, readUnsignedLongs,
+ *      readIntegersWithRebase, readLongsWithRebase. Per-row loops with
+ *      conversion; potential P3-style optimization candidates.
+ *   C. Variable-length - readBinary(total, v, rowId), per-row slice + length
+ *      decode pattern.
+ *   D. Single-value reads - readBoolean, readByte, readShort, readInteger,
+ *      readLong, readFloat, readDouble looped NUM_ROWS times. Measures per-call
+ *      overhead.
+ *   E. Skip paths - skipBooleans, skipBytes, skipShorts, skipIntegers, skipLongs,
+ *      skipFloats, skipDoubles, skipBinary, skipFixedLenByteArray.
+ *
+ * To run this benchmark:
+ * {{{
+ *   1. build/sbt "sql/Test/runMain <this class>"
+ *   2. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results in "benchmarks/VectorizedPlainValuesReaderBenchmark-results.txt".
+ *   3. GHA: `Run benchmarks` workflow, class = `*VectorizedPlainValuesReader*`.
+ * }}}
+ */
+object VectorizedPlainValuesReaderBenchmark extends BenchmarkBase {
+
+  private val NUM_ROWS = 1024 * 1024
+  private val NUM_ITERS = 5
+
+  // Volatile sink to prevent JIT from eliminating skip-only benchmark bodies. Trivial
+  // skip implementations are just `in.skip(N)` (a position increment); without an
+  // observable side effect, escape analysis and dead-code elimination can collapse the
+  // entire `newReader(...).skipX(...)` body to nothing, producing meaningless Infinity
+  // rates. Each skip case reads one byte after the skip and accumulates into `sink`
+  // to anchor the work.
+  @volatile private var sink: Long = 0L
+
+  // Append 8 trailing 0x00 bytes so the post-skip anchoring `readLong()` always has
+  // data to consume even when the skip exhausts the original payload. Plain
+  // single-value reads internally pull 4-8 bytes (e.g., readByte reads via readInteger,
+  // readLong reads 8), so the pad must cover the largest such read.
+  private val SINK_PAD_BYTES = 8
+  private def withTailPad(bytes: Array[Byte]): Array[Byte] = {
+    val out = new Array[Byte](bytes.length + SINK_PAD_BYTES)
+    System.arraycopy(bytes, 0, out, 0, bytes.length)
+    out
+  }
+
+  // --------------- PLAIN-encoded byte producers ---------------
+
+  private def plainIntBytes(count: Int)(f: Int => Int): Array[Byte] = {
+    val buf = ByteBuffer.allocate(count * 4).order(ByteOrder.LITTLE_ENDIAN)
+    var i = 0
+    while (i < count) { buf.putInt(f(i)); i += 1 }
+    buf.array()
+  }
+
+  private def plainLongBytes(count: Int)(f: Int => Long): Array[Byte] = {
+    val buf = ByteBuffer.allocate(count * 8).order(ByteOrder.LITTLE_ENDIAN)
+    var i = 0
+    while (i < count) { buf.putLong(f(i)); i += 1 }
+    buf.array()
+  }
+
+  private def plainFloatBytes(count: Int)(f: Int => Float): Array[Byte] = {
+    val buf = ByteBuffer.allocate(count * 4).order(ByteOrder.LITTLE_ENDIAN)
+    var i = 0
+    while (i < count) { buf.putFloat(f(i)); i += 1 }
+    buf.array()
+  }
+
+  private def plainDoubleBytes(count: Int)(f: Int => Double): Array[Byte] = {
+    val buf = ByteBuffer.allocate(count * 8).order(ByteOrder.LITTLE_ENDIAN)
+    var i = 0
+    while (i < count) { buf.putDouble(f(i)); i += 1 }
+    buf.array()
+  }
+
+  // PLAIN booleans are bit-packed: 8 booleans per byte.
+  private def plainBooleanBytes(count: Int): Array[Byte] = {
+    val byteCount = (count + 7) / 8
+    val out = new Array[Byte](byteCount)
+    var i = 0
+    while (i < count) {
+      if ((i & 1) == 0) out(i / 8) = (out(i / 8) | (1 << (i % 8))).toByte
+      i += 1
+    }
+    out
+  }
+
+  // 4-byte length prefix + payload, repeated.
+  private def plainBinaryBytes(count: Int, payloadLen: Int): Array[Byte] = {
+    val recordLen = 4 + payloadLen
+    val buf = ByteBuffer.allocate(count * recordLen).order(ByteOrder.LITTLE_ENDIAN)
+    val payload = new Array[Byte](payloadLen)
+    var i = 0
+    while (i < count) {
+      buf.putInt(payloadLen)
+      buf.put(payload)
+      i += 1
+    }
+    buf.array()
+  }
+
+  private def newReader(bytes: Array[Byte]): VectorizedPlainValuesReader = {
+    val r = new VectorizedPlainValuesReader
+    r.initFromPage(NUM_ROWS, ByteBufferInputStream.wrap(ByteBuffer.wrap(bytes)))
+    r
+  }
+
+  /** Adds a case that runs `body` after pre-warming the body once. */
+  private def addCase(benchmark: Benchmark, label: String)(body: () => Unit): Unit = {
+    body()
+    benchmark.addCase(label) { _ => body() }
+  }
+
+  // --------------- Group A: fixed-size bulk reads ---------------
+
+  private def runBulkBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "Fixed-size bulk reads", NUM_ROWS.toLong, NUM_ITERS, output = output)
+
+    val intVec = new OnHeapColumnVector(NUM_ROWS, IntegerType)
+    val longVec = new OnHeapColumnVector(NUM_ROWS, LongType)
+    val floatVec = new OnHeapColumnVector(NUM_ROWS, FloatType)
+    val doubleVec = new OnHeapColumnVector(NUM_ROWS, DoubleType)
+    val boolVec = new OnHeapColumnVector(NUM_ROWS, BooleanType)
+    val byteVec = new OnHeapColumnVector(NUM_ROWS, ByteType)
+    val shortVec = new OnHeapColumnVector(NUM_ROWS, ShortType)
+
+    val intBytes = plainIntBytes(NUM_ROWS)(i => i)
+    val longBytes = plainLongBytes(NUM_ROWS)(_.toLong)
+    val floatBytes = plainFloatBytes(NUM_ROWS)(_.toFloat)
+    val doubleBytes = plainDoubleBytes(NUM_ROWS)(_.toDouble)
+    val boolBytes = plainBooleanBytes(NUM_ROWS)
+
+    addCase(benchmark, "readBooleans") { () =>
+      newReader(boolBytes).readBooleans(NUM_ROWS, boolVec, 0)
+    }
+    addCase(benchmark, "readBytes") { () =>
+      newReader(intBytes).readBytes(NUM_ROWS, byteVec, 0)
+    }
+    addCase(benchmark, "readShorts") { () =>
+      newReader(intBytes).readShorts(NUM_ROWS, shortVec, 0)
+    }
+    addCase(benchmark, "readIntegers") { () =>
+      newReader(intBytes).readIntegers(NUM_ROWS, intVec, 0)
+    }
+    addCase(benchmark, "readLongs") { () =>
+      newReader(longBytes).readLongs(NUM_ROWS, longVec, 0)
+    }
+    addCase(benchmark, "readFloats") { () =>
+      newReader(floatBytes).readFloats(NUM_ROWS, floatVec, 0)
+    }
+    addCase(benchmark, "readDoubles") { () =>
+      newReader(doubleBytes).readDoubles(NUM_ROWS, doubleVec, 0)
+    }
+    benchmark.run()
+  }
+
+  // --------------- Group B: conversion bulk reads ---------------
+
+  private def runConversionBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "Conversion bulk reads", NUM_ROWS.toLong, NUM_ITERS, output = output)
+
+    val longVec = new OnHeapColumnVector(NUM_ROWS, LongType)
+    val intVec = new OnHeapColumnVector(NUM_ROWS, IntegerType)
+    val tsVec = new OnHeapColumnVector(NUM_ROWS, TimestampType)
+    // readUnsignedLongs stores UINT64 values via putByteArray into arrayData(), so the
+    // target vector must be a byte-array decimal (precision > 18) for arrayData to be
+    // allocated. Decimal(20, 0) is the canonical UINT64 mapping in production.
+    val uint64DecVec = new OnHeapColumnVector(NUM_ROWS, DecimalType(20, 0))
+
+    val intBytes = plainIntBytes(NUM_ROWS)(i => i)
+    val longBytes = plainLongBytes(NUM_ROWS)(_.toLong)
+
+    // UINT32 -> Long via readUnsignedIntegers (per-row loop in the reader).
+    addCase(benchmark, "readUnsignedIntegers") { () =>
+      newReader(intBytes).readUnsignedIntegers(NUM_ROWS, longVec, 0)
+    }
+
+    // UINT64 -> Decimal(20, 0) via readUnsignedLongs (per-row loop).
+    addCase(benchmark, "readUnsignedLongs") { () =>
+      uint64DecVec.reset() // clear arrayData so payloads do not accumulate across iterations
+      newReader(longBytes).readUnsignedLongs(NUM_ROWS, uint64DecVec, 0)
+    }
+
+    // DATE legacy rebase. Use values that don't trigger rebase to measure the no-rebase
+    // fast path; failIfRebase=false is the common production setting.
+    val safeDateBytes = plainIntBytes(NUM_ROWS)(_ => 18000)
+    addCase(benchmark, "readIntegersWithRebase, no rebase needed") { () =>
+      newReader(safeDateBytes).readIntegersWithRebase(NUM_ROWS, intVec, 0, false)
+    }
+
+    // TIMESTAMP_MICROS legacy rebase, no-rebase values.
+    val safeTsBytes = plainLongBytes(NUM_ROWS)(_ => 1577836800000000L)
+    addCase(benchmark, "readLongsWithRebase, no rebase needed") { () =>
+      newReader(safeTsBytes).readLongsWithRebase(NUM_ROWS, tsVec, 0, false, "UTC")
+    }
+
+    benchmark.run()
+  }
+
+  // --------------- Group C: variable-length reads ---------------
+
+  private def runVariableLengthBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "Variable-length reads", NUM_ROWS.toLong, NUM_ITERS, output = output)
+
+    val binaryVec = new OnHeapColumnVector(NUM_ROWS, BinaryType)
+
+    Seq(8, 32, 128, 512).foreach { payloadLen =>
+      val bytes = plainBinaryBytes(NUM_ROWS, payloadLen)
+      addCase(benchmark, s"readBinary, payloadLen=$payloadLen") { () =>
+        binaryVec.reset() // clear arrayData so payloads do not accumulate across iterations
+        newReader(bytes).readBinary(NUM_ROWS, binaryVec, 0)
+      }
+    }
+    benchmark.run()
+  }
+
+  // --------------- Group D: single-value reads ---------------
+
+  private def runSingleValueBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "Single-value reads", NUM_ROWS.toLong, NUM_ITERS, output = output)
+
+    val intBytes = plainIntBytes(NUM_ROWS)(i => i)
+    val longBytes = plainLongBytes(NUM_ROWS)(_.toLong)
+    val floatBytes = plainFloatBytes(NUM_ROWS)(_.toFloat)
+    val doubleBytes = plainDoubleBytes(NUM_ROWS)(_.toDouble)
+    val boolBytes = plainBooleanBytes(NUM_ROWS)
+
+    addCase(benchmark, "readBoolean") { () =>
+      val r = newReader(boolBytes)
+      var j = 0
+      while (j < NUM_ROWS) { r.readBoolean(); j += 1 }
+    }
+    addCase(benchmark, "readByte") { () =>
+      val r = newReader(intBytes)
+      var j = 0
+      while (j < NUM_ROWS) { r.readByte(); j += 1 }
+    }
+    addCase(benchmark, "readShort") { () =>
+      val r = newReader(intBytes)
+      var j = 0
+      while (j < NUM_ROWS) { r.readShort(); j += 1 }
+    }
+    addCase(benchmark, "readInteger") { () =>
+      val r = newReader(intBytes)
+      var j = 0
+      while (j < NUM_ROWS) { r.readInteger(); j += 1 }
+    }
+    addCase(benchmark, "readLong") { () =>
+      val r = newReader(longBytes)
+      var j = 0
+      while (j < NUM_ROWS) { r.readLong(); j += 1 }
+    }
+    addCase(benchmark, "readFloat") { () =>
+      val r = newReader(floatBytes)
+      var j = 0
+      while (j < NUM_ROWS) { r.readFloat(); j += 1 }
+    }
+    addCase(benchmark, "readDouble") { () =>
+      val r = newReader(doubleBytes)
+      var j = 0
+      while (j < NUM_ROWS) { r.readDouble(); j += 1 }
+    }
+    benchmark.run()
+  }
+
+  // --------------- Group E: skip paths ---------------
+
+  private def runSkipBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "Skip", NUM_ROWS.toLong, NUM_ITERS, output = output)
+
+    // Pad each input by 1 byte so the post-skip readByte() anchors a side effect
+    // and prevents JIT from eliding the skip body.
+    val intBytes = withTailPad(plainIntBytes(NUM_ROWS)(i => i))
+    val longBytes = withTailPad(plainLongBytes(NUM_ROWS)(_.toLong))
+    val floatBytes = withTailPad(plainFloatBytes(NUM_ROWS)(_.toFloat))
+    val doubleBytes = withTailPad(plainDoubleBytes(NUM_ROWS)(_.toDouble))
+    val boolBytes = withTailPad(plainBooleanBytes(NUM_ROWS))
+
+    Seq(8, 32, 128, 512).foreach { payloadLen =>
+      val bytes = withTailPad(plainBinaryBytes(NUM_ROWS, payloadLen))
+      addCase(benchmark, s"skipBinary, payloadLen=$payloadLen") { () =>
+        val r = newReader(bytes)
+        r.skipBinary(NUM_ROWS)
+        sink += r.readLong()
+      }
+    }
+
+    Seq(4, 16, 64).foreach { len =>
+      val bytes = withTailPad(new Array[Byte](NUM_ROWS * len))
+      addCase(benchmark, s"skipFixedLenByteArray, len=$len") { () =>
+        val r = newReader(bytes)
+        r.skipFixedLenByteArray(NUM_ROWS, len)
+        sink += r.readLong()
+      }
+    }
+
+    addCase(benchmark, "skipBooleans") { () =>
+      val r = newReader(boolBytes)
+      r.skipBooleans(NUM_ROWS)
+      sink += r.readLong()
+    }
+    addCase(benchmark, "skipBytes") { () =>
+      val r = newReader(intBytes)
+      r.skipBytes(NUM_ROWS)
+      sink += r.readLong()
+    }
+    addCase(benchmark, "skipShorts") { () =>
+      val r = newReader(intBytes)
+      r.skipShorts(NUM_ROWS)
+      sink += r.readLong()
+    }
+    addCase(benchmark, "skipIntegers") { () =>
+      val r = newReader(intBytes)
+      r.skipIntegers(NUM_ROWS)
+      sink += r.readLong()
+    }
+    addCase(benchmark, "skipLongs") { () =>
+      val r = newReader(longBytes)
+      r.skipLongs(NUM_ROWS)
+      sink += r.readLong()
+    }
+    addCase(benchmark, "skipFloats") { () =>
+      val r = newReader(floatBytes)
+      r.skipFloats(NUM_ROWS)
+      sink += r.readLong()
+    }
+    addCase(benchmark, "skipDoubles") { () =>
+      val r = newReader(doubleBytes)
+      r.skipDoubles(NUM_ROWS)
+      sink += r.readLong()
+    }
+
+    benchmark.run()
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    runBenchmark("Fixed-size bulk reads") { runBulkBenchmark() }
+    runBenchmark("Conversion bulk reads") { runConversionBenchmark() }
+    runBenchmark("Variable-length reads") { runVariableLengthBenchmark() }
+    runBenchmark("Single-value reads") { runSingleValueBenchmark() }
+    runBenchmark("Skip") { runSkipBenchmark() }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReaderBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReaderBenchmark.scala
@@ -18,6 +18,8 @@
 package org.apache.spark.sql.execution.datasources.parquet
 
 import java.nio.ByteBuffer
+import java.util.PrimitiveIterator
+import java.util.stream.LongStream
 
 import scala.util.Random
 
@@ -40,6 +42,20 @@ import org.apache.spark.sql.types.{BooleanType, IntegerType}
  *      path used when the caller needs materialized definition levels (e.g., nested columns).
  *   D. readBatch nullable without def-level materialization -- the `readBatchInternal` path used
  *      for flat nullable columns where only null/non-null disposition matters.
+ *   E. readBatch with row-index filtering -- exercises the with-filter code path through
+ *      `readBatchInternal{WithDefLevels}`'s range checks when Parquet column-index filtering is
+ *      active. Sweep over two filter shapes (single contiguous range, alternating windows) and
+ *      the same null ratios as C/D.
+ *   F. Single-value reads -- per-call overhead of `readBoolean`, `readInteger`,
+ *      `readValueDictionaryId` looped NUM_ROWS times. Establishes baseline against the bulk
+ *      Group A/B paths.
+ *   G. skipBooleans / skipIntegers -- forward-skip path used by row-index filtering and
+ *      pushdown. RLE + PACKED across the same parameter sweeps as A/B.
+ *
+ * Not yet covered (deferred): `readBatchRepeated` and `readIntegersRepeated` for nested
+ * columns require setting up a `ParquetReadState` with `maxRepetitionLevel > 0`, a separate
+ * def-levels reader, and encoded rep-level streams; better added together with the matching
+ * suite-level coverage in a focused follow-up.
  *
  * Cold = fresh reader per iteration (exercises cold `currentBuffer` growth).
  * Reused = reader pre-warmed outside the timed region; inside is only `initFromPage` + read.
@@ -68,10 +84,24 @@ object VectorizedRleValuesReaderBenchmark extends BenchmarkBase {
   // --------------- ReadState helpers (delegate to shared reflection bridge) ---------------
 
   private def newReadState(maxDef: Int, valuesInPage: Int): AnyRef = {
-    val state = ParquetReadStateTestAccess.newState(
+    val state = ParquetTestAccess.newState(
       intColumnDescriptor(maxDef), maxDef == 0)
-    ParquetReadStateTestAccess.resetForNewBatch(state, BATCH_SIZE)
-    ParquetReadStateTestAccess.resetForNewPage(state, valuesInPage, 0L)
+    ParquetTestAccess.resetForNewBatch(state, BATCH_SIZE)
+    ParquetTestAccess.resetForNewPage(state, valuesInPage, 0L)
+    state
+  }
+
+  // State variant with a fresh row-index iterator. `rowRanges` inside ParquetReadState is
+  // iterated forward and never reset, so Group E measurements must construct a new state per
+  // benchmark iteration. The iterator is built from `indexFactory` on each call.
+  private def newReadStateWithRowIndexes(
+      maxDef: Int,
+      valuesInPage: Int,
+      indexFactory: () => PrimitiveIterator.OfLong): AnyRef = {
+    val state = ParquetTestAccess.newState(
+      intColumnDescriptor(maxDef), maxDef == 0, indexFactory())
+    ParquetTestAccess.resetForNewBatch(state, BATCH_SIZE)
+    ParquetTestAccess.resetForNewPage(state, valuesInPage, 0L)
     state
   }
 
@@ -258,7 +288,7 @@ object VectorizedRleValuesReaderBenchmark extends BenchmarkBase {
           benchmark.addCase(
               f"nullRatio=${nullRatio}%.1f, $clusterTag") { _ =>
             reader.initFromPage(NUM_ROWS, toInputStream(bytes))
-            ParquetReadStateTestAccess.resetForNewPage(
+            ParquetTestAccess.resetForNewPage(
               state, NUM_ROWS, 0L)
             runBatches(reader, state, values, defLevelsVec, factory())
           }
@@ -277,11 +307,186 @@ object VectorizedRleValuesReaderBenchmark extends BenchmarkBase {
     var produced = 0
     while (produced < NUM_ROWS) {
       val toRead = math.min(BATCH_SIZE, NUM_ROWS - produced)
-      ParquetReadStateTestAccess.resetForNewBatch(state, toRead)
-      ParquetReadStateTestAccess.readBatch(
+      ParquetTestAccess.resetForNewBatch(state, toRead)
+      ParquetTestAccess.readBatch(
         reader, state, values, defLevelsVec, valueReader, integerUpdater)
       produced += toRead
     }
+  }
+
+  // --------------- Group E: readBatch with row-index filtering ---------------
+
+  /** Kept row indices: contiguous range `[keptStart, keptStart + keptCount)`. */
+  private def contiguousIndexFactory(
+      keptStart: Long,
+      keptCount: Long): () => PrimitiveIterator.OfLong =
+    () => LongStream.range(keptStart, keptStart + keptCount).iterator()
+
+  /** Kept row indices: every other `windowSize`-row window starting at index 0. */
+  private def alternatingWindowsIndexFactory(
+      totalRows: Long,
+      windowSize: Long): () => PrimitiveIterator.OfLong = { () =>
+    new PrimitiveIterator.OfLong {
+      private var i = 0L
+      override def hasNext: Boolean = i < totalRows
+      override def nextLong(): Long = {
+        // Advance through only the "kept" windows. Window k in [k*windowSize, (k+1)*windowSize)
+        // is kept when k is even.
+        while ((i / windowSize) % 2 != 0 && i < totalRows) i += 1
+        if (i >= totalRows) throw new NoSuchElementException
+        val out = i
+        i += 1
+        out
+      }
+    }
+  }
+
+  private def runRowRangeFilterBenchmark(
+      label: String,
+      buildValueReader: Int => ValueReaderFactory,
+      materializeDefLevels: Boolean): Unit = {
+    val benchmark = new Benchmark(
+      label, NUM_ROWS.toLong, NUM_ITERS, output = output)
+    val values = new OnHeapColumnVector(NUM_ROWS, IntegerType)
+    val defLevelsVec: WritableColumnVector =
+      if (materializeDefLevels) new OnHeapColumnVector(NUM_ROWS, IntegerType)
+      else null
+
+    // One contiguous range covering the middle 50% of rows; and alternating 1000-row windows
+    // (50% kept, but with many skip/read transitions inside each batch).
+    val filterShapes: Seq[(String, () => PrimitiveIterator.OfLong)] = Seq(
+      "contiguous 50%" -> contiguousIndexFactory(NUM_ROWS / 4L, NUM_ROWS / 2L),
+      "alt 1000-row windows" -> alternatingWindowsIndexFactory(NUM_ROWS.toLong, 1000L)
+    )
+
+    val nullRatios = Seq(0.0, 0.3, 0.9)
+
+    filterShapes.foreach { case (shapeTag, indexFactory) =>
+      nullRatios.foreach { nullRatio =>
+        val defLevels =
+          packedFriendlyDefLevels(NUM_ROWS, nullRatio, clustered = false)
+        val nonNullCount = defLevels.count(_ == 1)
+        val bytes = encodeRle(defLevels, bitWidth = 1)
+        val factory = buildValueReader(nonNullCount)
+
+        // Pre-warm the full pipeline with a fresh state so JIT has seen the with-filter path.
+        val reader = new VectorizedRleValuesReader(1, false)
+        reader.initFromPage(NUM_ROWS, toInputStream(bytes))
+        val warmState =
+          newReadStateWithRowIndexes(maxDef = 1, valuesInPage = NUM_ROWS, indexFactory)
+        runBatches(reader, warmState, values, defLevelsVec, factory())
+
+        benchmark.addCase(
+            f"nullRatio=${nullRatio}%.1f, $shapeTag") { _ =>
+          reader.initFromPage(NUM_ROWS, toInputStream(bytes))
+          // `rowRanges` in ParquetReadState is iterated forward and not reset by
+          // resetForNewPage/Batch, so we must construct a fresh state per measurement
+          // iteration. Iterator construction cost is small compared to decoding NUM_ROWS.
+          val state =
+            newReadStateWithRowIndexes(maxDef = 1, valuesInPage = NUM_ROWS, indexFactory)
+          runBatches(reader, state, values, defLevelsVec, factory())
+        }
+      }
+    }
+    benchmark.run()
+  }
+
+  // --------------- Group F: single-value reads ---------------
+
+  private def runSingleValueBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "Single-value reads", NUM_ROWS.toLong, NUM_ITERS, output = output)
+
+    // Boolean - bitWidth=1, alternating values (forces PACKED).
+    val boolBytes = encodeRle(packedFriendlyBooleans(NUM_ROWS, 0.5), bitWidth = 1)
+    val boolWarm = new VectorizedRleValuesReader(1, false)
+    boolWarm.initFromPage(NUM_ROWS, toInputStream(boolBytes))
+    var i = 0
+    while (i < NUM_ROWS) { boolWarm.readBoolean(); i += 1 }
+
+    benchmark.addCase("readBoolean") { _ =>
+      val r = new VectorizedRleValuesReader(1, false)
+      r.initFromPage(NUM_ROWS, toInputStream(boolBytes))
+      var j = 0
+      while (j < NUM_ROWS) { r.readBoolean(); j += 1 }
+    }
+
+    // readInteger / readValueDictionaryId across bitWidths. Use random PACKED data so each
+    // call reads a fresh value (RLE-only data would short-circuit too aggressively).
+    Seq(4, 8, 12, 20).foreach { bitWidth =>
+      val bytes = encodeRle(packedFriendlyDictIds(NUM_ROWS, bitWidth), bitWidth)
+
+      val warmInt = new VectorizedRleValuesReader(bitWidth, false)
+      warmInt.initFromPage(NUM_ROWS, toInputStream(bytes))
+      var k = 0
+      while (k < NUM_ROWS) { warmInt.readInteger(); k += 1 }
+
+      benchmark.addCase(s"readInteger, bitWidth=$bitWidth") { _ =>
+        val r = new VectorizedRleValuesReader(bitWidth, false)
+        r.initFromPage(NUM_ROWS, toInputStream(bytes))
+        var j = 0
+        while (j < NUM_ROWS) { r.readInteger(); j += 1 }
+      }
+
+      benchmark.addCase(s"readValueDictionaryId, bitWidth=$bitWidth") { _ =>
+        val r = new VectorizedRleValuesReader(bitWidth, false)
+        r.initFromPage(NUM_ROWS, toInputStream(bytes))
+        var j = 0
+        while (j < NUM_ROWS) { r.readValueDictionaryId(); j += 1 }
+      }
+    }
+    benchmark.run()
+  }
+
+  // --------------- Group G: skip paths ---------------
+
+  private def runSkipBenchmark(): Unit = {
+    val benchmark = new Benchmark(
+      "Skip", NUM_ROWS.toLong, NUM_ITERS, output = output)
+
+    // skipBooleans across the same true-ratio sweep as Group A.
+    Seq(0.0, 0.5, 1.0).foreach { trueRatio =>
+      val bytes = encodeRle(
+        packedFriendlyBooleans(NUM_ROWS, trueRatio), bitWidth = 1)
+
+      val warm = new VectorizedRleValuesReader(1, false)
+      warm.initFromPage(NUM_ROWS, toInputStream(bytes))
+      warm.skipBooleans(NUM_ROWS)
+
+      benchmark.addCase(f"skipBooleans, trueRatio=${trueRatio}%.1f") { _ =>
+        val r = new VectorizedRleValuesReader(1, false)
+        r.initFromPage(NUM_ROWS, toInputStream(bytes))
+        r.skipBooleans(NUM_ROWS)
+      }
+    }
+
+    // skipIntegers across the same bitWidth sweep as Group B; PACKED + RLE shapes.
+    Seq(4, 8, 12, 20).foreach { bitWidth =>
+      val packedBytes = encodeRle(
+        packedFriendlyDictIds(NUM_ROWS, bitWidth), bitWidth)
+      val rleBytes = encodeRle(Array.fill(NUM_ROWS)(0), bitWidth)
+
+      val warmPacked = new VectorizedRleValuesReader(bitWidth, false)
+      warmPacked.initFromPage(NUM_ROWS, toInputStream(packedBytes))
+      warmPacked.skipIntegers(NUM_ROWS)
+
+      benchmark.addCase(s"skipIntegers PACKED, bitWidth=$bitWidth") { _ =>
+        val r = new VectorizedRleValuesReader(bitWidth, false)
+        r.initFromPage(NUM_ROWS, toInputStream(packedBytes))
+        r.skipIntegers(NUM_ROWS)
+      }
+
+      val warmRle = new VectorizedRleValuesReader(bitWidth, false)
+      warmRle.initFromPage(NUM_ROWS, toInputStream(rleBytes))
+      warmRle.skipIntegers(NUM_ROWS)
+
+      benchmark.addCase(s"skipIntegers RLE, bitWidth=$bitWidth") { _ =>
+        val r = new VectorizedRleValuesReader(bitWidth, false)
+        r.initFromPage(NUM_ROWS, toInputStream(rleBytes))
+        r.skipIntegers(NUM_ROWS)
+      }
+    }
+    benchmark.run()
   }
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
@@ -302,6 +507,24 @@ object VectorizedRleValuesReaderBenchmark extends BenchmarkBase {
         "Nullable batch without def-levels",
         plainIntFactory,
         materializeDefLevels = false)
+    }
+    runBenchmark("Nullable batch decode with row-index filtering (with def-levels)") {
+      runRowRangeFilterBenchmark(
+        "Nullable batch with def-levels, row-index filtered",
+        plainIntFactory,
+        materializeDefLevels = true)
+    }
+    runBenchmark("Nullable batch decode with row-index filtering (without def-levels)") {
+      runRowRangeFilterBenchmark(
+        "Nullable batch without def-levels, row-index filtered",
+        plainIntFactory,
+        materializeDefLevels = false)
+    }
+    runBenchmark("Single-value reads") {
+      runSingleValueBenchmark()
+    }
+    runBenchmark("Skip") {
+      runSkipBenchmark()
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReaderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReaderSuite.scala
@@ -158,8 +158,8 @@ private object VectorizedRleValuesReaderSuite {
     val valueReader = new VectorizedPlainValuesReader
     valueReader.initFromPage(
       nonNullCount, ByteBufferInputStream.wrap(ByteBuffer.wrap(plainBytes)))
-    val state = ParquetReadStateTestAccess.newState(intColumnDescriptor(maxDef), maxDef == 0)
-    ParquetReadStateTestAccess.resetForNewPage(state, n, 0L)
+    val state = ParquetTestAccess.newState(intColumnDescriptor(maxDef), maxDef == 0)
+    ParquetTestAccess.resetForNewPage(state, n, 0L)
 
     var produced = 0
     var expectedValueIdx = 0
@@ -167,9 +167,9 @@ private object VectorizedRleValuesReaderSuite {
       val toRead = math.min(batchSize, n - produced)
       val values = new OnHeapColumnVector(toRead, IntegerType)
       val defLevelsVec = new OnHeapColumnVector(toRead, IntegerType)
-      ParquetReadStateTestAccess.resetForNewBatch(state, toRead)
+      ParquetTestAccess.resetForNewBatch(state, toRead)
       val defLevelsArg: WritableColumnVector = if (withDefLevels) defLevelsVec else null
-      ParquetReadStateTestAccess.readBatch(
+      ParquetTestAccess.readBatch(
         reader, state, values, defLevelsArg, valueReader, integerUpdater)
 
       var expectedNullsInBatch = 0
@@ -223,14 +223,14 @@ private object VectorizedRleValuesReaderSuite {
     val valueReader = new VectorizedPlainValuesReader
     valueReader.initFromPage(
       nonNullCount, ByteBufferInputStream.wrap(ByteBuffer.wrap(plainBytes)))
-    val state = ParquetReadStateTestAccess.newState(
+    val state = ParquetTestAccess.newState(
       intColumnDescriptor(maxDef), maxDef == 0, longIterator(includedPositions))
-    ParquetReadStateTestAccess.resetForNewPage(state, n, 0L)
+    ParquetTestAccess.resetForNewPage(state, n, 0L)
 
     val size = includedPositions.length
     val values = new OnHeapColumnVector(size, IntegerType)
-    ParquetReadStateTestAccess.resetForNewBatch(state, size)
-    ParquetReadStateTestAccess.readBatch(reader, state, values, null, valueReader, integerUpdater)
+    ParquetTestAccess.resetForNewBatch(state, size)
+    ParquetTestAccess.readBatch(reader, state, values, null, valueReader, integerUpdater)
 
     val prefixNonNulls = defLevels.scanLeft(0) { (c, d) =>
       c + (if (d == maxDef) 1 else 0)
@@ -262,7 +262,7 @@ private object VectorizedRleValuesReaderSuite {
     val bitWidth = if (maxDef == 0) 0 else 32 - Integer.numberOfLeadingZeros(maxDef)
     val reader = new VectorizedRleValuesReader(bitWidth, false)
     val state =
-      ParquetReadStateTestAccess.newState(intColumnDescriptor(maxDef), maxDef == 0)
+      ParquetTestAccess.newState(intColumnDescriptor(maxDef), maxDef == 0)
 
     var pageFirstRow = 0L
     pages.foreach { pageDefLevels =>
@@ -275,15 +275,15 @@ private object VectorizedRleValuesReaderSuite {
       val valueReader = new VectorizedPlainValuesReader
       valueReader.initFromPage(
         nonNullCount, ByteBufferInputStream.wrap(ByteBuffer.wrap(plainBytes)))
-      ParquetReadStateTestAccess.resetForNewPage(state, pageN, pageFirstRow)
+      ParquetTestAccess.resetForNewPage(state, pageN, pageFirstRow)
 
       var produced = 0
       var expectedValueIdx = 0
       while (produced < pageN) {
         val toRead = math.min(batchSize, pageN - produced)
         val values = new OnHeapColumnVector(toRead, IntegerType)
-        ParquetReadStateTestAccess.resetForNewBatch(state, toRead)
-        ParquetReadStateTestAccess.readBatch(
+        ParquetTestAccess.resetForNewBatch(state, toRead)
+        ParquetTestAccess.readBatch(
           reader, state, values, null, valueReader, integerUpdater)
 
         var i = 0


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add benchmark coverage for the Parquet vectorized-read decode surface that has none today, plus extend the existing `VectorizedRleValuesReaderBenchmark` to its full public API:

- **`ParquetVectorUpdaterBenchmark`** (new) — every `ParquetVectorUpdater` family obtained through `ParquetVectorUpdaterFactory.getUpdater`. Six groups: identity, type-converting, rebase, unsigned, decimal, FixedLenByteArray.
- **`VectorizedDeltaReaderBenchmark`** (new) — all three delta decoders (`VectorizedDeltaBinaryPackedReader`, `VectorizedDeltaByteArrayReader`, `VectorizedDeltaLengthByteArrayReader`). Five groups covering bulk read/skip across value distributions and prefix-overlap shapes, plus single-value reads and byte/short/unsigned variants.
- **`VectorizedPlainValuesReaderBenchmark`** (new) — every public read/skip method on `VectorizedPlainValuesReader`. Five groups: fixed-size bulk, conversion bulk (unsigned, with-rebase), variable-length, single-value, skip.
- **`VectorizedRleValuesReaderBenchmark`** (extended) — three new groups: row-index-filtered reads (with-filter code path), single-value reads, skip paths.

### Why are the changes needed?

`ParquetVectorUpdater` and the delta / plain decoders sit on the hot path of every Parquet column read but have no in-repo benchmark coverage. Coverage is intentionally broad — every public read/skip method is included even when it's already memcpy-optimal — so the result files track the long-term performance baseline and future iterative optimization does not have to add benchmark coverage as a precursor.


### Does this PR introduce _any_ user-facing change?
No. 

### How was this patch tested?
- Pass Github Actions


### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code
