### PR TITLE
[MINOR][PS][DOCS] Replace curly quotes with ASCII in pandas-on-Spark index comments

### DIFF
--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -872,7 +872,7 @@ class Index(IndexOpsMixin):
         with ps.option_context("compute.default_index_type", "distributed"):
             # The attached index caused by `reset_index` below is used for sorting only,
             # and it will be dropped soon,
-            # so we enforce “distributed” default index type
+            # so we enforce "distributed" default index type
             psser = self.to_series().reset_index(drop=True)
         return Index(psser.drop_duplicates(keep=keep).sort_index())
 

--- a/python/pyspark/pandas/indexes/datetimes.py
+++ b/python/pyspark/pandas/indexes/datetimes.py
@@ -806,7 +806,7 @@ class DatetimeIndex(Index):
         psdf = psdf.pandas_on_spark.attach_id_column("distributed-sequence", id_column_name)
         with ps.option_context("compute.default_index_type", "distributed"):
             # The attached index in the statement below will be dropped soon,
-            # so we enforce “distributed” default index type
+            # so we enforce "distributed" default index type
             psdf = psdf.pandas_on_spark.apply_batch(pandas_between_time)
         return ps.Index(first_series(psdf).rename(self.name))
 
@@ -851,7 +851,7 @@ class DatetimeIndex(Index):
         psdf = psdf.pandas_on_spark.attach_id_column("distributed-sequence", id_column_name)
         with ps.option_context("compute.default_index_type", "distributed"):
             # The attached index in the statement below will be dropped soon,
-            # so we enforce “distributed” default index type
+            # so we enforce "distributed" default index type
             psdf = psdf.pandas_on_spark.apply_batch(pandas_at_time)
         return ps.Index(first_series(psdf).rename(self.name))
 

--- a/python/pyspark/pandas/indexes/multi.py
+++ b/python/pyspark/pandas/indexes/multi.py
@@ -961,7 +961,7 @@ class MultiIndex(Index):
         with ps.option_context("compute.default_index_type", "distributed"):
             # The attached index caused by `reset_index` below is used for sorting only,
             # and it will be dropped soon,
-            # so we enforce “distributed” default index type
+            # so we enforce "distributed" default index type
             psdf = self.to_frame().reset_index(drop=True)
         return ps.MultiIndex.from_frame(psdf.drop_duplicates(keep=keep).sort_index())
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replaces left/right curly double quotes (U+201C/U+201D) with ASCII double quotes (U+0022) in four identical comments in pandas-on-Spark index modules:

- `python/pyspark/pandas/indexes/datetimes.py` (2 sites)
- `python/pyspark/pandas/indexes/multi.py`
- `python/pyspark/pandas/indexes/base.py`

Each comment reads `# so we enforce "distributed" default index type`.

### Why are the changes needed?

The project convention is ASCII-only in code and comments; typographic quotes are a common slip and were flagged by `grep -P "[^\x00-\x7F]"`.

### Does this PR introduce _any_ user-facing change?

No. Comment-only change.

### How was this patch tested?

No tests. The change is comment-only and produces an empty AST diff. Verified `grep -P "[^\x00-\x7F]"` no longer reports the four sites.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (model: claude-opus-4-7)