### PR TITLE
[SPARK-56634][PYTHON][TESTS] Enable and fix pyspark.sql.tests.connect.test_session

### DIFF
--- a/python/pyspark/sql/tests/connect/test_session.py
+++ b/python/pyspark/sql/tests/connect/test_session.py
@@ -104,3 +104,9 @@ class SparkSessionTestCase(unittest.TestCase):
         s3 = RemoteSparkSession.builder.remote("sc://other").getOrCreate()
 
         self.assertIsNot(s1, s3)
+
+
+if __name__ == "__main__":
+    from pyspark.testing import main
+
+    main()

--- a/python/pyspark/sql/tests/connect/test_session.py
+++ b/python/pyspark/sql/tests/connect/test_session.py
@@ -52,6 +52,8 @@ class SparkSessionTestCase(unittest.TestCase):
             CustomChannelBuilder("sc://other")
         ).getOrCreate()
         host = test_session.client.host
+        # Skip release_session() since "sc://other" is a fake remote.
+        test_session.release_session_on_close = False
         test_session.stop()
 
         self.assertEqual("other", host)
@@ -59,12 +61,14 @@ class SparkSessionTestCase(unittest.TestCase):
     def test_creates_session_with_remote(self):
         test_session = RemoteSparkSession.builder.remote("sc://other").getOrCreate()
         host = test_session.client.host
+        test_session.release_session_on_close = False
         test_session.stop()
 
         self.assertEqual("other", host)
 
     def test_session_stop(self):
         session = RemoteSparkSession.builder.remote("sc://other").getOrCreate()
+        session.release_session_on_close = False
 
         self.assertFalse(session.is_stopped)
         session.stop()
@@ -75,6 +79,7 @@ class SparkSessionTestCase(unittest.TestCase):
         session2 = RemoteSparkSession.builder.remote("sc://other").getOrCreate()
 
         self.assertIs(session, session2)
+        session.release_session_on_close = False
         session.stop()
 
     def test_active_session_expires_when_client_closes(self):

--- a/python/pyspark/sql/tests/connect/test_session.py
+++ b/python/pyspark/sql/tests/connect/test_session.py
@@ -35,6 +35,11 @@ if should_test_connect:
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class SparkSessionTestCase(unittest.TestCase):
+    def setUp(self):
+        # Reset class-level session state so tests are order-independent.
+        RemoteSparkSession._default_session = None
+        RemoteSparkSession._active_session.session = None
+
     def test_fails_to_create_session_without_remote_and_channel_builder(self):
         with self.assertRaises(ValueError):
             RemoteSparkSession.builder.getOrCreate()
@@ -98,14 +103,14 @@ class SparkSessionTestCase(unittest.TestCase):
 
     def test_default_session_expires_when_client_closes(self):
         s1 = RemoteSparkSession.builder.remote("sc://other").getOrCreate()
-        s2 = RemoteSparkSession.getDefaultSession()
+        s2 = RemoteSparkSession._get_default_session()
 
         self.assertIs(s1, s2)
 
         # We don't call close() to avoid executing ExecutePlanResponseReattachableIterator
         s1._client._closed = True
 
-        self.assertIsNone(RemoteSparkSession.getDefaultSession())
+        self.assertIsNone(RemoteSparkSession._get_default_session())
         s3 = RemoteSparkSession.builder.remote("sc://other").getOrCreate()
 
         self.assertIsNot(s1, s3)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Four related changes to `python/pyspark/sql/tests/connect/test_session.py`:

1. Add the standard `if __name__ == "__main__"` block (matching the convention used by every other `test_*.py` module in the same directory). It is the only `test_*.py` file under `python/pyspark/**/tests/` missing this block.
2. Fix four tests that called `session.stop()` against a fake remote (`sc://other`). `stop()` invokes `client.release_session()`, which makes a real gRPC `ReleaseSession` call and retries until exhaustion. The fix sets `release_session_on_close = False` before `stop()`, matching the same intent as `test_active_session_expires_when_client_closes` / `test_default_session_expires_when_client_closes`, which set `_client._closed = True` for similar reasons.
3. Add a `setUp` that resets `RemoteSparkSession._default_session` and `_active_session.session` to `None`, so tests are order-independent. `_set_default_and_active_session` only sets state when it is currently `None`, and several tests intentionally leak state via the `_client._closed = True` workaround.
4. Replace `RemoteSparkSession.getDefaultSession()` with `RemoteSparkSession._get_default_session()` in `test_default_session_expires_when_client_closes` (2 occurrences). `getDefaultSession` does not exist on either `pyspark.sql.connect.session.SparkSession` or `pyspark.sql.session.SparkSession`; the actual classmethod is `_get_default_session`.

### Why are the changes needed?

The test runner invokes each module via `bin/pyspark <module>` → `python -m <module>`. Without a `__main__` block, that just imports the module's class definitions and exits — **no tests ran**. CI was a silent no-op for this file. Adding the `__main__` block exposed three pre-existing latent bugs (timeouts on `stop()`, an undefined-method call, and order-dependent state), each of which has been broken since the corresponding test was added. All four changes must land together for the file to actually contribute coverage.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pre-existing tests in this file. The `__main__` block is byte-identical to the pattern used by sibling files (e.g., `test_connect_basic.py`). All test fixes only affect test files; production `stop()` semantics are unchanged (`release_session_on_close` is a public attribute on `SparkSession`, defaulting to `True`).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)