### PR TITLE
[MINOR][PS][DOCS] Replace ellipsis with ASCII in pandas-on-Spark DataFrame docstrings

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -7988,7 +7988,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             first puts NaNs at the beginning, last puts NaNs at the end. Not implemented for
             MultiIndex.
         ignore_index : bool, default False
-            If True, the resulting axis will be labeled 0, 1, …, n - 1.
+            If True, the resulting axis will be labeled 0, 1, ..., n - 1.
 
             .. versionadded:: 3.4.0
 
@@ -9646,7 +9646,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         random_state : int, optional
             Seed for the random number generator (if int).
         ignore_index : bool, default False
-            If True, the resulting index will be labeled 0, 1, …, n - 1.
+            If True, the resulting index will be labeled 0, 1, ..., n - 1.
 
             .. versionadded:: 3.4.0
 
@@ -10249,7 +10249,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         inplace : boolean, default False
             Whether to drop duplicates in place or to return a copy.
         ignore_index : boolean, default False
-            If True, the resulting axis will be labeled 0, 1, …, n - 1.
+            If True, the resulting axis will be labeled 0, 1, ..., n - 1.
 
         Returns
         -------
@@ -13351,7 +13351,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         column : str or tuple
             Column to explode.
         ignore_index : bool, default False
-            If True, the resulting index will be labeled 0, 1, …, n - 1.
+            If True, the resulting index will be labeled 0, 1, ..., n - 1.
 
         Returns
         -------


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replaces the Unicode horizontal ellipsis character (U+2026, `…`) with three ASCII dots (`...`) in four `ignore_index` parameter docstrings in `python/pyspark/pandas/frame.py` (lines 7991, 9649, 10252, 13354):

```
    If True, the resulting axis/index will be labeled 0, 1, …, n - 1.
  → If True, the resulting axis/index will be labeled 0, 1, ..., n - 1.
```

### Why are the changes needed?

Project convention is ASCII-only in code and comments. The same docstring already uses the ASCII form at `frame.py:7879` and in `python/pyspark/pandas/series.py:3002, 3133`, so this just makes the four outliers consistent with the rest of the file.

### Does this PR introduce _any_ user-facing change?

No. Docstring-only change; rendering is essentially identical.

### How was this patch tested?

No tests. Verified `grep -P "[^\x00-\x7F]"` no longer reports the four sites and that the ASCII form already exists at `frame.py:7879`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (model: claude-opus-4-7)