### PR TITLE
[SPARK-56364][BUILD][TESTS][FOLLOWUP] Expand pathing JARs in createJarWithScalaSources

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkTestUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkTestUtils.scala
@@ -21,7 +21,7 @@ import java.io.{File, FileInputStream, FileOutputStream}
 import java.net.{URI, URL}
 import java.nio.file.Files
 import java.util.Arrays
-import java.util.jar.{JarEntry, JarOutputStream}
+import java.util.jar.{JarEntry, JarFile, JarOutputStream}
 import javax.tools.{JavaFileObject, SimpleJavaFileObject, ToolProvider}
 
 import scala.jdk.CollectionConverters._
@@ -170,7 +170,14 @@ private[spark] trait SparkTestUtils {
     val compilerClass = SparkClassUtils.classForName[AnyRef]("scala.tools.nsc.Main")
     val processMethod = compilerClass.getMethod("process", classOf[Array[String]])
 
-    val cpStr = classpathUrls.map(_.getFile).mkString(File.pathSeparator)
+    // When the classpath is supplied via a "pathing JAR" (a single JAR whose manifest
+    // Class-Path attribute points to the real dependencies), `scala.tools.nsc.Main` does
+    // not resolve the manifest entries and ends up unable to see scala-library.jar,
+    // failing with "object scala in compiler mirror not found". Pathing JARs are used
+    // on Windows to work around CMD's command-line length limit and by some build/CI
+    // tools. Expand any such JARs before invoking scalac so the classpath is complete.
+    val expandedClasspath = classpathUrls.flatMap(expandManifestClasspath)
+    val cpStr = expandedClasspath.map(_.getFile).mkString(File.pathSeparator)
     val args = Array("-classpath", cpStr, "-d", classDir.getAbsolutePath) ++
       sourceFiles.map(_.getAbsolutePath)
 
@@ -200,6 +207,34 @@ private[spark] trait SparkTestUtils {
     }
 
     jarFile.toURI.toURL
+  }
+
+  /**
+   * If `url` points to a "pathing JAR" (a JAR whose manifest declares a `Class-Path`
+   * attribute), return the URLs referenced by that attribute (resolved relative to
+   * the JAR's parent directory) followed by the original URL. Otherwise return the
+   * original URL unchanged.
+   */
+  private[spark] def expandManifestClasspath(url: URL): Seq[URL] = {
+    val file = new File(url.getFile)
+    if (!file.exists() || !file.getName.endsWith(".jar")) return Seq(url)
+    try {
+      val jarFile = new JarFile(file)
+      try {
+        val cpAttr = Option(jarFile.getManifest)
+          .flatMap(m => Option(m.getMainAttributes.getValue("Class-Path")))
+        cpAttr match {
+          case Some(cp) =>
+            val parentUri = file.getParentFile.toURI
+            val expanded = cp.split(" ").filter(_.nonEmpty).flatMap { e =>
+              try Some(new File(parentUri.resolve(e)).toURI.toURL)
+              catch { case _: Exception => None }
+            }
+            expanded.toSeq :+ url
+          case None => Seq(url)
+        }
+      } finally jarFile.close()
+    } catch { case _: Exception => Seq(url) }
   }
 
   private def listFilesRecursively(dir: File): Seq[File] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Followup to https://github.com/apache/spark/pull/55218.

When `createJarWithScalaSources` (introduced in #55218) is invoked in a process whose `java.class.path` is a single "pathing JAR" — a JAR with no class entries whose manifest `Class-Path` attribute lists the real dependencies — `scala.tools.nsc.Main` does not resolve the manifest entries. The compiler therefore cannot see `scala-library.jar`, and compilation fails with `object scala in compiler mirror not found`.

This PR adds an `expandManifestClasspath` helper that detects such JARs and resolves their manifest `Class-Path` entries (relative to the JAR's parent directory) before passing the classpath to scalac.

### Why are the changes needed?

Pathing JARs are commonly emitted to work around platform-specific command-line length limits — most notably on Windows, where CMD's command-line limit forces tools to produce a single classpath JAR rather than a long `-cp` string. Some build/CI tooling does the same. Without this fix, `createJarWithScalaSources` is silently broken in those environments, even though a regular file-listing classpath continues to work.

### Does this PR introduce _any_ user-facing change?

No. Only test-utility code is affected.

### How was this patch tested?

Verified that `createJarWithScalaSources` still succeeds with a normal classpath, and now also succeeds when invoked with a classpath consisting of a single pathing JAR whose manifest `Class-Path` lists the real dependencies. The expansion is a no-op for non-JAR URLs and for JARs that have no manifest `Class-Path` attribute, so the existing OSS test paths are unaffected.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7
