### PR TITLE
[SPARK-56640][BUILD] Upgrade `commons-io` to 2.22.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -44,7 +44,7 @@ commons-compiler/3.1.9//commons-compiler-3.1.9.jar
 commons-compress/1.28.0//commons-compress-1.28.0.jar
 commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
-commons-io/2.21.0//commons-io-2.21.0.jar
+commons-io/2.22.0//commons-io-2.22.0.jar
 commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/3.20.0//commons-lang3-3.20.0.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
     <netlib.ludovic.dev.version>3.2.0</netlib.ludovic.dev.version>
     <commons-codec.version>1.21.0</commons-codec.version>
     <commons-compress.version>1.28.0</commons-compress.version>
-    <commons-io.version>2.21.0</commons-io.version>
+    <commons-io.version>2.22.0</commons-io.version>
     <!-- To support Hive UDF jars built by Hive 2.0.0 ~ 2.3.9 and 3.0.0 ~ 3.1.3. -->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `commons-io:commons-io` to 2.22.0 for Apache Spark 4.2.0.

### Why are the changes needed?

To bring the latest bug fixes and improvements from the upstream `commons-io` project.

- https://commons.apache.org/proper/commons-io/changes.html#a2.22.0 (2026-04-19)
- https://github.com/apache/commons-io/releases/tag/rel%2Fcommons-io-2.22.0

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)