### PR TITLE
[SPARK-56639][SQL] frozen path semantics

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -139,10 +139,9 @@ object FakeV2SessionCatalog extends TableCatalog with FunctionCatalog with Suppo
  *                              even if a temp view `t` has been created.
  * @param outerPlan The query plan from the outer query that can be used to resolve star
  *                  expressions in a subquery.
- * @param resolutionPathEntries When resolving a view body, the ordered path for unqualified
- *                              relation names. Stays [[None]] in this PR; population from the
- *                              frozen path stored in view metadata is wired in a follow-up.
- *                              Outside views: compute from session
+ * @param resolutionPathEntries When resolving a view or SQL function body, the ordered frozen
+ *                              path for unqualified relation/function names (if persisted in
+ *                              metadata). Outside views/functions, compute from session
  *                              [[CatalogManager.sqlResolutionPathEntries]].
  */
 case class AnalysisContext(
@@ -211,6 +210,8 @@ object AnalysisContext {
     val context = AnalysisContext(
       isDefault = false,
       catalogAndNamespace = viewDesc.viewCatalogAndNamespace,
+      resolutionPathEntries = viewDesc.viewStoredResolutionPath
+        .flatMap(CatalogManager.deserializePathEntries),
       nestedViewDepth = originContext.nestedViewDepth + 1,
       maxNestedViewDepth = maxNestedViewDepth,
       relationCache = originContext.relationCache,
@@ -224,7 +225,10 @@ object AnalysisContext {
 
   def withAnalysisContext[A](function: SQLFunction)(f: => A): A = {
     val originContext = value.get()
-    val context = originContext.copy(collation = function.collation)
+    val context = originContext.copy(
+      resolutionPathEntries = function.functionStoredResolutionPath
+        .flatMap(CatalogManager.deserializePathEntries),
+      collation = function.collation)
     set(context)
     try f finally { set(originContext) }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -211,7 +211,8 @@ object AnalysisContext {
       isDefault = false,
       catalogAndNamespace = viewDesc.viewCatalogAndNamespace,
       resolutionPathEntries = viewDesc.viewStoredResolutionPath
-        .flatMap(CatalogManager.deserializePathEntries),
+        .map(CatalogManager.deserializePathEntriesOrFail(
+          _, "view", viewDesc.identifier.unquotedString)),
       nestedViewDepth = originContext.nestedViewDepth + 1,
       maxNestedViewDepth = maxNestedViewDepth,
       relationCache = originContext.relationCache,
@@ -228,7 +229,8 @@ object AnalysisContext {
     // Function body analysis should not inherit any caller-pinned path; use only function metadata.
     val context = originContext.copy(
       resolutionPathEntries = function.functionStoredResolutionPath
-        .flatMap(CatalogManager.deserializePathEntries),
+        .map(CatalogManager.deserializePathEntriesOrFail(
+          _, "SQL function", function.name.unquotedString)),
       collation = function.collation)
     set(context)
     try f finally { set(originContext) }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -225,6 +225,7 @@ object AnalysisContext {
 
   def withAnalysisContext[A](function: SQLFunction)(f: => A): A = {
     val originContext = value.get()
+    // Function body analysis should not inherit any caller-pinned path; use only function metadata.
     val context = originContext.copy(
       resolutionPathEntries = function.functionStoredResolutionPath
         .flatMap(CatalogManager.deserializePathEntries),
@@ -1007,8 +1008,8 @@ class Analyzer(
     // This is done by keeping the catalog and namespace in `AnalysisContext`, and analyzer will
     // look at `AnalysisContext.catalogAndNamespace` when resolving relations with single-part name.
     // If `AnalysisContext.catalogAndNamespace` is non-empty, analyzer will expand single-part names
-    // with it, instead of current catalog and namespace. Unqualified relation PATH will be
-    // snapshotted in `AnalysisContext.resolutionPathEntries` in a follow-up PR.
+    // with it, instead of current catalog and namespace. For views/functions with persisted frozen
+    // PATH, `AnalysisContext.resolutionPathEntries` drives unqualified relation lookup order.
     private def resolveViews(
         plan: LogicalPlan,
         options: CaseInsensitiveStringMap): LogicalPlan = plan match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
@@ -126,8 +126,8 @@ class RelationResolution(
   /**
    * Path entries for unqualified relation resolution.
    *
-   * Inside a view, [[AnalysisContext.resolutionPathEntries]] will be
-   * populated from the frozen path stored in view metadata (follow-up PR).
+   * Inside a view or SQL function, [[AnalysisContext.resolutionPathEntries]] uses the
+   * persisted frozen path from metadata when available.
    * When PATH is disabled, legacy resolution rules apply.
    */
   private def relationResolutionEntries: Seq[Seq[String]] = {
@@ -135,8 +135,6 @@ class RelationResolution(
     if (pinned.isDefined && conf.pathEnabled) {
       pinned.get
     } else {
-      // Keep expanding CurrentSchemaEntry using the live session catalog/namespace until the
-      // follow-up PR wires frozen resolutionPathEntries for view analysis.
       val expandCatalog = catalogManager.currentCatalog.name
       val expandNamespace = catalogManager.currentNamespace.toSeq
       val (pathCatalog, pathNamespace) =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.connector.catalog
 
 import scala.collection.mutable
+import scala.util.Try
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.SQLConfHelper
@@ -348,5 +349,31 @@ private[sql] object CatalogManager {
     import org.json4s.jackson.JsonMethods.compact
     compact(JArray(entries.map(parts =>
       JArray(parts.map(JString(_)).toList)).toList))
+  }
+
+  /**
+   * Parse a stored frozen path string from view/function metadata.
+   * Returns None if the payload is malformed.
+   */
+  def deserializePathEntries(storedPathStr: String): Option[Seq[Seq[String]]] = {
+    import org.json4s.JsonAST.{JArray, JString}
+    import org.json4s.jackson.JsonMethods.parse
+
+    Try(parse(storedPathStr)).toOption match {
+      case Some(JArray(entries)) if entries.nonEmpty =>
+        val converted = entries.foldLeft(Option(Seq.empty[Seq[String]])) { (acc, entry) =>
+          acc.flatMap { collected =>
+            entry match {
+              case JArray(parts) if parts.nonEmpty =>
+                val strings = parts.collect { case JString(s) => s }
+                if (strings.size == parts.size) Some(collected :+ strings)
+                else None
+              case _ => None
+            }
+          }
+        }
+        converted.filter(_.nonEmpty)
+      case _ => None
+    }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -21,6 +21,7 @@ import scala.collection.mutable
 import scala.util.Try
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.catalog.{SessionCatalog, TempVariableManager}
 import org.apache.spark.sql.catalyst.util.StringUtils
@@ -351,44 +352,65 @@ private[sql] object CatalogManager extends Logging {
       JArray(parts.map(JString(_)).toList)).toList))
   }
 
-  /**
-   * Parse a stored frozen path string from view/function metadata.
-   * Returns None if the payload is malformed.
-   */
-  def deserializePathEntries(storedPathStr: String): Option[Seq[Seq[String]]] = {
+  private def parsePathEntries(storedPathStr: String): Either[String, Seq[Seq[String]]] = {
     import org.json4s.JsonAST.{JArray, JString}
     import org.json4s.jackson.JsonMethods.parse
 
     Try(parse(storedPathStr)).toOption match {
       case Some(JArray(entries)) =>
-        entries.foldLeft(Option(Seq.empty[Seq[String]])) { (acc, entry) =>
-          acc.flatMap { collected =>
-            entry match {
-              case JArray(parts) =>
-                val strings = parts.collect { case JString(s) => s }
-                if (strings.size == parts.size) Some(collected :+ strings)
-                else {
-                  logWarning(
-                    s"Invalid stored SQL path metadata: expected string parts in array entry: " +
-                      s"$storedPathStr")
-                  None
-                }
-              case _ =>
-                logWarning(
-                  s"Invalid stored SQL path metadata: expected array entry but found non-array: " +
-                    s"$storedPathStr")
-                None
+        entries.foldLeft(Right(Seq.empty[Seq[String]]): Either[String, Seq[Seq[String]]]) {
+          (acc, entry) =>
+            acc.flatMap { collected =>
+              entry match {
+                case JArray(parts) =>
+                  val strings = parts.collect { case JString(s) => s }
+                  if (strings.size == parts.size) Right(collected :+ strings)
+                  else Left("expected all array entry parts to be JSON strings")
+                case _ =>
+                  Left("expected each top-level array entry to be a JSON array")
+              }
             }
-          }
         }
       case Some(_) =>
-        logWarning(
-          s"Invalid stored SQL path metadata: expected top-level JSON array: $storedPathStr")
-        None
+        Left("expected top-level JSON array")
       case None =>
+        Left("failed to parse JSON payload")
+    }
+  }
+
+  /**
+   * Parse a stored frozen path string from view/function metadata.
+   * Returns None if the payload is malformed.
+   */
+  def deserializePathEntries(storedPathStr: String): Option[Seq[Seq[String]]] = {
+    parsePathEntries(storedPathStr) match {
+      case Right(entries) => Some(entries)
+      case Left(reason) =>
         logWarning(
-          s"Invalid stored SQL path metadata: failed to parse JSON payload: $storedPathStr")
+          s"Invalid stored SQL path metadata: $reason. Raw payload: $storedPathStr")
         None
+    }
+  }
+
+  /**
+   * Parse stored frozen path metadata and fail analysis if malformed.
+   */
+  def deserializePathEntriesOrFail(
+      storedPathStr: String,
+      objectType: String,
+      objectName: String): Seq[Seq[String]] = {
+    parsePathEntries(storedPathStr) match {
+      case Right(entries) => entries
+      case Left(reason) =>
+        throw new AnalysisException(
+          message = s"Invalid stored SQL path metadata for $objectType '$objectName': " +
+            s"$reason. Raw payload: $storedPathStr",
+          line = None,
+          startPosition = None,
+          cause = None,
+          errorClass = None,
+          messageParameters = Map.empty,
+          context = Array.empty)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -235,7 +235,7 @@ class CatalogManager(
   }
 }
 
-private[sql] object CatalogManager {
+private[sql] object CatalogManager extends Logging {
 
   val SESSION_CATALOG_NAME: String = "spark_catalog"
   val SYSTEM_CATALOG_NAME = "system"
@@ -360,20 +360,35 @@ private[sql] object CatalogManager {
     import org.json4s.jackson.JsonMethods.parse
 
     Try(parse(storedPathStr)).toOption match {
-      case Some(JArray(entries)) if entries.nonEmpty =>
-        val converted = entries.foldLeft(Option(Seq.empty[Seq[String]])) { (acc, entry) =>
+      case Some(JArray(entries)) =>
+        entries.foldLeft(Option(Seq.empty[Seq[String]])) { (acc, entry) =>
           acc.flatMap { collected =>
             entry match {
-              case JArray(parts) if parts.nonEmpty =>
+              case JArray(parts) =>
                 val strings = parts.collect { case JString(s) => s }
                 if (strings.size == parts.size) Some(collected :+ strings)
-                else None
-              case _ => None
+                else {
+                  logWarning(
+                    s"Invalid stored SQL path metadata: expected string parts in array entry: " +
+                      s"$storedPathStr")
+                  None
+                }
+              case _ =>
+                logWarning(
+                  s"Invalid stored SQL path metadata: expected array entry but found non-array: " +
+                    s"$storedPathStr")
+                None
             }
           }
         }
-        converted.filter(_.nonEmpty)
-      case _ => None
+      case Some(_) =>
+        logWarning(
+          s"Invalid stored SQL path metadata: expected top-level JSON array: $storedPathStr")
+        None
+      case None =>
+        logWarning(
+          s"Invalid stored SQL path metadata: failed to parse JSON payload: $storedPathStr")
+        None
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogManagerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogManagerSuite.scala
@@ -127,6 +127,29 @@ class CatalogManagerSuite extends SparkFunSuite with SQLHelper {
       }
     }
   }
+
+  test("deserializePathEntries parses valid payloads") {
+    val stored =
+      """[["spark_catalog","default"],["system","builtin"],["spark_catalog","db1","ns1"]]"""
+    assert(CatalogManager.deserializePathEntries(stored).contains(Seq(
+      Seq("spark_catalog", "default"),
+      Seq("system", "builtin"),
+      Seq("spark_catalog", "db1", "ns1"))))
+    assert(CatalogManager.deserializePathEntries("[]").contains(Seq.empty))
+  }
+
+  test("deserializePathEntries returns None for malformed payloads") {
+    val malformedPayloads = Seq(
+      "",
+      "not_json",
+      "{}",
+      """["spark_catalog"]""",
+      """[["spark_catalog"], 1]""",
+      """[[1]]""")
+    malformedPayloads.foreach { payload =>
+      assert(CatalogManager.deserializePathEntries(payload).isEmpty, s"payload=$payload")
+    }
+  }
 }
 
 class DummyCatalog extends CatalogPlugin {

--- a/sql/core/src/test/scala/org/apache/spark/sql/AlwaysPersistedConfigsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/AlwaysPersistedConfigsSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql
 
+import java.util.Locale
+
 import org.scalactic.source.Position
 import org.scalatest.Tag
 
@@ -31,6 +33,7 @@ import org.apache.spark.sql.catalyst.catalog.{
 }
 import org.apache.spark.sql.catalyst.expressions.Alias
 import org.apache.spark.sql.catalyst.plans.logical.{OneRowRelation, Project, View}
+import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
@@ -169,6 +172,62 @@ class AlwaysPersistedConfigsSuite extends SharedSparkSession {
     assert(sqlConf.settings.get("spark.sql.ansi.enabled") == "false")
   }
 
+  test("Current schema marker is materialized in persisted view path") {
+    withView(testViewName) {
+      withSQLConf(SQLConf.PATH_ENABLED.key -> "true") {
+        sql("CREATE DATABASE IF NOT EXISTS path_materialized_view")
+        try {
+          sql("USE path_materialized_view")
+          sql("SET PATH = current_schema, system.builtin")
+          sql(s"CREATE VIEW $testViewName AS SELECT 1")
+          val metadata = spark.sessionState.catalog.getTableMetadata(TableIdentifier(testViewName))
+          val storedPath = metadata.viewStoredResolutionPath.getOrElse(
+            fail("Expected persisted view resolution path to be set"))
+          val parsed = CatalogManager.deserializePathEntries(storedPath).getOrElse(
+            fail(s"Expected a valid serialized path, got: $storedPath"))
+          assert(parsed.head == Seq("spark_catalog", "path_materialized_view"))
+          assert(!storedPath.toLowerCase(Locale.ROOT).contains("current_schema"))
+        } finally {
+          sql("SET PATH = DEFAULT_PATH")
+          sql(s"DROP VIEW IF EXISTS path_materialized_view.$testViewName")
+          sql(s"DROP VIEW IF EXISTS $testViewName")
+          sql("USE default")
+          sql("DROP DATABASE IF EXISTS path_materialized_view")
+        }
+      }
+    }
+  }
+
+  test("Current schema marker is materialized in persisted function path") {
+    withUserDefinedFunction(testFunctionName -> false) {
+      withSQLConf(SQLConf.PATH_ENABLED.key -> "true") {
+        sql("CREATE DATABASE IF NOT EXISTS path_materialized_fn")
+        try {
+          sql("USE path_materialized_fn")
+          sql("SET PATH = current_schema, system.builtin")
+          sql(
+            s"""
+               |CREATE OR REPLACE FUNCTION $testFunctionName()
+               |RETURN SELECT 1
+               |""".stripMargin)
+          val function = analyzedSqlFunction(testFunctionName)
+          val storedPath = function.functionStoredResolutionPath.getOrElse(
+            fail("Expected persisted function resolution path to be set"))
+          val parsed = CatalogManager.deserializePathEntries(storedPath).getOrElse(
+            fail(s"Expected a valid serialized path, got: $storedPath"))
+          assert(parsed.head == Seq("spark_catalog", "path_materialized_fn"))
+          assert(!storedPath.toLowerCase(Locale.ROOT).contains("current_schema"))
+        } finally {
+          sql("SET PATH = DEFAULT_PATH")
+          sql(s"DROP FUNCTION IF EXISTS path_materialized_fn.$testFunctionName")
+          sql(s"DROP FUNCTION IF EXISTS $testFunctionName")
+          sql("USE default")
+          sql("DROP DATABASE IF EXISTS path_materialized_fn")
+        }
+      }
+    }
+  }
+
   private def testView(confName: String, expectedValue: String): Unit = {
     sql(s"CREATE VIEW $testViewName AS SELECT CAST('string' AS BIGINT) AS alias")
 
@@ -185,21 +244,19 @@ class AlwaysPersistedConfigsSuite extends SharedSparkSession {
          |RETURN SELECT CAST('string' AS BIGINT) AS alias
          |""".stripMargin)
 
-    val df = sql(s"select $testFunctionName()")
+    assert(analyzedSqlFunction(testFunctionName).properties.get(confName).get == expectedValue)
+  }
 
-    assert(
-      df.queryExecution.analyzed
-        .asInstanceOf[Project]
-        .projectList
-        .head
-        .asInstanceOf[Alias]
-        .child
-        .asInstanceOf[SQLScalarFunction]
-        .function
-        .asInstanceOf[SQLFunction]
-        .properties
-        .get(confName)
-        .get == expectedValue
-    )
+  private def analyzedSqlFunction(functionName: String): SQLFunction = {
+    val df = sql(s"select $functionName()")
+    df.queryExecution.analyzed
+      .asInstanceOf[Project]
+      .projectList
+      .head
+      .asInstanceOf[Alias]
+      .child
+      .asInstanceOf[SQLScalarFunction]
+      .function
+      .asInstanceOf[SQLFunction]
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/AlwaysPersistedConfigsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/AlwaysPersistedConfigsSuite.scala
@@ -24,6 +24,7 @@ import org.scalatest.Tag
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.AnalysisContext
 import org.apache.spark.sql.catalyst.analysis.SQLScalarFunction
 import org.apache.spark.sql.catalyst.catalog.{
   CatalogStorageFormat,
@@ -247,6 +248,27 @@ class AlwaysPersistedConfigsSuite extends SharedSparkSession {
             sql("SET PATH = DEFAULT_PATH")
           }
         }
+      }
+    }
+  }
+
+  test("Malformed persisted SQL function path fails analysis context setup") {
+    withUserDefinedFunction(testFunctionName -> false) {
+      withSQLConf(SQLConf.PATH_ENABLED.key -> "true") {
+        sql(
+          s"""
+             |CREATE OR REPLACE FUNCTION $testFunctionName()
+             |RETURN SELECT 1
+             |""".stripMargin)
+        val function = analyzedSqlFunction(testFunctionName)
+        val broken = function.copy(
+          properties = function.properties + (SQLFunction.FUNCTION_RESOLUTION_PATH -> "{bad-json"))
+        val e = intercept[AnalysisException] {
+          AnalysisContext.withAnalysisContext(broken) {
+            ()
+          }
+        }
+        assert(e.getMessage.contains("Invalid stored SQL path metadata for SQL function"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/AlwaysPersistedConfigsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/AlwaysPersistedConfigsSuite.scala
@@ -228,6 +228,29 @@ class AlwaysPersistedConfigsSuite extends SharedSparkSession {
     }
   }
 
+  test("Session-only path is omitted from persisted view metadata and remains queryable") {
+    withTable("default.path_empty_src") {
+      withView(testViewName) {
+        withSQLConf(SQLConf.PATH_ENABLED.key -> "true") {
+          sql("CREATE TABLE default.path_empty_src (id INT) USING parquet")
+          sql("INSERT INTO default.path_empty_src VALUES (1)")
+          try {
+            // Persisted objects strip system.session; a session-only path should not be persisted.
+            sql("SET PATH = system.session")
+            sql(
+              s"CREATE VIEW $testViewName AS SELECT id FROM spark_catalog.default.path_empty_src")
+            val metadata =
+              spark.sessionState.catalog.getTableMetadata(TableIdentifier(testViewName))
+            assert(metadata.viewStoredResolutionPath.isEmpty)
+            checkAnswer(sql(s"SELECT id FROM default.$testViewName"), Row(1))
+          } finally {
+            sql("SET PATH = DEFAULT_PATH")
+          }
+        }
+      }
+    }
+  }
+
   private def testView(confName: String, expectedValue: String): Unit = {
     sql(s"CREATE VIEW $testViewName AS SELECT CAST('string' AS BIGINT) AS alias")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -361,6 +361,50 @@ class SetPathSuite extends SharedSparkSession {
     }
   }
 
+  test("PATH enabled: case-sensitive mode does not treat differently cased entries as duplicates") {
+    withSQLConf(
+      SQLConf.PATH_ENABLED.key -> "true",
+      SQLConf.CASE_SENSITIVE.key -> "true") {
+      sql("SET PATH = spark_catalog.DEFAULT, spark_catalog.default")
+      val stored = spark.sessionState.catalogManager.sessionPathEntries.get
+      val rendered = stored.map(_.resolve("ignored", Nil).mkString("."))
+      assert(rendered === Seq("spark_catalog.DEFAULT", "spark_catalog.default"))
+    }
+  }
+
+  test("PATH enabled: unqualified session variable lookup follows PATH") {
+    withPathEnabled {
+      sql("DECLARE VARIABLE system.session.path_var_gate = 7")
+      try {
+        sql("SET PATH = spark_catalog.default")
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql("DROP TEMPORARY VARIABLE path_var_gate")
+          },
+          condition = "UNRESOLVED_VARIABLE",
+          sqlState = "42883",
+          parameters = Map(
+            "variableName" -> "`path_var_gate`",
+            "searchPath" -> "`SYSTEM`.`SESSION`"))
+
+        sql("SET PATH = spark_catalog.default, system.session")
+        sql("DROP TEMPORARY VARIABLE path_var_gate")
+      } finally {
+        sql("DROP TEMPORARY VARIABLE IF EXISTS system.session.path_var_gate")
+      }
+    }
+  }
+
+  test("PATH enabled: current_path does not accept arguments") {
+    withPathEnabled {
+      val e = intercept[AnalysisException] {
+        sql("SET PATH = DEFAULT_PATH")
+        sql("SELECT current_path(1)")
+      }
+      assert(e.getCondition == "WRONG_NUM_ARGS.WITHOUT_SUGGESTION", e.getMessage)
+    }
+  }
+
   test("PATH enabled: DEFAULT_PATH respects sessionFunctionResolutionOrder = first") {
     withSQLConf(
       SQLConf.PATH_ENABLED.key -> "true",

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -398,7 +398,6 @@ class SetPathSuite extends SharedSparkSession {
   test("PATH enabled: current_path does not accept arguments") {
     withPathEnabled {
       val e = intercept[AnalysisException] {
-        sql("SET PATH = DEFAULT_PATH")
         sql("SELECT current_path(1)")
       }
       assert(e.getCondition == "WRONG_NUM_ARGS.WITHOUT_SUGGESTION", e.getMessage)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -397,6 +397,8 @@ class SetPathSuite extends SharedSparkSession {
 
   test("PATH enabled: current_path does not accept arguments") {
     withPathEnabled {
+      // Ensure built-in function lookup succeeds so this assertion targets arg-count semantics.
+      sql("SET PATH = DEFAULT_PATH")
       val e = intercept[AnalysisException] {
         sql("SELECT current_path(1)")
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -26,8 +26,8 @@ import org.apache.spark.sql.test.SharedSparkSession
  * DEFAULT_PATH, SYSTEM_PATH, CURRENT_SCHEMA/CURRENT_DATABASE expansion,
  * PATH (append), duplicate detection, and error conditions.
  *
- * Resolution-level tests (tables/functions resolving via the stored path)
- * belong in a separate suite once the resolution engine is wired.
+ * Resolution-level tests (tables/functions resolving via stored frozen path)
+ * are covered in SQLViewSuite and SQLFunctionSuite (SPARK-56639).
  */
 class SetPathSuite extends SharedSparkSession {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 /**
@@ -109,6 +110,37 @@ class SQLFunctionSuite extends SharedSparkSession {
           stop = 60
         )
       )
+    }
+  }
+
+  test("SPARK-56639: SQL function uses frozen SQL path") {
+    withSQLConf(SQLConf.PATH_ENABLED.key -> "true") {
+      withDatabase("path_func_db_a", "path_func_db_b") {
+        withTable("path_func_db_a.frozen_t", "path_func_db_b.frozen_t") {
+          withUserDefinedFunction("frozen_fn" -> false) {
+            sql("USE default")
+            sql("CREATE DATABASE path_func_db_a")
+            sql("CREATE DATABASE path_func_db_b")
+            sql("CREATE TABLE path_func_db_a.frozen_t USING parquet AS SELECT 10 AS id")
+            sql("CREATE TABLE path_func_db_b.frozen_t USING parquet AS SELECT 20 AS id")
+            try {
+              sql("SET PATH = spark_catalog.path_func_db_a, system.builtin")
+              sql(
+                """
+                  |CREATE FUNCTION frozen_fn()
+                  |RETURNS INT
+                  |RETURN (SELECT MAX(id) FROM frozen_t)
+                  |""".stripMargin)
+              sql("SET PATH = spark_catalog.path_func_db_b, system.builtin")
+
+              checkAnswer(sql("SELECT MAX(id) FROM frozen_t"), Row(20))
+              checkAnswer(sql("SELECT default.frozen_fn()"), Row(10))
+            } finally {
+              sql("SET PATH = DEFAULT_PATH")
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
@@ -174,4 +174,55 @@ class SQLFunctionSuite extends SharedSparkSession {
       }
     }
   }
+
+  test("SPARK-56639: current_schema/current_path in SQL functions use invoker context") {
+    withSQLConf(SQLConf.PATH_ENABLED.key -> "true") {
+      withDatabase("path_ctx_fn_a", "path_ctx_fn_b") {
+        withUserDefinedFunction("path_ctx_fn_a.f_scalar_ctx" -> false,
+          "path_ctx_fn_a.f_table_ctx" -> false) {
+          sql("CREATE DATABASE path_ctx_fn_a")
+          sql("CREATE DATABASE path_ctx_fn_b")
+          try {
+            sql("USE path_ctx_fn_a")
+            sql(
+              """
+                |CREATE FUNCTION path_ctx_fn_a.f_scalar_ctx()
+                |RETURNS STRING
+                |RETURN concat(current_schema(), '::', current_path())
+                |""".stripMargin)
+            sql(
+              """
+                |CREATE FUNCTION path_ctx_fn_a.f_table_ctx()
+                |RETURNS TABLE(cs STRING, cp STRING)
+                |RETURN SELECT current_schema() AS cs, current_path() AS cp
+                |""".stripMargin)
+
+            sql("USE path_ctx_fn_b")
+            sql("SET PATH = DEFAULT_PATH")
+
+            val scalar = sql("SELECT path_ctx_fn_a.f_scalar_ctx()").head().getString(0)
+            assert(scalar.startsWith("path_ctx_fn_b::"),
+              s"Expected scalar function to use invoker current_schema, got: $scalar")
+            assert(scalar.contains("path_ctx_fn_b"),
+              s"Expected scalar function to use invoker current_path, got: $scalar")
+            assert(!scalar.contains("path_ctx_fn_a"),
+              s"Did not expect creator schema in scalar function context, got: $scalar")
+
+            val table = sql("SELECT cs, cp FROM path_ctx_fn_a.f_table_ctx()").head()
+            val tableSchema = table.getString(0)
+            val tablePath = table.getString(1)
+            assert(tableSchema == "path_ctx_fn_b",
+              s"Expected table function to use invoker current_schema, got: $tableSchema")
+            assert(tablePath.contains("path_ctx_fn_b"),
+              s"Expected table function to use invoker current_path, got: $tablePath")
+            assert(!tablePath.contains("path_ctx_fn_a"),
+              s"Did not expect creator schema in table function context, got: $tablePath")
+          } finally {
+            sql("SET PATH = DEFAULT_PATH")
+            sql("USE default")
+          }
+        }
+      }
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
@@ -143,4 +143,35 @@ class SQLFunctionSuite extends SharedSparkSession {
       }
     }
   }
+
+  test("SPARK-56639: SQL table function uses frozen SQL path") {
+    withSQLConf(SQLConf.PATH_ENABLED.key -> "true") {
+      withDatabase("path_tvf_db_a", "path_tvf_db_b") {
+        withTable("path_tvf_db_a.frozen_t", "path_tvf_db_b.frozen_t") {
+          withUserDefinedFunction("frozen_tvf" -> false) {
+            sql("USE default")
+            sql("CREATE DATABASE path_tvf_db_a")
+            sql("CREATE DATABASE path_tvf_db_b")
+            sql("CREATE TABLE path_tvf_db_a.frozen_t USING parquet AS SELECT 100 AS id")
+            sql("CREATE TABLE path_tvf_db_b.frozen_t USING parquet AS SELECT 200 AS id")
+            try {
+              sql("SET PATH = spark_catalog.path_tvf_db_a, system.builtin")
+              sql(
+                """
+                  |CREATE FUNCTION frozen_tvf()
+                  |RETURNS TABLE(id INT)
+                  |RETURN SELECT MAX(id) AS id FROM frozen_t
+                  |""".stripMargin)
+              sql("SET PATH = spark_catalog.path_tvf_db_b, system.builtin")
+
+              checkAnswer(sql("SELECT MAX(id) FROM frozen_t"), Row(200))
+              checkAnswer(sql("SELECT * FROM default.frozen_tvf()"), Row(100))
+            } finally {
+              sql("SET PATH = DEFAULT_PATH")
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLFunctionSuite.scala
@@ -175,6 +175,7 @@ class SQLFunctionSuite extends SharedSparkSession {
     }
   }
 
+  // Regression guard: frozen resolution path must not leak into CURRENT_SCHEMA/CURRENT_PATH.
   test("SPARK-56639: current_schema/current_path in SQL functions use invoker context") {
     withSQLConf(SQLConf.PATH_ENABLED.key -> "true") {
       withDatabase("path_ctx_fn_a", "path_ctx_fn_b") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -1435,4 +1435,39 @@ abstract class SQLViewSuite extends QueryTest {
       }
     }
   }
+
+  test("SPARK-56639: current_schema/current_path in persisted view use invoker context") {
+    withSQLConf(PATH_ENABLED.key -> "true") {
+      withDatabase("path_ctx_view_a", "path_ctx_view_b") {
+        withView("path_ctx_view_a.v_ctx") {
+          sql("CREATE DATABASE path_ctx_view_a")
+          sql("CREATE DATABASE path_ctx_view_b")
+          try {
+            sql("USE path_ctx_view_a")
+            sql(
+              """
+                |CREATE VIEW path_ctx_view_a.v_ctx AS
+                |SELECT current_schema() AS cs, current_path() AS cp
+                |""".stripMargin)
+
+            sql("USE path_ctx_view_b")
+            sql("SET PATH = DEFAULT_PATH")
+            val row = sql("SELECT cs, cp FROM path_ctx_view_a.v_ctx").head()
+            val currentSchema = row.getString(0)
+            val currentPath = row.getString(1)
+
+            assert(currentSchema == "path_ctx_view_b",
+              s"Expected invoker current_schema, got: $currentSchema")
+            assert(currentPath.contains("path_ctx_view_b"),
+              s"Expected invoker current_path to include path_ctx_view_b, got: $currentPath")
+            assert(!currentPath.contains("path_ctx_view_a"),
+              s"Did not expect creator schema in current_path, got: $currentPath")
+          } finally {
+            sql("SET PATH = DEFAULT_PATH")
+            sql("USE default")
+          }
+        }
+      }
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -1409,4 +1409,30 @@ abstract class SQLViewSuite extends QueryTest {
       }
     }
   }
+
+  test("SPARK-56639: permanent view uses frozen SQL path") {
+    withSQLConf(PATH_ENABLED.key -> "true") {
+      withDatabase("path_view_db_a", "path_view_db_b") {
+        withTable("path_view_db_a.frozen_t", "path_view_db_b.frozen_t") {
+          withView("default.v_path_frozen") {
+            sql("USE default")
+            sql("CREATE DATABASE path_view_db_a")
+            sql("CREATE DATABASE path_view_db_b")
+            sql("CREATE TABLE path_view_db_a.frozen_t USING parquet AS SELECT 1 AS id")
+            sql("CREATE TABLE path_view_db_b.frozen_t USING parquet AS SELECT 2 AS id")
+            try {
+              sql("SET PATH = spark_catalog.path_view_db_a, system.builtin")
+              sql("CREATE VIEW default.v_path_frozen AS SELECT id FROM frozen_t")
+              sql("SET PATH = spark_catalog.path_view_db_b, system.builtin")
+
+              checkAnswer(sql("SELECT id FROM frozen_t"), Row(2))
+              checkAnswer(sql("SELECT id FROM default.v_path_frozen"), Row(1))
+            } finally {
+              sql("SET PATH = DEFAULT_PATH")
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -1436,6 +1436,7 @@ abstract class SQLViewSuite extends QueryTest {
     }
   }
 
+  // Regression guard: frozen resolution path must not leak into CURRENT_SCHEMA/CURRENT_PATH.
   test("SPARK-56639: current_schema/current_path in persisted view use invoker context") {
     withSQLConf(PATH_ENABLED.key -> "true") {
       withDatabase("path_ctx_view_a", "path_ctx_view_b") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution
 import org.apache.spark.{SparkArithmeticException, SparkException}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.{Add, Alias, Divide}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.Project
@@ -1433,6 +1434,22 @@ abstract class SQLViewSuite extends QueryTest {
           }
         }
       }
+    }
+  }
+
+  test("SPARK-56639: malformed persisted view path fails analysis") {
+    withView("default.v_bad_path_metadata") {
+      sql("CREATE VIEW default.v_bad_path_metadata AS SELECT 1 AS id")
+      val ident = TableIdentifier("v_bad_path_metadata", Some("default"))
+      val metadata = spark.sessionState.catalog.getTableMetadata(ident)
+      val corrupted = metadata.copy(
+        properties = metadata.properties + (CatalogTable.VIEW_RESOLUTION_PATH -> "{bad-json"))
+      spark.sessionState.catalog.alterTable(corrupted)
+
+      val e = intercept[AnalysisException] {
+        sql("SELECT * FROM default.v_bad_path_metadata").collect()
+      }
+      assert(e.getMessage.contains("Invalid stored SQL path metadata for view"), e.getMessage)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR wires frozen SQL PATH semantics into analysis for persisted views and SQL functions (scalar and table).

Specifically:
- `AnalysisContext.withAnalysisContext(viewDesc)` now reads `viewStoredResolutionPath` and seeds `resolutionPathEntries` from persisted metadata when present.
- `AnalysisContext.withAnalysisContext(function)` now reads `functionStoredResolutionPath` and seeds `resolutionPathEntries` for SQL function body analysis.
- `CatalogManager.deserializePathEntries` is added to parse stored JSON path entries into analysis-time path entries.
- Relation-resolution comments/docs are updated to reflect that persisted frozen path is now applied.
- Regression tests are added:
  - `SQLViewSuite`: persisted view keeps creation-time PATH semantics.
  - `SQLFunctionSuite`: persisted SQL scalar function keeps creation-time PATH semantics.
  - `SQLFunctionSuite`: persisted SQL table function keeps creation-time PATH semantics.

### Why are the changes needed?

Without this wiring, persisted views/functions may resolve unqualified names using the caller's current PATH instead of the PATH captured at creation time. That can cause behavior drift after `SET PATH` changes. This PR makes persisted object resolution stable and deterministic.

### Does this PR introduce _any_ user-facing change?

Yes.

For persisted views and SQL functions (including SQL table functions) created with PATH enabled, unqualified name resolution now consistently follows the stored creation-time PATH, even if the session PATH changes later.

### How was this patch tested?

Added/updated unit tests and ran focused suites locally:
- `build/sbt 'sql/testOnly org.apache.spark.sql.execution.SimpleSQLViewSuite'`
- `build/sbt 'sql/testOnly org.apache.spark.sql.execution.SQLFunctionSuite'`

Both suites passed with the new regression tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor Codex 5.3