### PR TITLE
[SPARK-56630][INFRA][FOLLOWUP] Make unidoc surface real javadoc failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ Spark Connect protocol is defined in proto files under `sql/connect/common/src/m
 
 Avoid introducing non-ASCII characters in code or comments. String literals may contain non-ASCII when the content requires it (error messages, test data, etc.). Identifiers are ASCII by convention. The common failure mode is typographic characters (em-dash, smart quotes, ellipsis, non-breaking space) sneaking into comments; scalastyle flags some of these. Spot-check before committing: `grep -rn -P "[^\x00-\x7F]" <files>`.
 
+Scaladoc member-link convention: when linking to a method or field of another class from a `/** */` doc comment, use `[[Class#method]]`, not `[[Class.method]]`. genjavadoc passes wiki-style links through as javadoc `{@link ...}`, and javadoc reads `.` as the inner-class separator; if `Class` is a regular `class` / `trait` (not a Scala `object`) and has no companion-object member with that name, javadoc fails to resolve and the unidoc step fails with `error: reference not found`. The `#` form is the Javadoc-canonical member separator and resolves cleanly. Same-class members can still be referenced bare as `[[methodName]]`.
+
 ## Build and Test
 
 Build and tests can take a long time. Before running tests, ask the user if they have more changes to make.

--- a/docs/_plugins/build_api_docs.rb
+++ b/docs/_plugins/build_api_docs.rb
@@ -164,11 +164,19 @@ def stream_and_capture(command, log_file)
 end
 
 # Scans the captured unidoc log and prints a pointer to the most likely
-# culprit source file. The heuristic: when javadoc dies mid-HTML-generation,
-# the last "Generating .../X.html" line before "javadoc exited with exit code"
-# names the class that tripped it. Prints nothing actionable if the failure
-# mode doesn't match (e.g. a scaladoc error), in which case the full log above
-# already shows what's wrong.
+# culprit source file. Two failure modes are surfaced:
+#
+# 1. javadoc dies mid-HTML-generation. The last "Generating .../X.html" line
+#    before "javadoc exited with exit code" names the class that tripped it.
+#
+# 2. javadoc completes HTML generation but reports a non-zero "<N> errors"
+#    count from doclint reference checks. With "-verbose" enabled in the
+#    javacOptions, each such error appears in the log as
+#       <path>.java:<line>: error: reference not found
+#    and we list them so the developer knows exactly which {@link} to fix.
+#
+# Prints nothing actionable if neither pattern matches (e.g. a scaladoc
+# error), in which case the full log above already shows what's wrong.
 def diagnose_unidoc_failure(log_file)
   return unless File.exist?(log_file)
   begin
@@ -186,6 +194,22 @@ def diagnose_unidoc_failure(log_file)
         end
       end
     end
+
+    # "error: reference not found" lines come from javadoc's reference doclint
+    # check on broken {@link Class.member} or {@link Class#member} refs in the
+    # generated stubs (under target/java/...). The line number in the message
+    # is into the *generated* .java, not the original .scala source -- finding
+    # the offending scaladoc usually means opening that target/java file at
+    # that line and reading the {@link ...} on it back to the .scala doc.
+    ansi = /\e\[[0-9;]*[A-Za-z]/
+    ref_errors = []
+    lines.each do |line|
+      stripped = line.gsub(ansi, '')
+      if stripped =~ %r{^(?:\[(?:error|warn|info)\]\s+)?(\S+\.java):(\d+):\s+error: reference not found}
+        ref_errors << "#{$1}:#{$2}"
+      end
+    end
+    ref_errors.uniq!
 
     banner = "=" * 78
     $stderr.puts ""
@@ -209,6 +233,23 @@ def diagnose_unidoc_failure(log_file)
       $stderr.puts "  NOTE: the '[error]' lines above on files under"
       $stderr.puts "  target/java/... are benign genjavadoc stubs -- every PR"
       $stderr.puts "  emits them and they do not cause the exit. Ignore them."
+    elsif !ref_errors.empty?
+      $stderr.puts ""
+      $stderr.puts "  Javadoc reference-resolution errors (each one is a broken"
+      $stderr.puts "  {@link} in a doc comment that genjavadoc copied verbatim"
+      $stderr.puts "  from the corresponding scaladoc; fix the [[link]] in the"
+      $stderr.puts "  Scala source):"
+      $stderr.puts ""
+      ref_errors.first(50).each { |e| $stderr.puts "    #{e}" }
+      if ref_errors.size > 50
+        $stderr.puts "    ... and #{ref_errors.size - 50} more"
+      end
+      $stderr.puts ""
+      $stderr.puts "  Common cause: [[Class.member]] in scaladoc when Class is a"
+      $stderr.puts "  regular `class`/`trait` (not a Scala `object`) and there is"
+      $stderr.puts "  no companion-object member with that name. genjavadoc emits"
+      $stderr.puts "  {@link Class.member}, javadoc reads `.` as the inner-class"
+      $stderr.puts "  separator and fails to resolve. Use [[Class#member]] instead."
     elsif javadoc_exit_idx
       $stderr.puts ""
       $stderr.puts "  Javadoc exited but no class HTML generation was in progress;"

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1699,7 +1699,10 @@ object Unidoc {
         "-tag", "todo:X",
         "-tag", "groupname:X",
         "-tag", "inheritdoc",
-        "--ignore-source-errors", "-notree"
+        "--ignore-source-errors", "-notree",
+        "-Xmaxerrs", "999999",
+        "-Xmaxwarns", "999999",
+        "-verbose"
       )
     },
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Three changes that let the unidoc diagnostic banner added in SPARK-56630 PR https://github.com/apache/spark/pull/55548 actually pinpoint the source of a docs-job failure, plus a note on the most common scaladoc convention behind those failures. None of them silences a real failure — they just remove the existing masking layers that hide which scaladoc / Java doc-comment is the cause.

1. **`project/SparkBuild.scala`** — bump `-Xmaxerrs` and `-Xmaxwarns` from javadoc's defaults of 100 to 999999, and add `-verbose`.
   - `-Xmaxerrs 100` made javadoc bail during source loading whenever the cumulative count of benign genjavadoc-stub errors crossed 100, before any HTML was generated. The diagnostic banner from SPARK-56630 cannot identify a culprit class in that mode because there is no `Generating .../<Class>.html` line yet.
   - `-Xmaxwarns 100` capped the printed warning count even when javadoc completed; on a real Spark unidoc run the actual warning count from doclint (`no comment`, `empty <p> tag`, `no @return`, `no @param ...`) is in the tens of thousands, and per-link `error: reference not found` messages were being clipped along with them.
   - `-verbose` makes javadoc emit a `<path>.java:<line>: error: reference not found` line for every broken `{@link}` it encounters during HTML generation. Without it, javadoc tracks reference errors in its internal counter and reports the bulk total in the final `<N> errors / <M> warnings` summary, but does not print a file:line for each one. The flag also dumps `Loading source file ...` progress lines, so the unidoc log grows by an order of magnitude; that is the price of being able to debug reference errors at all from CI logs.

2. **`docs/_plugins/build_api_docs.rb`** — extend the diagnostic banner. The original banner names the class javadoc was rendering when it crashed mid-HTML-generation. With `-verbose` now enabled, the build can also fail with a non-zero `<N> errors` summary after javadoc completed all HTML output, when broken `{@link}` references push the doclint reference-error count above zero. The extension scans the captured log for `error: reference not found` lines and lists their `<path>.java:<line>` in the banner, plus a short note about the most common root cause (`[[Class.member]]` in scaladoc on a regular class/trait — fix by using `[[Class#member]]`).

3. **`AGENTS.md`** — document the `[[Class#method]]` member-link convention in the Development Notes section, so contributors and AI agents reach for the `#` form from the start instead of triggering the unidoc failure and reading the convention back out of the banner.


### Why are the changes needed?

Today, when the unidoc step fails, the visible signal is hundreds of `[error]` lines on `target/java/...` files (`error: illegal combination of modifiers: abstract and static`, `error: cannot find symbol` on type variables, etc.). Those errors are inert — they come from the way genjavadoc lifts type-parameterised methods into static Java emission, every Spark unidoc run produces them, and javadoc normally finishes anyway. The commit message for https://github.com/apache/spark/pull/55548 documents this. The actual cause of the failure is something else: either javadoc bailed because `-Xmaxerrs 100` was hit during source loading, or javadoc completed but reported a non-zero error count from broken `{@link}` references.

The diagnostic banner from https://github.com/apache/spark/pull/55548 only handles the mid-HTML-generation crash mode, and only when javadoc reaches HTML generation in the first place. Both the source-loading early bailout and the post-HTML reference-error tally were invisible to it. As a concrete example: PR #55371's docs job was failing deterministically with the SPARK-56630 banner reporting "Javadoc exited but no class HTML generation was in progress" — useless because the failure mode was the early bailout. With `-Xmaxerrs` / `-Xmaxwarns` raised, the same run reached HTML generation and reported `6 errors / 22188 warnings`, but the 6 errors had no per-error log line and the banner had nothing to say. With `-verbose` and the extended banner, the same run prints

```
==============================================================================
Unidoc failed -- diagnostic summary
==============================================================================

  Javadoc reference-resolution errors (each one is a broken
  {@link} in a doc comment that genjavadoc copied verbatim
  from the corresponding scaladoc; fix the [[link]] in the
  Scala source):

    /__w/.../core/target/java/org/apache/spark/util/LastAttemptAccumulator.java:9
    /__w/.../core/target/java/org/apache/spark/util/LastAttemptAccumulator.java:15
    /__w/.../core/target/java/org/apache/spark/util/LastAttemptAccumulator.java:22
    /__w/.../core/target/java/org/apache/spark/util/LastAttemptAccumulator.java:23
    /__w/.../core/target/java/org/apache/spark/util/LastAttemptAccumulator.java:42
    /__w/.../core/target/java/org/apache/spark/util/LastAttemptAccumulator.java:51

  Common cause: [[Class.member]] in scaladoc when Class is a
  regular `class`/`trait` (not a Scala `object`) and there is
  no companion-object member with that name. genjavadoc emits
  {@link Class.member}, javadoc reads `.` as the inner-class
  separator and fails to resolve. Use [[Class#member]] instead.
==============================================================================
```

which points the developer directly at the `{@link}` they need to fix.

These changes do not silence any real failure. javadoc still exits non-zero when there are real errors. They only remove the noise-driven and clipping-driven masks so the SPARK-56630 banner can do its job.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Locally:

- With deliberately broken `[[AccumulatorV2.add]]`-style refs in a scaladoc comment, `build/sbt -Pkinesis-asl unidoc` completed all 2465 HTML files but reported a non-zero error count and exited non-zero. The diagnostic banner listed each broken-reference file:line entry.

- After converting the same refs to the `[[AccumulatorV2#add]]` form, the same command reported `Main Java API documentation successful.` and exited zero.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude (Opus 4.7)