### PR TITLE
[SPARK-56632][SQL][CONNECT] Fix AMBIGUOUS_COLUMN_REFERENCE regression for reused DataFrame in natural join

### DIFF
--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -558,6 +558,26 @@ class ColumnTestsMixin:
             self.assertTrue(df1.join(df2, "id", how).select(df1["id"]).count() >= 0, how)
             self.assertTrue(df1.join(df2, "id", how).select(df2["id"]).count() >= 0, how)
 
+    def test_select_regular_column_with_reused_dataframe_hidden_in_natural_join(self):
+        # A DataFrame appears both as a direct join side and inside a natural/USING
+        # join that hides one of its columns into `metadataOutput`. When resolving
+        # `dim["dim_id"]`, two candidates match the plan id: one from `p.output`
+        # (the direct join side) and one only visible via `p.metadataOutput` (the
+        # reused `dim` nested under the USING-join wrapper). We should prefer the
+        # regular candidate and not throw AMBIGUOUS_COLUMN_REFERENCE.
+        fact = self.spark.createDataFrame([(1, 10, "T1"), (2, 20, "T2")], ["id", "fk", "txn_id"])
+        dim = self.spark.createDataFrame([(10, "X"), (20, "Y"), (30, "Z")], ["dim_id", "dim_name"])
+        events = self.spark.createDataFrame(
+            [(10, "T1", 100), (20, "T2", 200)], ["dim_id", "txn_id", "amount"]
+        )
+        enriched = events.join(dim, "dim_id", "left")
+        result = (
+            fact.join(dim, fact["fk"] == dim["dim_id"], "left")
+            .join(enriched, "txn_id", "full_outer")
+            .select(dim["dim_id"])
+        )
+        self.assertEqual(result.count(), 2)
+
     def test_drop_notexistent_col(self):
         df1 = self.spark.createDataFrame(
             [("a", "b", "c")],

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -576,7 +576,10 @@ class ColumnTestsMixin:
             .join(enriched, "txn_id", "full_outer")
             .select(dim["dim_id"])
         )
-        self.assertEqual(result.count(), 2)
+        self.assertEqual(
+            [r["dim_id"] for r in result.sort("txn_id").collect()],
+            [10, 20],
+        )
 
     def test_drop_notexistent_col(self):
         df1 = self.spark.createDataFrame(

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -577,10 +577,11 @@ class ColumnTestsMixin:
         result = (
             df1.join(df2, df1["key"] == df2["id"], "left")
             .join(enriched, "val", "full_outer")
+            .sort("val")
             .select(df2["id"])
         )
         self.assertEqual(
-            [r["id"] for r in result.sort("val").collect()],
+            [r["id"] for r in result.collect()],
             [10, 20],
         )
 

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -561,26 +561,26 @@ class ColumnTestsMixin:
     def test_select_regular_column_with_reused_dataframe_hidden_in_natural_join(self):
         # A DataFrame appears both as a direct join side and inside a natural/USING
         # join that hides one of its columns into `metadataOutput`. When resolving
-        # `dim["k"]`, two candidates match the plan id: one from `p.output` (the
+        # `dim["id"]`, two candidates match the plan id: one from `p.output` (the
         # direct join side) and one only visible via `p.metadataOutput` (the reused
         # `dim` nested under the USING-join wrapper). We should prefer the regular
         # candidate and not throw AMBIGUOUS_COLUMN_REFERENCE.
-        fact = self.spark.createDataFrame([(10, "T1"), (20, "T2")], ["fk", "t"])
-        dim = self.spark.createDataFrame([(10,), (20,), (30,)], ["k"])
-        # The second row's k (99) does not match any dim row, so the USING
-        # left-join in `enriched` produces NULL on the dim side for t "T2".
-        # If `dim["k"]` were resolved to the hidden (USING-wrapper) candidate,
+        fact = self.spark.createDataFrame([(10, "T1"), (20, "T2")], ["fk", "val"])
+        dim = self.spark.createDataFrame([(10,), (20,), (30,)], ["id"])
+        # The second row's id (99) does not match any dim row, so the USING
+        # left-join in `enriched` produces NULL on the dim side for val "T2".
+        # If `dim["id"]` were resolved to the hidden (USING-wrapper) candidate,
         # the second row would yield NULL instead of 20, and the assertion below
-        # would fail. This pins resolution to the direct-side `k`.
-        events = self.spark.createDataFrame([(10, "T1"), (99, "T2")], ["k", "t"])
-        enriched = events.join(dim, "k", "left")
+        # would fail. This pins resolution to the direct-side `id`.
+        events = self.spark.createDataFrame([(10, "T1"), (99, "T2")], ["id", "val"])
+        enriched = events.join(dim, "id", "left")
         result = (
-            fact.join(dim, fact["fk"] == dim["k"], "left")
-            .join(enriched, "t", "full_outer")
-            .select(dim["k"])
+            fact.join(dim, fact["fk"] == dim["id"], "left")
+            .join(enriched, "val", "full_outer")
+            .select(dim["id"])
         )
         self.assertEqual(
-            [r["k"] for r in result.sort("t").collect()],
+            [r["id"] for r in result.sort("val").collect()],
             [10, 20],
         )
 

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -567,8 +567,13 @@ class ColumnTestsMixin:
         # regular candidate and not throw AMBIGUOUS_COLUMN_REFERENCE.
         fact = self.spark.createDataFrame([(1, 10, "T1"), (2, 20, "T2")], ["id", "fk", "txn_id"])
         dim = self.spark.createDataFrame([(10, "X"), (20, "Y"), (30, "Z")], ["dim_id", "dim_name"])
+        # The second row's dim_id (99) does not match any dim row, so the USING
+        # left-join in `enriched` produces NULL on the dim side for txn_id "T2".
+        # If `dim["dim_id"]` were resolved to the hidden (USING-wrapper) candidate,
+        # the second row would yield NULL instead of 20, and the assertion below
+        # would fail. This pins resolution to the direct-side `dim_id`.
         events = self.spark.createDataFrame(
-            [(10, "T1", 100), (20, "T2", 200)], ["dim_id", "txn_id", "amount"]
+            [(10, "T1", 100), (99, "T2", 200)], ["dim_id", "txn_id", "amount"]
         )
         enriched = events.join(dim, "dim_id", "left")
         result = (

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -561,28 +561,26 @@ class ColumnTestsMixin:
     def test_select_regular_column_with_reused_dataframe_hidden_in_natural_join(self):
         # A DataFrame appears both as a direct join side and inside a natural/USING
         # join that hides one of its columns into `metadataOutput`. When resolving
-        # `dim["dim_id"]`, two candidates match the plan id: one from `p.output`
-        # (the direct join side) and one only visible via `p.metadataOutput` (the
-        # reused `dim` nested under the USING-join wrapper). We should prefer the
-        # regular candidate and not throw AMBIGUOUS_COLUMN_REFERENCE.
-        fact = self.spark.createDataFrame([(1, 10, "T1"), (2, 20, "T2")], ["id", "fk", "txn_id"])
-        dim = self.spark.createDataFrame([(10, "X"), (20, "Y"), (30, "Z")], ["dim_id", "dim_name"])
-        # The second row's dim_id (99) does not match any dim row, so the USING
-        # left-join in `enriched` produces NULL on the dim side for txn_id "T2".
-        # If `dim["dim_id"]` were resolved to the hidden (USING-wrapper) candidate,
+        # `dim["k"]`, two candidates match the plan id: one from `p.output` (the
+        # direct join side) and one only visible via `p.metadataOutput` (the reused
+        # `dim` nested under the USING-join wrapper). We should prefer the regular
+        # candidate and not throw AMBIGUOUS_COLUMN_REFERENCE.
+        fact = self.spark.createDataFrame([(10, "T1"), (20, "T2")], ["fk", "t"])
+        dim = self.spark.createDataFrame([(10,), (20,), (30,)], ["k"])
+        # The second row's k (99) does not match any dim row, so the USING
+        # left-join in `enriched` produces NULL on the dim side for t "T2".
+        # If `dim["k"]` were resolved to the hidden (USING-wrapper) candidate,
         # the second row would yield NULL instead of 20, and the assertion below
-        # would fail. This pins resolution to the direct-side `dim_id`.
-        events = self.spark.createDataFrame(
-            [(10, "T1", 100), (99, "T2", 200)], ["dim_id", "txn_id", "amount"]
-        )
-        enriched = events.join(dim, "dim_id", "left")
+        # would fail. This pins resolution to the direct-side `k`.
+        events = self.spark.createDataFrame([(10, "T1"), (99, "T2")], ["k", "t"])
+        enriched = events.join(dim, "k", "left")
         result = (
-            fact.join(dim, fact["fk"] == dim["dim_id"], "left")
-            .join(enriched, "txn_id", "full_outer")
-            .select(dim["dim_id"])
+            fact.join(dim, fact["fk"] == dim["k"], "left")
+            .join(enriched, "t", "full_outer")
+            .select(dim["k"])
         )
         self.assertEqual(
-            [r["dim_id"] for r in result.sort("txn_id").collect()],
+            [r["k"] for r in result.sort("t").collect()],
             [10, 20],
         )
 

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -561,23 +561,23 @@ class ColumnTestsMixin:
     def test_select_regular_column_with_reused_dataframe_hidden_in_natural_join(self):
         # A DataFrame appears both as a direct join side and inside a natural/USING
         # join that hides one of its columns into `metadataOutput`. When resolving
-        # `dim["id"]`, two candidates match the plan id: one from `p.output` (the
+        # `df2["id"]`, two candidates match the plan id: one from `p.output` (the
         # direct join side) and one only visible via `p.metadataOutput` (the reused
-        # `dim` nested under the USING-join wrapper). We should prefer the regular
+        # `df2` nested under the USING-join wrapper). We should prefer the regular
         # candidate and not throw AMBIGUOUS_COLUMN_REFERENCE.
-        fact = self.spark.createDataFrame([(10, "T1"), (20, "T2")], ["fk", "val"])
-        dim = self.spark.createDataFrame([(10,), (20,), (30,)], ["id"])
-        # The second row's id (99) does not match any dim row, so the USING
-        # left-join in `enriched` produces NULL on the dim side for val "T2".
-        # If `dim["id"]` were resolved to the hidden (USING-wrapper) candidate,
+        df1 = self.spark.createDataFrame([(10, "T1"), (20, "T2")], ["key", "val"])
+        df2 = self.spark.createDataFrame([(10,), (20,), (30,)], ["id"])
+        # The second row's id (99) does not match any df2 row, so the USING
+        # left-join in `enriched` produces NULL on the df2 side for val "T2".
+        # If `df2["id"]` were resolved to the hidden (USING-wrapper) candidate,
         # the second row would yield NULL instead of 20, and the assertion below
         # would fail. This pins resolution to the direct-side `id`.
-        events = self.spark.createDataFrame([(10, "T1"), (99, "T2")], ["id", "val"])
-        enriched = events.join(dim, "id", "left")
+        df3 = self.spark.createDataFrame([(10, "T1"), (99, "T2")], ["id", "val"])
+        enriched = df3.join(df2, "id", "left")
         result = (
-            fact.join(dim, fact["fk"] == dim["id"], "left")
+            df1.join(df2, df1["key"] == df2["id"], "left")
             .join(enriched, "val", "full_outer")
-            .select(dim["id"])
+            .select(df2["id"])
         )
         self.assertEqual(
             [r["id"] for r in result.sort("val").collect()],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -529,7 +529,7 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
 
     val isMetadataAccess = u.containsTag(LogicalPlan.IS_METADATA_COL)
 
-    val (resolved, matched) = resolveDataFrameColumnByPlanId(
+    val (candidates, matched) = resolveDataFrameColumnByPlanId(
       u, planId, isMetadataAccess, q, 0)
     if (!matched) {
       // Can not find the target plan node with plan id, e.g.
@@ -538,27 +538,41 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
       //  df1.select(df2.a)   <-   illegal reference df2.a
       throw QueryCompilationErrors.cannotResolveDataFrameColumn(u)
     }
-    resolved.map(_._1)
+
+    // If there is at least one regular (`hidden = false`) candidate, run the
+    // merge over regular candidates only and ignore hidden ones (e.g. a
+    // natural/USING join hidden key). Otherwise run the merge over hidden
+    // candidates.
+    val (regular, hidden) = candidates.partition(!_.hidden)
+    val finalists = if (regular.nonEmpty) regular else hidden
+    finalists.sortBy(_.depth).foldLeft(Option.empty[Candidate]) {
+      case (None, c) => Some(c)
+      // If the current winner is a direct match (depth 0) and a further
+      // candidate is nested deeper, prefer the direct one.
+      case (Some(c1), c2) if c1.depth == 0 && c2.depth != 0 => Some(c1)
+      case _ => throw QueryCompilationErrors.ambiguousColumnReferences(u)
+    }.map(_.expr)
   }
+
+  // Candidate threaded through the plan walk:
+  //   - expr:   the resolved expression
+  //   - depth:  the depth at which it was matched
+  //   - hidden: whether the candidate's references live in `p.metadataOutput`
+  //             at some plan node along the way (e.g. a natural/USING join
+  //             wrapper that hides a join key via `Project.hiddenOutputTag`).
+  private case class Candidate(expr: NamedExpression, depth: Int, hidden: Boolean)
 
   private def resolveDataFrameColumnByPlanId(
       u: UnresolvedAttribute,
       id: Long,
       isMetadataAccess: Boolean,
       q: Seq[LogicalPlan],
-      currentDepth: Int): (Option[(NamedExpression, Int)], Boolean) = {
+      currentDepth: Int): (Seq[Candidate], Boolean) = {
     val resolved = q.map(resolveDataFrameColumnRecursively(
       u, id, isMetadataAccess, _, currentDepth))
-    val merged = resolved
-      .flatMap(_._1)
-      .sortBy(_._2) // sort by depth
-      .foldLeft(Option.empty[(NamedExpression, Int)]) {
-        case (None, (r2, d2)) => Some((r2, d2))
-        case (Some((r1, 0)), (r2, d2)) if d2 != 0 => Some((r1, 0))
-        case _ => throw QueryCompilationErrors.ambiguousColumnReferences(u)
-      }
+    val candidates = resolved.flatMap(_._1)
     val matched = resolved.exists(_._2)
-    (merged, matched)
+    (candidates, matched)
   }
 
   private def resolveDataFrameColumnRecursively(
@@ -566,8 +580,8 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
       id: Long,
       isMetadataAccess: Boolean,
       p: LogicalPlan,
-      currentDepth: Int): (Option[(NamedExpression, Int)], Boolean) = {
-    val (resolved, matched) = if (p.getTagValue(LogicalPlan.PLAN_ID_TAG).contains(id)) {
+      currentDepth: Int): (Seq[Candidate], Boolean) = {
+    val (candidates, matched) = if (p.getTagValue(LogicalPlan.PLAN_ID_TAG).contains(id)) {
       val resolved = if (!isMetadataAccess) {
         p.resolve(u.nameParts, conf.resolver)
       } else if (u.nameParts.size == 1) {
@@ -575,10 +589,12 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
       } else {
         None
       }
-      // The targe plan node is found, but might still fail to resolve.
-      // In this case, return None to delay the failure, so it is possible to be
+      // The target plan node is found, but might still fail to resolve. In this
+      // case, return an empty Seq to delay the failure, so it is possible to be
       // resolved in the next iteration.
-      (resolved.map(r => (r, currentDepth)), true)
+      // Always initialize `hidden = false` here; the filter below will set it
+      // correctly based on whether the references live in `p.metadataOutput`.
+      (resolved.map(Candidate(_, currentDepth, hidden = false)).toSeq, true)
     } else {
       val children = p match {
         // treat Union node as the leaf node
@@ -616,12 +632,22 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
     // df = spark.range(10).withColumn("v", sf.col("id") + 1)
     // df.select(df.v).sort(df.id)
     //
-    // In this case, resolveDataFrameColumnByPlanId returns None,
+    // In this case, resolveDataFrameColumnByPlanId returns an empty Seq,
     // the dataframe column 'df.id' will remain unresolved, and the analyzer
     // will try to resolve 'id' without plan id later.
-    val filtered = resolved.filter { r =>
-      // A DataFrame column can be resolved as a metadata column, we should keep it.
-      r._1.references.subsetOf(AttributeSet(p.output ++ p.metadataOutput))
+    //
+    // A DataFrame column can also be resolved as a metadata column at some
+    // ancestor plan (e.g. a natural/USING join wrapper that hides a join key
+    // via `Project.hiddenOutputTag`). We accept that here but tag the candidate
+    // as `hidden` so the top-level merge in `resolveDataFrameColumn` can prefer
+    // a regular (p.output) match over hidden (p.metadataOutput) ones.
+    val filtered = candidates.flatMap { c =>
+      val hidden = c.hidden || c.expr.references.subsetOf(AttributeSet(p.metadataOutput))
+      if (c.expr.references.subsetOf(AttributeSet(p.output ++ p.metadataOutput))) {
+        Some(c.copy(hidden = hidden))
+      } else {
+        None
+      }
     }
     (filtered, matched)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -504,7 +504,10 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
   //    5, resolve the expression against the target node, the resolved attribute will be
   //       filtered by the output attributes of nodes in the path (from matching to root node);
   //    6. if more than one resolved attributes are found in the above recursive process,
-  //       fails with 'AMBIGUOUS_COLUMN_REFERENCE'.
+  //       disambiguate by preferring regular candidates (visible via `output`) over
+  //       hidden ones (only via `metadataOutput`), then preferring depth-0 (direct)
+  //       matches over deeper ones; fails with 'AMBIGUOUS_COLUMN_REFERENCE' if neither
+  //       tiebreaker yields a single winner.
   //    7. if all the resolved attributes are filtered out, return the original expression
   //       as it is.
   private def tryResolveDataFrameColumns(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix an `AMBIGUOUS_COLUMN_REFERENCE` regression introduced by SPARK-55070 when a DataFrame is referenced both directly in a join and also nested under a natural/USING join elsewhere in the same plan.

Introduce a `Candidate(expr, depth, hidden)` case class. Both `resolveDataFrameColumnByPlanId` and `resolveDataFrameColumnRecursively` now return `(Seq[Candidate], Boolean)` — they collect candidates rather than merging eagerly. The walk latches `hidden = h || r.references.subsetOf(AttributeSet(p.metadataOutput))` at each ancestor; the filter then keeps candidates whose references are visible in `p.output ++ p.metadataOutput`.

The merge is **lifted from per-recursion-level to the top of `resolveDataFrameColumn`**. Two effects:

1. After the walk returns the full candidate list, partition by `hidden`:
   - if any regular (`hidden = false`) candidate exists, run the merge over regulars only and ignore hidden ones (e.g. the natural/USING-join hidden key);
   - otherwise run the same merge over hidden candidates (preserves SPARK-55070's `rhs["join_key"]` case where the only matching candidate is hidden).
2. Subtree-internal collisions no longer throw early — a depth-0 candidate from a different subtree can rescue a case the upstream foldLeft would have thrown on. The depth-0 direct-match tiebreaker in the final `foldLeft` is preserved.

### Why are the changes needed?

SPARK-55070 broadened the ancestor filter in `resolveDataFrameColumnRecursively` from `p.outputSet` to `p.output ++ p.metadataOutput` so that `rhs["join_key"]` works after a natural/USING join (where one join key is hidden in `Project.hiddenOutputTag`). But when the same DataFrame is both used directly in a join and also nested under a natural/USING-join wrapper elsewhere in the plan, the broadened filter lets both candidates through `resolveDataFrameColumnByPlanId`'s merge, tripping `throw ambiguousColumnReferences(u)`.

For example, queries like:

```python
enriched = events.join(dim, "dim_id", "left")   # USING join hides dim's dim_id
result = (fact
  .join(dim, fact["fk"] == dim["dim_id"], "left")  # direct use of dim
  .join(enriched, "txn_id", "full_outer")
  .select(dim["dim_id"]))                          # previously AMBIGUOUS
```

now resolve `dim["dim_id"]` to the direct-usage output candidate.

### Does this PR introduce _any_ user-facing change?

Yes — bug fix. Queries that referenced a DataFrame both directly in a join and nested under a natural/USING join (where the wrapper hides one of the columns into `metadataOutput`) previously raised `AMBIGUOUS_COLUMN_REFERENCE`. They now resolve to the direct-usage candidate.

### How was this patch tested?

- New `test_select_regular_column_with_reused_dataframe_hidden_in_natural_join` added to `ColumnTestsMixin` in `python/pyspark/sql/tests/test_column.py`. The events data is constructed so the USING-wrapper's hidden `dim_id` would be NULL on one row while the direct-join `dim_id` is non-null, pinning resolution to the direct candidate (not just verifying the throw is gone).
- Manually verified `pyspark.sql.tests.test_column` (classic) and `pyspark.sql.tests.connect.test_parity_column` (Connect, both `ColumnParityTests` and `ColumnParityTestsWithNonStrictDFColResolution`): the new test passes; pre-existing `test_column_date_time_op` errors with `UNSUPPORTED_TIME_TYPE` are unrelated to this change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (model: claude-opus-4-7)