### PR TITLE
[SPARK-56652][SQL] Always emit RELY/NORELY in DESCRIBE EXTENDED constraint output

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/constraints/BaseConstraint.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/constraints/BaseConstraint.java
@@ -65,12 +65,7 @@ abstract class BaseConstraint implements Constraint {
   public String toDDL() {
     // The validation status is not included in the DDL output as it's not part of
     // the Spark SQL syntax for constraints.
-    return String.format(
-        "CONSTRAINT %s %s %s %s",
-        name,
-        definition(),
-        enforced ? "ENFORCED" : "NOT ENFORCED",
-        rely ? "RELY" : "NORELY");
+    return "CONSTRAINT " + name + " " + toDescription();
   }
 
   public String toDescription() {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/constraints/BaseConstraint.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/constraints/BaseConstraint.java
@@ -74,13 +74,11 @@ abstract class BaseConstraint implements Constraint {
   }
 
   public String toDescription() {
-    StringJoiner joiner = new StringJoiner(" ");
-    joiner.add(definition());
-    joiner.add(enforced ? "ENFORCED" : "NOT ENFORCED");
-    if (rely) {
-      joiner.add("RELY");
-    }
-    return joiner.toString();
+    return String.format(
+        "%s %s %s",
+        definition(),
+        enforced ? "ENFORCED" : "NOT ENFORCED",
+        rely ? "RELY" : "NORELY");
   }
 
   @Override

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
@@ -360,21 +360,20 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
              |$defaultUsing
         """.stripMargin)
 
-        // Skipped showing NORELY since it is the default value.
+        // ENFORCED/NOT ENFORCED and RELY/NORELY are always emitted to match SHOW CREATE TABLE.
         var expectedConstraintsDdl = Array(
           "# Constraints,,",
-          "pk_table_pk,PRIMARY KEY (id) NOT ENFORCED,",
+          "pk_table_pk,PRIMARY KEY (id) NOT ENFORCED NORELY,",
           s"fk_a,FOREIGN KEY (a) REFERENCES $fkTable (id) NOT ENFORCED RELY,",
-          "uk_b,UNIQUE (b) NOT ENFORCED,",
-          "uk_a_c,UNIQUE (a, c) NOT ENFORCED,",
-          "c1,CHECK (c IS NOT NULL) ENFORCED,",
-          "c2,CHECK (id > 0) ENFORCED,"
+          "uk_b,UNIQUE (b) NOT ENFORCED NORELY,",
+          "uk_a_c,UNIQUE (a, c) NOT ENFORCED NORELY,",
+          "c1,CHECK (c IS NOT NULL) ENFORCED NORELY,",
+          "c2,CHECK (id > 0) ENFORCED NORELY,"
         )
         var descDdL = sql(s"DESCRIBE EXTENDED $tbl").collect().map(_.mkString(","))
           .dropWhile(_ != "# Constraints,,")
         assert(descDdL === expectedConstraintsDdl)
 
-        // Show non-default value for RELY.
         sql(s"ALTER TABLE $tbl ADD CONSTRAINT c3 CHECK (b IS NOT NULL) RELY")
         descDdL = sql(s"DESCRIBE EXTENDED $tbl").collect().map(_.mkString(","))
           .dropWhile(_ != "# Constraints,,")
@@ -386,7 +385,7 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
         descDdL = sql(s"DESCRIBE EXTENDED $tbl").collect().map(_.mkString(","))
           .dropWhile(_ != "# Constraints,,")
         assert(descDdL === expectedConstraintsDdl
-          .filter(_ != "c1,CHECK (c IS NOT NULL) ENFORCED,"))
+          .filter(_ != "c1,CHECK (c IS NOT NULL) ENFORCED NORELY,"))
       }
     }
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?

`BaseConstraint.toDescription()` now always emits `RELY|NORELY`, matching `toDDL()` used by SHOW CREATE TABLE. Previously, `toDescription()` skipped the `NORELY` token when `rely=false`, so the same constraint rendered differently across the two surfaces.

After this change, the invariant holds:
`toDDL` is `"CONSTRAINT " + name + " " + toDescription`.

### Why are the changes needed?

After SPARK-52141 (DESCRIBE EXTENDED) and SPARK-52142 (SHOW CREATE TABLE) landed, the two surfaces render the same constraint asymmetrically:

| State        | DESCRIBE EXTENDED (before)        | SHOW CREATE TABLE                   |
|--------------|-----------------------------------|-------------------------------------|
| PK default   | PRIMARY KEY (a) NOT ENFORCED      | PRIMARY KEY (a) NOT ENFORCED NORELY |
| CHECK default| CHECK (...) ENFORCED              | CHECK (...) ENFORCED NORELY         |

The original review on PR #51577 considered skipping both `NOT ENFORCED` and `NORELY` when default, but only `NORELY` was skipped because `ENFORCED`'s default is per-subclass and not visible to `BaseConstraint`. The result is a confusing experience: SHOW CREATE TABLE reports the rely state explicitly while DESCRIBE EXTENDED hides it for the default value.

### Does this PR introduce any user-facing change?

Slight output change in DESCRIBE EXTENDED command output. DESCRIBE EXTENDED now emits `NORELY` for constraints whose `rely` value is the default. PRIMARY KEY / UNIQUE / FOREIGN KEY / CHECK constraints all show the full `ENFORCED|NOT ENFORCED RELY|NORELY` suffix, matching SHOW CREATE TABLE.

### How was this patch tested?

Updated golden strings in the v2 `DescribeTableSuite` "desc table constraints" test. Ran:

  build/sbt 'sql/testOnly \
    org.apache.spark.sql.execution.command.v2.DescribeTableSuite \
    org.apache.spark.sql.execution.command.v2.ShowCreateTableSuite'

41 tests pass.

### Was this patch authored or co-authored using generative AI tooling?

Claude Opus 4.7 