### PR TITLE
[SPARK-56653][K8S][DOCS] Document `spark.kubernetes.(executor.useDriverPodIP|allocation.maxPendingPodsPerRp|driver.annotateExitException)`

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1558,6 +1558,14 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>3.2.0</td>
 </tr>
 <tr>
+  <td><code>spark.kubernetes.driver.annotateExitException</code></td>
+  <td><code>false</code></td>
+  <td>
+    If set to true, Spark will store the exit exception failed applications in the Kubernetes API server using the <code>spark.exit-exception</code> annotation.
+  </td>
+  <td>4.1.0</td>
+</tr>
+<tr>
   <td><code>spark.kubernetes.driver.service.ipFamilyPolicy</code></td>
   <td><code>SingleStack</code></td>
   <td>
@@ -1574,6 +1582,14 @@ See the [configuration page](configuration.html) for information on Spark config
     <code>IPv4</code> and <code>IPv6</code>.
   </td>
   <td>3.4.0</td>
+</tr>
+<tr>
+  <td><code>spark.kubernetes.executor.useDriverPodIP</code></td>
+  <td><code>false</code></td>
+  <td>
+    If true, executor pods use Driver pod IP directly instead of Driver Service.
+  </td>
+  <td>4.1.0</td>
 </tr>
 <tr>
   <td><code>spark.kubernetes.driver.ownPersistentVolumeClaim</code></td>
@@ -1671,6 +1687,17 @@ See the [configuration page](configuration.html) for information on Spark config
     allocation for all the used resource profiles.
   </td>
   <td>3.2.0</td>
+</tr>
+<tr>
+  <td><code>spark.kubernetes.allocation.maxPendingPodsPerRp</code></td>
+  <td><code>Int.MaxValue</code></td>
+  <td>
+    Maximum number of pending PODs allowed per resource profile ID during executor
+    allocation. This provides finer-grained control over pending pods by limiting them
+    per resource profile rather than globally. When set, this limit is enforced
+    independently for each resource profile ID.
+  </td>
+  <td>4.1.0</td>
 </tr>
 <tr>
   <td><code>spark.kubernetes.allocation.pods.allocator</code></td>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR documents three missing Spark configurations introduced in Spark 4.1.0.

| Property | Default | Since | Introduced in |
| --- | --- | --- | --- |
| `spark.kubernetes.executor.useDriverPodIP` | `false` | 4.1.0 | SPARK-53944 |
| `spark.kubernetes.driver.annotateExitException` | `false` | 4.1.0 | SPARK-53335 |
| `spark.kubernetes.allocation.maxPendingPodsPerRp` | `Int.MaxValue` | 4.1.0 | SPARK-53324 |

### Why are the changes needed?

Three user-facing Kubernetes configurations added in Spark 4.1.0 but weren't documented yet.

- https://github.com/apache/spark/pull/52650
- https://github.com/apache/spark/pull/52068
- https://github.com/apache/spark/pull/51913

### Does this PR introduce _any_ user-facing change?

No. Documentation-only update.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)