### PR TITLE
[SPARK-56649][PYTHON][TESTS] Add ASV microbenchmark for SQL_GROUPED_MAP_PANDAS_ITER_UDF

### DIFF
--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -1081,6 +1081,55 @@ class GroupedMapPandasUDFPeakmemBench(_GroupedMapPandasBenchMixin, _PeakmemBench
     pass
 
 
+# -- SQL_GROUPED_MAP_PANDAS_ITER_UDF -------------------------------------------
+# UDF receives ``Iterator[pandas.DataFrame]`` per group, returns
+# ``Iterator[pandas.DataFrame]``.
+
+
+class _GroupedMapPandasIterBenchMixin(_GroupedMapPandasBenchMixin):
+    """Provides ``_write_scenario`` for SQL_GROUPED_MAP_PANDAS_ITER_UDF."""
+
+    def _grouped_map_pandas_iter_identity(pdfs):
+        yield from pdfs
+
+    def _grouped_map_pandas_iter_sort(pdfs):
+        for pdf in pdfs:
+            yield pdf.sort_values(pdf.columns[0])
+
+    def _grouped_map_pandas_iter_key_identity(key, pdfs):
+        yield from pdfs
+
+    _udfs = {
+        "identity_udf": (_grouped_map_pandas_iter_identity, None, 1),
+        "sort_udf": (_grouped_map_pandas_iter_sort, None, 1),
+        "key_identity_udf": (_grouped_map_pandas_iter_key_identity, None, 2),
+    }
+    params = [list(_GroupedMapPandasBenchMixin._scenario_configs), list(_udfs)]
+    param_names = ["scenario", "udf"]
+
+    def _write_scenario(self, scenario, udf_name, buf):
+        groups, schema = self._build_scenario(scenario)
+        udf_func, ret_type, n_args = self._udfs[udf_name]
+        if ret_type is None:
+            ret_type = StructType(schema.fields[n_args - 1 :]) if n_args > 1 else schema
+        n_cols = len(schema.fields)
+        arg_offsets = MockUDFFactory.make_grouped_arg_offsets(n_args - 1, n_cols - (n_args - 1))
+        MockProtocolWriter.write_worker_input(
+            PythonEvalType.SQL_GROUPED_MAP_PANDAS_ITER_UDF,
+            lambda b: MockProtocolWriter.write_udf_payload(udf_func, ret_type, arg_offsets, b),
+            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, buf=b),
+            buf,
+        )
+
+
+class GroupedMapPandasIterUDFTimeBench(_GroupedMapPandasIterBenchMixin, _TimeBenchBase):
+    pass
+
+
+class GroupedMapPandasIterUDFPeakmemBench(_GroupedMapPandasIterBenchMixin, _PeakmemBenchBase):
+    pass
+
+
 # -- SQL_MAP_ARROW_ITER_UDF ------------------------------------------------
 # UDF receives ``Iterator[pa.RecordBatch]``, returns ``Iterator[pa.RecordBatch]``.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds ASV microbenchmark `GroupedMapPandasIterUDF{Time,Peakmem}Bench` for `SQL_GROUPED_MAP_PANDAS_ITER_UDF` in `python/benchmarks/bench_eval_type.py`.

### Why are the changes needed?

Establish a baseline before refactoring `SQL_GROUPED_MAP_PANDAS_ITER_UDF` (subtask of [SPARK-55724](https://issues.apache.org/jira/browse/SPARK-55724)).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`COLUMNS=120 asv run --bench GroupedMapPandasIterUDF --python=same -a repeat=3`

```text
[75.00%] ··· bench_eval_type.GroupedMapPandasIterUDFPeakmemBench.peakmem_worker                                      ok
[75.00%] ··· ================= ============== ========== ==================
             --                                    udf
             ----------------- --------------------------------------------
                  scenario      identity_udf   sort_udf   key_identity_udf
             ================= ============== ========== ==================
               sm_grp_few_col       477M         478M           471M
              sm_grp_many_col       484M         485M           484M
               lg_grp_few_col       634M         635M           550M
              lg_grp_many_col       767M         768M           765M
                mixed_types         467M         467M           467M
             ================= ============== ========== ==================

[100.00%] ··· bench_eval_type.GroupedMapPandasIterUDFTimeBench.time_worker                                            ok
[100.00%] ··· ================= ============== ============ ==================
              --                                     udf
              ----------------- ----------------------------------------------
                   scenario      identity_udf    sort_udf    key_identity_udf
              ================= ============== ============ ==================
                sm_grp_few_col     438±4ms       495±5ms         412±4ms
               sm_grp_many_col     357±10ms      374±70ms        346±2ms
                lg_grp_few_col     790±8ms      1.01±0.05s       707±10ms
               lg_grp_many_col     932±20ms      1.02±0s         939±10ms
                 mixed_types       429±2ms       467±2ms         396±2ms
              ================= ============== ============ ==================
```

### Was this patch authored or co-authored using generative AI tooling?

No.