### PR TITLE
[SPARK-56657][PYTHON][TESTS] Add ASV microbenchmark for SQL_MAP_PANDAS_ITER_UDF

### DIFF
--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -1167,6 +1167,89 @@ class MapArrowIterUDFPeakmemBench(_MapArrowIterBenchMixin, _PeakmemBenchBase):
     pass
 
 
+# -- SQL_MAP_PANDAS_ITER_UDF -------------------------------------------------
+# UDF receives ``Iterator[pandas.DataFrame]``, returns ``Iterator[pandas.DataFrame]``.
+
+
+class _MapPandasIterBenchMixin:
+    """Provides ``_write_scenario`` for SQL_MAP_PANDAS_ITER_UDF.
+
+    Wraps input batches in a struct column to match the JVM-side wire format
+    (``MapInBatchEvaluatorFactory`` wraps each row in another row, and the
+    Pandas serializer turns that struct back into a ``pandas.DataFrame``
+    when ``df_for_struct=True``).
+    """
+
+    def _identity_pdf_iter(it):
+        yield from it
+
+    def _sort_pdf_iter(it):
+        for pdf in it:
+            yield pdf.sort_values(pdf.columns[0]).reset_index(drop=True)
+
+    def _filter_pdf_iter(it):
+        for pdf in it:
+            yield pdf[pdf[pdf.columns[0]].notna()]
+
+    # Scaled down vs SQL_MAP_ARROW_ITER_UDF: pandas conversion adds
+    # per-batch Arrow<->Pandas overhead across all columns.
+    _scenario_configs = {
+        "sm_batch_few_col": ("mixed", 100_000, 5, 1_000),
+        "sm_batch_many_col": ("mixed", 10_000, 50, 1_000),
+        "lg_batch_few_col": ("mixed", 1_000_000, 5, 10_000),
+        "lg_batch_many_col": ("mixed", 100_000, 50, 10_000),
+        "pure_ints": ("pure_ints", 200_000, 10, 5_000),
+        "pure_floats": ("pure_floats", 200_000, 10, 5_000),
+        "pure_strings": ("pure_strings", 200_000, 10, 5_000),
+        "pure_ts": ("pure_ts", 200_000, 10, 5_000),
+        "mixed_types": ("mixed", 200_000, 10, 5_000),
+    }
+
+    @staticmethod
+    def _build_scenario(name):
+        """Build a single scenario by name."""
+        np.random.seed(42)
+        type_key, num_rows, num_cols, batch_size = _MapPandasIterBenchMixin._scenario_configs[name]
+        pool = MockDataFactory.NAMED_TYPE_POOLS[type_key]
+        struct_type = MockDataFactory.make_struct_type(
+            num_fields=num_cols,
+            base_types=pool,
+        )
+        return MockDataFactory.make_batches(
+            num_rows=num_rows,
+            num_cols=1,
+            spark_type_pool=[struct_type],
+            batch_size=batch_size,
+        )
+
+    _udfs = {
+        "identity_udf": (_identity_pdf_iter, [0]),
+        "sort_udf": (_sort_pdf_iter, [0]),
+        "filter_udf": (_filter_pdf_iter, [0]),
+    }
+    params = [list(_scenario_configs), list(_udfs)]
+    param_names = ["scenario", "udf"]
+
+    def _write_scenario(self, scenario, udf_name, buf):
+        batches, schema = self._build_scenario(scenario)
+        udf_func, arg_offsets = self._udfs[udf_name]
+        ret_type = schema.fields[0].dataType
+        MockProtocolWriter.write_worker_input(
+            PythonEvalType.SQL_MAP_PANDAS_ITER_UDF,
+            lambda b: MockProtocolWriter.write_udf_payload(udf_func, ret_type, arg_offsets, b),
+            lambda b: MockProtocolWriter.write_data_payload(iter(batches), b),
+            buf,
+        )
+
+
+class MapPandasIterUDFTimeBench(_MapPandasIterBenchMixin, _TimeBenchBase):
+    pass
+
+
+class MapPandasIterUDFPeakmemBench(_MapPandasIterBenchMixin, _PeakmemBenchBase):
+    pass
+
+
 # -- SQL_SCALAR_ARROW_UDF ---------------------------------------------------
 # UDF receives ``pa.Array`` columns, returns ``pa.Array``.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds ASV microbenchmark coverage for `SQL_MAP_PANDAS_ITER_UDF` (eval type backing `DataFrame.mapInPandas`) in `python/benchmarks/bench_eval_type.py`: `MapPandasIterUDFTimeBench` and `MapPandasIterUDFPeakmemBench`.

### Why are the changes needed?

Baseline coverage under SPARK-55724 before the upcoming `read_udfs()` consolidation refactor.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`COLUMNS=120 asv run --bench MapPandasIter --python=same -a repeat=3`, two stable runs locally.

```text
=================== ============== =========== ============
--                                    udf
------------------- ---------------------------------------
      scenario       identity_udf    sort_udf   filter_udf
=================== ============== =========== ============
  sm_batch_few_col     293+/-20ms    339+/-30ms   328+/-10ms
 sm_batch_many_col     199+/-9ms     217+/-10ms   199+/-1ms
  lg_batch_few_col     652+/-10ms    796+/-6ms    721+/-20ms
 lg_batch_many_col     747+/-7ms    1.10+/-0.3s   781+/-30ms
     pure_ints         137+/-10ms    154+/-2ms    143+/-1ms
    pure_floats        133+/-4ms     152+/-3ms    142+/-5ms
   pure_strings        590+/-9ms     719+/-6ms    597+/-10ms
      pure_ts          201+/-6ms     223+/-4ms    211+/-5ms
    mixed_types        380+/-3ms     446+/-4ms    407+/-6ms
=================== ============== =========== ============
```

```text
=================== ============== ========== ============
--                                   udf
------------------- --------------------------------------
      scenario       identity_udf   sort_udf   filter_udf
=================== ============== ========== ============
  sm_batch_few_col       473M         474M        473M
 sm_batch_many_col       478M         478M        477M
  lg_batch_few_col       522M         523M        522M
 lg_batch_many_col       565M         566M        567M
     pure_ints           484M         485M        484M
    pure_floats          497M         498M        497M
   pure_strings          511M         512M        511M
      pure_ts            501M         501M        501M
    mixed_types          494M         496M        494M
=================== ============== ========== ============
```

### Was this patch authored or co-authored using generative AI tooling?

No.