### PR TITLE
[SPARK-56659][SQL] Show function resources in DESCRIBE FUNCTION EXTENDED output

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -239,6 +239,15 @@ class SessionCatalog(
   @GuardedBy("this")
   protected val tempViews = new mutable.HashMap[String, TemporaryViewRelation]
 
+  /**
+   * Resources (`USING JAR/FILE`) attached to temporary functions. Only entries with
+   * non-empty resources are stored. Keyed by the registry-side identifier produced
+   * by [[tempFunctionIdentifier]] so lookups match what the function registry uses.
+   */
+  @GuardedBy("this")
+  protected val tempFunctionResources =
+    new mutable.HashMap[FunctionIdentifier, Seq[FunctionResource]]
+
   // Note: we track current database here because certain operations do not explicitly
   // specify the database (e.g. DROP TABLE my_table). In these cases we must first
   // check whether the temporary view or function exists, then, if not, operate on
@@ -2100,6 +2109,16 @@ class SessionCatalog(
     }
     val info = makeExprInfoForHiveFunction(funcDefinition)
     registry.registerFunction(identToRegister, info, functionBuilder)
+    if (func.database.isEmpty) {
+      // Always sync the side map so CREATE OR REPLACE without USING clears stale resources.
+      synchronized {
+        if (funcDefinition.resources.nonEmpty) {
+          tempFunctionResources.put(identToRegister, funcDefinition.resources)
+        } else {
+          tempFunctionResources.remove(identToRegister)
+        }
+      }
+    }
   }
 
   private def makeExprInfoForHiveFunction(func: CatalogFunction): ExpressionInfo = {
@@ -2245,7 +2264,10 @@ class SessionCatalog(
   def unregisterFunction(name: FunctionIdentifier): Boolean = {
     // If it's an unqualified name, it's a temp function stored with session namespace database
     val tempIdent = if (name.database.isEmpty) tempFunctionIdentifier(name.funcName) else name
-    functionRegistry.dropFunction(tempIdent) || tableFunctionRegistry.dropFunction(tempIdent)
+    val dropped =
+      functionRegistry.dropFunction(tempIdent) || tableFunctionRegistry.dropFunction(tempIdent)
+    if (dropped) synchronized { tempFunctionResources.remove(tempIdent) }
+    dropped
   }
 
   /**
@@ -2253,11 +2275,23 @@ class SessionCatalog(
    */
   def dropTempFunction(name: String, ignoreIfNotExists: Boolean): Unit = {
     val tempIdent = tempFunctionIdentifier(name)
-    if (!functionRegistry.dropFunction(tempIdent) &&
-        !tableFunctionRegistry.dropFunction(tempIdent) &&
-        !ignoreIfNotExists) {
+    val dropped =
+      functionRegistry.dropFunction(tempIdent) || tableFunctionRegistry.dropFunction(tempIdent)
+    if (dropped) {
+      synchronized { tempFunctionResources.remove(tempIdent) }
+    } else if (!ignoreIfNotExists) {
       throw new NoSuchTempFunctionException(name)
     }
+  }
+
+  /**
+   * Returns the resources attached to a temporary function (or `Nil` if none / not a temp).
+   * The lookup uses the registry-side temp identifier so the caller may pass an unqualified
+   * [[FunctionIdentifier]].
+   */
+  def getTempFunctionResources(name: FunctionIdentifier): Seq[FunctionResource] = synchronized {
+    val tempIdent = if (name.database.isEmpty) tempFunctionIdentifier(name.funcName) else name
+    tempFunctionResources.getOrElse(tempIdent, Nil)
   }
 
   /**
@@ -2764,6 +2798,7 @@ class SessionCatalog(
     globalTempViewManager.clear()
     functionRegistry.clear()
     tableFunctionRegistry.clear()
+    tempFunctionResources.clear()
     tableRelationCache.invalidateAll()
     // restore built-in functions
     FunctionRegistry.builtin.listFunction().foreach { f =>
@@ -2795,6 +2830,7 @@ class SessionCatalog(
     target.currentDb = currentDb
     // copy over temporary views
     tempViews.foreach(kv => target.tempViews.put(kv._1, kv._2))
+    tempFunctionResources.foreach(kv => target.tempFunctionResources.put(kv._1, kv._2))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -130,7 +130,19 @@ case class DescribeFunctionCommand(
       }
 
     if (isExtended) {
-      (result ++ sqlPathRows) :+ Row(s"Extended Usage:${info.getExtended}")
+      val catalog = sparkSession.sessionState.catalog
+      val resources = if (info.getDb == null) {
+        // Temporary or built-in function: built-in functions never carry resources, so this
+        // returns Nil for them without contacting the metastore.
+        catalog.getTempFunctionResources(identifier)
+      } else if (catalog.isPersistentFunction(identifier)) {
+        catalog.getFunctionMetadata(identifier).resources
+      } else {
+        Nil
+      }
+      val resourceRows =
+        resources.map(r => Row(s"Resource: ${r.resourceType.resourceType} ${r.uri}"))
+      (result ++ resourceRows ++ sqlPathRows) :+ Row(s"Extended Usage:${info.getExtended}")
     } else {
       result
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -269,6 +269,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with TestHiveSingleton {
         s"Function: $SESSION_CATALOG_NAME.default.udtf_count",
         "Class: org.apache.spark.sql.hive.execution.GenericUDTFCount2",
         "Usage: N/A")
+      checkKeywordsNotExist(sql("describe function udtf_count"), "Resource:")
 
       checkAnswer(
         sql("SELECT udtf_count(a) FROM (SELECT 1 AS a FROM src LIMIT 3) t"),
@@ -278,6 +279,13 @@ abstract class SQLQuerySuiteBase extends QueryTest with TestHiveSingleton {
         s"Function: $SESSION_CATALOG_NAME.default.udtf_count",
         "Class: org.apache.spark.sql.hive.execution.GenericUDTFCount2",
         "Usage: N/A")
+      checkKeywordsNotExist(sql("describe function udtf_count"), "Resource:")
+
+      checkKeywordsExist(sql("describe function extended udtf_count"),
+        s"Function: $SESSION_CATALOG_NAME.default.udtf_count",
+        "Class: org.apache.spark.sql.hive.execution.GenericUDTFCount2",
+        s"Resource: jar ${TestUDTFJar.jar.toURI}",
+        "Extended Usage:")
     }
   }
 
@@ -294,6 +302,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with TestHiveSingleton {
         "Function: udtf_count_temp",
         "Class: org.apache.spark.sql.hive.execution.GenericUDTFCount2",
         "Usage: N/A")
+      checkKeywordsNotExist(sql("describe function udtf_count_temp"), "Resource:")
 
       checkAnswer(
         sql("SELECT udtf_count_temp(a) FROM (SELECT 1 AS a FROM src LIMIT 3) t"),
@@ -303,6 +312,37 @@ abstract class SQLQuerySuiteBase extends QueryTest with TestHiveSingleton {
         "Function: udtf_count_temp",
         "Class: org.apache.spark.sql.hive.execution.GenericUDTFCount2",
         "Usage: N/A")
+      checkKeywordsNotExist(sql("describe function udtf_count_temp"), "Resource:")
+
+      checkKeywordsExist(sql("describe function extended udtf_count_temp"),
+        "Function: udtf_count_temp",
+        "Class: org.apache.spark.sql.hive.execution.GenericUDTFCount2",
+        s"Resource: jar ${TestUDTFJar.jar.toURI}",
+        "Extended Usage:")
+
+      // CREATE OR REPLACE without USING must drop the previously recorded resources.
+      sql(
+        """
+          |CREATE OR REPLACE TEMPORARY FUNCTION udtf_count_temp
+          |AS 'org.apache.spark.sql.hive.execution.GenericUDTFCount2'
+        """.stripMargin)
+      checkKeywordsNotExist(sql("describe function extended udtf_count_temp"), "Resource:")
+
+      // DROP must also clear recorded resources so a later same-name function (no USING)
+      // does not inherit stale resources.
+      sql(
+        s"""
+           |CREATE OR REPLACE TEMPORARY FUNCTION udtf_count_temp
+           |AS 'org.apache.spark.sql.hive.execution.GenericUDTFCount2'
+           |USING JAR '${TestUDTFJar.jar.toURI}'
+        """.stripMargin)
+      sql("DROP TEMPORARY FUNCTION udtf_count_temp")
+      sql(
+        """
+          |CREATE TEMPORARY FUNCTION udtf_count_temp
+          |AS 'org.apache.spark.sql.hive.execution.GenericUDTFCount2'
+        """.stripMargin)
+      checkKeywordsNotExist(sql("describe function extended udtf_count_temp"), "Resource:")
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

DESCRIBE FUNCTION EXTENDED now emits a Resource: row for each USING JAR/FILE resource attached to a function, matching Hive's behavior. This applies to both persistent and temporary user-defined functions; plain
DESCRIBE FUNCTION is unchanged (also matching Hive — Hive only shows resources in the EXTENDED form).

Implementation:
- DescribeFunctionCommand (sql/core/.../execution/command/functions.scala): in the EXTENDED branch, look up resources — for persistent functions via SessionCatalog.getFunctionMetadata(...).resources; for
temporary functions via the new SessionCatalog.getTempFunctionResources(...) accessor.
- SessionCatalog: previously the USING JAR/FILE clause for a temporary function was loaded into the classloader and then discarded — neither FunctionRegistry nor ExpressionInfo carries resource metadata, so there
 was nowhere to read it back from. This PR adds a tempFunctionResources side map (keyed by the same tempFunctionIdentifier the registry uses) populated in registerFunction and cleared in dropTempFunction /
unregisterFunction / reset / copyStateTo. The write hook always syncs (put if non-empty, remove otherwise) so CREATE OR REPLACE TEMPORARY FUNCTION ... AS '...' (no USING) clears any previously recorded resources.


### Why are the changes needed?

To align Spark SQL with Hive. In Hive, DESCRIBE FUNCTION EXTENDED lists the resources bound to a UDF, which operators commonly rely on to confirm what JARs/files a function depends on. Spark accepted the USING
JAR/FILE syntax but silently dropped this metadata from the EXTENDED output, so users had to query the underlying metastore (or read application logs) to verify the binding. This PR closes the gap and makes
Spark's behavior match Hive's:

- Plain DESCRIBE FUNCTION — no resources (Hive parity).
- DESCRIBE FUNCTION EXTENDED — resources listed (Hive parity).

### Does this PR introduce _any_ user-facing change?

Yes — DESCRIBE FUNCTION EXTENDED output gains Resource: rows, matching Hive.

Before:
```
spark-sql> DESCRIBE FUNCTION EXTENDED my_db.my_udf;
Function: spark_catalog.my_db.my_udf
Class: com.example.MyUDF
Usage: N/A
Extended Usage:
```

After:
```
spark-sql> DESCRIBE FUNCTION EXTENDED my_db.my_udf;
Function: spark_catalog.my_db.my_udf
Class: com.example.MyUDF
Usage: N/A
Resource: jar file:/path/to/my-udf.jar
Extended Usage:
```

Same for temporary functions:
```
spark-sql> CREATE TEMPORARY FUNCTION t_udf AS 'com.example.MyUDF' USING JAR '/path/to/my-udf.jar';
spark-sql> DESCRIBE FUNCTION EXTENDED t_udf;
Function: t_udf
Class: com.example.MyUDF
Usage: N/A
Resource: jar file:/path/to/my-udf.jar
Extended Usage:
```


Plain DESCRIBE FUNCTION is unchanged. RPC impact: plain DESCRIBE FUNCTION issues no extra metastore calls (unchanged); DESCRIBE FUNCTION EXTENDED on a persistent function adds one getFunction call; on a temporary
 or built-in function it issues no RPC (lookup is an in-memory HashMap.get). Function execution path is untouched.


### How was this patch tested?
- Updated describe functions - user defined functions and describe functions - temporary user defined functions in org.apache.spark.sql.hive.execution.SQLQuerySuite to assert (a) plain DESCRIBE FUNCTION does not
emit Resource:, and (b) DESCRIBE FUNCTION EXTENDED does — matching Hive's split.
- Added regression coverage for the temp-function side map: CREATE OR REPLACE TEMPORARY FUNCTION without USING clears stale resources, and DROP TEMPORARY FUNCTION followed by re-creating without USING does not
inherit the previous resources.
- Ran org.apache.spark.sql.catalyst.catalog.InMemorySessionCatalogSuite (103 tests) to confirm the new SessionCatalog state changes don't regress existing temp function lifecycle behavior.


### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)