### PR TITLE
[SPARK-56658][PYTHON][TESTS] Add ASV microbenchmark for SQL_WINDOW_AGG_PANDAS_UDF

### DIFF
--- a/python/benchmarks/bench_eval_type.py
+++ b/python/benchmarks/bench_eval_type.py
@@ -1468,3 +1468,78 @@ class WindowAggArrowUDFTimeBench(_WindowAggArrowBenchMixin, _TimeBenchBase):
 
 class WindowAggArrowUDFPeakmemBench(_WindowAggArrowBenchMixin, _PeakmemBenchBase):
     pass
+
+
+# -- SQL_WINDOW_AGG_PANDAS_UDF -----------------------------------------------
+# UDF receives ``pd.Series`` columns for the entire window partition, returns scalar.
+
+
+class _WindowAggPandasBenchMixin:
+    """Provides _write_scenario for SQL_WINDOW_AGG_PANDAS_UDF."""
+
+    def _window_agg_pandas_sum(col):
+        """Sum a single Pandas Series."""
+        return col.sum()
+
+    def _window_agg_pandas_mean_multi(col0, col1):
+        """Mean of two Pandas Series combined."""
+        return (col0.mean() or 0) + (col1.mean() or 0)
+
+    _scenario_configs = {
+        "few_groups_sm": (50, 5_000, 5),
+        "few_groups_lg": (50, 50_000, 5),
+        "many_groups_sm": (2_000, 500, 5),
+        "many_groups_lg": (500, 10_000, 5),
+        "wide_cols": (200, 5_000, 20),
+    }
+
+    @staticmethod
+    def _build_scenario(name):
+        """Build a single scenario by name."""
+        np.random.seed(42)
+        num_groups, rows_per_group, n_cols = _WindowAggPandasBenchMixin._scenario_configs[name]
+        return MockDataFactory.make_grouped_batches(
+            num_groups=num_groups,
+            num_rows=rows_per_group,
+            num_cols=n_cols,
+            spark_type_pool=MockDataFactory.NUMERIC_TYPES,
+            batch_size=rows_per_group,
+        )
+
+    _udfs = {
+        "sum_udf": _window_agg_pandas_sum,
+        "mean_multi_udf": _window_agg_pandas_mean_multi,
+    }
+    params = [list(_scenario_configs), list(_udfs)]
+    param_names = ["scenario", "udf"]
+
+    def _write_scenario(self, scenario, udf_name, buf):
+        groups, _schema = self._build_scenario(scenario)
+        udf_func = self._udfs[udf_name]
+
+        # sum_udf uses 1 arg, mean_multi_udf uses 2 args
+        if "multi" in udf_name:
+            arg_offsets = [0, 1]
+        else:
+            arg_offsets = [0]
+
+        return_type = DoubleType()
+
+        def write_udf(b):
+            MockProtocolWriter.write_udf_payload(udf_func, return_type, arg_offsets, b)
+
+        MockProtocolWriter.write_worker_input(
+            PythonEvalType.SQL_WINDOW_AGG_PANDAS_UDF,
+            write_udf,
+            lambda b: MockProtocolWriter.write_grouped_data_payload(groups, buf=b),
+            buf,
+            runner_conf={"window_bound_types": "unbounded"},
+        )
+
+
+class WindowAggPandasUDFTimeBench(_WindowAggPandasBenchMixin, _TimeBenchBase):
+    pass
+
+
+class WindowAggPandasUDFPeakmemBench(_WindowAggPandasBenchMixin, _PeakmemBenchBase):
+    pass


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add ASV micro-benchmarks for `SQL_WINDOW_AGG_PANDAS_UDF` to `python/benchmarks/bench_eval_type.py`, mirroring the existing `SQL_WINDOW_AGG_ARROW_UDF` benchmarks added in [SPARK-56120](https://issues.apache.org/jira/browse/SPARK-56120).

The new mixin `_WindowAggPandasBenchMixin` reuses the same scenario shapes and UDF set as the Arrow variant (sum, mean_multi) and writes the worker payload with `runner_conf={"window_bound_types": "unbounded"}`.

### Why are the changes needed?

Part of [SPARK-55724](https://issues.apache.org/jira/browse/SPARK-55724). Establishes performance baselines before refactoring this eval type.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`./python/asv check --python=same` passes. Local run with `-a repeat=3`:

```text
bench_eval_type.WindowAggPandasUDFTimeBench.time_worker
================ ============ ================
--                            udf
---------------- -----------------------------
    scenario       sum_udf     mean_multi_udf
================ ============ ================
 few_groups_sm    50.3+/-0.2ms   57.2+/-2ms
 few_groups_lg    98.9+/-0.9ms   109+/-2ms
 many_groups_sm   1.84+/-0s      2.10+/-0.04s
 many_groups_lg   540+/-1ms      639+/-30ms
   wide_cols      515+/-20ms     515+/-0.7ms
================ ============ ================

bench_eval_type.WindowAggPandasUDFPeakmemBench.peakmem_worker
================ ========= ================
--                          udf
---------------- --------------------------
    scenario      sum_udf   mean_multi_udf
================ ========= ================
 few_groups_sm     472M         469M
 few_groups_lg     536M         532M
 many_groups_sm    502M         500M
 many_groups_lg    607M         605M
   wide_cols       588M         585M
================ ========= ================
```

### Was this patch authored or co-authored using generative AI tooling?

No.