### PR TITLE
[SPARK-56662][PYTHON][TESTS] Fix mixin/base inheritance order in PySpark test classes

### DIFF
--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -180,7 +180,7 @@ class ArtifactTestsMixin:
 
 
 @unittest.skipIf(is_remote_only(), "Requires JVM access")
-class ArtifactTests(ReusedConnectTestCase, ArtifactTestsMixin):
+class ArtifactTests(ArtifactTestsMixin, ReusedConnectTestCase):
     @classmethod
     def root(cls):
         from pyspark.core.files import SparkFiles

--- a/python/pyspark/sql/tests/connect/client/test_artifact_localcluster.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact_localcluster.py
@@ -20,7 +20,7 @@ from pyspark.sql.tests.connect.client.test_artifact import ArtifactTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
-class LocalClusterArtifactTests(ReusedConnectTestCase, ArtifactTestsMixin):
+class LocalClusterArtifactTests(ArtifactTestsMixin, ReusedConnectTestCase):
     @classmethod
     def conf(cls):
         return (

--- a/python/pyspark/sql/tests/connect/test_utils.py
+++ b/python/pyspark/sql/tests/connect/test_utils.py
@@ -19,7 +19,7 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.sql.tests.test_utils import UtilsTestsMixin
 
 
-class ConnectUtilsTests(ReusedConnectTestCase, UtilsTestsMixin):
+class ConnectUtilsTests(UtilsTestsMixin, ReusedConnectTestCase):
     pass
 
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_map.py
@@ -541,7 +541,7 @@ class MapInPandasTestsMixin:
             )
 
 
-class MapInPandasTests(ReusedSQLTestCase, MapInPandasTestsMixin):
+class MapInPandasTests(MapInPandasTestsMixin, ReusedSQLTestCase):
     @classmethod
     def setUpClass(cls):
         ReusedSQLTestCase.setUpClass()

--- a/python/pyspark/sql/tests/test_errors.py
+++ b/python/pyspark/sql/tests/test_errors.py
@@ -52,7 +52,7 @@ class ErrorsTestsMixin:
                 self.spark.sql("select cast('abc' as boolean)").show()
 
 
-class ErrorsTests(ReusedSQLTestCase, ErrorsTestsMixin):
+class ErrorsTests(ErrorsTestsMixin, ReusedSQLTestCase):
     pass
 
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -3981,7 +3981,7 @@ class FunctionsTestsMixin:
         self.assertEqual(result[1][1], ["Frank", "Dave"])  # Sales
 
 
-class FunctionsTests(ReusedSQLTestCase, FunctionsTestsMixin):
+class FunctionsTests(FunctionsTestsMixin, ReusedSQLTestCase):
     pass
 
 

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1872,7 +1872,7 @@ class UtilsTestsMixin:
             assertSchemaEqual(s1, s2)
 
 
-class UtilsTests(ReusedSQLTestCase, UtilsTestsMixin):
+class UtilsTests(UtilsTestsMixin, ReusedSQLTestCase):
     pass
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Seven concrete PySpark test classes declare the framework base class before the test mixin (e.g. `class X(ReusedSQLTestCase, XTestsMixin)`), while the rest of the codebase consistently puts the mixin first. This PR reorders the parent classes in those 7 files to follow the project convention (mixin first, base class last):

- `python/pyspark/sql/tests/test_utils.py` — `UtilsTests`
- `python/pyspark/sql/tests/test_errors.py` — `ErrorsTests`
- `python/pyspark/sql/tests/test_functions.py` — `FunctionsTests`
- `python/pyspark/sql/tests/pandas/test_pandas_map.py` — `MapInPandasTests`
- `python/pyspark/sql/tests/connect/client/test_artifact.py` — `ArtifactTests`
- `python/pyspark/sql/tests/connect/client/test_artifact_localcluster.py` — `LocalClusterArtifactTests`
- `python/pyspark/sql/tests/connect/test_utils.py` — `ConnectUtilsTests`

### Why are the changes needed?

Python resolves attribute and method lookups along the **Method Resolution Order (MRO)** — the linear sequence computed via C3 linearization from the parent list. The first class in the MRO that defines the requested attribute wins, and `super()` delegates to the *next* class in the MRO (not the syntactic parent).

The order of parents in the class declaration directly drives the MRO:

```python
class X(ReusedSQLTestCase, XTestsMixin): ...
# MRO: X -> ReusedSQLTestCase -> ... -> XTestsMixin -> object
# `setUp` defined on the mixin would be SHADOWED by ReusedSQLTestCase.setUp.

class X(XTestsMixin, ReusedSQLTestCase): ...
# MRO: X -> XTestsMixin -> ReusedSQLTestCase -> ... -> object
# `setUp` defined on the mixin takes precedence, then super() chains
# into ReusedSQLTestCase.setUp as expected.
```

Today none of the affected mixins override `setUp` / `tearDown` / `setUpClass` / `tearDownClass`, so MRO resolves to the same target either way and the current behavior is identical. The inconsistency is a latent footgun: any future lifecycle hook added to the mixin would be silently shadowed in these 7 classes only, while the same hook would work correctly in the ~50 sibling test classes that follow the convention. That class of bug surfaces only at runtime in the affected suites and is easy to miss during review.

Standardizing the parent ordering makes the convention enforceable by inspection.

### Does this PR introduce _any_ user-facing change?

No. This is a test-only change with no behavioral impact today.

### How was this patch tested?

Existing tests. The change is a parent-class reorder that does not affect MRO resolution for any currently overridden method.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)