### PR TITLE
[MINOR][PYTHON][TESTS] Drop legacy `(object)` base from PySpark test mixins

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -42,7 +42,7 @@ if have_pandas:
     not have_pandas or not have_pyarrow,
     pandas_requirement_message or pyarrow_requirement_message,
 )
-class MapInArrowTestsMixin(object):
+class MapInArrowTestsMixin:
     def test_map_in_arrow(self):
         def func(iterator):
             for batch in iterator:

--- a/python/pyspark/sql/tests/test_resources.py
+++ b/python/pyspark/sql/tests/test_resources.py
@@ -32,7 +32,7 @@ from pyspark.testing.utils import (
     not have_pandas or not have_pyarrow,
     pandas_requirement_message or pyarrow_requirement_message,
 )
-class ResourceProfileTestsMixin(object):
+class ResourceProfileTestsMixin:
     def test_map_in_arrow_without_profile(self):
         def func(iterator):
             tc = TaskContext.get()

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -58,7 +58,7 @@ from pyspark.testing.utils import assertDataFrameEqual, timeout
 from pyspark.util import is_remote_only
 
 
-class BaseUDFTestsMixin(object):
+class BaseUDFTestsMixin:
     def test_udf_with_callable(self):
         data = self.spark.createDataFrame([(i, i**2) for i in range(10)], ["number", "squared"])
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Three PySpark test mixin classes still inherit explicitly from `object`:

- `python/pyspark/sql/tests/test_udf.py` — `BaseUDFTestsMixin(object)`
- `python/pyspark/sql/tests/test_resources.py` — `ResourceProfileTestsMixin(object)`
- `python/pyspark/sql/tests/arrow/test_arrow_map.py` — `MapInArrowTestsMixin(object)`

This PR drops the explicit `(object)` base, matching the modern `class Foo:` form used by the other ~50 mixin classes in `pyspark.sql.tests`.

### Why are the changes needed?

`class Foo(object):` is a Python 2 idiom required to opt into new-style classes. Under Python 3 — which is the only version Spark supports — every class implicitly inherits from `object`, so the `(object)` base is dead code. Three mixins still carry the legacy form while the rest of the test suite has standardized on the modern form; aligning them keeps the codebase consistent and removes a small piece of cargo-culted boilerplate that occasionally gets copied into new mixins.

### Does this PR introduce _any_ user-facing change?

No. Test-only change with no behavioral impact.

### How was this patch tested?

Existing tests. `class Foo(object):` and `class Foo:` produce identical classes under Python 3 (same MRO, same `__bases__`, same `isinstance` results).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)