### PR TITLE
[SPARK-56663][SQL] Restore fast path for date_trunc MINUTE/HOUR/DAY

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -496,6 +496,10 @@ object DateTimeUtils extends SparkDateTimeUtils {
    * -07:52:58, see SPARK-33404) and 30/45-minute offsets (Asia/Kolkata +05:30, Asia/Kathmandu
    * +05:45) are handled correctly by this path because the offset is applied as part of
    * the arithmetic; no offset-alignment guard is needed.
+   *
+   * `unitMicros` must evenly divide `MICROS_PER_DAY`; otherwise wall-clock unit
+   * boundaries do not align to multiples of `unitMicros` in the shifted-local frame
+   * and the `floorMod` truncation is unsafe.
    */
   private def truncToUnitFast(
       micros: Long, zoneId: ZoneId, unitMicros: Long, fallbackUnit: ChronoUnit): Long = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -486,6 +486,43 @@ object DateTimeUtils extends SparkDateTimeUtils {
   }
 
   /**
+   * Fast path for truncating to MINUTE/HOUR/DAY using offset arithmetic instead of
+   * allocating a `ZonedDateTime` per row. The offset is resolved once for `micros`; the
+   * truncation then runs as `floorMod` in local time. We fall back to [[truncToUnit]] when
+   * the offset at the candidate truncated instant differs from the offset at `micros`,
+   * which means the truncation crosses a DST/historical transition and the local-time
+   * alignment we computed is no longer valid (see SPARK-30766/30857). The check is
+   * skipped for fixed-offset zones. Sub-minute offsets (e.g. America/Los_Angeles LMT
+   * -07:52:58, see SPARK-33404) and 30/45-minute offsets (Asia/Kolkata +05:30, Asia/Kathmandu
+   * +05:45) are handled correctly by this path because the offset is applied as part of
+   * the arithmetic; no offset-alignment guard is needed.
+   */
+  private def truncToUnitFast(
+      micros: Long, zoneId: ZoneId, unitMicros: Long, fallbackUnit: ChronoUnit): Long = {
+    val rules = zoneId.getRules
+    val originalSec = Math.floorDiv(micros, MICROS_PER_SECOND)
+    val originalOffsetSec =
+      rules.getOffset(Instant.ofEpochSecond(originalSec)).getTotalSeconds.toLong
+    val offsetMicros = originalOffsetSec * MICROS_PER_SECOND
+    try {
+      val local = Math.addExact(micros, offsetMicros)
+      val truncatedLocal = local - Math.floorMod(local, unitMicros)
+      val candidate = Math.subtractExact(truncatedLocal, offsetMicros)
+      if (!rules.isFixedOffset) {
+        val candidateSec = Math.floorDiv(candidate, MICROS_PER_SECOND)
+        val candidateOffsetSec =
+          rules.getOffset(Instant.ofEpochSecond(candidateSec)).getTotalSeconds.toLong
+        if (candidateOffsetSec != originalOffsetSec) {
+          return truncToUnit(micros, zoneId, fallbackUnit)
+        }
+      }
+      candidate
+    } catch {
+      case _: ArithmeticException => truncToUnit(micros, zoneId, fallbackUnit)
+    }
+  }
+
+  /**
    * Returns the trunc date time from original date time and trunc level.
    * Trunc level should be generated using `parseTruncLevel()`, should be between 0 and 9.
    */
@@ -499,9 +536,12 @@ object DateTimeUtils extends SparkDateTimeUtils {
         micros - Math.floorMod(micros, MICROS_PER_MILLIS)
       case TRUNC_TO_SECOND =>
         micros - Math.floorMod(micros, MICROS_PER_SECOND)
-      case TRUNC_TO_MINUTE => truncToUnit(micros, zoneId, ChronoUnit.MINUTES)
-      case TRUNC_TO_HOUR => truncToUnit(micros, zoneId, ChronoUnit.HOURS)
-      case TRUNC_TO_DAY => truncToUnit(micros, zoneId, ChronoUnit.DAYS)
+      case TRUNC_TO_MINUTE =>
+        truncToUnitFast(micros, zoneId, MICROS_PER_MINUTE, ChronoUnit.MINUTES)
+      case TRUNC_TO_HOUR =>
+        truncToUnitFast(micros, zoneId, MICROS_PER_HOUR, ChronoUnit.HOURS)
+      case TRUNC_TO_DAY =>
+        truncToUnitFast(micros, zoneId, MICROS_PER_DAY, ChronoUnit.DAYS)
       case _ => // Try to truncate date levels
         val dDays = microsToDays(micros, zoneId)
         daysToMicros(truncDate(dDays, level), zoneId)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -766,6 +766,97 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     }
   }
 
+  test("truncTimestamp with sub-hour zone offsets") {
+    // Asia/Kolkata (+05:30) and Asia/Kathmandu (+05:45) are not aligned to HOUR in UTC.
+    // The fast path applies the offset as part of its arithmetic, so HOUR/DAY truncation
+    // produces the correct local-aligned result without needing the slow path.
+    val kolkata = getZoneId("Asia/Kolkata")
+    val ts = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-01-15T09:42:17.123456+05:30"), kolkata).get
+    val expectedHour = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-01-15T09:00:00+05:30"), kolkata).get
+    assert(DateTimeUtils.truncTimestamp(ts, DateTimeUtils.TRUNC_TO_HOUR, kolkata) === expectedHour)
+    val expectedDay = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-01-15T00:00:00+05:30"), kolkata).get
+    assert(DateTimeUtils.truncTimestamp(ts, DateTimeUtils.TRUNC_TO_DAY, kolkata) === expectedDay)
+
+    val kathmandu = getZoneId("Asia/Kathmandu")
+    val ts2 = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-01-15T09:42:17.123456+05:45"), kathmandu).get
+    val expectedHour2 = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-01-15T09:00:00+05:45"), kathmandu).get
+    assert(DateTimeUtils.truncTimestamp(
+      ts2, DateTimeUtils.TRUNC_TO_HOUR, kathmandu) === expectedHour2)
+  }
+
+  test("truncTimestamp across DST transitions") {
+    val la = getZoneId("America/Los_Angeles")
+    // Spring-forward in LA: 2024-03-10 02:00 PDT does not exist; 02:30 local maps to
+    // 2024-03-10 03:30 PDT in wall-clock terms. Use an instant just after the transition
+    // so HOUR/DAY truncation candidate falls into the pre-transition offset window.
+    val postSpring = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-03-10T03:30:00-07:00"), la).get
+    val expectedHour = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-03-10T03:00:00-07:00"), la).get
+    assert(DateTimeUtils.truncTimestamp(postSpring, DateTimeUtils.TRUNC_TO_HOUR, la)
+      === expectedHour)
+    val expectedDay = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-03-10T00:00:00-08:00"), la).get
+    assert(DateTimeUtils.truncTimestamp(postSpring, DateTimeUtils.TRUNC_TO_DAY, la)
+      === expectedDay)
+
+    // Fall-back in LA: 2024-11-03 01:30 occurs twice. Truncation to HOUR/DAY should
+    // produce the same wall-clock boundary as the slow path regardless.
+    val postFall = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-11-03T01:30:00-08:00"), la).get
+    val expectedHour2 = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-11-03T01:00:00-08:00"), la).get
+    assert(DateTimeUtils.truncTimestamp(postFall, DateTimeUtils.TRUNC_TO_HOUR, la)
+      === expectedHour2)
+    val expectedDay2 = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-11-03T00:00:00-07:00"), la).get
+    assert(DateTimeUtils.truncTimestamp(postFall, DateTimeUtils.TRUNC_TO_DAY, la)
+      === expectedDay2)
+  }
+
+  test("SPARK-30766/30857: truncTimestamp before the epoch in HOUR/DAY") {
+    val la = getZoneId("America/Los_Angeles")
+    val ts1 = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("1960-02-11T00:01:02.123"), la).get
+    val expectedHour1 = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("1960-02-11T00:00:00"), la).get
+    assert(DateTimeUtils.truncTimestamp(ts1, DateTimeUtils.TRUNC_TO_HOUR, la) === expectedHour1)
+    val expectedDay1 = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("1960-02-11T00:00:00"), la).get
+    assert(DateTimeUtils.truncTimestamp(ts1, DateTimeUtils.TRUNC_TO_DAY, la) === expectedDay1)
+  }
+
+  test("truncTimestamp at America/Sao_Paulo midnight DST gap") {
+    // 2018-11-04 was the last Brazilian DST start; the offset jumped from -3
+    // to -2 at exactly midnight local. The local times 00:00-00:59 on this
+    // date did not exist, so DAY truncation must resolve the gap forward to
+    // 01:00 BRST. Exercises the fast path's DST-fallback for midnight gaps.
+    val zone = getZoneId("America/Sao_Paulo")
+    val ts = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2018-11-04T12:00:00-02:00"), zone).get
+    val expected = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2018-11-04T01:00:00-02:00"), zone).get
+    assert(DateTimeUtils.truncTimestamp(ts, DateTimeUtils.TRUNC_TO_DAY, zone) === expected)
+  }
+
+  test("truncTimestamp at Pacific/Apia after the 2011 calendar shift") {
+    // Pacific/Apia jumped from UTC-11 to UTC+13 on 2011-12-30, skipping the
+    // local date Dec 30 entirely. Verify that DAY truncation at a clean,
+    // post-transition, no-DST instant (June 2012, austral winter, +13)
+    // resolves to local midnight via the fast path.
+    val zone = getZoneId("Pacific/Apia")
+    val ts = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2012-06-15T13:00:00+13:00"), zone).get
+    val expected = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2012-06-15T00:00:00+13:00"), zone).get
+    assert(DateTimeUtils.truncTimestamp(ts, DateTimeUtils.TRUNC_TO_DAY, zone) === expected)
+  }
+
   test("SPARK-51554: time truncation using timeTrunc") {
     // 01:02:03.400500600
     val input = localTimeToNanos(LocalTime.of(1, 2, 3, 400500600))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -695,6 +695,8 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       withDefaultTimeZone(zid) {
         val inputTS = DateTimeUtils.stringToTimestamp(
           UTF8String.fromString("1769-10-17T17:10:02.123456"), defaultZoneId)
+        testTrunc(DateTimeUtils.TRUNC_TO_DAY, "1769-10-17T00:00:00", inputTS.get, zid)
+        testTrunc(DateTimeUtils.TRUNC_TO_HOUR, "1769-10-17T17:00:00", inputTS.get, zid)
         testTrunc(DateTimeUtils.TRUNC_TO_MINUTE, "1769-10-17T17:10:00", inputTS.get, zid)
         testTrunc(DateTimeUtils.TRUNC_TO_SECOND, "1769-10-17T17:10:02", inputTS.get, zid)
         testTrunc(DateTimeUtils.TRUNC_TO_MILLISECOND, "1769-10-17T17:10:02.123", inputTS.get, zid)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -793,9 +793,9 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
 
   test("truncTimestamp across DST transitions") {
     val la = getZoneId("America/Los_Angeles")
-    // Spring-forward in LA: 2024-03-10 02:00 PDT does not exist; 02:30 local maps to
-    // 2024-03-10 03:30 PDT in wall-clock terms. Use an instant just after the transition
-    // so HOUR/DAY truncation candidate falls into the pre-transition offset window.
+    // Spring-forward in LA: local 02:00-02:59 doesn't exist on 2024-03-10
+    // (01:59 PST jumps to 03:00 PDT). Pick 03:30 PDT just after the transition
+    // so the HOUR/DAY truncation candidate falls into the pre-transition window.
     val postSpring = DateTimeUtils.stringToTimestamp(
       UTF8String.fromString("2024-03-10T03:30:00-07:00"), la).get
     val expectedHour = DateTimeUtils.stringToTimestamp(

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk21-results.txt
@@ -2,460 +2,460 @@
 datetime +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  983           1003          28         10.2          98.3       1.0X
-date + interval(m, d)                               949            954           8         10.5          94.9       1.0X
-date + interval(m, d, ms)                          3751           3807          79          2.7         375.1       0.3X
-date - interval(m)                                  847            852           4         11.8          84.7       1.2X
-date - interval(m, d)                               867            872           7         11.5          86.7       1.1X
-date - interval(m, d, ms)                          3765           3767           3          2.7         376.5       0.3X
-timestamp + interval(m)                            1537           1543           9          6.5         153.7       0.6X
-timestamp + interval(m, d)                         1575           1578           5          6.4         157.5       0.6X
-timestamp + interval(m, d, ms)                     1716           1717           2          5.8         171.6       0.6X
-timestamp - interval(m)                            1511           1517           7          6.6         151.1       0.7X
-timestamp - interval(m, d)                         1573           1574           1          6.4         157.3       0.6X
-timestamp - interval(m, d, ms)                     1708           1715           9          5.9         170.8       0.6X
+date + interval(m)                                  826            872          75         12.1          82.6       1.0X
+date + interval(m, d)                               822            856          33         12.2          82.2       1.0X
+date + interval(m, d, ms)                          3529           3537          11          2.8         352.9       0.2X
+date - interval(m)                                  791            799           8         12.6          79.1       1.0X
+date - interval(m, d)                               823            837          12         12.2          82.3       1.0X
+date - interval(m, d, ms)                          3537           3555          25          2.8         353.7       0.2X
+timestamp + interval(m)                            1842           1857          22          5.4         184.2       0.4X
+timestamp + interval(m, d)                         1886           1889           5          5.3         188.6       0.4X
+timestamp + interval(m, d, ms)                     1934           1942          11          5.2         193.4       0.4X
+timestamp - interval(m)                            1708           1715          11          5.9         170.8       0.5X
+timestamp - interval(m, d)                         1747           1748           2          5.7         174.7       0.5X
+timestamp - interval(m, d, ms)                     1896           1905          13          5.3         189.6       0.4X
 
 
 ================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    213            214           2         47.0          21.3       1.0X
-cast to timestamp wholestage on                     221            226           4         45.2          22.1       1.0X
+cast to timestamp wholestage off                    213            220          10         47.0          21.3       1.0X
+cast to timestamp wholestage on                     204            207           5         49.1          20.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    623            630          11         16.1          62.3       1.0X
-year of timestamp wholestage on                     640            645           6         15.6          64.0       1.0X
+year of timestamp wholestage off                    634            640           9         15.8          63.4       1.0X
+year of timestamp wholestage on                     636            646           9         15.7          63.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 658            663           8         15.2          65.8       1.0X
-quarter of timestamp wholestage on                  666            670           4         15.0          66.6       1.0X
+quarter of timestamp wholestage off                 672            675           4         14.9          67.2       1.0X
+quarter of timestamp wholestage on                  684            692           6         14.6          68.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   639            639           0         15.6          63.9       1.0X
-month of timestamp wholestage on                    648            652           5         15.4          64.8       1.0X
+month of timestamp wholestage off                   671            680          13         14.9          67.1       1.0X
+month of timestamp wholestage on                    672            680          10         14.9          67.2       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1039           1041           3          9.6         103.9       1.0X
-weekofyear of timestamp wholestage on              1041           1046           5          9.6         104.1       1.0X
+weekofyear of timestamp wholestage off              960            962           4         10.4          96.0       1.0X
+weekofyear of timestamp wholestage on               970            988          13         10.3          97.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     647            650           4         15.5          64.7       1.0X
-day of timestamp wholestage on                      652            656           3         15.3          65.2       1.0X
+day of timestamp wholestage off                     656            657           1         15.3          65.6       1.0X
+day of timestamp wholestage on                      663            670           5         15.1          66.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               675            678           5         14.8          67.5       1.0X
-dayofyear of timestamp wholestage on                688            690           1         14.5          68.8       1.0X
+dayofyear of timestamp wholestage off               677            684          10         14.8          67.7       1.0X
+dayofyear of timestamp wholestage on                700            704           4         14.3          70.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              660            660           0         15.1          66.0       1.0X
-dayofmonth of timestamp wholestage on               655            660           4         15.3          65.5       1.0X
+dayofmonth of timestamp wholestage off              666            671           7         15.0          66.6       1.0X
+dayofmonth of timestamp wholestage on               658            666           6         15.2          65.8       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               803            807           6         12.5          80.3       1.0X
-dayofweek of timestamp wholestage on                818            827          10         12.2          81.8       1.0X
+dayofweek of timestamp wholestage off               777            796          27         12.9          77.7       1.0X
+dayofweek of timestamp wholestage on                788            796          10         12.7          78.8       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 746            746           0         13.4          74.6       1.0X
-weekday of timestamp wholestage on                  756            761           4         13.2          75.6       1.0X
+weekday of timestamp wholestage off                 747            748           0         13.4          74.7       1.0X
+weekday of timestamp wholestage on                  762            770           9         13.1          76.2       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    546            547           1         18.3          54.6       1.0X
-hour of timestamp wholestage on                     558            559           1         17.9          55.8       1.0X
+hour of timestamp wholestage off                    589            590           1         17.0          58.9       1.0X
+hour of timestamp wholestage on                     598            604           7         16.7          59.8       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  543            544           1         18.4          54.3       1.0X
-minute of timestamp wholestage on                   553            556           3         18.1          55.3       1.0X
+minute of timestamp wholestage off                  617            618           1         16.2          61.7       1.0X
+minute of timestamp wholestage on                   596            603           8         16.8          59.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  544            562          26         18.4          54.4       1.0X
-second of timestamp wholestage on                   557            561           5         17.9          55.7       1.0X
+second of timestamp wholestage off                  595            612          24         16.8          59.5       1.0X
+second of timestamp wholestage on                   599            610           9         16.7          59.9       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         184            187           4         54.2          18.4       1.0X
-current_date wholestage on                          218            222           4         46.0          21.8       0.8X
+current_date wholestage off                         181            187           8         55.2          18.1       1.0X
+current_date wholestage on                          201            211          14         49.7          20.1       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    197            199           3         50.9          19.7       1.0X
-current_timestamp wholestage on                     231            239           8         43.3          23.1       0.9X
+current_timestamp wholestage off                    193            198           6         51.7          19.3       1.0X
+current_timestamp wholestage on                     212            223          17         47.1          21.2       0.9X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         600            601           1         16.7          60.0       1.0X
-cast to date wholestage on                          604            607           3         16.5          60.4       1.0X
+cast to date wholestage off                         611            628          23         16.4          61.1       1.0X
+cast to date wholestage on                          609            617           5         16.4          60.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             671            672           2         14.9          67.1       1.0X
-last_day wholestage on                              696            700           3         14.4          69.6       1.0X
+last_day wholestage off                             674            678           7         14.8          67.4       1.0X
+last_day wholestage on                              683            692           9         14.6          68.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             629            631           3         15.9          62.9       1.0X
-next_day wholestage on                              635            640           3         15.7          63.5       1.0X
+next_day wholestage off                             650            653           4         15.4          65.0       1.0X
+next_day wholestage on                              638            641           5         15.7          63.8       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             578            579           2         17.3          57.8       1.0X
-date_add wholestage on                              605            609           5         16.5          60.5       1.0X
+date_add wholestage off                             596            602           9         16.8          59.6       1.0X
+date_add wholestage on                              595            602           9         16.8          59.5       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             579            581           2         17.3          57.9       1.0X
-date_sub wholestage on                              605            608           3         16.5          60.5       1.0X
+date_sub wholestage off                             599            607          11         16.7          59.9       1.0X
+date_sub wholestage on                              602            607           8         16.6          60.2       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           802            804           3         12.5          80.2       1.0X
-add_months wholestage on                            830            834           4         12.1          83.0       1.0X
+add_months wholestage off                           817            818           1         12.2          81.7       1.0X
+add_months wholestage on                            811            818           8         12.3          81.1       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3329           3330           1          3.0         332.9       1.0X
-format date wholestage on                          3471           3493          23          2.9         347.1       1.0X
+format date wholestage off                         2731           2744          19          3.7         273.1       1.0X
+format date wholestage on                          2750           2785          45          3.6         275.0       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       2655           2656           2          3.8         265.5       1.0X
-from_unixtime wholestage on                        2677           2687           8          3.7         267.7       1.0X
+from_unixtime wholestage off                       2936           2939           4          3.4         293.6       1.0X
+from_unixtime wholestage on                        2766           2779          15          3.6         276.6       1.1X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   713            714           1         14.0          71.3       1.0X
-from_utc_timestamp wholestage on                    778            779           1         12.9          77.8       0.9X
+from_utc_timestamp wholestage off                   729            731           4         13.7          72.9       1.0X
+from_utc_timestamp wholestage on                    790            799           7         12.7          79.0       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                     747            750           4         13.4          74.7       1.0X
-to_utc_timestamp wholestage on                      850            854           4         11.8          85.0       0.9X
+to_utc_timestamp wholestage off                     860            864           6         11.6          86.0       1.0X
+to_utc_timestamp wholestage on                      870            878           7         11.5          87.0       1.0X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        245            251           9         40.8          24.5       1.0X
-cast interval wholestage on                         220            226           4         45.4          22.0       1.1X
+cast interval wholestage off                        219            239          28         45.6          21.9       1.0X
+cast interval wholestage on                         212            220           6         47.2          21.2       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                             985            994          13         10.2          98.5       1.0X
-datediff wholestage on                              995            997           2         10.0          99.5       1.0X
+datediff wholestage off                            1033           1035           3          9.7         103.3       1.0X
+datediff wholestage on                             1047           1053           6          9.6         104.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      2736           2738           3          3.7         273.6       1.0X
-months_between wholestage on                       2771           2776           5          3.6         277.1       1.0X
+months_between wholestage off                      3185           3191           8          3.1         318.5       1.0X
+months_between wholestage on                       3224           3231           9          3.1         322.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               406            407           2          2.5         405.9       1.0X
-window wholestage on                                651            684          25          1.5         650.8       0.6X
+window wholestage off                               529            538          12          1.9         529.2       1.0X
+window wholestage on                                659            668           9          1.5         658.8       0.8X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     1433           1434           0          7.0         143.3       1.0X
-date_trunc YEAR wholestage on                      1392           1395           2          7.2         139.2       1.0X
+date_trunc YEAR wholestage off                     1667           1671           6          6.0         166.7       1.0X
+date_trunc YEAR wholestage on                      1664           1670           6          6.0         166.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     1432           1434           2          7.0         143.2       1.0X
-date_trunc YYYY wholestage on                      1395           1399           4          7.2         139.5       1.0X
+date_trunc YYYY wholestage off                     1663           1665           3          6.0         166.3       1.0X
+date_trunc YYYY wholestage on                      1655           1666          10          6.0         165.5       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       1432           1442          14          7.0         143.2       1.0X
-date_trunc YY wholestage on                        1393           1394           2          7.2         139.3       1.0X
+date_trunc YY wholestage off                       1666           1670           6          6.0         166.6       1.0X
+date_trunc YY wholestage on                        1660           1674          14          6.0         166.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      1420           1423           5          7.0         142.0       1.0X
-date_trunc MON wholestage on                       1425           1429           3          7.0         142.5       1.0X
+date_trunc MON wholestage off                      1697           1700           5          5.9         169.7       1.0X
+date_trunc MON wholestage on                       1678           1696          24          6.0         167.8       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    1423           1424           0          7.0         142.3       1.0X
-date_trunc MONTH wholestage on                     1422           1426           2          7.0         142.2       1.0X
+date_trunc MONTH wholestage off                    1709           1716          10          5.9         170.9       1.0X
+date_trunc MONTH wholestage on                     1671           1678           7          6.0         167.1       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       1424           1424           1          7.0         142.4       1.0X
-date_trunc MM wholestage on                        1423           1431           8          7.0         142.3       1.0X
+date_trunc MM wholestage off                       1710           1717          11          5.8         171.0       1.0X
+date_trunc MM wholestage on                        1670           1679           5          6.0         167.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      1251           1257           9          8.0         125.1       1.0X
-date_trunc DAY wholestage on                       1277           1283           7          7.8         127.7       1.0X
+date_trunc DAY wholestage off                       636            638           3         15.7          63.6       1.0X
+date_trunc DAY wholestage on                        585            589           5         17.1          58.5       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       1250           1250           0          8.0         125.0       1.0X
-date_trunc DD wholestage on                        1278           1278           1          7.8         127.8       1.0X
+date_trunc DD wholestage off                        635            648          18         15.7          63.5       1.0X
+date_trunc DD wholestage on                         581            587           5         17.2          58.1       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     1212           1213           1          8.3         121.2       1.0X
-date_trunc HOUR wholestage on                      1233           1237           3          8.1         123.3       1.0X
+date_trunc HOUR wholestage off                      614            617           5         16.3          61.4       1.0X
+date_trunc HOUR wholestage on                       575            579           2         17.4          57.5       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                   1243           1244           1          8.0         124.3       1.0X
-date_trunc MINUTE wholestage on                    1216           1222           7          8.2         121.6       1.0X
+date_trunc MINUTE wholestage off                    617            619           2         16.2          61.7       1.0X
+date_trunc MINUTE wholestage on                     579            589          16         17.3          57.9       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    304            309           7         32.9          30.4       1.0X
-date_trunc SECOND wholestage on                     261            265           4         38.3          26.1       1.2X
+date_trunc SECOND wholestage off                    302            302           1         33.2          30.2       1.0X
+date_trunc SECOND wholestage on                     273            279           7         36.7          27.3       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     1351           1352           0          7.4         135.1       1.0X
-date_trunc WEEK wholestage on                      1320           1326           4          7.6         132.0       1.0X
+date_trunc WEEK wholestage off                     1623           1631          12          6.2         162.3       1.0X
+date_trunc WEEK wholestage on                      1580           1597          17          6.3         158.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  1898           1900           3          5.3         189.8       1.0X
-date_trunc QUARTER wholestage on                   1824           1828           3          5.5         182.4       1.0X
+date_trunc QUARTER wholestage off                  2020           2025           6          4.9         202.0       1.0X
+date_trunc QUARTER wholestage on                   1958           1970           8          5.1         195.8       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           765            765           0         13.1          76.5       1.0X
-trunc year wholestage on                            728            731           2         13.7          72.8       1.1X
+trunc year wholestage off                           792            802          14         12.6          79.2       1.0X
+trunc year wholestage on                            744            750          11         13.4          74.4       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           759            760           2         13.2          75.9       1.0X
-trunc yyyy wholestage on                            728            730           2         13.7          72.8       1.0X
+trunc yyyy wholestage off                           798            801           4         12.5          79.8       1.0X
+trunc yyyy wholestage on                            743            761          18         13.5          74.3       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             765            767           2         13.1          76.5       1.0X
-trunc yy wholestage on                              728            730           2         13.7          72.8       1.1X
+trunc yy wholestage off                             792            802          14         12.6          79.2       1.0X
+trunc yy wholestage on                              744            755          14         13.4          74.4       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            737            738           1         13.6          73.7       1.0X
-trunc mon wholestage on                             699            700           1         14.3          69.9       1.1X
+trunc mon wholestage off                            768            771           3         13.0          76.8       1.0X
+trunc mon wholestage on                             721            731          10         13.9          72.1       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          732            740          11         13.7          73.2       1.0X
-trunc month wholestage on                           698            710          13         14.3          69.8       1.0X
+trunc month wholestage off                          774            781           9         12.9          77.4       1.0X
+trunc month wholestage on                           723            728           6         13.8          72.3       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             734            736           4         13.6          73.4       1.0X
-trunc mm wholestage on                              698            700           3         14.3          69.8       1.1X
+trunc mm wholestage off                             766            770           5         13.0          76.6       1.0X
+trunc mm wholestage on                              724            732           9         13.8          72.4       1.1X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                      97             98           2         10.3          96.9       1.0X
-to timestamp str wholestage on                       98            101           3         10.2          98.0       1.0X
+to timestamp str wholestage off                     107            107           0          9.3         107.0       1.0X
+to timestamp str wholestage on                      123            127           4          8.1         122.9       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         706            707           1          1.4         706.4       1.0X
-to_timestamp wholestage on                          686            690           5          1.5         685.8       1.0X
+to_timestamp wholestage off                         643            650           9          1.6         643.1       1.0X
+to_timestamp wholestage on                          659            669          11          1.5         659.2       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    687            688           1          1.5         687.1       1.0X
-to_unix_timestamp wholestage on                     679            681           2          1.5         679.3       1.0X
+to_unix_timestamp wholestage off                    660            660           1          1.5         659.5       1.0X
+to_unix_timestamp wholestage on                     660            666           5          1.5         659.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          131            132           1          7.6         131.3       1.0X
-to date str wholestage on                           126            129           2          7.9         126.5       1.0X
+to date str wholestage off                          163            163           1          6.1         162.9       1.0X
+to date str wholestage on                           169            172           5          5.9         168.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              654            658           5          1.5         654.1       1.0X
-to_date wholestage on                               641            642           1          1.6         640.9       1.0X
+to_date wholestage off                              654            658           5          1.5         654.5       1.0X
+to_date wholestage on                               656            662           4          1.5         656.5       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  267            270           4         18.7          53.4       1.0X
-From java.time.LocalDate                            217            219           2         23.0          43.4       1.2X
-Collect java.sql.Date                              1294           1345          74          3.9         258.7       0.2X
-Collect java.time.LocalDate                         997           1039          60          5.0         199.5       0.3X
-From java.sql.Timestamp                             229            237           7         21.9          45.8       1.2X
-From java.time.Instant                              190            208          17         26.3          38.1       1.4X
-Collect longs                                      1009           1090          98          5.0         201.9       0.3X
-Collect java.sql.Timestamp                         1066           1137          63          4.7         213.2       0.3X
-Collect java.time.Instant                          1012           1172         140          4.9         202.4       0.3X
-java.sql.Date to Hive string                       3822           3929          93          1.3         764.4       0.1X
-java.time.LocalDate to Hive string                 3120           3139          17          1.6         624.0       0.1X
-java.sql.Timestamp to Hive string                  6506           6623         166          0.8        1301.2       0.0X
-java.time.Instant to Hive string                   4192           4217          25          1.2         838.4       0.1X
+From java.sql.Date                                  317            319           4         15.8          63.3       1.0X
+From java.time.LocalDate                            235            235           1         21.3          46.9       1.3X
+Collect java.sql.Date                              1550           1622          77          3.2         310.1       0.2X
+Collect java.time.LocalDate                        1021           1145         108          4.9         204.2       0.3X
+From java.sql.Timestamp                             241            257          15         20.8          48.1       1.3X
+From java.time.Instant                              206            215          13         24.2          41.3       1.5X
+Collect longs                                      1065           1186         205          4.7         213.0       0.3X
+Collect java.sql.Timestamp                         1330           1414          73          3.8         266.1       0.2X
+Collect java.time.Instant                          1180           1303         107          4.2         236.0       0.3X
+java.sql.Date to Hive string                       5630           5668          38          0.9        1125.9       0.1X
+java.time.LocalDate to Hive string                 4147           4197          67          1.2         829.3       0.1X
+java.sql.Timestamp to Hive string                  7441           7609         160          0.7        1488.1       0.0X
+java.time.Instant to Hive string                   5179           5237          94          1.0        1035.8       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk25-results.txt
@@ -2,460 +2,460 @@
 datetime +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  827            865          58         12.1          82.7       1.0X
-date + interval(m, d)                               808            823          21         12.4          80.8       1.0X
-date + interval(m, d, ms)                          3344           3345           1          3.0         334.4       0.2X
-date - interval(m)                                  793            795           2         12.6          79.3       1.0X
-date - interval(m, d)                               806            815           8         12.4          80.6       1.0X
-date - interval(m, d, ms)                          3384           3385           2          3.0         338.4       0.2X
-timestamp + interval(m)                            1652           1657           7          6.1         165.2       0.5X
-timestamp + interval(m, d)                         1701           1704           4          5.9         170.1       0.5X
-timestamp + interval(m, d, ms)                     2033           2033           0          4.9         203.3       0.4X
-timestamp - interval(m)                            1778           1782           6          5.6         177.8       0.5X
-timestamp - interval(m, d)                         1839           1842           4          5.4         183.9       0.4X
-timestamp - interval(m, d, ms)                     2045           2050           8          4.9         204.5       0.4X
+date + interval(m)                                  836            853          23         12.0          83.6       1.0X
+date + interval(m, d)                               827            891         101         12.1          82.7       1.0X
+date + interval(m, d, ms)                          3338           3343           7          3.0         333.8       0.3X
+date - interval(m)                                  805            808           4         12.4          80.5       1.0X
+date - interval(m, d)                               823            826           4         12.1          82.3       1.0X
+date - interval(m, d, ms)                          3338           3344           8          3.0         333.8       0.3X
+timestamp + interval(m)                            1697           1700           4          5.9         169.7       0.5X
+timestamp + interval(m, d)                         1757           1761           5          5.7         175.7       0.5X
+timestamp + interval(m, d, ms)                     2124           2125           1          4.7         212.4       0.4X
+timestamp - interval(m)                            1861           1868          11          5.4         186.1       0.4X
+timestamp - interval(m, d)                         1940           1941           1          5.2         194.0       0.4X
+timestamp - interval(m, d, ms)                     2120           2124           5          4.7         212.0       0.4X
 
 
 ================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    197            199           2         50.7          19.7       1.0X
-cast to timestamp wholestage on                     206            214           6         48.6          20.6       1.0X
+cast to timestamp wholestage off                    199            200           1         50.2          19.9       1.0X
+cast to timestamp wholestage on                     214            228          26         46.8          21.4       0.9X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    656            665          12         15.2          65.6       1.0X
-year of timestamp wholestage on                     604            613          14         16.6          60.4       1.1X
+year of timestamp wholestage off                    604            605           1         16.6          60.4       1.0X
+year of timestamp wholestage on                     609            616           7         16.4          60.9       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 648            649           1         15.4          64.8       1.0X
-quarter of timestamp wholestage on                  622            630           5         16.1          62.2       1.0X
+quarter of timestamp wholestage off                 656            665          13         15.3          65.6       1.0X
+quarter of timestamp wholestage on                  640            649           7         15.6          64.0       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   623            626           4         16.0          62.3       1.0X
-month of timestamp wholestage on                    620            624           3         16.1          62.0       1.0X
+month of timestamp wholestage off                   626            626           1         16.0          62.6       1.0X
+month of timestamp wholestage on                    620            625           3         16.1          62.0       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1002           1003           2         10.0         100.2       1.0X
-weekofyear of timestamp wholestage on               981            992          19         10.2          98.1       1.0X
+weekofyear of timestamp wholestage off             1028           1029           1          9.7         102.8       1.0X
+weekofyear of timestamp wholestage on              1032           1040           9          9.7         103.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     628            628           1         15.9          62.8       1.0X
-day of timestamp wholestage on                      621            626           4         16.1          62.1       1.0X
+day of timestamp wholestage off                     640            642           3         15.6          64.0       1.0X
+day of timestamp wholestage on                      626            630           4         16.0          62.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               667            679          17         15.0          66.7       1.0X
-dayofyear of timestamp wholestage on                659            669           9         15.2          65.9       1.0X
+dayofyear of timestamp wholestage off               666            674          11         15.0          66.6       1.0X
+dayofyear of timestamp wholestage on                665            670           5         15.0          66.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              630            644          21         15.9          63.0       1.0X
-dayofmonth of timestamp wholestage on               621            626           3         16.1          62.1       1.0X
+dayofmonth of timestamp wholestage off              638            638           0         15.7          63.8       1.0X
+dayofmonth of timestamp wholestage on               623            635          12         16.1          62.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               792            794           2         12.6          79.2       1.0X
-dayofweek of timestamp wholestage on                786            787           2         12.7          78.6       1.0X
+dayofweek of timestamp wholestage off               796            797           1         12.6          79.6       1.0X
+dayofweek of timestamp wholestage on                798            802           2         12.5          79.8       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 730            745          23         13.7          73.0       1.0X
-weekday of timestamp wholestage on                  730            734           3         13.7          73.0       1.0X
+weekday of timestamp wholestage off                 732            732           1         13.7          73.2       1.0X
+weekday of timestamp wholestage on                  736            738           2         13.6          73.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    539            540           1         18.6          53.9       1.0X
-hour of timestamp wholestage on                     535            538           4         18.7          53.5       1.0X
+hour of timestamp wholestage off                    533            534           2         18.8          53.3       1.0X
+hour of timestamp wholestage on                     545            547           2         18.3          54.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  537            540           5         18.6          53.7       1.0X
-minute of timestamp wholestage on                   538            544          13         18.6          53.8       1.0X
+minute of timestamp wholestage off                  535            539           5         18.7          53.5       1.0X
+minute of timestamp wholestage on                   545            547           3         18.4          54.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  535            535           0         18.7          53.5       1.0X
-second of timestamp wholestage on                   546            550           2         18.3          54.6       1.0X
+second of timestamp wholestage off                  537            541           6         18.6          53.7       1.0X
+second of timestamp wholestage on                   547            552           5         18.3          54.7       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         189            191           2         52.8          18.9       1.0X
-current_date wholestage on                          203            206           3         49.4          20.3       0.9X
+current_date wholestage off                         192            201          13         52.2          19.2       1.0X
+current_date wholestage on                          208            212           5         48.1          20.8       0.9X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    211            239          40         47.4          21.1       1.0X
-current_timestamp wholestage on                     210            220          11         47.5          21.0       1.0X
+current_timestamp wholestage off                    202            205           5         49.6          20.2       1.0X
+current_timestamp wholestage on                     212            217           5         47.2          21.2       1.0X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         571            574           5         17.5          57.1       1.0X
-cast to date wholestage on                          574            577           4         17.4          57.4       1.0X
+cast to date wholestage off                         591            591           1         16.9          59.1       1.0X
+cast to date wholestage on                          584            586           1         17.1          58.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             659            661           3         15.2          65.9       1.0X
-last_day wholestage on                              659            668           6         15.2          65.9       1.0X
+last_day wholestage off                             651            653           3         15.4          65.1       1.0X
+last_day wholestage on                              672            678           6         14.9          67.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             607            609           3         16.5          60.7       1.0X
-next_day wholestage on                              610            616           4         16.4          61.0       1.0X
+next_day wholestage off                             622            623           2         16.1          62.2       1.0X
+next_day wholestage on                              611            617           4         16.4          61.1       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             559            562           4         17.9          55.9       1.0X
-date_add wholestage on                              572            579           9         17.5          57.2       1.0X
+date_add wholestage off                             564            569           8         17.7          56.4       1.0X
+date_add wholestage on                              564            570           4         17.7          56.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             566            577          15         17.7          56.6       1.0X
-date_sub wholestage on                              573            575           2         17.5          57.3       1.0X
+date_sub wholestage off                             568            568           1         17.6          56.8       1.0X
+date_sub wholestage on                              573            575           2         17.4          57.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           791            793           3         12.6          79.1       1.0X
-add_months wholestage on                            792            799           5         12.6          79.2       1.0X
+add_months wholestage off                           799            809          15         12.5          79.9       1.0X
+add_months wholestage on                            805            814          14         12.4          80.5       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         2790           2842          74          3.6         279.0       1.0X
-format date wholestage on                          2810           2831          13          3.6         281.0       1.0X
+format date wholestage off                         2907           2981         104          3.4         290.7       1.0X
+format date wholestage on                          2902           2909           9          3.4         290.2       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       2669           2671           4          3.7         266.9       1.0X
-from_unixtime wholestage on                        2648           2657           9          3.8         264.8       1.0X
+from_unixtime wholestage off                       2825           2825           0          3.5         282.5       1.0X
+from_unixtime wholestage on                        2667           2673           6          3.8         266.7       1.1X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   681            686           7         14.7          68.1       1.0X
-from_utc_timestamp wholestage on                    719            725           7         13.9          71.9       0.9X
+from_utc_timestamp wholestage off                   733            733           1         13.6          73.3       1.0X
+from_utc_timestamp wholestage on                    698            701           8         14.3          69.8       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                     824            826           2         12.1          82.4       1.0X
-to_utc_timestamp wholestage on                      856            860           3         11.7          85.6       1.0X
+to_utc_timestamp wholestage off                     863            866           4         11.6          86.3       1.0X
+to_utc_timestamp wholestage on                      873            876           2         11.5          87.3       1.0X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        245            248           5         40.9          24.5       1.0X
-cast interval wholestage on                         210            215           5         47.7          21.0       1.2X
+cast interval wholestage off                        285            286           1         35.1          28.5       1.0X
+cast interval wholestage on                         208            211           3         48.1          20.8       1.4X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                             963            965           2         10.4          96.3       1.0X
-datediff wholestage on                              911            917           6         11.0          91.1       1.1X
+datediff wholestage off                             943            943           0         10.6          94.3       1.0X
+datediff wholestage on                              940            945           4         10.6          94.0       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      3058           3059           2          3.3         305.8       1.0X
-months_between wholestage on                       3073           3082           5          3.3         307.3       1.0X
+months_between wholestage off                      3189           3192           5          3.1         318.9       1.0X
+months_between wholestage on                       3184           3191           5          3.1         318.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               351            352           1          2.8         351.3       1.0X
-window wholestage on                                703            710           7          1.4         703.4       0.5X
+window wholestage off                               574            586          17          1.7         573.6       1.0X
+window wholestage on                                686            714          26          1.5         685.8       0.8X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     1631           1633           3          6.1         163.1       1.0X
-date_trunc YEAR wholestage on                      1671           1679           5          6.0         167.1       1.0X
+date_trunc YEAR wholestage off                     1705           1708           4          5.9         170.5       1.0X
+date_trunc YEAR wholestage on                      1635           1639           3          6.1         163.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     1635           1643          11          6.1         163.5       1.0X
-date_trunc YYYY wholestage on                      1679           1682           2          6.0         167.9       1.0X
+date_trunc YYYY wholestage off                     1709           1710           2          5.9         170.9       1.0X
+date_trunc YYYY wholestage on                      1636           1639           3          6.1         163.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       1631           1635           5          6.1         163.1       1.0X
-date_trunc YY wholestage on                        1681           1683           1          5.9         168.1       1.0X
+date_trunc YY wholestage off                       1708           1710           2          5.9         170.8       1.0X
+date_trunc YY wholestage on                        1635           1637           2          6.1         163.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      1656           1657           2          6.0         165.6       1.0X
-date_trunc MON wholestage on                       1626           1630           3          6.2         162.6       1.0X
+date_trunc MON wholestage off                      1795           1797           3          5.6         179.5       1.0X
+date_trunc MON wholestage on                       1633           1636           3          6.1         163.3       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    1655           1655           1          6.0         165.5       1.0X
-date_trunc MONTH wholestage on                     1625           1629           4          6.2         162.5       1.0X
+date_trunc MONTH wholestage off                    1795           1795           0          5.6         179.5       1.0X
+date_trunc MONTH wholestage on                     1632           1633           1          6.1         163.2       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       1655           1658           4          6.0         165.5       1.0X
-date_trunc MM wholestage on                        1624           1633          11          6.2         162.4       1.0X
+date_trunc MM wholestage off                       1797           1798           0          5.6         179.7       1.0X
+date_trunc MM wholestage on                        1633           1635           3          6.1         163.3       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      1194           1195           2          8.4         119.4       1.0X
-date_trunc DAY wholestage on                       1260           1264           5          7.9         126.0       0.9X
+date_trunc DAY wholestage off                       571            572           1         17.5          57.1       1.0X
+date_trunc DAY wholestage on                        541            546           5         18.5          54.1       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       1195           1197           4          8.4         119.5       1.0X
-date_trunc DD wholestage on                        1260           1262           1          7.9         126.0       0.9X
+date_trunc DD wholestage off                        572            572           0         17.5          57.2       1.0X
+date_trunc DD wholestage on                         543            550           5         18.4          54.3       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     1197           1199           4          8.4         119.7       1.0X
-date_trunc HOUR wholestage on                      1149           1152           2          8.7         114.9       1.0X
+date_trunc HOUR wholestage off                      546            547           1         18.3          54.6       1.0X
+date_trunc HOUR wholestage on                       516            518           2         19.4          51.6       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                   1290           1290           0          7.8         129.0       1.0X
-date_trunc MINUTE wholestage on                    1216           1217           1          8.2         121.6       1.1X
+date_trunc MINUTE wholestage off                    547            552           7         18.3          54.7       1.0X
+date_trunc MINUTE wholestage on                     498            502           3         20.1          49.8       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    309            309           1         32.4          30.9       1.0X
-date_trunc SECOND wholestage on                     274            277           2         36.5          27.4       1.1X
+date_trunc SECOND wholestage off                    308            308           0         32.4          30.8       1.0X
+date_trunc SECOND wholestage on                     269            273           3         37.1          26.9       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     1523           1543          27          6.6         152.3       1.0X
-date_trunc WEEK wholestage on                      1644           1645           2          6.1         164.4       0.9X
+date_trunc WEEK wholestage off                     1619           1622           4          6.2         161.9       1.0X
+date_trunc WEEK wholestage on                      1547           1551           3          6.5         154.7       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  2130           2141          15          4.7         213.0       1.0X
-date_trunc QUARTER wholestage on                   1996           2008          24          5.0         199.6       1.1X
+date_trunc QUARTER wholestage off                  2163           2171          12          4.6         216.3       1.0X
+date_trunc QUARTER wholestage on                   2016           2040          16          5.0         201.6       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           767            767           1         13.0          76.7       1.0X
-trunc year wholestage on                            728            732           4         13.7          72.8       1.1X
+trunc year wholestage off                           781            782           1         12.8          78.1       1.0X
+trunc year wholestage on                            736            739           2         13.6          73.6       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           766            766           0         13.1          76.6       1.0X
-trunc yyyy wholestage on                            727            731           3         13.7          72.7       1.1X
+trunc yyyy wholestage off                           783            783           0         12.8          78.3       1.0X
+trunc yyyy wholestage on                            735            738           2         13.6          73.5       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             766            767           0         13.0          76.6       1.0X
-trunc yy wholestage on                              726            730           3         13.8          72.6       1.1X
+trunc yy wholestage off                             782            785           3         12.8          78.2       1.0X
+trunc yy wholestage on                              737            739           2         13.6          73.7       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            727            728           1         13.8          72.7       1.0X
-trunc mon wholestage on                             696            703           7         14.4          69.6       1.0X
+trunc mon wholestage off                            750            750           0         13.3          75.0       1.0X
+trunc mon wholestage on                             688            689           2         14.5          68.8       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          721            724           4         13.9          72.1       1.0X
-trunc month wholestage on                           693            705          11         14.4          69.3       1.0X
+trunc month wholestage off                          751            765          20         13.3          75.1       1.0X
+trunc month wholestage on                           686            689           3         14.6          68.6       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             728            728           0         13.7          72.8       1.0X
-trunc mm wholestage on                              700            706           6         14.3          70.0       1.0X
+trunc mm wholestage off                             751            751           1         13.3          75.1       1.0X
+trunc mm wholestage on                              685            688           4         14.6          68.5       1.1X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                      89             91           2         11.2          89.5       1.0X
-to timestamp str wholestage on                       86             97          14         11.6          86.1       1.0X
+to timestamp str wholestage off                      92             93           2         10.9          91.9       1.0X
+to timestamp str wholestage on                       84             86           1         11.9          83.9       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         548            548           0          1.8         548.4       1.0X
-to_timestamp wholestage on                          571            575           4          1.8         571.4       1.0X
+to_timestamp wholestage off                         611            611           1          1.6         610.9       1.0X
+to_timestamp wholestage on                          601            603           2          1.7         601.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    574            574           0          1.7         573.8       1.0X
-to_unix_timestamp wholestage on                     569            576          10          1.8         569.3       1.0X
+to_unix_timestamp wholestage off                    609            611           4          1.6         608.6       1.0X
+to_unix_timestamp wholestage on                     593            595           2          1.7         593.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          106            108           4          9.4         105.9       1.0X
-to date str wholestage on                           105            106           1          9.5         105.2       1.0X
+to date str wholestage off                          111            114           4          9.0         110.9       1.0X
+to date str wholestage on                           110            112           2          9.1         109.9       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              543            545           2          1.8         543.5       1.0X
-to_date wholestage on                               555            556           1          1.8         554.9       1.0X
+to_date wholestage off                              620            622           3          1.6         620.0       1.0X
+to_date wholestage on                               611            613           2          1.6         611.3       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  292            293           2         17.1          58.4       1.0X
-From java.time.LocalDate                            227            229           3         22.0          45.4       1.3X
-Collect java.sql.Date                              1382           1410          28          3.6         276.4       0.2X
-Collect java.time.LocalDate                        1033           1171         123          4.8         206.7       0.3X
-From java.sql.Timestamp                             229            246          16         21.9          45.7       1.3X
-From java.time.Instant                              201            217          14         24.9          40.1       1.5X
-Collect longs                                      1030           1170         133          4.9         206.0       0.3X
-Collect java.sql.Timestamp                          946           1219         238          5.3         189.2       0.3X
-Collect java.time.Instant                          1036           1113         107          4.8         207.2       0.3X
-java.sql.Date to Hive string                       3823           3971         129          1.3         764.6       0.1X
-java.time.LocalDate to Hive string                 3058           3188         190          1.6         611.7       0.1X
-java.sql.Timestamp to Hive string                  6532           6816         249          0.8        1306.3       0.0X
-java.time.Instant to Hive string                   4228           4275          51          1.2         845.6       0.1X
+From java.sql.Date                                  290            291           1         17.2          58.1       1.0X
+From java.time.LocalDate                            224            227           2         22.3          44.8       1.3X
+Collect java.sql.Date                              1274           1300          30          3.9         254.8       0.2X
+Collect java.time.LocalDate                         939           1088         158          5.3         187.9       0.3X
+From java.sql.Timestamp                             248            257           8         20.2          49.6       1.2X
+From java.time.Instant                              195            205          16         25.7          38.9       1.5X
+Collect longs                                      1042           1067          22          4.8         208.3       0.3X
+Collect java.sql.Timestamp                         1136           1226          84          4.4         227.3       0.3X
+Collect java.time.Instant                           925           1042         101          5.4         185.0       0.3X
+java.sql.Date to Hive string                       4507           4562          81          1.1         901.3       0.1X
+java.time.LocalDate to Hive string                 3638           3757         103          1.4         727.6       0.1X
+java.sql.Timestamp to Hive string                  7280           7445         169          0.7        1456.0       0.0X
+java.time.Instant to Hive string                   4745           4883         136          1.1         949.1       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -2,460 +2,460 @@
 datetime +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  991           1086         134         10.1          99.1       1.0X
-date + interval(m, d)                               991           1006          21         10.1          99.1       1.0X
-date + interval(m, d, ms)                          3879           3886           9          2.6         387.9       0.3X
-date - interval(m)                                  978            981           5         10.2          97.8       1.0X
-date - interval(m, d)                              1007           1008           2          9.9         100.7       1.0X
-date - interval(m, d, ms)                          3911           3917           8          2.6         391.1       0.3X
-timestamp + interval(m)                            1659           1660           2          6.0         165.9       0.6X
-timestamp + interval(m, d)                         1721           1723           2          5.8         172.1       0.6X
-timestamp + interval(m, d, ms)                     2027           2039          17          4.9         202.7       0.5X
-timestamp - interval(m)                            1756           1762           9          5.7         175.6       0.6X
-timestamp - interval(m, d)                         1854           1860           9          5.4         185.4       0.5X
-timestamp - interval(m, d, ms)                     2022           2023           0          4.9         202.2       0.5X
+date + interval(m)                                 1027           1051          34          9.7         102.7       1.0X
+date + interval(m, d)                               996            996           1         10.0          99.6       1.0X
+date + interval(m, d, ms)                          4122           4129          10          2.4         412.2       0.2X
+date - interval(m)                                  974            981           5         10.3          97.4       1.1X
+date - interval(m, d)                              1001           1006           7         10.0         100.1       1.0X
+date - interval(m, d, ms)                          4146           4161          22          2.4         414.6       0.2X
+timestamp + interval(m)                            1819           1819           0          5.5         181.9       0.6X
+timestamp + interval(m, d)                         1866           1868           4          5.4         186.6       0.6X
+timestamp + interval(m, d, ms)                     2113           2117           5          4.7         211.3       0.5X
+timestamp - interval(m)                            1826           1834          11          5.5         182.6       0.6X
+timestamp - interval(m, d)                         1904           1905           1          5.3         190.4       0.5X
+timestamp - interval(m, d, ms)                     2110           2111           1          4.7         211.0       0.5X
 
 
 ================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    201            202           1         49.8          20.1       1.0X
-cast to timestamp wholestage on                     214            230          23         46.8          21.4       0.9X
+cast to timestamp wholestage off                    198            198           0         50.4          19.8       1.0X
+cast to timestamp wholestage on                     213            224          16         47.0          21.3       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    778            783           7         12.8          77.8       1.0X
-year of timestamp wholestage on                     784            788           2         12.8          78.4       1.0X
+year of timestamp wholestage off                    761            764           4         13.1          76.1       1.0X
+year of timestamp wholestage on                     759            764           5         13.2          75.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 803            806           5         12.5          80.3       1.0X
-quarter of timestamp wholestage on                  800            806           4         12.5          80.0       1.0X
+quarter of timestamp wholestage off                 783            784           1         12.8          78.3       1.0X
+quarter of timestamp wholestage on                  787            794           6         12.7          78.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   787            798          15         12.7          78.7       1.0X
-month of timestamp wholestage on                    781            791          10         12.8          78.1       1.0X
+month of timestamp wholestage off                   767            767           0         13.0          76.7       1.0X
+month of timestamp wholestage on                    771            773           1         13.0          77.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1126           1131           7          8.9         112.6       1.0X
-weekofyear of timestamp wholestage on              1152           1161          12          8.7         115.2       1.0X
+weekofyear of timestamp wholestage off             1030           1041          16          9.7         103.0       1.0X
+weekofyear of timestamp wholestage on              1041           1052          12          9.6         104.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     786            789           5         12.7          78.6       1.0X
-day of timestamp wholestage on                      781            781           0         12.8          78.1       1.0X
+day of timestamp wholestage off                     761            765           6         13.1          76.1       1.0X
+day of timestamp wholestage on                      760            763           2         13.2          76.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               813            814           2         12.3          81.3       1.0X
-dayofyear of timestamp wholestage on                805            807           2         12.4          80.5       1.0X
+dayofyear of timestamp wholestage off               798            798           0         12.5          79.8       1.0X
+dayofyear of timestamp wholestage on                799            802           3         12.5          79.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              791            794           5         12.6          79.1       1.0X
-dayofmonth of timestamp wholestage on               787            790           3         12.7          78.7       1.0X
+dayofmonth of timestamp wholestage off              772            774           2         12.9          77.2       1.0X
+dayofmonth of timestamp wholestage on               763            770           9         13.1          76.3       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               935            938           5         10.7          93.5       1.0X
-dayofweek of timestamp wholestage on                930            934           5         10.8          93.0       1.0X
+dayofweek of timestamp wholestage off               903            904           1         11.1          90.3       1.0X
+dayofweek of timestamp wholestage on                910            915           5         11.0          91.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 887            889           2         11.3          88.7       1.0X
-weekday of timestamp wholestage on                  885            892          10         11.3          88.5       1.0X
+weekday of timestamp wholestage off                 861            862           2         11.6          86.1       1.0X
+weekday of timestamp wholestage on                  869            880          16         11.5          86.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    611            615           5         16.4          61.1       1.0X
-hour of timestamp wholestage on                     610            617           9         16.4          61.0       1.0X
+hour of timestamp wholestage off                    598            600           4         16.7          59.8       1.0X
+hour of timestamp wholestage on                     602            609           6         16.6          60.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  609            613           6         16.4          60.9       1.0X
-minute of timestamp wholestage on                   611            618           9         16.4          61.1       1.0X
+minute of timestamp wholestage off                  598            599           1         16.7          59.8       1.0X
+minute of timestamp wholestage on                   603            611          11         16.6          60.3       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  613            613           1         16.3          61.3       1.0X
-second of timestamp wholestage on                   615            617           2         16.3          61.5       1.0X
+second of timestamp wholestage off                  604            604           0         16.6          60.4       1.0X
+second of timestamp wholestage on                   604            609           4         16.6          60.4       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         188            188           1         53.3          18.8       1.0X
-current_date wholestage on                          216            228          13         46.3          21.6       0.9X
+current_date wholestage off                         182            182           0         55.0          18.2       1.0X
+current_date wholestage on                          213            217           3         47.0          21.3       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    198            198           0         50.5          19.8       1.0X
-current_timestamp wholestage on                     224            238          20         44.7          22.4       0.9X
+current_timestamp wholestage off                    190            193           4         52.7          19.0       1.0X
+current_timestamp wholestage on                     216            232          12         46.4          21.6       0.9X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         684            684           0         14.6          68.4       1.0X
-cast to date wholestage on                          682            684           2         14.7          68.2       1.0X
+cast to date wholestage off                         659            661           4         15.2          65.9       1.0X
+cast to date wholestage on                          672            675           4         14.9          67.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             798            799           1         12.5          79.8       1.0X
-last_day wholestage on                              801            805           3         12.5          80.1       1.0X
+last_day wholestage off                             770            771           2         13.0          77.0       1.0X
+last_day wholestage on                              772            777           5         13.0          77.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             713            714           1         14.0          71.3       1.0X
-next_day wholestage on                              714            719           7         14.0          71.4       1.0X
+next_day wholestage off                             690            703          18         14.5          69.0       1.0X
+next_day wholestage on                              706            709           2         14.2          70.6       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             668            669           1         15.0          66.8       1.0X
-date_add wholestage on                              693            706          16         14.4          69.3       1.0X
+date_add wholestage off                             644            645           1         15.5          64.4       1.0X
+date_add wholestage on                              645            648           2         15.5          64.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             682            683           2         14.7          68.2       1.0X
-date_sub wholestage on                              692            694           2         14.4          69.2       1.0X
+date_sub wholestage off                             637            640           4         15.7          63.7       1.0X
+date_sub wholestage on                              650            657           8         15.4          65.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           934            935           1         10.7          93.4       1.0X
-add_months wholestage on                            935            942           6         10.7          93.5       1.0X
+add_months wholestage off                           908            916          12         11.0          90.8       1.0X
+add_months wholestage on                            911            915           5         11.0          91.1       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3548           3554           9          2.8         354.8       1.0X
-format date wholestage on                          3716           3721           4          2.7         371.6       1.0X
+format date wholestage off                         3288           3294           8          3.0         328.8       1.0X
+format date wholestage on                          3324           3363          51          3.0         332.4       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       3352           3355           4          3.0         335.2       1.0X
-from_unixtime wholestage on                        3530           3540           7          2.8         353.0       0.9X
+from_unixtime wholestage off                       3654           3656           2          2.7         365.4       1.0X
+from_unixtime wholestage on                        3622           3633          12          2.8         362.2       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   735            737           3         13.6          73.5       1.0X
-from_utc_timestamp wholestage on                    844            849           6         11.9          84.4       0.9X
+from_utc_timestamp wholestage off                   721            724           5         13.9          72.1       1.0X
+from_utc_timestamp wholestage on                    842            843           1         11.9          84.2       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1093           1095           3          9.2         109.3       1.0X
-to_utc_timestamp wholestage on                     1146           1159          18          8.7         114.6       1.0X
+to_utc_timestamp wholestage off                    1175           1186          17          8.5         117.5       1.0X
+to_utc_timestamp wholestage on                     1081           1092          14          9.3         108.1       1.1X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        222            224           3         45.1          22.2       1.0X
-cast interval wholestage on                         219            221           2         45.6          21.9       1.0X
+cast interval wholestage off                        230            231           2         43.5          23.0       1.0X
+cast interval wholestage on                         212            215           4         47.2          21.2       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1168           1170           4          8.6         116.8       1.0X
-datediff wholestage on                             1151           1153           2          8.7         115.1       1.0X
+datediff wholestage off                            1118           1121           4          8.9         111.8       1.0X
+datediff wholestage on                             1174           1185          20          8.5         117.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      3295           3308          18          3.0         329.5       1.0X
-months_between wholestage on                       3259           3262           4          3.1         325.9       1.0X
+months_between wholestage off                      3213           3217           5          3.1         321.3       1.0X
+months_between wholestage on                       3238           3248          16          3.1         323.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               394            405          16          2.5         393.6       1.0X
-window wholestage on                                651            668          12          1.5         651.4       0.6X
+window wholestage off                               632            647          21          1.6         632.3       1.0X
+window wholestage on                                629            652          17          1.6         629.0       1.0X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     1751           1756           6          5.7         175.1       1.0X
-date_trunc YEAR wholestage on                      1680           1683           2          6.0         168.0       1.0X
+date_trunc YEAR wholestage off                     1686           1687           1          5.9         168.6       1.0X
+date_trunc YEAR wholestage on                      1747           1749           2          5.7         174.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     1751           1751           0          5.7         175.1       1.0X
-date_trunc YYYY wholestage on                      1680           1684           7          6.0         168.0       1.0X
+date_trunc YYYY wholestage off                     1682           1684           2          5.9         168.2       1.0X
+date_trunc YYYY wholestage on                      1746           1749           2          5.7         174.6       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       1755           1756           1          5.7         175.5       1.0X
-date_trunc YY wholestage on                        1680           1683           3          6.0         168.0       1.0X
+date_trunc YY wholestage off                       1683           1683           1          5.9         168.3       1.0X
+date_trunc YY wholestage on                        1747           1749           3          5.7         174.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      1762           1773          16          5.7         176.2       1.0X
-date_trunc MON wholestage on                       1741           1749          11          5.7         174.1       1.0X
+date_trunc MON wholestage off                      1718           1727          13          5.8         171.8       1.0X
+date_trunc MON wholestage on                       1710           1716           6          5.8         171.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    1757           1767          15          5.7         175.7       1.0X
-date_trunc MONTH wholestage on                     1746           1751           9          5.7         174.6       1.0X
+date_trunc MONTH wholestage off                    1721           1723           3          5.8         172.1       1.0X
+date_trunc MONTH wholestage on                     1710           1730          32          5.8         171.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       1760           1761           1          5.7         176.0       1.0X
-date_trunc MM wholestage on                        1743           1746           4          5.7         174.3       1.0X
+date_trunc MM wholestage off                       1721           1721           0          5.8         172.1       1.0X
+date_trunc MM wholestage on                        1710           1719          10          5.8         171.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                      1309           1309           1          7.6         130.9       1.0X
-date_trunc DAY wholestage on                       1259           1261           2          7.9         125.9       1.0X
+date_trunc DAY wholestage off                       603            627          33         16.6          60.3       1.0X
+date_trunc DAY wholestage on                        561            567           9         17.8          56.1       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                       1310           1312           3          7.6         131.0       1.0X
-date_trunc DD wholestage on                        1259           1262           2          7.9         125.9       1.0X
+date_trunc DD wholestage off                        605            609           5         16.5          60.5       1.0X
+date_trunc DD wholestage on                         562            563           1         17.8          56.2       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                     1309           1312           5          7.6         130.9       1.0X
-date_trunc HOUR wholestage on                      1275           1281           5          7.8         127.5       1.0X
+date_trunc HOUR wholestage off                      605            608           4         16.5          60.5       1.0X
+date_trunc HOUR wholestage on                       563            570          12         17.8          56.3       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                   1339           1342           3          7.5         133.9       1.0X
-date_trunc MINUTE wholestage on                    1299           1301           2          7.7         129.9       1.0X
+date_trunc MINUTE wholestage off                    605            605           0         16.5          60.5       1.0X
+date_trunc MINUTE wholestage on                     560            561           1         17.9          56.0       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    320            320           0         31.3          32.0       1.0X
-date_trunc SECOND wholestage on                     275            277           3         36.4          27.5       1.2X
+date_trunc SECOND wholestage off                    325            326           1         30.8          32.5       1.0X
+date_trunc SECOND wholestage on                     281            284           2         35.6          28.1       1.2X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     1607           1616          12          6.2         160.7       1.0X
-date_trunc WEEK wholestage on                      1577           1583           5          6.3         157.7       1.0X
+date_trunc WEEK wholestage off                     1580           1583           4          6.3         158.0       1.0X
+date_trunc WEEK wholestage on                      1599           1601           2          6.3         159.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  2037           2042           6          4.9         203.7       1.0X
-date_trunc QUARTER wholestage on                   2031           2044          20          4.9         203.1       1.0X
+date_trunc QUARTER wholestage off                  2158           2168          13          4.6         215.8       1.0X
+date_trunc QUARTER wholestage on                   2138           2140           1          4.7         213.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           943            943           0         10.6          94.3       1.0X
-trunc year wholestage on                            894            899           5         11.2          89.4       1.1X
+trunc year wholestage off                           913            914           2         11.0          91.3       1.0X
+trunc year wholestage on                            910            917           8         11.0          91.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           941            941           0         10.6          94.1       1.0X
-trunc yyyy wholestage on                            895            902          10         11.2          89.5       1.1X
+trunc yyyy wholestage off                           913            914           1         11.0          91.3       1.0X
+trunc yyyy wholestage on                            913            921           7         10.9          91.3       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             941            943           3         10.6          94.1       1.0X
-trunc yy wholestage on                              894            896           1         11.2          89.4       1.1X
+trunc yy wholestage off                             912            913           1         11.0          91.2       1.0X
+trunc yy wholestage on                              911            913           2         11.0          91.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            914            914           1         10.9          91.4       1.0X
-trunc mon wholestage on                             869            872           3         11.5          86.9       1.1X
+trunc mon wholestage off                            889            890           1         11.2          88.9       1.0X
+trunc mon wholestage on                             869            879          19         11.5          86.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          914            915           2         10.9          91.4       1.0X
-trunc month wholestage on                           870            877          11         11.5          87.0       1.1X
+trunc month wholestage off                          889            890           2         11.2          88.9       1.0X
+trunc month wholestage on                           869            873           4         11.5          86.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             914            915           1         10.9          91.4       1.0X
-trunc mm wholestage on                              867            871           4         11.5          86.7       1.1X
+trunc mm wholestage off                             888            900          17         11.3          88.8       1.0X
+trunc mm wholestage on                              870            876           6         11.5          87.0       1.0X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     113            115           2          8.8         113.2       1.0X
-to timestamp str wholestage on                       99            102           3         10.1          98.6       1.1X
+to timestamp str wholestage off                     105            105           1          9.6         104.6       1.0X
+to timestamp str wholestage on                      100            104           6         10.0          99.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         740            741           1          1.4         740.4       1.0X
-to_timestamp wholestage on                          715            718           3          1.4         714.7       1.0X
+to_timestamp wholestage off                         796            800           6          1.3         795.8       1.0X
+to_timestamp wholestage on                          780            782           2          1.3         779.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    738            739           1          1.4         737.6       1.0X
-to_unix_timestamp wholestage on                     723            724           2          1.4         723.0       1.0X
+to_unix_timestamp wholestage off                    789            789           0          1.3         788.8       1.0X
+to_unix_timestamp wholestage on                     765            766           2          1.3         764.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          137            137           0          7.3         137.0       1.0X
-to date str wholestage on                           130            133           4          7.7         130.2       1.1X
+to date str wholestage off                          133            134           1          7.5         133.5       1.0X
+to date str wholestage on                           132            135           2          7.6         131.6       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              643            643           1          1.6         642.9       1.0X
-to_date wholestage on                               640            640           1          1.6         639.5       1.0X
+to_date wholestage off                              671            672           1          1.5         671.1       1.0X
+to_date wholestage on                               668            679          20          1.5         667.5       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  283            284           2         17.7          56.6       1.0X
-From java.time.LocalDate                            245            245           0         20.4          48.9       1.2X
-Collect java.sql.Date                              1196           1329         154          4.2         239.3       0.2X
-Collect java.time.LocalDate                         838           1051         221          6.0         167.6       0.3X
-From java.sql.Timestamp                             230            232           4         21.8          45.9       1.2X
-From java.time.Instant                              213            218           5         23.5          42.6       1.3X
-Collect longs                                      1000           1051          45          5.0         200.0       0.3X
-Collect java.sql.Timestamp                         1073           1234         170          4.7         214.7       0.3X
-Collect java.time.Instant                           963           1128         176          5.2         192.5       0.3X
-java.sql.Date to Hive string                       3889           3971         133          1.3         777.7       0.1X
-java.time.LocalDate to Hive string                 3186           3212          30          1.6         637.2       0.1X
-java.sql.Timestamp to Hive string                  6586           6653         111          0.8        1317.1       0.0X
-java.time.Instant to Hive string                   4888           4995          93          1.0         977.7       0.1X
+From java.sql.Date                                  288            289           1         17.4          57.6       1.0X
+From java.time.LocalDate                            244            246           2         20.5          48.9       1.2X
+Collect java.sql.Date                              1255           1337          72          4.0         251.0       0.2X
+Collect java.time.LocalDate                        1077           1099          20          4.6         215.3       0.3X
+From java.sql.Timestamp                             236            238           3         21.2          47.2       1.2X
+From java.time.Instant                              183            185           2         27.4          36.6       1.6X
+Collect longs                                       952           1050          98          5.3         190.3       0.3X
+Collect java.sql.Timestamp                         1002           1113          96          5.0         200.5       0.3X
+Collect java.time.Instant                           950           1050         124          5.3         190.0       0.3X
+java.sql.Date to Hive string                       4735           4742          10          1.1         946.9       0.1X
+java.time.LocalDate to Hive string                 3939           4073         160          1.3         787.7       0.1X
+java.sql.Timestamp to Hive string                  7243           7246           3          0.7        1448.6       0.0X
+java.time.Instant to Hive string                   5813           5958         141          0.9        1162.5       0.0X
 
 


### PR DESCRIPTION
Closes [SPARK-56663](https://issues.apache.org/jira/browse/SPARK-56663).

### What changes were proposed in this pull request?

This PR re-introduces a fast path in `DateTimeUtils.truncTimestamp` for `TRUNC_TO_MINUTE`, `TRUNC_TO_HOUR`, and `TRUNC_TO_DAY`. A new private `truncToUnitFast(micros, zoneId, unitMicros, fallbackUnit)` helper:

1. Resolves the zone offset for the input instant once (`zoneId.getRules.getOffset(...)`).
2. Truncates by `Math.floorMod` in local time: `local = micros + offsetMicros`, then `truncatedLocal = local - floorMod(local, unitMicros)`, then back: `candidate = truncatedLocal - offsetMicros`.
3. Re-checks the offset at `candidate` and falls back to the existing `truncatedTo()`-based slow path if it differs from the original offset (the SPARK-30766 / SPARK-30857 DST guard).
4. The DST re-check is skipped for `ZoneRules.isFixedOffset` zones.
5. `Math.addExact` / `subtractExact` guard the offset arithmetic; on overflow we also fall back to the slow path.

The arithmetic also handles sub-minute LMT offsets (e.g. America/Los_Angeles `-07:52:58` pre-1883 - the SPARK-33404 case) and 30/45-minute zones (Asia/Kolkata `+05:30`, Asia/Kathmandu `+05:45`) without an offset-alignment guard, because the offset is applied as part of the floorMod.

Date-level units (WEEK/MONTH/QUARTER/YEAR + `trunc(date, ...)`) are not touched in this PR; they still go through `microsToDays` / `daysToMicros`. Those can follow up in a separate ticket.

### Why are the changes needed?

SPARK-33404 (Nov 2020) fixed a correctness bug - `date_trunc('minute', '1769-10-17 17:10:02')` in `America/Los_Angeles` returned the original timestamp because the existing fast path ignored the time-zone offset and the LMT offset has second granularity. The fix routed MINUTE/HOUR/DAY through `microsToInstant().atZone(zoneId).truncatedTo(unit)`, which allocates `ZonedDateTime` per row.

The author of that fix flagged the regression on the follow-up benchmark PR:

> "Slow down is around 5.5 times" - MaxGekk, apache/spark#30338

That regression has stood for ~5.5 years with no follow-up ticket. This PR restores most of the lost throughput without re-introducing the LMT bug, by applying the offset before/after the floorMod and verifying the offset is unchanged at the truncated candidate (handling DST transitions that motivated SPARK-30766 / SPARK-30857).

`DateTimeBenchmark` Truncation results, wholestage on, ns/row on a 12th Gen Intel i7-1260P:

| level   | baseline | this PR | speedup |
|---------|---------:|--------:|--------:|
| MINUTE  |   136.0  |  69.5   |  1.96×  |
| HOUR    |   136.2  |  69.8   |  1.95×  |
| DAY     |   136.5  |  69.8   |  1.96×  |
| DD      |   136.7  |  70.1   |  1.95×  |

Other levels are unchanged (within noise).

### Does this PR introduce _any_ user-facing change?

No. The output of `date_trunc` for `MINUTE`/`HOUR`/`DAY` is identical to master in all cases; only the internal implementation changes.

### How was this patch tested?

- `DateTimeUtilsSuite` - all 63 tests pass, including:
  - `SPARK-33404: test truncTimestamp when time zone offset from UTC has a granularity of seconds`, which loops MINUTE/SECOND/MILLI/MICRO truncation across **every** available zone (covers historical LMT zones).
  - The existing `truncTimestamp` test, which loops HOUR/DAY/MINUTE/etc. across every available zone.
  - Five new tests added in this PR:
    - `truncTimestamp with sub-hour zone offsets` - Asia/Kolkata `+05:30` and Asia/Kathmandu `+05:45` HOUR/DAY truncation.
    - `truncTimestamp across DST transitions` - America/Los_Angeles spring-forward (2024-03-10) and fall-back (2024-11-03) for HOUR/DAY, exercising the offset-equality fallback.
    - `SPARK-30766/30857: truncTimestamp before the epoch in HOUR/DAY` - pre-1970 instant in America/Los_Angeles for HOUR and DAY.
    - `truncTimestamp at America/Sao_Paulo midnight DST gap` - 2018-11-04 (the last Brazilian DST start, jumping from -3 to -2 at exactly midnight local), exercising the case where the local day boundary itself falls in a gap and DAY truncation must resolve forward.
    - `truncTimestamp at Pacific/Apia after the 2011 calendar shift` - mid-2012 instant in a +13:00 zone whose history skipped a calendar date, verifying the fast path under a non-DST historical offset change.
- `DateExpressionsSuite` - all 68 tests pass.
- `DateTimeBenchmark` re-run locally with the numbers shown above. Per the contributor guide, the official `benchmarks/DateTimeBenchmark-results.txt` should be regenerated on the standard CI runner - happy to do that via the GitHub Actions benchmark workflow on request.

### Was this patch authored or co-authored using generative AI tooling?

Yes, co-authored by Claude Code.