### PR TITLE
[WIP][SPARK-56661] Introducing logical and physical planning nodes for language-agnostic Spark UDFs

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,6 +36,16 @@
   
   <dependencies>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-udf-worker-proto_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-udf-worker-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.scala-lang.modules</groupId>
       <artifactId>scala-parallel-collections_${scala.binary.version}</artifactId>
     </dependency>

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -47,8 +47,13 @@ import org.apache.spark.security.CryptoStreamUtils
 import org.apache.spark.serializer.{JavaSerializer, Serializer, SerializerManager}
 import org.apache.spark.shuffle.ShuffleManager
 import org.apache.spark.storage._
+import org.apache.spark.udf.worker.UDFWorkerSpecification
+import org.apache.spark.udf.worker.core.{UDFWorkerManager, WorkerSecurityScope,
+  WorkerSession}
+import org.apache.spark.udf.worker.core.direct.DirectUDFWorkerManager
 import org.apache.spark.util.{RpcUtils, Utils}
 import org.apache.spark.util.ArrayImplicits._
+import org.apache.spark.util.SparkUDFWorkerLogger
 
 /**
  * :: DeveloperApi ::
@@ -120,6 +125,31 @@ class SparkEnv (
       pythonExec: String, workerModule: String, daemonModule: String, envVars: Map[String, String])
   private val pythonWorkers = mutable.HashMap[PythonWorkersKey, PythonWorkerFactory]()
 
+  /**
+   * :: Experimental ::
+   * Session factory to generate UDF worker sessions
+   * using the new UDF framework proposed in SPARK-55278
+   */
+  private val udfWorkerManager: UDFWorkerManager = createUDFWorkerManager()
+
+  private def createUDFWorkerManager(): UDFWorkerManager = {
+    // TODO [SPARK-55278]: Select the right manager here.
+    new DirectUDFWorkerManager(new SparkUDFWorkerLogger())
+  }
+
+  /**
+   * :: Experimental ::
+   * Creates a [[WorkerSession]] for the given worker specification
+   * and optional security scope using the registered
+   * [[UDFWorkerManager]].
+   */
+  private[spark] def createExternalUDFSession(
+      workerSpec: UDFWorkerSpecification,
+      securityScope: Option[WorkerSecurityScope] = None
+  ): WorkerSession = {
+    udfWorkerManager.createSession(workerSpec, securityScope)
+  }
+
   // A general, soft-reference map for metadata needed during HadoopRDD split computation
   // (e.g., HadoopFileRDD uses this to cache JobConfs and InputFormats).
   private[spark] val hadoopJobMetadata =
@@ -134,6 +164,7 @@ class SparkEnv (
     if (!isStopped) {
       isStopped = true
       pythonWorkers.values.foreach(_.stop())
+      udfWorkerManager.stop()
       mapOutputTracker.stop()
       if (shuffleManager != null) {
         shuffleManager.stop()

--- a/core/src/main/scala/org/apache/spark/util/SparkUDFWorkerLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/SparkUDFWorkerLogger.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.util
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.udf.worker.core.WorkerLogger
+
+/**
+ * Adapts the UDF worker framework's [[WorkerLogger]] to Spark's
+ * [[Logging]] trait so that worker log messages go through the
+ * standard Spark logging pipeline.
+ */
+private[spark] class SparkUDFWorkerLogger
+    extends WorkerLogger with Logging {
+
+  override def info(msg: => String): Unit = {
+    logInfo(msg)
+  }
+  override def info(msg: => String, t: Throwable): Unit =
+    logInfo(msg, t)
+  override def warn(msg: => String): Unit = logWarning(msg)
+  override def warn(msg: => String, t: Throwable): Unit =
+    logWarning(msg, t)
+  override def debug(msg: => String): Unit = logDebug(msg)
+  override def debug(msg: => String, t: Throwable): Unit =
+    logDebug(msg, t)
+}

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -62,6 +62,16 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-tags_${scala.binary.version}</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-udf-worker-proto_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-udf-worker-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!--
       This spark-tags test-dep is needed even though it isn't used in this module, otherwise testing-cmds that exclude

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExternalUserDefinedFunction.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExternalUserDefinedFunction.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.sql.catalyst.trees.TreePattern.{EXTERNAL_UDF, TreePattern}
+import org.apache.spark.sql.types.DataType
+
+/**
+ * :: Experimental ::
+ * A serialized external UDF that is executed in an external worker process
+ * via the language-agnostic UDF worker framework.
+ *
+ * This is a Catalyst expression analogous to [[PythonUDF]] but
+ * language-agnostic. The [[payload]] carries an opaque serialized
+ * function definition whose interpretation is left to the worker.
+ * The optional [[inputTypes]] declare the expected argument types for
+ * validation during analysis; when absent, any input types are accepted.
+ *
+ * This expression is [[Unevaluable]] and requires a dedicated physical
+ * operator (e.g. [[org.apache.spark.sql.execution.externalUDF.MapPartitionExternalUDFExec]])
+ * to execute.
+ *
+ * @param name             Name of the UDF.
+ * @param payload          Opaque serialized function definition.
+ * @param dataType         Return type of the UDF.
+ * @param children         Input argument expressions.
+ * @param inputTypes       Optional declared input types for validation.
+ * @param udfDeterministic Whether this UDF is deterministic.
+ * @param udfNullable      Whether this UDF can return null.
+ * @param resultId         Unique expression ID for this invocation.
+ */
+@Experimental
+case class ExternalUserDefinedFunction(
+    name: String,
+    payload: Array[Byte],
+    dataType: DataType,
+    children: Seq[Expression],
+    inputTypes: Option[Seq[DataType]] = None,
+    udfDeterministic: Boolean,
+    udfNullable: Boolean,
+    resultId: ExprId = NamedExpression.newExprId)
+  extends Expression with NonSQLExpression with UserDefinedExpression with Unevaluable {
+
+  override lazy val deterministic: Boolean = udfDeterministic && children.forall(_.deterministic)
+
+  override def nullable: Boolean = udfNullable
+
+  override lazy val canonicalized: Expression = {
+    val canonicalizedChildren = children.map(_.canonicalized)
+    // `resultId` can be seen as cosmetic variation in ExternalUserDefinedFunction,
+    // as it doesn't affect the result.
+    this.copy(resultId = ExprId(-1)).withNewChildren(canonicalizedChildren)
+  }
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(EXTERNAL_UDF)
+
+  override protected def withNewChildrenInternal(
+      newChildren: IndexedSeq[Expression]): ExternalUserDefinedFunction =
+    copy(children = newChildren)
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/externalUDF/ExternalUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/externalUDF/ExternalUDF.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical.externalUDF
+
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet}
+import org.apache.spark.sql.catalyst.plans.logical.UnaryNode
+import org.apache.spark.udf.worker.UDFWorkerSpecification
+
+/**
+ * :: Experimental ::
+ * Base trait for logical plan nodes representing UDFs that are executed
+ * in an external worker process. This covers Python UDFs, and any future
+ * UDF languages that use the language-agnostic UDF worker framework.
+ */
+@Experimental
+trait ExternalUDF extends UnaryNode {
+
+  /** Specification describing how to create and communicate with the UDF worker. */
+  def workerSpec: UDFWorkerSpecification
+
+  /** Output attributes produced by this UDF node. */
+  def resultAttributes: Seq[Attribute]
+
+  override def output: Seq[Attribute] = resultAttributes
+
+  override val producedAttributes: AttributeSet = AttributeSet(resultAttributes)
+
+  // The UDF may reference any column from the child output.
+  // Explicitly include child.outputSet so the optimizer does not
+  // prune input columns that the external worker needs.
+  override lazy val references: AttributeSet = child.outputSet
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/externalUDF/MapPartitionsExternalUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/externalUDF/MapPartitionsExternalUDF.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical.externalUDF
+
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.sql.catalyst.expressions.{Attribute,
+  ExternalUserDefinedFunction}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.udf.worker.UDFWorkerSpecification
+
+/**
+ * :: Experimental ::
+ * Logical plan node for mapPartitions-style UDF execution in an
+ * external worker process.
+ *
+ * @param workerSpec       Specification describing the UDF worker.
+ * @param functionExpr     The UDF to invoke.
+ * @param resultAttributes Output attributes produced by the UDF.
+ * @param child            Input relation whose partitions are processed.
+ */
+@Experimental
+case class MapPartitionsExternalUDF(
+    workerSpec: UDFWorkerSpecification,
+    function: ExternalUserDefinedFunction,
+    resultAttributes: Seq[Attribute],
+    child: LogicalPlan)
+  extends ExternalUDF {
+
+  override protected def withNewChildInternal(
+      newChild: LogicalPlan): MapPartitionsExternalUDF =
+    copy(child = newChild)
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -48,6 +48,7 @@ object TreePattern extends Enumeration  {
   val DYNAMIC_PRUNING_SUBQUERY: Value = Value
   val EXISTS_SUBQUERY = Value
   val EXPRESSION_WITH_RANDOM_SEED: Value = Value
+  val EXTERNAL_UDF: Value = Value
   val EXTRACT_VALUE: Value = Value
   val FUNCTION_TABLE_RELATION_ARGUMENT_EXPRESSION: Value = Value
   val GENERATOR: Value = Value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4613,6 +4613,17 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val UNIFIED_UDF_EXECUTION_ENABLED =
+    buildConf("spark.sql.execution.udf.unified.execution.enabled")
+      .doc("When true, UDFs that support the language-agnostic " +
+        "UDF worker protocol are executed via the unified, " +
+        "external UDF worker framework instead of the " +
+        "language-specific runners. Experimental.")
+      .version("4.2.0")
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .booleanConf
+      .createWithDefault(false)
+
   val PYTHON_UDF_ARROW_ENABLED =
     buildConf("spark.sql.execution.pythonUDF.arrow.enabled")
       .doc("Enable Arrow optimization in regular Python UDFs. This optimization " +

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -302,6 +302,16 @@
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-compression</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-udf-worker-proto_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-udf-worker-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala
@@ -48,6 +48,7 @@ import org.apache.spark.sql.catalyst.json.{JacksonGenerator, JSONOptions}
 import org.apache.spark.sql.catalyst.parser.{ParseException, ParserUtils}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.plans.logical.externalUDF.MapPartitionsExternalUDF
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, TreeNodeTag, TreePattern}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, IntervalUtils}
@@ -61,6 +62,7 @@ import org.apache.spark.sql.execution.arrow.{ArrowBatchStreamWriter, ArrowConver
 import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.execution.datasources.LogicalRelationWithTable
 import org.apache.spark.sql.execution.datasources.v2.{ExtractV2ScanInfo, ExtractV2Table, FileTable}
+import org.apache.spark.sql.execution.externalUDF.PythonUDFWorkerSpecification
 import org.apache.spark.sql.execution.python.EvaluatePython
 import org.apache.spark.sql.execution.stat.StatFunctions
 import org.apache.spark.sql.internal.SQLConf
@@ -1461,14 +1463,36 @@ class Dataset[T] private[sql](
       isBarrier: Boolean = false,
       profile: ResourceProfile = null): DataFrame = {
     val func = funcCol.expr
-    Dataset.ofRows(
-      sparkSession,
+    val output = toAttributes(func.dataType.asInstanceOf[StructType])
+
+    if (SQLConf.get.getConf(SQLConf.UNIFIED_UDF_EXECUTION_ENABLED)) {
+      // If enabled, use the new, unified UDF execution path
+      val pythonUdf = func.asInstanceOf[PythonUDF]
+      val workerSpec =
+        PythonUDFWorkerSpecification.fromPythonFunction(
+          pythonUdf.func,
+          sparkSession.sparkContext.conf)
+      val udf = ExternalUserDefinedFunction(
+        name = pythonUdf.name,
+        payload = pythonUdf.func.command.toArray,
+        dataType = pythonUdf.dataType,
+        children = Seq.empty,
+        udfDeterministic = pythonUdf.udfDeterministic,
+        udfNullable = true)
+      Dataset.ofRows(
+        sparkSession,
+        MapPartitionsExternalUDF(
+          workerSpec, udf, output, logicalPlan))
+    } else {
+      Dataset.ofRows(
+        sparkSession,
       MapInPandas(
         func,
-        toAttributes(func.dataType.asInstanceOf[StructType]),
+        output,
         logicalPlan,
         isBarrier,
         Option(profile)))
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -971,6 +971,11 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         execution.python.MapInPandasExec(func, output, planLater(child), isBarrier, profile) :: Nil
       case logical.MapInArrow(func, output, child, isBarrier, profile) =>
         execution.python.MapInArrowExec(func, output, planLater(child), isBarrier, profile) :: Nil
+      case logical.externalUDF.MapPartitionsExternalUDF(
+          workerSpec, functionExpr, resultAttrs, child) =>
+        execution.externalUDF.MapPartitionExternalUDFExec(
+          workerSpec, functionExpr,
+          resultAttrs, planLater(child)) :: Nil
       case logical.AttachDistributedSequence(attr, child, cache) =>
         execution.python.AttachDistributedSequenceExec(attr, planLater(child), cache) :: Nil
       case logical.PythonWorkerLogs(jsonAttr) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExternalUDFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExternalUDFExec.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.externalUDF
+
+import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet}
+import org.apache.spark.sql.execution.UnaryExecNode
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.udf.worker.UDFWorkerSpecification
+import org.apache.spark.udf.worker.core.{WorkerSecurityScope, WorkerSession}
+
+/**
+ * :: Experimental ::
+ * Base trait for physical plan nodes that execute UDFs in an external
+ * worker process via the language-agnostic UDF worker framework.
+ *
+ * Sessions are created via [[SparkEnv#createExternalUDFSession]],
+ * which uses the [[UDFWorkerManager]] registered on the
+ * environment. This avoids serializing the factory as part of the
+ * physical plan.
+ */
+@Experimental
+trait ExternalUDFExec extends UnaryExecNode {
+
+  /** Specification describing how to create and communicate with the UDF worker. */
+  def workerSpec: UDFWorkerSpecification
+
+  /** Output attributes produced by this UDF execution. */
+  def resultAttributes: Seq[Attribute]
+
+  override def output: Seq[Attribute] = resultAttributes
+
+  override def producedAttributes: AttributeSet =
+    AttributeSet(resultAttributes)
+
+  // ---------------------------------------------------------------------------
+  // Metrics
+  // ---------------------------------------------------------------------------
+
+  protected def externalUdfMetrics: Map[String, SQLMetric] = Map(
+    // TODO [SPARK-55278]: Emit the correct metrics here
+  )
+
+  override lazy val metrics: Map[String, SQLMetric] = externalUdfMetrics
+
+  // ---------------------------------------------------------------------------
+  // Session lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Creates a [[WorkerSession]] via [[SparkEnv#createExternalUDFSession]]
+   * and registers cancellation on task failure. The provided function
+   * receives the session and must return the result iterator. Moreover,
+   * the function MUST close the session once all input data has been sent.
+   */
+  protected def withUDFWorkerSession(
+      taskContext: TaskContext,
+      securityScope: Option[WorkerSecurityScope] = None)(
+      f: WorkerSession => Iterator[InternalRow]
+  ): Iterator[InternalRow] = {
+    val session = SparkEnv.get.createExternalUDFSession(
+      workerSpec, securityScope)
+
+    logInfo(s"Task ${taskContext.taskAttemptId()} bound to" +
+      s" UDF worker session ${session.sessionId}")
+
+    // Make sure to cancel the session, if the task fails
+    taskContext.addTaskFailureListener { (_, _) =>
+      session.cancel()
+    }
+
+    f(session)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/MapPartitionExternalUDFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/MapPartitionExternalUDFExec.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.externalUDF
+
+import org.apache.spark.TaskContext
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute,
+  ExternalUserDefinedFunction}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.udf.worker.UDFWorkerSpecification
+import org.apache.spark.udf.worker.core.InitMessage
+
+/**
+ * :: Experimental ::
+ * Physical plan node that executes a mapPartitions-style UDF in an
+ * external worker process.
+ *
+ * @param workerSpec       Specification describing the UDF worker.
+ * @param functionExpr     The UDF to invoke.
+ * @param resultAttributes Output attributes produced by the UDF.
+ * @param child            Child plan providing input partitions.
+ */
+@Experimental
+case class MapPartitionExternalUDFExec(
+    workerSpec: UDFWorkerSpecification,
+    functionExpr: ExternalUserDefinedFunction,
+    resultAttributes: Seq[Attribute],
+    child: SparkPlan)
+  extends ExternalUDFExec {
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    child.execute().mapPartitionsInternal { rows =>
+      val taskContext = TaskContext.get()
+      withUDFWorkerSession(taskContext, securityScope = None) {
+        session =>
+          session.init(InitMessage(
+            functionPayload = functionExpr.payload,
+            inputSchema = Array.empty,
+            outputSchema = Array.empty))
+          session.close()
+          // TODO [SPARK-55278]: Stream rows to/from the worker
+          // via session.process().
+          rows
+      }
+    }
+  }
+
+  override protected def withNewChildInternal(
+      newChild: SparkPlan): MapPartitionExternalUDFExec =
+    copy(child = newChild)
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/PythonUDFWorkerSpecification.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/PythonUDFWorkerSpecification.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.externalUDF
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.SparkConf
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.api.python.{PythonFunction, PythonUtils}
+import org.apache.spark.internal.config.Python.PYTHON_WORKER_MODULE
+import org.apache.spark.udf.worker._
+
+/**
+ * :: Experimental ::
+ * Builds a [[UDFWorkerSpecification]] for Python UDFs from a
+ * [[PythonFunction]] and [[SparkConf]].
+ *
+ * Reuses the same information the existing
+ * [[org.apache.spark.api.python.PythonWorkerFactory]] uses:
+ *  - `pythonExec` from the function
+ *  - Environment variables from the function (which already
+ *    contain the caller-assembled `PYTHONPATH`), merged with
+ *    Spark's built-in Python path and the system `PYTHONPATH`
+ *  - Worker module from `spark.python.worker.module`
+ *
+ * Note: `pythonIncludes` are not added to the process
+ * environment. They are sent over the data channel to the
+ * already-running worker by the runner (see
+ * [[org.apache.spark.api.python.PythonRunner]]).
+ */
+@Experimental
+object PythonUDFWorkerSpecification {
+
+  /**
+   * Creates a [[UDFWorkerSpecification]] from a [[PythonFunction]].
+   *
+   * @param func the Python function containing pythonExec, env vars,
+   *             and includes
+   * @param conf the SparkConf for reading the worker module config
+   * @return a fully populated [[UDFWorkerSpecification]]
+   */
+  def fromPythonFunction(
+      func: PythonFunction,
+      conf: SparkConf): UDFWorkerSpecification = {
+
+    val workerModule = conf.get(PYTHON_WORKER_MODULE)
+      .getOrElse("pyspark.worker")
+
+    // Assemble PYTHONPATH the same way PythonWorkerFactory does
+    val pythonPath = PythonUtils.mergePythonPaths(
+      PythonUtils.sparkPythonPath,
+      func.envVars.asScala
+        .getOrElse("PYTHONPATH", ""),
+      sys.env.getOrElse("PYTHONPATH", ""))
+
+    // Merge func.envVars with the assembled PYTHONPATH
+    val envVars = new java.util.HashMap[String, String]()
+    envVars.putAll(func.envVars)
+    envVars.put("PYTHONPATH", pythonPath)
+    // Match PythonWorkerFactory behavior
+    envVars.put("PYTHONUNBUFFERED", "YES")
+    // Enable the execution mode supporting the new UDF execution
+    // framework.
+    // TODO [SPARK-55278]: Enable this on the python code
+    envVars.put("PYTHON_WORKER_UNIFIED_EXECUTION_ENABLED", "YES")
+
+    // Build the ProcessCallable:
+    //   command = [pythonExec, "-m", workerModule]
+    val callable = ProcessCallable.newBuilder()
+    callable.addCommand(func.pythonExec)
+    callable.addCommand("-m")
+    callable.addCommand(workerModule)
+    // TODO [SPARK-55278]: Add additional, python specific env vars
+    // or transform them into init-message fields
+    envVars.forEach((k, v) => callable.putEnvironmentVariables(k, v))
+
+    // Capabilities: ARROW data format, bidirectional streaming
+    val caps = WorkerCapabilities.newBuilder()
+      .addSupportedDataFormats(UDFWorkerDataFormat.ARROW)
+      .addSupportedCommunicationPatterns(
+        UDFProtoCommunicationPattern.BIDIRECTIONAL_STREAMING)
+
+    // Connection: Unix domain socket
+    val conn = WorkerConnectionSpec.newBuilder()
+      .setUnixDomainSocket(UnixDomainSocket.newBuilder())
+
+    val props = UDFWorkerProperties.newBuilder()
+      .setConnection(conn)
+
+    val direct = DirectWorker.newBuilder()
+      .setRunner(callable)
+      .setProperties(props)
+
+    UDFWorkerSpecification.newBuilder()
+      .setEnvironment(WorkerEnvironment.newBuilder())
+      .setCapabilities(caps)
+      .setDirect(direct)
+      .build()
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/ExternalUDFPlanningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/externalUDF/ExternalUDFPlanningSuite.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.externalUDF
+
+import scala.collection.mutable.ArrayBuffer
+import scala.jdk.CollectionConverters._
+import scala.reflect.ClassTag
+
+import org.apache.spark.api.python.{PythonEvalType, SimplePythonFunction}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, MapInPandas}
+import org.apache.spark.sql.catalyst.plans.logical.externalUDF.MapPartitionsExternalUDF
+import org.apache.spark.sql.execution.{SparkPlan}
+import org.apache.spark.sql.execution.python.{MapInPandasExec,
+  UserDefinedPythonFunction}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{IntegerType, StringType,
+  StructField, StructType}
+
+/**
+ * Tests that the unified UDF execution config gates the correct
+ * logical and physical plan nodes for mapInPandas.
+ */
+class ExternalUDFPlanningSuite extends SharedSparkSession {
+  import testImplicits._
+
+  private val outputSchema = StructType(Seq(
+    StructField("a", StringType),
+    StructField("b", IntegerType)))
+
+  private def dummyPythonFunction: SimplePythonFunction =
+    new SimplePythonFunction(
+      command = Array.emptyByteArray,
+      envVars = Map.empty[String, String].asJava,
+      pythonIncludes = ArrayBuffer.empty[String].asJava,
+      pythonExec = "python3",
+      pythonVer = "3.12",
+      broadcastVars = null,
+      accumulator = null)
+
+  private val mapInPandasUDF = UserDefinedPythonFunction(
+    name = "dummyMapInPandas",
+    func = dummyPythonFunction,
+    dataType = outputSchema,
+    pythonEvalType = PythonEvalType.SQL_MAP_PANDAS_ITER_UDF,
+    udfDeterministic = true)
+
+  private def applyMapInPandas(): org.apache.spark.sql.DataFrame = {
+    val inputDF = Seq(("hello", 1)).toDF("a", "b")
+    val udfColumn = mapInPandasUDF(
+      inputDF.columns.toIndexedSeq.map(inputDF.col): _*)
+    inputDF.mapInPandas(udfColumn)
+  }
+
+  /**
+   * Asserts that the logical plan contains a node of the expected
+   * type when the unified UDF execution config is set as specified.
+   */
+  private def assertLogicalNode[T <: LogicalPlan: ClassTag](
+      enabled: Boolean): Unit = {
+    val configValue = enabled.toString
+    withSQLConf(
+        SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key -> configValue) {
+      val result = applyMapInPandas()
+      val tag = implicitly[ClassTag[T]]
+      val node = result.queryExecution.analyzed.collectFirst {
+        case n if tag.runtimeClass.isInstance(n) => n
+      }
+      assert(node.isDefined,
+        s"Expected ${tag.runtimeClass.getSimpleName} in" +
+          " logical plan")
+    }
+  }
+
+  /**
+   * Asserts that the physical plan contains a node of the expected
+   * type when the unified UDF execution config is set as specified.
+   */
+  private def assertPhysicalNode[T <: SparkPlan: ClassTag](
+      enabled: Boolean): Unit = {
+    val configValue = enabled.toString
+    withSQLConf(
+        SQLConf.UNIFIED_UDF_EXECUTION_ENABLED.key -> configValue) {
+      val result = applyMapInPandas()
+      val tag = implicitly[ClassTag[T]]
+      val node = result.queryExecution.executedPlan.collectFirst {
+        case n if tag.runtimeClass.isInstance(n) => n
+      }
+      assert(node.isDefined,
+        s"Expected ${tag.runtimeClass.getSimpleName} in" +
+          " physical plan")
+    }
+  }
+
+  // -- Logical plan tests ---------------------------------------------------
+
+  test("mapInPandas uses MapInPandas logical node" +
+      " when config disabled") {
+    assertLogicalNode[MapInPandas](enabled = false)
+  }
+
+  test("mapInPandas uses MapPartitionsExternalUDF logical node" +
+      " when config enabled") {
+    assertLogicalNode[MapPartitionsExternalUDF](enabled = true)
+  }
+
+  // -- Physical plan tests --------------------------------------------------
+
+  test("mapInPandas uses MapInPandasExec physical node" +
+      " when config disabled") {
+    assertPhysicalNode[MapInPandasExec](enabled = false)
+  }
+
+  test("mapInPandas uses MapPartitionExternalUDFExec physical" +
+      " node when config enabled") {
+    assertPhysicalNode[MapPartitionExternalUDFExec](
+      enabled = true)
+  }
+}

--- a/udf/worker/core/pom.xml
+++ b/udf/worker/core/pom.xml
@@ -51,6 +51,11 @@
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/UDFWorkerManager.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/UDFWorkerManager.scala
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.udf.worker.core
+
+import java.util.{ArrayList, HashMap}
+
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.udf.worker.UDFWorkerSpecification
+
+/**
+ * :: Experimental :: Creates [[WorkerSession]] instances for a given
+ * [[UDFWorkerSpecification]], managing [[WorkerDispatcher]] instances and
+ * their lifecycle internally.
+ *
+ * Dispatchers are cached by spec (protobuf value equality) and reused across
+ * sessions. The manager tracks the number of active sessions per dispatcher
+ * via [[WorkerSession#addSessionCompletionListener]]. When the last session
+ * for a dispatcher is closed, the entry is removed and
+ * [[onAllDispatcherSessionsClosed]] is called.
+ *
+ * You might be wondering why the Dispatcher does not track the number of
+ * active sessions itself. The reason is that this would create a
+ * unavoidable race condition: Clients can provide different worker
+ * specs. Therefore, different dispatchers may be required, which cannot all
+ * exist for the whole Spark lifetime -> Dispatchers need to be removed/terminated
+ * at some point. If Dispatchers were to track their active sessions themselves
+ * and we would use this to decide on the dispatcher lifetime, it can always
+ * happen that there are concurrent [[createSession]] requests while
+ * the Dispatcher is being disposed off - which would create session
+ * initialization errors and may cause Spark task/query failures.
+ * Instead, we track the active sessions per Dispatcher globally
+ * in this manager.
+ *
+ * Thread safety: a single lock guards all state -- dispatchers, active
+ * sessions, and the stopping flag.
+ *
+ * Subclasses must implement [[doCreateDispatcher]] to provide a concrete
+ * dispatcher and [[onAllDispatcherSessionsClosed]] to control dispatcher
+ * teardown policy. Keeping a dispatcher alive after
+ * [[onAllDispatcherSessionsClosed]] should be a conscious decision
+ * and requires additional clean-up logic in the subclasses implemented
+ * via [[doStop]].
+ */
+@Experimental
+abstract class UDFWorkerManager(
+    workerLogger: WorkerLogger = WorkerLogger.NoOp
+) {
+
+  protected val logger: WorkerLogger =
+    workerLogger.forClass(getClass)
+
+  /*
+   * Why do we need an [[activeSessionCount]] and an [[activeSessions]]
+   * list? [[activeSessionCount]] is per dispatcher. [[activeSessions]]
+   * is globally and allows us to perform session cleanup on [[stop]].
+   * Moreover, this distinction allows us to create sessions without
+   * requiring a lock on [[lock]].
+   */
+  private class DispatcherEntry(val dispatcher: WorkerDispatcher) {
+    var activeSessionCount: Int = 0
+  }
+
+  // All fields below are guarded by `lock`.
+  private val lock = new Object
+  private val dispatchers =
+    new HashMap[UDFWorkerSpecification, DispatcherEntry]()
+  private val activeSessions = new ArrayList[WorkerSession]()
+  private var stopped = false
+
+  /**
+   * Creates a [[WorkerSession]] for the given worker specification and
+   * optional security scope.
+   *
+   * If a dispatcher for this spec already exists it is reused; otherwise
+   * [[doCreateDispatcher]] is called to create one. A completion listener
+   * is registered on the session to track when it closes.
+   */
+  final def createSession(
+      workerSpec: UDFWorkerSpecification,
+      securityScope: Option[WorkerSecurityScope] = None
+  ): WorkerSession = {
+    // Get the dispatcher
+    val entry = lock.synchronized {
+      if (stopped) {
+        throwStopped()
+      }
+      getOrCreateDispatcherEntry(workerSpec)
+    }
+
+    // Create a new session (potentially slow -> outside the lock).
+    // Note: This might fail if Spark is concurrently being stopped
+    // and the dispatcher is cleaned up. As Spark is stopping,
+    // this failure is acceptable. On the happy path, no sessions
+    // should try to be created while Spark is shutting down.
+    val session = entry.dispatcher.createSession(securityScope)
+    lock.synchronized {
+      if (stopped) {
+        session.close()
+        throwStopped()
+      }
+      activeSessions.add(session)
+    }
+
+    logger.info(s"Created session ${session.sessionId}" +
+      s" on dispatcher ${entry.dispatcher.dispatcherId}" +
+      s" (active: ${entry.activeSessionCount})")
+
+    // Register a completion listener that updates the
+    // state when the session is canceled or closed
+    session.addSessionCompletionListener { session =>
+      logger.info(s"Session ${session.sessionId} terminated")
+      lock.synchronized {
+        if (!stopped) {
+          activeSessions.remove(session)
+          handleSessionTermination(workerSpec)
+        }
+      }
+    }
+
+    session
+  }
+
+  /**
+   * Called on driver/executor shutdown. Cancels any active sessions,
+   * closes all cached dispatchers, and resets internal state.
+   *
+   * Safety net -- in normal operation, sessions are closed by task
+   * completion listeners and dispatchers are cleaned up via
+   * [[onAllDispatcherSessionsClosed]] when their last session closes.
+   */
+  final def stop(): Unit = {
+    logger.info("UDFWorkerManager stopping" +
+      s" (${activeSessions.size()} active sessions," +
+      s" ${dispatchers.size()} dispatchers)")
+
+    lock.synchronized {
+      stopped = true
+
+      // Cancel any sessions that are still active. Cancel is a
+      // no-op if the session was already closed/cancelled.
+      activeSessions.forEach { s =>
+        logger.debug(s"Cancelling session ${s.sessionId}" +
+          " during stop")
+        s.cancel()
+      }
+      activeSessions.clear()
+
+      // Close all dispatchers we control.
+      // When spark is stopped in a clean state
+      // (only finished tasks), it is expected
+      // that all dispatchers have been terminated
+      // already. This is a safety-net.
+      dispatchers.forEach { (_, entry) =>
+        logger.debug(s"Closing dispatcher" +
+          s" ${entry.dispatcher.dispatcherId} during stop")
+        entry.dispatcher.close()
+      }
+      dispatchers.clear()
+    }
+
+    // Perform cleanup in the sub classes
+    doStop()
+    logger.info("UDFWorkerManager stopped")
+  }
+
+  private def throwStopped(): Nothing =
+    throw new IllegalStateException(
+      "UDFWorkerManager is stopped")
+
+  // Must be called while holding `lock`.
+  private def handleSessionTermination(
+      workerSpec: UDFWorkerSpecification
+  ): Unit = {
+    val entry = dispatchers.get(workerSpec)
+    // Note: entry == null is unexpected and should
+    // throw here.
+    entry.activeSessionCount -= 1
+    if (entry.activeSessionCount == 0) {
+      logger.info("All sessions closed for dispatcher " +
+        s"${entry.dispatcher.dispatcherId}, removing from cache")
+      dispatchers.remove(workerSpec)
+      onAllDispatcherSessionsClosed(entry.dispatcher)
+    }
+  }
+
+  // Must be called while holding `lock`.
+  private def getOrCreateDispatcherEntry(
+      workerSpec: UDFWorkerSpecification
+  ): DispatcherEntry = {
+    var entry = dispatchers.get(workerSpec)
+    if (entry == null) {
+      val dispatcher = doCreateDispatcher(workerSpec, logger)
+      logger.info(s"Created dispatcher ${dispatcher.dispatcherId}")
+      entry = new DispatcherEntry(dispatcher)
+      dispatchers.put(workerSpec, entry)
+    }
+    entry.activeSessionCount += 1
+    entry
+  }
+
+  /**
+   * Creates a new [[WorkerDispatcher]] for the given specification.
+   * It is expected that creating the dispatcher
+   * itself is not slow while creating a session might be.
+   */
+  protected def doCreateDispatcher(
+      workerSpec: UDFWorkerSpecification,
+      logger: WorkerLogger
+  ): WorkerDispatcher
+
+  /**
+   * Called when the last active session for a dispatcher is closed.
+   * Subclasses must decide what to do with the now-idle dispatcher.
+   * Not called during [[stop]] -- the manager cleans up dispatchers
+   * it holds directly in that case. Cleanup of dispatchers not
+   * provided to the manager is the responsibility of the subclass
+   * via [[doStop]].
+   */
+  protected def onAllDispatcherSessionsClosed(
+      dispatcher: WorkerDispatcher
+  ): Unit
+
+  /**
+   * Called when the executor/driver stops. Subclasses should clean
+   * up any dispatchers/resources they hold beyond what the parent
+   * class manages.
+   */
+  protected def doStop(): Unit
+}

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/WorkerDispatcher.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/WorkerDispatcher.scala
@@ -31,6 +31,10 @@ import org.apache.spark.udf.worker.UDFWorkerSpecification
 @Experimental
 trait WorkerDispatcher extends AutoCloseable {
 
+  /** Unique identifier for this dispatcher. */
+  val dispatcherId: String =
+    java.util.UUID.randomUUID().toString
+
   def workerSpec: UDFWorkerSpecification
 
   /**

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/WorkerLogger.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/WorkerLogger.scala
@@ -36,8 +36,34 @@ import org.apache.spark.annotation.Experimental
 trait WorkerLogger {
   def warn(msg: => String): Unit
   def warn(msg: => String, t: Throwable): Unit
+  def info(msg: => String): Unit
+  def info(msg: => String, t: Throwable): Unit
   def debug(msg: => String): Unit
   def debug(msg: => String, t: Throwable): Unit
+
+  /**
+   * Returns a new [[WorkerLogger]] that prefixes every message with
+   * `[className]`. Useful for identifying which class produced a
+   * log line.
+   */
+  def forClass(clazz: Class[_]): WorkerLogger = {
+    val prefix = s"[${clazz.getSimpleName}] "
+    val parent = this
+    new WorkerLogger {
+      override def warn(msg: => String): Unit =
+        parent.warn(prefix + msg)
+      override def warn(msg: => String, t: Throwable): Unit =
+        parent.warn(prefix + msg, t)
+      override def info(msg: => String): Unit =
+        parent.info(prefix + msg)
+      override def info(msg: => String, t: Throwable): Unit =
+        parent.info(prefix + msg, t)
+      override def debug(msg: => String): Unit =
+        parent.debug(prefix + msg)
+      override def debug(msg: => String, t: Throwable): Unit =
+        parent.debug(prefix + msg, t)
+    }
+  }
 }
 
 object WorkerLogger {
@@ -45,6 +71,8 @@ object WorkerLogger {
   val NoOp: WorkerLogger = new WorkerLogger {
     override def warn(msg: => String): Unit = ()
     override def warn(msg: => String, t: Throwable): Unit = ()
+    override def info(msg: => String): Unit = ()
+    override def info(msg: => String, t: Throwable): Unit = ()
     override def debug(msg: => String): Unit = ()
     override def debug(msg: => String, t: Throwable): Unit = ()
   }

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/WorkerSession.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/WorkerSession.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.udf.worker.core
 
+import java.util.ArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 
 import org.apache.spark.annotation.Experimental
@@ -76,16 +77,66 @@ case class InitMessage(
  *  - [[close]] must always be called (use try-finally).
  *  - [[cancel]] may be called at any time to abort execution.
  *
- * The lifecycle is enforced here: [[init]] and [[process]] are `final`
- * and delegate to [[doInit]] / [[doProcess]] after AtomicBoolean guards.
+ * The lifecycle is enforced here: [[init]], [[process]], [[cancel]],
+ * and [[close]] are `final` and delegate to [[doInit]] / [[doProcess]] /
+ * [[doCancel]], and [[doClose]] after AtomicBoolean guards.
  * Subclasses implement the protocol-specific work and do not re-check
  * the contract.
+ *
+ * Completion listeners registered via [[addSessionCompletionListener]]
+ * are fired exactly once, after [[doClose]] or [[doCancel]]
+ * (whichever runs first). Note that the completion listener can
+ * be executed in a completely separate thread from the thread who
+ * registered the listener.
  */
 @Experimental
-abstract class WorkerSession extends AutoCloseable {
+abstract class WorkerSession(
+    workerLogger: WorkerLogger
+) extends AutoCloseable {
+
+  protected val logger: WorkerLogger =
+    workerLogger.forClass(getClass)
+
+  /** Unique identifier for this session. */
+  val sessionId: String = java.util.UUID.randomUUID().toString
 
   private val initialized = new AtomicBoolean(false)
   private val processed = new AtomicBoolean(false)
+  private val closed = new AtomicBoolean(false)
+
+  // Guards `completionListeners`, and `completionListenersFired`
+  // to ensure that a listener added after close is fired
+  // immediately and exactly once.
+  private val listenerLock = new Object
+  private var completionListenersFired = false
+  private val completionListeners =
+    new ArrayList[WorkerSession => Unit]()
+
+  /**
+   * Registers a closure to be invoked when this session completes
+   * (via [[close]] or [[cancel]]). Listeners fire exactly once, in
+   * registration order. If the session is already closed when
+   * registering, the listener is fired immediately.
+   */
+  final def addSessionCompletionListener(
+      f: WorkerSession => Unit): Unit = {
+    listenerLock.synchronized {
+      if (completionListenersFired) {
+        // Listeners from the list were already fired
+        // -> Invoke immediately.
+        f(this)
+      } else {
+        completionListeners.add(f)
+      }
+    }
+  }
+
+  private def fireCompletionListeners(): Unit = {
+    listenerLock.synchronized {
+      completionListenersFired = true
+      completionListeners.forEach(_(this))
+    }
+  }
 
   /**
    * Initializes the UDF execution. Must be called exactly once before
@@ -100,6 +151,7 @@ abstract class WorkerSession extends AutoCloseable {
     if (!initialized.compareAndSet(false, true)) {
       throw new IllegalStateException("init has already been called on this session")
     }
+    logger.info(s"Session $sessionId: init")
     doInit(message)
   }
 
@@ -117,21 +169,17 @@ abstract class WorkerSession extends AutoCloseable {
    * @param input iterator of raw input data batches (e.g., Arrow IPC)
    * @return iterator of raw result data batches
    */
-  final def process(input: Iterator[Array[Byte]]): Iterator[Array[Byte]] = {
+  final def process(
+      input: Iterator[Array[Byte]]): Iterator[Array[Byte]] = {
     if (!initialized.get()) {
       throw new IllegalStateException("process called before init")
     }
     if (!processed.compareAndSet(false, true)) {
       throw new IllegalStateException("process has already been called on this session")
     }
+    logger.info(s"Session $sessionId: process started")
     doProcess(input)
   }
-
-  /** Subclass hook for [[init]]. Called once, after the guard. */
-  protected def doInit(message: InitMessage): Unit
-
-  /** Subclass hook for [[process]]. Called at most once, after the guard. */
-  protected def doProcess(input: Iterator[Array[Byte]]): Iterator[Array[Byte]]
 
   /**
    * Requests cancellation of the current UDF execution.
@@ -141,8 +189,34 @@ abstract class WorkerSession extends AutoCloseable {
    * task interruption thread). It may be invoked at any point after
    * [[init]] and should be a no-op if execution has already finished.
    */
-  def cancel(): Unit
+  final def cancel(): Unit = {
+    // TODO [SPARK-55278]: Implement correct cancellation/finish semantics
+    //          according to the worker_spec.proto.
+    if (closed.compareAndSet(false, true)) {
+      logger.info(s"Session $sessionId: cancel")
+      doCancel()
+      fireCompletionListeners()
+    }
+  }
 
   /** Closes this session and releases resources. */
-  override def close(): Unit
+  override final def close(): Unit = {
+    if (closed.compareAndSet(false, true)) {
+      logger.info(s"Session $sessionId: close")
+      doClose()
+      fireCompletionListeners()
+    }
+  }
+
+  /** Subclass hook for [[init]]. Called once, after the guard. */
+  protected def doInit(message: InitMessage): Unit
+
+  /** Subclass hook for [[process]]. Called at most once, after the guard. */
+  protected def doProcess(input: Iterator[Array[Byte]]): Iterator[Array[Byte]]
+
+  /** Subclass hook for [[cancel]]. Called once, after the guard. */
+  protected def doCancel(): Unit
+
+  /** Subclass hook for [[close]]. Called at most once, after the guard. */
+  protected def doClose(): Unit
 }

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/DirectUDFWorkerManager.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/DirectUDFWorkerManager.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.udf.worker.core.direct
+
+import org.apache.spark.udf.worker.UDFWorkerSpecification
+import org.apache.spark.udf.worker.core.{UDFWorkerManager, WorkerDispatcher, WorkerLogger}
+
+class DirectUDFWorkerManager(
+    logger: WorkerLogger = WorkerLogger.NoOp
+) extends UDFWorkerManager(logger) {
+
+  protected def doCreateDispatcher(
+      workerSpec: UDFWorkerSpecification,
+      logger: WorkerLogger
+  ): WorkerDispatcher = {
+    // TODO [SPARK-55278]: Use actual Dispatcher implementation
+    // and correct caching semantics
+    return new SimpleDirectWorkerDispatcher(workerSpec, logger) {}
+  }
+
+  protected def onAllDispatcherSessionsClosed(
+      dispatcher: WorkerDispatcher
+  ): Unit = {
+    // No caching -> close directly
+    dispatcher.close()
+  }
+
+  protected def doStop(): Unit = {
+    // No dispatcher caching - no cleanup
+  }
+}

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/DirectUnixSocketWorkerDispatcher.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/DirectUnixSocketWorkerDispatcher.scala
@@ -37,7 +37,7 @@ import org.apache.spark.udf.worker.core.direct.DirectWorkerDispatcher.SOCKET_POL
 @Experimental
 abstract class DirectUnixSocketWorkerDispatcher(
     workerSpec: UDFWorkerSpecification,
-    logger: WorkerLogger = WorkerLogger.NoOp)
+    logger: WorkerLogger)
   extends DirectWorkerDispatcher(workerSpec, logger) {
 
   // Removed explicitly in closeTransport(). deleteOnExit is avoided because

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/DirectWorkerDispatcher.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/DirectWorkerDispatcher.scala
@@ -62,8 +62,11 @@ import org.apache.spark.udf.worker.core.direct.DirectWorkerDispatcher.{CallableR
 @Experimental
 abstract class DirectWorkerDispatcher(
     override val workerSpec: UDFWorkerSpecification,
-    protected val logger: WorkerLogger = WorkerLogger.NoOp)
+    workerLogger: WorkerLogger)
   extends WorkerDispatcher {
+
+  protected val logger: WorkerLogger =
+    workerLogger.forClass(getClass)
 
   // TODO: Connection pooling -- reuse idle workers across sessions.
   // TODO: Security scope isolation -- partition pool by WorkerSecurityScope.

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/DirectWorkerProcess.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/DirectWorkerProcess.scala
@@ -51,7 +51,7 @@ class DirectWorkerProcess(
     val id: String,
     private[direct] val artifacts: WorkerArtifacts,
     val gracefulTimeoutMs: Long,
-    protected val logger: WorkerLogger = WorkerLogger.NoOp,
+    protected val logger: WorkerLogger,
     private[direct] val onLastSessionReleased: DirectWorkerProcess => Unit = _ => ())
   extends AutoCloseable {
 

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/DirectWorkerSession.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/DirectWorkerSession.scala
@@ -19,7 +19,7 @@ package org.apache.spark.udf.worker.core.direct
 import java.util.concurrent.atomic.AtomicBoolean
 
 import org.apache.spark.annotation.Experimental
-import org.apache.spark.udf.worker.core.{WorkerConnection, WorkerSession}
+import org.apache.spark.udf.worker.core.{WorkerConnection, WorkerLogger, WorkerSession}
 
 /**
  * :: Experimental ::
@@ -41,14 +41,15 @@ import org.apache.spark.udf.worker.core.{WorkerConnection, WorkerSession}
  */
 @Experimental
 abstract class DirectWorkerSession(
-    private[core] val workerProcess: DirectWorkerProcess) extends WorkerSession {
-
+    private[core] val workerProcess: DirectWorkerProcess,
+    workerLogger: WorkerLogger)
+  extends WorkerSession(workerLogger) {
   private val released = new AtomicBoolean(false)
 
   /** The connection to the worker for this session. */
   def connection: WorkerConnection = workerProcess.connection
 
-  override def close(): Unit = {
+  override protected def doClose(): Unit = {
     if (released.compareAndSet(false, true)) {
       workerProcess.releaseSession()
     }

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/SimpleDirectUnixSocketWorkerDispatcher.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/SimpleDirectUnixSocketWorkerDispatcher.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.udf.worker.core.direct
+
+import java.net.{StandardProtocolFamily, UnixDomainSocketAddress}
+import java.nio.channels.SocketChannel
+
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.udf.worker.UDFWorkerSpecification
+import org.apache.spark.udf.worker.core.{
+  InitMessage,
+  UnixSocketWorkerConnection,
+  WorkerLogger,
+  WorkerSession
+}
+
+// All implementations in this file are temporary and will be removed
+// once the gRPC protocol lands with
+// https://github.com/apache/spark/pull/55657
+
+@Experimental
+private[direct] class SimpleWorkerConnection(
+    socketPath: String,
+    private val channel: SocketChannel
+) extends UnixSocketWorkerConnection(socketPath) {
+
+  override def isActive: Boolean = channel.isOpen
+
+  override def close(): Unit = {
+    channel.close()
+    super.close()
+  }
+}
+
+private[direct] object SimpleWorkerConnection {
+  def connect(
+      socketPath: String,
+      logger: WorkerLogger
+  ): SimpleWorkerConnection = {
+    val address = UnixDomainSocketAddress.of(socketPath)
+    val channel = SocketChannel.open(StandardProtocolFamily.UNIX)
+    channel.connect(address)
+    logger.info(s"Connected to worker via UDS at $socketPath")
+    new SimpleWorkerConnection(socketPath, channel)
+  }
+}
+
+@Experimental
+private[direct] class SimpleWorkerSession(
+    worker: DirectWorkerProcess,
+    private val workerLogger: WorkerLogger
+) extends DirectWorkerSession(worker, workerLogger) {
+
+  override protected[core] def doInit(message: InitMessage): Unit = {
+    val conn = connection
+      .asInstanceOf[SimpleWorkerConnection]
+    logger.info(
+      s"Session initialized on worker ${worker.id}, " +
+        s"connection active: ${conn.isActive}"
+    )
+  }
+
+  override protected[core] def doProcess(
+      input: Iterator[Array[Byte]]
+  ): Iterator[Array[Byte]] = {
+    input
+  }
+
+  override def doCancel(): Unit = {}
+
+  override def doClose(): Unit = {
+    worker.releaseSession()
+  }
+}
+
+@Experimental
+class SimpleDirectWorkerDispatcher(
+    workerSpec: UDFWorkerSpecification,
+    logger: WorkerLogger
+) extends DirectUnixSocketWorkerDispatcher(workerSpec, logger) {
+
+  override protected def createConnection(
+      socketPath: String
+  ): UnixSocketWorkerConnection =
+    SimpleWorkerConnection.connect(socketPath, logger)
+
+  override protected def createSessionForWorker(
+      worker: DirectWorkerProcess
+  ): WorkerSession =
+    new SimpleWorkerSession(worker, logger)
+}

--- a/udf/worker/core/src/test/scala/org/apache/spark/udf/worker/core/DirectWorkerDispatcherSuite.scala
+++ b/udf/worker/core/src/test/scala/org/apache/spark/udf/worker/core/DirectWorkerDispatcherSuite.scala
@@ -55,8 +55,9 @@ class SocketFileConnection(socketPath: String)
  *   no-op). Tracking the thread-safety contract in the docstring on
  *   [[org.apache.spark.udf.worker.core.WorkerSession.cancel]].
  */
-class StubWorkerSession(
-    workerProcess: DirectWorkerProcess) extends DirectWorkerSession(workerProcess) {
+private class StubWorkerSession(
+    workerProcess: DirectWorkerProcess)
+    extends DirectWorkerSession(workerProcess, WorkerLogger.NoOp) {
 
   override protected def doInit(message: InitMessage): Unit = {}
 
@@ -64,7 +65,9 @@ class StubWorkerSession(
       input: Iterator[Array[Byte]]): Iterator[Array[Byte]] =
     Iterator.empty
 
-  override def cancel(): Unit = {}
+  override protected def doCancel(): Unit = {}
+
+  override protected def doClose(): Unit = {}
 }
 
 /**
@@ -73,7 +76,7 @@ class StubWorkerSession(
  * implementation.
  */
 class TestDirectWorkerDispatcher(spec: UDFWorkerSpecification)
-    extends DirectUnixSocketWorkerDispatcher(spec) {
+    extends DirectUnixSocketWorkerDispatcher(spec, WorkerLogger.NoOp) {
 
   override protected def createConnection(
       socketPath: String): UnixSocketWorkerConnection =
@@ -362,7 +365,7 @@ class DirectWorkerDispatcherSuite
     val releaseLatch = new java.util.concurrent.CountDownLatch(1)
     val capturedWorkers =
       new java.util.concurrent.ConcurrentLinkedQueue[DirectWorkerProcess]()
-    val racing = new DirectUnixSocketWorkerDispatcher(specWithRunner(defaultRunner)) {
+    val racing = new DirectUnixSocketWorkerDispatcher(specWithRunner(defaultRunner), WorkerLogger.NoOp) {
       override protected def createConnection(
           socketPath: String): UnixSocketWorkerConnection =
         new SocketFileConnection(socketPath)
@@ -538,7 +541,7 @@ class DirectWorkerDispatcherSuite
     // worker must be terminated rather than leaked until dispatcher.close().
     var capturedWorker: DirectWorkerProcess = null
     val failingDispatcher =
-      new DirectUnixSocketWorkerDispatcher(specWithRunner(defaultRunner)) {
+      new DirectUnixSocketWorkerDispatcher(specWithRunner(defaultRunner), WorkerLogger.NoOp) {
         override protected def createConnection(
             socketPath: String): UnixSocketWorkerConnection =
           new SocketFileConnection(socketPath)
@@ -594,7 +597,7 @@ class DirectWorkerDispatcherSuite
   test("socket file is cleaned up when createConnection throws") {
     val capturedSocketPaths = new java.util.concurrent.ConcurrentLinkedQueue[String]()
     val failingDispatcher =
-      new DirectUnixSocketWorkerDispatcher(specWithRunner(defaultRunner)) {
+      new DirectUnixSocketWorkerDispatcher(specWithRunner(defaultRunner), WorkerLogger.NoOp) {
         override protected def createConnection(
             socketPath: String): UnixSocketWorkerConnection = {
           capturedSocketPaths.add(socketPath)
@@ -760,7 +763,7 @@ class DirectWorkerDispatcherSuite
       .addCommand("sleep 30").build()
     val env = WorkerEnvironment.newBuilder().setInstallation(slowInstall).build()
     val shortTimeoutDispatcher =
-      new DirectUnixSocketWorkerDispatcher(specWithEnv(env = env)) {
+      new DirectUnixSocketWorkerDispatcher(specWithEnv(env = env), WorkerLogger.NoOp) {
         override protected def callableTimeoutMs: Long = 500L
         override protected def createConnection(
             socketPath: String): UnixSocketWorkerConnection =
@@ -897,7 +900,7 @@ class DirectWorkerDispatcherSuite
           s"echo invoked >> ${counterFile.getAbsolutePath}; sleep 30").build())
       .build()
     val timeoutDispatcher =
-      new DirectUnixSocketWorkerDispatcher(specWithEnv(env = env)) {
+      new DirectUnixSocketWorkerDispatcher(specWithEnv(env = env), WorkerLogger.NoOp) {
         override protected def callableTimeoutMs: Long = 500L
         override protected def createConnection(
             socketPath: String): UnixSocketWorkerConnection =

--- a/udf/worker/core/src/test/scala/org/apache/spark/udf/worker/core/UDFWorkerManagerSuite.scala
+++ b/udf/worker/core/src/test/scala/org/apache/spark/udf/worker/core/UDFWorkerManagerSuite.scala
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.udf.worker.core
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{mock, verify, when}
+import org.mockito.invocation.InvocationOnMock
+// scalastyle:off funsuite
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.udf.worker._
+
+/**
+ * A minimal [[WorkerSession]] that tracks cancel/close calls.
+ */
+private class NoOpWorkerSession
+    extends WorkerSession(WorkerLogger.NoOp) {
+  var cancelled: Boolean = false
+  override protected def doInit(msg: InitMessage): Unit = {}
+  override protected def doProcess(
+      input: Iterator[Array[Byte]]): Iterator[Array[Byte]] =
+    Iterator.empty
+  override protected def doCancel(): Unit = { cancelled = true }
+  override protected def doClose(): Unit = {}
+}
+
+/**
+ * Holds a test [[UDFWorkerManager]] and all observable state,
+ * so tests can assert on whichever fields they care about.
+ */
+private case class TestManagerFixture(
+    manager: UDFWorkerManager,
+    createdDispatchers: ArrayBuffer[WorkerDispatcher],
+    closedDispatchers: ArrayBuffer[WorkerDispatcher],
+    doStopCalls: ArrayBuffer[Boolean],
+    createdSessions: ArrayBuffer[NoOpWorkerSession])
+
+private object TestManagerFixture {
+  def apply(): TestManagerFixture = {
+    val createdDispatchers = ArrayBuffer[WorkerDispatcher]()
+    val closedDispatchers = ArrayBuffer[WorkerDispatcher]()
+    val doStopCalls = ArrayBuffer[Boolean]()
+    val createdSessions = ArrayBuffer[NoOpWorkerSession]()
+
+    val manager = new UDFWorkerManager {
+      override protected def doCreateDispatcher(
+          workerSpec: UDFWorkerSpecification,
+          logger: WorkerLogger): WorkerDispatcher = {
+        val dispatcher = mock(classOf[WorkerDispatcher])
+        when(dispatcher.createSession(
+          any[Option[WorkerSecurityScope]]))
+          .thenAnswer((_: InvocationOnMock) => {
+            val session = new NoOpWorkerSession()
+            createdSessions += session
+            session
+          })
+        createdDispatchers += dispatcher
+        dispatcher
+      }
+      override protected def onAllDispatcherSessionsClosed(
+          dispatcher: WorkerDispatcher): Unit = {
+        closedDispatchers += dispatcher
+      }
+      override protected def doStop(): Unit = {
+        doStopCalls += true
+      }
+    }
+
+    TestManagerFixture(
+      manager, createdDispatchers, closedDispatchers,
+      doStopCalls, createdSessions)
+  }
+}
+
+class UDFWorkerManagerSuite
+    extends AnyFunSuite { // scalastyle:ignore funsuite
+
+  private def makeSpec(command: String): UDFWorkerSpecification = {
+    val callable = ProcessCallable.newBuilder()
+    callable.addCommand(command)
+    val caps = WorkerCapabilities.newBuilder()
+      .addSupportedDataFormats(UDFWorkerDataFormat.ARROW)
+      .addSupportedCommunicationPatterns(
+        UDFProtoCommunicationPattern.BIDIRECTIONAL_STREAMING)
+    val conn = WorkerConnectionSpec.newBuilder()
+      .setTcp(LocalTcpConnection.newBuilder())
+    val props = UDFWorkerProperties.newBuilder()
+      .setConnection(conn)
+    val direct = DirectWorker.newBuilder()
+      .setRunner(callable).setProperties(props)
+    UDFWorkerSpecification.newBuilder()
+      .setEnvironment(WorkerEnvironment.newBuilder())
+      .setCapabilities(caps).setDirect(direct).build()
+  }
+
+  test("Same spec reuses the same dispatcher") {
+    val fixture = TestManagerFixture()
+    val spec = makeSpec("worker.bin")
+
+    val s1 = fixture.manager.createSession(spec)
+    val s2 = fixture.manager.createSession(spec)
+
+    assert(fixture.createdDispatchers.size === 1)
+    verify(
+      fixture.createdDispatchers.head,
+      org.mockito.Mockito.times(2))
+      .createSession(any[Option[WorkerSecurityScope]])
+
+    s1.close()
+    s2.close()
+  }
+
+  test("Structurally equal specs reuse the same dispatcher") {
+    val fixture = TestManagerFixture()
+    val spec1 = makeSpec("worker.bin")
+    val spec2 = makeSpec("worker.bin")
+    assert(spec1 ne spec2)
+    assert(spec1 == spec2)
+
+    val s1 = fixture.manager.createSession(spec1)
+    val s2 = fixture.manager.createSession(spec2)
+
+    assert(fixture.createdDispatchers.size === 1)
+
+    s1.close()
+    s2.close()
+  }
+
+  test("Different specs create different dispatchers") {
+    val fixture = TestManagerFixture()
+
+    val sA = fixture.manager.createSession(makeSpec("worker-a.bin"))
+    val sB = fixture.manager.createSession(makeSpec("worker-b.bin"))
+
+    assert(fixture.createdDispatchers.size === 2)
+    assert(
+      fixture.createdDispatchers(0) ne
+        fixture.createdDispatchers(1))
+
+    sA.close()
+    sB.close()
+  }
+
+  test("onAllDispatcherSessionsClosed when last session closes") {
+    val fixture = TestManagerFixture()
+    val spec = makeSpec("worker.bin")
+
+    val s1 = fixture.manager.createSession(spec)
+    val s2 = fixture.manager.createSession(spec)
+
+    s1.close()
+    assert(fixture.closedDispatchers.isEmpty)
+
+    s2.close()
+    assert(fixture.closedDispatchers.size === 1)
+    assert(
+      fixture.closedDispatchers.head eq
+        fixture.createdDispatchers.head)
+  }
+
+  test("onAllDispatcherSessionsClosed not called while sessions remain") {
+    val fixture = TestManagerFixture()
+    val spec = makeSpec("worker.bin")
+
+    val s1 = fixture.manager.createSession(spec)
+    val s2 = fixture.manager.createSession(spec)
+    val s3 = fixture.manager.createSession(spec)
+
+    s1.close()
+    s2.close()
+    assert(fixture.closedDispatchers.isEmpty)
+
+    s3.close()
+    assert(fixture.closedDispatchers.size === 1)
+  }
+
+  test("New dispatcher after all sessions closed") {
+    val fixture = TestManagerFixture()
+    val spec = makeSpec("worker.bin")
+
+    val s1 = fixture.manager.createSession(spec)
+    val s2 = fixture.manager.createSession(spec)
+    assert(fixture.createdDispatchers.size === 1)
+
+    s1.close()
+    s2.close()
+    assert(fixture.closedDispatchers.size === 1)
+
+    val s3 = fixture.manager.createSession(spec)
+    assert(fixture.createdDispatchers.size === 2)
+    assert(
+      fixture.createdDispatchers(0) ne
+        fixture.createdDispatchers(1))
+
+    s3.close()
+    assert(fixture.closedDispatchers.size === 2)
+  }
+
+  test("Stop closes all cached dispatchers") {
+    val fixture = TestManagerFixture()
+
+    fixture.manager.createSession(makeSpec("worker-a.bin"))
+    fixture.manager.createSession(makeSpec("worker-b.bin"))
+    fixture.manager.stop()
+
+    fixture.createdDispatchers.foreach(d => verify(d).close())
+  }
+
+  test("Stop calls doStop for subclass cleanup") {
+    val fixture = TestManagerFixture()
+
+    fixture.manager.createSession(makeSpec("worker.bin"))
+    assert(fixture.doStopCalls.isEmpty)
+
+    fixture.manager.stop()
+    assert(fixture.doStopCalls.size === 1)
+  }
+
+  test("Stop cancels active sessions that were not closed") {
+    val fixture = TestManagerFixture()
+    val spec = makeSpec("worker.bin")
+
+    val s1 = fixture.manager.createSession(spec)
+    fixture.manager.createSession(spec)
+    s1.close()
+
+    assert(fixture.createdSessions.size === 2)
+    assert(!fixture.createdSessions(0).cancelled)
+    assert(!fixture.createdSessions(1).cancelled)
+
+    fixture.manager.stop()
+
+    assert(fixture.createdSessions(1).cancelled)
+  }
+
+  test("Stop does not cancel already closed sessions") {
+    val fixture = TestManagerFixture()
+    val spec = makeSpec("worker.bin")
+
+    val s1 = fixture.manager.createSession(spec)
+    s1.close()
+
+    fixture.manager.stop()
+
+    assert(!fixture.createdSessions(0).cancelled)
+  }
+
+  test("createSession throws after stop") {
+    val fixture = TestManagerFixture()
+    fixture.manager.stop()
+
+    intercept[IllegalStateException] {
+      fixture.manager.createSession(makeSpec("worker.bin"))
+    }
+  }
+}

--- a/udf/worker/core/src/test/scala/org/apache/spark/udf/worker/core/WorkerSessionSuite.scala
+++ b/udf/worker/core/src/test/scala/org/apache/spark/udf/worker/core/WorkerSessionSuite.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.udf.worker.core
+
+import java.util.concurrent.atomic.AtomicInteger
+
+// scalastyle:off funsuite
+import org.scalatest.funsuite.AnyFunSuite
+
+private class TestWorkerSession
+    extends WorkerSession(WorkerLogger.NoOp) {
+  override protected def doInit(msg: InitMessage): Unit = {}
+  override protected def doProcess(
+      input: Iterator[Array[Byte]]): Iterator[Array[Byte]] =
+    Iterator.empty
+  override protected def doCancel(): Unit = {}
+  override protected def doClose(): Unit = {}
+}
+
+class WorkerSessionSuite
+    extends AnyFunSuite { // scalastyle:ignore funsuite
+
+  test("Completion listener fires on close") {
+    val session = new TestWorkerSession()
+    val count = new AtomicInteger(0)
+    session.addSessionCompletionListener(_ => count.incrementAndGet())
+
+    session.close()
+    assert(count.get() === 1)
+  }
+
+  test("Completion listener fires on cancel") {
+    val session = new TestWorkerSession()
+    val count = new AtomicInteger(0)
+    session.addSessionCompletionListener(_ => count.incrementAndGet())
+
+    session.cancel()
+    assert(count.get() === 1)
+  }
+
+  test("Completion listener fires exactly once on close then cancel") {
+    val session = new TestWorkerSession()
+    val count = new AtomicInteger(0)
+    session.addSessionCompletionListener(_ => count.incrementAndGet())
+
+    session.close()
+    session.cancel()
+    assert(count.get() === 1)
+  }
+
+  test("Listener added after close fires immediately") {
+    val session = new TestWorkerSession()
+    session.close()
+
+    val count = new AtomicInteger(0)
+    session.addSessionCompletionListener(_ => count.incrementAndGet())
+    assert(count.get() === 1)
+  }
+
+  test("Listener added after cancel fires immediately") {
+    val session = new TestWorkerSession()
+    session.cancel()
+
+    val count = new AtomicInteger(0)
+    session.addSessionCompletionListener(_ => count.incrementAndGet())
+    assert(count.get() === 1)
+  }
+
+  test("Multiple listeners all fire exactly once") {
+    val session = new TestWorkerSession()
+    val count1 = new AtomicInteger(0)
+    val count2 = new AtomicInteger(0)
+    val count3 = new AtomicInteger(0)
+    session.addSessionCompletionListener(_ => count1.incrementAndGet())
+    session.addSessionCompletionListener(_ => count2.incrementAndGet())
+
+    session.close()
+
+    // Add a third after close
+    session.addSessionCompletionListener(_ => count3.incrementAndGet())
+
+    assert(count1.get() === 1)
+    assert(count2.get() === 1)
+    assert(count3.get() === 1)
+  }
+
+  test("Listener receives the correct session instance") {
+    val session = new TestWorkerSession()
+    var received: WorkerSession = null
+    session.addSessionCompletionListener(s => received = s)
+
+    session.close()
+    assert(received eq session)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This PR introduces new logical and physical Catalyst nodes for language-agnostic User Defined Functions (UDF) as part of [SPIP SPARK-55278](https://issues.apache.org/jira/browse/SPARK-55278), which proposes language-agnostic UDFs.

As a first step towards the goal of language-agnostic UDFs, we want to target mapPartition UDFs like `pyspark.sql.DataFrame.mapInArrow`, `pyspark.RDD.mapPartitions`, or `pyspark.sql.DataFrame.mapInArrow`. The overarching goal is to deprecate the current, language-specific Catalyst nodes (like `mapInArrow`). However, for now, the new nodes will exist in addition to the old ones until the new framework has reach maturity.

In summary, this PR introduces:

- A new Catalyst Expression, `ExternalUDFExpression`, which captures language-agnostic UDF properties (payload, name, etc.)
- A new Catalyst logical node, `ExternalUDF`, which serves as a base class for all language-agnostic UDF nodes
- A new Catalyst logical node, `MapPartitionExternalUDF`, which is the new, language-agnostic map partition node
- Catalyst physical nodes for both logical nodes
- `WorkerSessionFactory` - A factory class to generate new worker sessions using the new UDF worker approach

None of the changes introduced above are currently consumed in Spark. 

### Why are the changes needed?

This is the first step from the Spark planning side to enable UDFs written in any language.

This is the first step toward  language-agnostic UDF execution for Spark. Existing physical and logical planning nodes need to be replaced eventually to achieve this goal as they make language-specific assumptions.

### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New unit-tests were added.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Partially. However, the code was manually reviewed and adjusted.