### PR TITLE
[SPARK-56648][PYTHON] Refactor SQL_SCALAR_PANDAS_UDF

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -3102,8 +3102,8 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             [StructField(name, info[2]) for name, info in zip(col_names, udf_infos)]
         )
 
-        def func(split_index: int, batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
-            for input_batch in batches:
+        def func(split_index: int, data: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
+            for input_batch in data:
                 num_rows = input_batch.num_rows
 
                 # --- Input: Arrow -> pandas Series (struct columns become DataFrames) ---

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -3097,9 +3097,8 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
                 udf_func, udf_args_offsets, udf_kwargs_offsets
             )
             udf_infos.append((wrapped_func, args_kwargs_offsets, udf_return_type))
-        col_names = [f"_{i}" for i in range(len(udfs))]
         return_schema = StructType(
-            [StructField(name, info[2]) for name, info in zip(col_names, udf_infos)]
+            [StructField(f"_{i}", info[2]) for i, info in enumerate(udf_infos)]
         )
 
         def func(split_index: int, data: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -378,42 +378,6 @@ def wrap_udf(f, args_offsets, kwargs_offsets, return_type):
         return args_kwargs_offsets, lambda *a: func(*a)
 
 
-def wrap_scalar_pandas_udf(f, args_offsets, kwargs_offsets, return_type, runner_conf):
-    func, args_kwargs_offsets = wrap_kwargs_support(f, args_offsets, kwargs_offsets)
-
-    def verify_result_type(result):
-        if not hasattr(result, "__len__"):
-            pd_type = "pandas.DataFrame" if isinstance(return_type, StructType) else "pandas.Series"
-            raise PySparkTypeError(
-                errorClass="UDF_RETURN_TYPE",
-                messageParameters={
-                    "expected": pd_type,
-                    "actual": type(result).__name__,
-                },
-            )
-        return result
-
-    def verify_result_length(result, length):
-        if len(result) != length:
-            raise PySparkRuntimeError(
-                errorClass="SCHEMA_MISMATCH_FOR_PANDAS_UDF",
-                messageParameters={
-                    "udf_type": "pandas_udf",
-                    "expected": str(length),
-                    "actual": str(len(result)),
-                },
-            )
-        return result
-
-    return (
-        args_kwargs_offsets,
-        lambda *a: (
-            verify_result_length(verify_result_type(func(*a)), len(a[0])),
-            return_type,
-        ),
-    )
-
-
 def wrap_pandas_batch_iter_udf(f, return_type, runner_conf):
     iter_type_label = "pandas.DataFrame" if isinstance(return_type, StructType) else "pandas.Series"
 
@@ -1125,7 +1089,7 @@ def read_single_udf(pickleSer, infile, eval_type, runner_conf, udf_index):
 
     # the last returnType will be the return type of UDF
     if eval_type == PythonEvalType.SQL_SCALAR_PANDAS_UDF:
-        return wrap_scalar_pandas_udf(func, args_offsets, kwargs_offsets, return_type, runner_conf)
+        return func, args_offsets, kwargs_offsets, return_type
     elif eval_type == PythonEvalType.SQL_SCALAR_ARROW_UDF:
         return func, args_offsets, kwargs_offsets, return_type
     elif eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF:
@@ -2479,14 +2443,14 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
             PythonEvalType.SQL_SCALAR_ARROW_UDF,
             PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF,
             PythonEvalType.SQL_ARROW_BATCHED_UDF,
+            PythonEvalType.SQL_SCALAR_PANDAS_UDF,
         ):
             ser = ArrowStreamSerializer(write_start_stream=True)
         else:
             # Scalar Pandas UDF handles struct type arguments as pandas DataFrames instead of
             # pandas Series. See SPARK-27240.
             df_for_struct = (
-                eval_type == PythonEvalType.SQL_SCALAR_PANDAS_UDF
-                or eval_type == PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF
+                eval_type == PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF
                 or eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF
             )
 
@@ -3110,6 +3074,87 @@ def read_udfs(pickleSer, infile, eval_type, runner_conf, eval_conf):
                 # --- Output: pandas -> Arrow ---
                 yield PandasToArrowConversion.convert(
                     result_series,
+                    return_schema,
+                    timezone=runner_conf.timezone,
+                    safecheck=runner_conf.safecheck,
+                    arrow_cast=True,
+                    prefers_large_types=runner_conf.use_large_var_types,
+                    assign_cols_by_name=runner_conf.assign_cols_by_name,
+                    int_to_decimal_coercion_enabled=runner_conf.int_to_decimal_coercion_enabled,
+                )
+
+        # profiling is not supported for UDF
+        return func, None, ser, ser
+
+    if eval_type == PythonEvalType.SQL_SCALAR_PANDAS_UDF:
+        import pandas as pd
+        import pyarrow as pa
+
+        # --- UDF preparation ---
+        udf_infos = []
+        for udf_func, udf_args_offsets, udf_kwargs_offsets, udf_return_type in udfs:
+            wrapped_func, args_kwargs_offsets = wrap_kwargs_support(
+                udf_func, udf_args_offsets, udf_kwargs_offsets
+            )
+            udf_infos.append((wrapped_func, args_kwargs_offsets, udf_return_type))
+        col_names = [f"_{i}" for i in range(len(udfs))]
+        return_schema = StructType(
+            [StructField(name, info[2]) for name, info in zip(col_names, udf_infos)]
+        )
+
+        def func(split_index: int, batches: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
+            for input_batch in batches:
+                num_rows = input_batch.num_rows
+
+                # --- Input: Arrow -> pandas Series (struct columns become DataFrames) ---
+                pandas_columns = ArrowBatchTransformer.to_pandas(
+                    input_batch,
+                    timezone=runner_conf.timezone,
+                    struct_in_pandas="dict",
+                    ndarray_as_list=False,
+                    prefer_int_ext_dtype=runner_conf.prefer_int_ext_dtype,
+                    df_for_struct=True,
+                )
+
+                # --- Process: evaluate each UDF column-wise on pandas Series ---
+                results = []
+                for udf_func, offsets, udf_return_type in udf_infos:
+                    result = udf_func(*[pandas_columns[o] for o in offsets])
+                    if not hasattr(result, "__len__"):
+                        pd_type = (
+                            "pandas.DataFrame"
+                            if isinstance(udf_return_type, StructType)
+                            else "pandas.Series"
+                        )
+                        raise PySparkTypeError(
+                            errorClass="UDF_RETURN_TYPE",
+                            messageParameters={
+                                "expected": pd_type,
+                                "actual": type(result).__name__,
+                            },
+                        )
+                    if len(result) != num_rows:
+                        raise PySparkRuntimeError(
+                            errorClass="SCHEMA_MISMATCH_FOR_PANDAS_UDF",
+                            messageParameters={
+                                "udf_type": "pandas_udf",
+                                "expected": str(num_rows),
+                                "actual": str(len(result)),
+                            },
+                        )
+                    # struct_in_pandas="dict": UDF must return DataFrame for struct types
+                    if isinstance(udf_return_type, StructType) and not isinstance(
+                        result, pd.DataFrame
+                    ):
+                        raise PySparkValueError(
+                            "Invalid return type. Please make sure that the UDF returns a "
+                            "pandas.DataFrame when the specified return type is StructType."
+                        )
+                    results.append(result)
+
+                # --- Output: pandas -> Arrow ---
+                yield PandasToArrowConversion.convert(
+                    results,
                     return_schema,
                     timezone=runner_conf.timezone,
                     safecheck=runner_conf.safecheck,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Refactor `SQL_SCALAR_PANDAS_UDF` to use `ArrowStreamSerializer` as pure I/O, moving Arrow-to-Pandas and Pandas-to-Arrow conversion logic from `ArrowStreamPandasUDFSerializer` into `read_udfs()` in `worker.py`.

Specifically:
- Remove the dedicated `wrap_scalar_pandas_udf` wrapper.
- Route `SQL_SCALAR_PANDAS_UDF` through `ArrowStreamSerializer(write_start_stream=True)`.
- In `read_udfs()`, add a self-contained handler that:
  - Converts each Arrow `RecordBatch` to pandas Series via `ArrowBatchTransformer.to_pandas()` (with `struct_in_pandas="dict"`, `df_for_struct=True`, `ndarray_as_list=False`).
  - Invokes each UDF column-wise on the pandas inputs and validates the return type (must be array-like) and row count (must match input).
  - Enforces the existing rule that struct return types must be `pandas.DataFrame`.
  - Converts results back to an Arrow `RecordBatch` via `PandasToArrowConversion.convert()`.

### Why are the changes needed?

Part of [SPARK-55388](https://issues.apache.org/jira/browse/SPARK-55388). This consolidates UDF dispatch, verification, and conversion logic for `SQL_SCALAR_PANDAS_UDF` into a single inline handler in `read_udfs()`, mirroring the pattern already applied to `SQL_SCALAR_ARROW_UDF` ([SPARK-55390](https://issues.apache.org/jira/browse/SPARK-55390)) and `SQL_ARROW_BATCHED_UDF` ([SPARK-55902](https://issues.apache.org/jira/browse/SPARK-55902)). The dedicated `ArrowStreamPandasUDFSerializer` is no longer used by the scalar pandas path, reducing indirection and bringing the eval-type processing paths closer to a uniform structure.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests. No behavior change.

`pyspark.sql.tests.pandas.test_pandas_udf_scalar` (81 tests) plus `test_pandas_udf`, `test_pandas_udf_typehints`, `test_pandas_udf_window`, and `test_arrow_python_udf` all pass.

ASV benchmark comparison via `COLUMNS=120 asv run --python=same --bench "ScalarPandasUDF" --attribute "repeat=(3,5,5.0)"`. before = `upstream/master`, after = this PR.

**ScalarPandasUDFTimeBench** (latency, ms):

```text
scenario             udf              before    after    diff
-------------------  --------------  -------  -------  ------
sm_batch_few_col     identity_udf       366      381   +4.1%
sm_batch_few_col     sort_udf           509      503   -1.2%
sm_batch_few_col     nullcheck_udf      445      439   -1.3%
sm_batch_many_col    identity_udf       283      289   +2.1%
sm_batch_many_col    sort_udf           305      302   -1.0%
sm_batch_many_col    nullcheck_udf      293      291   -0.7%
lg_batch_few_col     identity_udf      1080     1090   +0.9%
lg_batch_few_col     sort_udf          1340     1330   -0.7%
lg_batch_few_col     nullcheck_udf     1160     1170   +0.9%
lg_batch_many_col    identity_udf      1220     1240   +1.6%
lg_batch_many_col    sort_udf          1280     1290   +0.8%
lg_batch_many_col    nullcheck_udf     1270     1260   -0.8%
pure_ints            identity_udf       190      190    0.0%
pure_ints            sort_udf           268      270   +0.7%
pure_ints            nullcheck_udf      217      220   +1.4%
pure_floats          identity_udf       187      188   +0.5%
pure_floats          sort_udf           280      277   -1.1%
pure_floats          nullcheck_udf      218      218    0.0%
pure_strings         identity_udf      1160     1130   -2.6%
pure_strings         sort_udf          1700     1680   -1.2%
pure_strings         nullcheck_udf     1110     1110    0.0%
pure_ts              identity_udf       348      360   +3.4%
pure_ts              sort_udf           441      419   -5.0%
pure_ts              nullcheck_udf      370      369   -0.3%
mixed_types          identity_udf       650      661   +1.7%
mixed_types          sort_udf           745      748   +0.4%
mixed_types          nullcheck_udf      692      697   +0.7%
```

**ScalarPandasUDFPeakmemBench** (peak memory, MB):

```text
scenario             udf              before    after    diff
-------------------  --------------  -------  -------  ------
sm_batch_few_col     identity_udf       481      481    0.0%
sm_batch_few_col     sort_udf           482      482    0.0%
sm_batch_few_col     nullcheck_udf      479      479    0.0%
sm_batch_many_col    identity_udf       481      481    0.0%
sm_batch_many_col    sort_udf           482      482    0.0%
sm_batch_many_col    nullcheck_udf      481      481    0.0%
lg_batch_few_col     identity_udf       621      621    0.0%
lg_batch_few_col     sort_udf           619      618   -0.2%
lg_batch_few_col     nullcheck_udf      602      602    0.0%
lg_batch_many_col    identity_udf       627      627    0.0%
lg_batch_many_col    sort_udf           629      628   -0.2%
lg_batch_many_col    nullcheck_udf      628      627   -0.2%
pure_ints            identity_udf       546      546    0.0%
pure_ints            sort_udf           547      547    0.0%
pure_ints            nullcheck_udf      544      544    0.0%
pure_floats          identity_udf       543      543    0.0%
pure_floats          sort_udf           545      544   -0.2%
pure_floats          nullcheck_udf      544      544    0.0%
pure_strings         identity_udf       564      563   -0.2%
pure_strings         sort_udf           565      564   -0.2%
pure_strings         nullcheck_udf      561      561    0.0%
pure_ts              identity_udf       546      546    0.0%
pure_ts              sort_udf           547      547    0.0%
pure_ts              nullcheck_udf      547      546   -0.2%
mixed_types          identity_udf       525      525    0.0%
mixed_types          sort_udf           526      526    0.0%
mixed_types          nullcheck_udf      525      525    0.0%
```

**Summary**: Latency variations stay within +-5% (run-to-run noise on this bench), and peak memory is flat (within +-1MB). The refactor reorganizes logic without changing data layout or buffering.

### Was this patch authored or co-authored using generative AI tooling?

No