### PR TITLE
[SPARK-56672][SQL] Rename TableViewCatalog.listRelationSummaries to listTableAndViewSummaries

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableViewCatalog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableViewCatalog.java
@@ -109,8 +109,8 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchViewException;
  *       a regular {@link Table} for a table, or a {@link MetadataTable} wrapping a
  *       {@link ViewInfo} for a view. Saves the {@code loadTable} -> {@code loadView} fallback
  *       on a cold cache.</li>
- *   <li>{@link #listRelationSummaries(String[])} -- a unified listing of tables and views with the
- *       kind preserved on each {@link TableSummary}. Default impl performs both
+ *   <li>{@link #listTableAndViewSummaries(String[])} -- a unified listing of tables and views
+ *       with the kind preserved on each {@link TableSummary}. Default impl performs both
  *       {@link TableCatalog#listTableSummaries} and {@link ViewCatalog#listViews}; override to
  *       fetch in one round trip.</li>
  * </ul>
@@ -149,7 +149,7 @@ public interface TableViewCatalog extends TableCatalog, ViewCatalog {
    * @throws NoSuchTableException if a table listed by the underlying enumeration disappears
    *                              before its summary can be assembled (default impl only)
    */
-  default TableSummary[] listRelationSummaries(String[] namespace)
+  default TableSummary[] listTableAndViewSummaries(String[] namespace)
       throws NoSuchNamespaceException, NoSuchTableException {
     TableSummary[] tableSummaries = listTableSummaries(namespace);
     Identifier[] viewIdentifiers = listViews(namespace);

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExec.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.execution.LeafExecNode
  * Physical plan node for showing tables.
  *
  * For a [[TableViewCatalog]] (one that exposes both tables and views in a shared identifier
- * namespace), this routes through [[TableViewCatalog#listRelationSummaries]] so that views are
+ * namespace), this routes through [[TableViewCatalog#listTableAndViewSummaries]] so that views are
  * included in the listing -- matching the v1 `SHOW TABLES` semantics where views appear
  * alongside tables. Pure [[TableCatalog]] catalogs continue to use `listTables` and return
  * tables only.
@@ -44,7 +44,8 @@ case class ShowTablesExec(
     val rows = new ArrayBuffer[InternalRow]()
 
     val identifiers: Array[Identifier] = catalog match {
-      case mc: TableViewCatalog => mc.listRelationSummaries(namespace.toArray).map(_.identifier())
+      case mc: TableViewCatalog =>
+        mc.listTableAndViewSummaries(namespace.toArray).map(_.identifier())
       case _ => catalog.listTables(namespace.toArray)
     }
     identifiers.foreach { ident =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2MetadataViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2MetadataViewSuite.scala
@@ -377,7 +377,7 @@ class DataSourceV2MetadataViewSuite extends QueryTest with SharedSparkSession {
 
   test("SHOW TABLES on a TableViewCatalog returns both tables and views (v1-parity)") {
     // For a `TableViewCatalog` (a catalog exposing both tables and views in a shared
-    // identifier namespace), SHOW TABLES routes through `listRelationSummaries` so views
+    // identifier namespace), SHOW TABLES routes through `listTableAndViewSummaries` so views
     // appear alongside tables -- matching the v1 SHOW TABLES output. Pure `TableCatalog`
     // catalogs (no view mixin) continue to use `listTables` and return tables only.
     seedV2View("v_in_show_tables")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the unified listing method on `TableViewCatalog` from `listRelationSummaries` to `listTableAndViewSummaries`. Updates the declaration in `TableViewCatalog.java` and the two existing references introduced by [SPARK-56655](https://issues.apache.org/jira/browse/SPARK-56655):

- `sql/catalyst/.../TableViewCatalog.java` -- method declaration + javadoc
- `sql/core/.../ShowTablesExec.scala` -- call site + scaladoc reference
- `sql/core/.../DataSourceV2MetadataViewSuite.scala` -- comment reference

### Why are the changes needed?

The new name explicitly states what the method returns (tables and views) and avoids overloading Spark's existing "Relation" terminology (`BaseRelation`, `LogicalRelation`, etc.), matching the rename rationale that already changed `RelationCatalog` -> `TableViewCatalog` in SPARK-56655. The API is still `@Evolving` and unreleased, so this is a pre-release rename with no deprecation cycle needed.

### Does this PR introduce _any_ user-facing change?

No end-user behavior change.

### How was this patch tested?

Pure rename; existing tests in `DataSourceV2MetadataViewSuite` exercise the renamed method via `SHOW TABLES` on a `TableViewCatalog`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude (Anthropic), claude-opus-4