### PR TITLE
[MINOR][PYTHON][TESTS] Rename `test_resources` to `test_parity_resources` for Connect parity convention

### DIFF
--- a/.github/workflows/build_python_connect.yml
+++ b/.github/workflows/build_python_connect.yml
@@ -118,7 +118,7 @@ jobs:
           mv python/lib lib.back
           mv python/pyspark pyspark.back
 
-          ./python/run-tests --parallelism=1 --python-executables=python3 --testnames "pyspark.resource.tests.test_connect_resources,pyspark.sql.tests.connect.client.test_artifact,pyspark.sql.tests.connect.client.test_artifact_localcluster,pyspark.sql.tests.connect.test_resources"
+          ./python/run-tests --parallelism=1 --python-executables=python3 --testnames "pyspark.resource.tests.test_connect_resources,pyspark.sql.tests.connect.client.test_artifact,pyspark.sql.tests.connect.client.test_artifact_localcluster,pyspark.sql.tests.connect.test_parity_resources"
 
           # Stop Spark Connect server.
           ./sbin/stop-connect-server.sh

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -1195,7 +1195,7 @@ pyspark_connect = Module(
         "pyspark.sql.tests.connect.client.test_client_call_stack_trace",
         "pyspark.sql.tests.connect.client.test_client_retries",
         "pyspark.sql.tests.connect.client.test_reattach",
-        "pyspark.sql.tests.connect.test_resources",
+        "pyspark.sql.tests.connect.test_parity_resources",
         "pyspark.sql.tests.connect.shell.test_progress",
         "pyspark.sql.tests.connect.test_df_debug",
         "pyspark.sql.tests.connect.arrow.test_parity_arrow",

--- a/python/pyspark/sql/tests/connect/test_parity_resources.py
+++ b/python/pyspark/sql/tests/connect/test_parity_resources.py
@@ -20,7 +20,7 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.sql.tests.test_resources import ResourceProfileTestsMixin
 
 
-class ResourceProfileTests(ResourceProfileTestsMixin, ReusedConnectTestCase):
+class ResourceProfileParityTests(ResourceProfileTestsMixin, ReusedConnectTestCase):
     @classmethod
     def master(cls):
         return os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local-cluster[1, 4, 1024]")


### PR DESCRIPTION
### What changes were proposed in this pull request?

The Connect parity test file `python/pyspark/sql/tests/connect/test_resources.py` and its class `ResourceProfileTests` are the only ones in `python/pyspark/sql/tests/connect/` that don't follow the naming convention used by 200+ other parity tests:

- Filename should be `test_parity_<name>.py`.
- Class name should be `<Name>ParityTests`.

This PR renames:
- `python/pyspark/sql/tests/connect/test_resources.py` -> `python/pyspark/sql/tests/connect/test_parity_resources.py`
- `ResourceProfileTests` -> `ResourceProfileParityTests`

References to the old module path are updated in `dev/sparktestsupport/modules.py` and `.github/workflows/build_python_connect.yml`.

### Why are the changes needed?

Consistency. The `test_parity_*` filename and `*ParityTests` class name are the established convention across the Connect parity test suite; this rename brings the resource profile parity tests in line and makes it easier to locate and identify parity tests at a glance.

### Does this PR introduce _any_ user-facing change?

No. Test-only change with no behavioral impact.

### How was this patch tested?

Existing tests; only filename and class name changed. The test module is still discovered through `dev/sparktestsupport/modules.py` and the connect CI workflow.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)