### PR TITLE
[SPARK-56674][SS][RTM][StreamingShuffle] Add streaming shuffle wire protocol 

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/CreditControlMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/CreditControlMessage.java
@@ -35,57 +35,57 @@ import io.netty.buffer.CompositeByteBuf;
  * previously-granted credit (i.e., a credit-grant delta).
  */
 public final class CreditControlMessage extends StreamingShuffleMessage {
-    public final int shuffleWriterId;
-    public final int shuffleReaderId;
+  public final int shuffleWriterId;
+  public final int shuffleReaderId;
 
-    /**
-     * In the current protocol revision the writer ignores this value and treats any
-     * CreditControlMessage as a "reader is ready" signal; senders should pass 1.
-     *
-     * Reserved for the future credit-based flow-control extension, in which this field
-     * will carry the number of additional DataMessages the writer may send beyond any
-     * previously-granted credit.
-     */
-    public final int numMessages;
+  /**
+   * In the current protocol revision the writer ignores this value and treats any
+   * CreditControlMessage as a "reader is ready" signal; senders should pass 1.
+   *
+   * Reserved for the future credit-based flow-control extension, in which this field
+   * will carry the number of additional DataMessages the writer may send beyond any
+   * previously-granted credit.
+   */
+  public final int numMessages;
 
-    public CreditControlMessage(int shuffleWriterId, int shuffleReaderId, int numMessages) {
-        this.shuffleWriterId = shuffleWriterId;
-        this.shuffleReaderId = shuffleReaderId;
-        this.numMessages = numMessages;
-    }
+  public CreditControlMessage(int shuffleWriterId, int shuffleReaderId, int numMessages) {
+    this.shuffleWriterId = shuffleWriterId;
+    this.shuffleReaderId = shuffleReaderId;
+    this.numMessages = numMessages;
+  }
 
-    @Override
-    public StreamingShuffleMessageType messageType() {
-        return StreamingShuffleMessageType.CREDIT_CONTROL_MESSAGE;
-    }
+  @Override
+  public StreamingShuffleMessageType messageType() {
+    return StreamingShuffleMessageType.CREDIT_CONTROL_MESSAGE;
+  }
 
-    @Override
-    public int headerLength() {
-        // 4 bytes for the shuffle writer ID, 4 bytes for the shuffle reader ID,
-        // 4 bytes for the number of messages
-        return super.headerLength() + 12;
-    }
+  @Override
+  public int headerLength() {
+    // 4 bytes for the shuffle writer ID, 4 bytes for the shuffle reader ID,
+    // 4 bytes for the number of messages
+    return super.headerLength() + 12;
+  }
 
-    @Override
-    public void encode(CompositeByteBuf buf) {
-        super.encode(buf);
+  @Override
+  public void encode(CompositeByteBuf buf) {
+    super.encode(buf);
 
-        // Write the shuffle writer ID
-        buf.writeInt(shuffleWriterId);
-        // Write the shuffle reader ID
-        buf.writeInt(shuffleReaderId);
-        // Write the number of messages
-        buf.writeInt(numMessages);
-    }
+    // Write the shuffle writer ID
+    buf.writeInt(shuffleWriterId);
+    // Write the shuffle reader ID
+    buf.writeInt(shuffleReaderId);
+    // Write the number of messages
+    buf.writeInt(numMessages);
+  }
 
-    public static CreditControlMessage decode(ByteBuf buf) {
-        // Read the shuffle writer ID
-        int shuffleWriterId = buf.readInt();
-        // Read the shuffle reader ID
-        int shuffleReaderId = buf.readInt();
-        // Read the number of messages
-        int numMessages = buf.readInt();
+  public static CreditControlMessage decode(ByteBuf buf) {
+    // Read the shuffle writer ID
+    int shuffleWriterId = buf.readInt();
+    // Read the shuffle reader ID
+    int shuffleReaderId = buf.readInt();
+    // Read the number of messages
+    int numMessages = buf.readInt();
 
-        return new CreditControlMessage(shuffleWriterId, shuffleReaderId, numMessages);
-    }
+    return new CreditControlMessage(shuffleWriterId, shuffleReaderId, numMessages);
+  }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/CreditControlMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/CreditControlMessage.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.streaming;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+
+/**
+ * Sent from the client to the server to indicate that the client is ready to receive
+ * the specified amount of messages from the server.
+ */
+public final class CreditControlMessage extends StreamingShuffleMessage {
+    public int shuffleWriterId;
+    public int shuffleReaderId;
+
+    public int numMessages;
+
+    public CreditControlMessage(int shuffleWriterId, int shuffleReaderId, int numMessages) {
+        this.shuffleWriterId = shuffleWriterId;
+        this.shuffleReaderId = shuffleReaderId;
+        this.numMessages = numMessages;
+    }
+
+    @Override
+    public StreamingShuffleMessageType messageType() {
+        return StreamingShuffleMessageType.CREDIT_CONTROL_MESSAGE;
+    }
+
+    @Override
+    public int headerLength() {
+        // 4 bytes for the shuffle writer ID, 4 bytes for the shuffle reader ID,
+        // 4 bytes for the number of messages
+        return super.headerLength() + 12;
+    }
+
+    @Override
+    public void encode(CompositeByteBuf buf) {
+        super.encode(buf);
+
+        // Write the shuffle writer ID
+        buf.writeInt(shuffleWriterId);
+        // Write the shuffle reader ID
+        buf.writeInt(shuffleReaderId);
+        // Write the number of messages
+        buf.writeInt(numMessages);
+    }
+
+    public static CreditControlMessage decode(ByteBuf buf) {
+        // Read the shuffle writer ID
+        int shuffleWriterId = buf.readInt();
+        // Read the shuffle reader ID
+        int shuffleReaderId = buf.readInt();
+        // Read the number of messages
+        int numMessages = buf.readInt();
+
+        return new CreditControlMessage(shuffleWriterId, shuffleReaderId, numMessages);
+    }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/CreditControlMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/CreditControlMessage.java
@@ -21,14 +21,32 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 
 /**
- * Sent from the client to the server to indicate that the client is ready to receive
- * the specified amount of messages from the server.
+ * Reader → writer control message.
+ *
+ * Current function: serves as a connection-establishment and per-consumption "ready"
+ * signal. The writer uses receipt of any CreditControlMessage as the trigger that the
+ * reader is ready to receive, and does not act on the numeric value of {@link
+ * #numMessages}. Backpressure today is handled at the TCP layer via channel autoRead,
+ * not via this message.
+ *
+ * Future function: this message is reserved as the carrier for a future credit-based
+ * flow-control extension. When that extension lands, {@link #numMessages} will carry
+ * the number of additional DataMessages the writer may send beyond any
+ * previously-granted credit (i.e., a credit-grant delta).
  */
 public final class CreditControlMessage extends StreamingShuffleMessage {
-    public int shuffleWriterId;
-    public int shuffleReaderId;
+    public final int shuffleWriterId;
+    public final int shuffleReaderId;
 
-    public int numMessages;
+    /**
+     * In the current protocol revision the writer ignores this value and treats any
+     * CreditControlMessage as a "reader is ready" signal; senders should pass 1.
+     *
+     * Reserved for the future credit-based flow-control extension, in which this field
+     * will carry the number of additional DataMessages the writer may send beyond any
+     * previously-granted credit.
+     */
+    public final int numMessages;
 
     public CreditControlMessage(int shuffleWriterId, int shuffleReaderId, int numMessages) {
         this.shuffleWriterId = shuffleWriterId;

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/DataMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/DataMessage.java
@@ -74,6 +74,20 @@ public final class DataMessage extends StreamingShuffleMessage {
     buf.addComponent(true, data.retainedSlice(data.readerIndex(), dataSize));
   }
 
+  /**
+   * Decodes a {@link DataMessage} from {@code message}. The 12-byte common header
+   * (message-type id + sequence number) has already been consumed by
+   * {@link StreamingShuffleMessage#decode(ByteBuf)}; this method reads the remaining
+   * 20-byte DataMessage header and treats the rest of {@code message} as the payload.
+   *
+   * On success, the returned DataMessage retains a reference to {@code message} via
+   * its {@code ownedBuf} field (refcount is incremented in the constructor), and the
+   * caller transfers ownership.
+   *
+   * On failure (an {@link IllegalArgumentException} is thrown — see the constructor's
+   * validation), the caller still owns {@code message} and is responsible for
+   * releasing it, since the constructor's {@code data.retain()} never ran.
+   */
   public static DataMessage decode(ByteBuf message) {
     int shuffleWriterId = message.readInt();
     int shuffleReaderId = message.readInt();
@@ -94,6 +108,11 @@ public final class DataMessage extends StreamingShuffleMessage {
   /**
    * Returns a slice of {@link #data} containing exactly the serialized records
    * (i.e., {@code dataSize} bytes starting at the current reader index).
+   *
+   * Uses {@code slice} (not {@code readSlice}), so this method DOES NOT advance the
+   * reader index of {@link #data}. The returned slice shares the underlying storage;
+   * no data is copied. Callers may freely consume the returned slice without
+   * affecting subsequent calls to this method.
    */
   public ByteBuf getRecordData() {
     return data.slice(data.readerIndex(), dataSize);

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/DataMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/DataMessage.java
@@ -22,11 +22,11 @@ import io.netty.buffer.CompositeByteBuf;
 
 public final class DataMessage extends StreamingShuffleMessage {
 
-    public ByteBuf data;
-    public int shuffleWriterId;
-    public int shuffleReaderId;
-    public int dataSize;
-    public long checksum;
+    public final ByteBuf data;
+    public final int shuffleWriterId;
+    public final int shuffleReaderId;
+    public final int dataSize;
+    public final long checksum;
 
     public DataMessage(int shuffleWriterId, int shuffleReaderId, int dataSize, ByteBuf data,
                        long checksum) {

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/DataMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/DataMessage.java
@@ -22,80 +22,80 @@ import io.netty.buffer.CompositeByteBuf;
 
 public final class DataMessage extends StreamingShuffleMessage {
 
-    public final ByteBuf data;
-    public final int shuffleWriterId;
-    public final int shuffleReaderId;
-    public final int dataSize;
-    public final long checksum;
+  public final ByteBuf data;
+  public final int shuffleWriterId;
+  public final int shuffleReaderId;
+  public final int dataSize;
+  public final long checksum;
 
-    public DataMessage(int shuffleWriterId, int shuffleReaderId, int dataSize, ByteBuf data,
-                       long checksum) {
-        if (dataSize < 0) {
-            throw new IllegalArgumentException(
-                "dataSize must be non-negative: " + dataSize);
-        }
-        if (dataSize != data.readableBytes()) {
-            throw new IllegalArgumentException(
-                "dataSize must equal data.readableBytes(): " +
-                    dataSize + " != " + data.readableBytes());
-        }
-        this.shuffleWriterId = shuffleWriterId;
-        this.shuffleReaderId = shuffleReaderId;
-        this.dataSize = dataSize;
-        this.data = data;
-        this.ownedBuf = data.retain();
-        this.checksum = checksum;
+  public DataMessage(int shuffleWriterId, int shuffleReaderId, int dataSize, ByteBuf data,
+      long checksum) {
+    if (dataSize < 0) {
+      throw new IllegalArgumentException(
+        "dataSize must be non-negative: " + dataSize);
     }
-
-    @Override
-    public StreamingShuffleMessageType messageType() {
-        return StreamingShuffleMessageType.DATA_MESSAGE_UNSAFE_ROW;
+    if (dataSize != data.readableBytes()) {
+      throw new IllegalArgumentException(
+        "dataSize must equal data.readableBytes(): " +
+          dataSize + " != " + data.readableBytes());
     }
+    this.shuffleWriterId = shuffleWriterId;
+    this.shuffleReaderId = shuffleReaderId;
+    this.dataSize = dataSize;
+    this.data = data;
+    this.ownedBuf = data.retain();
+    this.checksum = checksum;
+  }
 
-    @Override
-    public int headerLength() {
-        // 4 bytes EACH for shuffle writer ID, shuffle reader ID, data size
-        // 8 bytes for checksum
-        return super.headerLength() + 20;
+  @Override
+  public StreamingShuffleMessageType messageType() {
+    return StreamingShuffleMessageType.DATA_MESSAGE_UNSAFE_ROW;
+  }
+
+  @Override
+  public int headerLength() {
+    // 4 bytes EACH for shuffle writer ID, shuffle reader ID, data size
+    // 8 bytes for checksum
+    return super.headerLength() + 20;
+  }
+
+  @Override
+  public void encode(CompositeByteBuf buf) {
+    super.encode(buf);
+    buf.writeInt(shuffleWriterId);
+    buf.writeInt(shuffleReaderId);
+    buf.writeInt(dataSize);
+    buf.writeLong(checksum);
+
+    // Only encode exactly `dataSize` bytes of `data`, so the wire payload matches the
+    // header's dataSize even if the underlying ByteBuf has additional readable bytes.
+    // retainedSlice() also bumps the refcount, so this DataMessage's ownedBuf reference
+    // remains valid for later release().
+    buf.addComponent(true, data.retainedSlice(data.readerIndex(), dataSize));
+  }
+
+  public static DataMessage decode(ByteBuf message) {
+    int shuffleWriterId = message.readInt();
+    int shuffleReaderId = message.readInt();
+    int dataSize = message.readInt();
+    long checksum = message.readLong();
+    // Each streaming-shuffle frame carries exactly one DataMessage, so after reading the
+    // header the remaining readable bytes must equal `dataSize`. Strict equality catches
+    // both undersized frames (truncation) and oversized frames (trailing garbage) at the
+    // wire boundary rather than letting them propagate to getRecordData() later.
+    if (dataSize < 0 || dataSize != message.readableBytes()) {
+      throw new IllegalArgumentException(
+        "Invalid DataMessage dataSize=" + dataSize +
+          ", readable bytes after header=" + message.readableBytes());
     }
+    return new DataMessage(shuffleWriterId, shuffleReaderId, dataSize, message, checksum);
+  }
 
-    @Override
-    public void encode(CompositeByteBuf buf) {
-        super.encode(buf);
-        buf.writeInt(shuffleWriterId);
-        buf.writeInt(shuffleReaderId);
-        buf.writeInt(dataSize);
-        buf.writeLong(checksum);
-
-        // Only encode exactly `dataSize` bytes of `data`, so the wire payload matches the
-        // header's dataSize even if the underlying ByteBuf has additional readable bytes.
-        // retainedSlice() also bumps the refcount, so this DataMessage's ownedBuf reference
-        // remains valid for later release().
-        buf.addComponent(true, data.retainedSlice(data.readerIndex(), dataSize));
-    }
-
-    public static DataMessage decode(ByteBuf message) {
-        int shuffleWriterId = message.readInt();
-        int shuffleReaderId = message.readInt();
-        int dataSize = message.readInt();
-        long checksum = message.readLong();
-        // Each streaming-shuffle frame carries exactly one DataMessage, so after reading the
-        // header the remaining readable bytes must equal `dataSize`. Strict equality catches
-        // both undersized frames (truncation) and oversized frames (trailing garbage) at the
-        // wire boundary rather than letting them propagate to getRecordData() later.
-        if (dataSize < 0 || dataSize != message.readableBytes()) {
-            throw new IllegalArgumentException(
-                "Invalid DataMessage dataSize=" + dataSize +
-                    ", readable bytes after header=" + message.readableBytes());
-        }
-        return new DataMessage(shuffleWriterId, shuffleReaderId, dataSize, message, checksum);
-    }
-
-    /**
-     * Returns a slice of {@link #data} containing exactly the serialized records
-     * (i.e., {@code dataSize} bytes starting at the current reader index).
-     */
-    public ByteBuf getRecordData() {
-        return data.slice(data.readerIndex(), dataSize);
-    }
+  /**
+   * Returns a slice of {@link #data} containing exactly the serialized records
+   * (i.e., {@code dataSize} bytes starting at the current reader index).
+   */
+  public ByteBuf getRecordData() {
+    return data.slice(data.readerIndex(), dataSize);
+  }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/DataMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/DataMessage.java
@@ -30,6 +30,15 @@ public final class DataMessage extends StreamingShuffleMessage {
 
     public DataMessage(int shuffleWriterId, int shuffleReaderId, int dataSize, ByteBuf data,
                        long checksum) {
+        if (dataSize < 0) {
+            throw new IllegalArgumentException(
+                "dataSize must be non-negative: " + dataSize);
+        }
+        if (dataSize != data.readableBytes()) {
+            throw new IllegalArgumentException(
+                "dataSize must equal data.readableBytes(): " +
+                    dataSize + " != " + data.readableBytes());
+        }
         this.shuffleWriterId = shuffleWriterId;
         this.shuffleReaderId = shuffleReaderId;
         this.dataSize = dataSize;
@@ -58,9 +67,11 @@ public final class DataMessage extends StreamingShuffleMessage {
         buf.writeInt(dataSize);
         buf.writeLong(checksum);
 
-        // Adding data as a component to buf transfers ownership of data to buf. However,
-        // this DataMessage still has a reference to data, so we need to retain it here.
-        buf.addComponent(true, data.retain());
+        // Only encode exactly `dataSize` bytes of `data`, so the wire payload matches the
+        // header's dataSize even if the underlying ByteBuf has additional readable bytes.
+        // retainedSlice() also bumps the refcount, so this DataMessage's ownedBuf reference
+        // remains valid for later release().
+        buf.addComponent(true, data.retainedSlice(data.readerIndex(), dataSize));
     }
 
     public static DataMessage decode(ByteBuf message) {
@@ -68,9 +79,11 @@ public final class DataMessage extends StreamingShuffleMessage {
         int shuffleReaderId = message.readInt();
         int dataSize = message.readInt();
         long checksum = message.readLong();
-        // Validate dataSize at decode time so malformed frames fail at the wire boundary
-        // with a clear message, rather than later inside getRecordData().
-        if (dataSize < 0 || dataSize > message.readableBytes()) {
+        // Each streaming-shuffle frame carries exactly one DataMessage, so after reading the
+        // header the remaining readable bytes must equal `dataSize`. Strict equality catches
+        // both undersized frames (truncation) and oversized frames (trailing garbage) at the
+        // wire boundary rather than letting them propagate to getRecordData() later.
+        if (dataSize < 0 || dataSize != message.readableBytes()) {
             throw new IllegalArgumentException(
                 "Invalid DataMessage dataSize=" + dataSize +
                     ", readable bytes after header=" + message.readableBytes());

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/DataMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/DataMessage.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.streaming;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+
+public final class DataMessage extends StreamingShuffleMessage {
+
+    public ByteBuf data;
+    public int shuffleWriterId;
+    public int shuffleReaderId;
+    public int dataSize;
+    public long checksum;
+
+    public DataMessage(int shuffleWriterId, int shuffleReaderId, int dataSize, ByteBuf data,
+                       long checksum) {
+        this.shuffleWriterId = shuffleWriterId;
+        this.shuffleReaderId = shuffleReaderId;
+        this.dataSize = dataSize;
+        this.data = data;
+        this.ownedBuf = data.retain();
+        this.checksum = checksum;
+    }
+
+    @Override
+    public StreamingShuffleMessageType messageType() {
+        return StreamingShuffleMessageType.DATA_MESSAGE_UNSAFE_ROW;
+    }
+
+    @Override
+    public int headerLength() {
+        // 4 bytes EACH for shuffle writer ID, shuffle reader ID, data size
+        // 8 bytes for checksum
+        return super.headerLength() + 20;
+    }
+
+    @Override
+    public void encode(CompositeByteBuf buf) {
+        super.encode(buf);
+        buf.writeInt(shuffleWriterId);
+        buf.writeInt(shuffleReaderId);
+        buf.writeInt(dataSize);
+        buf.writeLong(checksum);
+
+        // Adding data as a component to buf transfers ownership of data to buf. However,
+        // this DataMessage still has a reference to data, so we need to retain it here.
+        buf.addComponent(true, data.retain());
+    }
+
+    public static DataMessage decode(ByteBuf message) {
+        int shuffleWriterId = message.readInt();
+        int shuffleReaderId = message.readInt();
+        int dataSize = message.readInt();
+        long checksum = message.readLong();
+        // Validate dataSize at decode time so malformed frames fail at the wire boundary
+        // with a clear message, rather than later inside getRecordData().
+        if (dataSize < 0 || dataSize > message.readableBytes()) {
+            throw new IllegalArgumentException(
+                "Invalid DataMessage dataSize=" + dataSize +
+                    ", readable bytes after header=" + message.readableBytes());
+        }
+        return new DataMessage(shuffleWriterId, shuffleReaderId, dataSize, message, checksum);
+    }
+
+    /**
+     * Returns a slice of {@link #data} containing exactly the serialized records
+     * (i.e., {@code dataSize} bytes starting at the current reader index).
+     */
+    public ByteBuf getRecordData() {
+        return data.slice(data.readerIndex(), dataSize);
+    }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/DataMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/DataMessage.java
@@ -20,6 +20,17 @@ package org.apache.spark.network.shuffle.streaming;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 
+/**
+ * Writer → reader data message. Carries a contiguous payload of serialized shuffle
+ * records together with the routing metadata (shuffleWriterId, shuffleReaderId,
+ * dataSize) and a CRC32C {@link #checksum} over the payload. Each DataMessage
+ * corresponds to one network frame on the streaming-shuffle wire.
+ *
+ * Memory ownership: the {@code data} ByteBuf passed to the constructor is retained
+ * once and stored as {@link #ownedBuf}, so callers must release their own reference
+ * separately. On {@link #release()} the retained reference is dropped. See the
+ * memory-ownership rules in {@link StreamingShuffleMessage}.
+ */
 public final class DataMessage extends StreamingShuffleMessage {
 
   public final ByteBuf data;

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/ShuffleChecksum.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/ShuffleChecksum.java
@@ -44,10 +44,13 @@ public final class ShuffleChecksum {
             throw new IllegalArgumentException(
                 "dataLength must be non-negative: " + dataLength);
         }
-        if (startIndex + dataLength > message.capacity()) {
+        // Bound the range against writerIndex() rather than capacity(): the checksum must
+        // cover actual written data only, never bytes in [writerIndex, capacity) which
+        // may be uninitialized.
+        if (startIndex + dataLength > message.writerIndex()) {
             throw new IllegalArgumentException(
-                "startIndex + dataLength exceeds buffer capacity: " +
-                    startIndex + " + " + dataLength + " > " + message.capacity());
+                "startIndex + dataLength exceeds writerIndex: " +
+                    startIndex + " + " + dataLength + " > " + message.writerIndex());
         }
         if (message.hasArray()) {
             // heap-based ByteBuf

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/ShuffleChecksum.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/ShuffleChecksum.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.streaming;
+
+import io.netty.buffer.ByteBuf;
+import java.util.zip.CRC32C;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Helper class for streaming shuffle checksum calculations.
+ */
+@NotThreadSafe
+public final class ShuffleChecksum {
+    private final CRC32C crc = new CRC32C();
+
+    /**
+     * Updates checksum for a specified portion of a ByteBuf message.
+     *
+     * @param message The ByteBuf to calculate checksum for
+     * @param startIndex The index of the first byte to calculate checksum for
+     * @param dataLength The length of the data to calculate checksum for
+     */
+    public void updateChecksum(ByteBuf message, int startIndex, int dataLength) {
+        if (startIndex < 0) {
+            throw new IllegalArgumentException(
+                "startIndex must be non-negative: " + startIndex);
+        }
+        if (dataLength < 0) {
+            throw new IllegalArgumentException(
+                "dataLength must be non-negative: " + dataLength);
+        }
+        if (startIndex + dataLength > message.capacity()) {
+            throw new IllegalArgumentException(
+                "startIndex + dataLength exceeds buffer capacity: " +
+                    startIndex + " + " + dataLength + " > " + message.capacity());
+        }
+        if (message.hasArray()) {
+            // heap-based ByteBuf
+            crc.update(message.array(), message.arrayOffset() + startIndex, dataLength);
+        } else {
+            // off-heap ByteBuf
+            crc.update(message.nioBuffer(startIndex, dataLength));
+        }
+    }
+
+    public long getValue() {
+        return crc.getValue();
+    }
+
+    public void reset() {
+        crc.reset();
+    }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/ShuffleChecksum.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/ShuffleChecksum.java
@@ -26,46 +26,46 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 public final class ShuffleChecksum {
-    private final CRC32C crc = new CRC32C();
+  private final CRC32C crc = new CRC32C();
 
-    /**
-     * Updates checksum for a specified portion of a ByteBuf message.
-     *
-     * @param message The ByteBuf to calculate checksum for
-     * @param startIndex The index of the first byte to calculate checksum for
-     * @param dataLength The length of the data to calculate checksum for
-     */
-    public void updateChecksum(ByteBuf message, int startIndex, int dataLength) {
-        if (startIndex < 0) {
-            throw new IllegalArgumentException(
-                "startIndex must be non-negative: " + startIndex);
-        }
-        if (dataLength < 0) {
-            throw new IllegalArgumentException(
-                "dataLength must be non-negative: " + dataLength);
-        }
-        // Bound the range against writerIndex() rather than capacity(): the checksum must
-        // cover actual written data only, never bytes in [writerIndex, capacity) which
-        // may be uninitialized.
-        if (startIndex + dataLength > message.writerIndex()) {
-            throw new IllegalArgumentException(
-                "startIndex + dataLength exceeds writerIndex: " +
-                    startIndex + " + " + dataLength + " > " + message.writerIndex());
-        }
-        if (message.hasArray()) {
-            // heap-based ByteBuf
-            crc.update(message.array(), message.arrayOffset() + startIndex, dataLength);
-        } else {
-            // off-heap ByteBuf
-            crc.update(message.nioBuffer(startIndex, dataLength));
-        }
+  /**
+   * Updates checksum for a specified portion of a ByteBuf message.
+   *
+   * @param message The ByteBuf to calculate checksum for
+   * @param startIndex The index of the first byte to calculate checksum for
+   * @param dataLength The length of the data to calculate checksum for
+   */
+  public void updateChecksum(ByteBuf message, int startIndex, int dataLength) {
+    if (startIndex < 0) {
+      throw new IllegalArgumentException(
+        "startIndex must be non-negative: " + startIndex);
     }
+    if (dataLength < 0) {
+      throw new IllegalArgumentException(
+        "dataLength must be non-negative: " + dataLength);
+    }
+    // Bound the range against writerIndex() rather than capacity(): the checksum must
+    // cover actual written data only, never bytes in [writerIndex, capacity) which
+    // may be uninitialized.
+    if (startIndex + dataLength > message.writerIndex()) {
+      throw new IllegalArgumentException(
+        "startIndex + dataLength exceeds writerIndex: " +
+          startIndex + " + " + dataLength + " > " + message.writerIndex());
+    }
+    if (message.hasArray()) {
+      // heap-based ByteBuf
+      crc.update(message.array(), message.arrayOffset() + startIndex, dataLength);
+    } else {
+      // off-heap ByteBuf
+      crc.update(message.nioBuffer(startIndex, dataLength));
+    }
+  }
 
-    public long getValue() {
-        return crc.getValue();
-    }
+  public long getValue() {
+    return crc.getValue();
+  }
 
-    public void reset() {
-        crc.reset();
-    }
+  public void reset() {
+    crc.reset();
+  }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessage.java
@@ -81,11 +81,28 @@ public abstract sealed class StreamingShuffleMessage
     buf.writeLong(seqNum);
   }
 
+  /**
+   * Returns the number of bytes the encoded message header occupies on the wire.
+   *
+   * For control messages (CreditControl, TerminationControl, TerminationAck) this is
+   * the full encoded length of the message. For {@link DataMessage} this is the header
+   * size only; the variable-length payload of {@code dataSize} bytes follows the header
+   * and is NOT included in this count. Callers use this value to pre-size the
+   * {@link CompositeByteBuf} that the encoded message is written into.
+   */
   public int headerLength() {
     // 4 bytes for message type, 8 bytes for the sequence number
     return 12;
   }
 
+  /**
+   * Registers a callback that will be invoked exactly once when {@link #release()}
+   * runs to completion. The callback runs AFTER {@code ownedBuf.release()} and is
+   * cleared after invocation, so a subsequent {@code release()} call on the same
+   * thread will not re-run it.
+   *
+   * Replaces any previously-registered callback. Not thread-safe; see {@link #release()}.
+   */
   public void setReleaseCallback(Runnable releaseCallback) {
     this.releaseCallback = releaseCallback;
   }

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessage.java
@@ -93,7 +93,8 @@ public abstract sealed class StreamingShuffleMessage
     /**
      * Releases any resources associated with this message.
      * In VERY RARE cases when the task fails unexpectedly, this method may be called twice.
-     * Implementations should not panic in such a case.
+     * This method is idempotent — a second call on the same thread is a no-op — but it is
+     * NOT thread-safe.
      */
     public void release() {
         if (ownedBuf != null) {
@@ -111,30 +112,15 @@ public abstract sealed class StreamingShuffleMessage
             StreamingShuffleMessageType.decode(message.readInt());
         long seqNum = message.readLong();
 
-        StreamingShuffleMessage shuffleMessage = null;
-
-        switch (messageType) {
-            case DATA_MESSAGE_UNSAFE_ROW:
-                shuffleMessage = DataMessage.decode(message);
-                break;
-            case CREDIT_CONTROL_MESSAGE:
-                shuffleMessage = CreditControlMessage.decode(message);
-                break;
-            case TERMINATION_CONTROL_MESSAGE:
-                shuffleMessage = TerminationControlMessage.decode(message);
-                break;
-            case TERMINATION_ACK_MESSAGE:
-                shuffleMessage = TerminationAckMessage.decode(message);
-                break;
-            default:
-                // Should not reach here: StreamingShuffleMessageType.decode() above already
-                // throws IllegalArgumentException for any unknown message-type ordinal, so
-                // messageType is guaranteed to be one of the four enum values handled above.
-                throw new IllegalStateException(
-                    "Unexpected StreamingShuffleMessageType: " + messageType);
-        }
-
-        // shuffleMessage cannot be null
+        // Switch expression over the enum is exhaustive; the compiler enforces that every
+        // case is handled, so any future StreamingShuffleMessageType added to the enum will
+        // cause this method to fail compilation until the corresponding case is added here.
+        StreamingShuffleMessage shuffleMessage = switch (messageType) {
+            case DATA_MESSAGE_UNSAFE_ROW -> DataMessage.decode(message);
+            case CREDIT_CONTROL_MESSAGE -> CreditControlMessage.decode(message);
+            case TERMINATION_CONTROL_MESSAGE -> TerminationControlMessage.decode(message);
+            case TERMINATION_ACK_MESSAGE -> TerminationAckMessage.decode(message);
+        };
         shuffleMessage.setSeqNum(seqNum);
 
         return shuffleMessage;

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessage.java
@@ -49,81 +49,81 @@ import io.netty.buffer.CompositeByteBuf;
  *     how to do this properly.
  */
 public abstract sealed class StreamingShuffleMessage
-    permits CreditControlMessage, DataMessage, TerminationAckMessage, TerminationControlMessage {
-    protected ByteBuf ownedBuf = null;
-    private Runnable releaseCallback = null;
+  permits CreditControlMessage, DataMessage, TerminationAckMessage, TerminationControlMessage {
+  protected ByteBuf ownedBuf = null;
+  private Runnable releaseCallback = null;
 
-    // To prevent any duplicate/out of order/missing messages, each writer will track the current
-    // max sequence number that has been sent to each reader. Similarly, each reader will track
-    // the latest sequence number it has received from each writer. Upon receiving a new message
-    // from any writer, reader will check if the sequence number is expected. When all finish, the
-    // reader will send TerminationAckMessage to the writer with the max sequence number that has
-    // been received, and the writer will check if the latest sequence recorded matches it.
+  // To prevent any duplicate/out of order/missing messages, each writer will track the current
+  // max sequence number that has been sent to each reader. Similarly, each reader will track
+  // the latest sequence number it has received from each writer. Upon receiving a new message
+  // from any writer, reader will check if the sequence number is expected. When all finish, the
+  // reader will send TerminationAckMessage to the writer with the max sequence number that has
+  // been received, and the writer will check if the latest sequence recorded matches it.
 
-    // Thus the sequence number is valid for the following message types:
-    // 1. all message types from a writer to a reader. To make sure that the reader
-    // receive all the messages sent by writer in order without missing or duplicate any.
-    // 2. TerminationAckMessage from a reader to a writer. To make sure at the end of the
-    // shuffle, the reader receives the same number of messages that the writer has sent.
-    // Essentially, other message types from reader to writer won't have a valid sequence number.
-    private long seqNum;
-    public void setSeqNum(long seqNum) {
-        this.seqNum = seqNum;
+  // Thus the sequence number is valid for the following message types:
+  // 1. all message types from a writer to a reader. To make sure that the reader
+  // receive all the messages sent by writer in order without missing or duplicate any.
+  // 2. TerminationAckMessage from a reader to a writer. To make sure at the end of the
+  // shuffle, the reader receives the same number of messages that the writer has sent.
+  // Essentially, other message types from reader to writer won't have a valid sequence number.
+  private long seqNum;
+  public void setSeqNum(long seqNum) {
+    this.seqNum = seqNum;
+  }
+  public long getSeqNum() { return seqNum; }
+
+  /** Returns the type of this message. */
+  public abstract StreamingShuffleMessageType messageType();
+
+  /** Encodes the current message into the provided ByteBuf. */
+  public void encode(CompositeByteBuf buf) {
+    buf.writeInt(messageType().id());
+    buf.writeLong(seqNum);
+  }
+
+  public int headerLength() {
+    // 4 bytes for message type, 8 bytes for the sequence number
+    return 12;
+  }
+
+  public void setReleaseCallback(Runnable releaseCallback) {
+    this.releaseCallback = releaseCallback;
+  }
+
+  /**
+   * Releases any resources associated with this message.
+   * In VERY RARE cases when the task fails unexpectedly, this method may be called twice.
+   * This method is idempotent — a second call on the same thread is a no-op — but it is
+   * NOT thread-safe.
+   */
+  public void release() {
+    if (ownedBuf != null) {
+      ownedBuf.release();
+      ownedBuf = null;
     }
-    public long getSeqNum() { return seqNum; }
-
-    /** Returns the type of this message. */
-    public abstract StreamingShuffleMessageType messageType();
-
-    /** Encodes the current message into the provided ByteBuf. */
-    public void encode(CompositeByteBuf buf) {
-        buf.writeInt(messageType().id());
-        buf.writeLong(seqNum);
+    if (releaseCallback != null) {
+      releaseCallback.run();
+      releaseCallback = null;
     }
+  }
 
-    public int headerLength() {
-        // 4 bytes for message type, 8 bytes for the sequence number
-        return 12;
-    }
+  public static StreamingShuffleMessage decode(ByteBuf message) {
+    StreamingShuffleMessageType messageType =
+      StreamingShuffleMessageType.decode(message.readInt());
+    long seqNum = message.readLong();
 
-    public void setReleaseCallback(Runnable releaseCallback) {
-        this.releaseCallback = releaseCallback;
-    }
+    // Switch expression over the enum is exhaustive; the compiler enforces that every
+    // case is handled, so any future StreamingShuffleMessageType added to the enum will
+    // cause this method to fail compilation until the corresponding case is added here.
+    StreamingShuffleMessage shuffleMessage = switch (messageType) {
+      case DATA_MESSAGE_UNSAFE_ROW -> DataMessage.decode(message);
+      case CREDIT_CONTROL_MESSAGE -> CreditControlMessage.decode(message);
+      case TERMINATION_CONTROL_MESSAGE -> TerminationControlMessage.decode(message);
+      case TERMINATION_ACK_MESSAGE -> TerminationAckMessage.decode(message);
+    };
+    shuffleMessage.setSeqNum(seqNum);
 
-    /**
-     * Releases any resources associated with this message.
-     * In VERY RARE cases when the task fails unexpectedly, this method may be called twice.
-     * This method is idempotent — a second call on the same thread is a no-op — but it is
-     * NOT thread-safe.
-     */
-    public void release() {
-        if (ownedBuf != null) {
-            ownedBuf.release();
-            ownedBuf = null;
-        }
-        if (releaseCallback != null) {
-            releaseCallback.run();
-            releaseCallback = null;
-        }
-    }
-
-    public static StreamingShuffleMessage decode(ByteBuf message) {
-        StreamingShuffleMessageType messageType =
-            StreamingShuffleMessageType.decode(message.readInt());
-        long seqNum = message.readLong();
-
-        // Switch expression over the enum is exhaustive; the compiler enforces that every
-        // case is handled, so any future StreamingShuffleMessageType added to the enum will
-        // cause this method to fail compilation until the corresponding case is added here.
-        StreamingShuffleMessage shuffleMessage = switch (messageType) {
-            case DATA_MESSAGE_UNSAFE_ROW -> DataMessage.decode(message);
-            case CREDIT_CONTROL_MESSAGE -> CreditControlMessage.decode(message);
-            case TERMINATION_CONTROL_MESSAGE -> TerminationControlMessage.decode(message);
-            case TERMINATION_ACK_MESSAGE -> TerminationAckMessage.decode(message);
-        };
-        shuffleMessage.setSeqNum(seqNum);
-
-        return shuffleMessage;
-    }
+    return shuffleMessage;
+  }
 
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessage.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.streaming;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+
+/**
+ * Base class for messages sent between the streaming shuffle writers (usually mappers) and
+ * readers (usually reducers).
+ *
+ * To prevent memory leaks, streaming shuffle programmers should always abide by the following
+ * principles:
+ *
+ *  1. If you create a buffer via ByteBufAllocator, you must explicitly release it.
+ *  2. If you create a new StreamingShuffleMessage, you must call .release() on it.
+ *
+ * To make these rules work out, implementations of StreamingShuffleMessage should abide
+ * by the following rules:
+ *
+ *  1. StreamingShuffleMessages should *not* modify the refcount of ByteBufs passed to them
+ *     during encoding. For message implementations without ByteBufs, this isn't a concern.
+ *     But for messages that have ByteBufs (e.g. DataMessage), the encoding method will likely
+ *     call compositeByteBuf.addComponent(), which transfers ownership of the ByteBuf to the
+ *     CompositeByteBuf and decrements the refcount of the ByteBuf. So that the caller can
+ *     *always* follow rule 1 above, the ByteBuf should be retained before being passed to the
+ *     CompositeByteBuf; if this is not done, the refcount of the ByteBuf after leaving
+ *     encode() will be 0, and if the caller follows rule 1, they will try to decrement an
+ *     already 0 refcount. See DataMessage for an example of how to do this properly.
+ *  2. If StreamingShuffleMessages keep a reference the ByteBufs passed to them during
+ *     decoding, they should increment the refcount of that ByteBuf, and assign it to
+ *     ownedBuf. This is so that resources get cleaned up when callers follow rule 2 above,
+ *     i.e. call .release() on the StreamingShuffleMessage. See DataMessage for an example of
+ *     how to do this properly.
+ */
+public abstract sealed class StreamingShuffleMessage
+    permits CreditControlMessage, DataMessage, TerminationAckMessage, TerminationControlMessage {
+    protected ByteBuf ownedBuf = null;
+    private Runnable releaseCallback = null;
+
+    // To prevent any duplicate/out of order/missing messages, each writer will track the current
+    // max sequence number that has been sent to each reader. Similarly, each reader will track
+    // the latest sequence number it has received from each writer. Upon receiving a new message
+    // from any writer, reader will check if the sequence number is expected. When all finish, the
+    // reader will send TerminationAckMessage to the writer with the max sequence number that has
+    // been received, and the writer will check if the latest sequence recorded matches it.
+
+    // Thus the sequence number is valid for the following message types:
+    // 1. all message types from a writer to a reader. To make sure that the reader
+    // receive all the messages sent by writer in order without missing or duplicate any.
+    // 2. TerminationAckMessage from a reader to a writer. To make sure at the end of the
+    // shuffle, the reader receives the same number of messages that the writer has sent.
+    // Essentially, other message types from reader to writer won't have a valid sequence number.
+    private long seqNum;
+    public void setSeqNum(long seqNum) {
+        this.seqNum = seqNum;
+    }
+    public long getSeqNum() { return seqNum; }
+
+    /** Returns the type of this message. */
+    public abstract StreamingShuffleMessageType messageType();
+
+    /** Encodes the current message into the provided ByteBuf. */
+    public void encode(CompositeByteBuf buf) {
+        buf.writeInt(messageType().id());
+        buf.writeLong(seqNum);
+    }
+
+    public int headerLength() {
+        // 4 bytes for message type, 8 bytes for the sequence number
+        return 12;
+    }
+
+    public void setReleaseCallback(Runnable releaseCallback) {
+        this.releaseCallback = releaseCallback;
+    }
+
+    /**
+     * Releases any resources associated with this message.
+     * In VERY RARE cases when the task fails unexpectedly, this method may be called twice.
+     * Implementations should not panic in such a case.
+     */
+    public void release() {
+        if (ownedBuf != null) {
+            ownedBuf.release();
+            ownedBuf = null;
+        }
+        if (releaseCallback != null) {
+            releaseCallback.run();
+            releaseCallback = null;
+        }
+    }
+
+    public static StreamingShuffleMessage decode(ByteBuf message) {
+        StreamingShuffleMessageType messageType =
+            StreamingShuffleMessageType.decode(message.readInt());
+        long seqNum = message.readLong();
+
+        StreamingShuffleMessage shuffleMessage = null;
+
+        switch (messageType) {
+            case DATA_MESSAGE_UNSAFE_ROW:
+                shuffleMessage = DataMessage.decode(message);
+                break;
+            case CREDIT_CONTROL_MESSAGE:
+                shuffleMessage = CreditControlMessage.decode(message);
+                break;
+            case TERMINATION_CONTROL_MESSAGE:
+                shuffleMessage = TerminationControlMessage.decode(message);
+                break;
+            case TERMINATION_ACK_MESSAGE:
+                shuffleMessage = TerminationAckMessage.decode(message);
+                break;
+            default:
+                // Should not reach here: StreamingShuffleMessageType.decode() above already
+                // throws IllegalArgumentException for any unknown message-type ordinal, so
+                // messageType is guaranteed to be one of the four enum values handled above.
+                throw new IllegalStateException(
+                    "Unexpected StreamingShuffleMessageType: " + messageType);
+        }
+
+        // shuffleMessage cannot be null
+        shuffleMessage.setSeqNum(seqNum);
+
+        return shuffleMessage;
+    }
+
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageType.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageType.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.streaming;
+
+public enum StreamingShuffleMessageType {
+    DATA_MESSAGE_UNSAFE_ROW(1),
+    CREDIT_CONTROL_MESSAGE(2),
+    TERMINATION_CONTROL_MESSAGE(3),
+    TERMINATION_ACK_MESSAGE(4);
+
+    private final int id;
+
+    StreamingShuffleMessageType(int id) {
+        this.id = id;
+    }
+
+    public int id() {
+        return id;
+    }
+
+    public static StreamingShuffleMessageType decode(int givenId) {
+        switch (givenId) {
+            case 1:
+                return DATA_MESSAGE_UNSAFE_ROW;
+            case 2:
+                return CREDIT_CONTROL_MESSAGE;
+            case 3:
+                return TERMINATION_CONTROL_MESSAGE;
+            case 4:
+                return TERMINATION_ACK_MESSAGE;
+            default:
+                throw new IllegalArgumentException("Unknown message type: " + givenId);
+        }
+    }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageType.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageType.java
@@ -18,28 +18,28 @@
 package org.apache.spark.network.shuffle.streaming;
 
 public enum StreamingShuffleMessageType {
-    DATA_MESSAGE_UNSAFE_ROW(1),
-    CREDIT_CONTROL_MESSAGE(2),
-    TERMINATION_CONTROL_MESSAGE(3),
-    TERMINATION_ACK_MESSAGE(4);
+  DATA_MESSAGE_UNSAFE_ROW(1),
+  CREDIT_CONTROL_MESSAGE(2),
+  TERMINATION_CONTROL_MESSAGE(3),
+  TERMINATION_ACK_MESSAGE(4);
 
-    private final int id;
+  private final int id;
 
-    StreamingShuffleMessageType(int id) {
-        this.id = id;
-    }
+  StreamingShuffleMessageType(int id) {
+    this.id = id;
+  }
 
-    public int id() {
-        return id;
-    }
+  public int id() {
+    return id;
+  }
 
-    public static StreamingShuffleMessageType decode(int givenId) {
-        return switch (givenId) {
-            case 1 -> DATA_MESSAGE_UNSAFE_ROW;
-            case 2 -> CREDIT_CONTROL_MESSAGE;
-            case 3 -> TERMINATION_CONTROL_MESSAGE;
-            case 4 -> TERMINATION_ACK_MESSAGE;
-            default -> throw new IllegalArgumentException("Unknown message type: " + givenId);
-        };
-    }
+  public static StreamingShuffleMessageType decode(int givenId) {
+    return switch (givenId) {
+      case 1 -> DATA_MESSAGE_UNSAFE_ROW;
+      case 2 -> CREDIT_CONTROL_MESSAGE;
+      case 3 -> TERMINATION_CONTROL_MESSAGE;
+      case 4 -> TERMINATION_ACK_MESSAGE;
+      default -> throw new IllegalArgumentException("Unknown message type: " + givenId);
+    };
+  }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageType.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageType.java
@@ -34,17 +34,12 @@ public enum StreamingShuffleMessageType {
     }
 
     public static StreamingShuffleMessageType decode(int givenId) {
-        switch (givenId) {
-            case 1:
-                return DATA_MESSAGE_UNSAFE_ROW;
-            case 2:
-                return CREDIT_CONTROL_MESSAGE;
-            case 3:
-                return TERMINATION_CONTROL_MESSAGE;
-            case 4:
-                return TERMINATION_ACK_MESSAGE;
-            default:
-                throw new IllegalArgumentException("Unknown message type: " + givenId);
-        }
+        return switch (givenId) {
+            case 1 -> DATA_MESSAGE_UNSAFE_ROW;
+            case 2 -> CREDIT_CONTROL_MESSAGE;
+            case 3 -> TERMINATION_CONTROL_MESSAGE;
+            case 4 -> TERMINATION_ACK_MESSAGE;
+            default -> throw new IllegalArgumentException("Unknown message type: " + givenId);
+        };
     }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationAckMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationAckMessage.java
@@ -21,8 +21,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 
 public final class TerminationAckMessage extends StreamingShuffleMessage {
-    public int shuffleWriterId;
-    public int shuffleReaderId;
+    public final int shuffleWriterId;
+    public final int shuffleReaderId;
 
     public TerminationAckMessage(int shuffleWriterId, int shuffleReaderId) {
         this.shuffleWriterId = shuffleWriterId;

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationAckMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationAckMessage.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.streaming;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+
+public final class TerminationAckMessage extends StreamingShuffleMessage {
+    public int shuffleWriterId;
+    public int shuffleReaderId;
+
+    public TerminationAckMessage(int shuffleWriterId, int shuffleReaderId) {
+        this.shuffleWriterId = shuffleWriterId;
+        this.shuffleReaderId = shuffleReaderId;
+    }
+
+    @Override
+    public StreamingShuffleMessageType messageType() {
+        return StreamingShuffleMessageType.TERMINATION_ACK_MESSAGE;
+    }
+
+    @Override
+    public int headerLength() {
+        // 4 bytes for the shuffle writer ID, 4 bytes for the shuffle reader ID
+        return super.headerLength() + 8;
+    }
+
+    @Override
+    public void encode(CompositeByteBuf buf) {
+        super.encode(buf);
+
+        // Write the shuffle writer ID
+        buf.writeInt(shuffleWriterId);
+        // Write the shuffle reader ID
+        buf.writeInt(shuffleReaderId);
+    }
+
+    public static TerminationAckMessage decode(ByteBuf buf) {
+        // Read the shuffle writer ID
+        int shuffleWriterId = buf.readInt();
+        // Read the shuffle reader ID
+        int shuffleReaderId = buf.readInt();
+
+        return new TerminationAckMessage(shuffleWriterId, shuffleReaderId);
+    }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationAckMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationAckMessage.java
@@ -21,41 +21,41 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 
 public final class TerminationAckMessage extends StreamingShuffleMessage {
-    public final int shuffleWriterId;
-    public final int shuffleReaderId;
+  public final int shuffleWriterId;
+  public final int shuffleReaderId;
 
-    public TerminationAckMessage(int shuffleWriterId, int shuffleReaderId) {
-        this.shuffleWriterId = shuffleWriterId;
-        this.shuffleReaderId = shuffleReaderId;
-    }
+  public TerminationAckMessage(int shuffleWriterId, int shuffleReaderId) {
+    this.shuffleWriterId = shuffleWriterId;
+    this.shuffleReaderId = shuffleReaderId;
+  }
 
-    @Override
-    public StreamingShuffleMessageType messageType() {
-        return StreamingShuffleMessageType.TERMINATION_ACK_MESSAGE;
-    }
+  @Override
+  public StreamingShuffleMessageType messageType() {
+    return StreamingShuffleMessageType.TERMINATION_ACK_MESSAGE;
+  }
 
-    @Override
-    public int headerLength() {
-        // 4 bytes for the shuffle writer ID, 4 bytes for the shuffle reader ID
-        return super.headerLength() + 8;
-    }
+  @Override
+  public int headerLength() {
+    // 4 bytes for the shuffle writer ID, 4 bytes for the shuffle reader ID
+    return super.headerLength() + 8;
+  }
 
-    @Override
-    public void encode(CompositeByteBuf buf) {
-        super.encode(buf);
+  @Override
+  public void encode(CompositeByteBuf buf) {
+    super.encode(buf);
 
-        // Write the shuffle writer ID
-        buf.writeInt(shuffleWriterId);
-        // Write the shuffle reader ID
-        buf.writeInt(shuffleReaderId);
-    }
+    // Write the shuffle writer ID
+    buf.writeInt(shuffleWriterId);
+    // Write the shuffle reader ID
+    buf.writeInt(shuffleReaderId);
+  }
 
-    public static TerminationAckMessage decode(ByteBuf buf) {
-        // Read the shuffle writer ID
-        int shuffleWriterId = buf.readInt();
-        // Read the shuffle reader ID
-        int shuffleReaderId = buf.readInt();
+  public static TerminationAckMessage decode(ByteBuf buf) {
+    // Read the shuffle writer ID
+    int shuffleWriterId = buf.readInt();
+    // Read the shuffle reader ID
+    int shuffleReaderId = buf.readInt();
 
-        return new TerminationAckMessage(shuffleWriterId, shuffleReaderId);
-    }
+    return new TerminationAckMessage(shuffleWriterId, shuffleReaderId);
+  }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationAckMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationAckMessage.java
@@ -20,6 +20,13 @@ package org.apache.spark.network.shuffle.streaming;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 
+/**
+ * Reader → writer acknowledgement of {@link TerminationControlMessage}. The
+ * {@code seqNum} field carries the last sequence number the reader observed from
+ * this writer; the writer compares that value against its own last-sent sequence
+ * number to detect lost or reordered messages, failing the task with
+ * STREAMING_SHUFFLE_INCORRECT_SEQUENCE_NUMBER on mismatch.
+ */
 public final class TerminationAckMessage extends StreamingShuffleMessage {
   public final int shuffleWriterId;
   public final int shuffleReaderId;

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationControlMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationControlMessage.java
@@ -20,6 +20,13 @@ package org.apache.spark.network.shuffle.streaming;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 
+/**
+ * Writer → reader control message that signals end-of-stream. After a writer has
+ * sent its last {@link DataMessage} to a given reader it sends one
+ * TerminationControlMessage on the same connection and waits for the matching
+ * {@link TerminationAckMessage} back. Receipt of this message tells the reader
+ * that no further DataMessages will arrive from this writer.
+ */
 public final class TerminationControlMessage extends StreamingShuffleMessage {
   public final int shuffleWriterId;
   public final int shuffleReaderId;

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationControlMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationControlMessage.java
@@ -21,8 +21,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 
 public final class TerminationControlMessage extends StreamingShuffleMessage {
-    public int shuffleWriterId;
-    public int shuffleReaderId;
+    public final int shuffleWriterId;
+    public final int shuffleReaderId;
 
     public TerminationControlMessage(int shuffleWriterId, int shuffleReaderId) {
         this.shuffleWriterId = shuffleWriterId;

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationControlMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationControlMessage.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.streaming;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+
+public final class TerminationControlMessage extends StreamingShuffleMessage {
+    public int shuffleWriterId;
+    public int shuffleReaderId;
+
+    public TerminationControlMessage(int shuffleWriterId, int shuffleReaderId) {
+        this.shuffleWriterId = shuffleWriterId;
+        this.shuffleReaderId = shuffleReaderId;
+    }
+
+    @Override
+    public StreamingShuffleMessageType messageType() {
+        return StreamingShuffleMessageType.TERMINATION_CONTROL_MESSAGE;
+    }
+
+    @Override
+    public int headerLength() {
+        // 4 bytes for the shuffle writer ID, 4 bytes for the shuffle reader ID
+        return super.headerLength() + 8;
+    }
+
+    @Override
+    public void encode(CompositeByteBuf buf) {
+        super.encode(buf);
+
+        // Write the shuffle writer ID
+        buf.writeInt(shuffleWriterId);
+        // Write the shuffle reader ID
+        buf.writeInt(shuffleReaderId);
+    }
+
+    public static TerminationControlMessage decode(ByteBuf buf) {
+        // Read the shuffle writer ID
+        int shuffleWriterId = buf.readInt();
+        // Read the shuffle reader ID
+        int shuffleReaderId = buf.readInt();
+
+        return new TerminationControlMessage(shuffleWriterId, shuffleReaderId);
+    }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationControlMessage.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffle/streaming/TerminationControlMessage.java
@@ -21,41 +21,41 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 
 public final class TerminationControlMessage extends StreamingShuffleMessage {
-    public final int shuffleWriterId;
-    public final int shuffleReaderId;
+  public final int shuffleWriterId;
+  public final int shuffleReaderId;
 
-    public TerminationControlMessage(int shuffleWriterId, int shuffleReaderId) {
-        this.shuffleWriterId = shuffleWriterId;
-        this.shuffleReaderId = shuffleReaderId;
-    }
+  public TerminationControlMessage(int shuffleWriterId, int shuffleReaderId) {
+    this.shuffleWriterId = shuffleWriterId;
+    this.shuffleReaderId = shuffleReaderId;
+  }
 
-    @Override
-    public StreamingShuffleMessageType messageType() {
-        return StreamingShuffleMessageType.TERMINATION_CONTROL_MESSAGE;
-    }
+  @Override
+  public StreamingShuffleMessageType messageType() {
+    return StreamingShuffleMessageType.TERMINATION_CONTROL_MESSAGE;
+  }
 
-    @Override
-    public int headerLength() {
-        // 4 bytes for the shuffle writer ID, 4 bytes for the shuffle reader ID
-        return super.headerLength() + 8;
-    }
+  @Override
+  public int headerLength() {
+    // 4 bytes for the shuffle writer ID, 4 bytes for the shuffle reader ID
+    return super.headerLength() + 8;
+  }
 
-    @Override
-    public void encode(CompositeByteBuf buf) {
-        super.encode(buf);
+  @Override
+  public void encode(CompositeByteBuf buf) {
+    super.encode(buf);
 
-        // Write the shuffle writer ID
-        buf.writeInt(shuffleWriterId);
-        // Write the shuffle reader ID
-        buf.writeInt(shuffleReaderId);
-    }
+    // Write the shuffle writer ID
+    buf.writeInt(shuffleWriterId);
+    // Write the shuffle reader ID
+    buf.writeInt(shuffleReaderId);
+  }
 
-    public static TerminationControlMessage decode(ByteBuf buf) {
-        // Read the shuffle writer ID
-        int shuffleWriterId = buf.readInt();
-        // Read the shuffle reader ID
-        int shuffleReaderId = buf.readInt();
+  public static TerminationControlMessage decode(ByteBuf buf) {
+    // Read the shuffle writer ID
+    int shuffleWriterId = buf.readInt();
+    // Read the shuffle reader ID
+    int shuffleReaderId = buf.readInt();
 
-        return new TerminationControlMessage(shuffleWriterId, shuffleReaderId);
-    }
+    return new TerminationControlMessage(shuffleWriterId, shuffleReaderId);
+  }
 }

--- a/common/network-common/src/test/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageSuite.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.streaming;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link StreamingShuffleMessage} encode/decode round-trips and
+ * {@link ShuffleChecksum}.
+ */
+public class StreamingShuffleMessageSuite {
+
+  private static final int SEQ_NUM = 42;
+
+  // ---- helpers ---------------------------------------------------------------
+
+  private ByteBuf encodeAndSlice(StreamingShuffleMessage msg) {
+    msg.setSeqNum(SEQ_NUM);
+    CompositeByteBuf buf = Unpooled.compositeBuffer();
+    buf.capacity(msg.headerLength());
+    msg.encode(buf);
+    msg.release();
+    // Return a copy so we can freely advance the reader index
+    ByteBuf copy = Unpooled.buffer(buf.readableBytes());
+    copy.writeBytes(buf);
+    buf.release();
+    return copy;
+  }
+
+  // ---- CreditControlMessage --------------------------------------------------
+
+  @Test
+  public void testCreditControlRoundTrip() {
+    CreditControlMessage original = new CreditControlMessage(3, 7, 5);
+    ByteBuf encoded = encodeAndSlice(original);
+    try {
+      StreamingShuffleMessage decoded = StreamingShuffleMessage.decode(encoded);
+      assertInstanceOf(CreditControlMessage.class, decoded);
+      CreditControlMessage credit = (CreditControlMessage) decoded;
+      assertEquals(SEQ_NUM, credit.getSeqNum());
+      assertEquals(3, credit.shuffleWriterId);
+      assertEquals(7, credit.shuffleReaderId);
+      assertEquals(5, credit.numMessages);
+    } finally {
+      encoded.release();
+    }
+  }
+
+  // ---- TerminationControlMessage ---------------------------------------------
+
+  @Test
+  public void testTerminationControlRoundTrip() {
+    TerminationControlMessage original = new TerminationControlMessage(1, 2);
+    ByteBuf encoded = encodeAndSlice(original);
+    try {
+      StreamingShuffleMessage decoded = StreamingShuffleMessage.decode(encoded);
+      assertInstanceOf(TerminationControlMessage.class, decoded);
+      TerminationControlMessage term = (TerminationControlMessage) decoded;
+      assertEquals(SEQ_NUM, term.getSeqNum());
+      assertEquals(1, term.shuffleWriterId);
+      assertEquals(2, term.shuffleReaderId);
+    } finally {
+      encoded.release();
+    }
+  }
+
+  // ---- TerminationAckMessage -------------------------------------------------
+
+  @Test
+  public void testTerminationAckRoundTrip() {
+    TerminationAckMessage original = new TerminationAckMessage(4, 8);
+    original.setSeqNum(99);  // echo back last seen seqNum
+    CompositeByteBuf buf = Unpooled.compositeBuffer();
+    buf.capacity(original.headerLength());
+    original.encode(buf);
+    ByteBuf copy = Unpooled.buffer(buf.readableBytes());
+    copy.writeBytes(buf);
+    buf.release();
+
+    try {
+      StreamingShuffleMessage decoded = StreamingShuffleMessage.decode(copy);
+      assertInstanceOf(TerminationAckMessage.class, decoded);
+      TerminationAckMessage ack = (TerminationAckMessage) decoded;
+      assertEquals(99, ack.getSeqNum());
+      assertEquals(4, ack.shuffleWriterId);
+      assertEquals(8, ack.shuffleReaderId);
+    } finally {
+      copy.release();
+    }
+  }
+
+  // ---- DataMessage -----------------------------------------------------------
+
+  @Test
+  public void testDataMessageRoundTrip() {
+    byte[] payload = "hello streaming shuffle".getBytes();
+    ByteBuf payloadBuf = Unpooled.wrappedBuffer(payload);
+    long checksum = 0xDEADBEEFL;
+
+    DataMessage original = new DataMessage(2, 5, payload.length, payloadBuf, checksum);
+    original.setSeqNum(10);
+    CompositeByteBuf buf = Unpooled.compositeBuffer();
+    buf.capacity(original.headerLength());
+    original.encode(buf);
+    original.release();
+    payloadBuf.release();
+
+    ByteBuf copy = Unpooled.buffer(buf.readableBytes());
+    copy.writeBytes(buf);
+    buf.release();
+
+    try {
+      StreamingShuffleMessage decoded = StreamingShuffleMessage.decode(copy);
+      assertInstanceOf(DataMessage.class, decoded);
+      DataMessage dm = (DataMessage) decoded;
+      assertEquals(10, dm.getSeqNum());
+      assertEquals(2, dm.shuffleWriterId);
+      assertEquals(5, dm.shuffleReaderId);
+      assertEquals(payload.length, dm.dataSize);
+      assertEquals(checksum, dm.checksum);
+
+      ByteBuf recordData = dm.getRecordData();
+      byte[] out = new byte[payload.length];
+      recordData.readBytes(out);
+      assertArrayEquals(payload, out);
+      dm.release();
+    } finally {
+      copy.release();
+    }
+  }
+
+  // ---- ShuffleChecksum -------------------------------------------------------
+
+  @Test
+  public void testShuffleChecksumHeapBuffer() {
+    byte[] data = {1, 2, 3, 4, 5};
+    ByteBuf buf = Unpooled.wrappedBuffer(data); // heap-backed
+
+    ShuffleChecksum cs = new ShuffleChecksum();
+    cs.updateChecksum(buf, 0, data.length);
+    long value1 = cs.getValue();
+    assertTrue(value1 != 0);
+
+    cs.reset();
+    cs.updateChecksum(buf, 0, data.length);
+    assertEquals(value1, cs.getValue(), "Checksum should be deterministic");
+    buf.release();
+  }
+
+  @Test
+  public void testShuffleChecksumDirectBuffer() {
+    byte[] data = {10, 20, 30};
+    ByteBuf heap = Unpooled.wrappedBuffer(data);
+    ByteBuf direct = Unpooled.directBuffer(data.length);
+    direct.writeBytes(data);
+
+    ShuffleChecksum csHeap = new ShuffleChecksum();
+    csHeap.updateChecksum(heap, 0, data.length);
+
+    ShuffleChecksum csDirect = new ShuffleChecksum();
+    csDirect.updateChecksum(direct, 0, data.length);
+
+    assertEquals(csHeap.getValue(), csDirect.getValue(),
+        "Heap and direct buffer checksums should match");
+
+    heap.release();
+    direct.release();
+  }
+
+  @Test
+  public void testInvalidMessageTypeThrows() {
+    ByteBuf buf = Unpooled.buffer(12);
+    buf.writeInt(999); // unknown type
+    buf.writeLong(0L);
+    assertThrows(IllegalArgumentException.class, () -> StreamingShuffleMessage.decode(buf));
+    buf.release();
+  }
+}

--- a/common/network-common/src/test/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageSuite.java
@@ -282,6 +282,90 @@ public class StreamingShuffleMessageSuite {
   }
 
   @Test
+  public void testShuffleChecksumNonZeroStartIndex() {
+    // Verify that startIndex correctly offsets where the checksum begins, and that the
+    // result matches an independent reference computation. Cover heap and direct buffers.
+    byte[] data = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    int startIndex = 3;
+    int dataLength = 5; // bytes 3..7 inclusive
+
+    // Reference CRC32C computed over the same sub-range.
+    java.util.zip.CRC32C reference = new java.util.zip.CRC32C();
+    reference.update(data, startIndex, dataLength);
+    long expected = reference.getValue();
+
+    ByteBuf heap = Unpooled.wrappedBuffer(data);
+    ShuffleChecksum csHeap = new ShuffleChecksum();
+    csHeap.updateChecksum(heap, startIndex, dataLength);
+    assertEquals(expected, csHeap.getValue(),
+        "Heap buffer checksum should match reference for sub-range");
+    heap.release();
+
+    ByteBuf direct = Unpooled.directBuffer(data.length);
+    direct.writeBytes(data);
+    ShuffleChecksum csDirect = new ShuffleChecksum();
+    csDirect.updateChecksum(direct, startIndex, dataLength);
+    assertEquals(expected, csDirect.getValue(),
+        "Direct buffer checksum should match reference for sub-range");
+    direct.release();
+  }
+
+  @Test
+  public void testShuffleChecksumRejectsOutOfBoundsRange() {
+    // 5 bytes written, but the test asks for bytes [3..8). Should fail because
+    // startIndex (3) + dataLength (5) = 8 > writerIndex (5).
+    byte[] data = {1, 2, 3, 4, 5};
+    ByteBuf buf = Unpooled.wrappedBuffer(data);
+    try {
+      ShuffleChecksum cs = new ShuffleChecksum();
+      assertThrows(IllegalArgumentException.class,
+          () -> cs.updateChecksum(buf, 3, 5));
+    } finally {
+      buf.release();
+    }
+  }
+
+  @Test
+  public void testShuffleChecksumRejectsRangeBeyondWriterIndexButWithinCapacity() {
+    // capacity = 10 but only 5 bytes written. Requesting [0..8) should fail because
+    // 8 > writerIndex (5), even though 8 <= capacity (10). Guards against checksumming
+    // uninitialized bytes.
+    ByteBuf buf = Unpooled.buffer(10);
+    buf.writeBytes(new byte[]{1, 2, 3, 4, 5});
+    try {
+      ShuffleChecksum cs = new ShuffleChecksum();
+      assertThrows(IllegalArgumentException.class,
+          () -> cs.updateChecksum(buf, 0, 8));
+    } finally {
+      buf.release();
+    }
+  }
+
+  @Test
+  public void testShuffleChecksumRejectsNegativeStartIndex() {
+    ByteBuf buf = Unpooled.wrappedBuffer(new byte[]{1, 2, 3});
+    try {
+      ShuffleChecksum cs = new ShuffleChecksum();
+      assertThrows(IllegalArgumentException.class,
+          () -> cs.updateChecksum(buf, -1, 2));
+    } finally {
+      buf.release();
+    }
+  }
+
+  @Test
+  public void testShuffleChecksumRejectsNegativeDataLength() {
+    ByteBuf buf = Unpooled.wrappedBuffer(new byte[]{1, 2, 3});
+    try {
+      ShuffleChecksum cs = new ShuffleChecksum();
+      assertThrows(IllegalArgumentException.class,
+          () -> cs.updateChecksum(buf, 0, -1));
+    } finally {
+      buf.release();
+    }
+  }
+
+  @Test
   public void testInvalidMessageTypeThrows() {
     ByteBuf buf = Unpooled.buffer(12);
     buf.writeInt(999); // unknown type

--- a/common/network-common/src/test/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageSuite.java
@@ -90,23 +90,16 @@ public class StreamingShuffleMessageSuite {
   @Test
   public void testTerminationAckRoundTrip() {
     TerminationAckMessage original = new TerminationAckMessage(4, 8);
-    original.setSeqNum(99);  // echo back last seen seqNum
-    CompositeByteBuf buf = Unpooled.compositeBuffer();
-    buf.capacity(original.headerLength());
-    original.encode(buf);
-    ByteBuf copy = Unpooled.buffer(buf.readableBytes());
-    copy.writeBytes(buf);
-    buf.release();
-
+    ByteBuf encoded = encodeAndSlice(original);
     try {
-      StreamingShuffleMessage decoded = StreamingShuffleMessage.decode(copy);
+      StreamingShuffleMessage decoded = StreamingShuffleMessage.decode(encoded);
       assertInstanceOf(TerminationAckMessage.class, decoded);
       TerminationAckMessage ack = (TerminationAckMessage) decoded;
-      assertEquals(99, ack.getSeqNum());
+      assertEquals(SEQ_NUM, ack.getSeqNum());
       assertEquals(4, ack.shuffleWriterId);
       assertEquals(8, ack.shuffleReaderId);
     } finally {
-      copy.release();
+      encoded.release();
     }
   }
 
@@ -119,22 +112,14 @@ public class StreamingShuffleMessageSuite {
     long checksum = 0xDEADBEEFL;
 
     DataMessage original = new DataMessage(2, 5, payload.length, payloadBuf, checksum);
-    original.setSeqNum(10);
-    CompositeByteBuf buf = Unpooled.compositeBuffer();
-    buf.capacity(original.headerLength());
-    original.encode(buf);
-    original.release();
+    ByteBuf encoded = encodeAndSlice(original);
     payloadBuf.release();
 
-    ByteBuf copy = Unpooled.buffer(buf.readableBytes());
-    copy.writeBytes(buf);
-    buf.release();
-
     try {
-      StreamingShuffleMessage decoded = StreamingShuffleMessage.decode(copy);
+      StreamingShuffleMessage decoded = StreamingShuffleMessage.decode(encoded);
       assertInstanceOf(DataMessage.class, decoded);
       DataMessage dm = (DataMessage) decoded;
-      assertEquals(10, dm.getSeqNum());
+      assertEquals(SEQ_NUM, dm.getSeqNum());
       assertEquals(2, dm.shuffleWriterId);
       assertEquals(5, dm.shuffleReaderId);
       assertEquals(payload.length, dm.dataSize);
@@ -146,8 +131,46 @@ public class StreamingShuffleMessageSuite {
       assertArrayEquals(payload, out);
       dm.release();
     } finally {
-      copy.release();
+      encoded.release();
     }
+  }
+
+  @Test
+  public void testReleaseIsIdempotent() {
+    byte[] payload = "hi".getBytes();
+    ByteBuf payloadBuf = Unpooled.wrappedBuffer(payload);
+    // Constructor calls data.retain(), so refcount is now 2 (1 original + 1 retain).
+    DataMessage msg = new DataMessage(0, 0, payload.length, payloadBuf, 0L);
+    assertEquals(2, payloadBuf.refCnt());
+
+    msg.release();
+    assertEquals(1, payloadBuf.refCnt());
+
+    // Second release should be a no-op — refcount must not drop further or throw.
+    msg.release();
+    assertEquals(1, payloadBuf.refCnt());
+
+    payloadBuf.release();
+  }
+
+  @Test
+  public void testReleaseCallbackRunsExactlyOnce() {
+    byte[] payload = "hi".getBytes();
+    ByteBuf payloadBuf = Unpooled.wrappedBuffer(payload);
+    DataMessage msg = new DataMessage(0, 0, payload.length, payloadBuf, 0L);
+
+    java.util.concurrent.atomic.AtomicInteger callbackInvocations =
+        new java.util.concurrent.atomic.AtomicInteger(0);
+    msg.setReleaseCallback(callbackInvocations::incrementAndGet);
+
+    msg.release();
+    assertEquals(1, callbackInvocations.get());
+
+    // Second release: idempotent — callback must NOT fire again.
+    msg.release();
+    assertEquals(1, callbackInvocations.get());
+
+    payloadBuf.release();
   }
 
   @Test

--- a/common/network-common/src/test/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageSuite.java
@@ -150,6 +150,99 @@ public class StreamingShuffleMessageSuite {
     }
   }
 
+  @Test
+  public void testDataMessageRejectsDataSizeLargerThanReadableBytes() {
+    byte[] payload = "hello".getBytes();
+    ByteBuf payloadBuf = Unpooled.wrappedBuffer(payload);
+    try {
+      // dataSize (10) > data.readableBytes() (5)
+      assertThrows(IllegalArgumentException.class,
+          () -> new DataMessage(0, 0, payload.length + 5, payloadBuf, 0L));
+    } finally {
+      payloadBuf.release();
+    }
+  }
+
+  @Test
+  public void testDataMessageRejectsDataSizeSmallerThanReadableBytes() {
+    byte[] payload = "hello".getBytes();
+    ByteBuf payloadBuf = Unpooled.wrappedBuffer(payload);
+    try {
+      // dataSize (3) < data.readableBytes() (5)
+      assertThrows(IllegalArgumentException.class,
+          () -> new DataMessage(0, 0, payload.length - 2, payloadBuf, 0L));
+    } finally {
+      payloadBuf.release();
+    }
+  }
+
+  @Test
+  public void testDataMessageRejectsNegativeDataSize() {
+    byte[] payload = "hello".getBytes();
+    ByteBuf payloadBuf = Unpooled.wrappedBuffer(payload);
+    try {
+      assertThrows(IllegalArgumentException.class,
+          () -> new DataMessage(0, 0, -1, payloadBuf, 0L));
+    } finally {
+      payloadBuf.release();
+    }
+  }
+
+  @Test
+  public void testDataMessageDecodeRejectsTrailingBytes() {
+    // Encode a valid DataMessage, then append junk bytes to the encoded buffer.
+    // decode() should reject because dataSize != message.readableBytes() after the header.
+    byte[] payload = "hello".getBytes();
+    ByteBuf payloadBuf = Unpooled.wrappedBuffer(payload);
+    DataMessage original = new DataMessage(1, 2, payload.length, payloadBuf, 0L);
+    original.setSeqNum(SEQ_NUM);
+    CompositeByteBuf buf = Unpooled.compositeBuffer();
+    buf.capacity(original.headerLength());
+    original.encode(buf);
+    original.release();
+    payloadBuf.release();
+
+    // Copy encoded bytes then append 3 extra junk bytes.
+    ByteBuf corrupted = Unpooled.buffer(buf.readableBytes() + 3);
+    corrupted.writeBytes(buf);
+    buf.release();
+    corrupted.writeBytes(new byte[]{0x7f, 0x7f, 0x7f});
+
+    try {
+      assertThrows(IllegalArgumentException.class,
+          () -> StreamingShuffleMessage.decode(corrupted));
+    } finally {
+      corrupted.release();
+    }
+  }
+
+  @Test
+  public void testDataMessageDecodeRejectsTruncatedFrame() {
+    // Encode a valid DataMessage, then strip a trailing byte from the encoded buffer.
+    // decode() should reject because dataSize > message.readableBytes() after the header.
+    byte[] payload = "hello".getBytes();
+    ByteBuf payloadBuf = Unpooled.wrappedBuffer(payload);
+    DataMessage original = new DataMessage(1, 2, payload.length, payloadBuf, 0L);
+    original.setSeqNum(SEQ_NUM);
+    CompositeByteBuf buf = Unpooled.compositeBuffer();
+    buf.capacity(original.headerLength());
+    original.encode(buf);
+    original.release();
+    payloadBuf.release();
+
+    int truncatedSize = buf.readableBytes() - 1;
+    ByteBuf truncated = Unpooled.buffer(truncatedSize);
+    truncated.writeBytes(buf, truncatedSize);
+    buf.release();
+
+    try {
+      assertThrows(IllegalArgumentException.class,
+          () -> StreamingShuffleMessage.decode(truncated));
+    } finally {
+      truncated.release();
+    }
+  }
+
   // ---- ShuffleChecksum -------------------------------------------------------
 
   @Test

--- a/common/network-common/src/test/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/shuffle/streaming/StreamingShuffleMessageSuite.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class StreamingShuffleMessageSuite {
 
-  private static final int SEQ_NUM = 42;
+  private static final long SEQ_NUM = 42L;
 
   // ---- helpers ---------------------------------------------------------------
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

 ### Context                                                                                                                                                                                
   
  This is the first PR in a stack that contributes a new **streaming shuffle** implementation to Apache Spark. Streaming shuffle is a push-based shuffle designed for low-latency,           
  continuously-running queries (e.g., Real-Time mode in Structured Streaming) where the map and reduce stages must run concurrently rather than sequentially. Each map task hosts a Netty
  server that pushes records to reduce tasks as they are produced; reduce tasks open clients to those servers and consume records as a stream — no on-disk materialization, no map-stage     
  barrier.                                                   

  Because the full implementation spans the network protocol, driver-side coordination, plugin layer, executor-side writer/reader, engine integration, and tests, it is split into nine      
  independently reviewable PRs:
                                                                                                                                                                                             
  1. **Wire protocol (this PR)** — binary message types in `network-common`, pure Java.                                                                                                      
  2. **Output tracker** — driver-side coordination service mapping shuffle IDs to writer task locations.
  3. **Shuffle manager + Netty handlers + logging mixin** — the `ShuffleManager` plugin entry point, the bidirectional Netty handlers, and a `TaskContext`-aware logging trait.              
  4. **SparkEnv + DAGScheduler integration** — wires the tracker into `SparkEnv` and registers shuffles from `DAGScheduler`.                                                                 
  5. **Writer** — `StreamingShuffleWriter` (server-side push).                                                                                                                               
  6. **Reader** — `StreamingShuffleReader` (client-side pull).                                                                                                                               
  7. **MultiShuffleManager** — routes per-shuffle to streaming or sort shuffle based on a task-local property, so one cluster can host both.                                                 
  8. **Tests** — end-to-end suite for the streaming shuffle plugin.                                                                                                                          
  9. **Documentation** — design and configuration reference. 
                                                                                                                                                                                             
  Each PR compiles standalone. The plugin only becomes usable end-to-end after PRs 1–7.
                                                                                                                                                                                             
  ### Changes in this PR                                     

  This PR introduces the binary wire protocol used by the streaming shuffle, contained in a new package `org.apache.spark.network.shuffle.streaming` under `common/network-common`. All
  classes are pure Java and depend only on Netty (already in `network-common`) and `java.util.zip.CRC32C` (Java 9+). No new Maven dependencies are introduced.

  The protocol consists of four message types sharing a 12-byte common header (4-byte message-type id + 8-byte sequence number):

  - **`StreamingShuffleMessage`** — abstract sealed base class. Owns a `ByteBuf`, exposes `setSeqNum`/`getSeqNum`, and dispatches `decode()` to the concrete subclass based on the
  message-type id read from the wire. Documents the refcount/ownership rules concrete subclasses must follow.
  - **`StreamingShuffleMessageType`** — enum of the four message IDs (`DATA_MESSAGE_UNSAFE_ROW=1`, `CREDIT_CONTROL_MESSAGE=2`, `TERMINATION_CONTROL_MESSAGE=3`, `TERMINATION_ACK_MESSAGE=4`).
   Each enum constant carries an explicit `id()` value that is used on the wire — not the JVM enum ordinal — so the encoding is stable against changes to declaration order.
  `StreamingShuffleMessageType.decode(int)` throws `IllegalArgumentException` when the wire id does not match any known message type.
  - **`DataMessage`** — writer → reader. Carries serialized records along with `(shuffleWriterId, shuffleReaderId, dataSize, CRC32C checksum)` in the header. The constructor validates
  `dataSize == data.readableBytes()`; `encode()` writes exactly `dataSize` bytes of payload (via `data.retainedSlice(data.readerIndex(), dataSize)`); `decode()` validates that the
  post-header readable bytes equal `dataSize` exactly, rejecting both truncated and trailing-junk frames at the wire boundary.
  - **`CreditControlMessage`** — reader → writer. Sent on connection establishment as the initial handshake; reserved for finer-grained credit-based flow control in future revisions.
  - **`TerminationControlMessage`** — writer → reader. End-of-stream signal.
  - **`TerminationAckMessage`** — reader → writer. Echoes the last sequence number the reader observed, so the writer can verify no messages were lost or reordered.

  Supporting class:

  - **`ShuffleChecksum`** — stateful CRC32C helper that supports both heap and direct `ByteBuf`s, used by the writer to stamp checksums into outgoing `DataMessage`s and by the reader to
  verify them. Range arguments are validated against the buffer's `writerIndex()` so the checksum cannot accidentally cover bytes in `[writerIndex, capacity)` that have not been written.

  Tests in `StreamingShuffleMessageSuite` cover:
  - Encode/decode round-trips for every message type
  - CRC32C determinism and equivalence across heap and direct buffers; sub-range checksums with non-zero `startIndex` compared against a reference computation; out-of-bounds,
  beyond-`writerIndex`, and negative-argument rejection
  - `DataMessage` framing: rejection of `dataSize` larger/smaller than `data.readableBytes()`, negative `dataSize`, and decoded frames with trailing junk or truncation
  - Unknown wire message-type ids → `IllegalArgumentException`

  The protocol is designed to be reviewable on its own — the message layout, sequence-numbering scheme, memory-ownership rules, framing invariants, and checksum approach can all be
  evaluated without reading any of the executor- or driver-side code that comes in the follow-up PRs.
      
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

**This is one part of creating the Streaming Shuffle needed for Real-time Mode (RTM).**  

Spark's existing `SortShuffleManager` materializes map outputs to local disk and gates the reduce stage on map-stage completion. This design is well-suited to batch jobs but introduces   
  two latency floors that are unacceptable for continuously-running, low-latency queries:
                                                                                                                                                                                             
  1. **Map-stage barrier.** Reducers cannot start until every mapper has finished writing its output files. End-to-end latency is bound by the slowest mapper.                               
  2. **Disk materialization.** Every record is serialized to a local file and read back, even when the consumer is ready immediately. The fsync/read path adds tens of milliseconds of
  overhead per batch.                                                                                                                                                                        
                                                             
  Real-Time mode in Structured Streaming, and other long-running query workloads where map and reduce tasks coexist for the lifetime of the query, require a shuffle that:                   
                                                             
  - Streams records from mappers to reducers as they are produced.                                                                                                                           
  - Lets the reduce stage run concurrently with the map stage.
  - Avoids on-disk intermediate state entirely.                                                                                                                                              
  - Provides backpressure so a slow reader can throttle the upstream iterator without dropping data.
  - Detects message loss, reordering, or in-flight corruption (since there is no on-disk re-read to fall back on).                                                                           
                                                                                                                                                                                             
  Streaming shuffle is the new `ShuffleManager` implementation that meets these requirements. The full implementation involves driver-side coordination, executor-side push/pull components, 
  engine integration, and supporting infrastructure — together too large to land in a single PR.                                                                                             
                                                                                                                                                                                             
  This PR contributes the **wire protocol** layer, which is the natural foundation. Every other piece in the stack (the tracker, writer, reader, handlers, tests) depends on the message     
  types, sequence-numbering rules, and checksum scheme defined here, so it must land first. The protocol layer is also the most contract-heavy part of the design: getting the message
  layout, ownership rules, and integrity check right up front avoids costly churn in later PRs. By making this an independent, standalone-reviewable PR, reviewers can scrutinize the wire   
  format, refcount discipline, and CRC32C approach without being distracted by Spark-internal coordination logic that has not yet been introduced.

                                                             
The final product can be viewed here for context:

https://github.com/apache/spark/compare/master...jerrypeng:spark:stack/streaming-shuffle-pr9-docs?expand=1


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit tests cover encode/decode round-trips for all message types, determinism of the checksum, heap/direct buffer equivalence, and the unknown-type error path.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
