### PR TITLE
[SPARK-56675][BUILD] Make sbt publishLocal work

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -299,6 +299,8 @@ object SparkBuild extends PomBuild {
       .orElse(sys.props.get("java.home"))
       .map(file),
     publishMavenStyle := true,
+    packageDoc / publishArtifact := false,
+    packageSrc / publishArtifact := (if (sys.env.contains("PUBLISH_PACKAGE_SRC")) true else false),
     unidocGenjavadocVersion := "0.19",
 
     // Override SBT's default resolvers:


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes an issue that `sbt publishLocal` doesn't work.
The reason is that `packageDoc/publishArtifact` doesn't work (so `sbt doc` also doesn't work).
In the Spark community, API documents are generated using `unidoc` and I feel having API documents in `~/.m2` or `~/.ivy2` is not so useful.
So, the solution is publishing API documents by `packageDoc / publishArtifact := false`.
In addition, this PR allows developers to configure whether to publish source JARs by an environment variable `PUBLISH_PACKAGE_SRC`. The default value is `false`, which is the same behavior as `mvn install`.

### Why are the changes needed?
Having artifacts in `~/.m2` or `~.ivy2` is useful for downstream developers

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Confirmed artifacts are in both `~/.m2` and `~/.ivy2` by the following command.
```
$ build/sbt publishLocal
```

Also confirmed `*-sources.jar` are in both `~/.m2` and `~/.ivy2` by the following command.
```
$ PUBLISH_PACKAGE_SRC=1 build/sbt publishLocal
```

### Was this patch authored or co-authored using generative AI tooling?
No.
