### PR TITLE
[SPARK-56678][SQL] Use structured Catalog/Namespace/Table rows in DESCRIBE TABLE EXTENDED for v2 tables and views

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/MetadataTable.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/MetadataTable.java
@@ -50,9 +50,12 @@ public class MetadataTable implements Table {
 
   /**
    * @param info metadata for the table or view. Pass a {@link ViewInfo} for a view.
-   * @param name human-readable name for this table, used by places that read {@link #name()}
-   *             (e.g. the {@code Name} row of {@code DESCRIBE TABLE EXTENDED}). Catalogs
-   *             returning a {@code MetadataTable} from {@link TableCatalog#loadTable} or
+   * @param name human-readable name for this table, returned by {@link #name()} and surfaced
+   *             in places that read it (e.g. {@code BatchScan} plan-tree labels and
+   *             partition-management error messages). {@code DESCRIBE TABLE EXTENDED} no
+   *             longer reads this field -- it emits the resolved identifier as structured
+   *             {@code Catalog} / {@code Namespace} / {@code Table} rows. Catalogs returning
+   *             a {@code MetadataTable} from {@link TableCatalog#loadTable} or
    *             {@link TableViewCatalog#loadTableOrView} should typically pass
    *             {@code ident.toString()}, matching the quoted multi-part form used elsewhere
    *             for v2 identifiers.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/MetadataTable.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/MetadataTable.java
@@ -52,8 +52,8 @@ public class MetadataTable implements Table {
    * @param info metadata for the table or view. Pass a {@link ViewInfo} for a view.
    * @param name human-readable name for this table, returned by {@link #name()} and surfaced
    *             in places that read it (e.g. {@code BatchScan} plan-tree labels and
-   *             partition-management error messages). {@code DESCRIBE TABLE EXTENDED} no
-   *             longer reads this field -- it emits the resolved identifier as structured
+   *             partition-management error messages). {@code DESCRIBE TABLE EXTENDED} does
+   *             not read this field; it emits the resolved identifier as structured
    *             {@code Catalog} / {@code Namespace} / {@code Table} rows. Catalogs returning
    *             a {@code MetadataTable} from {@link TableCatalog#loadTable} or
    *             {@link TableViewCatalog#loadTableOrView} should typically pass

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -550,7 +550,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       DescribeTableExec(output, r.catalog.name(), r.identifier, r.table, isExtended) :: Nil
 
     case DescribeTablePartition(r: ResolvedTable, part, isExtended, output) =>
-      DescribeTablePartitionExec(output, r.catalog.name(), r.table.asPartitionable, r.identifier,
+      DescribeTablePartitionExec(output, r.table.asPartitionable, r.identifier,
         Seq(part).asResolvedPartitionSpecs.head, isExtended) :: Nil
 
     case DescribeColumn(r: ResolvedTable, column, isExtended, output) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -547,10 +547,10 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       DescribeNamespaceExec(output, catalog.asNamespaceCatalog, ns, extended) :: Nil
 
     case DescribeRelation(r: ResolvedTable, isExtended, output) =>
-      DescribeTableExec(output, r.table, isExtended) :: Nil
+      DescribeTableExec(output, r.catalog.name(), r.identifier, r.table, isExtended) :: Nil
 
     case DescribeTablePartition(r: ResolvedTable, part, isExtended, output) =>
-      DescribeTablePartitionExec(output, r.table.asPartitionable, r.identifier,
+      DescribeTablePartitionExec(output, r.catalog.name(), r.table.asPartitionable, r.identifier,
         Seq(part).asResolvedPartitionSpecs.head, isExtended) :: Nil
 
     case DescribeColumn(r: ResolvedTable, column, isExtended, output) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
@@ -76,8 +76,12 @@ private[v2] trait DescribeIdentifierRows extends LeafV2CommandExec {
  * them directly off `this`, so the partition exec doesn't need to thread the table-only
  * `catalogName` / `identifier` arguments that `DescribeTableExec` consumes for the EXTENDED
  * `# Detailed Table Information` block.
+ *
+ * Kept orthogonal to [[DescribeIdentifierRows]] so `DescribeTablePartitionExec` (which only
+ * needs the schema/partitioning rows) doesn't inherit identifier-row helpers it never calls.
+ * `DescribeTableExec` mixes both traits in.
  */
-private[v2] trait DescribeTableBaseRows extends DescribeIdentifierRows {
+private[v2] trait DescribeTableBaseRows extends LeafV2CommandExec {
   def table: Table
 
   /** Schema + partitioning + clustering rows, shared with DescribeTablePartitionExec. */
@@ -163,7 +167,7 @@ case class DescribeTableExec(
     catalogName: String,
     identifier: Identifier,
     table: Table,
-    isExtended: Boolean) extends DescribeTableBaseRows {
+    isExtended: Boolean) extends DescribeTableBaseRows with DescribeIdentifierRows {
   override protected def run(): Seq[InternalRow] = {
     val rows = new ArrayBuffer[InternalRow]()
     addBaseDescription(rows)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
@@ -33,14 +33,51 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.ArrayImplicits._
 
 /**
+ * Catalog / Namespace / [Database] / <entity> row formatting shared by
+ * `DescribeTableExec.addTableDetails` and `DescribeV2ViewExec.run`. Hosting it in one place
+ * keeps the v1-compat rule (single-segment namespaces additionally surface a `Database` row,
+ * mirroring v1 `CatalogTable.toJsonLinkedHashMap`) as a single source of truth so the table
+ * and view paths can't drift.
+ */
+private[v2] trait DescribeIdentifierRows extends LeafV2CommandExec {
+  /**
+   * Append the structured identifier rows (`Catalog`, `Namespace`, optional v1-compat
+   * `Database`, `<entityLabel>`) to `rows`. `entityLabel` is `"Table"` for a v2 table and
+   * `"View"` for a v2 view -- the only divergence between the two paths.
+   *
+   * Row shapes:
+   *  - `Catalog` carries the catalog plugin name (always present for v2).
+   *  - `Namespace` is the canonical multi-segment representation, joined with `.` and with
+   *    `quoteIfNeeded` applied per segment (so segments containing dots round-trip).
+   *  - `Database` is emitted only when the namespace is exactly one segment, matching v1's
+   *    `identifier.database.get` (raw segment, no quoting). Multi-segment namespaces can't
+   *    be rendered as a single-string `database` losslessly, so the row is omitted in that
+   *    case; consumers needing a quoting-safe form should read `Namespace`.
+   *  - `<entityLabel>` is the unqualified entity name from `Identifier.name()`.
+   */
+  protected def addIdentifierRows(
+      rows: ArrayBuffer[InternalRow],
+      catalogName: String,
+      identifier: Identifier,
+      entityLabel: String): Unit = {
+    rows += toCatalystRow("Catalog", catalogName, "")
+    rows += toCatalystRow("Namespace", identifier.namespace().quoted, "")
+    if (identifier.namespace().length == 1) {
+      rows += toCatalystRow("Database", identifier.namespace().head, "")
+    }
+    rows += toCatalystRow(entityLabel, identifier.name(), "")
+  }
+}
+
+/**
  * Schema + partitioning + clustering row formatting shared by `DescribeTableExec.run()` (which
  * uses it for the schema-row prefix) and `DescribeTablePartitionExec.run()` (which uses it as
- * the entire pre-partition section). Pulling these helpers into a trait lets the partition
- * exec call them directly off `this` -- the prior shape constructed a `DescribeTableExec`
- * inner instance just to invoke `addBaseDescription`, which forced threading unused
- * `catalogName` / `identifier` constructor args through the partition exec.
+ * the entire pre-partition section). Mixing the helpers into a trait lets each exec invoke
+ * them directly off `this`, so the partition exec doesn't need to thread the table-only
+ * `catalogName` / `identifier` arguments that `DescribeTableExec` consumes for the EXTENDED
+ * `# Detailed Table Information` block.
  */
-private[v2] trait DescribeTableBaseRows extends LeafV2CommandExec {
+private[v2] trait DescribeTableBaseRows extends DescribeIdentifierRows {
   def table: Table
 
   /** Schema + partitioning + clustering rows, shared with DescribeTablePartitionExec. */
@@ -143,24 +180,7 @@ case class DescribeTableExec(
   private def addTableDetails(rows: ArrayBuffer[InternalRow]): Unit = {
     rows += emptyRow()
     rows += toCatalystRow("# Detailed Table Information", "", "")
-    rows += toCatalystRow("Catalog", catalogName, "")
-    // The `Namespace` row is always emitted as the canonical v2 representation. Multi-segment
-    // namespaces use `Identifier.namespace().quoted` so segments containing dots round-trip;
-    // a zero-segment (root) namespace renders as an empty string -- intentional, so consumers
-    // can distinguish "table at the catalog root" from a missing row.
-    rows += toCatalystRow("Namespace", identifier.namespace().quoted, "")
-    // For v1 compatibility, also emit a `Database` row when the namespace is exactly one
-    // segment, mirroring v1 `CatalogTable.toJsonLinkedHashMap` which renders the `database`
-    // part of `TableIdentifier` as `Database`. Multi-segment namespaces can't be rendered
-    // as a single-string `database` losslessly, and a zero-segment (root) namespace has no
-    // single-name representation, so the `Database` row is omitted in those cases and
-    // consumers must read `Namespace` instead. The value is the raw segment (no
-    // `quoteIfNeeded`), matching v1's `identifier.database.get`; consumers needing a
-    // quoting-safe form should read `Namespace`, where `quoted` is applied per segment.
-    if (identifier.namespace().length == 1) {
-      rows += toCatalystRow("Database", identifier.namespace().head, "")
-    }
-    rows += toCatalystRow("Table", identifier.name(), "")
+    addIdentifierRows(rows, catalogName, identifier, entityLabel = "Table")
 
     val tableType = if (table.properties().containsKey(TableCatalog.PROP_EXTERNAL)) {
       CatalogTableType.EXTERNAL.name

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
@@ -32,12 +32,101 @@ import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.ArrayImplicits._
 
+/**
+ * Schema + partitioning + clustering row formatting shared by `DescribeTableExec.run()` (which
+ * uses it for the schema-row prefix) and `DescribeTablePartitionExec.run()` (which uses it as
+ * the entire pre-partition section). Pulling these helpers into a trait lets the partition
+ * exec call them directly off `this` -- the prior shape constructed a `DescribeTableExec`
+ * inner instance just to invoke `addBaseDescription`, which forced threading unused
+ * `catalogName` / `identifier` constructor args through the partition exec.
+ */
+private[v2] trait DescribeTableBaseRows extends LeafV2CommandExec {
+  def table: Table
+
+  /** Schema + partitioning + clustering rows, shared with DescribeTablePartitionExec. */
+  protected def addBaseDescription(rows: ArrayBuffer[InternalRow]): Unit = {
+    addSchema(rows)
+    addPartitioning(rows)
+    addClustering(rows)
+  }
+
+  private def addSchema(rows: ArrayBuffer[InternalRow]): Unit = {
+    rows ++= table.columns().map{ column =>
+      toCatalystRow(
+        column.name, column.dataType.simpleString, column.comment)
+    }
+  }
+
+  private def addClusteringToRows(
+      clusterBySpec: ClusterBySpec,
+      rows: ArrayBuffer[InternalRow]): Unit = {
+    rows += toCatalystRow("# Clustering Information", "", "")
+    rows += toCatalystRow(s"# ${output.head.name}", output(1).name, output(2).name)
+    rows ++= clusterBySpec.columnNames.map { fieldNames =>
+      val schema = CatalogV2Util.v2ColumnsToStructType(table.columns())
+      val nestedField = schema.findNestedField(fieldNames.fieldNames.toIndexedSeq)
+      assert(nestedField.isDefined,
+        "The clustering column " +
+          s"${fieldNames.fieldNames.map(quoteIfNeeded).mkString(".")} " +
+          s"was not found in the table schema ${schema.catalogString}.")
+      nestedField.get
+    }.map { case (path, field) =>
+      toCatalystRow(
+        (path :+ field.name).map(quoteIfNeeded).mkString("."),
+        field.dataType.simpleString,
+        field.getComment().orNull)
+    }
+  }
+
+  private def addClustering(rows: ArrayBuffer[InternalRow]): Unit = {
+    ClusterBySpec.extractClusterBySpec(table.partitioning.toIndexedSeq).foreach { clusterBySpec =>
+      addClusteringToRows(clusterBySpec, rows)
+    }
+  }
+
+  private def addPartitioning(rows: ArrayBuffer[InternalRow]): Unit = {
+    // Clustering columns are handled in addClustering().
+    val partitioning = table.partitioning
+      .filter(t => !t.isInstanceOf[ClusterByTransform])
+    if (partitioning.nonEmpty) {
+      val partitionColumnsOnly = table.partitioning.forall(t => t.isInstanceOf[IdentityTransform])
+      if (partitionColumnsOnly) {
+        rows += toCatalystRow("# Partition Information", "", "")
+        rows += toCatalystRow(s"# ${output(0).name}", output(1).name, output(2).name)
+        val schema = CatalogV2Util.v2ColumnsToStructType(table.columns())
+        rows ++= table.partitioning
+          .map(_.asInstanceOf[IdentityTransform].ref.fieldNames())
+          .map { fieldNames =>
+            val nestedField = schema.findNestedField(fieldNames.toImmutableArraySeq)
+            if (nestedField.isEmpty) {
+              throw QueryExecutionErrors.partitionColumnNotFoundInTheTableSchemaError(
+                fieldNames.toSeq,
+                schema)
+            }
+            nestedField.get
+          }.map { case (path, field) =>
+            toCatalystRow(
+              (path :+ field.name).map(quoteIfNeeded(_)).mkString("."),
+              field.dataType.simpleString,
+              field.getComment().orNull)
+          }
+      } else {
+        rows += toCatalystRow("", "", "")
+        rows += toCatalystRow("# Partitioning", "", "")
+        rows ++= table.partitioning.zipWithIndex.map {
+          case (transform, index) => toCatalystRow(s"Part $index", transform.describe(), "")
+        }
+      }
+    }
+  }
+}
+
 case class DescribeTableExec(
     output: Seq[Attribute],
     catalogName: String,
     identifier: Identifier,
     table: Table,
-    isExtended: Boolean) extends LeafV2CommandExec {
+    isExtended: Boolean) extends DescribeTableBaseRows {
   override protected def run(): Seq[InternalRow] = {
     val rows = new ArrayBuffer[InternalRow]()
     addBaseDescription(rows)
@@ -49,13 +138,6 @@ case class DescribeTableExec(
       addTableConstraints(rows)
     }
     rows.toSeq
-  }
-
-  /** Schema + partitioning + clustering rows, shared with DescribeTablePartitionExec. */
-  private[v2] def addBaseDescription(rows: ArrayBuffer[InternalRow]): Unit = {
-    addSchema(rows)
-    addPartitioning(rows)
-    addClustering(rows)
   }
 
   private def addTableDetails(rows: ArrayBuffer[InternalRow]): Unit = {
@@ -107,13 +189,6 @@ case class DescribeTableExec(
     }
   }
 
-  private def addSchema(rows: ArrayBuffer[InternalRow]): Unit = {
-    rows ++= table.columns().map{ column =>
-      toCatalystRow(
-        column.name, column.dataType.simpleString, column.comment)
-    }
-  }
-
   private def addTableConstraints(rows: ArrayBuffer[InternalRow]): Unit = {
     if (table.constraints.nonEmpty) {
       rows += emptyRow()
@@ -137,33 +212,6 @@ case class DescribeTableExec(
     case _ =>
   }
 
-  private def addClusteringToRows(
-      clusterBySpec: ClusterBySpec,
-      rows: ArrayBuffer[InternalRow]): Unit = {
-    rows += toCatalystRow("# Clustering Information", "", "")
-    rows += toCatalystRow(s"# ${output.head.name}", output(1).name, output(2).name)
-    rows ++= clusterBySpec.columnNames.map { fieldNames =>
-      val schema = CatalogV2Util.v2ColumnsToStructType(table.columns())
-      val nestedField = schema.findNestedField(fieldNames.fieldNames.toIndexedSeq)
-      assert(nestedField.isDefined,
-        "The clustering column " +
-          s"${fieldNames.fieldNames.map(quoteIfNeeded).mkString(".")} " +
-          s"was not found in the table schema ${schema.catalogString}.")
-      nestedField.get
-    }.map { case (path, field) =>
-      toCatalystRow(
-        (path :+ field.name).map(quoteIfNeeded).mkString("."),
-        field.dataType.simpleString,
-        field.getComment().orNull)
-    }
-  }
-
-  private def addClustering(rows: ArrayBuffer[InternalRow]): Unit = {
-    ClusterBySpec.extractClusterBySpec(table.partitioning.toIndexedSeq).foreach { clusterBySpec =>
-      addClusteringToRows(clusterBySpec, rows)
-    }
-  }
-
   private def addTableStats(rows: ArrayBuffer[InternalRow]): Unit = table match {
     case read: SupportsRead =>
       read.newScanBuilder(CaseInsensitiveStringMap.empty()).build() match {
@@ -179,42 +227,6 @@ case class DescribeTableExec(
         case _ =>
       }
     case _ =>
-  }
-
-  private def addPartitioning(rows: ArrayBuffer[InternalRow]): Unit = {
-    // Clustering columns are handled in addClustering().
-    val partitioning = table.partitioning
-      .filter(t => !t.isInstanceOf[ClusterByTransform])
-    if (partitioning.nonEmpty) {
-      val partitionColumnsOnly = table.partitioning.forall(t => t.isInstanceOf[IdentityTransform])
-      if (partitionColumnsOnly) {
-        rows += toCatalystRow("# Partition Information", "", "")
-        rows += toCatalystRow(s"# ${output(0).name}", output(1).name, output(2).name)
-        val schema = CatalogV2Util.v2ColumnsToStructType(table.columns())
-        rows ++= table.partitioning
-          .map(_.asInstanceOf[IdentityTransform].ref.fieldNames())
-          .map { fieldNames =>
-            val nestedField = schema.findNestedField(fieldNames.toImmutableArraySeq)
-            if (nestedField.isEmpty) {
-              throw QueryExecutionErrors.partitionColumnNotFoundInTheTableSchemaError(
-                fieldNames.toSeq,
-                schema)
-            }
-            nestedField.get
-          }.map { case (path, field) =>
-            toCatalystRow(
-              (path :+ field.name).map(quoteIfNeeded(_)).mkString("."),
-              field.dataType.simpleString,
-              field.getComment().orNull)
-          }
-      } else {
-        rows += emptyRow()
-        rows += toCatalystRow("# Partitioning", "", "")
-        rows ++= table.partitioning.zipWithIndex.map {
-          case (transform, index) => toCatalystRow(s"Part $index", transform.describe(), "")
-        }
-      }
-    }
   }
 
   private def emptyRow(): InternalRow = toCatalystRow("", "", "")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
@@ -33,17 +33,16 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.ArrayImplicits._
 
 /**
- * Catalog / Namespace / [Database] / <entity> row formatting shared by
+ * Catalog / Namespace / Database / <entity> row formatting shared by
  * `DescribeTableExec.addTableDetails` and `DescribeV2ViewExec.run`. Hosting it in one place
- * keeps the v1-compat rule (single-segment namespaces additionally surface a `Database` row,
- * mirroring v1 `CatalogTable.toJsonLinkedHashMap`) as a single source of truth so the table
- * and view paths can't drift.
+ * keeps the row layout (including the v1-compat `Database` row) as a single source of truth
+ * so the table and view paths can't drift.
  */
 private[v2] trait DescribeIdentifierRows extends LeafV2CommandExec {
   /**
-   * Append the structured identifier rows (`Catalog`, `Namespace`, optional v1-compat
-   * `Database`, `<entityLabel>`) to `rows`. `entityLabel` is `"Table"` for a v2 table and
-   * `"View"` for a v2 view -- the only divergence between the two paths.
+   * Append the structured identifier rows (`Catalog`, `Namespace`, `Database`,
+   * `<entityLabel>`) to `rows`. `entityLabel` is `"Table"` for a v2 table and `"View"` for a
+   * v2 view -- the only divergence between the two paths.
    *
    * Row shapes:
    *  - `Catalog` carries the catalog plugin name (always present for v2).
@@ -51,10 +50,11 @@ private[v2] trait DescribeIdentifierRows extends LeafV2CommandExec {
    *    `quoteIfNeeded` applied per segment (so segments containing dots round-trip). Always
    *    emitted; for an empty namespace (root-level entity) the value is the empty string,
    *    so the row's presence stays uniform across v2 outputs.
-   *  - `Database` is emitted only when the namespace is exactly one segment, matching v1's
-   *    `identifier.database.get` (raw segment, no quoting). Multi-segment and empty
-   *    namespaces can't be rendered as a single-string `database` losslessly, so the row is
-   *    omitted in those cases; consumers needing a quoting-safe form should read `Namespace`.
+   *  - `Database` is always emitted for v1 compatibility. Its value is the trailing
+   *    namespace segment (so multi-segment namespaces still surface their leaf segment),
+   *    or the empty string when the namespace is the catalog root. Consumers that need
+   *    the full namespace should read `Namespace`; `Database` alone is not round-trip-safe
+   *    for multi-segment cases.
    *  - `<entityLabel>` is the unqualified entity name from `Identifier.name()`.
    */
   protected def addIdentifierRows(
@@ -64,9 +64,7 @@ private[v2] trait DescribeIdentifierRows extends LeafV2CommandExec {
       entityLabel: String): Unit = {
     rows += toCatalystRow("Catalog", catalogName, "")
     rows += toCatalystRow("Namespace", identifier.namespace().quoted, "")
-    if (identifier.namespace().length == 1) {
-      rows += toCatalystRow("Database", identifier.namespace().head, "")
-    }
+    rows += toCatalystRow("Database", identifier.namespace().lastOption.getOrElse(""), "")
     rows += toCatalystRow(entityLabel, identifier.name(), "")
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
@@ -62,12 +62,17 @@ case class DescribeTableExec(
     rows += emptyRow()
     rows += toCatalystRow("# Detailed Table Information", "", "")
     rows += toCatalystRow("Catalog", catalogName, "")
+    // The `Namespace` row is always emitted as the canonical v2 representation. Multi-segment
+    // namespaces use `Identifier.namespace().quoted` so segments containing dots round-trip;
+    // a zero-segment (root) namespace renders as an empty string -- intentional, so consumers
+    // can distinguish "table at the catalog root" from a missing row.
     rows += toCatalystRow("Namespace", identifier.namespace().quoted, "")
-    // For v1 compatibility, also emit a `Database` row when the namespace is a single
-    // segment, mirroring v1 `CatalogTable.toJsonLinkedHashMap` which renders the
-    // `database` part of `TableIdentifier` as `Database`. v2 multi-segment namespaces
-    // can't be rendered as a single-string `database` losslessly, so the `Database`
-    // row is omitted in that case and consumers must read `Namespace` instead.
+    // For v1 compatibility, also emit a `Database` row when the namespace is exactly one
+    // segment, mirroring v1 `CatalogTable.toJsonLinkedHashMap` which renders the `database`
+    // part of `TableIdentifier` as `Database`. Multi-segment namespaces can't be rendered
+    // as a single-string `database` losslessly, and a zero-segment (root) namespace has no
+    // single-name representation, so the `Database` row is omitted in those cases and
+    // consumers must read `Namespace` instead.
     if (identifier.namespace().length == 1) {
       rows += toCatalystRow("Database", identifier.namespace().head, "")
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
@@ -24,7 +24,8 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.{CatalogTableType, ClusterBySpec}
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, ResolveDefaultColumns}
-import org.apache.spark.sql.connector.catalog.{CatalogV2Util, SupportsMetadataColumns, SupportsRead, Table, TableCatalog}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, SupportsMetadataColumns, SupportsRead, Table, TableCatalog}
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.NamespaceHelper
 import org.apache.spark.sql.connector.expressions.{ClusterByTransform, IdentityTransform}
 import org.apache.spark.sql.connector.read.SupportsReportStatistics
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -33,6 +34,8 @@ import org.apache.spark.util.ArrayImplicits._
 
 case class DescribeTableExec(
     output: Seq[Attribute],
+    catalogName: String,
+    identifier: Identifier,
     table: Table,
     isExtended: Boolean) extends LeafV2CommandExec {
   override protected def run(): Seq[InternalRow] = {
@@ -58,7 +61,17 @@ case class DescribeTableExec(
   private def addTableDetails(rows: ArrayBuffer[InternalRow]): Unit = {
     rows += emptyRow()
     rows += toCatalystRow("# Detailed Table Information", "", "")
-    rows += toCatalystRow("Name", table.name(), "")
+    rows += toCatalystRow("Catalog", catalogName, "")
+    rows += toCatalystRow("Namespace", identifier.namespace().quoted, "")
+    // For v1 compatibility, also emit a `Database` row when the namespace is a single
+    // segment, mirroring v1 `CatalogTable.toJsonLinkedHashMap` which renders the
+    // `database` part of `TableIdentifier` as `Database`. v2 multi-segment namespaces
+    // can't be rendered as a single-string `database` losslessly, so the `Database`
+    // row is omitted in that case and consumers must read `Namespace` instead.
+    if (identifier.namespace().length == 1) {
+      rows += toCatalystRow("Database", identifier.namespace().head, "")
+    }
+    rows += toCatalystRow("Table", identifier.name(), "")
 
     val tableType = if (table.properties().containsKey(TableCatalog.PROP_EXTERNAL)) {
       CatalogTableType.EXTERNAL.name

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
@@ -72,7 +72,9 @@ case class DescribeTableExec(
     // part of `TableIdentifier` as `Database`. Multi-segment namespaces can't be rendered
     // as a single-string `database` losslessly, and a zero-segment (root) namespace has no
     // single-name representation, so the `Database` row is omitted in those cases and
-    // consumers must read `Namespace` instead.
+    // consumers must read `Namespace` instead. The value is the raw segment (no
+    // `quoteIfNeeded`), matching v1's `identifier.database.get`; consumers needing a
+    // quoting-safe form should read `Namespace`, where `quoted` is applied per segment.
     if (identifier.namespace().length == 1) {
       rows += toCatalystRow("Database", identifier.namespace().head, "")
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
@@ -48,11 +48,13 @@ private[v2] trait DescribeIdentifierRows extends LeafV2CommandExec {
    * Row shapes:
    *  - `Catalog` carries the catalog plugin name (always present for v2).
    *  - `Namespace` is the canonical multi-segment representation, joined with `.` and with
-   *    `quoteIfNeeded` applied per segment (so segments containing dots round-trip).
+   *    `quoteIfNeeded` applied per segment (so segments containing dots round-trip). Always
+   *    emitted; for an empty namespace (root-level entity) the value is the empty string,
+   *    so the row's presence stays uniform across v2 outputs.
    *  - `Database` is emitted only when the namespace is exactly one segment, matching v1's
-   *    `identifier.database.get` (raw segment, no quoting). Multi-segment namespaces can't
-   *    be rendered as a single-string `database` losslessly, so the row is omitted in that
-   *    case; consumers needing a quoting-safe form should read `Namespace`.
+   *    `identifier.database.get` (raw segment, no quoting). Multi-segment and empty
+   *    namespaces can't be rendered as a single-string `database` losslessly, so the row is
+   *    omitted in those cases; consumers needing a quoting-safe form should read `Namespace`.
    *  - `<entityLabel>` is the unqualified entity name from `Identifier.name()`.
    */
   protected def addIdentifierRows(
@@ -83,6 +85,9 @@ private[v2] trait DescribeIdentifierRows extends LeafV2CommandExec {
  */
 private[v2] trait DescribeTableBaseRows extends LeafV2CommandExec {
   def table: Table
+
+  /** A blank `("", "", "")` row used as a section separator in DESCRIBE output. */
+  protected def emptyRow(): InternalRow = toCatalystRow("", "", "")
 
   /** Schema + partitioning + clustering rows, shared with DescribeTablePartitionExec. */
   protected def addBaseDescription(rows: ArrayBuffer[InternalRow]): Unit = {
@@ -152,7 +157,7 @@ private[v2] trait DescribeTableBaseRows extends LeafV2CommandExec {
               field.getComment().orNull)
           }
       } else {
-        rows += toCatalystRow("", "", "")
+        rows += emptyRow()
         rows += toCatalystRow("# Partitioning", "", "")
         rows ++= table.partitioning.zipWithIndex.map {
           case (transform, index) => toCatalystRow(s"Part $index", transform.describe(), "")
@@ -252,6 +257,4 @@ case class DescribeTableExec(
       }
     case _ =>
   }
-
-  private def emptyRow(): InternalRow = toCatalystRow("", "", "")
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTablePartitionExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTablePartitionExec.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.errors.QueryCompilationErrors
 
 case class DescribeTablePartitionExec(
     output: Seq[Attribute],
+    catalogName: String,
     table: SupportsPartitionManagement,
     tableIdent: Identifier,
     partSpec: ResolvedPartitionSpec,
@@ -39,7 +40,8 @@ case class DescribeTablePartitionExec(
 
     // Delegate schema + partitioning + clustering to DescribeTableExec.
     val rows = new ArrayBuffer[InternalRow]()
-    DescribeTableExec(output, table, isExtended = false).addBaseDescription(rows)
+    DescribeTableExec(output, catalogName, tableIdent, table, isExtended = false)
+      .addBaseDescription(rows)
 
     if (isExtended) {
       addPartitionDetails(rows, partitionRow)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTablePartitionExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTablePartitionExec.scala
@@ -38,11 +38,12 @@ case class DescribeTablePartitionExec(
   override protected def run(): Seq[InternalRow] = {
     val partitionRow = validateAndGetPartition()
 
-    // Delegate schema + partitioning + clustering to DescribeTableExec. We pass
-    // `catalogName` / `tableIdent` for ctor completeness only -- with `isExtended = false`,
-    // only `addBaseDescription` runs, which reads neither field; the structured
-    // `# Detailed Table Information` block (which is what consumes them) is gated on
-    // `isExtended`.
+    // Delegate schema + partitioning + clustering to DescribeTableExec by calling
+    // `addBaseDescription` directly (rather than `run()`). That helper reads only `output`
+    // and `table`, so `catalogName` / `tableIdent` are passed for ctor-completeness only --
+    // `addTableDetails` (the only consumer of those fields) is reached only via `run()` and
+    // never fires here. `isExtended = false` matches the contract of the inner exec but is
+    // not what makes the fields unused; bypassing `run()` is.
     val rows = new ArrayBuffer[InternalRow]()
     DescribeTableExec(output, catalogName, tableIdent, table, isExtended = false)
       .addBaseDescription(rows)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTablePartitionExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTablePartitionExec.scala
@@ -37,9 +37,9 @@ case class DescribeTablePartitionExec(
   override protected def run(): Seq[InternalRow] = {
     val partitionRow = validateAndGetPartition()
 
-    // Delegate schema + partitioning + clustering rows to the shared `DescribeTableBaseRows`
-    // trait (mixed in by both this exec and `DescribeTableExec`). The pre-PR shape constructed
-    // a `DescribeTableExec` inner instance just to invoke its `addBaseDescription` helper.
+    // Schema + partitioning + clustering rows come from the shared `DescribeTableBaseRows`
+    // trait, which is mixed in by both this exec and `DescribeTableExec` so each can call
+    // the helper directly off `this`.
     val rows = new ArrayBuffer[InternalRow]()
     addBaseDescription(rows)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTablePartitionExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTablePartitionExec.scala
@@ -29,24 +29,19 @@ import org.apache.spark.sql.errors.QueryCompilationErrors
 
 case class DescribeTablePartitionExec(
     output: Seq[Attribute],
-    catalogName: String,
     table: SupportsPartitionManagement,
     tableIdent: Identifier,
     partSpec: ResolvedPartitionSpec,
-    isExtended: Boolean) extends LeafV2CommandExec {
+    isExtended: Boolean) extends DescribeTableBaseRows {
 
   override protected def run(): Seq[InternalRow] = {
     val partitionRow = validateAndGetPartition()
 
-    // Delegate schema + partitioning + clustering to DescribeTableExec by calling
-    // `addBaseDescription` directly (rather than `run()`). That helper reads only `output`
-    // and `table`, so `catalogName` / `tableIdent` are passed for ctor-completeness only --
-    // `addTableDetails` (the only consumer of those fields) is reached only via `run()` and
-    // never fires here. `isExtended = false` matches the contract of the inner exec but is
-    // not what makes the fields unused; bypassing `run()` is.
+    // Delegate schema + partitioning + clustering rows to the shared `DescribeTableBaseRows`
+    // trait (mixed in by both this exec and `DescribeTableExec`). The pre-PR shape constructed
+    // a `DescribeTableExec` inner instance just to invoke its `addBaseDescription` helper.
     val rows = new ArrayBuffer[InternalRow]()
-    DescribeTableExec(output, catalogName, tableIdent, table, isExtended = false)
-      .addBaseDescription(rows)
+    addBaseDescription(rows)
 
     if (isExtended) {
       addPartitionDetails(rows, partitionRow)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTablePartitionExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTablePartitionExec.scala
@@ -38,7 +38,11 @@ case class DescribeTablePartitionExec(
   override protected def run(): Seq[InternalRow] = {
     val partitionRow = validateAndGetPartition()
 
-    // Delegate schema + partitioning + clustering to DescribeTableExec.
+    // Delegate schema + partitioning + clustering to DescribeTableExec. We pass
+    // `catalogName` / `tableIdent` for ctor completeness only -- with `isExtended = false`,
+    // only `addBaseDescription` runs, which reads neither field; the structured
+    // `# Detailed Table Information` block (which is what consumes them) is gated on
+    // `isExtended`.
     val rows = new ArrayBuffer[InternalRow]()
     DescribeTableExec(output, catalogName, tableIdent, table, isExtended = false)
       .addBaseDescription(rows)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ViewInspectionExecs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ViewInspectionExecs.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.util.{escapeSingleQuotedString, quoteIfNeeded, ResolveDefaultColumns}
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumnsUtils.CURRENT_DEFAULT_COLUMN_METADATA_KEY
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, TableCatalog, ViewInfo}
-import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.NamespaceHelper
 import org.apache.spark.sql.errors.QueryCompilationErrors
 
 /**
@@ -148,9 +147,9 @@ case class ShowV2ViewColumnsExec(
 /**
  * Physical plan node for DESCRIBE TABLE on a v2 view. Schema rows first; when EXTENDED is
  * specified, an additional `# Detailed View Information` block emits the v2-native fields:
- * the resolved-identifier components as separate rows (`Catalog`, `Namespace`, an optional
- * v1-compat `Database` row when the namespace is a single segment, and `View`), followed by
- * view text, captured creation context, schema-binding mode, query column names, and user
+ * the resolved-identifier components via [[DescribeIdentifierRows#addIdentifierRows]] (which
+ * also surfaces a v1-compat `Database` row for single-segment namespaces), followed by view
+ * text, captured creation context, schema-binding mode, query column names, and user
  * TBLPROPERTIES. v2 views are unpartitioned by definition, so the partition-spec branch from
  * v1 `DescribeTableCommand` is unreachable here.
  */
@@ -159,7 +158,7 @@ case class DescribeV2ViewExec(
     catalogName: String,
     identifier: Identifier,
     viewInfo: ViewInfo,
-    isExtended: Boolean) extends LeafV2CommandExec with SQLConfHelper {
+    isExtended: Boolean) extends DescribeIdentifierRows with SQLConfHelper {
 
   override protected def run(): Seq[InternalRow] = {
     val result = new ArrayBuffer[InternalRow]
@@ -169,14 +168,7 @@ case class DescribeV2ViewExec(
     if (isExtended) {
       result += toCatalystRow("", "", "")
       result += toCatalystRow("# Detailed View Information", "", "")
-      result += toCatalystRow("Catalog", catalogName, "")
-      result += toCatalystRow("Namespace", identifier.namespace().quoted, "")
-      // For v1 compatibility (see DescribeTableExec.addTableDetails), also emit a
-      // `Database` row when the namespace is a single segment.
-      if (identifier.namespace().length == 1) {
-        result += toCatalystRow("Database", identifier.namespace().head, "")
-      }
-      result += toCatalystRow("View", identifier.name(), "")
+      addIdentifierRows(result, catalogName, identifier, entityLabel = "View")
       // Promote first-class reserved fields (Owner / Comment / Collation) to top-level rows
       // before the EXTENDED Properties block, mirroring v1 `CatalogTable.toJsonLinkedHashMap`
       // which renders these as their own rows rather than burying them in `Table Properties`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ViewInspectionExecs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ViewInspectionExecs.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.util.{escapeSingleQuotedString, quoteIfNeeded, ResolveDefaultColumns}
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumnsUtils.CURRENT_DEFAULT_COLUMN_METADATA_KEY
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, TableCatalog, ViewInfo}
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.NamespaceHelper
 import org.apache.spark.sql.errors.QueryCompilationErrors
 
 /**
@@ -167,9 +168,13 @@ case class DescribeV2ViewExec(
       result += toCatalystRow("", "", "")
       result += toCatalystRow("# Detailed View Information", "", "")
       result += toCatalystRow("Catalog", catalogName, "")
-      val qualified = (identifier.namespace() :+ identifier.name())
-        .map(quoteIfNeeded).mkString(".")
-      result += toCatalystRow("Identifier", qualified, "")
+      result += toCatalystRow("Namespace", identifier.namespace().quoted, "")
+      // For v1 compatibility (see DescribeTableExec.addTableDetails), also emit a
+      // `Database` row when the namespace is a single segment.
+      if (identifier.namespace().length == 1) {
+        result += toCatalystRow("Database", identifier.namespace().head, "")
+      }
+      result += toCatalystRow("View", identifier.name(), "")
       // Promote first-class reserved fields (Owner / Comment / Collation) to top-level rows
       // before the EXTENDED Properties block, mirroring v1 `CatalogTable.toJsonLinkedHashMap`
       // which renders these as their own rows rather than burying them in `Table Properties`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ViewInspectionExecs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ViewInspectionExecs.scala
@@ -147,10 +147,12 @@ case class ShowV2ViewColumnsExec(
 
 /**
  * Physical plan node for DESCRIBE TABLE on a v2 view. Schema rows first; when EXTENDED is
- * specified, an additional `# Detailed View Information` block emits the v2-native fields
- * (catalog, identifier, view text, captured creation context, schema-binding mode, query
- * column names, user TBLPROPERTIES). v2 views are unpartitioned by definition, so the
- * partition-spec branch from v1 `DescribeTableCommand` is unreachable here.
+ * specified, an additional `# Detailed View Information` block emits the v2-native fields:
+ * the resolved-identifier components as separate rows (`Catalog`, `Namespace`, an optional
+ * v1-compat `Database` row when the namespace is a single segment, and `View`), followed by
+ * view text, captured creation context, schema-binding mode, query column names, and user
+ * TBLPROPERTIES. v2 views are unpartitioned by definition, so the partition-spec branch from
+ * v1 `DescribeTableCommand` is unreachable here.
  */
 case class DescribeV2ViewExec(
     output: Seq[Attribute],

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2MetadataTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2MetadataTableSuite.scala
@@ -83,24 +83,6 @@ class DataSourceV2MetadataTableSuite extends QueryTest with SharedSparkSession {
     checkAnswer(spark.table(tableName), 0.until(10).map(i => Row(i, -i)))
   }
 
-  test("DESCRIBE TABLE EXTENDED on a non-view MetadataTable shows the real identifier") {
-    // MetadataTable.name() is read by DescribeTableExec's "Name" row. Pin that it
-    // reflects the catalog-supplied identifier (here TestingDataSourceTableCatalog passes
-    // `ident.toString`) rather than a generic placeholder, so the DESCRIBE output is
-    // meaningful for users.
-    withTempPath { path =>
-      val loc = path.getCanonicalPath
-      val tableName = s"table_catalog.`$loc`.test_json"
-      spark.range(1).select($"id".cast("string").as("col")).write.json(loc)
-      val nameRow = sql(s"DESCRIBE TABLE EXTENDED $tableName")
-        .collect()
-        .find(_.getString(0) == "Name")
-        .getOrElse(fail("DESCRIBE output missing the `Name` row"))
-      val rendered = nameRow.getString(1)
-      assert(rendered.contains("test_json"), s"expected the real identifier, got: $rendered")
-    }
-  }
-
   test("fully-qualified column reference uses the real catalog name") {
     withTempPath { path =>
       val loc = path.getCanonicalPath

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3912,8 +3912,8 @@ class DataSourceV2SQLSuiteV1Filter
         QueryTest.checkAnswer(
           descriptionDf.filter(
             "!(col_name in ('Catalog', 'Created Time', 'Created By', 'Database', " +
-              "'index', 'Location', 'Name', 'Owner', 'Provider', 'Table', 'Table Properties', " +
-              "'Type', '_partition', ''))"),
+              "'index', 'Location', 'Name', 'Namespace', 'Owner', 'Provider', 'Table', " +
+              "'Table Properties', 'Type', '_partition', ''))"),
           Seq(
             Row("# Detailed Table Information", "", ""),
             Row("# Column Default Values", "", ""),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
@@ -242,10 +242,11 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
   }
 
   test("DESCRIBE TABLE EXTENDED with a multi-segment namespace omits Database " +
-      "and dot-quotes Namespace") {
+      "and joins Namespace with dots") {
     // Multi-segment v2 namespaces can't be rendered as a single-string `database`
     // losslessly, so the v1-compat `Database` row is omitted; only `Namespace` is
-    // emitted, with `quoteIfNeeded` applied per segment.
+    // emitted, with segments joined by `.` (and `quoteIfNeeded` applied per segment --
+    // not exercised here because both segments are valid bare identifiers).
     withNamespaceAndTable("ns1.ns2", "table") { tbl =>
       sql(s"CREATE TABLE $tbl (id bigint) $defaultUsing")
       val rows = sql(s"DESCRIBE TABLE EXTENDED $tbl").collect()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
@@ -222,10 +222,10 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
 
   test("DESCRIBE TABLE EXTENDED emits structured Catalog/Namespace/Table rows") {
     // Pin that DescribeTableExec emits the resolved-identifier components as separate
-    // rows under the `# Detailed Table Information` block, so consumers don't have to
-    // parse a single concatenated `Name` row to recover them. Also pin that for a
-    // single-segment namespace, an additional `Database` row is emitted alongside
-    // `Namespace` for v1 compatibility (mirroring v1 `CatalogTable` output).
+    // rows under the `# Detailed Table Information` block, so consumers can read each
+    // part programmatically rather than splitting a concatenated identifier string. Also
+    // pin that for a single-segment namespace, an additional `Database` row is emitted
+    // alongside `Namespace` for v1 compatibility (mirroring v1 `CatalogTable` output).
     withNamespaceAndTable("ns", "table") { tbl =>
       sql(s"CREATE TABLE $tbl (id bigint) $defaultUsing")
       val rows = sql(s"DESCRIBE TABLE EXTENDED $tbl").collect()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
@@ -206,7 +206,10 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
           Row("_partition", "string", "Partition key used to store the row"),
           Row("", "", ""),
           Row("# Detailed Table Information", "", ""),
-          Row("Name", tbl, ""),
+          Row("Catalog", catalog, ""),
+          Row("Namespace", "ns", ""),
+          Row("Database", "ns", ""),
+          Row("Table", "table", ""),
           Row("Type", "MANAGED", ""),
           Row("Comment", "this is a test table", ""),
           Row("Location", "file:/tmp/testcat/table_name", ""),
@@ -214,6 +217,27 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
           Row(TableCatalog.PROP_OWNER.capitalize, Utils.getCurrentUserName(), ""),
           Row("Table Properties", "[bar=baz]", ""),
           Row("Statistics", "0 bytes, 0 rows", null)))
+    }
+  }
+
+  test("DESCRIBE TABLE EXTENDED emits structured Catalog/Namespace/Table rows") {
+    // Pin that DescribeTableExec emits the resolved-identifier components as separate
+    // rows under the `# Detailed Table Information` block, so consumers don't have to
+    // parse a single concatenated `Name` row to recover them. Also pin that for a
+    // single-segment namespace, an additional `Database` row is emitted alongside
+    // `Namespace` for v1 compatibility (mirroring v1 `CatalogTable` output).
+    withNamespaceAndTable("ns", "table") { tbl =>
+      sql(s"CREATE TABLE $tbl (id bigint) $defaultUsing")
+      val rows = sql(s"DESCRIBE TABLE EXTENDED $tbl").collect()
+      def findRowValue(name: String): String = rows
+        .find(_.getString(0) == name)
+        .getOrElse(fail(s"DESCRIBE output missing the `$name` row"))
+        .getString(1)
+      assert(findRowValue("Catalog") == catalog)
+      assert(findRowValue("Namespace") == "ns")
+      assert(findRowValue("Database") == "ns",
+        "single-segment namespace must also surface as a `Database` row for v1 parity")
+      assert(findRowValue("Table") == "table")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
@@ -241,20 +241,20 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
     }
   }
 
-  test("DESCRIBE TABLE EXTENDED with a multi-segment namespace omits Database " +
-      "and joins Namespace with dots") {
-    // Multi-segment v2 namespaces can't be rendered as a single-string `database`
-    // losslessly, so the v1-compat `Database` row is omitted; only `Namespace` is
-    // emitted, with segments joined by `.` (and `quoteIfNeeded` applied per segment --
-    // not exercised here because both segments are valid bare identifiers).
+  test("DESCRIBE TABLE EXTENDED with a multi-segment namespace surfaces the leaf " +
+      "segment in `Database` and joins `Namespace` with dots") {
+    // Multi-segment v2 namespaces still emit a `Database` row for v1 compatibility,
+    // carrying the trailing namespace segment. `Namespace` carries the full dot-joined
+    // form for consumers that need the complete path (with `quoteIfNeeded` applied per
+    // segment -- not exercised here because both segments are valid bare identifiers).
     withNamespaceAndTable("ns1.ns2", "table") { tbl =>
       sql(s"CREATE TABLE $tbl (id bigint) $defaultUsing")
       val rows = sql(s"DESCRIBE TABLE EXTENDED $tbl").collect()
       val byName = rows.map(r => r.getString(0) -> r.getString(1)).toMap
       assert(byName.get("Catalog").contains(catalog))
       assert(byName.get("Namespace").contains("ns1.ns2"))
-      assert(!byName.contains("Database"),
-        "multi-segment namespace must NOT emit the v1-compat `Database` row")
+      assert(byName.get("Database").contains("ns2"),
+        "multi-segment namespace must surface the trailing segment as `Database`")
       assert(byName.get("Table").contains("table"))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
@@ -241,6 +241,23 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase
     }
   }
 
+  test("DESCRIBE TABLE EXTENDED with a multi-segment namespace omits Database " +
+      "and dot-quotes Namespace") {
+    // Multi-segment v2 namespaces can't be rendered as a single-string `database`
+    // losslessly, so the v1-compat `Database` row is omitted; only `Namespace` is
+    // emitted, with `quoteIfNeeded` applied per segment.
+    withNamespaceAndTable("ns1.ns2", "table") { tbl =>
+      sql(s"CREATE TABLE $tbl (id bigint) $defaultUsing")
+      val rows = sql(s"DESCRIBE TABLE EXTENDED $tbl").collect()
+      val byName = rows.map(r => r.getString(0) -> r.getString(1)).toMap
+      assert(byName.get("Catalog").contains(catalog))
+      assert(byName.get("Namespace").contains("ns1.ns2"))
+      assert(!byName.contains("Database"),
+        "multi-segment namespace must NOT emit the v1-compat `Database` row")
+      assert(byName.get("Table").contains("table"))
+    }
+  }
+
   test("describe a non-existent column") {
     withNamespaceAndTable("ns", "tbl") { tbl =>
       sql(s"""

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeViewSuite.scala
@@ -49,10 +49,11 @@ class DescribeViewSuite
     assert(byName.get("View").contains("v2_desc_struct_rows"))
   }
 
-  test("V2: extended on a multi-segment namespace omits Database and dot-quotes Namespace") {
+  test("V2: extended on a multi-segment namespace omits Database and joins Namespace with dots") {
     // Multi-segment v2 namespaces can't be rendered as a single-string `database`
     // losslessly, so the v1-compat `Database` row is omitted; only `Namespace` is
-    // emitted, with `quoteIfNeeded` applied per segment.
+    // emitted, with segments joined by `.` (and `quoteIfNeeded` applied per segment --
+    // not exercised here because both segments are valid bare identifiers).
     val ns = s"$catalog.ns1.ns2"
     withNamespace(ns) {
       sql(s"CREATE NAMESPACE IF NOT EXISTS $ns")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeViewSuite.scala
@@ -33,4 +33,38 @@ class DescribeViewSuite
     assert(rows.contains("# Detailed View Information"),
       s"v2 extended describe should emit the View header; got:\n${rows.mkString("\n")}")
   }
+
+  test("V2: extended emits structured Catalog/Namespace/View rows") {
+    // Pin the v2 view layout: structured `Catalog`/`Namespace`/`View` rows under
+    // `# Detailed View Information`, plus the v1-compat `Database` row when the namespace
+    // is a single segment. Mirrors the table-side pin in `DescribeTableSuite`.
+    val view = s"$catalog.$namespace.v2_desc_struct_rows"
+    sql(s"CREATE VIEW $view AS SELECT 1 AS x")
+    val rows = sql(s"DESCRIBE TABLE EXTENDED $view").collect()
+    val byName = rows.map(r => r.getString(0) -> r.getString(1)).toMap
+    assert(byName.get("Catalog").contains(catalog))
+    assert(byName.get("Namespace").contains(namespace))
+    assert(byName.get("Database").contains(namespace),
+      "single-segment namespace must also surface as a `Database` row for v1 parity")
+    assert(byName.get("View").contains("v2_desc_struct_rows"))
+  }
+
+  test("V2: extended on a multi-segment namespace omits Database and dot-quotes Namespace") {
+    // Multi-segment v2 namespaces can't be rendered as a single-string `database`
+    // losslessly, so the v1-compat `Database` row is omitted; only `Namespace` is
+    // emitted, with `quoteIfNeeded` applied per segment.
+    val ns = s"$catalog.ns1.ns2"
+    withNamespace(ns) {
+      sql(s"CREATE NAMESPACE IF NOT EXISTS $ns")
+      val view = s"$ns.v2_desc_multi_ns"
+      sql(s"CREATE VIEW $view AS SELECT 1 AS x")
+      val rows = sql(s"DESCRIBE TABLE EXTENDED $view").collect()
+      val byName = rows.map(r => r.getString(0) -> r.getString(1)).toMap
+      assert(byName.get("Catalog").contains(catalog))
+      assert(byName.get("Namespace").contains("ns1.ns2"))
+      assert(!byName.contains("Database"),
+        "multi-segment namespace must NOT emit the v1-compat `Database` row")
+      assert(byName.get("View").contains("v2_desc_multi_ns"))
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeViewSuite.scala
@@ -49,11 +49,11 @@ class DescribeViewSuite
     assert(byName.get("View").contains("v2_desc_struct_rows"))
   }
 
-  test("V2: extended on a multi-segment namespace omits Database and joins Namespace with dots") {
-    // Multi-segment v2 namespaces can't be rendered as a single-string `database`
-    // losslessly, so the v1-compat `Database` row is omitted; only `Namespace` is
-    // emitted, with segments joined by `.` (and `quoteIfNeeded` applied per segment --
-    // not exercised here because both segments are valid bare identifiers).
+  test("V2: extended on a multi-segment namespace surfaces the leaf segment in " +
+      "`Database` and joins `Namespace` with dots") {
+    // Multi-segment v2 namespaces still emit a `Database` row for v1 compatibility,
+    // carrying the trailing namespace segment. `Namespace` carries the full dot-joined
+    // form for consumers that need the complete path.
     val ns = s"$catalog.ns1.ns2"
     withNamespace(ns) {
       sql(s"CREATE NAMESPACE IF NOT EXISTS $ns")
@@ -63,8 +63,8 @@ class DescribeViewSuite
       val byName = rows.map(r => r.getString(0) -> r.getString(1)).toMap
       assert(byName.get("Catalog").contains(catalog))
       assert(byName.get("Namespace").contains("ns1.ns2"))
-      assert(!byName.contains("Database"),
-        "multi-segment namespace must NOT emit the v1-compat `Database` row")
+      assert(byName.get("Database").contains("ns2"),
+        "multi-segment namespace must surface the trailing segment as `Database`")
       assert(byName.get("View").contains("v2_desc_multi_ns"))
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Standardize the `# Detailed Table Information` / `# Detailed View
Information` block in `DESCRIBE TABLE EXTENDED` output for v2 tables
and views to emit structured rows derived from the resolved
identifier:

- For tables (`DescribeTableExec`): the single `Name` row that came
  from `Table.name()` is replaced by `Catalog`, `Namespace`,
  `Database`, and `Table`.
- For views (`DescribeV2ViewExec`): the `Catalog` + `Identifier`
  pair (where `Identifier` was a single string concatenating
  namespace and name with `.`) is replaced by `Catalog`,
  `Namespace`, `Database`, and `View`.

The catalog name and resolved `Identifier` are threaded from
`ResolvedTable` / `ResolvedPersistentView` through the v2 execs.
`DescribeTablePartitionExec` is updated to pass the catalog name to
the inner `DescribeTableExec` it constructs for the schema/partition
header.

The `Namespace` row uses `Identifier.namespace().quoted` —
dot-separated, with back-tick quoting only on segments that need it
— matching the existing Spark convention for multi-segment
namespaces. This keeps the row round-trip-safe for namespaces with
dots in segments while staying readable for the common single-level
case.

#### `Database` row for v1 compatibility

v1 `DescribeTableCommand` (via `CatalogTable.toJsonLinkedHashMap`)
emits `Catalog` / `Database` / `Table` rows, where `Database` is
the single-string `database` field of `TableIdentifier`. To keep
DESCRIBE consumers that read the `Database` row working uniformly
across v1 (HMS) and v2, this PR also emits a `Database` row in the
v2 output. The row is **always present**:

- For a single-segment namespace, `Database` is that single
  segment (matches v1 exactly).
- For a multi-segment namespace, `Database` is the trailing
  segment — multi-segment namespaces still surface their leaf
  segment under the v1-compat row, while consumers that need the
  full namespace read `Namespace`.
- For a root-level entity (empty namespace), `Database` is the
  empty string. The row is still emitted so the layout is uniform
  across all v2 namespaces.

`Database` alone is not round-trip-safe for multi-segment cases;
`Namespace` is the canonical v2 representation.

### Why are the changes needed?

In a multi-catalog deployment, the catalog name is a first-class
part of a v2 table or view identifier. The previous output buried
it inside connector-controlled strings:

- `Table.name()` for tables is connector-defined; some connectors
  return `catalog.namespace.name`, others just `namespace.name`,
  others use a custom format. The result is that `DESCRIBE TABLE`
  output looks different across catalogs even for the same logical
  table shape.
- `Identifier` for v2 views collapsed namespace and name into a
  single dotted string, so consumers had to parse the dot back out
  and could not unambiguously round-trip multi-level namespaces
  with dots in segments.

Splitting the components into `Catalog`, `Namespace`,
`Database`, and `Table` / `View` rows:
- gives `DESCRIBE TABLE EXTENDED` a uniform shape across v2
  connectors,
- makes the catalog name explicit and surfaceable when multiple v2
  catalogs are configured,
- handles multi-level namespaces naturally via
  `Identifier.namespace().quoted`,
- aligns the table and view sections so consumers can read the same
  rows from either, switching only on the section header
  (`# Detailed Table Information` vs `# Detailed View Information`),
- with the always-emitted `Database` compatibility row, lets
  consumers built for v1 (HMS) keep working without changes,
- is parseable programmatically without splitting strings.

### Does this PR introduce any user-facing change?

Yes, slight output change in `DESCRIBE TABLE EXTENDED` for v2 tables
and v2 views.

For v2 tables, single-segment namespace (most common):
- Before: `Name | testcat.ns.t | `
- After: `Catalog | testcat | `, `Namespace | ns | `,
  `Database | ns | `, `Table | t | `.

For v2 tables, multi-segment namespace:
- Before: `Name | testcat.ns1.ns2.t | `
- After: `Catalog | testcat | `, `Namespace | ns1.ns2 | `,
  `Database | ns2 | `, `Table | t | `.

For v2 views, single-segment namespace:
- Before: `Catalog | testcat | `, `Identifier | ns.v | `
- After: `Catalog | testcat | `, `Namespace | ns | `,
  `Database | ns | `, `View | v | `.

For v2 views, multi-segment namespace:
- Before: `Catalog | testcat | `, `Identifier | ns1.ns2.v | `
- After: `Catalog | testcat | `, `Namespace | ns1.ns2 | `,
  `Database | ns2 | `, `View | v | `.

v1 paths (session-catalog tables and views via HMS) are unchanged.
Tools that read DESCRIBE output should switch from concatenating
`Name` / `Identifier` to reading the structured rows.

### How was this patch tested?

- Updated the affected golden assertion in `DescribeTableSuite`
  (`DESCRIBE TABLE EXTENDED of a partitioned table`) to match the
  new row layout including the `Database` compatibility row.
- Added focused tests in v2 `DescribeTableSuite` pinning the
  structured rows on a freshly created v2 table for both
  single-segment (`ns`) and multi-segment (`ns1.ns2`) namespaces —
  the multi-segment test pins that `Database` carries the trailing
  segment while `Namespace` carries the full dot-joined form.
- Added parallel tests in v2 `DescribeViewSuite` pinning the same
  layout for v2 views (single-segment and multi-segment).
- Removed the now-redundant `DESCRIBE TABLE EXTENDED on a non-view
  MetadataTable shows the real identifier` test in
  `DataSourceV2MetadataTableSuite` (the structured-row layout is
  what's pinned by the new tests in `v2.DescribeTableSuite`; the
  identifier-passthrough behavior is no longer tied to
  `MetadataTable.name()`).

Ran:

  build/sbt 'sql/testOnly \
    org.apache.spark.sql.execution.command.v2.DescribeTableSuite \
    org.apache.spark.sql.execution.command.v2.DescribeViewSuite \
    org.apache.spark.sql.connector.DataSourceV2MetadataTableSuite \
    org.apache.spark.sql.connector.DataSourceV2MetadataViewSuite'

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7
