### PR TITLE
[SPARK-55810][UI] Fix missing spacing between table and pagination controls in Jobs and Stages page

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/PagedTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/PagedTable.scala
@@ -218,7 +218,7 @@ private[spark] trait PagedTable[T] {
       }
     }
 
-    <div class="d-flex justify-content-between align-items-center">
+    <div class="d-flex justify-content-between align-items-center mb-3">
       <div class="d-flex align-items-center">
         <span class="pe-1">Page: </span>
         <ul class="pagination mb-0">


### PR DESCRIPTION


<!--

-->

### What changes were proposed in this pull request?
This PR fixes a UI regression in the Spark Web UI (Jobs and Stages pages) where spacing between the data table and the pagination controls ("Page", "Jump to", "Show items") was missing ([SPARK-55810](https://issues.apache.org/jira/browse/SPARK-55810)).

The issue was introduced during the Bootstrap upgrade in #54552, which caused the pagination controls to appear visually attached to the table. This change restores appropriate spacing between these elements to improve layout clarity and consistency.


### Why are the changes needed?
Without proper spacing, the table and pagination controls appear cramped and visually misaligned, which negatively impacts readability and overall user experience in the Spark Web UI.

This is a regression caused by the Bootstrap upgrade and should be fixed to maintain UI consistency.


### Does this PR introduce _any_ user-facing change?
Yes.

It improves the visual layout of the Jobs and Stages pages in the Spark Web UI by restoring proper spacing between the table and pagination controls.


### How was this patch tested?

1. Built Spark locally and ran spark-shell
2. Opened the Spark Web UI and navigated to the "Jobs" and "Stages" tabs
3. Verified that spacing between the table and pagination controls is correctly applied
4. Compared behavior before and after the fix to confirm the issue is resolved


### Was this patch authored or co-authored using generative AI tooling?
No.

### Screenshots

| Stages page before the fix | Stages page after the fix |
|---------------|--------------|
| <img width="1512" height="674" alt="Screenshot 2026-05-04 at 2 22 16 PM" src="https://github.com/user-attachments/assets/5d8824d3-0fb9-475f-a739-60bdc36db37d" /> | <img width="1509" height="720" alt="Screenshot 2026-05-01 at 9 28 42 PM" src="https://github.com/user-attachments/assets/e3c0928c-ba43-4a74-aeaf-4d4e93f60ef9" /> |

| Jobs page before the fix | Jobs page after the fix |
|--------------|------------|
| <img src="https://github.com/user-attachments/assets/d70cd94f-d52a-485e-b474-20c1777db3c6" width="100%"/> | <img src="https://github.com/user-attachments/assets/1c242b55-d62a-46f0-8bdb-64abb0ca785e" width="100%"/> |
| <img src="https://github.com/user-attachments/assets/5574d44d-722e-403f-ac73-3db69f495655" width="100%"/> | <img src="https://github.com/user-attachments/assets/20015117-1f5d-44ce-b4c1-07a45c640409" width="100%"/> |

