### PR TITLE
[SPARK-40193][SQL][FOLLOWUP] Rename `spark.sql.optimizer.mergeSubplans.( -> filterPropagation.)symmetricFilterPropagation.enabled`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6593,20 +6593,20 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val MERGE_SUBPLANS_SYMMETRIC_FILTER_PROPAGATION_ENABLED =
-    buildConf("spark.sql.optimizer.mergeSubplans.filterPropagation.symmetricFilterPropagation.enabled")
-      .doc("When set to true, two non-grouping aggregate subplans that both have filter " +
-        "conditions (but with different predicates) can be merged into a single scan using " +
-        "FILTER (WHERE ...) clauses on each aggregate expression. " +
-        "Merging two filtered scans broadens the combined filter to OR(f1, f2), which may " +
-        "reduce IO pruning (e.g. partition or file skipping) compared to the individual " +
-        "filters. Disabled by default; enable once the behaviour has been validated in your " +
-        "workload, particularly on heavily partitioned or file-pruned tables. " +
-        s"Has no effect when ${MERGE_SUBPLANS_FILTER_PROPAGATION_ENABLED.key} is false.")
-      .version("4.2.0")
-      .withBindingPolicy(ConfigBindingPolicy.SESSION)
-      .booleanConf
-      .createWithDefault(false)
+  val MERGE_SUBPLANS_SYMMETRIC_FILTER_PROPAGATION_ENABLED = buildConf(
+    "spark.sql.optimizer.mergeSubplans.filterPropagation.symmetricFilterPropagation.enabled")
+    .doc("When set to true, two non-grouping aggregate subplans that both have filter " +
+      "conditions (but with different predicates) can be merged into a single scan using " +
+      "FILTER (WHERE ...) clauses on each aggregate expression. " +
+      "Merging two filtered scans broadens the combined filter to OR(f1, f2), which may " +
+      "reduce IO pruning (e.g. partition or file skipping) compared to the individual " +
+      "filters. Disabled by default; enable once the behaviour has been validated in your " +
+      "workload, particularly on heavily partitioned or file-pruned tables. " +
+      s"Has no effect when ${MERGE_SUBPLANS_FILTER_PROPAGATION_ENABLED.key} is false.")
+    .version("4.2.0")
+    .withBindingPolicy(ConfigBindingPolicy.SESSION)
+    .booleanConf
+    .createWithDefault(false)
 
   val ERROR_MESSAGE_FORMAT = buildConf("spark.sql.error.messageFormat")
     .doc("When PRETTY, the error message consists of textual representation of error class, " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6594,7 +6594,7 @@ object SQLConf {
       .createWithDefault(true)
 
   val MERGE_SUBPLANS_SYMMETRIC_FILTER_PROPAGATION_ENABLED =
-    buildConf("spark.sql.optimizer.mergeSubplans.symmetricFilterPropagation.enabled")
+    buildConf("spark.sql.optimizer.mergeSubplans.filterPropagation.symmetricFilterPropagation.enabled")
       .doc("When set to true, two non-grouping aggregate subplans that both have filter " +
         "conditions (but with different predicates) can be merged into a single scan using " +
         "FILTER (WHERE ...) clauses on each aggregate expression. " +


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR renames the SQL config key 

`spark.sql.optimizer.mergeSubplans.symmetricFilterPropagation.enabled` to `spark.sql.optimizer.mergeSubplans.filterPropagation.symmetricFilterPropagation.enabled`.

### Why are the changes needed?

To follow the Apache Spark configuration namespace rule. The new key better reflects the configuration hierarchy. `spark.sql.optimizer.mergeSubplans.filterPropagation.enabled` is the parent gate for filter propagation in `MergeSubplans`, and the symmetric variant is a sub-feature of it. Nesting the symmetric flag under `filterPropagation.*` makes that relationship explicit, and groups related options together when listed alphabetically.

The previous key `mergeSubplans.symmetricFilterPropagation.enabled` placed the two sibling options at different levels of the namespace, which obscured the dependency (the symmetric flag has no effect when filter propagation is disabled, as documented in the config `doc`).

This config was added in 4.2.0 and has not been released yet, so no backwards-compat alias is required.

### Does this PR introduce _any_ user-facing change?

No. The config has not been released yet (introduced for 4.2.0).

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7