### PR TITLE
[SPARK-56684][K8S] Expose `KubernetesClusterSchedulerBackend.kubernetesClient` to `k8s` package

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -47,7 +47,7 @@ import org.apache.spark.util.ArrayImplicits._
 private[spark] class KubernetesClusterSchedulerBackend(
     scheduler: TaskSchedulerImpl,
     sc: SparkContext,
-    kubernetesClient: KubernetesClient,
+    private[k8s] val kubernetesClient: KubernetesClient,
     executorService: ScheduledExecutorService,
     snapshotsStore: ExecutorPodsSnapshotsStore,
     podAllocator: AbstractPodsAllocator,

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
@@ -160,6 +160,10 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
     verify(configMapResource).create()
   }
 
+  test("SPARK-56684: kubernetesClient is exposed within the k8s package") {
+    assert(schedulerBackendUnderTest.kubernetesClient eq kubernetesClient)
+  }
+
   test("Stop all components") {
     when(podsWithNamespace.withLabel(SPARK_APP_ID_LABEL, TEST_SPARK_APP_ID)).thenReturn(labeledPods)
     when(labeledPods.withLabel(SPARK_ROLE_LABEL, SPARK_POD_EXECUTOR_ROLE)).thenReturn(labeledPods)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR promotes the `kubernetesClient` constructor parameter of `KubernetesClusterSchedulerBackend` to a `private[k8s] val`, exposing it as a read-only member to other components in the `org.apache.spark.scheduler.cluster.k8s` package.

### Why are the changes needed?

Like `ExecutorResizePlugin`, many plugins currently build its own `KubernetesClient` via `SparkKubernetesClientFactory.createKubernetesClient(...)`. This produces multiple clients in the driver process that target the same API server with the same credentials.

The driver already owns a single `KubernetesClient` through `KubernetesClusterSchedulerBackend`, whose lifecycle is managed in `start()` / `stop()`. Exposing it as `private[k8s] val` lets package-local components reuse this shared client in follow-up work, without widening the API surface to other modules or external users.

This PR is intentionally limited to the visibility change. Reusing the shared client from existing plugins is left to follow-up PRs so each change stays minimal and reviewable.

### Does this PR introduce _any_ user-facing change?

No. The visibility is `private[k8s]`, so the change is invisible outside the `org.apache.spark.scheduler.cluster.k8s` package.

### How was this patch tested?

Pass the CIs with a new unit test.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7