### PR TITLE
[SPARK-56686][SQL] Support streaming row-level CDC post-processing

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -666,6 +666,11 @@
       "The Change Data Capture (CDC) connector violated the `Changelog` contract at runtime."
     ],
     "subClass" : {
+      "NULL_COMMIT_TIMESTAMP" : {
+        "message" : [
+          "Connector emitted a row with a NULL `_commit_timestamp` on a streaming read engaging post-processing. The `Changelog` contract requires `_commit_timestamp` to be non-NULL for streaming reads, since post-processing uses it as event time to advance the watermark."
+        ]
+      },
       "UNEXPECTED_CHANGE_TYPE" : {
         "message" : [
           "Connector emitted a row with a `_change_type` value that is not one of the four supported types (`insert`, `delete`, `update_preimage`, `update_postimage`). The `Changelog` contract requires every emitted row to carry one of these four values."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3297,9 +3297,9 @@
           "`startingVersion` is required when `endingVersion` is specified for CDC queries."
         ]
       },
-      "STREAMING_POST_PROCESSING_NOT_SUPPORTED" : {
+      "STREAMING_NET_CHANGES_NOT_SUPPORTED" : {
         "message" : [
-          "Change Data Capture (CDC) streaming reads on connector `<changelogName>` do not yet support post-processing (carry-over removal, update detection, or net change computation). The requested combination of options would require post-processing, which is currently only available for batch reads. Use a batch read, or set `deduplicationMode = none` and `computeUpdates = false` to receive raw change rows in streaming."
+          "Change Data Capture (CDC) streaming reads on connector `<changelogName>` do not yet support net change computation (`deduplicationMode = netChanges`). Net change computation reasons over the entire requested version range and is currently only available for batch reads. Use a batch read, or set `deduplicationMode` to `none` or `dropCarryovers` for streaming."
         ]
       },
       "UPDATE_DETECTION_REQUIRES_CARRY_OVER_REMOVAL" : {

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -132,24 +132,25 @@ abstract class DataStreamReader {
    * }}}
    *
    * Streaming reads support the same `computeUpdates` and `deduplicationMode = dropCarryovers`
-   * post-processing as batch reads. `deduplicationMode = netChanges` is currently
-   * batch-only -- it requires reasoning over the entire requested range, which is not
-   * incrementalized yet. Requesting it on a streaming read raises an explicit
+   * post-processing as batch reads. `deduplicationMode = netChanges` is currently batch-only --
+   * it requires reasoning over the entire requested range, which is not incrementalized yet.
+   * Requesting it on a streaming read raises an explicit
    * `INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED` error.
    *
-   * When the requested options engage row-level post-processing (carry-over removal or
-   * update detection), the rewrite injects an internal `EventTimeWatermark` on
-   * `_commit_timestamp` and a stateful streaming aggregate. Two implications follow:
+   * When the requested options engage row-level post-processing (carry-over removal or update
+   * detection), the rewrite injects an internal `EventTimeWatermark` on `_commit_timestamp` and a
+   * stateful streaming aggregate. Two implications follow:
    *   - A commit's events are emitted in the next micro-batch after the commit is read
-   *     (append-mode aggregate eviction is `eventTime <= watermark`, and the watermark
-   *     advances to the max `_commit_timestamp` observed in the previous batch). A stream
-   *     that reads its last commit and stops will keep that commit's events in state until
-   *     a subsequent (no-data) micro-batch fires.
-   *   - The watermark metadata is preserved on the user-visible `_commit_timestamp` output.
-   *     If a downstream `withWatermark` is added on a different column, the global watermark
-   *     becomes the `min` of the two (under the default
-   *     `spark.sql.streaming.multipleWatermarkPolicy = min`), which can rate-limit
-   *     downstream stateful operators.
+   *     (append-mode aggregate eviction is `eventTime <= watermark`, and the watermark advances
+   *     to the max `_commit_timestamp` observed in the previous batch). A stream that reads its
+   *     last commit and stops will keep that commit's events in state until a subsequent
+   *     (no-data) micro-batch fires.
+   *   - The query is constrained to `Append` output mode; `Update` and `Complete` are
+   *     rejected at writer-start time with
+   *     `STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION`. The internal watermark metadata is
+   *     stripped from the user-visible `_commit_timestamp` output, so downstream
+   *     user-supplied watermarks on other columns do not interact with it via the global
+   *     multi-watermark policy.
    *
    * @param tableName
    *   a qualified or unqualified name that designates a table.

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -141,7 +141,7 @@ abstract class DataStreamReader {
    * detection), the rewrite injects an internal `EventTimeWatermark` on `_commit_timestamp` and a
    * stateful streaming aggregate. Two implications follow:
    *   - A commit's events are emitted in the next micro-batch after the commit is read
-   *     (append-mode aggregate eviction is `eventTime <= watermark`, and the watermark advances
+   *     (append-mode aggregate eviction is `eventTime &lt;= watermark`, and the watermark advances
    *     to the max `_commit_timestamp` observed in the previous batch). A stream that reads its
    *     last commit and stops will keep that commit's events in state until a subsequent
    *     (no-data) micro-batch fires.

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -141,10 +141,10 @@ abstract class DataStreamReader {
    * detection), the rewrite injects an internal `EventTimeWatermark` on `_commit_timestamp` and a
    * stateful streaming aggregate. Two implications follow:
    *   - A commit's events are emitted in the next micro-batch after the commit is read
-   *     (append-mode aggregate eviction is `eventTime &lt;= watermark`, and the watermark advances
-   *     to the max `_commit_timestamp` observed in the previous batch). A stream that reads its
-   *     last commit and stops will keep that commit's events in state until a subsequent
-   *     (no-data) micro-batch fires.
+   *     (append-mode aggregate eviction is `eventTime &lt;= watermark`, and the watermark
+   *     advances to the max `_commit_timestamp` observed in the previous batch). A stream that
+   *     reads its last commit and stops will keep that commit's events in state until a
+   *     subsequent (no-data) micro-batch fires.
    *   - The query is constrained to `Append` output mode; `Update` and `Complete` are rejected at
    *     writer-start time with `STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION`. The internal
    *     watermark metadata is stripped from the user-visible `_commit_timestamp` output, so

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -137,6 +137,20 @@ abstract class DataStreamReader {
    * incrementalized yet. Requesting it on a streaming read raises an explicit
    * `INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED` error.
    *
+   * When the requested options engage row-level post-processing (carry-over removal or
+   * update detection), the rewrite injects an internal `EventTimeWatermark` on
+   * `_commit_timestamp` and a stateful streaming aggregate. Two implications follow:
+   *   - A commit's events are emitted in the next micro-batch after the commit is read
+   *     (append-mode aggregate eviction is `eventTime <= watermark`, and the watermark
+   *     advances to the max `_commit_timestamp` observed in the previous batch). A stream
+   *     that reads its last commit and stops will keep that commit's events in state until
+   *     a subsequent (no-data) micro-batch fires.
+   *   - The watermark metadata is preserved on the user-visible `_commit_timestamp` output.
+   *     If a downstream `withWatermark` is added on a different column, the global watermark
+   *     becomes the `min` of the two (under the default
+   *     `spark.sql.streaming.multipleWatermarkPolicy = min`), which can rate-limit
+   *     downstream stateful operators.
+   *
    * @param tableName
    *   a qualified or unqualified name that designates a table.
    * @since 4.2.0

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -131,6 +131,12 @@ abstract class DataStreamReader {
    *     .changes("my_table")
    * }}}
    *
+   * Streaming reads support the same `computeUpdates` and `deduplicationMode = dropCarryovers`
+   * post-processing as batch reads. `deduplicationMode = netChanges` is currently
+   * batch-only -- it requires reasoning over the entire requested range, which is not
+   * incrementalized yet. Requesting it on a streaming read raises an explicit
+   * `INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED` error.
+   *
    * @param tableName
    *   a qualified or unqualified name that designates a table.
    * @since 4.2.0

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -145,12 +145,11 @@ abstract class DataStreamReader {
    *     to the max `_commit_timestamp` observed in the previous batch). A stream that reads its
    *     last commit and stops will keep that commit's events in state until a subsequent
    *     (no-data) micro-batch fires.
-   *   - The query is constrained to `Append` output mode; `Update` and `Complete` are
-   *     rejected at writer-start time with
-   *     `STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION`. The internal watermark metadata is
-   *     stripped from the user-visible `_commit_timestamp` output, so downstream
-   *     user-supplied watermarks on other columns do not interact with it via the global
-   *     multi-watermark policy.
+   *   - The query is constrained to `Append` output mode; `Update` and `Complete` are rejected at
+   *     writer-start time with `STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION`. The internal
+   *     watermark metadata is stripped from the user-visible `_commit_timestamp` output, so
+   *     downstream user-supplied watermarks on other columns do not interact with it via the
+   *     global multi-watermark policy.
    *
    * @param tableName
    *   a qualified or unqualified name that designates a table.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
@@ -35,8 +35,16 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *       {@code update_preimage}, or {@code update_postimage}</li>
  *   <li>{@code _commit_version} (connector-defined type, e.g. LONG) — the version containing
  *       this change</li>
- *   <li>{@code _commit_timestamp} (TIMESTAMP) — the timestamp of the commit</li>
+ *   <li>{@code _commit_timestamp} (TIMESTAMP) -- the timestamp of the commit. All rows
+ *       belonging to a single {@code _commit_version} must share the same
+ *       {@code _commit_timestamp}; streaming post-processing uses it as event time and
+ *       expects the connector to emit {@code _commit_timestamp} in non-decreasing order
+ *       across micro-batches</li>
  * </ul>
+ * <p>
+ * Streaming reads support carry-over removal and update detection but not net change
+ * computation. The latter requires reasoning over the entire requested range and is
+ * batch-only.
  *
  * @since 4.2.0
  */
@@ -81,6 +89,12 @@ public interface Changelog {
    * Spark will collapse multiple changes per row identity into the net effect.
    * If {@code false}, the connector guarantees at most one change per row identity across
    * the entire changelog range, and Spark will skip net change computation.
+   * <p>
+   * Note this flag is range-scoped (across all commits in the request), not
+   * micro-batch-scoped. Streaming CDC reads currently reject
+   * {@code deduplicationMode = netChanges} because the per-row-identity collapse cannot
+   * be incrementalized: a row's full history may span an unbounded number of
+   * micro-batches.
    */
   boolean containsIntermediateChanges();
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
@@ -42,22 +42,29 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *       <ol>
  *         <li>All rows of a single commit must appear in the same micro-batch (i.e.
  *             micro-batch boundaries align with commit boundaries).</li>
- *         <li>Distinct {@code _commit_version} values must have distinct
- *             {@code _commit_timestamp} values.</li>
+ *         <li>Each micro-batch's rows must have {@code _commit_timestamp} strictly
+ *             greater than the maximum {@code _commit_timestamp} of any prior
+ *             micro-batch.</li>
  *       </ol>
  *       Streaming post-processing uses {@code _commit_timestamp} as event time with a
  *       zero-delay watermark, so once a micro-batch observes max event time T the
  *       global watermark advances to T. Both Spark's late-event filter and its
  *       state-eviction predicate then use {@code eventTime <= T} -- so any later row
- *       at exactly {@code _commit_timestamp = T} (whether from the same commit split
- *       across batches, or from a different commit that happens to share T) is
- *       silently dropped as late. Requirement 1 rules out the same-commit case;
- *       requirement 2 rules out the different-commit case. Atomic-commit CDC connectors
- *       (e.g. Delta versions, Iceberg snapshots) that derive {@code _commit_timestamp}
- *       from wall-clock time at commit time naturally satisfy both requirements.
- *       Behavior is undefined if {@code _commit_timestamp} is {@code NULL} on any row
- *       of a streaming read engaging post-processing -- a NULL group key never advances
- *       the watermark, which can stall emission of that group indefinitely</li>
+ *       at {@code _commit_timestamp <= T} (whether from the same commit split across
+ *       batches, a different commit emitted later, or simply an out-of-order commit)
+ *       is silently dropped as late. Requirement 1 keeps a single commit's rows
+ *       together; requirement 2 keeps distinct commits in strictly increasing
+ *       event-time order across batches. Multiple distinct commits with equal
+ *       {@code _commit_timestamp} are allowed within a single micro-batch -- only
+ *       <em>across</em> batches does timestamp progression need to be strictly
+ *       increasing. Atomic-commit CDC connectors (e.g. Delta versions, Iceberg
+ *       snapshots) that derive {@code _commit_timestamp} from wall-clock time at
+ *       commit time naturally satisfy both requirements.
+ *       {@code _commit_timestamp} must be non-{@code NULL} on every row of a streaming
+ *       read engaging post-processing. The row-level rewrite raises
+ *       {@code CHANGELOG_CONTRACT_VIOLATION.NULL_COMMIT_TIMESTAMP} on any row that
+ *       violates this; without the guard a NULL group key would never satisfy the
+ *       watermark eviction predicate and the row would sit in state indefinitely</li>
  * </ul>
  * <p>
  * Streaming reads support carry-over removal and update detection but not net change

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
@@ -38,13 +38,23 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *   <li>{@code _commit_timestamp} (TIMESTAMP) -- the timestamp of the commit. All rows
  *       belonging to a single {@code _commit_version} must share the same
  *       {@code _commit_timestamp}. For streaming reads with post-processing enabled,
- *       all rows of a single commit must additionally appear in the same micro-batch
- *       (i.e. micro-batch boundaries align with commit boundaries) -- streaming
- *       post-processing uses {@code _commit_timestamp} as event time with a zero-delay
- *       watermark, so a commit's group is finalized as soon as the watermark catches
- *       up to that timestamp; any rows of the same commit arriving in a later
- *       micro-batch would be treated as late and dropped. Atomic-commit CDC connectors
- *       (e.g. Delta versions, Iceberg snapshots) naturally satisfy this requirement.
+ *       two additional requirements apply:
+ *       <ol>
+ *         <li>All rows of a single commit must appear in the same micro-batch (i.e.
+ *             micro-batch boundaries align with commit boundaries).</li>
+ *         <li>Distinct {@code _commit_version} values must have distinct
+ *             {@code _commit_timestamp} values.</li>
+ *       </ol>
+ *       Streaming post-processing uses {@code _commit_timestamp} as event time with a
+ *       zero-delay watermark, so once a micro-batch observes max event time T the
+ *       global watermark advances to T. Both Spark's late-event filter and its
+ *       state-eviction predicate then use {@code eventTime <= T} -- so any later row
+ *       at exactly {@code _commit_timestamp = T} (whether from the same commit split
+ *       across batches, or from a different commit that happens to share T) is
+ *       silently dropped as late. Requirement 1 rules out the same-commit case;
+ *       requirement 2 rules out the different-commit case. Atomic-commit CDC connectors
+ *       (e.g. Delta versions, Iceberg snapshots) that derive {@code _commit_timestamp}
+ *       from wall-clock time at commit time naturally satisfy both requirements.
  *       Behavior is undefined if {@code _commit_timestamp} is {@code NULL} on any row
  *       of a streaming read engaging post-processing -- a NULL group key never advances
  *       the watermark, which can stall emission of that group indefinitely</li>

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
@@ -39,7 +39,10 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *       belonging to a single {@code _commit_version} must share the same
  *       {@code _commit_timestamp}; streaming post-processing uses it as event time and
  *       expects the connector to emit {@code _commit_timestamp} in non-decreasing order
- *       across micro-batches</li>
+ *       across micro-batches. Behavior is undefined if {@code _commit_timestamp} is
+ *       {@code NULL} on any row of a streaming read engaging post-processing -- a NULL
+ *       group key never advances the watermark, which can stall emission of that group
+ *       indefinitely</li>
  * </ul>
  * <p>
  * Streaming reads support carry-over removal and update detection but not net change

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
@@ -37,12 +37,17 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *       this change</li>
  *   <li>{@code _commit_timestamp} (TIMESTAMP) -- the timestamp of the commit. All rows
  *       belonging to a single {@code _commit_version} must share the same
- *       {@code _commit_timestamp}; streaming post-processing uses it as event time and
- *       expects the connector to emit {@code _commit_timestamp} in non-decreasing order
- *       across micro-batches. Behavior is undefined if {@code _commit_timestamp} is
- *       {@code NULL} on any row of a streaming read engaging post-processing -- a NULL
- *       group key never advances the watermark, which can stall emission of that group
- *       indefinitely</li>
+ *       {@code _commit_timestamp}. For streaming reads with post-processing enabled,
+ *       all rows of a single commit must additionally appear in the same micro-batch
+ *       (i.e. micro-batch boundaries align with commit boundaries) -- streaming
+ *       post-processing uses {@code _commit_timestamp} as event time with a zero-delay
+ *       watermark, so a commit's group is finalized as soon as the watermark catches
+ *       up to that timestamp; any rows of the same commit arriving in a later
+ *       micro-batch would be treated as late and dropped. Atomic-commit CDC connectors
+ *       (e.g. Delta versions, Iceberg snapshots) naturally satisfy this requirement.
+ *       Behavior is undefined if {@code _commit_timestamp} is {@code NULL} on any row
+ *       of a streaming read engaging post-processing -- a NULL group key never advances
+ *       the watermark, which can stall emission of that group indefinitely</li>
  * </ul>
  * <p>
  * Streaming reads support carry-over removal and update detection but not net change

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
@@ -217,10 +217,66 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
   }
 
   /**
-   * Streaming counterpart of [[addRowLevelPostProcessing]]. The batch version uses a
-   * Catalyst `Window` operator, which `UnsupportedOperationChecker` rejects on streaming
-   * queries (`NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING`). This version expresses the
-   * same logic with streaming-allowed primitives:
+   * Streaming counterpart of [[addRowLevelPostProcessing]].
+   *
+   * ==Why a different shape from the batch path?==
+   *
+   * The batch rewrite is Window-based:
+   * {{{
+   *   DataSourceV2Relation
+   *     -> Window partitioned by (rowId..., _commit_version)
+   *     -> [Filter (carry-over)]
+   *     -> [Project (update relabel)]
+   *     -> Project (drop helper columns)
+   * }}}
+   * [[org.apache.spark.sql.catalyst.analysis.UnsupportedOperationChecker]] rejects
+   * `Window` on streaming queries (`NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING`).
+   * Replacing it with a plain [[Aggregate]] is not enough on its own: an aggregate
+   * collapses each group to a single row, losing the per-input rows we still need to
+   * relabel/filter; and an append-mode streaming aggregate without an event-time
+   * watermark on a grouping key is itself rejected by the checker.
+   *
+   * ==The rewritten plan==
+   *
+   * Two adjustments over the naive substitution: (a) inject an [[EventTimeWatermark]]
+   * on `_commit_timestamp` (zero delay) so the aggregate is legal in append mode, and
+   * (b) buffer every input row of a group as `Inline`-able structs and re-explode after
+   * the aggregate so no rows are lost.
+   * {{{
+   *   DataSourceV2Relation
+   *     -> EventTimeWatermark(_commit_timestamp, 0s)
+   *     -> Aggregate
+   *          group by (rowId..., _commit_version, _commit_timestamp)
+   *          aggs    : _del_cnt, _ins_cnt
+   *                    [, _min_rv, _max_rv, _rv_cnt  (carry-over removal only)]
+   *                    , __spark_cdc_events = collect_list(struct(*))
+   *     -> [Filter (carry-over: _del_cnt=1 AND _ins_cnt=1
+   *                             AND _rv_cnt=2 AND _min_rv=_max_rv)]
+   *     -> Generate(Inline(__spark_cdc_events))   // re-emit one row per buffered input
+   *     -> [Project (update relabel)]
+   *     -> Project (drop helper columns)
+   * }}}
+   *
+   * ==Runtime walkthrough==
+   *
+   * Append-mode streaming aggregates emit a group when its event-time grouping key
+   * falls at or below the global watermark (eviction predicate `eventTime <= watermark`,
+   * applied at the start of the next micro-batch). Suppose three commits with
+   * `_commit_timestamp` 10, 20, 30 each arrive in their own micro-batch:
+   * {{{
+   *   batch  max _ts seen  watermark after batch  groups emitted by this batch
+   *   -----  ------------  ---------------------  ----------------------------
+   *     1         10                10            <none>
+   *     2         20                20            groups with _commit_timestamp == 10
+   *     3         30                30            groups with _commit_timestamp == 20
+   *   end-of-stream final flush                   groups with _commit_timestamp == 30
+   * }}}
+   * Because every row of a single commit shares the same `_commit_timestamp` (CDC
+   * contract), advancing past commit T releases every group whose grouping
+   * `_commit_timestamp` equals T -- one commit's worth of post-processed output per
+   * micro-batch, with the final commit flushed on stream termination.
+   *
+   * ==Per-operator detail==
    *
    *  1. [[EventTimeWatermark]] on `_commit_timestamp` (zero delay) -- required so the
    *     downstream stateful aggregate can emit groups in append output mode. By CDC
@@ -236,8 +292,9 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
    *     the batch path, plus an `__spark_cdc_events` array-of-struct buffering every
    *     input row of the group. `_commit_timestamp` is included in the grouping keys
    *     (besides being a no-op given the contract) to satisfy
-   *     [[UnsupportedOperationChecker]]'s requirement that the watermark attribute
-   *     appear among grouping expressions for append-mode streaming aggregations.
+   *     [[org.apache.spark.sql.catalyst.analysis.UnsupportedOperationChecker]]'s
+   *     requirement that the watermark attribute appear among grouping expressions for
+   *     append-mode streaming aggregations.
    *  3. [[Filter]] (only when carry-over removal is requested) on the same predicate as
    *     the batch path -- groups with `_del_cnt = 1 AND _ins_cnt = 1 AND _rv_cnt = 2 AND
    *     _min_rv = _max_rv` are dropped wholesale.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
@@ -17,8 +17,11 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
+import java.util.UUID
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{
+  CollectList,
   Count,
   First,
   Last,
@@ -32,6 +35,7 @@ import org.apache.spark.sql.connector.catalog.{Changelog, ChangelogInfo}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.{ChangelogTable, DataSourceV2Relation}
 import org.apache.spark.sql.types.{IntegerType, StringType}
+import org.apache.spark.unsafe.types.CalendarInterval
 
 /**
  * Post-processes a resolved [[ChangelogTable]] read to apply CDC option semantics
@@ -47,10 +51,17 @@ import org.apache.spark.sql.types.{IntegerType, StringType}
  *     carry-over pairs (same rowVersion on both sides) and the subsequent Project relabels
  *     real delete+insert pairs as update_preimage / update_postimage. Net change
  *     computation runs on top of that, collapsing intermediate states per `rowId`.
- *   - Streaming: post-processing is not yet supported. If the requested options would
- *     require any post-processing, the rule throws an explicit [[AnalysisException]] to
- *     prevent silent wrong results. Streams that don't require post-processing pass
- *     through unchanged.
+ *   - Streaming: row-level passes (carry-over removal and update detection) are supported
+ *     by rewriting the same logic in streaming-allowed primitives -- an
+ *     [[EventTimeWatermark]] on `_commit_timestamp`, a stateful [[Aggregate]] keyed by
+ *     `(rowId, _commit_version, _commit_timestamp)` that buffers events into an array, an
+ *     optional [[Filter]] for carry-over removal, a [[Generate]] using `Inline` to
+ *     re-emit the buffered events as rows, and an optional relabel [[Project]] for
+ *     update detection. Net change computation requires partitioning by `rowId` only and
+ *     reasoning over the entire requested range, which is fundamentally cross-batch and
+ *     not yet supported -- if `deduplicationMode = netChanges` is requested on a stream,
+ *     the rule throws an explicit [[AnalysisException]] to prevent silent wrong results.
+ *     Streams that don't require any post-processing pass through unchanged.
  */
 object ResolveChangelogTable extends Rule[LogicalPlan] {
 
@@ -64,8 +75,11 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
     final val MinRv = "__spark_cdc_min_rv"
     final val MaxRv = "__spark_cdc_max_rv"
     final val RvCnt = "__spark_cdc_rv_cnt"
+    // Streaming-only: array of struct buffering all input rows for one (rowId,
+    // _commit_version) group, fed into Generate(Inline(...)) to re-emit per-row.
+    final val Events = "__spark_cdc_events"
 
-    val all: Set[String] = Set(DelCnt, InsCnt, MinRv, MaxRv, RvCnt)
+    val all: Set[String] = Set(DelCnt, InsCnt, MinRv, MaxRv, RvCnt, Events)
   }
 
   /**
@@ -109,16 +123,21 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
 
     case rel @ StreamingRelationV2(_, _, table: ChangelogTable, _, _, _, _, _, _)
         if !table.resolved =>
-      // Streaming CDC reads do not yet apply post-processing. Run the same option /
-      // capability validation as the batch path so silent wrong results are impossible:
-      // either no post-processing would be required (fall through, return raw stream),
-      // or we throw an explicit AnalysisException.
       val changelog = table.changelog
       val req = evaluateRequirements(changelog, table.changelogInfo)
-      if (req.needsAny) {
-        throw QueryCompilationErrors.cdcStreamingPostProcessingNotSupported(changelog.name())
+      // Net-change computation partitions by `rowId` alone (without `_commit_version`) and
+      // reasons over the entire requested range, which is fundamentally cross-batch.
+      // Reject with an explicit error until a streaming-friendly implementation lands.
+      if (req.requiresNetChanges) {
+        throw QueryCompilationErrors.cdcStreamingNetChangesNotSupported(changelog.name())
       }
-      rel.copy(table = table.copy(resolved = true))
+      val resolvedRel = rel.copy(table = table.copy(resolved = true))
+      if (req.requiresCarryOverRemoval || req.requiresUpdateDetection) {
+        addStreamingRowLevelPostProcessing(
+          resolvedRel, changelog, req.requiresCarryOverRemoval, req.requiresUpdateDetection)
+      } else {
+        resolvedRel
+      }
   }
 
   // ---------------------------------------------------------------------------
@@ -195,6 +214,125 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
     if (requiresCarryOverRemoval) modifiedPlan = addCarryOverPairFilter(modifiedPlan)
     if (requiresUpdateDetection) modifiedPlan = addUpdateRelabelProjection(modifiedPlan)
     removeHelperColumns(modifiedPlan)
+  }
+
+  /**
+   * Streaming counterpart of [[addRowLevelPostProcessing]]. The batch version uses a
+   * Catalyst `Window` operator, which `UnsupportedOperationChecker` rejects on streaming
+   * queries (`NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING`). This version expresses the
+   * same logic with streaming-allowed primitives:
+   *
+   *  1. [[EventTimeWatermark]] on `_commit_timestamp` (zero delay) -- required so the
+   *     downstream stateful aggregate can emit groups in append output mode. By CDC
+   *     contract every row in a single commit shares `_commit_timestamp`, so taking it
+   *     as event time is safe.
+   *  2. [[Aggregate]] keyed by `(rowId..., _commit_version, _commit_timestamp)`. Computes
+   *     the same `_del_cnt` / `_ins_cnt` / (`_min_rv` / `_max_rv` / `_rv_cnt`) helpers as
+   *     the batch path, plus an `__spark_cdc_events` array-of-struct buffering every
+   *     input row of the group. `_commit_timestamp` is included in the grouping keys
+   *     (besides being a no-op given the contract) to satisfy
+   *     [[UnsupportedOperationChecker]]'s requirement that the watermark attribute
+   *     appear among grouping expressions for append-mode streaming aggregations.
+   *  3. [[Filter]] (only when carry-over removal is requested) on the same predicate as
+   *     the batch path -- groups with `_del_cnt = 1 AND _ins_cnt = 1 AND _rv_cnt = 2 AND
+   *     _min_rv = _max_rv` are dropped wholesale.
+   *  4. [[Generate]] using `Inline(events)` to re-emit one output row per buffered input
+   *     row. `unrequiredChildIndex` drops the duplicate grouping columns and the events
+   *     buffer; the helper count columns flow through.
+   *  5. [[Project]] (only when update detection is requested) applying the same
+   *     `CHANGELOG_CONTRACT_VIOLATION.UNEXPECTED_MULTIPLE_CHANGES_PER_ROW_VERSION`
+   *     guard and `_change_type` relabel as the batch path.
+   *  6. Final [[Project]] (via [[removeHelperColumns]]) drops `__spark_cdc_*` helpers so
+   *     the output schema matches the connector's declared schema.
+   */
+  private def addStreamingRowLevelPostProcessing(
+      plan: LogicalPlan,
+      cl: Changelog,
+      requiresCarryOverRemoval: Boolean,
+      requiresUpdateDetection: Boolean): LogicalPlan = {
+    val rawCommitTsAttr = getAttribute(plan, "_commit_timestamp")
+    val watermarked = EventTimeWatermark(
+      UUID.randomUUID(), rawCommitTsAttr, new CalendarInterval(0, 0, 0L), plan)
+
+    val rowIdExprs = V2ExpressionUtils.resolveRefs[NamedExpression](
+      cl.rowId().toSeq, watermarked)
+    val commitVersionAttr = getAttribute(watermarked, "_commit_version")
+    // Pick up the post-watermark `_commit_timestamp` attribute -- it carries the
+    // EventTimeWatermark.delayKey metadata that UnsupportedOperationChecker scans for.
+    val commitTimestampAttr = getAttribute(watermarked, "_commit_timestamp")
+    val changeTypeAttr = getAttribute(watermarked, "_change_type")
+
+    val groupingExprs: Seq[Expression] =
+      rowIdExprs ++ Seq(commitVersionAttr, commitTimestampAttr)
+    val groupingNamedExprs: Seq[NamedExpression] =
+      groupingExprs.map(_.asInstanceOf[NamedExpression])
+
+    val insertIf = If(EqualTo(changeTypeAttr, Literal(Changelog.CHANGE_TYPE_INSERT)),
+      Literal(1), Literal(null, IntegerType))
+    val deleteIf = If(EqualTo(changeTypeAttr, Literal(Changelog.CHANGE_TYPE_DELETE)),
+      Literal(1), Literal(null, IntegerType))
+    val delCntAlias = Alias(
+      Count(Seq(deleteIf)).toAggregateExpression(), HelperColumn.DelCnt)()
+    val insCntAlias = Alias(
+      Count(Seq(insertIf)).toAggregateExpression(), HelperColumn.InsCnt)()
+
+    val rvAliases = if (requiresCarryOverRemoval) {
+      val rowVersionExpr = V2ExpressionUtils.resolveRef[NamedExpression](
+        cl.rowVersion(), watermarked)
+      Seq(
+        Alias(Min(rowVersionExpr).toAggregateExpression(), HelperColumn.MinRv)(),
+        Alias(Max(rowVersionExpr).toAggregateExpression(), HelperColumn.MaxRv)(),
+        Alias(Count(Seq(rowVersionExpr)).toAggregateExpression(), HelperColumn.RvCnt)())
+    } else Seq.empty
+
+    // Buffer every input row as a struct so Inline can re-emit them after the aggregate.
+    // `_commit_version` and `_commit_timestamp` appear inside the struct as well as in the
+    // grouping keys; the duplicates are dropped via `unrequiredChildIndex` below.
+    val structOfAllCols = CreateStruct(watermarked.output)
+    val eventsAlias = Alias(
+      new CollectList(structOfAllCols).toAggregateExpression(), HelperColumn.Events)()
+
+    val aggregateExprs: Seq[NamedExpression] =
+      groupingNamedExprs ++ Seq(delCntAlias, insCntAlias) ++ rvAliases :+ eventsAlias
+    val aggregated = Aggregate(groupingExprs, aggregateExprs, watermarked)
+
+    val filtered: LogicalPlan = if (requiresCarryOverRemoval) {
+      val delCnt = getAttribute(aggregated, HelperColumn.DelCnt)
+      val insCnt = getAttribute(aggregated, HelperColumn.InsCnt)
+      val minRv = getAttribute(aggregated, HelperColumn.MinRv)
+      val maxRv = getAttribute(aggregated, HelperColumn.MaxRv)
+      val rvCnt = getAttribute(aggregated, HelperColumn.RvCnt)
+      val isCarryoverPair = And(
+        And(EqualTo(delCnt, Literal(1L)), EqualTo(insCnt, Literal(1L))),
+        And(EqualTo(rvCnt, Literal(2L)), EqualTo(minRv, maxRv)))
+      Filter(Not(isCarryoverPair), aggregated)
+    } else aggregated
+
+    // Inline the struct array back into rows. Drop the events column (consumed by Inline)
+    // and the grouping-key columns (re-emitted from inside the struct) so the final shape
+    // matches the connector's schema plus the surviving helper count columns.
+    val eventsAttr = getAttribute(filtered, HelperColumn.Events)
+    val groupingAttrSet = AttributeSet(groupingNamedExprs.map(_.toAttribute))
+    val unrequiredChildIndex: Seq[Int] = filtered.output.zipWithIndex.collect {
+      case (a, i) if a.exprId == eventsAttr.exprId => i
+      case (a, i) if groupingAttrSet.contains(a) => i
+    }
+    val generatorOutput: Seq[Attribute] = watermarked.output.map { col =>
+      AttributeReference(col.name, col.dataType, col.nullable, col.metadata)()
+    }
+    val generated = Generate(
+      Inline(eventsAttr),
+      unrequiredChildIndex = unrequiredChildIndex,
+      outer = false,
+      qualifier = None,
+      generatorOutput = generatorOutput,
+      child = filtered)
+
+    val withRelabel: LogicalPlan = if (requiresUpdateDetection) {
+      addUpdateRelabelProjection(generated)
+    } else generated
+
+    removeHelperColumns(withRelabel)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.connector.catalog.{Changelog, ChangelogInfo}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.{ChangelogTable, DataSourceV2Relation}
-import org.apache.spark.sql.types.{IntegerType, MetadataBuilder, StringType}
+import org.apache.spark.sql.types.{BooleanType, IntegerType, MetadataBuilder, StringType}
 import org.apache.spark.unsafe.types.CalendarInterval
 
 /**
@@ -244,6 +244,7 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
    * the aggregate so no rows are lost.
    * {{{
    *   DataSourceV2Relation
+   *     -> Filter (RaiseError on NULL _commit_timestamp)
    *     -> EventTimeWatermark(_commit_timestamp, 0s)
    *     -> Aggregate
    *          group by (rowId..., _commit_version, _commit_timestamp)
@@ -255,6 +256,7 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
    *     -> Generate(Inline(__spark_cdc_events))   // re-emit one row per buffered input
    *     -> [Project (update relabel)]
    *     -> Project (drop helper columns)
+   *     -> Project (strip internal EventTimeWatermark metadata)
    * }}}
    *
    * ==Runtime walkthrough==
@@ -278,15 +280,16 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
    *
    * ==Per-operator detail==
    *
+   *  0. [[Filter]] guarding against NULL `_commit_timestamp` -- raises
+   *     `CHANGELOG_CONTRACT_VIOLATION.NULL_COMMIT_TIMESTAMP` for any row that
+   *     violates the contract. A NULL would never satisfy the downstream Aggregate's
+   *     `eventTime <= watermark` eviction predicate (NULL is silent in MAX, never
+   *     compares less-than-or-equal), so its group would be held in state forever.
+   *     Failing fast surfaces the connector bug instead of producing no output.
    *  1. [[EventTimeWatermark]] on `_commit_timestamp` (zero delay) -- required so the
    *     downstream stateful aggregate can emit groups in append output mode. By CDC
    *     contract every row in a single commit shares `_commit_timestamp`, so taking it
-   *     as event time is safe. Note: this is currently the only analyzer rule that
-   *     auto-injects an [[EventTimeWatermark]] (others resolve user-supplied watermarks).
-   *     The watermark metadata is preserved on the user-visible `_commit_timestamp`
-   *     output (since [[Generate]]'s `generatorOutput` copies attribute metadata), so a
-   *     downstream user-supplied `withWatermark` on a different column will interact
-   *     with this internal watermark under the global multi-watermark policy.
+   *     as event time is safe.
    *  2. [[Aggregate]] keyed by `(rowId..., _commit_version, _commit_timestamp)`. Computes
    *     the same `_del_cnt` / `_ins_cnt` / (`_min_rv` / `_max_rv` / `_rv_cnt`) helpers as
    *     the batch path, plus an `__spark_cdc_events` array-of-struct buffering every
@@ -304,17 +307,29 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
    *  5. [[Project]] (only when update detection is requested) applying the same
    *     `CHANGELOG_CONTRACT_VIOLATION.UNEXPECTED_MULTIPLE_CHANGES_PER_ROW_VERSION`
    *     guard and `_change_type` relabel as the batch path.
-   *  6. Final [[Project]] (via [[removeHelperColumns]]) drops `__spark_cdc_*` helpers so
+   *  6. [[Project]] (via [[removeHelperColumns]]) drops `__spark_cdc_*` helpers so
    *     the output schema matches the connector's declared schema.
+   *  7. Final [[Project]] (via [[stripCommitTimestampWatermarkMetadata]]) clears the
+   *     `EventTimeWatermark.delayKey` from the user-visible `_commit_timestamp`
+   *     attribute so a downstream user-supplied `withWatermark` on a different column
+   *     does not interact with our internal watermark via the global multi-watermark
+   *     policy.
    */
   private def addStreamingRowLevelPostProcessing(
       plan: LogicalPlan,
       cl: Changelog,
       requiresCarryOverRemoval: Boolean,
       requiresUpdateDetection: Boolean): LogicalPlan = {
-    val rawCommitTsAttr = getAttribute(plan, "_commit_timestamp")
+    // Fail fast on a NULL `_commit_timestamp`. The downstream Aggregate uses it as
+    // both an event-time watermark column and a grouping key; a NULL group-key value
+    // would never satisfy the `eventTime <= watermark` eviction predicate, so the
+    // group would silently stall (held in state until end of stream). Mirrors the
+    // runtime check in [[CdcNetChangesStatefulProcessor]] -- fail fast at the
+    // contract violation rather than producing no output.
+    val plan1 = addNullCommitTimestampGuard(plan)
+    val rawCommitTsAttr = getAttribute(plan1, "_commit_timestamp")
     val watermarked = EventTimeWatermark(
-      UUID.randomUUID(), rawCommitTsAttr, new CalendarInterval(0, 0, 0L), plan)
+      UUID.randomUUID(), rawCommitTsAttr, new CalendarInterval(0, 0, 0L), plan1)
 
     val rowIdExprs = V2ExpressionUtils.resolveRefs[NamedExpression](
       cl.rowId().toSeq, watermarked)
@@ -402,6 +417,26 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
     // it must be cleared here at the boundary of the rewrite.
     val cleaned = stripCommitTimestampWatermarkMetadata(withRelabel)
     removeHelperColumns(cleaned)
+  }
+
+  /**
+   * Adds a `Filter` that raises
+   * `CHANGELOG_CONTRACT_VIOLATION.NULL_COMMIT_TIMESTAMP` for any input row whose
+   * `_commit_timestamp` is `NULL`. Used as the first step of the streaming row-level
+   * rewrite so a contract-violating connector fails fast instead of silently stalling
+   * the downstream stateful aggregate's group.
+   */
+  private def addNullCommitTimestampGuard(input: LogicalPlan): LogicalPlan = {
+    val commitTsAttr = getAttribute(input, "_commit_timestamp")
+    val raise = RaiseError(
+      Literal("CHANGELOG_CONTRACT_VIOLATION.NULL_COMMIT_TIMESTAMP"),
+      CreateMap(Nil),
+      BooleanType)
+    // CaseWhen returns the default branch (true) for non-null timestamps and
+    // evaluates the side-effecting RaiseError for nulls; the row never passes the
+    // filter on a contract violation.
+    val checkExpr = CaseWhen(Seq(IsNull(commitTsAttr) -> raise), Literal(true))
+    Filter(checkExpr, input)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.connector.catalog.{Changelog, ChangelogInfo}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.{ChangelogTable, DataSourceV2Relation}
-import org.apache.spark.sql.types.{IntegerType, StringType}
+import org.apache.spark.sql.types.{IntegerType, MetadataBuilder, StringType}
 import org.apache.spark.unsafe.types.CalendarInterval
 
 /**
@@ -395,7 +395,36 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
       addUpdateRelabelProjection(generated)
     } else generated
 
-    removeHelperColumns(withRelabel)
+    // Strip the auto-injected EventTimeWatermark metadata from the user-visible
+    // `_commit_timestamp` so it does not interact with downstream user-supplied
+    // watermarks via the global multi-watermark policy. The metadata flows through
+    // Generate(Inline) (which copies attribute metadata) and the relabel Project, so
+    // it must be cleared here at the boundary of the rewrite.
+    val cleaned = stripCommitTimestampWatermarkMetadata(withRelabel)
+    removeHelperColumns(cleaned)
+  }
+
+  /**
+   * Final boundary for the streaming row-level rewrite: rebuilds the user-visible
+   * `_commit_timestamp` attribute with empty watermark-related metadata. Other
+   * attributes flow through unchanged.
+   */
+  private def stripCommitTimestampWatermarkMetadata(input: LogicalPlan): LogicalPlan = {
+    val projectList: Seq[NamedExpression] = input.output.map { attr =>
+      if (attr.name == "_commit_timestamp" &&
+          attr.metadata.contains(EventTimeWatermark.delayKey)) {
+        val cleanedMetadata = new MetadataBuilder()
+          .withMetadata(attr.metadata)
+          .remove(EventTimeWatermark.delayKey)
+          .build()
+        Alias(attr.withMetadata(cleanedMetadata), attr.name)(
+          exprId = attr.exprId,
+          qualifier = attr.qualifier)
+      } else {
+        attr
+      }
+    }
+    Project(projectList, input)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.catalyst.analysis
 
 import java.util.UUID
 
+import org.apache.spark.SparkRuntimeException
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{
   CollectList,
@@ -28,13 +30,14 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.{
   Max,
   Min
 }
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.connector.catalog.{Changelog, ChangelogInfo}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.{ChangelogTable, DataSourceV2Relation}
-import org.apache.spark.sql.types.{BooleanType, IntegerType, MetadataBuilder, StringType}
+import org.apache.spark.sql.types.{BooleanType, DataType, IntegerType, MetadataBuilder, StringType}
 import org.apache.spark.unsafe.types.CalendarInterval
 
 /**
@@ -428,15 +431,18 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
    */
   private def addNullCommitTimestampGuard(input: LogicalPlan): LogicalPlan = {
     val commitTsAttr = getAttribute(input, "_commit_timestamp")
-    val raise = RaiseError(
-      Literal("CHANGELOG_CONTRACT_VIOLATION.NULL_COMMIT_TIMESTAMP"),
-      CreateMap(Nil),
-      BooleanType)
-    // CaseWhen returns the default branch (true) for non-null timestamps and
-    // evaluates the side-effecting RaiseError for nulls; the row never passes the
-    // filter on a contract violation.
-    val checkExpr = CaseWhen(Seq(IsNull(commitTsAttr) -> raise), Literal(true))
-    Filter(checkExpr, input)
+    // Use a dedicated, side-effecting catalyst expression rather than a
+    // `CaseWhen(IsNull(c) -> RaiseError, true)` predicate. Spark's
+    // `NullPropagation` rule rewrites `IsNull(c)` to `false` whenever `c.nullable`
+    // is `false` and similarly eliminates `AssertNotNull(c)` for non-nullable `c`
+    // (`expressions.scala:920-926`). A connector can reasonably declare
+    // `_commit_timestamp` as non-nullable in its schema while still emitting NULL
+    // at runtime in violation of the contract -- under those rules the guard
+    // would be optimized away and the runtime NULL would silently stall the
+    // group. `CdcAssertCommitTimestampNotNull` is unrecognised by
+    // `NullPropagation` and stays in the plan regardless of the column's
+    // declared nullability, surfacing the violation immediately.
+    Filter(CdcAssertCommitTimestampNotNull(commitTsAttr), input)
   }
 
   /**
@@ -773,4 +779,40 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
       throw new IllegalStateException(
         s"Required column '$name' not found in plan output: " +
           plan.output.map(_.name).mkString(", ")))
+}
+
+/**
+ * Side-effecting Boolean expression: returns `true` if the child is non-NULL and throws
+ * `CHANGELOG_CONTRACT_VIOLATION.NULL_COMMIT_TIMESTAMP` if the child is NULL. Used as the
+ * predicate of the streaming row-level rewrite's NULL guard `Filter`.
+ *
+ * The point of this dedicated expression is to remain in the plan no matter what the
+ * connector declares for `_commit_timestamp.nullable`: Spark's `NullPropagation` rules
+ * (`Optimizer.scala`'s `expressions.scala:920-926`) rewrite `IsNull(c) -> false` and
+ * eliminate `AssertNotNull(c)` whenever `c.nullable` is `false`. A connector that
+ * declares `_commit_timestamp` non-nullable but emits NULL at runtime would slip past
+ * those simpler shapes; this class is unrecognised by `NullPropagation` so the runtime
+ * check stays put.
+ */
+case class CdcAssertCommitTimestampNotNull(child: Expression)
+    extends UnaryExpression
+    with CodegenFallback
+    with NonSQLExpression {
+
+  override def dataType: DataType = BooleanType
+  override def foldable: Boolean = false
+  override def nullable: Boolean = false
+
+  override def eval(input: InternalRow): Any = {
+    if (child.eval(input) == null) {
+      throw new SparkRuntimeException(
+        errorClass = "CHANGELOG_CONTRACT_VIOLATION.NULL_COMMIT_TIMESTAMP",
+        messageParameters = Map.empty)
+    }
+    true
+  }
+
+  override protected def withNewChildInternal(
+      newChild: Expression): CdcAssertCommitTimestampNotNull =
+    copy(child = newChild)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
@@ -225,7 +225,12 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
    *  1. [[EventTimeWatermark]] on `_commit_timestamp` (zero delay) -- required so the
    *     downstream stateful aggregate can emit groups in append output mode. By CDC
    *     contract every row in a single commit shares `_commit_timestamp`, so taking it
-   *     as event time is safe.
+   *     as event time is safe. Note: this is currently the only analyzer rule that
+   *     auto-injects an [[EventTimeWatermark]] (others resolve user-supplied watermarks).
+   *     The watermark metadata is preserved on the user-visible `_commit_timestamp`
+   *     output (since [[Generate]]'s `generatorOutput` copies attribute metadata), so a
+   *     downstream user-supplied `withWatermark` on a different column will interact
+   *     with this internal watermark under the global multi-watermark policy.
    *  2. [[Aggregate]] keyed by `(rowId..., _commit_version, _commit_timestamp)`. Computes
    *     the same `_del_cnt` / `_ins_cnt` / (`_min_rv` / `_max_rv` / `_rv_cnt`) helpers as
    *     the batch path, plus an `__spark_cdc_events` array-of-struct buffering every
@@ -286,8 +291,9 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
     } else Seq.empty
 
     // Buffer every input row as a struct so Inline can re-emit them after the aggregate.
-    // `_commit_version` and `_commit_timestamp` appear inside the struct as well as in the
-    // grouping keys; the duplicates are dropped via `unrequiredChildIndex` below.
+    // The grouping-key columns (rowId..., `_commit_version`, `_commit_timestamp`) appear
+    // both inside the struct and as top-level grouping outputs; the top-level duplicates
+    // are dropped via `unrequiredChildIndex` below.
     val structOfAllCols = CreateStruct(watermarked.output)
     val eventsAlias = Alias(
       new CollectList(structOfAllCols).toAggregateExpression(), HelperColumn.Events)()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -23,7 +23,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{ANALYSIS_ERROR, QUERY_PLAN}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.ExtendedAnalysisException
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, CurrentDate, CurrentTimestampLike, Expression, GroupingSets, LocalTimestamp, MonotonicallyIncreasingID, SessionWindow, WindowExpression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, CurrentDate, CurrentTimestampLike, Expression, GroupingSets, LocalTimestamp, MonotonicallyIncreasingID, NamedExpression, SessionWindow, WindowExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -278,6 +278,26 @@ object UnsupportedOperationChecker extends Logging {
           outputMode, "no streaming aggregations")
 
       case _ =>
+    }
+
+    // The streaming Change Data Capture (CDC) row-level post-processing rewrite in
+    // [[ResolveChangelogTable.addStreamingRowLevelPostProcessing]] injects a streaming
+    // Aggregate buffering input rows into the helper column
+    // `ResolveChangelogTable.HelperColumn.Events` ("__spark_cdc_events") before
+    // re-emitting them via `Generate(Inline(...))`. The rewrite is designed and
+    // validated only for Append output mode -- under Update or Complete the Aggregate
+    // would re-emit per-batch state changes or the full result table per batch
+    // respectively, neither of which matches batch CDC semantics. Reject those modes
+    // at analysis time with a clear error rather than silently producing a misleading
+    // change feed.
+    if (outputMode != InternalOutputModes.Append &&
+        aggregates.exists(a => a.aggregateExpressions.exists {
+          case ne: NamedExpression if ne.resolved =>
+            ne.name == ResolveChangelogTable.HelperColumn.Events
+          case _ => false
+        })) {
+      throw QueryCompilationErrors.unsupportedOutputModeForStreamingOperationError(
+        outputMode, "Change Data Capture (CDC) streaming reads with post-processing")
     }
 
     /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3869,9 +3869,9 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("changelogName" -> changelogName))
   }
 
-  def cdcStreamingPostProcessingNotSupported(changelogName: String): AnalysisException = {
+  def cdcStreamingNetChangesNotSupported(changelogName: String): AnalysisException = {
     new AnalysisException(
-      errorClass = "INVALID_CDC_OPTION.STREAMING_POST_PROCESSING_NOT_SUPPORTED",
+      errorClass = "INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED",
       messageParameters = Map("changelogName" -> changelogName))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryChangelogCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryChangelogCatalog.scala
@@ -142,6 +142,10 @@ class InMemoryChangelogCatalog extends InMemoryCatalog {
  *                       real updates. Do NOT pass the commit version, which is constant
  *                       within a partition and would cause every delete+insert pair to
  *                       look like a carry-over
+ * @param commitTimestampNullable whether the connector declares `_commit_timestamp` as
+ *                                nullable. Defaults to `true`. Tests that need to
+ *                                exercise NullPropagation behaviour on a non-nullable
+ *                                schema can set this to `false`.
  */
 case class ChangelogProperties(
     containsCarryoverRows: Boolean = false,
@@ -149,7 +153,8 @@ case class ChangelogProperties(
     representsUpdateAsDeleteAndInsert: Boolean = false,
     rowIdNames: Seq[String] = Seq.empty,
     rowIdPaths: Seq[Seq[String]] = Seq.empty,
-    rowVersionName: Option[String] = None)
+    rowVersionName: Option[String] = None,
+    commitTimestampNullable: Boolean = true)
 
 /**
  * A test [[Changelog]] that returns pre-populated change rows.
@@ -167,7 +172,7 @@ class InMemoryChangelog(
   private val cdcColumns: Array[Column] = dataColumns ++ Array(
     Column.create("_change_type", StringType),
     Column.create("_commit_version", LongType),
-    Column.create("_commit_timestamp", TimestampType))
+    Column.create("_commit_timestamp", TimestampType, properties.commitTimestampNullable))
 
   override def name(): String = tableName
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
@@ -732,9 +732,10 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
       .start()
     try {
       q.processAllAvailable()
-      // End-of-input flushes the watermark, so all groups including the highest
-      // commit get emitted. v1 inserts + Alice's real delete survive; Bob's
-      // carry-over pair at v2 is dropped.
+      // The next micro-batch advances the input watermark to the max _commit_timestamp
+      // seen in the previous batch; append-mode aggregate eviction (eventTime <= watermark)
+      // then emits all groups including the highest commit. v1 inserts + Alice's real
+      // delete survive; Bob's carry-over pair at v2 is dropped.
       checkAnswer(
         spark.sql("SELECT * FROM cdc_stream_carryover"),
         Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
@@ -715,11 +715,11 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
     catalog.addChangeRows(id, Seq(
       // v1: insert Alice (rcv=1), Bob (rcv=1)
       ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
-      ppRow(2L, "Bob",   1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      ppRow(2L, "Bob", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
       // v2: real delete Alice + carry-over for Bob (rcv unchanged)
       ppRow(1L, "Alice", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
-      ppRow(2L, "Bob",   1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
-      ppRow(2L, "Bob",   1L, CHANGE_TYPE_INSERT, 2L, 2000000L)))
+      ppRow(2L, "Bob", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(2L, "Bob", 1L, CHANGE_TYPE_INSERT, 2L, 2000000L)))
 
     val q = spark.readStream
       .option("startingVersion", "1")
@@ -740,7 +740,7 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
         spark.sql("SELECT * FROM cdc_stream_carryover"),
         Seq(
           Row(1L, "Alice", CHANGE_TYPE_INSERT, 1L),
-          Row(2L, "Bob",   CHANGE_TYPE_INSERT, 1L),
+          Row(2L, "Bob", CHANGE_TYPE_INSERT, 1L),
           Row(1L, "Alice", CHANGE_TYPE_DELETE, 2L)))
     } finally {
       q.stop()
@@ -758,7 +758,7 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
       // v1: insert Alice (rcv=1)
       ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
       // v2: real update Alice -> Robert (delete old, insert new)
-      ppRow(1L, "Alice",  1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
       ppRow(1L, "Robert", 2L, CHANGE_TYPE_INSERT, 2L, 2000000L)))
 
     val q = spark.readStream
@@ -777,8 +777,8 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
       checkAnswer(
         spark.sql("SELECT * FROM cdc_stream_updates"),
         Seq(
-          Row(1L, "Alice",  CHANGE_TYPE_INSERT, 1L),
-          Row(1L, "Alice",  CHANGE_TYPE_UPDATE_PREIMAGE, 2L),
+          Row(1L, "Alice", CHANGE_TYPE_INSERT, 1L),
+          Row(1L, "Alice", CHANGE_TYPE_UPDATE_PREIMAGE, 2L),
           Row(1L, "Robert", CHANGE_TYPE_UPDATE_POSTIMAGE, 2L)))
     } finally {
       q.stop()

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
@@ -857,4 +857,39 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
     assert(e.getMessage.contains("Change Data Capture"),
       s"Error should mention CDC: ${e.getMessage}")
   }
+
+  test("streaming row-level rewrite raises on NULL _commit_timestamp") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsCarryoverRows = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    // Insert a row with NULL _commit_timestamp (last column).
+    val row = InternalRow(
+      1L, UTF8String.fromString("Alice"), 1L,
+      UTF8String.fromString(CHANGE_TYPE_INSERT), 1L, null)
+    catalog.addChangeRows(id, Seq(row))
+
+    val q = spark.readStream
+      .option("startingVersion", "1")
+      .changes(fullTableName)
+      .writeStream
+      .format("memory")
+      .queryName("cdc_stream_null_ts")
+      .outputMode("append")
+      .start()
+    try {
+      val e = intercept[org.apache.spark.sql.streaming.StreamingQueryException] {
+        q.processAllAvailable()
+      }
+      // The CHANGELOG_CONTRACT_VIOLATION runtime error wraps the message; it should
+      // mention NULL_COMMIT_TIMESTAMP somewhere in the chain.
+      assert(e.getMessage.contains("NULL_COMMIT_TIMESTAMP") ||
+        Option(e.getCause).map(_.getMessage).getOrElse("").contains("NULL_COMMIT_TIMESTAMP"),
+        s"Expected NULL_COMMIT_TIMESTAMP in the error chain. Got: ${e.getMessage}")
+    } finally {
+      q.stop()
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
@@ -802,4 +802,59 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
     assert(e.getCondition == "INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED",
       s"Unexpected error: ${e.getMessage}")
   }
+
+  // The streaming row-level rewrite injects a streaming Aggregate, which is only
+  // semantically valid with Append output mode (Update / Complete would re-emit
+  // per-batch updates or the entire result table per batch, neither of which matches
+  // batch CDC semantics). UnsupportedOperationChecker now rejects those modes.
+
+  test("streaming row-level post-processing with update output mode is rejected") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsCarryoverRows = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+    catalog.addChangeRows(id, Seq(
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L)))
+
+    val e = intercept[AnalysisException] {
+      spark.readStream
+        .option("startingVersion", "1")
+        .changes(fullTableName)
+        .writeStream
+        .format("memory")
+        .queryName("cdc_stream_update_rejected")
+        .outputMode("update")
+        .start()
+    }
+    assert(e.getCondition == "STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION",
+      s"Unexpected error: ${e.getMessage}")
+    assert(e.getMessage.contains("Change Data Capture"),
+      s"Error should mention CDC: ${e.getMessage}")
+  }
+
+  test("streaming row-level post-processing with complete output mode is rejected") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsCarryoverRows = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+    catalog.addChangeRows(id, Seq(
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L)))
+
+    val e = intercept[AnalysisException] {
+      spark.readStream
+        .option("startingVersion", "1")
+        .changes(fullTableName)
+        .writeStream
+        .format("memory")
+        .queryName("cdc_stream_complete_rejected")
+        .outputMode("complete")
+        .start()
+    }
+    assert(e.getCondition == "STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION",
+      s"Unexpected error: ${e.getMessage}")
+    assert(e.getMessage.contains("Change Data Capture"),
+      s"Error should mention CDC: ${e.getMessage}")
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
@@ -25,7 +25,8 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.NamedStreamingRelation
 import org.apache.spark.sql.catalyst.streaming.UserProvided
 import org.apache.spark.sql.connector.catalog._
-import org.apache.spark.sql.connector.catalog.Changelog.{CHANGE_TYPE_DELETE, CHANGE_TYPE_INSERT}
+import org.apache.spark.sql.connector.catalog.Changelog.{
+  CHANGE_TYPE_DELETE, CHANGE_TYPE_INSERT, CHANGE_TYPE_UPDATE_POSTIMAGE, CHANGE_TYPE_UPDATE_PREIMAGE}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{LongType, StringType}
@@ -661,5 +662,143 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
         .changes(fullTableName)
     }
     assert(e.getMessage.contains("changes"))
+  }
+
+  // ---------- Streaming: row-level post-processing ----------
+  //
+  // Streaming row-level passes (carry-over removal, update detection) rewrite the plan
+  // into Aggregate(rowId, _commit_version, _commit_timestamp) -> [Filter] ->
+  // Generate(Inline(events)) -> [relabel Project], under an EventTimeWatermark on
+  // _commit_timestamp.
+
+  /** Schema variant for post-processing tests: includes `row_commit_version`. */
+  private def recreateWithRowVersion(): Identifier = {
+    val id = ident
+    val cat = catalog
+    if (cat.tableExists(id)) cat.dropTable(id)
+    cat.createTable(
+      id,
+      Array(
+        Column.create("id", LongType, false),
+        Column.create("data", StringType),
+        Column.create("row_commit_version", LongType, false)),
+      Array.empty,
+      new util.HashMap[String, String]())
+    cat.clearChangeRows(id)
+    id
+  }
+
+  /** Row constructor for the row-version-enabled schema. */
+  private def ppRow(
+      id: Long,
+      data: String,
+      rcv: Long,
+      changeType: String,
+      commitVersion: Long,
+      commitTimestampMicros: Long): InternalRow = {
+    InternalRow(
+      id,
+      UTF8String.fromString(data),
+      rcv,
+      UTF8String.fromString(changeType),
+      commitVersion,
+      commitTimestampMicros)
+  }
+
+  test("streaming carry-over removal drops CoW pairs") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsCarryoverRows = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    catalog.addChangeRows(id, Seq(
+      // v1: insert Alice (rcv=1), Bob (rcv=1)
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      ppRow(2L, "Bob",   1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      // v2: real delete Alice + carry-over for Bob (rcv unchanged)
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(2L, "Bob",   1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(2L, "Bob",   1L, CHANGE_TYPE_INSERT, 2L, 2000000L)))
+
+    val q = spark.readStream
+      .option("startingVersion", "1")
+      .changes(fullTableName)
+      .select("id", "data", "_change_type", "_commit_version")
+      .writeStream
+      .format("memory")
+      .queryName("cdc_stream_carryover")
+      .outputMode("append")
+      .start()
+    try {
+      q.processAllAvailable()
+      // End-of-input flushes the watermark, so all groups including the highest
+      // commit get emitted. v1 inserts + Alice's real delete survive; Bob's
+      // carry-over pair at v2 is dropped.
+      checkAnswer(
+        spark.sql("SELECT * FROM cdc_stream_carryover"),
+        Seq(
+          Row(1L, "Alice", CHANGE_TYPE_INSERT, 1L),
+          Row(2L, "Bob",   CHANGE_TYPE_INSERT, 1L),
+          Row(1L, "Alice", CHANGE_TYPE_DELETE, 2L)))
+    } finally {
+      q.stop()
+    }
+  }
+
+  test("streaming update detection relabels delete+insert as update") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      representsUpdateAsDeleteAndInsert = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    catalog.addChangeRows(id, Seq(
+      // v1: insert Alice (rcv=1)
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      // v2: real update Alice -> Robert (delete old, insert new)
+      ppRow(1L, "Alice",  1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(1L, "Robert", 2L, CHANGE_TYPE_INSERT, 2L, 2000000L)))
+
+    val q = spark.readStream
+      .option("startingVersion", "1")
+      .option("computeUpdates", "true")
+      .option("deduplicationMode", "none")
+      .changes(fullTableName)
+      .select("id", "data", "_change_type", "_commit_version")
+      .writeStream
+      .format("memory")
+      .queryName("cdc_stream_updates")
+      .outputMode("append")
+      .start()
+    try {
+      q.processAllAvailable()
+      checkAnswer(
+        spark.sql("SELECT * FROM cdc_stream_updates"),
+        Seq(
+          Row(1L, "Alice",  CHANGE_TYPE_INSERT, 1L),
+          Row(1L, "Alice",  CHANGE_TYPE_UPDATE_PREIMAGE, 2L),
+          Row(1L, "Robert", CHANGE_TYPE_UPDATE_POSTIMAGE, 2L)))
+    } finally {
+      q.stop()
+    }
+  }
+
+  test("streaming with deduplicationMode=netChanges throws") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsIntermediateChanges = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    val e = intercept[AnalysisException] {
+      spark.readStream
+        .option("startingVersion", "1")
+        .option("deduplicationMode", "netChanges")
+        .changes(fullTableName)
+        .queryExecution.analyzed
+    }
+    assert(e.getCondition == "INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED",
+      s"Unexpected error: ${e.getMessage}")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogResolutionSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.connector
 import java.util.Collections
 
 import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
@@ -208,12 +209,13 @@ class ChangelogResolutionSuite extends SharedSparkSession {
   }
 
   // ===========================================================================
-  // Streaming post-processing rejection
+  // Streaming post-processing
   // ===========================================================================
   //
-  // Streaming CDC reads bypass the post-processing analyzer rule's transformation
-  // path. To prevent silent wrong results when the requested options would require
-  // post-processing, the rule throws an explicit AnalysisException for streaming.
+  // Row-level passes (carry-over removal and update detection) rewrite the streaming plan
+  // into Aggregate -> [Filter] -> Generate(Inline) -> [Project] under an
+  // EventTimeWatermark on `_commit_timestamp`. Net-change computation is still rejected
+  // since it requires reasoning over the entire requested range.
 
   /** Re-creates the test table with non-nullable columns suitable as rowId / rowVersion. */
   private def recreatePostProcessingTable(): Identifier = {
@@ -230,7 +232,23 @@ class ChangelogResolutionSuite extends SharedSparkSession {
     ident
   }
 
-  test("DataStreamReader - changes() with carry-over capability throws") {
+  private def assertStreamingRowLevelRewrite(plan: LogicalPlan): Unit = {
+    import org.apache.spark.sql.catalyst.plans.logical.{
+      Aggregate, EventTimeWatermark, Generate}
+    val watermarks = plan.collect { case w: EventTimeWatermark => w }
+    assert(watermarks.nonEmpty,
+      s"Expected EventTimeWatermark in streaming row-level rewrite. Plan:\n$plan")
+    assert(watermarks.head.eventTime.name == "_commit_timestamp",
+      s"Watermark must be on `_commit_timestamp`. Plan:\n$plan")
+    val aggs = plan.collect { case a: Aggregate => a }
+    assert(aggs.nonEmpty,
+      s"Expected Aggregate in streaming row-level rewrite. Plan:\n$plan")
+    val gens = plan.collect { case g: Generate => g }
+    assert(gens.nonEmpty,
+      s"Expected Generate(Inline) in streaming row-level rewrite. Plan:\n$plan")
+  }
+
+  test("DataStreamReader - changes() with carry-over capability rewrites plan") {
     val ident = recreatePostProcessingTable()
     val cat = spark.sessionState.catalogManager
       .catalog(cdcCatalogName)
@@ -240,17 +258,13 @@ class ChangelogResolutionSuite extends SharedSparkSession {
       rowIdNames = Seq("id"),
       rowVersionName = Some("row_commit_version")))
 
-    checkError(
-      intercept[AnalysisException] {
-        spark.readStream
-          .changes(s"$cdcCatalogName.test_table")
-          .queryExecution.analyzed
-      },
-      condition = "INVALID_CDC_OPTION.STREAMING_POST_PROCESSING_NOT_SUPPORTED",
-      parameters = Map("changelogName" -> s"$cdcCatalogName.test_table_changelog"))
+    val analyzed = spark.readStream
+      .changes(s"$cdcCatalogName.test_table")
+      .queryExecution.analyzed
+    assertStreamingRowLevelRewrite(analyzed)
   }
 
-  test("DataStreamReader - changes() with computeUpdates throws") {
+  test("DataStreamReader - changes() with computeUpdates rewrites plan") {
     val ident = recreatePostProcessingTable()
     val cat = spark.sessionState.catalogManager
       .catalog(cdcCatalogName)
@@ -260,15 +274,32 @@ class ChangelogResolutionSuite extends SharedSparkSession {
       rowIdNames = Seq("id"),
       rowVersionName = Some("row_commit_version")))
 
+    val analyzed = spark.readStream
+      .option("computeUpdates", "true")
+      .option("deduplicationMode", "none")
+      .changes(s"$cdcCatalogName.test_table")
+      .queryExecution.analyzed
+    assertStreamingRowLevelRewrite(analyzed)
+  }
+
+  test("DataStreamReader - changes() with deduplicationMode=netChanges throws") {
+    val ident = recreatePostProcessingTable()
+    val cat = spark.sessionState.catalogManager
+      .catalog(cdcCatalogName)
+      .asInstanceOf[InMemoryChangelogCatalog]
+    cat.setChangelogProperties(ident, ChangelogProperties(
+      containsIntermediateChanges = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
     checkError(
       intercept[AnalysisException] {
         spark.readStream
-          .option("computeUpdates", "true")
-          .option("deduplicationMode", "none")
+          .option("deduplicationMode", "netChanges")
           .changes(s"$cdcCatalogName.test_table")
           .queryExecution.analyzed
       },
-      condition = "INVALID_CDC_OPTION.STREAMING_POST_PROCESSING_NOT_SUPPORTED",
+      condition = "INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED",
       parameters = Map("changelogName" -> s"$cdcCatalogName.test_table_changelog"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTablePostProcessingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTablePostProcessingSuite.scala
@@ -368,23 +368,9 @@ class ResolveChangelogTablePostProcessingSuite
       s"Expected ChangelogTable to be marked resolved by the rule. Plan:\n$plan")
   }
 
-  test("streaming with deduplicationMode=netChanges is rejected") {
-    catalog.setChangelogProperties(ident, ChangelogProperties(
-      containsIntermediateChanges = true,
-      rowIdNames = Seq("id"),
-      rowVersionName = Some("row_commit_version")))
-
-    checkError(
-      exception = intercept[AnalysisException] {
-        spark.readStream
-          .option("startingVersion", "1")
-          .option("deduplicationMode", "netChanges")
-          .changes(s"$catalogName.$testTableName")
-          .queryExecution.analyzed
-      },
-      condition = "INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED",
-      parameters = Map("changelogName" -> s"$catalogName.${testTableName}_changelog"))
-  }
+  // The streaming netChanges rejection is covered by
+  // ResolveChangelogTableStreamingPostProcessingSuite -- not duplicated here, since
+  // this suite focuses on the batch path.
 
   // ===========================================================================
   // Combined

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTablePostProcessingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTablePostProcessingSuite.scala
@@ -368,9 +368,9 @@ class ResolveChangelogTablePostProcessingSuite
       s"Expected ChangelogTable to be marked resolved by the rule. Plan:\n$plan")
   }
 
-  test("streaming with post-processing options is rejected") {
+  test("streaming with deduplicationMode=netChanges is rejected") {
     catalog.setChangelogProperties(ident, ChangelogProperties(
-      containsCarryoverRows = true,
+      containsIntermediateChanges = true,
       rowIdNames = Seq("id"),
       rowVersionName = Some("row_commit_version")))
 
@@ -378,10 +378,11 @@ class ResolveChangelogTablePostProcessingSuite
       exception = intercept[AnalysisException] {
         spark.readStream
           .option("startingVersion", "1")
+          .option("deduplicationMode", "netChanges")
           .changes(s"$catalogName.$testTableName")
           .queryExecution.analyzed
       },
-      condition = "INVALID_CDC_OPTION.STREAMING_POST_PROCESSING_NOT_SUPPORTED",
+      condition = "INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED",
       parameters = Map("changelogName" -> s"$catalogName.${testTableName}_changelog"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
@@ -134,12 +134,13 @@ class ResolveChangelogTableStreamingPostProcessingSuite
   }
 
   private def assertContainsNullCommitTimestampGuard(plan: LogicalPlan): Unit = {
+    import org.apache.spark.sql.catalyst.analysis.CdcAssertCommitTimestampNotNull
     val nullGuards = plan.collect {
       case f: Filter
-        if f.condition.toString.contains("NULL_COMMIT_TIMESTAMP") => f
+        if f.condition.isInstanceOf[CdcAssertCommitTimestampNotNull] => f
     }
     assert(nullGuards.size == 1,
-      s"Expected exactly one NULL_COMMIT_TIMESTAMP guard Filter. Plan:\n$plan")
+      s"Expected exactly one CdcAssertCommitTimestampNotNull guard Filter. Plan:\n$plan")
   }
 
   // ===========================================================================
@@ -202,7 +203,8 @@ class ResolveChangelogTableStreamingPostProcessingSuite
     // The relabel Project must reference _change_type (CaseWhen rewrites it).
     val projects = analyzed.collect { case p: Project => p }
     assert(projects.exists { p =>
-      p.projectList.exists(_.toString.toLowerCase.contains("update_preimage"))
+      p.projectList.exists(
+        _.toString.toLowerCase(java.util.Locale.ROOT).contains("update_preimage"))
     }, s"Expected a Project that emits `update_preimage`. Plan:\n$analyzed")
 
     assertHelperColumnsRemoved(analyzed)
@@ -305,11 +307,12 @@ class ResolveChangelogTableStreamingPostProcessingSuite
       rowVersionName = Some("row_commit_version")))
 
     val analyzed = streamingDf().queryExecution.analyzed
+    import org.apache.spark.sql.catalyst.analysis.CdcAssertCommitTimestampNotNull
     // The guard must sit BELOW the EventTimeWatermark (we don't want a NULL row to
     // be considered for watermark advancement at all). Verify by walking the plan
     // top-down and finding the guard before any Aggregate.
     val guards = analyzed.collect {
-      case f: Filter if f.condition.toString.contains("NULL_COMMIT_TIMESTAMP") => f
+      case f: Filter if f.condition.isInstanceOf[CdcAssertCommitTimestampNotNull] => f
     }
     assert(guards.size == 1, s"Expected exactly one guard. Plan:\n$analyzed")
     val guard = guards.head
@@ -324,5 +327,53 @@ class ResolveChangelogTableStreamingPostProcessingSuite
     }
     assert(isSourceBelowGuard,
       s"NULL guard Filter should sit directly above the streaming relation. Plan:\n$analyzed")
+  }
+
+  test("NULL guard predicate is not foldable when _commit_timestamp is non-nullable") {
+    import org.apache.spark.sql.catalyst.analysis.CdcAssertCommitTimestampNotNull
+    import org.apache.spark.sql.catalyst.expressions.{IsNull, Literal}
+    import org.apache.spark.sql.catalyst.optimizer.NullPropagation
+    // Streaming plans can't be sent through the batch optimizer (UnsupportedOperationChecker
+    // rejects streaming sources in that path), so we directly exercise the rule that the
+    // reviewer flagged: NullPropagation must not eliminate our predicate even when the
+    // child column is non-nullable. Spark's NullPropagation simplifies `IsNull(c)` and
+    // `AssertNotNull(c)` to constants for non-nullable `c`, but it has no rule for
+    // `CdcAssertCommitTimestampNotNull`, so the predicate stays in place.
+    catalog.setChangelogProperties(identifier, ChangelogProperties(
+      containsCarryoverRows = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version"),
+      commitTimestampNullable = false))
+
+    val analyzed = streamingDf().queryExecution.analyzed
+    val tsAttrAnalyzed = analyzed.collect {
+      case rel: org.apache.spark.sql.catalyst.streaming.StreamingRelationV2 =>
+        rel.output.find(_.name == "_commit_timestamp").get
+    }.head
+    assert(!tsAttrAnalyzed.nullable,
+      s"Test setup expected non-nullable `_commit_timestamp` on the source. Plan:\n$analyzed")
+
+    val guardsBefore = analyzed.collect {
+      case f: Filter if f.condition.isInstanceOf[CdcAssertCommitTimestampNotNull] => f
+    }
+    assert(guardsBefore.size == 1,
+      s"NULL guard must be present in the analyzed plan. Plan:\n$analyzed")
+
+    // Run NullPropagation on the predicate. It should be a no-op because the rule does
+    // not recognize `CdcAssertCommitTimestampNotNull`. (As a sanity check: the same rule
+    // would simplify a plain `IsNull(non-nullable)` to a Boolean literal.)
+    val tsAttr = guardsBefore.head.condition.asInstanceOf[CdcAssertCommitTimestampNotNull].child
+    val analyzedPredicate = guardsBefore.head.condition
+    val tsIsNullPlan = Filter(IsNull(tsAttr), analyzed)
+    val optimizedTsIsNull = NullPropagation(tsIsNullPlan).asInstanceOf[Filter].condition
+    assert(optimizedTsIsNull.isInstanceOf[Literal],
+      s"Sanity check: NullPropagation should fold IsNull(non-nullable) to a literal. " +
+        s"Got: $optimizedTsIsNull")
+
+    val cdcGuardPlan = Filter(analyzedPredicate, analyzed)
+    val optimizedGuard = NullPropagation(cdcGuardPlan).asInstanceOf[Filter].condition
+    assert(optimizedGuard.isInstanceOf[CdcAssertCommitTimestampNotNull],
+      s"NullPropagation must NOT simplify CdcAssertCommitTimestampNotNull. " +
+        s"Got: $optimizedGuard")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
@@ -117,6 +117,14 @@ class ResolveChangelogTableStreamingPostProcessingSuite
         outputNames.mkString(", "))
   }
 
+  private def assertNoWatermarkMetadataOnOutput(plan: LogicalPlan): Unit = {
+    import org.apache.spark.sql.catalyst.plans.logical.EventTimeWatermark
+    val leaks = plan.output.filter(_.metadata.contains(EventTimeWatermark.delayKey))
+    assert(leaks.isEmpty,
+      s"User-visible output must not carry EventTimeWatermark.delayKey metadata; " +
+        s"found on: ${leaks.map(_.name).mkString(",")}. Plan:\n$plan")
+  }
+
   private def assertInlineGenerate(plan: LogicalPlan): Unit = {
     val gens = plan.collect { case g: Generate => g }
     assert(gens.size == 1,
@@ -151,6 +159,7 @@ class ResolveChangelogTableStreamingPostProcessingSuite
 
     assertInlineGenerate(analyzed)
     assertHelperColumnsRemoved(analyzed)
+    assertNoWatermarkMetadataOnOutput(analyzed)
   }
 
   // ===========================================================================
@@ -182,6 +191,7 @@ class ResolveChangelogTableStreamingPostProcessingSuite
     }, s"Expected a Project that emits `update_preimage`. Plan:\n$analyzed")
 
     assertHelperColumnsRemoved(analyzed)
+    assertNoWatermarkMetadataOnOutput(analyzed)
   }
 
   // ===========================================================================
@@ -208,6 +218,7 @@ class ResolveChangelogTableStreamingPostProcessingSuite
 
     assertInlineGenerate(analyzed)
     assertHelperColumnsRemoved(analyzed)
+    assertNoWatermarkMetadataOnOutput(analyzed)
   }
 
   // ===========================================================================
@@ -242,5 +253,28 @@ class ResolveChangelogTableStreamingPostProcessingSuite
     }
     assert(e.getCondition == "INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED",
       s"Unexpected error: ${e.getMessage}")
+  }
+
+  // ===========================================================================
+  // Watermark metadata is internal-only and stripped from user-visible output
+  // ===========================================================================
+
+  test("watermark metadata is stripped from user-visible _commit_timestamp") {
+    import org.apache.spark.sql.catalyst.plans.logical.EventTimeWatermark
+    catalog.setChangelogProperties(identifier, ChangelogProperties(
+      containsCarryoverRows = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    val analyzed = streamingDf().queryExecution.analyzed
+    // Internally, the EventTimeWatermark must still be present.
+    assertWatermarkOnCommitTimestamp(analyzed)
+    // But none of the user-visible output attributes should leak the watermark
+    // metadata; downstream user-supplied watermarks must not interact with our
+    // auto-injected internal watermark via the global multi-watermark policy.
+    val ts = analyzed.output.find(_.name == "_commit_timestamp")
+    assert(ts.isDefined, s"Expected `_commit_timestamp` in output. Plan:\n$analyzed")
+    assert(!ts.get.metadata.contains(EventTimeWatermark.delayKey),
+      s"Watermark metadata leaked to user-visible `_commit_timestamp`. Plan:\n$analyzed")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import java.util.Collections
+
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.catalyst.expressions.Inline
+import org.apache.spark.sql.catalyst.plans.logical.{
+  Aggregate, EventTimeWatermark, Filter, Generate, LogicalPlan, Project}
+import org.apache.spark.sql.connector.catalog.{
+  ChangelogProperties, Column, Identifier, InMemoryChangelogCatalog}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.LongType
+
+/**
+ * Plan-shape tests for the streaming arm of
+ * [[org.apache.spark.sql.catalyst.analysis.ResolveChangelogTable]]. These mirror the batch
+ * checks in [[ResolveChangelogTablePostProcessingSuite]] but assert on the rewritten
+ * logical plan rather than running the streaming query end-to-end (the end-to-end
+ * coverage lives in [[ChangelogEndToEndSuite]]).
+ *
+ * The streaming row-level rewrite is:
+ *   EventTimeWatermark(_commit_timestamp, 0s)
+ *     -> Aggregate keyed by (rowId..., _commit_version, _commit_timestamp)
+ *     -> [Filter (carry-over)]
+ *     -> Generate(Inline(events))
+ *     -> [Project (update relabel)]
+ *     -> Project (drop helper columns)
+ */
+class ResolveChangelogTableStreamingPostProcessingSuite
+    extends QueryTest
+    with SharedSparkSession
+    with BeforeAndAfterEach {
+
+  private val catalogName = "cdc_streaming_pp"
+  private val testTableName = "events"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(
+      s"spark.sql.catalog.$catalogName",
+      classOf[InMemoryChangelogCatalog].getName)
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    val cat = catalog
+    val ident = identifier
+    if (cat.tableExists(ident)) cat.dropTable(ident)
+    cat.clearChangeRows(ident)
+    cat.setChangelogProperties(ident, ChangelogProperties())
+    cat.createTable(
+      ident,
+      Array(
+        Column.create("id", LongType, false),
+        Column.create("row_commit_version", LongType, false)),
+      Array.empty[Transform],
+      Collections.emptyMap[String, String]())
+  }
+
+  private def catalog: InMemoryChangelogCatalog =
+    spark.sessionState.catalogManager
+      .catalog(catalogName)
+      .asInstanceOf[InMemoryChangelogCatalog]
+
+  private def identifier: Identifier = Identifier.of(Array.empty, testTableName)
+
+  private def streamingDf(opts: (String, String)*): DataFrame = {
+    val reader = spark.readStream.option("startingVersion", "1")
+    opts.foldLeft(reader) { case (r, (k, v)) => r.option(k, v) }
+      .changes(s"$catalogName.$testTableName")
+  }
+
+  private def assertWatermarkOnCommitTimestamp(plan: LogicalPlan): Unit = {
+    val wm = plan.collect { case w: EventTimeWatermark => w }
+    assert(wm.size == 1,
+      s"Expected exactly one EventTimeWatermark; found ${wm.size}. Plan:\n$plan")
+    assert(wm.head.eventTime.name == "_commit_timestamp",
+      s"Watermark must be on `_commit_timestamp` but was on `${wm.head.eventTime.name}`. " +
+        s"Plan:\n$plan")
+    assert(wm.head.delay.months == 0 && wm.head.delay.days == 0 &&
+      wm.head.delay.microseconds == 0L,
+      s"Watermark delay must be zero. Plan:\n$plan")
+  }
+
+  private def assertNoStreamingPostProcessing(plan: LogicalPlan): Unit = {
+    assert(plan.collect { case w: EventTimeWatermark => w }.isEmpty,
+      s"No EventTimeWatermark expected for raw streaming pass-through. Plan:\n$plan")
+    val planStr = plan.treeString
+    assert(!planStr.contains("__spark_cdc_"),
+      s"Helper columns must not appear in pass-through plan. Plan:\n$planStr")
+  }
+
+  private def assertHelperColumnsRemoved(plan: LogicalPlan): Unit = {
+    val outputNames = plan.output.map(_.name).toSet
+    assert(!outputNames.exists(_.startsWith("__spark_cdc_")),
+      s"Helper columns must be dropped before the user-visible output. Output: " +
+        outputNames.mkString(", "))
+  }
+
+  private def assertInlineGenerate(plan: LogicalPlan): Unit = {
+    val gens = plan.collect { case g: Generate => g }
+    assert(gens.size == 1,
+      s"Expected exactly one Generate; found ${gens.size}. Plan:\n$plan")
+    assert(gens.head.generator.isInstanceOf[Inline],
+      s"Generate must use Inline. Plan:\n$plan")
+  }
+
+  // ===========================================================================
+  // Carry-over removal only
+  // ===========================================================================
+
+  test("carry-over removal injects watermark + Aggregate + Filter + Generate") {
+    catalog.setChangelogProperties(identifier, ChangelogProperties(
+      containsCarryoverRows = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    val analyzed = streamingDf().queryExecution.analyzed
+    assertWatermarkOnCommitTimestamp(analyzed)
+
+    val aggs = analyzed.collect { case a: Aggregate => a }
+    assert(aggs.size == 1, s"Expected one Aggregate. Plan:\n$analyzed")
+    val groupingNames = aggs.head.groupingExpressions.collect {
+      case ne: org.apache.spark.sql.catalyst.expressions.NamedExpression => ne.name
+    }
+    assert(groupingNames.toSet == Set("id", "_commit_version", "_commit_timestamp"),
+      s"Expected grouping by (id, _commit_version, _commit_timestamp); got $groupingNames")
+
+    val filters = analyzed.collect { case f: Filter => f }
+    assert(filters.size == 1, s"Expected one Filter for carry-over removal. Plan:\n$analyzed")
+
+    assertInlineGenerate(analyzed)
+    assertHelperColumnsRemoved(analyzed)
+  }
+
+  // ===========================================================================
+  // Update detection only
+  // ===========================================================================
+
+  test("update detection alone injects watermark + Aggregate + Generate + relabel Project") {
+    catalog.setChangelogProperties(identifier, ChangelogProperties(
+      representsUpdateAsDeleteAndInsert = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    val analyzed = streamingDf(
+      "computeUpdates" -> "true",
+      "deduplicationMode" -> "none").queryExecution.analyzed
+    assertWatermarkOnCommitTimestamp(analyzed)
+
+    // No carry-over Filter when only update detection runs.
+    val filters = analyzed.collect { case f: Filter => f }
+    assert(filters.isEmpty,
+      s"No Filter expected for update-detection-only path. Plan:\n$analyzed")
+
+    assertInlineGenerate(analyzed)
+
+    // The relabel Project must reference _change_type (CaseWhen rewrites it).
+    val projects = analyzed.collect { case p: Project => p }
+    assert(projects.exists { p =>
+      p.projectList.exists(_.toString.toLowerCase.contains("update_preimage"))
+    }, s"Expected a Project that emits `update_preimage`. Plan:\n$analyzed")
+
+    assertHelperColumnsRemoved(analyzed)
+  }
+
+  // ===========================================================================
+  // Both passes
+  // ===========================================================================
+
+  test("carry-over + update detection share a single Aggregate") {
+    catalog.setChangelogProperties(identifier, ChangelogProperties(
+      containsCarryoverRows = true,
+      representsUpdateAsDeleteAndInsert = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    val analyzed = streamingDf("computeUpdates" -> "true").queryExecution.analyzed
+    assertWatermarkOnCommitTimestamp(analyzed)
+
+    val aggs = analyzed.collect { case a: Aggregate => a }
+    assert(aggs.size == 1, s"Should fuse both passes into a single Aggregate. Plan:\n$analyzed")
+
+    // Filter for carry-over removal AND a Project for relabeling.
+    val filters = analyzed.collect { case f: Filter => f }
+    assert(filters.size == 1,
+      s"Exactly one Filter expected for combined path. Plan:\n$analyzed")
+
+    assertInlineGenerate(analyzed)
+    assertHelperColumnsRemoved(analyzed)
+  }
+
+  // ===========================================================================
+  // No post-processing -> no rewrite
+  // ===========================================================================
+
+  test("no post-processing required: raw streaming relation passes through") {
+    // No capability flags set -> no Aggregate, no watermark.
+    val analyzed = streamingDf().queryExecution.analyzed
+    assertNoStreamingPostProcessing(analyzed)
+  }
+
+  test("computeUpdates without representsUpdateAsDeleteAndInsert: no rewrite") {
+    // Connector says updates are already materialized -> nothing to do.
+    val analyzed = streamingDf(
+      "computeUpdates" -> "true").queryExecution.analyzed
+    assertNoStreamingPostProcessing(analyzed)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
@@ -133,6 +133,15 @@ class ResolveChangelogTableStreamingPostProcessingSuite
       s"Generate must use Inline. Plan:\n$plan")
   }
 
+  private def assertContainsNullCommitTimestampGuard(plan: LogicalPlan): Unit = {
+    val nullGuards = plan.collect {
+      case f: Filter
+        if f.condition.toString.contains("NULL_COMMIT_TIMESTAMP") => f
+    }
+    assert(nullGuards.size == 1,
+      s"Expected exactly one NULL_COMMIT_TIMESTAMP guard Filter. Plan:\n$plan")
+  }
+
   // ===========================================================================
   // Carry-over removal only
   // ===========================================================================
@@ -154,8 +163,11 @@ class ResolveChangelogTableStreamingPostProcessingSuite
     assert(groupingNames.toSet == Set("id", "_commit_version", "_commit_timestamp"),
       s"Expected grouping by (id, _commit_version, _commit_timestamp); got $groupingNames")
 
+    // Two Filters: the NULL `_commit_timestamp` guard + the carry-over predicate.
     val filters = analyzed.collect { case f: Filter => f }
-    assert(filters.size == 1, s"Expected one Filter for carry-over removal. Plan:\n$analyzed")
+    assert(filters.size == 2,
+      s"Expected NULL guard + carry-over Filter. Plan:\n$analyzed")
+    assertContainsNullCommitTimestampGuard(analyzed)
 
     assertInlineGenerate(analyzed)
     assertHelperColumnsRemoved(analyzed)
@@ -177,10 +189,13 @@ class ResolveChangelogTableStreamingPostProcessingSuite
       "deduplicationMode" -> "none").queryExecution.analyzed
     assertWatermarkOnCommitTimestamp(analyzed)
 
-    // No carry-over Filter when only update detection runs.
+    // No carry-over Filter when only update detection runs -- but the NULL
+    // `_commit_timestamp` guard Filter is always present.
     val filters = analyzed.collect { case f: Filter => f }
-    assert(filters.isEmpty,
-      s"No Filter expected for update-detection-only path. Plan:\n$analyzed")
+    assert(filters.size == 1,
+      s"Only the NULL guard Filter is expected for update-detection-only path. " +
+        s"Plan:\n$analyzed")
+    assertContainsNullCommitTimestampGuard(analyzed)
 
     assertInlineGenerate(analyzed)
 
@@ -211,10 +226,11 @@ class ResolveChangelogTableStreamingPostProcessingSuite
     val aggs = analyzed.collect { case a: Aggregate => a }
     assert(aggs.size == 1, s"Should fuse both passes into a single Aggregate. Plan:\n$analyzed")
 
-    // Filter for carry-over removal AND a Project for relabeling.
+    // Two Filters: NULL guard + carry-over removal.
     val filters = analyzed.collect { case f: Filter => f }
-    assert(filters.size == 1,
-      s"Exactly one Filter expected for combined path. Plan:\n$analyzed")
+    assert(filters.size == 2,
+      s"Expected NULL guard + carry-over Filter for combined path. Plan:\n$analyzed")
+    assertContainsNullCommitTimestampGuard(analyzed)
 
     assertInlineGenerate(analyzed)
     assertHelperColumnsRemoved(analyzed)
@@ -276,5 +292,37 @@ class ResolveChangelogTableStreamingPostProcessingSuite
     assert(ts.isDefined, s"Expected `_commit_timestamp` in output. Plan:\n$analyzed")
     assert(!ts.get.metadata.contains(EventTimeWatermark.delayKey),
       s"Watermark metadata leaked to user-visible `_commit_timestamp`. Plan:\n$analyzed")
+  }
+
+  // ===========================================================================
+  // NULL _commit_timestamp guard
+  // ===========================================================================
+
+  test("NULL _commit_timestamp guard Filter is the first operator after the source") {
+    catalog.setChangelogProperties(identifier, ChangelogProperties(
+      containsCarryoverRows = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    val analyzed = streamingDf().queryExecution.analyzed
+    // The guard must sit BELOW the EventTimeWatermark (we don't want a NULL row to
+    // be considered for watermark advancement at all). Verify by walking the plan
+    // top-down and finding the guard before any Aggregate.
+    val guards = analyzed.collect {
+      case f: Filter if f.condition.toString.contains("NULL_COMMIT_TIMESTAMP") => f
+    }
+    assert(guards.size == 1, s"Expected exactly one guard. Plan:\n$analyzed")
+    val guard = guards.head
+    val guardChild = guard.child
+    // The guard's child should be the bare relation (or a SubqueryAlias wrapping it),
+    // not the EventTimeWatermark.
+    val isSourceBelowGuard = guardChild match {
+      case _: org.apache.spark.sql.catalyst.streaming.StreamingRelationV2 => true
+      case org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias(_,
+            _: org.apache.spark.sql.catalyst.streaming.StreamingRelationV2) => true
+      case _ => false
+    }
+    assert(isSourceBelowGuard,
+      s"NULL guard Filter should sit directly above the streaming relation. Plan:\n$analyzed")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
@@ -21,7 +21,7 @@ import java.util.Collections
 
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest}
 import org.apache.spark.sql.catalyst.expressions.Inline
 import org.apache.spark.sql.catalyst.plans.logical.{
   Aggregate, EventTimeWatermark, Filter, Generate, LogicalPlan, Project}
@@ -225,5 +225,22 @@ class ResolveChangelogTableStreamingPostProcessingSuite
     val analyzed = streamingDf(
       "computeUpdates" -> "true").queryExecution.analyzed
     assertNoStreamingPostProcessing(analyzed)
+  }
+
+  // ===========================================================================
+  // Net change computation rejection
+  // ===========================================================================
+
+  test("deduplicationMode=netChanges is rejected on streaming") {
+    catalog.setChangelogProperties(identifier, ChangelogProperties(
+      containsIntermediateChanges = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    val e = intercept[AnalysisException] {
+      streamingDf("deduplicationMode" -> "netChanges").queryExecution.analyzed
+    }
+    assert(e.getCondition == "INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED",
+      s"Unexpected error: ${e.getMessage}")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR implements row-level CDC post-processing (carry-over removal and update detection) for DSv2 streaming reads. Previously, streaming `changes()` rejected any post-processing with a blanket `INVALID_CDC_OPTION.STREAMING_POST_PROCESSING_NOT_SUPPORTED` error.

The batch path (added in #55508 and #55583) uses a Catalyst `Window` keyed by `(rowId, _commit_version)`, which `UnsupportedOperationChecker` rejects on streaming queries (`NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING`). The streaming rewrite in `ResolveChangelogTable` now expresses the same logic with streaming-allowed primitives:

```
EventTimeWatermark(_commit_timestamp, 0s)
  -> Aggregate keyed by (rowId..., _commit_version, _commit_timestamp)
       (count_if delete/insert, [min/max/count rowVersion,] collect_list(struct(*)))
  -> [Filter on the carry-over predicate]
  -> Generate(Inline(events))
  -> [Project relabeling _change_type for delete+insert pairs]
  -> Project dropping __spark_cdc_* helpers
```

Including `_commit_timestamp` in the grouping keys is required to satisfy the Append-mode streaming aggregation contract (the watermark attribute must appear among the grouping expressions). By CDC convention all rows in a single commit share `_commit_timestamp`, so this is a no-op semantically relative to the batch `(rowId, _commit_version)` grouping.

`deduplicationMode = netChanges` is still rejected -- net change computation partitions by `rowId` alone and reasons over the entire requested range, which is fundamentally cross-batch. The existing error class `INVALID_CDC_OPTION.STREAMING_POST_PROCESSING_NOT_SUPPORTED` is replaced with the more specific `INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED`, which now names the offending option and points users at the supported streaming alternatives.

Doc updates:
- `Changelog.java` clarifies that all rows of a single `_commit_version` must share `_commit_timestamp`, and that streaming reads expect non-decreasing `_commit_timestamp` across micro-batches.
- `Changelog.java` notes that `containsIntermediateChanges()` is range-scoped, hence the streaming limitation for `netChanges`.
- `DataStreamReader.changes()` Scaladoc lists the `netChanges` streaming limitation.

### Why are the changes needed?

Without this PR, any streaming CDC read against a connector that emits CoW carry-over pairs (`containsCarryoverRows = true`) or represents updates as raw delete+insert (`representsUpdateAsDeleteAndInsert = true`) raises an analysis error, forcing users to fall back to batch reads. The batch-only restriction is unnecessary for these passes -- they don't need cross-version state -- and it surprises users since the same options work on batch reads.

### Does this PR introduce _any_ user-facing change?

Yes.
- Streaming `spark.readStream.changes(...)` now supports `computeUpdates = true` and `deduplicationMode = dropCarryovers`. Previously these threw `INVALID_CDC_OPTION.STREAMING_POST_PROCESSING_NOT_SUPPORTED`.
- The error class `INVALID_CDC_OPTION.STREAMING_POST_PROCESSING_NOT_SUPPORTED` is renamed to `INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED` with a more specific message. The new error fires only for `deduplicationMode = netChanges` on streaming reads.
- `DataStreamReader.changes()` Scaladoc is updated accordingly.
- `Changelog.java` Scaladoc clarifies the `_commit_timestamp` contract for streaming.

### How was this patch tested?

86 tests across 4 CDC suites (all passing):

- `ResolveChangelogTableStreamingPostProcessingSuite` (new, 5 tests) -- plan-shape assertions covering carry-over only, update detection only, both fused, and the no-rewrite pass-through cases. Verifies the `EventTimeWatermark` + `Aggregate` + `Generate(Inline)` rewrite shape.
- `ChangelogResolutionSuite` -- the two existing streaming throw-tests are flipped to plan-shape assertions; a new test covers the `netChanges` streaming throw.
- `ResolveChangelogTablePostProcessingSuite` -- the existing streaming throw test is updated to cover the `netChanges`-only case.
- `ChangelogEndToEndSuite` -- three new streaming end-to-end tests using `InMemoryChangelogCatalog`: carry-over removal drops CoW pairs, update detection relabels delete+insert as update, and `netChanges` throws.

Also confirmed `UnsupportedOperationsSuite` (216 tests) still passes -- the rewritten plan does not contain `Window` or any other streaming-rejected operator.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)