### PR TITLE
[SPARK-56687][SQL] Support netChanges for DSv2 CDC streaming reads

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3308,11 +3308,6 @@
           "`startingVersion` is required when `endingVersion` is specified for CDC queries."
         ]
       },
-      "STREAMING_NET_CHANGES_NOT_SUPPORTED" : {
-        "message" : [
-          "Change Data Capture (CDC) streaming reads on connector `<changelogName>` do not yet support net change computation (`deduplicationMode = netChanges`). Net change computation reasons over the entire requested version range and is currently only available for batch reads. Use a batch read, or set `deduplicationMode` to `none` or `dropCarryovers` for streaming."
-        ]
-      },
       "UPDATE_DETECTION_REQUIRES_CARRY_OVER_REMOVAL" : {
         "message" : [
           "`computeUpdates` cannot be used with `deduplicationMode=none` on connector `<changelogName>` because the connector emits copy-on-write carry-over pairs (`containsCarryoverRows()` returns true) that would be silently mislabeled as updates. Set `deduplicationMode` to `dropCarryovers` or `netChanges`."

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -131,15 +131,19 @@ abstract class DataStreamReader {
    *     .changes("my_table")
    * }}}
    *
-   * Streaming reads support the same `computeUpdates` and `deduplicationMode = dropCarryovers`
-   * post-processing as batch reads. `deduplicationMode = netChanges` is currently batch-only --
-   * it requires reasoning over the entire requested range, which is not incrementalized yet.
-   * Requesting it on a streaming read raises an explicit
-   * `INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED` error.
+   * Streaming reads support all of the same post-processing as batch reads -- `computeUpdates`,
+   * `deduplicationMode = dropCarryovers`, and `deduplicationMode = netChanges`. The streaming
+   * netChanges path holds per-row-identity state in the state store and emits the SPIP collapse
+   * output once the global watermark advances past the last `_commit_timestamp` observed for that
+   * row identity. Row identities only touched in the latest observed commit are therefore not
+   * emitted until a later commit (with strictly greater `_commit_timestamp`) advances the
+   * watermark past them, or the source terminates -- bounded streams produce the same output as
+   * the corresponding batch read.
    *
-   * When the requested options engage row-level post-processing (carry-over removal or update
-   * detection), the rewrite injects an internal `EventTimeWatermark` on `_commit_timestamp` and a
-   * stateful streaming aggregate. Two implications follow:
+   * When the requested options engage post-processing (carry-over removal, update detection, or
+   * netChanges), the rewrite injects an internal `EventTimeWatermark` on `_commit_timestamp` and
+   * a stateful streaming operator (an aggregate for the row-level passes, a `transformWithState`
+   * for netChanges). Two implications follow:
    *   - A commit's events are emitted in the next micro-batch after the commit is read
    *     (append-mode aggregate eviction is `eventTime &lt;= watermark`, and the watermark
    *     advances to the max `_commit_timestamp` observed in the previous batch). A stream that

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -143,18 +143,18 @@ abstract class DataStreamReader {
    * changes for a row identity over the entire requested version range. Streaming netChanges is
    * incremental: it collapses changes that fall within a single watermark window for a row
    * identity (i.e. up to the timer firing that emits its current net result). After a row
-   * identity's net result has been emitted, subsequent commits on the same identity start a
-   * fresh window and produce additional output rows -- streaming cannot retract previously
-   * emitted results to match the batch range-scoped collapse. For a query that observes id=1
-   * inserted at v1 and deleted at v3 with another commit at v2 in between, batch netChanges over
-   * [v1..v3] cancels to no row, while streaming emits an `insert` (when v2 advances the
-   * watermark past v1) followed later by a `delete` (when end-of-stream or another commit
-   * advances the watermark past v3).
+   * identity's net result has been emitted, subsequent commits on the same identity start a fresh
+   * window and produce additional output rows -- streaming cannot retract previously emitted
+   * results to match the batch range-scoped collapse. For a query that observes id=1 inserted at
+   * v1 and deleted at v3 with another commit at v2 in between, batch netChanges over [v1..v3]
+   * cancels to no row, while streaming emits an `insert` (when v2 advances the watermark past v1)
+   * followed later by a `delete` (when end-of-stream or another commit advances the watermark
+   * past v3).
    *
    * Because the streaming netChanges path uses `transformWithState`, the state store provider
    * must be RocksDB. Set `spark.sql.streaming.stateStore.providerClass` to
-   * `org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider` before starting
-   * a streaming netChanges query; the default HDFS-backed provider is rejected at query start.
+   * `org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider` before starting a
+   * streaming netChanges query; the default HDFS-backed provider is rejected at query start.
    *
    * When the requested options engage post-processing (carry-over removal, update detection, or
    * netChanges), the rewrite injects an internal `EventTimeWatermark` on `_commit_timestamp` and

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -137,8 +137,24 @@ abstract class DataStreamReader {
    * output once the global watermark advances past the last `_commit_timestamp` observed for that
    * row identity. Row identities only touched in the latest observed commit are therefore not
    * emitted until a later commit (with strictly greater `_commit_timestamp`) advances the
-   * watermark past them, or the source terminates -- bounded streams produce the same output as
-   * the corresponding batch read.
+   * watermark past them, or the source terminates.
+   *
+   * Streaming netChanges differs from batch netChanges in scope. Batch netChanges collapses all
+   * changes for a row identity over the entire requested version range. Streaming netChanges is
+   * incremental: it collapses changes that fall within a single watermark window for a row
+   * identity (i.e. up to the timer firing that emits its current net result). After a row
+   * identity's net result has been emitted, subsequent commits on the same identity start a
+   * fresh window and produce additional output rows -- streaming cannot retract previously
+   * emitted results to match the batch range-scoped collapse. For a query that observes id=1
+   * inserted at v1 and deleted at v3 with another commit at v2 in between, batch netChanges over
+   * [v1..v3] cancels to no row, while streaming emits an `insert` (when v2 advances the
+   * watermark past v1) followed later by a `delete` (when end-of-stream or another commit
+   * advances the watermark past v3).
+   *
+   * Because the streaming netChanges path uses `transformWithState`, the state store provider
+   * must be RocksDB. Set `spark.sql.streaming.stateStore.providerClass` to
+   * `org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider` before starting
+   * a streaming netChanges query; the default HDFS-backed provider is rejected at query start.
    *
    * When the requested options engage post-processing (carry-over removal, update detection, or
    * netChanges), the rewrite injects an internal `EventTimeWatermark` on `_commit_timestamp` and

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
@@ -33,8 +33,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * <ul>
  *   <li>{@code _change_type} (STRING) — the kind of change: {@code insert}, {@code delete},
  *       {@code update_preimage}, or {@code update_postimage}</li>
- *   <li>{@code _commit_version} (connector-defined type, e.g. LONG) — the version containing
- *       this change</li>
+ *   <li>{@code _commit_version} (LONG) — the version containing this change. Spark
+ *       post-processing compares versions as primitive longs</li>
  *   <li>{@code _commit_timestamp} (TIMESTAMP) -- the timestamp of the commit. All rows
  *       belonging to a single {@code _commit_version} must share the same
  *       {@code _commit_timestamp}. For streaming reads with post-processing enabled,
@@ -61,15 +61,16 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *       snapshots) that derive {@code _commit_timestamp} from wall-clock time at
  *       commit time naturally satisfy both requirements.
  *       {@code _commit_timestamp} must be non-{@code NULL} on every row of a streaming
- *       read engaging post-processing. The row-level rewrite raises
- *       {@code CHANGELOG_CONTRACT_VIOLATION.NULL_COMMIT_TIMESTAMP} on any row that
- *       violates this; without the guard a NULL group key would never satisfy the
- *       watermark eviction predicate and the row would sit in state indefinitely</li>
+ *       read engaging post-processing; both the row-level Aggregate path and the
+ *       netChanges {@code transformWithState} path raise
+ *       {@code CHANGELOG_CONTRACT_VIOLATION.NULL_COMMIT_TIMESTAMP} on a violation</li>
  * </ul>
  * <p>
- * Streaming reads support carry-over removal and update detection but not net change
- * computation. The latter requires reasoning over the entire requested range and is
- * batch-only.
+ * Streaming reads support carry-over removal, update detection, and net change
+ * computation. Net change collapses are kept in the state store keyed by row identity;
+ * row identities only touched in the latest observed commit are held back until either a
+ * later commit (with strictly greater `_commit_timestamp`) advances the global watermark
+ * past them, or the source terminates.
  *
  * @since 4.2.0
  */
@@ -116,10 +117,7 @@ public interface Changelog {
    * the entire changelog range, and Spark will skip net change computation.
    * <p>
    * Note this flag is range-scoped (across all commits in the request), not
-   * micro-batch-scoped. Streaming CDC reads currently reject
-   * {@code deduplicationMode = netChanges} because the per-row-identity collapse cannot
-   * be incrementalized: a row's full history may span an unbounded number of
-   * micro-batches.
+   * micro-batch-scoped.
    */
   boolean containsIntermediateChanges();
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
@@ -33,10 +33,12 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * <ul>
  *   <li>{@code _change_type} (STRING) — the kind of change: {@code insert}, {@code delete},
  *       {@code update_preimage}, or {@code update_postimage}</li>
- *   <li>{@code _commit_version} (LONG, required type) — the version containing this
- *       change. Spark post-processing compares versions as primitive longs and the
- *       streaming netChanges path reads this column as a primitive long; connectors
- *       must declare this column with {@code LongType}</li>
+ *   <li>{@code _commit_version} — the commit version containing this change. Must be of
+ *       an atomic orderable type (e.g. {@code LongType}, {@code StringType},
+ *       {@code IntegerType}, {@code TimestampType}); complex types
+ *       ({@code ArrayType}, {@code MapType}, {@code StructType}) are rejected.
+ *       Spark post-processing sorts rows of a given row identity by this column to
+ *       determine the first and last events</li>
  *   <li>{@code _commit_timestamp} (TIMESTAMP) -- the timestamp of the commit. All rows
  *       belonging to a single {@code _commit_version} must share the same
  *       {@code _commit_timestamp}. For streaming reads with post-processing enabled,

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
@@ -33,8 +33,10 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * <ul>
  *   <li>{@code _change_type} (STRING) — the kind of change: {@code insert}, {@code delete},
  *       {@code update_preimage}, or {@code update_postimage}</li>
- *   <li>{@code _commit_version} (LONG) — the version containing this change. Spark
- *       post-processing compares versions as primitive longs</li>
+ *   <li>{@code _commit_version} (LONG, required type) — the version containing this
+ *       change. Spark post-processing compares versions as primitive longs and the
+ *       streaming netChanges path reads this column as a primitive long; connectors
+ *       must declare this column with {@code LongType}</li>
  *   <li>{@code _commit_timestamp} (TIMESTAMP) -- the timestamp of the commit. All rows
  *       belonging to a single {@code _commit_version} must share the same
  *       {@code _commit_timestamp}. For streaming reads with post-processing enabled,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CdcNetChangesStatefulProcessor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CdcNetChangesStatefulProcessor.scala
@@ -74,6 +74,22 @@ private[analysis] class CdcNetChangesStatefulProcessor(
 
   // Hoisted out of `relabel` so we don't pay a linear `fieldIndex` scan per emitted row.
   private val changeTypeIdx: Int = inputSchema.fieldIndex("_change_type")
+  private val commitVersionIdx: Int = inputSchema.fieldIndex("_commit_version")
+
+  // `_commit_version` is connector-defined and may be any atomic orderable type
+  // (LongType, StringType, IntegerType, TimestampType, ...). The
+  // [[org.apache.spark.sql.execution.datasources.v2.ChangelogTable.validateSchema]]
+  // analyzer-time check guarantees the column is `AtomicType`, and the boxed Java
+  // values of every atomic type are `Comparable`, so we use a generic
+  // `Comparable.compareTo` to order rows of a single key here -- mirroring the batch
+  // path which uses Catalyst's generic `SortOrder` on the same attribute.
+  private val versionOrdering: Ordering[Row] = new Ordering[Row] {
+    override def compare(a: Row, b: Row): Int = {
+      val av = a.get(commitVersionIdx).asInstanceOf[Comparable[Any]]
+      val bv = b.get(commitVersionIdx)
+      av.compareTo(bv)
+    }
+  }
 
   override def init(outputMode: OutputMode, timeMode: TimeMode): Unit = {
     val handle = getHandle
@@ -87,10 +103,13 @@ private[analysis] class CdcNetChangesStatefulProcessor(
       inputRows: Iterator[Row],
       timerValues: TimerValues): Iterator[Row] = {
     val handle = getHandle
-    val sorted = inputRows.toSeq.sortBy { row =>
-      val v = row.getAs[Long]("_commit_version")
-      val ct = row.getAs[String]("_change_type")
-      val rank = ct match {
+    // Sort by (_commit_version, change_type rank) -- pre-events (delete /
+    // update_preimage) before post-events (insert / update_postimage) within a single
+    // commit version, matching the batch path's `(_commit_version, change_type_rank)`
+    // ordering. We compose the version ordering (generic Comparable) with the rank
+    // ordering as a tiebreaker.
+    val sorted = inputRows.toSeq.sorted(versionOrdering.orElse(Ordering.by { row =>
+      row.getAs[String](changeTypeIdx) match {
         case Changelog.CHANGE_TYPE_UPDATE_PREIMAGE | Changelog.CHANGE_TYPE_DELETE => 0
         case Changelog.CHANGE_TYPE_INSERT | Changelog.CHANGE_TYPE_UPDATE_POSTIMAGE => 1
         case _ => throw new SparkException(
@@ -98,8 +117,7 @@ private[analysis] class CdcNetChangesStatefulProcessor(
           messageParameters = Map.empty,
           cause = null)
       }
-      (v, rank)
-    }
+    }))
     if (sorted.isEmpty) return Iterator.empty
 
     if (!firstEvent.exists()) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CdcNetChangesStatefulProcessor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CdcNetChangesStatefulProcessor.scala
@@ -19,8 +19,10 @@ package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{Encoder, Row}
+import org.apache.spark.sql.catalyst.CatalystTypeConverters
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.connector.catalog.Changelog
 import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.types.StructType
@@ -77,17 +79,22 @@ private[analysis] class CdcNetChangesStatefulProcessor(
   private val commitVersionIdx: Int = inputSchema.fieldIndex("_commit_version")
 
   // `_commit_version` is connector-defined and may be any atomic orderable type
-  // (LongType, StringType, IntegerType, TimestampType, ...). The
-  // [[org.apache.spark.sql.execution.datasources.v2.ChangelogTable.validateSchema]]
-  // analyzer-time check guarantees the column is `AtomicType`, and the boxed Java
-  // values of every atomic type are `Comparable`, so we use a generic
-  // `Comparable.compareTo` to order rows of a single key here -- mirroring the batch
-  // path which uses Catalyst's generic `SortOrder` on the same attribute.
+  // (LongType, StringType, IntegerType, TimestampType, BinaryType, ...). To order
+  // rows generically -- without assuming the boxed external Java value is
+  // `Comparable` (e.g. BinaryType -> Array[Byte], which is not) -- we route the
+  // value through Catalyst: convert the external Row value to its Catalyst-internal
+  // form and compare with the type-aware interpreted ordering. This mirrors the
+  // batch path which uses Catalyst's `SortOrder` on the same attribute.
+  private val versionDataType = inputSchema(commitVersionIdx).dataType
+  private val versionToCatalyst: Any => Any =
+    CatalystTypeConverters.createToCatalystConverter(versionDataType)
+  private val versionInternalOrdering: Ordering[Any] =
+    TypeUtils.getInterpretedOrdering(versionDataType)
   private val versionOrdering: Ordering[Row] = new Ordering[Row] {
     override def compare(a: Row, b: Row): Int = {
-      val av = a.get(commitVersionIdx).asInstanceOf[Comparable[Any]]
-      val bv = b.get(commitVersionIdx)
-      av.compareTo(bv)
+      val av = versionToCatalyst(a.get(commitVersionIdx))
+      val bv = versionToCatalyst(b.get(commitVersionIdx))
+      versionInternalOrdering.compare(av, bv)
     }
   }
 
@@ -106,7 +113,7 @@ private[analysis] class CdcNetChangesStatefulProcessor(
     // Sort by (_commit_version, change_type rank) -- pre-events (delete /
     // update_preimage) before post-events (insert / update_postimage) within a single
     // commit version, matching the batch path's `(_commit_version, change_type_rank)`
-    // ordering. We compose the version ordering (generic Comparable) with the rank
+    // ordering. We compose the type-aware Catalyst version ordering with the rank
     // ordering as a tiebreaker.
     val sorted = inputRows.toSeq.sorted(versionOrdering.orElse(Ordering.by { row =>
       row.getAs[String](changeTypeIdx) match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CdcNetChangesStatefulProcessor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CdcNetChangesStatefulProcessor.scala
@@ -36,11 +36,13 @@ import org.apache.spark.sql.types.StructType
  * matrix on `(existedBefore, existsAfter)`. That `Window` is rejected on streaming
  * queries (`NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING`).
  *
- * This processor reproduces the same semantics with `transformWithState`. Per-row-identity
+ * This processor reuses the same SPIP collapse matrix with `transformWithState`, applied
+ * per watermark window rather than over the full requested version range. Per-row-identity
  * state stores the first event ever observed and the most-recent event observed; an event
  * time timer keyed on `_commit_timestamp` advances with each batch and fires once the
  * global watermark passes the latest event time observed for the key, at which point the
- * SPIP matrix is evaluated and the net result is emitted.
+ * SPIP matrix is evaluated and the net result is emitted. See the paragraph below for how
+ * the per-window collapse differs from batch netChanges' range-scoped collapse.
  *
  * Output schema: identical to the connector's changelog schema.
  *

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CdcNetChangesStatefulProcessor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CdcNetChangesStatefulProcessor.scala
@@ -42,10 +42,18 @@ import org.apache.spark.sql.types.StructType
  *
  * Output schema: identical to the connector's changelog schema.
  *
- * Documented limitation: row identities only touched in the latest observed commit do not
- * emit until a later commit (with strictly greater `_commit_timestamp`) advances the
- * watermark past them, or the source terminates. End-of-stream flushes all pending
- * timers, so bounded streams produce the same output as the corresponding batch read.
+ * Streaming netChanges is incremental: per-row-identity state is cleared once its current
+ * net result is emitted (timer fire or end-of-stream flush). Subsequent commits on the same
+ * identity arrive against empty state and produce additional output rows independently. This
+ * differs from batch netChanges, which collapses every change for a row identity across the
+ * entire requested version range; the streaming path cannot retract previously emitted output
+ * to match that range-scoped collapse. For example, with id=1 inserted at v1 and deleted at
+ * v3 and an unrelated commit at v2 in between, batch netChanges over [v1..v3] emits nothing
+ * for id=1, while streaming emits an `insert` (after v2 advances the watermark past v1) and
+ * later a `delete` (after end-of-stream or another commit advances the watermark past v3).
+ *
+ * End-of-stream flushes all pending timers, so a bounded stream's output matches a batch
+ * netChanges only when no row identity is touched again after its first emission.
  *
  * @param inputSchema    schema of the rows fed into this processor; the connector's
  *                       changelog schema (data columns + `_change_type` +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CdcNetChangesStatefulProcessor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CdcNetChangesStatefulProcessor.scala
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.{Encoder, Row}
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.connector.catalog.Changelog
+import org.apache.spark.sql.streaming._
+import org.apache.spark.sql.types.StructType
+
+/**
+ * StatefulProcessor that incrementalises CDC net-change computation for streaming reads.
+ *
+ * The batch path (`ResolveChangelogTable.injectNetChangeComputation`) uses a Catalyst
+ * `Window` partitioned by `rowId` and ordered by `(_commit_version, change_type_rank)` to
+ * extract the first and last events per row identity, then applies the SPIP collapse
+ * matrix on `(existedBefore, existsAfter)`. That `Window` is rejected on streaming
+ * queries (`NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING`).
+ *
+ * This processor reproduces the same semantics with `transformWithState`. Per-row-identity
+ * state stores the first event ever observed and the most-recent event observed; an event
+ * time timer keyed on `_commit_timestamp` advances with each batch and fires once the
+ * global watermark passes the latest event time observed for the key, at which point the
+ * SPIP matrix is evaluated and the net result is emitted.
+ *
+ * Output schema: identical to the connector's changelog schema.
+ *
+ * Documented limitation: row identities only touched in the latest observed commit do not
+ * emit until a later commit (with strictly greater `_commit_timestamp`) advances the
+ * watermark past them, or the source terminates. End-of-stream flushes all pending
+ * timers, so bounded streams produce the same output as the corresponding batch read.
+ *
+ * @param inputSchema    schema of the rows fed into this processor; the connector's
+ *                       changelog schema (data columns + `_change_type` +
+ *                       `_commit_version` + `_commit_timestamp`) optionally extended with
+ *                       rowId helper columns added by
+ *                       [[org.apache.spark.sql.catalyst.analysis.ResolveChangelogTable]].
+ * @param computeUpdates whether `(existedBefore, existsAfter) = (true, true)` should be
+ *                       relabeled as `update_preimage` / `update_postimage` (true) or kept
+ *                       as `delete` / `insert` (false), matching the batch contract.
+ */
+private[analysis] class CdcNetChangesStatefulProcessor(
+    inputSchema: StructType,
+    computeUpdates: Boolean)
+  extends StatefulProcessor[Row, Row, Row] {
+
+  @transient private var firstEvent: ValueState[Row] = _
+  @transient private var lastEvent: ValueState[Row] = _
+
+  // Hoisted out of `relabel` so we don't pay a linear `fieldIndex` scan per emitted row.
+  private val changeTypeIdx: Int = inputSchema.fieldIndex("_change_type")
+
+  override def init(outputMode: OutputMode, timeMode: TimeMode): Unit = {
+    val handle = getHandle
+    val rowEncoder: Encoder[Row] = ExpressionEncoder(inputSchema)
+    firstEvent = handle.getValueState[Row]("firstEvent", rowEncoder, TTLConfig.NONE)
+    lastEvent = handle.getValueState[Row]("lastEvent", rowEncoder, TTLConfig.NONE)
+  }
+
+  override def handleInputRows(
+      key: Row,
+      inputRows: Iterator[Row],
+      timerValues: TimerValues): Iterator[Row] = {
+    val handle = getHandle
+    val sorted = inputRows.toSeq.sortBy { row =>
+      val v = row.getAs[Long]("_commit_version")
+      val ct = row.getAs[String]("_change_type")
+      val rank = ct match {
+        case Changelog.CHANGE_TYPE_UPDATE_PREIMAGE | Changelog.CHANGE_TYPE_DELETE => 0
+        case Changelog.CHANGE_TYPE_INSERT | Changelog.CHANGE_TYPE_UPDATE_POSTIMAGE => 1
+        case _ => throw new SparkException(
+          errorClass = "CHANGELOG_CONTRACT_VIOLATION.UNEXPECTED_CHANGE_TYPE",
+          messageParameters = Map.empty,
+          cause = null)
+      }
+      (v, rank)
+    }
+    if (sorted.isEmpty) return Iterator.empty
+
+    if (!firstEvent.exists()) {
+      firstEvent.update(sorted.head)
+    }
+    lastEvent.update(sorted.last)
+
+    // Re-arm the per-key event-time timer to the latest observed `_commit_timestamp`.
+    // Without dropping any existing timers we'd risk an earlier timer firing first and
+    // emitting state that later events would then re-populate, producing duplicate
+    // output for the same row identity.
+    //
+    // A NULL `_commit_timestamp` cannot be turned into a timer epoch and would NPE on
+    // `getTime()`. The `Changelog` Javadoc requires non-NULL `_commit_timestamp` on
+    // streaming reads engaging post-processing, so we surface the contract violation
+    // with a clear error class rather than failing the micro-batch with an opaque NPE.
+    val ts = sorted.last.getAs[java.sql.Timestamp]("_commit_timestamp")
+    if (ts == null) {
+      throw new SparkException(
+        errorClass = "CHANGELOG_CONTRACT_VIOLATION.NULL_COMMIT_TIMESTAMP",
+        messageParameters = Map.empty,
+        cause = null)
+    }
+    val newTimerMs = ts.getTime
+    val existing = handle.listTimers().toList
+    existing.foreach(handle.deleteTimer)
+    handle.registerTimer(newTimerMs)
+
+    Iterator.empty
+  }
+
+  override def handleExpiredTimer(
+      key: Row,
+      timerValues: TimerValues,
+      expiredTimerInfo: ExpiredTimerInfo): Iterator[Row] = {
+    if (!firstEvent.exists()) return Iterator.empty
+
+    val first = firstEvent.get()
+    val last = lastEvent.get()
+    val firstChangeType = first.getAs[String]("_change_type")
+    val lastChangeType = last.getAs[String]("_change_type")
+
+    val existedBefore =
+      firstChangeType == Changelog.CHANGE_TYPE_DELETE ||
+        firstChangeType == Changelog.CHANGE_TYPE_UPDATE_PREIMAGE
+    val existsAfter =
+      lastChangeType == Changelog.CHANGE_TYPE_INSERT ||
+        lastChangeType == Changelog.CHANGE_TYPE_UPDATE_POSTIMAGE
+
+    val (preLabel, postLabel) =
+      if (computeUpdates) {
+        (Changelog.CHANGE_TYPE_UPDATE_PREIMAGE, Changelog.CHANGE_TYPE_UPDATE_POSTIMAGE)
+      } else {
+        (Changelog.CHANGE_TYPE_DELETE, Changelog.CHANGE_TYPE_INSERT)
+      }
+
+    val out: Iterator[Row] = (existedBefore, existsAfter) match {
+      case (false, false) => Iterator.empty
+      case (false, true) => Iterator(relabel(last, Changelog.CHANGE_TYPE_INSERT))
+      case (true, false) => Iterator(relabel(first, Changelog.CHANGE_TYPE_DELETE))
+      case (true, true) => Iterator(relabel(first, preLabel), relabel(last, postLabel))
+    }
+
+    firstEvent.clear()
+    lastEvent.clear()
+    out
+  }
+
+  private def relabel(row: Row, newChangeType: String): Row = {
+    val values = row.toSeq.toArray
+    values(changeTypeIdx) = newChangeType
+    new GenericRowWithSchema(values, inputSchema)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
@@ -641,7 +641,12 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
    *     matrix and emits 0, 1, or 2 output rows.
    *  4. [[SerializeFromObject]] (added by the `transformWithState` factory) brings the
    *     processor's `Row` outputs back into a regular tabular shape.
-   *  5. Final [[Project]] drops the rowId helper columns so the user-visible schema
+   *  5. [[Project]] (via [[stripCommitTimestampWatermarkMetadata]]) clears the
+   *     auto-injected `EventTimeWatermark.delayKey` metadata from the user-visible
+   *     `_commit_timestamp`. The metadata is preserved through the `transformWithState`
+   *     encoder roundtrip and would otherwise interact with downstream user-supplied
+   *     watermarks via the global multi-watermark policy.
+   *  6. Final [[Project]] drops the rowId helper columns so the user-visible schema
    *     matches the connector's declared changelog schema.
    *
    * Streaming netChanges is incremental, not range-scoped: per-row-identity state is
@@ -718,9 +723,18 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
     // 4. Wrap with SerializeFromObject so the obj column becomes regular tabular output.
     val serialized = CatalystSerde.serialize(tws)(rowEncoder)
 
-    // 5. Drop the rowId helper columns so the final output matches the connector's schema.
+    // 5. Strip the auto-injected EventTimeWatermark metadata from the user-visible
+    //    `_commit_timestamp`. The metadata is preserved through the `transformWithState`
+    //    encoder roundtrip (the encoder schema carries StructField metadata), so we
+    //    must clear it here at the boundary of the rewrite -- otherwise downstream
+    //    user-supplied watermarks would interact with our internal watermark via the
+    //    global multi-watermark policy. Mirrors the row-level path's call at the end
+    //    of `addStreamingRowLevelPostProcessing`.
+    val cleaned = stripCommitTimestampWatermarkMetadata(serialized)
+
+    // 6. Drop the rowId helper columns so the final output matches the connector's schema.
     val helperNames = rowIdHelpers.map(_.name).toSet
-    Project(serialized.output.filterNot(a => helperNames.contains(a.name)), serialized)
+    Project(cleaned.output.filterNot(a => helperNames.contains(a.name)), cleaned)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
@@ -644,10 +644,13 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
    *  5. Final [[Project]] drops the rowId helper columns so the user-visible schema
    *     matches the connector's declared changelog schema.
    *
-   * Documented limitation: row identities only touched in the latest observed commit do
-   * not emit until a later commit (with strictly greater `_commit_timestamp`) advances
-   * the watermark past them, or the source terminates. For bounded streams this matches
-   * the batch output exactly.
+   * Streaming netChanges is incremental, not range-scoped: per-row-identity state is
+   * cleared on emission, so a later commit on the same identity starts a fresh window
+   * and produces additional output rows. Batch netChanges over the same version range
+   * would have collapsed those changes; streaming cannot retract already-emitted rows
+   * to match that. End-of-stream flushes all pending timers, so a bounded stream's
+   * output matches batch only when no row identity is touched again after its first
+   * emission.
    */
   private def addStreamingNetChangeComputation(
       plan: LogicalPlan,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 
 import org.apache.spark.SparkRuntimeException
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{
   CollectList,
@@ -37,7 +38,8 @@ import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.connector.catalog.{Changelog, ChangelogInfo}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.{ChangelogTable, DataSourceV2Relation}
-import org.apache.spark.sql.types.{BooleanType, DataType, IntegerType, MetadataBuilder, StringType}
+import org.apache.spark.sql.streaming.{OutputMode, StatefulProcessor}
+import org.apache.spark.sql.types.{BooleanType, DataType, IntegerType, MetadataBuilder, StringType, StructField, StructType}
 import org.apache.spark.unsafe.types.CalendarInterval
 
 /**
@@ -60,11 +62,14 @@ import org.apache.spark.unsafe.types.CalendarInterval
  *     `(rowId, _commit_version, _commit_timestamp)` that buffers events into an array, an
  *     optional [[Filter]] for carry-over removal, a [[Generate]] using `Inline` to
  *     re-emit the buffered events as rows, and an optional relabel [[Project]] for
- *     update detection. Net change computation requires partitioning by `rowId` only and
- *     reasoning over the entire requested range, which is fundamentally cross-batch and
- *     not yet supported -- if `deduplicationMode = netChanges` is requested on a stream,
- *     the rule throws an explicit [[AnalysisException]] to prevent silent wrong results.
- *     Streams that don't require any post-processing pass through unchanged.
+ *     update detection. Net change computation is supported by delegating per-row-identity
+ *     state management to a [[CdcNetChangesStatefulProcessor]] driven by
+ *     [[TransformWithState]] -- the processor keeps the first and last event observed for
+ *     each row identity and emits the SPIP collapse output when the global watermark
+ *     advances past the last `_commit_timestamp` seen for that key. Row identities only
+ *     touched in the latest observed commit are held back until a later commit advances
+ *     the watermark or the source terminates. Streams that don't require any
+ *     post-processing pass through unchanged.
  */
 object ResolveChangelogTable extends Rule[LogicalPlan] {
 
@@ -95,6 +100,10 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
     final val FirstRowChangeTypeValue =
       "__spark_cdc_first_row_change_type_value"
     final val LastRowChangeTypeValue = "__spark_cdc_last_row_change_type_value"
+    // Streaming-only: rowId expressions are aliased to top-level helper columns named
+    // `__spark_cdc_rowid_<idx>` so they can be referenced as plain Attributes in the
+    // grouping list of `transformWithState`.
+    def rowIdColumn(idx: Int): String = s"__spark_cdc_rowid_$idx"
 
     val all: Set[String] =
       Set(RowNumber, RowCount, FirstRowChangeTypeValue, LastRowChangeTypeValue)
@@ -128,19 +137,25 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
         if !table.resolved =>
       val changelog = table.changelog
       val req = evaluateRequirements(changelog, table.changelogInfo)
-      // Net-change computation partitions by `rowId` alone (without `_commit_version`) and
-      // reasons over the entire requested range, which is fundamentally cross-batch.
-      // Reject with an explicit error until a streaming-friendly implementation lands.
-      if (req.requiresNetChanges) {
-        throw QueryCompilationErrors.cdcStreamingNetChangesNotSupported(changelog.name())
-      }
       val resolvedRel = rel.copy(table = table.copy(resolved = true))
+      var updatedRel: LogicalPlan = resolvedRel
       if (req.requiresCarryOverRemoval || req.requiresUpdateDetection) {
-        addStreamingRowLevelPostProcessing(
+        updatedRel = addStreamingRowLevelPostProcessing(
           resolvedRel, changelog, req.requiresCarryOverRemoval, req.requiresUpdateDetection)
-      } else {
-        resolvedRel
       }
+      if (req.requiresNetChanges) {
+        // Resolve the rowId references against `updatedRel` (the post-row-level plan)
+        // rather than the bare `resolvedRel`. The streaming row-level rewrite uses
+        // Aggregate + Generate(Inline), neither of which preserves the original
+        // attribute ExprIds for the inlined columns; resolving against `resolvedRel`
+        // yields stale ExprIds that fail post-analysis attribute resolution. The
+        // row-level rewrite preserves the connector's schema (column names) on its
+        // output, so name-based resolution against `updatedRel` recovers the right
+        // attributes regardless of any preceding wrapping.
+        updatedRel = addStreamingNetChangeComputation(
+          updatedRel, changelog, table.changelogInfo.computeUpdates())
+      }
+      updatedRel
   }
 
   // ---------------------------------------------------------------------------
@@ -598,6 +613,111 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
     val filteredAndRelabeledPlan =
       removeIntermediateChangelogEntriesAndRelabelChangeTypes(windowedPlan, computeUpdates)
     filteredAndRelabeledPlan
+  }
+
+  /**
+   * Streaming counterpart of [[injectNetChangeComputation]]. The batch version uses a
+   * Catalyst `Window` partitioned by `rowId`, which is rejected on streaming queries.
+   * This version delegates the per-`rowId` first/last extraction and the SPIP collapse
+   * matrix to a [[CdcNetChangesStatefulProcessor]] driven by `transformWithState`:
+   *
+   *  1. [[EventTimeWatermark]] on `_commit_timestamp` (zero delay) so the global query
+   *     watermark advances with each batch. When this rewrite runs on top of the row-level
+   *     post-processing rewrite (combined `containsCarryoverRows` /
+   *     `representsUpdateAsDeleteAndInsert` + `containsIntermediateChanges` path), the
+   *     row-level rewrite has already injected an identical `EventTimeWatermark` and we
+   *     reuse it instead of stacking a second one. Stacking watermarks on the same column
+   *     fails the multi-watermark check unless `STATEFUL_OPERATOR_ALLOW_MULTIPLE` is set,
+   *     and even then it would just produce two redundant nodes.
+   *  2. [[Project]] that aliases each rowId expression to a top-level helper column. This
+   *     lets us address the rowId as an `Attribute` for the `transformWithState` grouping,
+   *     which in turn makes nested rowId paths (e.g. `payload.id`) work without special
+   *     casing.
+   *  3. [[TransformWithState]] keyed by the rowId helper attributes, in
+   *     [[org.apache.spark.sql.catalyst.plans.logical.EventTime]] mode. The processor
+   *     buffers the first and last event per row identity; an event-time timer set to the
+   *     latest observed `_commit_timestamp` fires once the global watermark advances past
+   *     it, at which point the processor evaluates the SPIP `(existedBefore, existsAfter)`
+   *     matrix and emits 0, 1, or 2 output rows.
+   *  4. [[SerializeFromObject]] (added by the `transformWithState` factory) brings the
+   *     processor's `Row` outputs back into a regular tabular shape.
+   *  5. Final [[Project]] drops the rowId helper columns so the user-visible schema
+   *     matches the connector's declared changelog schema.
+   *
+   * Documented limitation: row identities only touched in the latest observed commit do
+   * not emit until a later commit (with strictly greater `_commit_timestamp`) advances
+   * the watermark past them, or the source terminates. For bounded streams this matches
+   * the batch output exactly.
+   */
+  private def addStreamingNetChangeComputation(
+      plan: LogicalPlan,
+      cl: Changelog,
+      computeUpdates: Boolean): LogicalPlan = {
+    // 1. Inject (or reuse, if already injected by the row-level rewrite) a watermark on
+    //    `_commit_timestamp`. The row-level rewrite already adds one with zero delay, so
+    //    we only add it when no watermark is present in the lineage to avoid stacking
+    //    EventTimeWatermark nodes (which is rejected by the multi-watermark check
+    //    unless STATEFUL_OPERATOR_ALLOW_MULTIPLE is set).
+    val needsWatermark = !plan.exists {
+      case _: EventTimeWatermark => true
+      case _ => false
+    }
+    val watermarked: LogicalPlan = if (needsWatermark) {
+      val rawCommitTsAttr = getAttribute(plan, "_commit_timestamp")
+      EventTimeWatermark(
+        UUID.randomUUID(), rawCommitTsAttr, new CalendarInterval(0, 0, 0L), plan)
+    } else plan
+
+    // 2. Resolve rowId expressions against the watermarked plan. Resolving here (after
+    //    any preceding row-level rewrite) ensures the attribute ExprIds match the
+    //    columns in `plan.output` -- name-based resolution recovers them by their
+    //    connector-declared names. Then project them to top-level helper columns so
+    //    they can be referenced as plain Attributes by `transformWithState`'s grouping.
+    val rowIdExprs =
+      V2ExpressionUtils.resolveRefs[NamedExpression](cl.rowId().toSeq, watermarked)
+    val rowIdHelpers: Seq[Alias] = rowIdExprs.zipWithIndex.map { case (expr, idx) =>
+      Alias(expr, NetChangesHelperColumns.rowIdColumn(idx))()
+    }
+    val originalCols: Seq[Attribute] = watermarked.output
+    val withHelpers = Project(originalCols ++ rowIdHelpers, watermarked)
+
+    // 3. Build the input/output Row encoder for the processor. The schema is the
+    //    watermarked plan's schema plus the rowId helper columns.
+    val processorInputSchema = StructType(
+      withHelpers.output.map { a =>
+        StructField(a.name, a.dataType, a.nullable, a.metadata)
+      })
+    val rowEncoder = ExpressionEncoder(processorInputSchema)
+    val groupingAttrs: Seq[Attribute] = rowIdHelpers.map(_.toAttribute)
+    val keyEncoder = ExpressionEncoder(StructType(rowIdHelpers.map { a =>
+      StructField(a.name, a.dataType, a.nullable, a.metadata)
+    }))
+
+    val processor = new CdcNetChangesStatefulProcessor(processorInputSchema, computeUpdates)
+
+    val tws = new TransformWithState(
+      keyDeserializer = UnresolvedDeserializer(keyEncoder.deserializer, groupingAttrs),
+      valueDeserializer = UnresolvedDeserializer(rowEncoder.deserializer, withHelpers.output),
+      groupingAttributes = groupingAttrs,
+      dataAttributes = withHelpers.output,
+      statefulProcessor = processor.asInstanceOf[StatefulProcessor[Any, Any, Any]],
+      timeMode = EventTime,
+      outputMode = OutputMode.Append(),
+      keyEncoder = keyEncoder.asInstanceOf[ExpressionEncoder[Any]],
+      outputObjAttr = CatalystSerde.generateObjAttr(rowEncoder),
+      child = withHelpers,
+      hasInitialState = false,
+      initialStateGroupingAttrs = groupingAttrs,
+      initialStateDataAttrs = withHelpers.output,
+      initialStateDeserializer = UnresolvedDeserializer(keyEncoder.deserializer, groupingAttrs),
+      initialState = LocalRelation(keyEncoder.schema))
+
+    // 4. Wrap with SerializeFromObject so the obj column becomes regular tabular output.
+    val serialized = CatalystSerde.serialize(tws)(rowEncoder)
+
+    // 5. Drop the rowId helper columns so the final output matches the connector's schema.
+    val helperNames = rowIdHelpers.map(_.name).toSet
+    Project(serialized.output.filterNot(a => helperNames.contains(a.name)), serialized)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -280,22 +280,34 @@ object UnsupportedOperationChecker extends Logging {
       case _ =>
     }
 
-    // The streaming Change Data Capture (CDC) row-level post-processing rewrite in
-    // [[ResolveChangelogTable.addStreamingRowLevelPostProcessing]] injects a streaming
-    // Aggregate buffering input rows into the helper column
-    // `ResolveChangelogTable.HelperColumn.Events` ("__spark_cdc_events") before
-    // re-emitting them via `Generate(Inline(...))`. The rewrite is designed and
-    // validated only for Append output mode -- under Update or Complete the Aggregate
-    // would re-emit per-batch state changes or the full result table per batch
-    // respectively, neither of which matches batch CDC semantics. Reject those modes
-    // at analysis time with a clear error rather than silently producing a misleading
-    // change feed.
+    // The streaming Change Data Capture (CDC) post-processing rewrites in
+    // [[ResolveChangelogTable]] are designed and validated only for Append output mode.
+    // Two markers can identify a CDC-rewritten plan:
+    //   - The row-level rewrite (`addStreamingRowLevelPostProcessing`) injects a
+    //     streaming Aggregate buffering input rows into the helper column
+    //     `ResolveChangelogTable.HelperColumn.Events` ("__spark_cdc_events") before
+    //     re-emitting them via `Generate(Inline(...))`.
+    //   - The netChanges rewrite (`addStreamingNetChangeComputation`) injects a
+    //     `TransformWithState` driven by `CdcNetChangesStatefulProcessor`.
+    // Under Update or Complete the Aggregate / TransformWithState would re-emit
+    // per-batch state changes or the full result table per batch, neither of which
+    // matches batch CDC semantics. (Complete mode without any streaming Aggregate is
+    // already rejected by the generic `aggregates.isEmpty` check above, so the
+    // netChanges-only marker is needed here primarily to catch Update mode.) Reject
+    // those modes at analysis time with a clear error rather than silently producing
+    // a misleading change feed.
+    val containsCdcEventsAggregate = aggregates.exists(a => a.aggregateExpressions.exists {
+      case ne: NamedExpression if ne.resolved =>
+        ne.name == ResolveChangelogTable.HelperColumn.Events
+      case _ => false
+    })
+    val containsCdcNetChangesProcessor = plan.exists {
+      case t: TransformWithState if t.isStreaming &&
+        t.statefulProcessor.isInstanceOf[CdcNetChangesStatefulProcessor] => true
+      case _ => false
+    }
     if (outputMode != InternalOutputModes.Append &&
-        aggregates.exists(a => a.aggregateExpressions.exists {
-          case ne: NamedExpression if ne.resolved =>
-            ne.name == ResolveChangelogTable.HelperColumn.Events
-          case _ => false
-        })) {
+        (containsCdcEventsAggregate || containsCdcNetChangesProcessor)) {
       throw QueryCompilationErrors.unsupportedOutputModeForStreamingOperationError(
         outputMode, "Change Data Capture (CDC) streaming reads with post-processing")
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3897,12 +3897,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("changelogName" -> changelogName))
   }
 
-  def cdcStreamingNetChangesNotSupported(changelogName: String): AnalysisException = {
-    new AnalysisException(
-      errorClass = "INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED",
-      messageParameters = Map("changelogName" -> changelogName))
-  }
-
   def changelogMissingColumnError(
       changelogName: String, columnName: String): AnalysisException = {
     new AnalysisException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ChangelogTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ChangelogTable.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.connector.catalog.{Changelog, ChangelogInfo, Column,
 import org.apache.spark.sql.connector.catalog.TableCapability.{BATCH_READ, MICRO_BATCH_READ}
 import org.apache.spark.sql.connector.read.ScanBuilder
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.types.{DataType, StringType, TimestampType}
+import org.apache.spark.sql.types.{DataType, LongType, StringType, TimestampType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
@@ -39,8 +39,7 @@ case class ChangelogTable(
     resolved: Boolean = false) extends Table with SupportsRead {
 
   // Validate that the connector returned a schema with the required CDC metadata columns
-  // and correct types. `_commit_version` is connector-defined per the Changelog contract,
-  // so its type is not checked.
+  // and correct types.
   ChangelogTable.validateSchema(changelog)
 
   override def name: String = changelog.name
@@ -67,7 +66,7 @@ object ChangelogTable {
       }
     }
     check("_change_type", StringType)
-    check("_commit_version")           // connector-defined, any type accepted
+    check("_commit_version", LongType)
     check("_commit_timestamp", TimestampType)
 
     // Only call `rowId()` / `rowVersion()` when a capability requires them; a connector

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ChangelogTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ChangelogTable.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.connector.catalog.{Changelog, ChangelogInfo, Column,
 import org.apache.spark.sql.connector.catalog.TableCapability.{BATCH_READ, MICRO_BATCH_READ}
 import org.apache.spark.sql.connector.read.ScanBuilder
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.types.{DataType, LongType, StringType, TimestampType}
+import org.apache.spark.sql.types.{AtomicType, DataType, StringType, TimestampType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
@@ -66,7 +66,15 @@ object ChangelogTable {
       }
     }
     check("_change_type", StringType)
-    check("_commit_version", LongType)
+    // `_commit_version` is connector-defined but must be an atomic orderable type. Both
+    // the batch (Catalyst `SortOrder`) and the streaming netChanges (typed Comparable
+    // ordering inside the stateful processor) paths require an orderable scalar.
+    val versionCol = byName.getOrElse("_commit_version",
+      throw QueryCompilationErrors.changelogMissingColumnError(cl.name, "_commit_version"))
+    if (!versionCol.dataType.isInstanceOf[AtomicType]) {
+      throw QueryCompilationErrors.changelogInvalidColumnTypeError(
+        cl.name, "_commit_version", "an atomic orderable type", versionCol.dataType.sql)
+    }
     check("_commit_timestamp", TimestampType)
 
     // Only call `rowId()` / `rowVersion()` when a capability requires them; a connector

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
@@ -785,22 +785,94 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
     }
   }
 
-  test("streaming with deduplicationMode=netChanges throws") {
+  // TransformWithState requires the RocksDB state store backend.
+  private val rocksDbProviderConf = SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+    "org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider"
+
+  test("streaming netChanges collapses INSERT then DELETE to no output") {
     val id = recreateWithRowVersion()
     catalog.setChangelogProperties(id, ChangelogProperties(
       containsIntermediateChanges = true,
       rowIdNames = Seq("id"),
       rowVersionName = Some("row_commit_version")))
 
-    val e = intercept[AnalysisException] {
-      spark.readStream
+    catalog.addChangeRows(id, Seq(
+      // v1: insert Alice (rcv=1)
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      // v2: delete Alice -- net cancels out
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      // v3: insert Bob -- emits at end-of-input flush
+      ppRow(2L, "Bob", 3L, CHANGE_TYPE_INSERT, 3L, 3000000L)))
+
+    withSQLConf(rocksDbProviderConf) {
+      val q = spark.readStream
         .option("startingVersion", "1")
         .option("deduplicationMode", "netChanges")
         .changes(fullTableName)
-        .queryExecution.analyzed
+        .select("id", "data", "_change_type", "_commit_version")
+        .writeStream
+        .format("memory")
+        .queryName("cdc_stream_netchanges_cancel")
+        .outputMode("append")
+        .start()
+      try {
+        q.processAllAvailable()
+        // End-of-input flushes all timers so Bob's insert emits.
+        // Alice's INSERT then DELETE cancels out (no row), and the final "Bob" stays.
+        checkAnswer(
+          spark.sql("SELECT * FROM cdc_stream_netchanges_cancel"),
+          Seq(Row(2L, "Bob", CHANGE_TYPE_INSERT, 3L)))
+      } finally {
+        q.stop()
+      }
     }
-    assert(e.getCondition == "INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED",
-      s"Unexpected error: ${e.getMessage}")
+  }
+
+  test("streaming netChanges with computeUpdates labels persisting rows as updates") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsIntermediateChanges = true,
+      representsUpdateAsDeleteAndInsert = false, // updates already materialized
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    // Row identity 1 already exists before the stream window, so the first event we
+    // observe is its update_preimage -> existedBefore = true. The last event is the
+    // update_postimage in v2 -> existsAfter = true. With computeUpdates = true the
+    // (true, true) cell of the SPIP matrix emits a relabeled
+    // update_preimage + update_postimage pair (rather than delete + insert).
+    catalog.addChangeRows(id, Seq(
+      // v1: pre-existing Alice updated to Bob
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_UPDATE_PREIMAGE,  1L, 1000000L),
+      ppRow(1L, "Bob",   1L, CHANGE_TYPE_UPDATE_POSTIMAGE, 1L, 1000000L),
+      // v2: Bob updated to Robert -- the v1 preimage and the v2 postimage are the
+      // first and last events for row identity 1 across the entire range.
+      ppRow(1L, "Bob",    1L, CHANGE_TYPE_UPDATE_PREIMAGE,  2L, 2000000L),
+      ppRow(1L, "Robert", 2L, CHANGE_TYPE_UPDATE_POSTIMAGE, 2L, 2000000L)))
+
+    withSQLConf(rocksDbProviderConf) {
+      val q = spark.readStream
+        .option("startingVersion", "1")
+        .option("deduplicationMode", "netChanges")
+        .option("computeUpdates", "true")
+        .changes(fullTableName)
+        .select("id", "data", "_change_type")
+        .writeStream
+        .format("memory")
+        .queryName("cdc_stream_netchanges_update")
+        .outputMode("append")
+        .start()
+      try {
+        q.processAllAvailable()
+        checkAnswer(
+          spark.sql("SELECT * FROM cdc_stream_netchanges_update"),
+          Seq(
+            Row(1L, "Alice",  CHANGE_TYPE_UPDATE_PREIMAGE),
+            Row(1L, "Robert", CHANGE_TYPE_UPDATE_POSTIMAGE)))
+      } finally {
+        q.stop()
+      }
+    }
   }
 
   // The streaming row-level rewrite injects a streaming Aggregate, which is only
@@ -890,6 +962,151 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
         s"Expected NULL_COMMIT_TIMESTAMP in the error chain. Got: ${e.getMessage}")
     } finally {
       q.stop()
+    }
+  }
+
+  test("streaming netChanges emits DELETE for pre-existing row deleted in range") {
+    // Exercises the SPIP `(true, false)` cell: existedBefore = true (first event is a
+    // delete or update_preimage), existsAfter = false (last event is a delete).
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsIntermediateChanges = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    catalog.addChangeRows(id, Seq(
+      // v1: pre-existing Alice gets updated to Bob.
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_UPDATE_PREIMAGE,  1L, 1000000L),
+      ppRow(1L, "Bob",   1L, CHANGE_TYPE_UPDATE_POSTIMAGE, 1L, 1000000L),
+      // v2: Bob deleted -- the v1 preimage is the first event and the v2 delete is
+      // the last event for row identity 1 across the entire range.
+      ppRow(1L, "Bob",   1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      // v3: insert Carol -- gives the watermark something to advance past, so row
+      // identity 1's timer fires before end-of-input.
+      ppRow(2L, "Carol", 3L, CHANGE_TYPE_INSERT, 3L, 3000000L)))
+
+    withSQLConf(rocksDbProviderConf) {
+      val q = spark.readStream
+        .option("startingVersion", "1")
+        .option("deduplicationMode", "netChanges")
+        .changes(fullTableName)
+        .select("id", "data", "_change_type")
+        .writeStream
+        .format("memory")
+        .queryName("cdc_stream_netchanges_delete")
+        .outputMode("append")
+        .start()
+      try {
+        q.processAllAvailable()
+        checkAnswer(
+          spark.sql("SELECT * FROM cdc_stream_netchanges_delete"),
+          Seq(
+            // (true, false): emit a single DELETE carrying the *first* event's data
+            // (the preimage), per the batch contract.
+            Row(1L, "Alice", CHANGE_TYPE_DELETE),
+            Row(2L, "Carol", CHANGE_TYPE_INSERT)))
+      } finally {
+        q.stop()
+      }
+    }
+  }
+
+  test("streaming netChanges without computeUpdates keeps persisting rows as DELETE+INSERT") {
+    // Exercises the SPIP `(true, true)` cell with computeUpdates = false: the pair is
+    // emitted as DELETE + INSERT rather than relabeled as
+    // update_preimage + update_postimage.
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsIntermediateChanges = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    catalog.addChangeRows(id, Seq(
+      // v1: pre-existing Alice updated to Bob.
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_UPDATE_PREIMAGE,  1L, 1000000L),
+      ppRow(1L, "Bob",   1L, CHANGE_TYPE_UPDATE_POSTIMAGE, 1L, 1000000L),
+      // v2: Bob updated to Robert -- row identity 1 spans (preimage Alice) ..
+      // (postimage Robert).
+      ppRow(1L, "Bob",    1L, CHANGE_TYPE_UPDATE_PREIMAGE,  2L, 2000000L),
+      ppRow(1L, "Robert", 2L, CHANGE_TYPE_UPDATE_POSTIMAGE, 2L, 2000000L)))
+
+    withSQLConf(rocksDbProviderConf) {
+      val q = spark.readStream
+        .option("startingVersion", "1")
+        .option("deduplicationMode", "netChanges")
+        // computeUpdates defaults to false.
+        .changes(fullTableName)
+        .select("id", "data", "_change_type")
+        .writeStream
+        .format("memory")
+        .queryName("cdc_stream_netchanges_no_compute_updates")
+        .outputMode("append")
+        .start()
+      try {
+        q.processAllAvailable()
+        checkAnswer(
+          spark.sql("SELECT * FROM cdc_stream_netchanges_no_compute_updates"),
+          Seq(
+            Row(1L, "Alice",  CHANGE_TYPE_DELETE),
+            Row(1L, "Robert", CHANGE_TYPE_INSERT)))
+      } finally {
+        q.stop()
+      }
+    }
+  }
+
+  test("streaming netChanges + carry-over removal: combined post-processing") {
+    // Validates the design point that the row-level rewrite and the netChanges rewrite
+    // share a single EventTimeWatermark on `_commit_timestamp` and produce the
+    // expected combined result. Carry-over CoW pairs are dropped before the netChanges
+    // collapse runs, so the final emission only reflects real content changes.
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsCarryoverRows = true,
+      containsIntermediateChanges = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    catalog.addChangeRows(id, Seq(
+      // v1: insert Alice, Bob (rcv=1).
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      ppRow(2L, "Bob",   1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      // v2: real delete Alice + carry-over for Bob (rcv unchanged means CoW rewrite,
+      // no content change).
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(2L, "Bob",   1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(2L, "Bob",   1L, CHANGE_TYPE_INSERT, 2L, 2000000L),
+      // v3: insert Carol -- advances the watermark past v2 so timers for row
+      // identities 1 and 2 fire and the netChanges output is emitted.
+      ppRow(3L, "Carol", 3L, CHANGE_TYPE_INSERT, 3L, 3000000L)))
+
+    withSQLConf(rocksDbProviderConf) {
+      val q = spark.readStream
+        .option("startingVersion", "1")
+        .option("deduplicationMode", "netChanges")
+        .changes(fullTableName)
+        .select("id", "data", "_change_type")
+        .writeStream
+        .format("memory")
+        .queryName("cdc_stream_netchanges_with_carryover")
+        .outputMode("append")
+        .start()
+      try {
+        q.processAllAvailable()
+        // After carry-over removal: Alice has v1 INSERT + v2 DELETE; Bob has only
+        // v1 INSERT (the v2 CoW pair was dropped); Carol has v3 INSERT.
+        // After netChanges:
+        //   Alice -- (false, false) -> no output
+        //   Bob   -- (false, true)  -> emit INSERT
+        //   Carol -- (false, true)  -> emit INSERT
+        checkAnswer(
+          spark.sql("SELECT * FROM cdc_stream_netchanges_with_carryover"),
+          Seq(
+            Row(2L, "Bob",   CHANGE_TYPE_INSERT),
+            Row(3L, "Carol", CHANGE_TYPE_INSERT)))
+      } finally {
+        q.stop()
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
@@ -843,11 +843,11 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
     // update_preimage + update_postimage pair (rather than delete + insert).
     catalog.addChangeRows(id, Seq(
       // v1: pre-existing Alice updated to Bob
-      ppRow(1L, "Alice", 1L, CHANGE_TYPE_UPDATE_PREIMAGE,  1L, 1000000L),
-      ppRow(1L, "Bob",   1L, CHANGE_TYPE_UPDATE_POSTIMAGE, 1L, 1000000L),
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_UPDATE_PREIMAGE, 1L, 1000000L),
+      ppRow(1L, "Bob", 1L, CHANGE_TYPE_UPDATE_POSTIMAGE, 1L, 1000000L),
       // v2: Bob updated to Robert -- the v1 preimage and the v2 postimage are the
       // first and last events for row identity 1 across the entire range.
-      ppRow(1L, "Bob",    1L, CHANGE_TYPE_UPDATE_PREIMAGE,  2L, 2000000L),
+      ppRow(1L, "Bob", 1L, CHANGE_TYPE_UPDATE_PREIMAGE, 2L, 2000000L),
       ppRow(1L, "Robert", 2L, CHANGE_TYPE_UPDATE_POSTIMAGE, 2L, 2000000L)))
 
     withSQLConf(rocksDbProviderConf) {
@@ -867,7 +867,7 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
         checkAnswer(
           spark.sql("SELECT * FROM cdc_stream_netchanges_update"),
           Seq(
-            Row(1L, "Alice",  CHANGE_TYPE_UPDATE_PREIMAGE),
+            Row(1L, "Alice", CHANGE_TYPE_UPDATE_PREIMAGE),
             Row(1L, "Robert", CHANGE_TYPE_UPDATE_POSTIMAGE)))
       } finally {
         q.stop()
@@ -930,6 +930,70 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
       s"Error should mention CDC: ${e.getMessage}")
   }
 
+  // The streaming netChanges-only path injects a TransformWithState whose internal
+  // outputMode is Append. Without an explicit per-operator check the analyzer would
+  // happily accept the user requesting Update output mode at the writer, even though
+  // the rewrite is only valid for Append (Update would re-emit per-batch state changes
+  // that don't match batch netChanges semantics). UnsupportedOperationChecker therefore
+  // detects the netChanges processor and rejects non-Append modes with a clear error.
+  // (Complete is also rejected by the generic "Complete requires aggregations" check
+  // since the netChanges-only path has no streaming Aggregate, but we assert it here
+  // too for symmetry with the row-level rejection tests above.)
+
+  test("streaming netChanges with update output mode is rejected") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsIntermediateChanges = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+    catalog.addChangeRows(id, Seq(
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L)))
+
+    val e = intercept[AnalysisException] {
+      withSQLConf(rocksDbProviderConf) {
+        spark.readStream
+          .option("startingVersion", "1")
+          .option("deduplicationMode", "netChanges")
+          .changes(fullTableName)
+          .writeStream
+          .format("memory")
+          .queryName("cdc_stream_netchanges_update_rejected")
+          .outputMode("update")
+          .start()
+      }
+    }
+    assert(e.getCondition == "STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION",
+      s"Unexpected error: ${e.getMessage}")
+    assert(e.getMessage.contains("Change Data Capture"),
+      s"Error should mention CDC: ${e.getMessage}")
+  }
+
+  test("streaming netChanges with complete output mode is rejected") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsIntermediateChanges = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+    catalog.addChangeRows(id, Seq(
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L)))
+
+    val e = intercept[AnalysisException] {
+      withSQLConf(rocksDbProviderConf) {
+        spark.readStream
+          .option("startingVersion", "1")
+          .option("deduplicationMode", "netChanges")
+          .changes(fullTableName)
+          .writeStream
+          .format("memory")
+          .queryName("cdc_stream_netchanges_complete_rejected")
+          .outputMode("complete")
+          .start()
+      }
+    }
+    assert(e.getCondition == "STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION",
+      s"Unexpected error: ${e.getMessage}")
+  }
+
   test("streaming row-level rewrite raises on NULL _commit_timestamp") {
     val id = recreateWithRowVersion()
     catalog.setChangelogProperties(id, ChangelogProperties(
@@ -976,11 +1040,11 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
 
     catalog.addChangeRows(id, Seq(
       // v1: pre-existing Alice gets updated to Bob.
-      ppRow(1L, "Alice", 1L, CHANGE_TYPE_UPDATE_PREIMAGE,  1L, 1000000L),
-      ppRow(1L, "Bob",   1L, CHANGE_TYPE_UPDATE_POSTIMAGE, 1L, 1000000L),
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_UPDATE_PREIMAGE, 1L, 1000000L),
+      ppRow(1L, "Bob", 1L, CHANGE_TYPE_UPDATE_POSTIMAGE, 1L, 1000000L),
       // v2: Bob deleted -- the v1 preimage is the first event and the v2 delete is
       // the last event for row identity 1 across the entire range.
-      ppRow(1L, "Bob",   1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(1L, "Bob", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
       // v3: insert Carol -- gives the watermark something to advance past, so row
       // identity 1's timer fires before end-of-input.
       ppRow(2L, "Carol", 3L, CHANGE_TYPE_INSERT, 3L, 3000000L)))
@@ -1023,11 +1087,11 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
 
     catalog.addChangeRows(id, Seq(
       // v1: pre-existing Alice updated to Bob.
-      ppRow(1L, "Alice", 1L, CHANGE_TYPE_UPDATE_PREIMAGE,  1L, 1000000L),
-      ppRow(1L, "Bob",   1L, CHANGE_TYPE_UPDATE_POSTIMAGE, 1L, 1000000L),
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_UPDATE_PREIMAGE, 1L, 1000000L),
+      ppRow(1L, "Bob", 1L, CHANGE_TYPE_UPDATE_POSTIMAGE, 1L, 1000000L),
       // v2: Bob updated to Robert -- row identity 1 spans (preimage Alice) ..
       // (postimage Robert).
-      ppRow(1L, "Bob",    1L, CHANGE_TYPE_UPDATE_PREIMAGE,  2L, 2000000L),
+      ppRow(1L, "Bob", 1L, CHANGE_TYPE_UPDATE_PREIMAGE, 2L, 2000000L),
       ppRow(1L, "Robert", 2L, CHANGE_TYPE_UPDATE_POSTIMAGE, 2L, 2000000L)))
 
     withSQLConf(rocksDbProviderConf) {
@@ -1047,7 +1111,7 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
         checkAnswer(
           spark.sql("SELECT * FROM cdc_stream_netchanges_no_compute_updates"),
           Seq(
-            Row(1L, "Alice",  CHANGE_TYPE_DELETE),
+            Row(1L, "Alice", CHANGE_TYPE_DELETE),
             Row(1L, "Robert", CHANGE_TYPE_INSERT)))
       } finally {
         q.stop()
@@ -1070,12 +1134,12 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
     catalog.addChangeRows(id, Seq(
       // v1: insert Alice, Bob (rcv=1).
       ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
-      ppRow(2L, "Bob",   1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      ppRow(2L, "Bob", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
       // v2: real delete Alice + carry-over for Bob (rcv unchanged means CoW rewrite,
       // no content change).
       ppRow(1L, "Alice", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
-      ppRow(2L, "Bob",   1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
-      ppRow(2L, "Bob",   1L, CHANGE_TYPE_INSERT, 2L, 2000000L),
+      ppRow(2L, "Bob", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(2L, "Bob", 1L, CHANGE_TYPE_INSERT, 2L, 2000000L),
       // v3: insert Carol -- advances the watermark past v2 so timers for row
       // identities 1 and 2 fire and the netChanges output is emitted.
       ppRow(3L, "Carol", 3L, CHANGE_TYPE_INSERT, 3L, 3000000L)))
@@ -1102,7 +1166,7 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
         checkAnswer(
           spark.sql("SELECT * FROM cdc_stream_netchanges_with_carryover"),
           Seq(
-            Row(2L, "Bob",   CHANGE_TYPE_INSERT),
+            Row(2L, "Bob", CHANGE_TYPE_INSERT),
             Row(3L, "Carol", CHANGE_TYPE_INSERT)))
       } finally {
         q.stop()

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogResolutionSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.connector.expressions.{FieldReference, NamedReferenc
 import org.apache.spark.sql.connector.read.ScanBuilder
 import org.apache.spark.sql.execution.datasources.v2.{ChangelogTable, DataSourceV2Relation}
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{IntegerType, LongType, StringType, TimestampType}
+import org.apache.spark.sql.types.{ArrayType, IntegerType, LongType, MapType, StringType, StructField, StructType, TimestampType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
@@ -380,8 +380,20 @@ class ChangelogResolutionSuite extends SharedSparkSession {
       parameters = wrongType("_commit_timestamp", "TIMESTAMP", "BIGINT"))
   }
 
-  test("ChangelogTable - wrong _commit_version data type throws") {
-    Seq(IntegerType -> "INT", StringType -> "STRING").foreach { case (versionType, sql) =>
+  test("ChangelogTable - _commit_version accepts any atomic orderable type") {
+    Seq(LongType, IntegerType, StringType, TimestampType).foreach { versionType =>
+      ChangelogTable(
+        cl("any_cl", validChangeType, "_commit_version" -> versionType, validTimestamp),
+        stubInfo())
+    }
+  }
+
+  test("ChangelogTable - non-atomic _commit_version data type throws") {
+    val structVersion = StructType(Seq(StructField("v", LongType)))
+    Seq[(org.apache.spark.sql.types.DataType, String)](
+      ArrayType(LongType) -> "ARRAY<BIGINT>",
+      MapType(StringType, LongType) -> "MAP<STRING, BIGINT>",
+      structVersion -> structVersion.sql).foreach { case (versionType, sql) =>
       checkError(
         intercept[AnalysisException] {
           ChangelogTable(
@@ -389,7 +401,7 @@ class ChangelogResolutionSuite extends SharedSparkSession {
             stubInfo())
         },
         condition = "INVALID_CHANGELOG_SCHEMA.INVALID_COLUMN_TYPE",
-        parameters = wrongType("_commit_version", "BIGINT", sql))
+        parameters = wrongType("_commit_version", "an atomic orderable type", sql))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogResolutionSuite.scala
@@ -282,7 +282,8 @@ class ChangelogResolutionSuite extends SharedSparkSession {
     assertStreamingRowLevelRewrite(analyzed)
   }
 
-  test("DataStreamReader - changes() with deduplicationMode=netChanges throws") {
+  test("DataStreamReader - changes() with deduplicationMode=netChanges rewrites plan") {
+    import org.apache.spark.sql.catalyst.plans.logical.TransformWithState
     val ident = recreatePostProcessingTable()
     val cat = spark.sessionState.catalogManager
       .catalog(cdcCatalogName)
@@ -292,15 +293,13 @@ class ChangelogResolutionSuite extends SharedSparkSession {
       rowIdNames = Seq("id"),
       rowVersionName = Some("row_commit_version")))
 
-    checkError(
-      intercept[AnalysisException] {
-        spark.readStream
-          .option("deduplicationMode", "netChanges")
-          .changes(s"$cdcCatalogName.test_table")
-          .queryExecution.analyzed
-      },
-      condition = "INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED",
-      parameters = Map("changelogName" -> s"$cdcCatalogName.test_table_changelog"))
+    val analyzed = spark.readStream
+      .option("deduplicationMode", "netChanges")
+      .changes(s"$cdcCatalogName.test_table")
+      .queryExecution.analyzed
+    val tws = analyzed.collect { case t: TransformWithState => t }
+    assert(tws.size == 1,
+      s"Expected exactly one TransformWithState; found ${tws.size}. Plan:\n$analyzed")
   }
 
   // ===========================================================================

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogResolutionSuite.scala
@@ -380,11 +380,16 @@ class ChangelogResolutionSuite extends SharedSparkSession {
       parameters = wrongType("_commit_timestamp", "TIMESTAMP", "BIGINT"))
   }
 
-  test("ChangelogTable - _commit_version type is connector-defined (any type accepted)") {
-    Seq(IntegerType, LongType, StringType).foreach { versionType =>
-      ChangelogTable(
-        cl("any_cl", validChangeType, "_commit_version" -> versionType, validTimestamp),
-        stubInfo())
+  test("ChangelogTable - wrong _commit_version data type throws") {
+    Seq(IntegerType -> "INT", StringType -> "STRING").foreach { case (versionType, sql) =>
+      checkError(
+        intercept[AnalysisException] {
+          ChangelogTable(
+            cl("bad_cl", validChangeType, "_commit_version" -> versionType, validTimestamp),
+            stubInfo())
+        },
+        condition = "INVALID_CHANGELOG_SCHEMA.INVALID_COLUMN_TYPE",
+        parameters = wrongType("_commit_version", "BIGINT", sql))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTablePostProcessingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTablePostProcessingSuite.scala
@@ -368,7 +368,7 @@ class ResolveChangelogTablePostProcessingSuite
       s"Expected ChangelogTable to be marked resolved by the rule. Plan:\n$plan")
   }
 
-  // The streaming netChanges rejection is covered by
+  // The streaming netChanges path is covered by
   // ResolveChangelogTableStreamingPostProcessingSuite -- not duplicated here, since
   // this suite focuses on the batch path.
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
@@ -263,6 +263,12 @@ class ResolveChangelogTableStreamingPostProcessingSuite
       s"Expected TransformWithState grouping by [__spark_cdc_rowid_0]; got $groupingNames. " +
         s"Plan:\n$analyzed")
     assertHelperColumnsRemoved(analyzed)
+    // The auto-injected `EventTimeWatermark` metadata flows through the
+    // `transformWithState` encoder roundtrip on the netChanges-only path. The
+    // rewrite must strip it from the user-visible `_commit_timestamp` so a
+    // downstream user-supplied watermark cannot accidentally interact with our
+    // internal watermark via the global multi-watermark policy.
+    assertNoWatermarkMetadataOnOutput(analyzed)
   }
 
   test("netChanges with composite rowId groups by all helper columns") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
@@ -21,10 +21,10 @@ import java.util.Collections
 
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest}
+import org.apache.spark.sql.{DataFrame, QueryTest}
 import org.apache.spark.sql.catalyst.expressions.Inline
 import org.apache.spark.sql.catalyst.plans.logical.{
-  Aggregate, EventTimeWatermark, Filter, Generate, LogicalPlan, Project}
+  Aggregate, EventTimeWatermark, Filter, Generate, LogicalPlan, Project, TransformWithState}
 import org.apache.spark.sql.connector.catalog.{
   ChangelogProperties, Column, Identifier, InMemoryChangelogCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
@@ -240,6 +240,87 @@ class ResolveChangelogTableStreamingPostProcessingSuite
   }
 
   // ===========================================================================
+  // Net changes
+  // ===========================================================================
+
+  test("netChanges alone injects watermark + TransformWithState") {
+    catalog.setChangelogProperties(identifier, ChangelogProperties(
+      containsIntermediateChanges = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    val analyzed = streamingDf(
+      "deduplicationMode" -> "netChanges").queryExecution.analyzed
+    assertWatermarkOnCommitTimestamp(analyzed)
+    val tws = analyzed.collect { case t: TransformWithState => t }
+    assert(tws.size == 1,
+      s"Expected exactly one TransformWithState; found ${tws.size}. Plan:\n$analyzed")
+    // Guard against a regression that grouped by the wrong attributes (e.g. omitting a
+    // rowId column or grouping by `_commit_version`) -- the size check alone would still
+    // pass.
+    val groupingNames = tws.head.groupingAttributes.map(_.name)
+    assert(groupingNames == Seq("__spark_cdc_rowid_0"),
+      s"Expected TransformWithState grouping by [__spark_cdc_rowid_0]; got $groupingNames. " +
+        s"Plan:\n$analyzed")
+    assertHelperColumnsRemoved(analyzed)
+  }
+
+  test("netChanges with composite rowId groups by all helper columns") {
+    // Recreate with a two-column rowId so we exercise the rowIdColumn(idx) helper
+    // for idx > 0. The single-rowId test asserts the size-1 case; this guards
+    // against a regression that hard-codes a single helper attribute.
+    val cat = catalog
+    val ident = identifier
+    cat.dropTable(ident)
+    cat.createTable(
+      ident,
+      Array(
+        Column.create("ns", LongType, false),
+        Column.create("id", LongType, false),
+        Column.create("row_commit_version", LongType, false)),
+      Array.empty[Transform],
+      Collections.emptyMap[String, String]())
+    cat.setChangelogProperties(ident, ChangelogProperties(
+      containsIntermediateChanges = true,
+      rowIdNames = Seq("ns", "id"),
+      rowVersionName = Some("row_commit_version")))
+
+    val analyzed = streamingDf(
+      "deduplicationMode" -> "netChanges").queryExecution.analyzed
+    assertWatermarkOnCommitTimestamp(analyzed)
+    val tws = analyzed.collect { case t: TransformWithState => t }
+    assert(tws.size == 1, s"Expected one TransformWithState. Plan:\n$analyzed")
+    val groupingNames = tws.head.groupingAttributes.map(_.name)
+    assert(groupingNames == Seq("__spark_cdc_rowid_0", "__spark_cdc_rowid_1"),
+      s"Expected grouping by [__spark_cdc_rowid_0, __spark_cdc_rowid_1]; got $groupingNames. " +
+        s"Plan:\n$analyzed")
+    assertHelperColumnsRemoved(analyzed)
+  }
+
+  test("netChanges + carry-over removal share a single watermark") {
+    catalog.setChangelogProperties(identifier, ChangelogProperties(
+      containsCarryoverRows = true,
+      containsIntermediateChanges = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    val analyzed = streamingDf(
+      "deduplicationMode" -> "netChanges").queryExecution.analyzed
+    val watermarks = analyzed.collect { case w: EventTimeWatermark => w }
+    assert(watermarks.size == 1,
+      s"Combined row-level + netChanges path should share one EventTimeWatermark. " +
+        s"Plan:\n$analyzed")
+    val aggs = analyzed.collect { case a: Aggregate => a }
+    assert(aggs.size == 1,
+      s"Row-level Aggregate should still be present. Plan:\n$analyzed")
+    val tws = analyzed.collect { case t: TransformWithState => t }
+    assert(tws.size == 1,
+      s"netChanges TransformWithState should be on top of the row-level rewrite. " +
+        s"Plan:\n$analyzed")
+    assertHelperColumnsRemoved(analyzed)
+  }
+
+  // ===========================================================================
   // No post-processing -> no rewrite
   // ===========================================================================
 
@@ -254,23 +335,6 @@ class ResolveChangelogTableStreamingPostProcessingSuite
     val analyzed = streamingDf(
       "computeUpdates" -> "true").queryExecution.analyzed
     assertNoStreamingPostProcessing(analyzed)
-  }
-
-  // ===========================================================================
-  // Net change computation rejection
-  // ===========================================================================
-
-  test("deduplicationMode=netChanges is rejected on streaming") {
-    catalog.setChangelogProperties(identifier, ChangelogProperties(
-      containsIntermediateChanges = true,
-      rowIdNames = Seq("id"),
-      rowVersionName = Some("row_commit_version")))
-
-    val e = intercept[AnalysisException] {
-      streamingDf("deduplicationMode" -> "netChanges").queryExecution.analyzed
-    }
-    assert(e.getCondition == "INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED",
-      s"Unexpected error: ${e.getMessage}")
   }
 
   // ===========================================================================


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR completes the DSv2 CDC streaming post-processing surface by implementing `deduplicationMode = netChanges` for streaming reads. The previous PR (#55636 / SPARK-56686) added carry-over removal and update detection for streaming but left netChanges batch-only.

The batch path (`ResolveChangelogTable.injectNetChangeComputation`) uses a Catalyst `Window` partitioned by `rowId` and ordered by `(_commit_version, change_type_rank)` to find the first and last events per row identity, then applies the SPIP collapse matrix on `(existedBefore, existsAfter)`. `Window` is rejected on streaming children (`NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING`), and unlike the row-level passes the netChanges aggregate is keyed by `rowId` only -- there's no commit-version + commit-timestamp grouping that would let us reuse the streaming Aggregate pattern.

This PR adds a streaming-friendly equivalent by delegating per-row-identity state management to a new `CdcNetChangesStatefulProcessor` driven by `TransformWithState`:

- The processor stores the first event ever observed and the most-recent event observed for each row identity in `ValueState[Row]`.
- An event-time timer is armed on each batch to the latest `_commit_timestamp` observed for the key. When the global watermark advances past the timer, `handleExpiredTimer` evaluates the SPIP matrix and emits 0, 1, or 2 output rows -- identical semantics to the batch path.
- Existing per-key timers are deleted before re-arming so that out-of-order events for an earlier commit can't fire a stale timer between batches and produce duplicate output for the same row identity.

The analyzer rule constructs `TransformWithState` directly (no precedent in catalyst for this; the typed-Dataset DSL is the usual entry point). Encoders for the input/output `Row` and the rowId tuple are built via `ExpressionEncoder(StructType)`. Nested rowId paths (e.g. `payload.id`) are handled by aliasing each rowId expression to a top-level `__spark_cdc_rowid_<i>` helper column before the `TransformWithState`, then dropping the helpers in a final `Project` so the user-visible schema matches the connector's declared changelog schema.

Plan shape:

```
EventTimeWatermark(_commit_timestamp, 0s)
  -> Project (alias rowId expressions to flat helper columns)
  -> TransformWithState (grouping = rowId helpers, EventTime mode, Append)
  -> SerializeFromObject
  -> Project (drop rowId helper columns)
```

When carry-over removal / update detection are also requested, the row-level rewrite is applied first; the netChanges `TransformWithState` then sits on top of it and the rule reuses the existing `EventTimeWatermark` rather than stacking another (multi-watermark stacking is rejected unless `STATEFUL_OPERATOR_ALLOW_MULTIPLE` is set).

#### Documented limitation

Row identities only touched in the latest observed commit are held back until a later commit (with strictly greater `_commit_timestamp`) advances the watermark past them, or the source terminates. End-of-input flushes all timers, so bounded streams produce output equivalent to the corresponding batch read. This matches the steady-state behavior of the row-level streaming rewrite.

Also removes the now-obsolete error class `INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED` introduced in SPARK-56686.

### Why are the changes needed?

Without this PR, `deduplicationMode = netChanges` is unavailable on streaming CDC reads, forcing users with intermediate-state connectors (`containsIntermediateChanges = true`) to fall back to batch reads when they want a deduplicated change feed. With SPARK-56686 already shipping carry-over removal and update detection for streaming, netChanges was the only post-processing pass still gated to batch -- this completes the surface.

### Does this PR introduce _any_ user-facing change?

Yes.
- Streaming `spark.readStream.changes(...)` now supports `deduplicationMode = netChanges`. Previously this threw `INVALID_CDC_OPTION.STREAMING_NET_CHANGES_NOT_SUPPORTED`.
- That error class is removed; the wording in `DataStreamReader.changes()` and `Changelog.java` Scaladoc has been updated to describe the supported behavior and the latest-commit limitation.

Note: the netChanges streaming path uses `TransformWithState`, which requires the RocksDB state store backend (`spark.sql.streaming.stateStore.providerClass = ...RocksDBStateStoreProvider`). Spark surfaces `UNSUPPORTED_FEATURE.STORE_BACKEND_NOT_SUPPORTED_FOR_TWS` if the default HDFS-backed provider is left in place, so this is discoverable.

### How was this patch tested?

89 tests pass across 4 CDC suites (all green):

- `ResolveChangelogTableStreamingPostProcessingSuite` -- two new plan-shape tests: `netChanges alone injects watermark + TransformWithState` and `netChanges + carry-over removal share a single watermark` (verifies that the netChanges `TransformWithState` reuses the row-level rewrite's `EventTimeWatermark` rather than stacking another).
- `ChangelogResolutionSuite` -- the `netChanges throws` test from SPARK-56686 is flipped to assert that exactly one `TransformWithState` appears in the analyzed plan.
- `ResolveChangelogTablePostProcessingSuite` -- the corresponding netChanges throw test is similarly flipped.
- `ChangelogEndToEndSuite` -- two new end-to-end tests that drive a streaming query against `InMemoryChangelogCatalog` with the RocksDB state store: `streaming netChanges collapses INSERT then DELETE to no output` (confirms the `(false, false)` cancel case and that end-of-input flushes the latest commit's group) and `streaming netChanges with computeUpdates labels persisting rows as updates` (confirms the `(false, true)` case relabels correctly).

Also confirmed `UnsupportedOperationsSuite` (216 tests) still passes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)