### PR TITLE
[SPARK-56689][K8S] Improve `ExecutorResizePlugin` to reuse `KubernetesClusterSchedulerBackend.kubernetesClient`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorResizePlugin.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorResizePlugin.scala
@@ -30,9 +30,8 @@ import org.apache.spark.SparkContext
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
-import org.apache.spark.deploy.k8s.SparkKubernetesClientFactory
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.LogKeys.{CONFIG, CONFIG2, EXECUTOR_ID, MEMORY_SIZE}
+import org.apache.spark.internal.LogKeys.{CLASS_NAME, CONFIG, CONFIG2, EXECUTOR_ID, MEMORY_SIZE}
 import org.apache.spark.util.{ThreadUtils, Utils}
 
 /**
@@ -47,7 +46,6 @@ class ExecutorResizePlugin extends SparkPlugin {
 
 class ExecutorResizeDriverPlugin extends DriverPlugin with Logging {
   private var sparkContext: SparkContext = _
-  private var kubernetesClient: KubernetesClient = _
 
   private val periodicService: ScheduledExecutorService =
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("executor-resize-plugin")
@@ -67,40 +65,33 @@ class ExecutorResizeDriverPlugin extends DriverPlugin with Logging {
     val factor = sc.conf.getDouble(EXECUTOR_RESIZE_FACTOR.key, 0.1)
     val namespace = sc.conf.get(KUBERNETES_NAMESPACE)
 
+    // Scheduler is not created yet at init time; resolve it lazily in the periodic task.
     sparkContext = sc
 
-    try {
-      kubernetesClient = SparkKubernetesClientFactory.createKubernetesClient(
-        sc.conf.get(KUBERNETES_DRIVER_MASTER_URL),
-        Option(namespace),
-        KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX,
-        SparkKubernetesClientFactory.ClientType.Driver,
-        sc.conf,
-        None)
-
-      periodicService.scheduleAtFixedRate(() => {
-        try {
-          checkAndIncreaseMemory(namespace, threshold, factor)
-        } catch {
-          case e: Throwable => logError("Error in memory check thread", e)
+    periodicService.scheduleAtFixedRate(() => {
+      try {
+        sparkContext.schedulerBackend match {
+          case backend: KubernetesClusterSchedulerBackend =>
+            checkAndIncreaseMemory(namespace, threshold, factor, backend.kubernetesClient)
+          case _ =>
+            logWarning(log"This plugin expects " +
+              log"${MDC(CLASS_NAME, classOf[KubernetesClusterSchedulerBackend].getSimpleName)}.")
         }
-      }, interval, interval, TimeUnit.SECONDS)
-    } catch {
-      case e: Exception =>
-        logError("Failed to initialize", e)
-    }
+      } catch {
+        case e: Throwable => logError("Error in memory check thread", e)
+      }
+    }, interval, interval, TimeUnit.SECONDS)
 
     Map.empty[String, String].asJava
   }
 
-  override def shutdown(): Unit = {
-    periodicService.shutdown()
-    if (kubernetesClient != null) {
-      kubernetesClient.close()
-    }
-  }
+  override def shutdown(): Unit = periodicService.shutdown()
 
-  private def checkAndIncreaseMemory(namespace: String, threshold: Double, factor: Double): Unit = {
+  private def checkAndIncreaseMemory(
+      namespace: String,
+      threshold: Double,
+      factor: Double,
+      kubernetesClient: KubernetesClient): Unit = {
     val appId = sparkContext.applicationId
 
     // Get all running executor pods for this application

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorResizePlugin.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorResizePlugin.scala
@@ -68,7 +68,7 @@ class ExecutorResizeDriverPlugin extends DriverPlugin with Logging {
     // Scheduler is not created yet at init time; resolve it lazily in the periodic task.
     sparkContext = sc
 
-    periodicService.scheduleAtFixedRate(() => {
+    periodicService.scheduleAtFixedRate(() => if (!sparkContext.isStopped) {
       try {
         sparkContext.schedulerBackend match {
           case backend: KubernetesClusterSchedulerBackend =>

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorResizePluginSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorResizePluginSuite.scala
@@ -43,6 +43,7 @@ class ExecutorResizePluginSuite
 
   private var kubernetesClient: KubernetesClient = _
   private var sparkContext: SparkContext = _
+  private var schedulerBackend: KubernetesClusterSchedulerBackend = _
   private var podOperations: PODS = _
   private var podsWithNamespace: PODS_WITH_NAMESPACE = _
   private var labeledPods: LABELED_PODS = _
@@ -56,6 +57,7 @@ class ExecutorResizePluginSuite
   before {
     kubernetesClient = mock(classOf[KubernetesClient])
     sparkContext = mock(classOf[SparkContext])
+    schedulerBackend = mock(classOf[KubernetesClusterSchedulerBackend])
     podOperations = mock(classOf[PODS])
     podsWithNamespace = mock(classOf[PODS_WITH_NAMESPACE])
     labeledPods = mock(classOf[LABELED_PODS])
@@ -64,6 +66,8 @@ class ExecutorResizePluginSuite
     podMetricOperations = mock(classOf[PodMetricOperation])
 
     when(sparkContext.applicationId).thenReturn(appId)
+    when(sparkContext.schedulerBackend).thenReturn(schedulerBackend)
+    when(schedulerBackend.kubernetesClient).thenReturn(kubernetesClient)
     when(kubernetesClient.pods()).thenReturn(podOperations)
     when(podOperations.inNamespace(namespace)).thenReturn(podsWithNamespace)
     when(podsWithNamespace.withLabel(SPARK_APP_ID_LABEL, appId)).thenReturn(labeledPods)
@@ -75,15 +79,9 @@ class ExecutorResizePluginSuite
 
   private def createPlugin(): ExecutorResizeDriverPlugin = {
     val plugin = new ExecutorResizeDriverPlugin()
-    // Use reflection to set private fields
     val scField = plugin.getClass.getDeclaredField("sparkContext")
     scField.setAccessible(true)
     scField.set(plugin, sparkContext)
-
-    val clientField = plugin.getClass.getDeclaredField("kubernetesClient")
-    clientField.setAccessible(true)
-    clientField.set(plugin, kubernetesClient)
-
     plugin
   }
 
@@ -126,7 +124,7 @@ class ExecutorResizePluginSuite
     val plugin = createPlugin()
     when(podList.getItems).thenReturn(Collections.emptyList())
 
-    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1))
+    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
 
     verify(podMetricOperations, never()).metrics(anyString(), anyString())
   }
@@ -144,7 +142,7 @@ class ExecutorResizePluginSuite
 
     when(podList.getItems).thenReturn(Collections.singletonList(pod))
 
-    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1))
+    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
 
     verify(podMetricOperations, never()).metrics(anyString(), anyString())
   }
@@ -160,7 +158,7 @@ class ExecutorResizePluginSuite
     val podResource = mock(classOf[SINGLE_POD])
     when(podsWithNamespace.withName("spark-executor-1")).thenReturn(podResource)
 
-    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1))
+    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
 
     verify(podResource, never()).patch(any(), any(classOf[Pod]))
   }
@@ -177,7 +175,7 @@ class ExecutorResizePluginSuite
     when(podsWithNamespace.withName("spark-executor-1")).thenReturn(podResource)
     when(podResource.subresource(anyString())).thenReturn(podResource)
 
-    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1))
+    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
 
     verify(podResource, times(1)).patch(any(), any(classOf[Pod]))
   }
@@ -193,7 +191,7 @@ class ExecutorResizePluginSuite
     val podResource = mock(classOf[SINGLE_POD])
     when(podsWithNamespace.withName("spark-executor-1")).thenReturn(podResource)
 
-    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1))
+    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
 
     verify(podResource, never()).patch(any(), any(classOf[Pod]))
   }
@@ -225,7 +223,7 @@ class ExecutorResizePluginSuite
     val podResource = mock(classOf[SINGLE_POD])
     when(podsWithNamespace.withName("spark-executor-1")).thenReturn(podResource)
 
-    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1))
+    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
 
     verify(podResource, never()).patch(any(), any(classOf[Pod]))
   }
@@ -248,7 +246,7 @@ class ExecutorResizePluginSuite
     when(podsWithNamespace.withName("spark-executor-2")).thenReturn(podResource2)
     when(podResource2.subresource(anyString())).thenReturn(podResource2)
 
-    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1))
+    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
 
     verify(podResource1, never()).patch(any(), any(classOf[Pod]))
     verify(podResource2, times(1)).patch(any(), any(classOf[Pod]))
@@ -267,7 +265,7 @@ class ExecutorResizePluginSuite
     when(podResource.subresource(anyString())).thenReturn(podResource)
 
     // Use 50% threshold - 60% usage should trigger resize
-    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.5, 0.1))
+    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.5, 0.1, kubernetesClient))
 
     verify(podResource, times(1)).patch(any(), any(classOf[Pod]))
   }
@@ -285,7 +283,7 @@ class ExecutorResizePluginSuite
     when(podsWithNamespace.withName("spark-executor-1")).thenReturn(podResource)
     when(podResource.subresource(anyString())).thenReturn(podResource)
 
-    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1))
+    plugin.invokePrivate(_checkAndIncreaseMemory(namespace, 0.9, 0.1, kubernetesClient))
 
     verify(podResource, times(1)).patch(any(), any(classOf[Pod]))
   }
@@ -301,9 +299,6 @@ class ExecutorResizePluginSuite
       val result = plugin.init(sc, pluginCtx)
 
       assert(result.isEmpty)
-      val clientField = plugin.getClass.getDeclaredField("kubernetesClient")
-      clientField.setAccessible(true)
-      assert(clientField.get(plugin) == null)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR improves `ExecutorResizeDriverPlugin` to reuse the `KubernetesClient` owned by `KubernetesClusterSchedulerBackend` instead of creating its own client via `SparkKubernetesClientFactory.createKubernetesClient(...)`.

### Why are the changes needed?

Before this PR, the driver process held two `KubernetesClient` instances pointing at the same API server with the same credentials: one owned by `KubernetesClusterSchedulerBackend` and one created by `ExecutorResizeDriverPlugin`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the updated unit tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7