### PR TITLE
[SPARK-56690][SQL] - Expose common `TaskMemoryManager` API on `HashedRelation` to avoid code duplication

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -125,6 +125,16 @@ private[execution] sealed trait HashedRelation extends KnownSizeEstimation {
 
 private[execution] object HashedRelation {
 
+  def createTaskMemoryManager(): TaskMemoryManager = {
+    new TaskMemoryManager(
+      new UnifiedMemoryManager(
+        new SparkConf().set(MEMORY_OFFHEAP_ENABLED.key, "false"),
+        Runtime.getRuntime.maxMemory,
+        Runtime.getRuntime.maxMemory / 2,
+        1),
+      0)
+  }
+
   /**
    * Create a HashedRelation from an Iterator of InternalRow.
    *
@@ -142,13 +152,7 @@ private[execution] object HashedRelation {
       allowsNullKey: Boolean = false,
       ignoresDuplicatedKey: Boolean = false): HashedRelation = {
     val mm = Option(taskMemoryManager).getOrElse {
-      new TaskMemoryManager(
-        new UnifiedMemoryManager(
-          new SparkConf().set(MEMORY_OFFHEAP_ENABLED.key, "false"),
-          Runtime.getRuntime.maxMemory,
-          Runtime.getRuntime.maxMemory / 2,
-          1),
-        0)
+      createTaskMemoryManager()
     }
 
     if (!input.hasNext && !allowsNullKey) {
@@ -400,13 +404,7 @@ private[joins] class UnsafeHashedRelation(
     // This is used in Broadcast, shared by multiple tasks, so we use on-heap memory
     // TODO(josh): This needs to be revisited before we merge this patch; making this change now
     // so that tests compile:
-    val taskMemoryManager = new TaskMemoryManager(
-      new UnifiedMemoryManager(
-        new SparkConf().set(MEMORY_OFFHEAP_ENABLED.key, "false"),
-        Runtime.getRuntime.maxMemory,
-        Runtime.getRuntime.maxMemory / 2,
-        1),
-      0)
+    val taskMemoryManager = HashedRelation.createTaskMemoryManager()
 
     val pageSizeBytes = Option(SparkEnv.get).map(_.memoryManager.pageSizeBytes)
       .getOrElse(new SparkConf().get(BUFFER_PAGESIZE).getOrElse(16L * 1024 * 1024))
@@ -574,15 +572,7 @@ private[execution] final class LongToUnsafeRowMap(
 
   // needed by serializer
   def this() = {
-    this(
-      new TaskMemoryManager(
-        new UnifiedMemoryManager(
-          new SparkConf().set(MEMORY_OFFHEAP_ENABLED.key, "false"),
-          Runtime.getRuntime.maxMemory,
-          Runtime.getRuntime.maxMemory / 2,
-          1),
-        0),
-      0)
+    this(HashedRelation.createTaskMemoryManager(), 0)
   }
 
   private def init(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.SparkException
 import org.apache.spark.internal.config.{MEMORY_OFFHEAP_ENABLED, MEMORY_OFFHEAP_SIZE}
 import org.apache.spark.internal.config.Kryo._
-import org.apache.spark.memory.{TaskMemoryManager, UnifiedMemoryManager}
+import org.apache.spark.memory.{TaskMemoryManager, TestMemoryConsumer, UnifiedMemoryManager}
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.serializer.KryoSerializer
 import org.apache.spark.sql.catalyst.InternalRow
@@ -757,6 +757,13 @@ abstract class HashedRelationSuite extends SharedSparkSession {
       assert(it.hasNext != ignoresDuplicatedKey)
       map.free()
     }
+  }
+
+  test("Verify TaskMemoryManager creation") {
+    val taskMemoryManager = HashedRelation.createTaskMemoryManager()
+    val testMemoryConsumer = new TestMemoryConsumer(taskMemoryManager)
+    val memoryPage = taskMemoryManager.allocatePage(100, testMemoryConsumer)
+    assert(memoryPage.size() > 0)
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, `HashedRelation` creates `TaskMemoryManager` by duplicating same `TaskMemoryManager` definition on following APIs:
```
HashedRelation.apply()
UnsafeHashedRelation.read()
LongToUnsafeRowMap.this()
```
It will be useful to expose a single `TaskMemoryManager` creation API to avoid code duplication and this approach will be useful for the following kind of cases by managing the required logic with single definition:
https://issues.apache.org/jira/browse/SPARK-54354
https://github.com/apache/spark/pull/53065

### Why are the changes needed?
It will be useful for long-term maintenance.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Being added new UT case and existing test cases creating `HashedRelation` instance.

### Was this patch authored or co-authored using generative AI tooling?
No