### PR TITLE
[SPARK-56694][SQL] Fix `DynamicPruningSubquery` canonicalization for `buildKeys`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{HintInfo, LogicalPlan}
 import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.trees.UnaryLike
@@ -90,7 +91,7 @@ case class DynamicPruningSubquery(
     copy(
       pruningKey = pruningKey.canonicalized,
       buildQuery = buildQuery.canonicalized,
-      buildKeys = buildKeys.map(_.canonicalized),
+      buildKeys = buildKeys.map(QueryPlan.normalizeExpressions(_, buildQuery.output)),
       exprId = ExprId(0))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruningSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruningSubquerySuite.scala
@@ -86,4 +86,29 @@ class DynamicPruningSubquerySuite extends SparkFunSuite {
       .copy(broadcastKeyIndices = Seq(1))
     assert(dynamicPruningSubquery.resolved == false)
   }
+
+  test("SPARK-56694: Canonicalized buildKeys are consistent for identical build queries with " +
+      "different ExprIds") {
+    val attr1 = AttributeReference("key", IntegerType)()
+    val attr2 = AttributeReference("key", IntegerType)()
+    assert(attr1.exprId != attr2.exprId, "precondition: fresh attributes have distinct ExprIds")
+
+    val dpq1 = DynamicPruningSubquery(
+      pruningKey = Literal(1),
+      buildQuery = LocalRelation(attr1),
+      buildKeys = Seq(attr1),
+      broadcastKeyIndices = Seq(0),
+      onlyInBroadcast = false)
+
+    val dpq2 = DynamicPruningSubquery(
+      pruningKey = Literal(1),
+      buildQuery = LocalRelation(attr2),
+      buildKeys = Seq(attr2),
+      broadcastKeyIndices = Seq(0),
+      onlyInBroadcast = false)
+
+    assert(dpq1.canonicalized == dpq2.canonicalized,
+      "DynamicPruningSubquery with identical build queries but different ExprIds " +
+      "must produce identical canonicalized forms so PlanMerger can deduplicate them")
+  }
 }

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/explain.txt
@@ -1,12 +1,12 @@
 == Physical Plan ==
-TakeOrderedAndProject (129)
-+- * HashAggregate (128)
-   +- Exchange (127)
-      +- * HashAggregate (126)
-         +- Union (125)
-            :- * HashAggregate (82)
-            :  +- * HashAggregate (81)
-            :     +- Union (80)
+TakeOrderedAndProject (123)
++- * HashAggregate (122)
+   +- Exchange (121)
+      +- * HashAggregate (120)
+         +- Union (119)
+            :- * HashAggregate (76)
+            :  +- * HashAggregate (75)
+            :     +- Union (74)
             :        :- * Project (30)
             :        :  +- * BroadcastHashJoin LeftOuter BuildRight (29)
             :        :     :- * HashAggregate (15)
@@ -37,8 +37,8 @@ TakeOrderedAndProject (129)
             :        :                       :     :     +- Scan parquet spark_catalog.default.store_returns (16)
             :        :                       :     +- ReusedExchange (19)
             :        :                       +- ReusedExchange (22)
-            :        :- * Project (49)
-            :        :  +- * BroadcastNestedLoopJoin Inner BuildRight (48)
+            :        :- * Project (43)
+            :        :  +- * BroadcastNestedLoopJoin Inner BuildRight (42)
             :        :     :- * HashAggregate (38)
             :        :     :  +- Exchange (37)
             :        :     :     +- * HashAggregate (36)
@@ -47,87 +47,81 @@ TakeOrderedAndProject (129)
             :        :     :              :- * ColumnarToRow (32)
             :        :     :              :  +- Scan parquet spark_catalog.default.catalog_sales (31)
             :        :     :              +- ReusedExchange (33)
-            :        :     +- BroadcastExchange (47)
-            :        :        +- * HashAggregate (46)
-            :        :           +- Exchange (45)
-            :        :              +- * HashAggregate (44)
-            :        :                 +- * Project (43)
-            :        :                    +- * BroadcastHashJoin Inner BuildRight (42)
-            :        :                       :- * ColumnarToRow (40)
-            :        :                       :  +- Scan parquet spark_catalog.default.catalog_returns (39)
-            :        :                       +- ReusedExchange (41)
-            :        +- * Project (79)
-            :           +- * BroadcastHashJoin LeftOuter BuildRight (78)
-            :              :- * HashAggregate (64)
-            :              :  +- Exchange (63)
-            :              :     +- * HashAggregate (62)
-            :              :        +- * Project (61)
-            :              :           +- * BroadcastHashJoin Inner BuildRight (60)
-            :              :              :- * Project (55)
-            :              :              :  +- * BroadcastHashJoin Inner BuildRight (54)
-            :              :              :     :- * Filter (52)
-            :              :              :     :  +- * ColumnarToRow (51)
-            :              :              :     :     +- Scan parquet spark_catalog.default.web_sales (50)
-            :              :              :     +- ReusedExchange (53)
-            :              :              +- BroadcastExchange (59)
-            :              :                 +- * Filter (58)
-            :              :                    +- * ColumnarToRow (57)
-            :              :                       +- Scan parquet spark_catalog.default.web_page (56)
-            :              +- BroadcastExchange (77)
-            :                 +- * HashAggregate (76)
-            :                    +- Exchange (75)
-            :                       +- * HashAggregate (74)
-            :                          +- * Project (73)
-            :                             +- * BroadcastHashJoin Inner BuildRight (72)
-            :                                :- * Project (70)
-            :                                :  +- * BroadcastHashJoin Inner BuildRight (69)
-            :                                :     :- * Filter (67)
-            :                                :     :  +- * ColumnarToRow (66)
-            :                                :     :     +- Scan parquet spark_catalog.default.web_returns (65)
-            :                                :     +- ReusedExchange (68)
-            :                                +- ReusedExchange (71)
-            :- * HashAggregate (103)
-            :  +- Exchange (102)
-            :     +- * HashAggregate (101)
-            :        +- * HashAggregate (100)
-            :           +- * HashAggregate (99)
-            :              +- Union (98)
-            :                 :- * Project (87)
-            :                 :  +- * BroadcastHashJoin LeftOuter BuildRight (86)
-            :                 :     :- * HashAggregate (84)
-            :                 :     :  +- ReusedExchange (83)
-            :                 :     +- ReusedExchange (85)
-            :                 :- * Project (92)
-            :                 :  +- * BroadcastNestedLoopJoin Inner BuildRight (91)
-            :                 :     :- * HashAggregate (89)
-            :                 :     :  +- ReusedExchange (88)
-            :                 :     +- ReusedExchange (90)
-            :                 +- * Project (97)
-            :                    +- * BroadcastHashJoin LeftOuter BuildRight (96)
-            :                       :- * HashAggregate (94)
-            :                       :  +- ReusedExchange (93)
-            :                       +- ReusedExchange (95)
-            +- * HashAggregate (124)
-               +- Exchange (123)
-                  +- * HashAggregate (122)
-                     +- * HashAggregate (121)
-                        +- * HashAggregate (120)
-                           +- Union (119)
-                              :- * Project (108)
-                              :  +- * BroadcastHashJoin LeftOuter BuildRight (107)
-                              :     :- * HashAggregate (105)
-                              :     :  +- ReusedExchange (104)
-                              :     +- ReusedExchange (106)
-                              :- * Project (113)
-                              :  +- * BroadcastNestedLoopJoin Inner BuildRight (112)
-                              :     :- * HashAggregate (110)
-                              :     :  +- ReusedExchange (109)
-                              :     +- ReusedExchange (111)
-                              +- * Project (118)
-                                 +- * BroadcastHashJoin LeftOuter BuildRight (117)
-                                    :- * HashAggregate (115)
-                                    :  +- ReusedExchange (114)
-                                    +- ReusedExchange (116)
+            :        :     +- BroadcastExchange (41)
+            :        :        +- * Project (40)
+            :        :           +- * Scan OneRowRelation (39)
+            :        +- * Project (73)
+            :           +- * BroadcastHashJoin LeftOuter BuildRight (72)
+            :              :- * HashAggregate (58)
+            :              :  +- Exchange (57)
+            :              :     +- * HashAggregate (56)
+            :              :        +- * Project (55)
+            :              :           +- * BroadcastHashJoin Inner BuildRight (54)
+            :              :              :- * Project (49)
+            :              :              :  +- * BroadcastHashJoin Inner BuildRight (48)
+            :              :              :     :- * Filter (46)
+            :              :              :     :  +- * ColumnarToRow (45)
+            :              :              :     :     +- Scan parquet spark_catalog.default.web_sales (44)
+            :              :              :     +- ReusedExchange (47)
+            :              :              +- BroadcastExchange (53)
+            :              :                 +- * Filter (52)
+            :              :                    +- * ColumnarToRow (51)
+            :              :                       +- Scan parquet spark_catalog.default.web_page (50)
+            :              +- BroadcastExchange (71)
+            :                 +- * HashAggregate (70)
+            :                    +- Exchange (69)
+            :                       +- * HashAggregate (68)
+            :                          +- * Project (67)
+            :                             +- * BroadcastHashJoin Inner BuildRight (66)
+            :                                :- * Project (64)
+            :                                :  +- * BroadcastHashJoin Inner BuildRight (63)
+            :                                :     :- * Filter (61)
+            :                                :     :  +- * ColumnarToRow (60)
+            :                                :     :     +- Scan parquet spark_catalog.default.web_returns (59)
+            :                                :     +- ReusedExchange (62)
+            :                                +- ReusedExchange (65)
+            :- * HashAggregate (97)
+            :  +- Exchange (96)
+            :     +- * HashAggregate (95)
+            :        +- * HashAggregate (94)
+            :           +- * HashAggregate (93)
+            :              +- Union (92)
+            :                 :- * Project (81)
+            :                 :  +- * BroadcastHashJoin LeftOuter BuildRight (80)
+            :                 :     :- * HashAggregate (78)
+            :                 :     :  +- ReusedExchange (77)
+            :                 :     +- ReusedExchange (79)
+            :                 :- * Project (86)
+            :                 :  +- * BroadcastNestedLoopJoin Inner BuildRight (85)
+            :                 :     :- * HashAggregate (83)
+            :                 :     :  +- ReusedExchange (82)
+            :                 :     +- ReusedExchange (84)
+            :                 +- * Project (91)
+            :                    +- * BroadcastHashJoin LeftOuter BuildRight (90)
+            :                       :- * HashAggregate (88)
+            :                       :  +- ReusedExchange (87)
+            :                       +- ReusedExchange (89)
+            +- * HashAggregate (118)
+               +- Exchange (117)
+                  +- * HashAggregate (116)
+                     +- * HashAggregate (115)
+                        +- * HashAggregate (114)
+                           +- Union (113)
+                              :- * Project (102)
+                              :  +- * BroadcastHashJoin LeftOuter BuildRight (101)
+                              :     :- * HashAggregate (99)
+                              :     :  +- ReusedExchange (98)
+                              :     +- ReusedExchange (100)
+                              :- * Project (107)
+                              :  +- * BroadcastNestedLoopJoin Inner BuildRight (106)
+                              :     :- * HashAggregate (104)
+                              :     :  +- ReusedExchange (103)
+                              :     +- ReusedExchange (105)
+                              +- * Project (112)
+                                 +- * BroadcastHashJoin LeftOuter BuildRight (111)
+                                    :- * HashAggregate (109)
+                                    :  +- ReusedExchange (108)
+                                    +- ReusedExchange (110)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -145,7 +139,7 @@ Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_s
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 Condition : isnotnull(ss_store_sk#1)
 
-(4) ReusedExchange [Reuses operator id: 134]
+(4) ReusedExchange [Reuses operator id: 128]
 Output [1]: [d_date_sk#6]
 
 (5) BroadcastHashJoin [codegen id : 3]
@@ -219,7 +213,7 @@ Input [4]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, sr_returned_date_s
 Input [4]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, sr_returned_date_sk#19]
 Condition : isnotnull(sr_store_sk#16)
 
-(19) ReusedExchange [Reuses operator id: 134]
+(19) ReusedExchange [Reuses operator id: 128]
 Output [1]: [d_date_sk#20]
 
 (20) BroadcastHashJoin [codegen id : 6]
@@ -287,7 +281,7 @@ ReadSchema: struct<cs_call_center_sk:int,cs_ext_sales_price:decimal(7,2),cs_net_
 (32) ColumnarToRow [codegen id : 10]
 Input [4]: [cs_call_center_sk#34, cs_ext_sales_price#35, cs_net_profit#36, cs_sold_date_sk#37]
 
-(33) ReusedExchange [Reuses operator id: 134]
+(33) ReusedExchange [Reuses operator id: 128]
 Output [1]: [d_date_sk#38]
 
 (34) BroadcastHashJoin [codegen id : 10]
@@ -311,484 +305,450 @@ Results [3]: [cs_call_center_sk#34, sum#41, sum#42]
 Input [3]: [cs_call_center_sk#34, sum#41, sum#42]
 Arguments: hashpartitioning(cs_call_center_sk#34, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(38) HashAggregate [codegen id : 14]
+(38) HashAggregate [codegen id : 12]
 Input [3]: [cs_call_center_sk#34, sum#41, sum#42]
 Keys [1]: [cs_call_center_sk#34]
 Functions [2]: [sum(UnscaledValue(cs_ext_sales_price#35)), sum(UnscaledValue(cs_net_profit#36))]
 Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_sales_price#35))#43, sum(UnscaledValue(cs_net_profit#36))#44]
 Results [3]: [cs_call_center_sk#34, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#35))#43,17,2) AS sales#45, MakeDecimal(sum(UnscaledValue(cs_net_profit#36))#44,17,2) AS profit#46]
 
-(39) Scan parquet spark_catalog.default.catalog_returns
-Output [3]: [cr_return_amount#47, cr_net_loss#48, cr_returned_date_sk#49]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cr_returned_date_sk#49), dynamicpruningexpression(cr_returned_date_sk#49 IN dynamicpruning#5)]
-ReadSchema: struct<cr_return_amount:decimal(7,2),cr_net_loss:decimal(7,2)>
+(39) Scan OneRowRelation [codegen id : 11]
+Output: []
 
-(40) ColumnarToRow [codegen id : 12]
-Input [3]: [cr_return_amount#47, cr_net_loss#48, cr_returned_date_sk#49]
+(40) Project [codegen id : 11]
+Output [2]: [Subquery scalar-subquery#47, [id=#6].returns AS returns#48, ReusedSubquery Subquery scalar-subquery#47, [id=#6].profit_loss AS profit_loss#49]
+Input: []
 
-(41) ReusedExchange [Reuses operator id: 134]
-Output [1]: [d_date_sk#50]
+(41) BroadcastExchange
+Input [2]: [returns#48, profit_loss#49]
+Arguments: IdentityBroadcastMode, [plan_id=7]
 
-(42) BroadcastHashJoin [codegen id : 12]
-Left keys [1]: [cr_returned_date_sk#49]
-Right keys [1]: [d_date_sk#50]
+(42) BroadcastNestedLoopJoin [codegen id : 12]
 Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 12]
-Output [2]: [cr_return_amount#47, cr_net_loss#48]
-Input [4]: [cr_return_amount#47, cr_net_loss#48, cr_returned_date_sk#49, d_date_sk#50]
+Output [5]: [catalog channel AS channel#50, cs_call_center_sk#34 AS id#51, sales#45, returns#48, (profit#46 - profit_loss#49) AS profit#52]
+Input [5]: [cs_call_center_sk#34, sales#45, profit#46, returns#48, profit_loss#49]
 
-(44) HashAggregate [codegen id : 12]
-Input [2]: [cr_return_amount#47, cr_net_loss#48]
-Keys: []
-Functions [2]: [partial_sum(UnscaledValue(cr_return_amount#47)), partial_sum(UnscaledValue(cr_net_loss#48))]
-Aggregate Attributes [2]: [sum#51, sum#52]
-Results [2]: [sum#53, sum#54]
-
-(45) Exchange
-Input [2]: [sum#53, sum#54]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
-
-(46) HashAggregate [codegen id : 13]
-Input [2]: [sum#53, sum#54]
-Keys: []
-Functions [2]: [sum(UnscaledValue(cr_return_amount#47)), sum(UnscaledValue(cr_net_loss#48))]
-Aggregate Attributes [2]: [sum(UnscaledValue(cr_return_amount#47))#55, sum(UnscaledValue(cr_net_loss#48))#56]
-Results [2]: [MakeDecimal(sum(UnscaledValue(cr_return_amount#47))#55,17,2) AS returns#57, MakeDecimal(sum(UnscaledValue(cr_net_loss#48))#56,17,2) AS profit_loss#58]
-
-(47) BroadcastExchange
-Input [2]: [returns#57, profit_loss#58]
-Arguments: IdentityBroadcastMode, [plan_id=7]
-
-(48) BroadcastNestedLoopJoin [codegen id : 14]
-Join type: Inner
-Join condition: None
-
-(49) Project [codegen id : 14]
-Output [5]: [catalog channel AS channel#59, cs_call_center_sk#34 AS id#60, sales#45, returns#57, (profit#46 - profit_loss#58) AS profit#61]
-Input [5]: [cs_call_center_sk#34, sales#45, profit#46, returns#57, profit_loss#58]
-
-(50) Scan parquet spark_catalog.default.web_sales
-Output [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65]
+(44) Scan parquet spark_catalog.default.web_sales
+Output [4]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55, ws_sold_date_sk#56]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#65), dynamicpruningexpression(ws_sold_date_sk#65 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#56), dynamicpruningexpression(ws_sold_date_sk#56 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(ws_web_page_sk)]
 ReadSchema: struct<ws_web_page_sk:int,ws_ext_sales_price:decimal(7,2),ws_net_profit:decimal(7,2)>
 
-(51) ColumnarToRow [codegen id : 17]
-Input [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65]
+(45) ColumnarToRow [codegen id : 15]
+Input [4]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55, ws_sold_date_sk#56]
 
-(52) Filter [codegen id : 17]
-Input [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65]
-Condition : isnotnull(ws_web_page_sk#62)
+(46) Filter [codegen id : 15]
+Input [4]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55, ws_sold_date_sk#56]
+Condition : isnotnull(ws_web_page_sk#53)
 
-(53) ReusedExchange [Reuses operator id: 134]
-Output [1]: [d_date_sk#66]
+(47) ReusedExchange [Reuses operator id: 128]
+Output [1]: [d_date_sk#57]
 
-(54) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ws_sold_date_sk#65]
-Right keys [1]: [d_date_sk#66]
+(48) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [ws_sold_date_sk#56]
+Right keys [1]: [d_date_sk#57]
 Join type: Inner
 Join condition: None
 
-(55) Project [codegen id : 17]
-Output [3]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64]
-Input [5]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65, d_date_sk#66]
+(49) Project [codegen id : 15]
+Output [3]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55]
+Input [5]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55, ws_sold_date_sk#56, d_date_sk#57]
 
-(56) Scan parquet spark_catalog.default.web_page
-Output [1]: [wp_web_page_sk#67]
+(50) Scan parquet spark_catalog.default.web_page
+Output [1]: [wp_web_page_sk#58]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_page]
 PushedFilters: [IsNotNull(wp_web_page_sk)]
 ReadSchema: struct<wp_web_page_sk:int>
 
-(57) ColumnarToRow [codegen id : 16]
-Input [1]: [wp_web_page_sk#67]
+(51) ColumnarToRow [codegen id : 14]
+Input [1]: [wp_web_page_sk#58]
 
-(58) Filter [codegen id : 16]
-Input [1]: [wp_web_page_sk#67]
-Condition : isnotnull(wp_web_page_sk#67)
+(52) Filter [codegen id : 14]
+Input [1]: [wp_web_page_sk#58]
+Condition : isnotnull(wp_web_page_sk#58)
 
-(59) BroadcastExchange
-Input [1]: [wp_web_page_sk#67]
+(53) BroadcastExchange
+Input [1]: [wp_web_page_sk#58]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
 
-(60) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ws_web_page_sk#62]
-Right keys [1]: [wp_web_page_sk#67]
+(54) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [ws_web_page_sk#53]
+Right keys [1]: [wp_web_page_sk#58]
 Join type: Inner
 Join condition: None
 
-(61) Project [codegen id : 17]
-Output [3]: [ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#67]
-Input [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#67]
+(55) Project [codegen id : 15]
+Output [3]: [ws_ext_sales_price#54, ws_net_profit#55, wp_web_page_sk#58]
+Input [4]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55, wp_web_page_sk#58]
 
-(62) HashAggregate [codegen id : 17]
-Input [3]: [ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#67]
-Keys [1]: [wp_web_page_sk#67]
-Functions [2]: [partial_sum(UnscaledValue(ws_ext_sales_price#63)), partial_sum(UnscaledValue(ws_net_profit#64))]
-Aggregate Attributes [2]: [sum#68, sum#69]
-Results [3]: [wp_web_page_sk#67, sum#70, sum#71]
+(56) HashAggregate [codegen id : 15]
+Input [3]: [ws_ext_sales_price#54, ws_net_profit#55, wp_web_page_sk#58]
+Keys [1]: [wp_web_page_sk#58]
+Functions [2]: [partial_sum(UnscaledValue(ws_ext_sales_price#54)), partial_sum(UnscaledValue(ws_net_profit#55))]
+Aggregate Attributes [2]: [sum#59, sum#60]
+Results [3]: [wp_web_page_sk#58, sum#61, sum#62]
 
-(63) Exchange
-Input [3]: [wp_web_page_sk#67, sum#70, sum#71]
-Arguments: hashpartitioning(wp_web_page_sk#67, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+(57) Exchange
+Input [3]: [wp_web_page_sk#58, sum#61, sum#62]
+Arguments: hashpartitioning(wp_web_page_sk#58, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(64) HashAggregate [codegen id : 22]
-Input [3]: [wp_web_page_sk#67, sum#70, sum#71]
-Keys [1]: [wp_web_page_sk#67]
-Functions [2]: [sum(UnscaledValue(ws_ext_sales_price#63)), sum(UnscaledValue(ws_net_profit#64))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_sales_price#63))#72, sum(UnscaledValue(ws_net_profit#64))#73]
-Results [3]: [wp_web_page_sk#67, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#63))#72,17,2) AS sales#74, MakeDecimal(sum(UnscaledValue(ws_net_profit#64))#73,17,2) AS profit#75]
+(58) HashAggregate [codegen id : 20]
+Input [3]: [wp_web_page_sk#58, sum#61, sum#62]
+Keys [1]: [wp_web_page_sk#58]
+Functions [2]: [sum(UnscaledValue(ws_ext_sales_price#54)), sum(UnscaledValue(ws_net_profit#55))]
+Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_sales_price#54))#63, sum(UnscaledValue(ws_net_profit#55))#64]
+Results [3]: [wp_web_page_sk#58, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#54))#63,17,2) AS sales#65, MakeDecimal(sum(UnscaledValue(ws_net_profit#55))#64,17,2) AS profit#66]
 
-(65) Scan parquet spark_catalog.default.web_returns
-Output [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79]
+(59) Scan parquet spark_catalog.default.web_returns
+Output [4]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69, wr_returned_date_sk#70]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(wr_returned_date_sk#79), dynamicpruningexpression(wr_returned_date_sk#79 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(wr_returned_date_sk#70), dynamicpruningexpression(wr_returned_date_sk#70 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(wr_web_page_sk)]
 ReadSchema: struct<wr_web_page_sk:int,wr_return_amt:decimal(7,2),wr_net_loss:decimal(7,2)>
 
-(66) ColumnarToRow [codegen id : 20]
-Input [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79]
+(60) ColumnarToRow [codegen id : 18]
+Input [4]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69, wr_returned_date_sk#70]
 
-(67) Filter [codegen id : 20]
-Input [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79]
-Condition : isnotnull(wr_web_page_sk#76)
+(61) Filter [codegen id : 18]
+Input [4]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69, wr_returned_date_sk#70]
+Condition : isnotnull(wr_web_page_sk#67)
 
-(68) ReusedExchange [Reuses operator id: 134]
-Output [1]: [d_date_sk#80]
+(62) ReusedExchange [Reuses operator id: 128]
+Output [1]: [d_date_sk#71]
 
-(69) BroadcastHashJoin [codegen id : 20]
-Left keys [1]: [wr_returned_date_sk#79]
-Right keys [1]: [d_date_sk#80]
+(63) BroadcastHashJoin [codegen id : 18]
+Left keys [1]: [wr_returned_date_sk#70]
+Right keys [1]: [d_date_sk#71]
 Join type: Inner
 Join condition: None
 
-(70) Project [codegen id : 20]
-Output [3]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78]
-Input [5]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79, d_date_sk#80]
+(64) Project [codegen id : 18]
+Output [3]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69]
+Input [5]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69, wr_returned_date_sk#70, d_date_sk#71]
 
-(71) ReusedExchange [Reuses operator id: 59]
-Output [1]: [wp_web_page_sk#81]
+(65) ReusedExchange [Reuses operator id: 53]
+Output [1]: [wp_web_page_sk#72]
+
+(66) BroadcastHashJoin [codegen id : 18]
+Left keys [1]: [wr_web_page_sk#67]
+Right keys [1]: [wp_web_page_sk#72]
+Join type: Inner
+Join condition: None
+
+(67) Project [codegen id : 18]
+Output [3]: [wr_return_amt#68, wr_net_loss#69, wp_web_page_sk#72]
+Input [4]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69, wp_web_page_sk#72]
+
+(68) HashAggregate [codegen id : 18]
+Input [3]: [wr_return_amt#68, wr_net_loss#69, wp_web_page_sk#72]
+Keys [1]: [wp_web_page_sk#72]
+Functions [2]: [partial_sum(UnscaledValue(wr_return_amt#68)), partial_sum(UnscaledValue(wr_net_loss#69))]
+Aggregate Attributes [2]: [sum#73, sum#74]
+Results [3]: [wp_web_page_sk#72, sum#75, sum#76]
+
+(69) Exchange
+Input [3]: [wp_web_page_sk#72, sum#75, sum#76]
+Arguments: hashpartitioning(wp_web_page_sk#72, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(70) HashAggregate [codegen id : 19]
+Input [3]: [wp_web_page_sk#72, sum#75, sum#76]
+Keys [1]: [wp_web_page_sk#72]
+Functions [2]: [sum(UnscaledValue(wr_return_amt#68)), sum(UnscaledValue(wr_net_loss#69))]
+Aggregate Attributes [2]: [sum(UnscaledValue(wr_return_amt#68))#77, sum(UnscaledValue(wr_net_loss#69))#78]
+Results [3]: [wp_web_page_sk#72, MakeDecimal(sum(UnscaledValue(wr_return_amt#68))#77,17,2) AS returns#79, MakeDecimal(sum(UnscaledValue(wr_net_loss#69))#78,17,2) AS profit_loss#80]
+
+(71) BroadcastExchange
+Input [3]: [wp_web_page_sk#72, returns#79, profit_loss#80]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
 (72) BroadcastHashJoin [codegen id : 20]
-Left keys [1]: [wr_web_page_sk#76]
-Right keys [1]: [wp_web_page_sk#81]
-Join type: Inner
+Left keys [1]: [wp_web_page_sk#58]
+Right keys [1]: [wp_web_page_sk#72]
+Join type: LeftOuter
 Join condition: None
 
 (73) Project [codegen id : 20]
-Output [3]: [wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#81]
-Input [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#81]
+Output [5]: [web channel AS channel#81, wp_web_page_sk#58 AS id#82, sales#65, coalesce(returns#79, 0.00) AS returns#83, (profit#66 - coalesce(profit_loss#80, 0.00)) AS profit#84]
+Input [6]: [wp_web_page_sk#58, sales#65, profit#66, wp_web_page_sk#72, returns#79, profit_loss#80]
 
-(74) HashAggregate [codegen id : 20]
-Input [3]: [wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#81]
-Keys [1]: [wp_web_page_sk#81]
-Functions [2]: [partial_sum(UnscaledValue(wr_return_amt#77)), partial_sum(UnscaledValue(wr_net_loss#78))]
-Aggregate Attributes [2]: [sum#82, sum#83]
-Results [3]: [wp_web_page_sk#81, sum#84, sum#85]
+(74) Union
 
-(75) Exchange
-Input [3]: [wp_web_page_sk#81, sum#84, sum#85]
-Arguments: hashpartitioning(wp_web_page_sk#81, 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(76) HashAggregate [codegen id : 21]
-Input [3]: [wp_web_page_sk#81, sum#84, sum#85]
-Keys [1]: [wp_web_page_sk#81]
-Functions [2]: [sum(UnscaledValue(wr_return_amt#77)), sum(UnscaledValue(wr_net_loss#78))]
-Aggregate Attributes [2]: [sum(UnscaledValue(wr_return_amt#77))#86, sum(UnscaledValue(wr_net_loss#78))#87]
-Results [3]: [wp_web_page_sk#81, MakeDecimal(sum(UnscaledValue(wr_return_amt#77))#86,17,2) AS returns#88, MakeDecimal(sum(UnscaledValue(wr_net_loss#78))#87,17,2) AS profit_loss#89]
-
-(77) BroadcastExchange
-Input [3]: [wp_web_page_sk#81, returns#88, profit_loss#89]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
-
-(78) BroadcastHashJoin [codegen id : 22]
-Left keys [1]: [wp_web_page_sk#67]
-Right keys [1]: [wp_web_page_sk#81]
-Join type: LeftOuter
-Join condition: None
-
-(79) Project [codegen id : 22]
-Output [5]: [web channel AS channel#90, wp_web_page_sk#67 AS id#91, sales#74, coalesce(returns#88, 0.00) AS returns#92, (profit#75 - coalesce(profit_loss#89, 0.00)) AS profit#93]
-Input [6]: [wp_web_page_sk#67, sales#74, profit#75, wp_web_page_sk#81, returns#88, profit_loss#89]
-
-(80) Union
-
-(81) HashAggregate [codegen id : 23]
+(75) HashAggregate [codegen id : 21]
 Input [5]: [channel#30, id#31, sales#14, returns#32, profit#33]
 Keys [2]: [channel#30, id#31]
 Functions [3]: [partial_sum(sales#14), partial_sum(returns#32), partial_sum(profit#33)]
-Aggregate Attributes [6]: [sum#94, isEmpty#95, sum#96, isEmpty#97, sum#98, isEmpty#99]
-Results [8]: [channel#30, id#31, sum#100, isEmpty#101, sum#102, isEmpty#103, sum#104, isEmpty#105]
+Aggregate Attributes [6]: [sum#85, isEmpty#86, sum#87, isEmpty#88, sum#89, isEmpty#90]
+Results [8]: [channel#30, id#31, sum#91, isEmpty#92, sum#93, isEmpty#94, sum#95, isEmpty#96]
 
-(82) HashAggregate [codegen id : 23]
-Input [8]: [channel#30, id#31, sum#100, isEmpty#101, sum#102, isEmpty#103, sum#104, isEmpty#105]
+(76) HashAggregate [codegen id : 21]
+Input [8]: [channel#30, id#31, sum#91, isEmpty#92, sum#93, isEmpty#94, sum#95, isEmpty#96]
 Keys [2]: [channel#30, id#31]
 Functions [3]: [sum(sales#14), sum(returns#32), sum(profit#33)]
-Aggregate Attributes [3]: [sum(sales#14)#106, sum(returns#32)#107, sum(profit#33)#108]
-Results [5]: [channel#30, id#31, cast(sum(sales#14)#106 as decimal(37,2)) AS sales#109, cast(sum(returns#32)#107 as decimal(37,2)) AS returns#110, cast(sum(profit#33)#108 as decimal(38,2)) AS profit#111]
+Aggregate Attributes [3]: [sum(sales#14)#97, sum(returns#32)#98, sum(profit#33)#99]
+Results [5]: [channel#30, id#31, cast(sum(sales#14)#97 as decimal(37,2)) AS sales#100, cast(sum(returns#32)#98 as decimal(37,2)) AS returns#101, cast(sum(profit#33)#99 as decimal(38,2)) AS profit#102]
 
-(83) ReusedExchange [Reuses operator id: 14]
-Output [3]: [s_store_sk#112, sum#113, sum#114]
+(77) ReusedExchange [Reuses operator id: 14]
+Output [3]: [s_store_sk#103, sum#104, sum#105]
 
-(84) HashAggregate [codegen id : 31]
-Input [3]: [s_store_sk#112, sum#113, sum#114]
-Keys [1]: [s_store_sk#112]
-Functions [2]: [sum(UnscaledValue(ss_ext_sales_price#115)), sum(UnscaledValue(ss_net_profit#116))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ss_ext_sales_price#115))#12, sum(UnscaledValue(ss_net_profit#116))#13]
-Results [3]: [s_store_sk#112, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#115))#12,17,2) AS sales#117, MakeDecimal(sum(UnscaledValue(ss_net_profit#116))#13,17,2) AS profit#118]
+(78) HashAggregate [codegen id : 29]
+Input [3]: [s_store_sk#103, sum#104, sum#105]
+Keys [1]: [s_store_sk#103]
+Functions [2]: [sum(UnscaledValue(ss_ext_sales_price#106)), sum(UnscaledValue(ss_net_profit#107))]
+Aggregate Attributes [2]: [sum(UnscaledValue(ss_ext_sales_price#106))#12, sum(UnscaledValue(ss_net_profit#107))#13]
+Results [3]: [s_store_sk#103, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#106))#12,17,2) AS sales#108, MakeDecimal(sum(UnscaledValue(ss_net_profit#107))#13,17,2) AS profit#109]
 
-(85) ReusedExchange [Reuses operator id: 28]
-Output [3]: [s_store_sk#119, returns#120, profit_loss#121]
+(79) ReusedExchange [Reuses operator id: 28]
+Output [3]: [s_store_sk#110, returns#111, profit_loss#112]
 
-(86) BroadcastHashJoin [codegen id : 31]
-Left keys [1]: [s_store_sk#112]
-Right keys [1]: [s_store_sk#119]
+(80) BroadcastHashJoin [codegen id : 29]
+Left keys [1]: [s_store_sk#103]
+Right keys [1]: [s_store_sk#110]
 Join type: LeftOuter
 Join condition: None
 
-(87) Project [codegen id : 31]
-Output [5]: [store channel AS channel#122, s_store_sk#112 AS id#123, sales#117, coalesce(returns#120, 0.00) AS returns#124, (profit#118 - coalesce(profit_loss#121, 0.00)) AS profit#125]
-Input [6]: [s_store_sk#112, sales#117, profit#118, s_store_sk#119, returns#120, profit_loss#121]
+(81) Project [codegen id : 29]
+Output [5]: [store channel AS channel#113, s_store_sk#103 AS id#114, sales#108, coalesce(returns#111, 0.00) AS returns#115, (profit#109 - coalesce(profit_loss#112, 0.00)) AS profit#116]
+Input [6]: [s_store_sk#103, sales#108, profit#109, s_store_sk#110, returns#111, profit_loss#112]
 
-(88) ReusedExchange [Reuses operator id: 37]
-Output [3]: [cs_call_center_sk#126, sum#127, sum#128]
+(82) ReusedExchange [Reuses operator id: 37]
+Output [3]: [cs_call_center_sk#117, sum#118, sum#119]
 
-(89) HashAggregate [codegen id : 37]
-Input [3]: [cs_call_center_sk#126, sum#127, sum#128]
-Keys [1]: [cs_call_center_sk#126]
-Functions [2]: [sum(UnscaledValue(cs_ext_sales_price#129)), sum(UnscaledValue(cs_net_profit#130))]
-Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_sales_price#129))#43, sum(UnscaledValue(cs_net_profit#130))#44]
-Results [3]: [cs_call_center_sk#126, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#129))#43,17,2) AS sales#131, MakeDecimal(sum(UnscaledValue(cs_net_profit#130))#44,17,2) AS profit#132]
+(83) HashAggregate [codegen id : 33]
+Input [3]: [cs_call_center_sk#117, sum#118, sum#119]
+Keys [1]: [cs_call_center_sk#117]
+Functions [2]: [sum(UnscaledValue(cs_ext_sales_price#120)), sum(UnscaledValue(cs_net_profit#121))]
+Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_sales_price#120))#43, sum(UnscaledValue(cs_net_profit#121))#44]
+Results [3]: [cs_call_center_sk#117, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#120))#43,17,2) AS sales#122, MakeDecimal(sum(UnscaledValue(cs_net_profit#121))#44,17,2) AS profit#123]
 
-(90) ReusedExchange [Reuses operator id: 47]
-Output [2]: [returns#133, profit_loss#134]
+(84) ReusedExchange [Reuses operator id: 41]
+Output [2]: [returns#124, profit_loss#125]
 
-(91) BroadcastNestedLoopJoin [codegen id : 37]
+(85) BroadcastNestedLoopJoin [codegen id : 33]
 Join type: Inner
 Join condition: None
 
-(92) Project [codegen id : 37]
-Output [5]: [catalog channel AS channel#135, cs_call_center_sk#126 AS id#136, sales#131, returns#133, (profit#132 - profit_loss#134) AS profit#137]
-Input [5]: [cs_call_center_sk#126, sales#131, profit#132, returns#133, profit_loss#134]
+(86) Project [codegen id : 33]
+Output [5]: [catalog channel AS channel#126, cs_call_center_sk#117 AS id#127, sales#122, returns#124, (profit#123 - profit_loss#125) AS profit#128]
+Input [5]: [cs_call_center_sk#117, sales#122, profit#123, returns#124, profit_loss#125]
 
-(93) ReusedExchange [Reuses operator id: 63]
-Output [3]: [wp_web_page_sk#138, sum#139, sum#140]
+(87) ReusedExchange [Reuses operator id: 57]
+Output [3]: [wp_web_page_sk#129, sum#130, sum#131]
 
-(94) HashAggregate [codegen id : 45]
-Input [3]: [wp_web_page_sk#138, sum#139, sum#140]
-Keys [1]: [wp_web_page_sk#138]
-Functions [2]: [sum(UnscaledValue(ws_ext_sales_price#141)), sum(UnscaledValue(ws_net_profit#142))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_sales_price#141))#72, sum(UnscaledValue(ws_net_profit#142))#73]
-Results [3]: [wp_web_page_sk#138, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#141))#72,17,2) AS sales#143, MakeDecimal(sum(UnscaledValue(ws_net_profit#142))#73,17,2) AS profit#144]
+(88) HashAggregate [codegen id : 41]
+Input [3]: [wp_web_page_sk#129, sum#130, sum#131]
+Keys [1]: [wp_web_page_sk#129]
+Functions [2]: [sum(UnscaledValue(ws_ext_sales_price#132)), sum(UnscaledValue(ws_net_profit#133))]
+Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_sales_price#132))#63, sum(UnscaledValue(ws_net_profit#133))#64]
+Results [3]: [wp_web_page_sk#129, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#132))#63,17,2) AS sales#134, MakeDecimal(sum(UnscaledValue(ws_net_profit#133))#64,17,2) AS profit#135]
 
-(95) ReusedExchange [Reuses operator id: 77]
-Output [3]: [wp_web_page_sk#145, returns#146, profit_loss#147]
+(89) ReusedExchange [Reuses operator id: 71]
+Output [3]: [wp_web_page_sk#136, returns#137, profit_loss#138]
 
-(96) BroadcastHashJoin [codegen id : 45]
-Left keys [1]: [wp_web_page_sk#138]
-Right keys [1]: [wp_web_page_sk#145]
+(90) BroadcastHashJoin [codegen id : 41]
+Left keys [1]: [wp_web_page_sk#129]
+Right keys [1]: [wp_web_page_sk#136]
 Join type: LeftOuter
 Join condition: None
 
-(97) Project [codegen id : 45]
-Output [5]: [web channel AS channel#148, wp_web_page_sk#138 AS id#149, sales#143, coalesce(returns#146, 0.00) AS returns#150, (profit#144 - coalesce(profit_loss#147, 0.00)) AS profit#151]
-Input [6]: [wp_web_page_sk#138, sales#143, profit#144, wp_web_page_sk#145, returns#146, profit_loss#147]
+(91) Project [codegen id : 41]
+Output [5]: [web channel AS channel#139, wp_web_page_sk#129 AS id#140, sales#134, coalesce(returns#137, 0.00) AS returns#141, (profit#135 - coalesce(profit_loss#138, 0.00)) AS profit#142]
+Input [6]: [wp_web_page_sk#129, sales#134, profit#135, wp_web_page_sk#136, returns#137, profit_loss#138]
 
-(98) Union
+(92) Union
 
-(99) HashAggregate [codegen id : 46]
-Input [5]: [channel#122, id#123, sales#117, returns#124, profit#125]
-Keys [2]: [channel#122, id#123]
-Functions [3]: [partial_sum(sales#117), partial_sum(returns#124), partial_sum(profit#125)]
-Aggregate Attributes [6]: [sum#152, isEmpty#153, sum#154, isEmpty#155, sum#156, isEmpty#157]
-Results [8]: [channel#122, id#123, sum#158, isEmpty#159, sum#160, isEmpty#161, sum#162, isEmpty#163]
+(93) HashAggregate [codegen id : 42]
+Input [5]: [channel#113, id#114, sales#108, returns#115, profit#116]
+Keys [2]: [channel#113, id#114]
+Functions [3]: [partial_sum(sales#108), partial_sum(returns#115), partial_sum(profit#116)]
+Aggregate Attributes [6]: [sum#143, isEmpty#144, sum#145, isEmpty#146, sum#147, isEmpty#148]
+Results [8]: [channel#113, id#114, sum#149, isEmpty#150, sum#151, isEmpty#152, sum#153, isEmpty#154]
 
-(100) HashAggregate [codegen id : 46]
-Input [8]: [channel#122, id#123, sum#158, isEmpty#159, sum#160, isEmpty#161, sum#162, isEmpty#163]
-Keys [2]: [channel#122, id#123]
-Functions [3]: [sum(sales#117), sum(returns#124), sum(profit#125)]
-Aggregate Attributes [3]: [sum(sales#117)#106, sum(returns#124)#107, sum(profit#125)#108]
-Results [4]: [channel#122, sum(sales#117)#106 AS sales#164, sum(returns#124)#107 AS returns#165, sum(profit#125)#108 AS profit#166]
+(94) HashAggregate [codegen id : 42]
+Input [8]: [channel#113, id#114, sum#149, isEmpty#150, sum#151, isEmpty#152, sum#153, isEmpty#154]
+Keys [2]: [channel#113, id#114]
+Functions [3]: [sum(sales#108), sum(returns#115), sum(profit#116)]
+Aggregate Attributes [3]: [sum(sales#108)#97, sum(returns#115)#98, sum(profit#116)#99]
+Results [4]: [channel#113, sum(sales#108)#97 AS sales#155, sum(returns#115)#98 AS returns#156, sum(profit#116)#99 AS profit#157]
 
-(101) HashAggregate [codegen id : 46]
-Input [4]: [channel#122, sales#164, returns#165, profit#166]
-Keys [1]: [channel#122]
-Functions [3]: [partial_sum(sales#164), partial_sum(returns#165), partial_sum(profit#166)]
-Aggregate Attributes [6]: [sum#167, isEmpty#168, sum#169, isEmpty#170, sum#171, isEmpty#172]
-Results [7]: [channel#122, sum#173, isEmpty#174, sum#175, isEmpty#176, sum#177, isEmpty#178]
+(95) HashAggregate [codegen id : 42]
+Input [4]: [channel#113, sales#155, returns#156, profit#157]
+Keys [1]: [channel#113]
+Functions [3]: [partial_sum(sales#155), partial_sum(returns#156), partial_sum(profit#157)]
+Aggregate Attributes [6]: [sum#158, isEmpty#159, sum#160, isEmpty#161, sum#162, isEmpty#163]
+Results [7]: [channel#113, sum#164, isEmpty#165, sum#166, isEmpty#167, sum#168, isEmpty#169]
 
-(102) Exchange
-Input [7]: [channel#122, sum#173, isEmpty#174, sum#175, isEmpty#176, sum#177, isEmpty#178]
-Arguments: hashpartitioning(channel#122, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+(96) Exchange
+Input [7]: [channel#113, sum#164, isEmpty#165, sum#166, isEmpty#167, sum#168, isEmpty#169]
+Arguments: hashpartitioning(channel#113, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(103) HashAggregate [codegen id : 47]
-Input [7]: [channel#122, sum#173, isEmpty#174, sum#175, isEmpty#176, sum#177, isEmpty#178]
-Keys [1]: [channel#122]
-Functions [3]: [sum(sales#164), sum(returns#165), sum(profit#166)]
-Aggregate Attributes [3]: [sum(sales#164)#179, sum(returns#165)#180, sum(profit#166)#181]
-Results [5]: [channel#122, null AS id#182, sum(sales#164)#179 AS sales#183, sum(returns#165)#180 AS returns#184, sum(profit#166)#181 AS profit#185]
+(97) HashAggregate [codegen id : 43]
+Input [7]: [channel#113, sum#164, isEmpty#165, sum#166, isEmpty#167, sum#168, isEmpty#169]
+Keys [1]: [channel#113]
+Functions [3]: [sum(sales#155), sum(returns#156), sum(profit#157)]
+Aggregate Attributes [3]: [sum(sales#155)#170, sum(returns#156)#171, sum(profit#157)#172]
+Results [5]: [channel#113, null AS id#173, sum(sales#155)#170 AS sales#174, sum(returns#156)#171 AS returns#175, sum(profit#157)#172 AS profit#176]
 
-(104) ReusedExchange [Reuses operator id: 14]
-Output [3]: [s_store_sk#186, sum#187, sum#188]
+(98) ReusedExchange [Reuses operator id: 14]
+Output [3]: [s_store_sk#177, sum#178, sum#179]
 
-(105) HashAggregate [codegen id : 55]
-Input [3]: [s_store_sk#186, sum#187, sum#188]
-Keys [1]: [s_store_sk#186]
-Functions [2]: [sum(UnscaledValue(ss_ext_sales_price#189)), sum(UnscaledValue(ss_net_profit#190))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ss_ext_sales_price#189))#12, sum(UnscaledValue(ss_net_profit#190))#13]
-Results [3]: [s_store_sk#186, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#189))#12,17,2) AS sales#191, MakeDecimal(sum(UnscaledValue(ss_net_profit#190))#13,17,2) AS profit#192]
+(99) HashAggregate [codegen id : 51]
+Input [3]: [s_store_sk#177, sum#178, sum#179]
+Keys [1]: [s_store_sk#177]
+Functions [2]: [sum(UnscaledValue(ss_ext_sales_price#180)), sum(UnscaledValue(ss_net_profit#181))]
+Aggregate Attributes [2]: [sum(UnscaledValue(ss_ext_sales_price#180))#12, sum(UnscaledValue(ss_net_profit#181))#13]
+Results [3]: [s_store_sk#177, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#180))#12,17,2) AS sales#182, MakeDecimal(sum(UnscaledValue(ss_net_profit#181))#13,17,2) AS profit#183]
 
-(106) ReusedExchange [Reuses operator id: 28]
-Output [3]: [s_store_sk#193, returns#194, profit_loss#195]
+(100) ReusedExchange [Reuses operator id: 28]
+Output [3]: [s_store_sk#184, returns#185, profit_loss#186]
 
-(107) BroadcastHashJoin [codegen id : 55]
-Left keys [1]: [s_store_sk#186]
-Right keys [1]: [s_store_sk#193]
+(101) BroadcastHashJoin [codegen id : 51]
+Left keys [1]: [s_store_sk#177]
+Right keys [1]: [s_store_sk#184]
 Join type: LeftOuter
 Join condition: None
 
-(108) Project [codegen id : 55]
-Output [5]: [store channel AS channel#196, s_store_sk#186 AS id#197, sales#191, coalesce(returns#194, 0.00) AS returns#198, (profit#192 - coalesce(profit_loss#195, 0.00)) AS profit#199]
-Input [6]: [s_store_sk#186, sales#191, profit#192, s_store_sk#193, returns#194, profit_loss#195]
+(102) Project [codegen id : 51]
+Output [5]: [store channel AS channel#187, s_store_sk#177 AS id#188, sales#182, coalesce(returns#185, 0.00) AS returns#189, (profit#183 - coalesce(profit_loss#186, 0.00)) AS profit#190]
+Input [6]: [s_store_sk#177, sales#182, profit#183, s_store_sk#184, returns#185, profit_loss#186]
 
-(109) ReusedExchange [Reuses operator id: 37]
-Output [3]: [cs_call_center_sk#200, sum#201, sum#202]
+(103) ReusedExchange [Reuses operator id: 37]
+Output [3]: [cs_call_center_sk#191, sum#192, sum#193]
 
-(110) HashAggregate [codegen id : 61]
-Input [3]: [cs_call_center_sk#200, sum#201, sum#202]
-Keys [1]: [cs_call_center_sk#200]
-Functions [2]: [sum(UnscaledValue(cs_ext_sales_price#203)), sum(UnscaledValue(cs_net_profit#204))]
-Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_sales_price#203))#43, sum(UnscaledValue(cs_net_profit#204))#44]
-Results [3]: [cs_call_center_sk#200, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#203))#43,17,2) AS sales#205, MakeDecimal(sum(UnscaledValue(cs_net_profit#204))#44,17,2) AS profit#206]
+(104) HashAggregate [codegen id : 55]
+Input [3]: [cs_call_center_sk#191, sum#192, sum#193]
+Keys [1]: [cs_call_center_sk#191]
+Functions [2]: [sum(UnscaledValue(cs_ext_sales_price#194)), sum(UnscaledValue(cs_net_profit#195))]
+Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_sales_price#194))#43, sum(UnscaledValue(cs_net_profit#195))#44]
+Results [3]: [cs_call_center_sk#191, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#194))#43,17,2) AS sales#196, MakeDecimal(sum(UnscaledValue(cs_net_profit#195))#44,17,2) AS profit#197]
 
-(111) ReusedExchange [Reuses operator id: 47]
-Output [2]: [returns#207, profit_loss#208]
+(105) ReusedExchange [Reuses operator id: 41]
+Output [2]: [returns#198, profit_loss#199]
 
-(112) BroadcastNestedLoopJoin [codegen id : 61]
+(106) BroadcastNestedLoopJoin [codegen id : 55]
 Join type: Inner
 Join condition: None
 
-(113) Project [codegen id : 61]
-Output [5]: [catalog channel AS channel#209, cs_call_center_sk#200 AS id#210, sales#205, returns#207, (profit#206 - profit_loss#208) AS profit#211]
-Input [5]: [cs_call_center_sk#200, sales#205, profit#206, returns#207, profit_loss#208]
+(107) Project [codegen id : 55]
+Output [5]: [catalog channel AS channel#200, cs_call_center_sk#191 AS id#201, sales#196, returns#198, (profit#197 - profit_loss#199) AS profit#202]
+Input [5]: [cs_call_center_sk#191, sales#196, profit#197, returns#198, profit_loss#199]
 
-(114) ReusedExchange [Reuses operator id: 63]
-Output [3]: [wp_web_page_sk#212, sum#213, sum#214]
+(108) ReusedExchange [Reuses operator id: 57]
+Output [3]: [wp_web_page_sk#203, sum#204, sum#205]
 
-(115) HashAggregate [codegen id : 69]
-Input [3]: [wp_web_page_sk#212, sum#213, sum#214]
-Keys [1]: [wp_web_page_sk#212]
-Functions [2]: [sum(UnscaledValue(ws_ext_sales_price#215)), sum(UnscaledValue(ws_net_profit#216))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_sales_price#215))#72, sum(UnscaledValue(ws_net_profit#216))#73]
-Results [3]: [wp_web_page_sk#212, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#215))#72,17,2) AS sales#217, MakeDecimal(sum(UnscaledValue(ws_net_profit#216))#73,17,2) AS profit#218]
+(109) HashAggregate [codegen id : 63]
+Input [3]: [wp_web_page_sk#203, sum#204, sum#205]
+Keys [1]: [wp_web_page_sk#203]
+Functions [2]: [sum(UnscaledValue(ws_ext_sales_price#206)), sum(UnscaledValue(ws_net_profit#207))]
+Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_sales_price#206))#63, sum(UnscaledValue(ws_net_profit#207))#64]
+Results [3]: [wp_web_page_sk#203, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#206))#63,17,2) AS sales#208, MakeDecimal(sum(UnscaledValue(ws_net_profit#207))#64,17,2) AS profit#209]
 
-(116) ReusedExchange [Reuses operator id: 77]
-Output [3]: [wp_web_page_sk#219, returns#220, profit_loss#221]
+(110) ReusedExchange [Reuses operator id: 71]
+Output [3]: [wp_web_page_sk#210, returns#211, profit_loss#212]
 
-(117) BroadcastHashJoin [codegen id : 69]
-Left keys [1]: [wp_web_page_sk#212]
-Right keys [1]: [wp_web_page_sk#219]
+(111) BroadcastHashJoin [codegen id : 63]
+Left keys [1]: [wp_web_page_sk#203]
+Right keys [1]: [wp_web_page_sk#210]
 Join type: LeftOuter
 Join condition: None
 
-(118) Project [codegen id : 69]
-Output [5]: [web channel AS channel#222, wp_web_page_sk#212 AS id#223, sales#217, coalesce(returns#220, 0.00) AS returns#224, (profit#218 - coalesce(profit_loss#221, 0.00)) AS profit#225]
-Input [6]: [wp_web_page_sk#212, sales#217, profit#218, wp_web_page_sk#219, returns#220, profit_loss#221]
+(112) Project [codegen id : 63]
+Output [5]: [web channel AS channel#213, wp_web_page_sk#203 AS id#214, sales#208, coalesce(returns#211, 0.00) AS returns#215, (profit#209 - coalesce(profit_loss#212, 0.00)) AS profit#216]
+Input [6]: [wp_web_page_sk#203, sales#208, profit#209, wp_web_page_sk#210, returns#211, profit_loss#212]
+
+(113) Union
+
+(114) HashAggregate [codegen id : 64]
+Input [5]: [channel#187, id#188, sales#182, returns#189, profit#190]
+Keys [2]: [channel#187, id#188]
+Functions [3]: [partial_sum(sales#182), partial_sum(returns#189), partial_sum(profit#190)]
+Aggregate Attributes [6]: [sum#217, isEmpty#218, sum#219, isEmpty#220, sum#221, isEmpty#222]
+Results [8]: [channel#187, id#188, sum#223, isEmpty#224, sum#225, isEmpty#226, sum#227, isEmpty#228]
+
+(115) HashAggregate [codegen id : 64]
+Input [8]: [channel#187, id#188, sum#223, isEmpty#224, sum#225, isEmpty#226, sum#227, isEmpty#228]
+Keys [2]: [channel#187, id#188]
+Functions [3]: [sum(sales#182), sum(returns#189), sum(profit#190)]
+Aggregate Attributes [3]: [sum(sales#182)#97, sum(returns#189)#98, sum(profit#190)#99]
+Results [3]: [sum(sales#182)#97 AS sales#229, sum(returns#189)#98 AS returns#230, sum(profit#190)#99 AS profit#231]
+
+(116) HashAggregate [codegen id : 64]
+Input [3]: [sales#229, returns#230, profit#231]
+Keys: []
+Functions [3]: [partial_sum(sales#229), partial_sum(returns#230), partial_sum(profit#231)]
+Aggregate Attributes [6]: [sum#232, isEmpty#233, sum#234, isEmpty#235, sum#236, isEmpty#237]
+Results [6]: [sum#238, isEmpty#239, sum#240, isEmpty#241, sum#242, isEmpty#243]
+
+(117) Exchange
+Input [6]: [sum#238, isEmpty#239, sum#240, isEmpty#241, sum#242, isEmpty#243]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
+
+(118) HashAggregate [codegen id : 65]
+Input [6]: [sum#238, isEmpty#239, sum#240, isEmpty#241, sum#242, isEmpty#243]
+Keys: []
+Functions [3]: [sum(sales#229), sum(returns#230), sum(profit#231)]
+Aggregate Attributes [3]: [sum(sales#229)#244, sum(returns#230)#245, sum(profit#231)#246]
+Results [5]: [null AS channel#247, null AS id#248, sum(sales#229)#244 AS sales#249, sum(returns#230)#245 AS returns#250, sum(profit#231)#246 AS profit#251]
 
 (119) Union
 
-(120) HashAggregate [codegen id : 70]
-Input [5]: [channel#196, id#197, sales#191, returns#198, profit#199]
-Keys [2]: [channel#196, id#197]
-Functions [3]: [partial_sum(sales#191), partial_sum(returns#198), partial_sum(profit#199)]
-Aggregate Attributes [6]: [sum#226, isEmpty#227, sum#228, isEmpty#229, sum#230, isEmpty#231]
-Results [8]: [channel#196, id#197, sum#232, isEmpty#233, sum#234, isEmpty#235, sum#236, isEmpty#237]
-
-(121) HashAggregate [codegen id : 70]
-Input [8]: [channel#196, id#197, sum#232, isEmpty#233, sum#234, isEmpty#235, sum#236, isEmpty#237]
-Keys [2]: [channel#196, id#197]
-Functions [3]: [sum(sales#191), sum(returns#198), sum(profit#199)]
-Aggregate Attributes [3]: [sum(sales#191)#106, sum(returns#198)#107, sum(profit#199)#108]
-Results [3]: [sum(sales#191)#106 AS sales#238, sum(returns#198)#107 AS returns#239, sum(profit#199)#108 AS profit#240]
-
-(122) HashAggregate [codegen id : 70]
-Input [3]: [sales#238, returns#239, profit#240]
-Keys: []
-Functions [3]: [partial_sum(sales#238), partial_sum(returns#239), partial_sum(profit#240)]
-Aggregate Attributes [6]: [sum#241, isEmpty#242, sum#243, isEmpty#244, sum#245, isEmpty#246]
-Results [6]: [sum#247, isEmpty#248, sum#249, isEmpty#250, sum#251, isEmpty#252]
-
-(123) Exchange
-Input [6]: [sum#247, isEmpty#248, sum#249, isEmpty#250, sum#251, isEmpty#252]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
-
-(124) HashAggregate [codegen id : 71]
-Input [6]: [sum#247, isEmpty#248, sum#249, isEmpty#250, sum#251, isEmpty#252]
-Keys: []
-Functions [3]: [sum(sales#238), sum(returns#239), sum(profit#240)]
-Aggregate Attributes [3]: [sum(sales#238)#253, sum(returns#239)#254, sum(profit#240)#255]
-Results [5]: [null AS channel#256, null AS id#257, sum(sales#238)#253 AS sales#258, sum(returns#239)#254 AS returns#259, sum(profit#240)#255 AS profit#260]
-
-(125) Union
-
-(126) HashAggregate [codegen id : 72]
-Input [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
-Keys [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
+(120) HashAggregate [codegen id : 66]
+Input [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
+Keys [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
+Results [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
 
-(127) Exchange
-Input [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
-Arguments: hashpartitioning(channel#30, id#31, sales#109, returns#110, profit#111, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+(121) Exchange
+Input [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
+Arguments: hashpartitioning(channel#30, id#31, sales#100, returns#101, profit#102, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(128) HashAggregate [codegen id : 73]
-Input [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
-Keys [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
+(122) HashAggregate [codegen id : 67]
+Input [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
+Keys [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
+Results [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
 
-(129) TakeOrderedAndProject
-Input [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
-Arguments: 100, [channel#30 ASC NULLS FIRST, id#31 ASC NULLS FIRST], [channel#30, id#31, sales#109, returns#110, profit#111]
+(123) TakeOrderedAndProject
+Input [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
+Arguments: 100, [channel#30 ASC NULLS FIRST, id#31 ASC NULLS FIRST], [channel#30, id#31, sales#100, returns#101, profit#102]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
-BroadcastExchange (134)
-+- * Project (133)
-   +- * Filter (132)
-      +- * ColumnarToRow (131)
-         +- Scan parquet spark_catalog.default.date_dim (130)
+BroadcastExchange (128)
++- * Project (127)
+   +- * Filter (126)
+      +- * ColumnarToRow (125)
+         +- Scan parquet spark_catalog.default.date_dim (124)
 
 
-(130) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#6, d_date#261]
+(124) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#6, d_date#252]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1998-08-04), LessThanOrEqual(d_date,1998-09-03), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(131) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#6, d_date#261]
+(125) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#6, d_date#252]
 
-(132) Filter [codegen id : 1]
-Input [2]: [d_date_sk#6, d_date#261]
-Condition : (((isnotnull(d_date#261) AND (d_date#261 >= 1998-08-04)) AND (d_date#261 <= 1998-09-03)) AND isnotnull(d_date_sk#6))
+(126) Filter [codegen id : 1]
+Input [2]: [d_date_sk#6, d_date#252]
+Condition : (((isnotnull(d_date#252) AND (d_date#252 >= 1998-08-04)) AND (d_date#252 <= 1998-09-03)) AND isnotnull(d_date_sk#6))
 
-(133) Project [codegen id : 1]
+(127) Project [codegen id : 1]
 Output [1]: [d_date_sk#6]
-Input [2]: [d_date_sk#6, d_date#261]
+Input [2]: [d_date_sk#6, d_date#252]
 
-(134) BroadcastExchange
+(128) BroadcastExchange
 Input [1]: [d_date_sk#6]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
 
@@ -796,10 +756,69 @@ Subquery:2 Hosting operator id = 16 Hosting Expression = sr_returned_date_sk#19 
 
 Subquery:3 Hosting operator id = 31 Hosting Expression = cs_sold_date_sk#37 IN dynamicpruning#5
 
-Subquery:4 Hosting operator id = 39 Hosting Expression = cr_returned_date_sk#49 IN dynamicpruning#5
+Subquery:4 Hosting operator id = 40 Hosting Expression = Subquery scalar-subquery#47, [id=#6]
+* Project (137)
++- * HashAggregate (136)
+   +- Exchange (135)
+      +- * HashAggregate (134)
+         +- * Project (133)
+            +- * BroadcastHashJoin Inner BuildRight (132)
+               :- * ColumnarToRow (130)
+               :  +- Scan parquet spark_catalog.default.catalog_returns (129)
+               +- ReusedExchange (131)
 
-Subquery:5 Hosting operator id = 50 Hosting Expression = ws_sold_date_sk#65 IN dynamicpruning#5
 
-Subquery:6 Hosting operator id = 65 Hosting Expression = wr_returned_date_sk#79 IN dynamicpruning#5
+(129) Scan parquet spark_catalog.default.catalog_returns
+Output [3]: [cr_return_amount#253, cr_net_loss#254, cr_returned_date_sk#255]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cr_returned_date_sk#255), dynamicpruningexpression(cr_returned_date_sk#255 IN dynamicpruning#5)]
+ReadSchema: struct<cr_return_amount:decimal(7,2),cr_net_loss:decimal(7,2)>
+
+(130) ColumnarToRow [codegen id : 2]
+Input [3]: [cr_return_amount#253, cr_net_loss#254, cr_returned_date_sk#255]
+
+(131) ReusedExchange [Reuses operator id: 128]
+Output [1]: [d_date_sk#256]
+
+(132) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [cr_returned_date_sk#255]
+Right keys [1]: [d_date_sk#256]
+Join type: Inner
+Join condition: None
+
+(133) Project [codegen id : 2]
+Output [2]: [cr_return_amount#253, cr_net_loss#254]
+Input [4]: [cr_return_amount#253, cr_net_loss#254, cr_returned_date_sk#255, d_date_sk#256]
+
+(134) HashAggregate [codegen id : 2]
+Input [2]: [cr_return_amount#253, cr_net_loss#254]
+Keys: []
+Functions [2]: [partial_sum(UnscaledValue(cr_return_amount#253)), partial_sum(UnscaledValue(cr_net_loss#254))]
+Aggregate Attributes [2]: [sum#257, sum#258]
+Results [2]: [sum#259, sum#260]
+
+(135) Exchange
+Input [2]: [sum#259, sum#260]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=16]
+
+(136) HashAggregate [codegen id : 3]
+Input [2]: [sum#259, sum#260]
+Keys: []
+Functions [2]: [sum(UnscaledValue(cr_return_amount#253)), sum(UnscaledValue(cr_net_loss#254))]
+Aggregate Attributes [2]: [sum(UnscaledValue(cr_return_amount#253))#261, sum(UnscaledValue(cr_net_loss#254))#262]
+Results [2]: [MakeDecimal(sum(UnscaledValue(cr_return_amount#253))#261,17,2) AS returns#48, MakeDecimal(sum(UnscaledValue(cr_net_loss#254))#262,17,2) AS profit_loss#49]
+
+(137) Project [codegen id : 3]
+Output [1]: [named_struct(returns, returns#48, profit_loss, profit_loss#49) AS mergedValue#263]
+Input [2]: [returns#48, profit_loss#49]
+
+Subquery:5 Hosting operator id = 129 Hosting Expression = cr_returned_date_sk#255 IN dynamicpruning#5
+
+Subquery:6 Hosting operator id = 40 Hosting Expression = ReusedSubquery Subquery scalar-subquery#47, [id=#6]
+
+Subquery:7 Hosting operator id = 44 Hosting Expression = ws_sold_date_sk#56 IN dynamicpruning#5
+
+Subquery:8 Hosting operator id = 59 Hosting Expression = wr_returned_date_sk#70 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/simplified.txt
@@ -1,13 +1,13 @@
 TakeOrderedAndProject [channel,id,sales,returns,profit]
-  WholeStageCodegen (73)
+  WholeStageCodegen (67)
     HashAggregate [channel,id,sales,returns,profit]
       InputAdapter
         Exchange [channel,id,sales,returns,profit] #1
-          WholeStageCodegen (72)
+          WholeStageCodegen (66)
             HashAggregate [channel,id,sales,returns,profit]
               InputAdapter
                 Union
-                  WholeStageCodegen (23)
+                  WholeStageCodegen (21)
                     HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                         InputAdapter
@@ -66,7 +66,7 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                             ReusedExchange [d_date_sk] #3
                                                       InputAdapter
                                                         ReusedExchange [s_store_sk] #4
-                            WholeStageCodegen (14)
+                            WholeStageCodegen (12)
                               Project [cs_call_center_sk,sales,returns,profit,profit_loss]
                                 BroadcastNestedLoopJoin
                                   HashAggregate [cs_call_center_sk,sum,sum] [sum(UnscaledValue(cs_ext_sales_price)),sum(UnscaledValue(cs_net_profit)),sales,profit,sum,sum]
@@ -84,27 +84,33 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                   ReusedExchange [d_date_sk] #3
                                   InputAdapter
                                     BroadcastExchange #8
-                                      WholeStageCodegen (13)
-                                        HashAggregate [sum,sum] [sum(UnscaledValue(cr_return_amount)),sum(UnscaledValue(cr_net_loss)),returns,profit_loss,sum,sum]
-                                          InputAdapter
-                                            Exchange #9
-                                              WholeStageCodegen (12)
-                                                HashAggregate [cr_return_amount,cr_net_loss] [sum,sum,sum,sum]
-                                                  Project [cr_return_amount,cr_net_loss]
-                                                    BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.catalog_returns [cr_return_amount,cr_net_loss,cr_returned_date_sk]
-                                                            ReusedSubquery [d_date_sk] #1
-                                                      InputAdapter
-                                                        ReusedExchange [d_date_sk] #3
-                            WholeStageCodegen (22)
+                                      WholeStageCodegen (11)
+                                        Project
+                                          Subquery #2
+                                            WholeStageCodegen (3)
+                                              Project [returns,profit_loss]
+                                                HashAggregate [sum,sum] [sum(UnscaledValue(cr_return_amount)),sum(UnscaledValue(cr_net_loss)),returns,profit_loss,sum,sum]
+                                                  InputAdapter
+                                                    Exchange #9
+                                                      WholeStageCodegen (2)
+                                                        HashAggregate [cr_return_amount,cr_net_loss] [sum,sum,sum,sum]
+                                                          Project [cr_return_amount,cr_net_loss]
+                                                            BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.catalog_returns [cr_return_amount,cr_net_loss,cr_returned_date_sk]
+                                                                    ReusedSubquery [d_date_sk] #1
+                                                              InputAdapter
+                                                                ReusedExchange [d_date_sk] #3
+                                          ReusedSubquery [mergedValue] #2
+                                          Scan OneRowRelation
+                            WholeStageCodegen (20)
                               Project [wp_web_page_sk,sales,returns,profit,profit_loss]
                                 BroadcastHashJoin [wp_web_page_sk,wp_web_page_sk]
                                   HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(ws_ext_sales_price)),sum(UnscaledValue(ws_net_profit)),sales,profit,sum,sum]
                                     InputAdapter
                                       Exchange [wp_web_page_sk] #10
-                                        WholeStageCodegen (17)
+                                        WholeStageCodegen (15)
                                           HashAggregate [wp_web_page_sk,ws_ext_sales_price,ws_net_profit] [sum,sum,sum,sum]
                                             Project [ws_ext_sales_price,ws_net_profit,wp_web_page_sk]
                                               BroadcastHashJoin [ws_web_page_sk,wp_web_page_sk]
@@ -119,18 +125,18 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                       ReusedExchange [d_date_sk] #3
                                                 InputAdapter
                                                   BroadcastExchange #11
-                                                    WholeStageCodegen (16)
+                                                    WholeStageCodegen (14)
                                                       Filter [wp_web_page_sk]
                                                         ColumnarToRow
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.web_page [wp_web_page_sk]
                                   InputAdapter
                                     BroadcastExchange #12
-                                      WholeStageCodegen (21)
+                                      WholeStageCodegen (19)
                                         HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(wr_return_amt)),sum(UnscaledValue(wr_net_loss)),returns,profit_loss,sum,sum]
                                           InputAdapter
                                             Exchange [wp_web_page_sk] #13
-                                              WholeStageCodegen (20)
+                                              WholeStageCodegen (18)
                                                 HashAggregate [wp_web_page_sk,wr_return_amt,wr_net_loss] [sum,sum,sum,sum]
                                                   Project [wr_return_amt,wr_net_loss,wp_web_page_sk]
                                                     BroadcastHashJoin [wr_web_page_sk,wp_web_page_sk]
@@ -145,17 +151,17 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                             ReusedExchange [d_date_sk] #3
                                                       InputAdapter
                                                         ReusedExchange [wp_web_page_sk] #11
-                  WholeStageCodegen (47)
+                  WholeStageCodegen (43)
                     HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
                         Exchange [channel] #14
-                          WholeStageCodegen (46)
+                          WholeStageCodegen (42)
                             HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                   InputAdapter
                                     Union
-                                      WholeStageCodegen (31)
+                                      WholeStageCodegen (29)
                                         Project [s_store_sk,sales,returns,profit,profit_loss]
                                           BroadcastHashJoin [s_store_sk,s_store_sk]
                                             HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(ss_ext_sales_price)),sum(UnscaledValue(ss_net_profit)),sales,profit,sum,sum]
@@ -163,7 +169,7 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                 ReusedExchange [s_store_sk,sum,sum] #2
                                             InputAdapter
                                               ReusedExchange [s_store_sk,returns,profit_loss] #5
-                                      WholeStageCodegen (37)
+                                      WholeStageCodegen (33)
                                         Project [cs_call_center_sk,sales,returns,profit,profit_loss]
                                           BroadcastNestedLoopJoin
                                             HashAggregate [cs_call_center_sk,sum,sum] [sum(UnscaledValue(cs_ext_sales_price)),sum(UnscaledValue(cs_net_profit)),sales,profit,sum,sum]
@@ -171,7 +177,7 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                 ReusedExchange [cs_call_center_sk,sum,sum] #7
                                             InputAdapter
                                               ReusedExchange [returns,profit_loss] #8
-                                      WholeStageCodegen (45)
+                                      WholeStageCodegen (41)
                                         Project [wp_web_page_sk,sales,returns,profit,profit_loss]
                                           BroadcastHashJoin [wp_web_page_sk,wp_web_page_sk]
                                             HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(ws_ext_sales_price)),sum(UnscaledValue(ws_net_profit)),sales,profit,sum,sum]
@@ -179,17 +185,17 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                 ReusedExchange [wp_web_page_sk,sum,sum] #10
                                             InputAdapter
                                               ReusedExchange [wp_web_page_sk,returns,profit_loss] #12
-                  WholeStageCodegen (71)
+                  WholeStageCodegen (65)
                     HashAggregate [sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),channel,id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
                         Exchange #15
-                          WholeStageCodegen (70)
+                          WholeStageCodegen (64)
                             HashAggregate [sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                   InputAdapter
                                     Union
-                                      WholeStageCodegen (55)
+                                      WholeStageCodegen (51)
                                         Project [s_store_sk,sales,returns,profit,profit_loss]
                                           BroadcastHashJoin [s_store_sk,s_store_sk]
                                             HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(ss_ext_sales_price)),sum(UnscaledValue(ss_net_profit)),sales,profit,sum,sum]
@@ -197,7 +203,7 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                 ReusedExchange [s_store_sk,sum,sum] #2
                                             InputAdapter
                                               ReusedExchange [s_store_sk,returns,profit_loss] #5
-                                      WholeStageCodegen (61)
+                                      WholeStageCodegen (55)
                                         Project [cs_call_center_sk,sales,returns,profit,profit_loss]
                                           BroadcastNestedLoopJoin
                                             HashAggregate [cs_call_center_sk,sum,sum] [sum(UnscaledValue(cs_ext_sales_price)),sum(UnscaledValue(cs_net_profit)),sales,profit,sum,sum]
@@ -205,7 +211,7 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                 ReusedExchange [cs_call_center_sk,sum,sum] #7
                                             InputAdapter
                                               ReusedExchange [returns,profit_loss] #8
-                                      WholeStageCodegen (69)
+                                      WholeStageCodegen (63)
                                         Project [wp_web_page_sk,sales,returns,profit,profit_loss]
                                           BroadcastHashJoin [wp_web_page_sk,wp_web_page_sk]
                                             HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(ws_ext_sales_price)),sum(UnscaledValue(ws_net_profit)),sales,profit,sum,sum]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/explain.txt
@@ -1,13 +1,13 @@
 == Physical Plan ==
-TakeOrderedAndProject (98)
-+- * HashAggregate (97)
-   +- Exchange (96)
-      +- * HashAggregate (95)
-         +- Union (94)
-            :- * HashAggregate (83)
-            :  +- Exchange (82)
-            :     +- * HashAggregate (81)
-            :        +- Union (80)
+TakeOrderedAndProject (92)
++- * HashAggregate (91)
+   +- Exchange (90)
+      +- * HashAggregate (89)
+         +- Union (88)
+            :- * HashAggregate (77)
+            :  +- Exchange (76)
+            :     +- * HashAggregate (75)
+            :        +- Union (74)
             :           :- * Project (30)
             :           :  +- * BroadcastHashJoin LeftOuter BuildRight (29)
             :           :     :- * HashAggregate (15)
@@ -38,8 +38,8 @@ TakeOrderedAndProject (98)
             :           :                       :     :     +- Scan parquet spark_catalog.default.store_returns (16)
             :           :                       :     +- ReusedExchange (19)
             :           :                       +- ReusedExchange (22)
-            :           :- * Project (49)
-            :           :  +- * BroadcastNestedLoopJoin Inner BuildLeft (48)
+            :           :- * Project (43)
+            :           :  +- * BroadcastNestedLoopJoin Inner BuildLeft (42)
             :           :     :- BroadcastExchange (39)
             :           :     :  +- * HashAggregate (38)
             :           :     :     +- Exchange (37)
@@ -49,54 +49,48 @@ TakeOrderedAndProject (98)
             :           :     :                 :- * ColumnarToRow (32)
             :           :     :                 :  +- Scan parquet spark_catalog.default.catalog_sales (31)
             :           :     :                 +- ReusedExchange (33)
-            :           :     +- * HashAggregate (47)
-            :           :        +- Exchange (46)
-            :           :           +- * HashAggregate (45)
-            :           :              +- * Project (44)
-            :           :                 +- * BroadcastHashJoin Inner BuildRight (43)
-            :           :                    :- * ColumnarToRow (41)
-            :           :                    :  +- Scan parquet spark_catalog.default.catalog_returns (40)
-            :           :                    +- ReusedExchange (42)
-            :           +- * Project (79)
-            :              +- * BroadcastHashJoin LeftOuter BuildRight (78)
-            :                 :- * HashAggregate (64)
-            :                 :  +- Exchange (63)
-            :                 :     +- * HashAggregate (62)
-            :                 :        +- * Project (61)
-            :                 :           +- * BroadcastHashJoin Inner BuildRight (60)
-            :                 :              :- * Project (55)
-            :                 :              :  +- * BroadcastHashJoin Inner BuildRight (54)
-            :                 :              :     :- * Filter (52)
-            :                 :              :     :  +- * ColumnarToRow (51)
-            :                 :              :     :     +- Scan parquet spark_catalog.default.web_sales (50)
-            :                 :              :     +- ReusedExchange (53)
-            :                 :              +- BroadcastExchange (59)
-            :                 :                 +- * Filter (58)
-            :                 :                    +- * ColumnarToRow (57)
-            :                 :                       +- Scan parquet spark_catalog.default.web_page (56)
-            :                 +- BroadcastExchange (77)
-            :                    +- * HashAggregate (76)
-            :                       +- Exchange (75)
-            :                          +- * HashAggregate (74)
-            :                             +- * Project (73)
-            :                                +- * BroadcastHashJoin Inner BuildRight (72)
-            :                                   :- * Project (70)
-            :                                   :  +- * BroadcastHashJoin Inner BuildRight (69)
-            :                                   :     :- * Filter (67)
-            :                                   :     :  +- * ColumnarToRow (66)
-            :                                   :     :     +- Scan parquet spark_catalog.default.web_returns (65)
-            :                                   :     +- ReusedExchange (68)
-            :                                   +- ReusedExchange (71)
-            :- * HashAggregate (88)
-            :  +- Exchange (87)
-            :     +- * HashAggregate (86)
-            :        +- * HashAggregate (85)
-            :           +- ReusedExchange (84)
-            +- * HashAggregate (93)
-               +- Exchange (92)
-                  +- * HashAggregate (91)
-                     +- * HashAggregate (90)
-                        +- ReusedExchange (89)
+            :           :     +- * Project (41)
+            :           :        +- * Scan OneRowRelation (40)
+            :           +- * Project (73)
+            :              +- * BroadcastHashJoin LeftOuter BuildRight (72)
+            :                 :- * HashAggregate (58)
+            :                 :  +- Exchange (57)
+            :                 :     +- * HashAggregate (56)
+            :                 :        +- * Project (55)
+            :                 :           +- * BroadcastHashJoin Inner BuildRight (54)
+            :                 :              :- * Project (49)
+            :                 :              :  +- * BroadcastHashJoin Inner BuildRight (48)
+            :                 :              :     :- * Filter (46)
+            :                 :              :     :  +- * ColumnarToRow (45)
+            :                 :              :     :     +- Scan parquet spark_catalog.default.web_sales (44)
+            :                 :              :     +- ReusedExchange (47)
+            :                 :              +- BroadcastExchange (53)
+            :                 :                 +- * Filter (52)
+            :                 :                    +- * ColumnarToRow (51)
+            :                 :                       +- Scan parquet spark_catalog.default.web_page (50)
+            :                 +- BroadcastExchange (71)
+            :                    +- * HashAggregate (70)
+            :                       +- Exchange (69)
+            :                          +- * HashAggregate (68)
+            :                             +- * Project (67)
+            :                                +- * BroadcastHashJoin Inner BuildRight (66)
+            :                                   :- * Project (64)
+            :                                   :  +- * BroadcastHashJoin Inner BuildRight (63)
+            :                                   :     :- * Filter (61)
+            :                                   :     :  +- * ColumnarToRow (60)
+            :                                   :     :     +- Scan parquet spark_catalog.default.web_returns (59)
+            :                                   :     +- ReusedExchange (62)
+            :                                   +- ReusedExchange (65)
+            :- * HashAggregate (82)
+            :  +- Exchange (81)
+            :     +- * HashAggregate (80)
+            :        +- * HashAggregate (79)
+            :           +- ReusedExchange (78)
+            +- * HashAggregate (87)
+               +- Exchange (86)
+                  +- * HashAggregate (85)
+                     +- * HashAggregate (84)
+                        +- ReusedExchange (83)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -114,7 +108,7 @@ Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_s
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 Condition : isnotnull(ss_store_sk#1)
 
-(4) ReusedExchange [Reuses operator id: 103]
+(4) ReusedExchange [Reuses operator id: 97]
 Output [1]: [d_date_sk#6]
 
 (5) BroadcastHashJoin [codegen id : 3]
@@ -188,7 +182,7 @@ Input [4]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, sr_returned_date_s
 Input [4]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, sr_returned_date_sk#19]
 Condition : isnotnull(sr_store_sk#16)
 
-(19) ReusedExchange [Reuses operator id: 103]
+(19) ReusedExchange [Reuses operator id: 97]
 Output [1]: [d_date_sk#20]
 
 (20) BroadcastHashJoin [codegen id : 6]
@@ -256,7 +250,7 @@ ReadSchema: struct<cs_call_center_sk:int,cs_ext_sales_price:decimal(7,2),cs_net_
 (32) ColumnarToRow [codegen id : 10]
 Input [4]: [cs_call_center_sk#34, cs_ext_sales_price#35, cs_net_profit#36, cs_sold_date_sk#37]
 
-(33) ReusedExchange [Reuses operator id: 103]
+(33) ReusedExchange [Reuses operator id: 97]
 Output [1]: [d_date_sk#38]
 
 (34) BroadcastHashJoin [codegen id : 10]
@@ -291,331 +285,297 @@ Results [3]: [cs_call_center_sk#34, MakeDecimal(sum(UnscaledValue(cs_ext_sales_p
 Input [3]: [cs_call_center_sk#34, sales#45, profit#46]
 Arguments: IdentityBroadcastMode, [plan_id=6]
 
-(40) Scan parquet spark_catalog.default.catalog_returns
-Output [3]: [cr_return_amount#47, cr_net_loss#48, cr_returned_date_sk#49]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cr_returned_date_sk#49), dynamicpruningexpression(cr_returned_date_sk#49 IN dynamicpruning#5)]
-ReadSchema: struct<cr_return_amount:decimal(7,2),cr_net_loss:decimal(7,2)>
+(40) Scan OneRowRelation
+Output: []
 
-(41) ColumnarToRow [codegen id : 13]
-Input [3]: [cr_return_amount#47, cr_net_loss#48, cr_returned_date_sk#49]
+(41) Project
+Output [2]: [Subquery scalar-subquery#47, [id=#7].returns AS returns#48, ReusedSubquery Subquery scalar-subquery#47, [id=#7].profit_loss AS profit_loss#49]
+Input: []
 
-(42) ReusedExchange [Reuses operator id: 103]
-Output [1]: [d_date_sk#50]
-
-(43) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [cr_returned_date_sk#49]
-Right keys [1]: [d_date_sk#50]
+(42) BroadcastNestedLoopJoin [codegen id : 12]
 Join type: Inner
 Join condition: None
 
-(44) Project [codegen id : 13]
-Output [2]: [cr_return_amount#47, cr_net_loss#48]
-Input [4]: [cr_return_amount#47, cr_net_loss#48, cr_returned_date_sk#49, d_date_sk#50]
+(43) Project [codegen id : 12]
+Output [5]: [catalog channel AS channel#50, cs_call_center_sk#34 AS id#51, sales#45, returns#48, (profit#46 - profit_loss#49) AS profit#52]
+Input [5]: [cs_call_center_sk#34, sales#45, profit#46, returns#48, profit_loss#49]
 
-(45) HashAggregate [codegen id : 13]
-Input [2]: [cr_return_amount#47, cr_net_loss#48]
-Keys: []
-Functions [2]: [partial_sum(UnscaledValue(cr_return_amount#47)), partial_sum(UnscaledValue(cr_net_loss#48))]
-Aggregate Attributes [2]: [sum#51, sum#52]
-Results [2]: [sum#53, sum#54]
-
-(46) Exchange
-Input [2]: [sum#53, sum#54]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
-
-(47) HashAggregate
-Input [2]: [sum#53, sum#54]
-Keys: []
-Functions [2]: [sum(UnscaledValue(cr_return_amount#47)), sum(UnscaledValue(cr_net_loss#48))]
-Aggregate Attributes [2]: [sum(UnscaledValue(cr_return_amount#47))#55, sum(UnscaledValue(cr_net_loss#48))#56]
-Results [2]: [MakeDecimal(sum(UnscaledValue(cr_return_amount#47))#55,17,2) AS returns#57, MakeDecimal(sum(UnscaledValue(cr_net_loss#48))#56,17,2) AS profit_loss#58]
-
-(48) BroadcastNestedLoopJoin [codegen id : 14]
-Join type: Inner
-Join condition: None
-
-(49) Project [codegen id : 14]
-Output [5]: [catalog channel AS channel#59, cs_call_center_sk#34 AS id#60, sales#45, returns#57, (profit#46 - profit_loss#58) AS profit#61]
-Input [5]: [cs_call_center_sk#34, sales#45, profit#46, returns#57, profit_loss#58]
-
-(50) Scan parquet spark_catalog.default.web_sales
-Output [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65]
+(44) Scan parquet spark_catalog.default.web_sales
+Output [4]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55, ws_sold_date_sk#56]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#65), dynamicpruningexpression(ws_sold_date_sk#65 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#56), dynamicpruningexpression(ws_sold_date_sk#56 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(ws_web_page_sk)]
 ReadSchema: struct<ws_web_page_sk:int,ws_ext_sales_price:decimal(7,2),ws_net_profit:decimal(7,2)>
 
-(51) ColumnarToRow [codegen id : 17]
-Input [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65]
+(45) ColumnarToRow [codegen id : 15]
+Input [4]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55, ws_sold_date_sk#56]
 
-(52) Filter [codegen id : 17]
-Input [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65]
-Condition : isnotnull(ws_web_page_sk#62)
+(46) Filter [codegen id : 15]
+Input [4]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55, ws_sold_date_sk#56]
+Condition : isnotnull(ws_web_page_sk#53)
 
-(53) ReusedExchange [Reuses operator id: 103]
-Output [1]: [d_date_sk#66]
+(47) ReusedExchange [Reuses operator id: 97]
+Output [1]: [d_date_sk#57]
 
-(54) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ws_sold_date_sk#65]
-Right keys [1]: [d_date_sk#66]
+(48) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [ws_sold_date_sk#56]
+Right keys [1]: [d_date_sk#57]
 Join type: Inner
 Join condition: None
 
-(55) Project [codegen id : 17]
-Output [3]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64]
-Input [5]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65, d_date_sk#66]
+(49) Project [codegen id : 15]
+Output [3]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55]
+Input [5]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55, ws_sold_date_sk#56, d_date_sk#57]
 
-(56) Scan parquet spark_catalog.default.web_page
-Output [1]: [wp_web_page_sk#67]
+(50) Scan parquet spark_catalog.default.web_page
+Output [1]: [wp_web_page_sk#58]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_page]
 PushedFilters: [IsNotNull(wp_web_page_sk)]
 ReadSchema: struct<wp_web_page_sk:int>
 
-(57) ColumnarToRow [codegen id : 16]
-Input [1]: [wp_web_page_sk#67]
+(51) ColumnarToRow [codegen id : 14]
+Input [1]: [wp_web_page_sk#58]
 
-(58) Filter [codegen id : 16]
-Input [1]: [wp_web_page_sk#67]
-Condition : isnotnull(wp_web_page_sk#67)
+(52) Filter [codegen id : 14]
+Input [1]: [wp_web_page_sk#58]
+Condition : isnotnull(wp_web_page_sk#58)
 
-(59) BroadcastExchange
-Input [1]: [wp_web_page_sk#67]
+(53) BroadcastExchange
+Input [1]: [wp_web_page_sk#58]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
 
-(60) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ws_web_page_sk#62]
-Right keys [1]: [wp_web_page_sk#67]
+(54) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [ws_web_page_sk#53]
+Right keys [1]: [wp_web_page_sk#58]
 Join type: Inner
 Join condition: None
 
-(61) Project [codegen id : 17]
-Output [3]: [ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#67]
-Input [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#67]
+(55) Project [codegen id : 15]
+Output [3]: [ws_ext_sales_price#54, ws_net_profit#55, wp_web_page_sk#58]
+Input [4]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55, wp_web_page_sk#58]
 
-(62) HashAggregate [codegen id : 17]
-Input [3]: [ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#67]
-Keys [1]: [wp_web_page_sk#67]
-Functions [2]: [partial_sum(UnscaledValue(ws_ext_sales_price#63)), partial_sum(UnscaledValue(ws_net_profit#64))]
-Aggregate Attributes [2]: [sum#68, sum#69]
-Results [3]: [wp_web_page_sk#67, sum#70, sum#71]
+(56) HashAggregate [codegen id : 15]
+Input [3]: [ws_ext_sales_price#54, ws_net_profit#55, wp_web_page_sk#58]
+Keys [1]: [wp_web_page_sk#58]
+Functions [2]: [partial_sum(UnscaledValue(ws_ext_sales_price#54)), partial_sum(UnscaledValue(ws_net_profit#55))]
+Aggregate Attributes [2]: [sum#59, sum#60]
+Results [3]: [wp_web_page_sk#58, sum#61, sum#62]
 
-(63) Exchange
-Input [3]: [wp_web_page_sk#67, sum#70, sum#71]
-Arguments: hashpartitioning(wp_web_page_sk#67, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+(57) Exchange
+Input [3]: [wp_web_page_sk#58, sum#61, sum#62]
+Arguments: hashpartitioning(wp_web_page_sk#58, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(64) HashAggregate [codegen id : 22]
-Input [3]: [wp_web_page_sk#67, sum#70, sum#71]
-Keys [1]: [wp_web_page_sk#67]
-Functions [2]: [sum(UnscaledValue(ws_ext_sales_price#63)), sum(UnscaledValue(ws_net_profit#64))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_sales_price#63))#72, sum(UnscaledValue(ws_net_profit#64))#73]
-Results [3]: [wp_web_page_sk#67, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#63))#72,17,2) AS sales#74, MakeDecimal(sum(UnscaledValue(ws_net_profit#64))#73,17,2) AS profit#75]
+(58) HashAggregate [codegen id : 20]
+Input [3]: [wp_web_page_sk#58, sum#61, sum#62]
+Keys [1]: [wp_web_page_sk#58]
+Functions [2]: [sum(UnscaledValue(ws_ext_sales_price#54)), sum(UnscaledValue(ws_net_profit#55))]
+Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_sales_price#54))#63, sum(UnscaledValue(ws_net_profit#55))#64]
+Results [3]: [wp_web_page_sk#58, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#54))#63,17,2) AS sales#65, MakeDecimal(sum(UnscaledValue(ws_net_profit#55))#64,17,2) AS profit#66]
 
-(65) Scan parquet spark_catalog.default.web_returns
-Output [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79]
+(59) Scan parquet spark_catalog.default.web_returns
+Output [4]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69, wr_returned_date_sk#70]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(wr_returned_date_sk#79), dynamicpruningexpression(wr_returned_date_sk#79 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(wr_returned_date_sk#70), dynamicpruningexpression(wr_returned_date_sk#70 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(wr_web_page_sk)]
 ReadSchema: struct<wr_web_page_sk:int,wr_return_amt:decimal(7,2),wr_net_loss:decimal(7,2)>
 
-(66) ColumnarToRow [codegen id : 20]
-Input [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79]
+(60) ColumnarToRow [codegen id : 18]
+Input [4]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69, wr_returned_date_sk#70]
 
-(67) Filter [codegen id : 20]
-Input [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79]
-Condition : isnotnull(wr_web_page_sk#76)
+(61) Filter [codegen id : 18]
+Input [4]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69, wr_returned_date_sk#70]
+Condition : isnotnull(wr_web_page_sk#67)
 
-(68) ReusedExchange [Reuses operator id: 103]
-Output [1]: [d_date_sk#80]
+(62) ReusedExchange [Reuses operator id: 97]
+Output [1]: [d_date_sk#71]
 
-(69) BroadcastHashJoin [codegen id : 20]
-Left keys [1]: [wr_returned_date_sk#79]
-Right keys [1]: [d_date_sk#80]
+(63) BroadcastHashJoin [codegen id : 18]
+Left keys [1]: [wr_returned_date_sk#70]
+Right keys [1]: [d_date_sk#71]
 Join type: Inner
 Join condition: None
 
-(70) Project [codegen id : 20]
-Output [3]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78]
-Input [5]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79, d_date_sk#80]
+(64) Project [codegen id : 18]
+Output [3]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69]
+Input [5]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69, wr_returned_date_sk#70, d_date_sk#71]
 
-(71) ReusedExchange [Reuses operator id: 59]
-Output [1]: [wp_web_page_sk#81]
+(65) ReusedExchange [Reuses operator id: 53]
+Output [1]: [wp_web_page_sk#72]
 
-(72) BroadcastHashJoin [codegen id : 20]
-Left keys [1]: [wr_web_page_sk#76]
-Right keys [1]: [wp_web_page_sk#81]
+(66) BroadcastHashJoin [codegen id : 18]
+Left keys [1]: [wr_web_page_sk#67]
+Right keys [1]: [wp_web_page_sk#72]
 Join type: Inner
 Join condition: None
 
-(73) Project [codegen id : 20]
-Output [3]: [wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#81]
-Input [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#81]
+(67) Project [codegen id : 18]
+Output [3]: [wr_return_amt#68, wr_net_loss#69, wp_web_page_sk#72]
+Input [4]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69, wp_web_page_sk#72]
 
-(74) HashAggregate [codegen id : 20]
-Input [3]: [wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#81]
-Keys [1]: [wp_web_page_sk#81]
-Functions [2]: [partial_sum(UnscaledValue(wr_return_amt#77)), partial_sum(UnscaledValue(wr_net_loss#78))]
-Aggregate Attributes [2]: [sum#82, sum#83]
-Results [3]: [wp_web_page_sk#81, sum#84, sum#85]
+(68) HashAggregate [codegen id : 18]
+Input [3]: [wr_return_amt#68, wr_net_loss#69, wp_web_page_sk#72]
+Keys [1]: [wp_web_page_sk#72]
+Functions [2]: [partial_sum(UnscaledValue(wr_return_amt#68)), partial_sum(UnscaledValue(wr_net_loss#69))]
+Aggregate Attributes [2]: [sum#73, sum#74]
+Results [3]: [wp_web_page_sk#72, sum#75, sum#76]
 
-(75) Exchange
-Input [3]: [wp_web_page_sk#81, sum#84, sum#85]
-Arguments: hashpartitioning(wp_web_page_sk#81, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+(69) Exchange
+Input [3]: [wp_web_page_sk#72, sum#75, sum#76]
+Arguments: hashpartitioning(wp_web_page_sk#72, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(76) HashAggregate [codegen id : 21]
-Input [3]: [wp_web_page_sk#81, sum#84, sum#85]
-Keys [1]: [wp_web_page_sk#81]
-Functions [2]: [sum(UnscaledValue(wr_return_amt#77)), sum(UnscaledValue(wr_net_loss#78))]
-Aggregate Attributes [2]: [sum(UnscaledValue(wr_return_amt#77))#86, sum(UnscaledValue(wr_net_loss#78))#87]
-Results [3]: [wp_web_page_sk#81, MakeDecimal(sum(UnscaledValue(wr_return_amt#77))#86,17,2) AS returns#88, MakeDecimal(sum(UnscaledValue(wr_net_loss#78))#87,17,2) AS profit_loss#89]
+(70) HashAggregate [codegen id : 19]
+Input [3]: [wp_web_page_sk#72, sum#75, sum#76]
+Keys [1]: [wp_web_page_sk#72]
+Functions [2]: [sum(UnscaledValue(wr_return_amt#68)), sum(UnscaledValue(wr_net_loss#69))]
+Aggregate Attributes [2]: [sum(UnscaledValue(wr_return_amt#68))#77, sum(UnscaledValue(wr_net_loss#69))#78]
+Results [3]: [wp_web_page_sk#72, MakeDecimal(sum(UnscaledValue(wr_return_amt#68))#77,17,2) AS returns#79, MakeDecimal(sum(UnscaledValue(wr_net_loss#69))#78,17,2) AS profit_loss#80]
 
-(77) BroadcastExchange
-Input [3]: [wp_web_page_sk#81, returns#88, profit_loss#89]
+(71) BroadcastExchange
+Input [3]: [wp_web_page_sk#72, returns#79, profit_loss#80]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-(78) BroadcastHashJoin [codegen id : 22]
-Left keys [1]: [wp_web_page_sk#67]
-Right keys [1]: [wp_web_page_sk#81]
+(72) BroadcastHashJoin [codegen id : 20]
+Left keys [1]: [wp_web_page_sk#58]
+Right keys [1]: [wp_web_page_sk#72]
 Join type: LeftOuter
 Join condition: None
 
-(79) Project [codegen id : 22]
-Output [5]: [web channel AS channel#90, wp_web_page_sk#67 AS id#91, sales#74, coalesce(returns#88, 0.00) AS returns#92, (profit#75 - coalesce(profit_loss#89, 0.00)) AS profit#93]
-Input [6]: [wp_web_page_sk#67, sales#74, profit#75, wp_web_page_sk#81, returns#88, profit_loss#89]
+(73) Project [codegen id : 20]
+Output [5]: [web channel AS channel#81, wp_web_page_sk#58 AS id#82, sales#65, coalesce(returns#79, 0.00) AS returns#83, (profit#66 - coalesce(profit_loss#80, 0.00)) AS profit#84]
+Input [6]: [wp_web_page_sk#58, sales#65, profit#66, wp_web_page_sk#72, returns#79, profit_loss#80]
 
-(80) Union
+(74) Union
 
-(81) HashAggregate [codegen id : 23]
+(75) HashAggregate [codegen id : 21]
 Input [5]: [channel#30, id#31, sales#14, returns#32, profit#33]
 Keys [2]: [channel#30, id#31]
 Functions [3]: [partial_sum(sales#14), partial_sum(returns#32), partial_sum(profit#33)]
-Aggregate Attributes [6]: [sum#94, isEmpty#95, sum#96, isEmpty#97, sum#98, isEmpty#99]
-Results [8]: [channel#30, id#31, sum#100, isEmpty#101, sum#102, isEmpty#103, sum#104, isEmpty#105]
+Aggregate Attributes [6]: [sum#85, isEmpty#86, sum#87, isEmpty#88, sum#89, isEmpty#90]
+Results [8]: [channel#30, id#31, sum#91, isEmpty#92, sum#93, isEmpty#94, sum#95, isEmpty#96]
 
-(82) Exchange
-Input [8]: [channel#30, id#31, sum#100, isEmpty#101, sum#102, isEmpty#103, sum#104, isEmpty#105]
+(76) Exchange
+Input [8]: [channel#30, id#31, sum#91, isEmpty#92, sum#93, isEmpty#94, sum#95, isEmpty#96]
 Arguments: hashpartitioning(channel#30, id#31, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(83) HashAggregate [codegen id : 24]
-Input [8]: [channel#30, id#31, sum#100, isEmpty#101, sum#102, isEmpty#103, sum#104, isEmpty#105]
+(77) HashAggregate [codegen id : 22]
+Input [8]: [channel#30, id#31, sum#91, isEmpty#92, sum#93, isEmpty#94, sum#95, isEmpty#96]
 Keys [2]: [channel#30, id#31]
 Functions [3]: [sum(sales#14), sum(returns#32), sum(profit#33)]
-Aggregate Attributes [3]: [sum(sales#14)#106, sum(returns#32)#107, sum(profit#33)#108]
-Results [5]: [channel#30, id#31, cast(sum(sales#14)#106 as decimal(37,2)) AS sales#109, cast(sum(returns#32)#107 as decimal(37,2)) AS returns#110, cast(sum(profit#33)#108 as decimal(38,2)) AS profit#111]
+Aggregate Attributes [3]: [sum(sales#14)#97, sum(returns#32)#98, sum(profit#33)#99]
+Results [5]: [channel#30, id#31, cast(sum(sales#14)#97 as decimal(37,2)) AS sales#100, cast(sum(returns#32)#98 as decimal(37,2)) AS returns#101, cast(sum(profit#33)#99 as decimal(38,2)) AS profit#102]
 
-(84) ReusedExchange [Reuses operator id: 82]
-Output [8]: [channel#112, id#113, sum#114, isEmpty#115, sum#116, isEmpty#117, sum#118, isEmpty#119]
+(78) ReusedExchange [Reuses operator id: 76]
+Output [8]: [channel#103, id#104, sum#105, isEmpty#106, sum#107, isEmpty#108, sum#109, isEmpty#110]
 
-(85) HashAggregate [codegen id : 48]
-Input [8]: [channel#112, id#113, sum#114, isEmpty#115, sum#116, isEmpty#117, sum#118, isEmpty#119]
-Keys [2]: [channel#112, id#113]
-Functions [3]: [sum(sales#120), sum(returns#121), sum(profit#122)]
-Aggregate Attributes [3]: [sum(sales#120)#106, sum(returns#121)#107, sum(profit#122)#108]
-Results [4]: [channel#112, sum(sales#120)#106 AS sales#123, sum(returns#121)#107 AS returns#124, sum(profit#122)#108 AS profit#125]
+(79) HashAggregate [codegen id : 44]
+Input [8]: [channel#103, id#104, sum#105, isEmpty#106, sum#107, isEmpty#108, sum#109, isEmpty#110]
+Keys [2]: [channel#103, id#104]
+Functions [3]: [sum(sales#111), sum(returns#112), sum(profit#113)]
+Aggregate Attributes [3]: [sum(sales#111)#97, sum(returns#112)#98, sum(profit#113)#99]
+Results [4]: [channel#103, sum(sales#111)#97 AS sales#114, sum(returns#112)#98 AS returns#115, sum(profit#113)#99 AS profit#116]
 
-(86) HashAggregate [codegen id : 48]
-Input [4]: [channel#112, sales#123, returns#124, profit#125]
-Keys [1]: [channel#112]
-Functions [3]: [partial_sum(sales#123), partial_sum(returns#124), partial_sum(profit#125)]
-Aggregate Attributes [6]: [sum#126, isEmpty#127, sum#128, isEmpty#129, sum#130, isEmpty#131]
-Results [7]: [channel#112, sum#132, isEmpty#133, sum#134, isEmpty#135, sum#136, isEmpty#137]
+(80) HashAggregate [codegen id : 44]
+Input [4]: [channel#103, sales#114, returns#115, profit#116]
+Keys [1]: [channel#103]
+Functions [3]: [partial_sum(sales#114), partial_sum(returns#115), partial_sum(profit#116)]
+Aggregate Attributes [6]: [sum#117, isEmpty#118, sum#119, isEmpty#120, sum#121, isEmpty#122]
+Results [7]: [channel#103, sum#123, isEmpty#124, sum#125, isEmpty#126, sum#127, isEmpty#128]
 
-(87) Exchange
-Input [7]: [channel#112, sum#132, isEmpty#133, sum#134, isEmpty#135, sum#136, isEmpty#137]
-Arguments: hashpartitioning(channel#112, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+(81) Exchange
+Input [7]: [channel#103, sum#123, isEmpty#124, sum#125, isEmpty#126, sum#127, isEmpty#128]
+Arguments: hashpartitioning(channel#103, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(88) HashAggregate [codegen id : 49]
-Input [7]: [channel#112, sum#132, isEmpty#133, sum#134, isEmpty#135, sum#136, isEmpty#137]
-Keys [1]: [channel#112]
-Functions [3]: [sum(sales#123), sum(returns#124), sum(profit#125)]
-Aggregate Attributes [3]: [sum(sales#123)#138, sum(returns#124)#139, sum(profit#125)#140]
-Results [5]: [channel#112, null AS id#141, sum(sales#123)#138 AS sales#142, sum(returns#124)#139 AS returns#143, sum(profit#125)#140 AS profit#144]
+(82) HashAggregate [codegen id : 45]
+Input [7]: [channel#103, sum#123, isEmpty#124, sum#125, isEmpty#126, sum#127, isEmpty#128]
+Keys [1]: [channel#103]
+Functions [3]: [sum(sales#114), sum(returns#115), sum(profit#116)]
+Aggregate Attributes [3]: [sum(sales#114)#129, sum(returns#115)#130, sum(profit#116)#131]
+Results [5]: [channel#103, null AS id#132, sum(sales#114)#129 AS sales#133, sum(returns#115)#130 AS returns#134, sum(profit#116)#131 AS profit#135]
 
-(89) ReusedExchange [Reuses operator id: 82]
-Output [8]: [channel#145, id#146, sum#147, isEmpty#148, sum#149, isEmpty#150, sum#151, isEmpty#152]
+(83) ReusedExchange [Reuses operator id: 76]
+Output [8]: [channel#136, id#137, sum#138, isEmpty#139, sum#140, isEmpty#141, sum#142, isEmpty#143]
 
-(90) HashAggregate [codegen id : 73]
-Input [8]: [channel#145, id#146, sum#147, isEmpty#148, sum#149, isEmpty#150, sum#151, isEmpty#152]
-Keys [2]: [channel#145, id#146]
-Functions [3]: [sum(sales#153), sum(returns#154), sum(profit#155)]
-Aggregate Attributes [3]: [sum(sales#153)#106, sum(returns#154)#107, sum(profit#155)#108]
-Results [3]: [sum(sales#153)#106 AS sales#156, sum(returns#154)#107 AS returns#157, sum(profit#155)#108 AS profit#158]
+(84) HashAggregate [codegen id : 67]
+Input [8]: [channel#136, id#137, sum#138, isEmpty#139, sum#140, isEmpty#141, sum#142, isEmpty#143]
+Keys [2]: [channel#136, id#137]
+Functions [3]: [sum(sales#144), sum(returns#145), sum(profit#146)]
+Aggregate Attributes [3]: [sum(sales#144)#97, sum(returns#145)#98, sum(profit#146)#99]
+Results [3]: [sum(sales#144)#97 AS sales#147, sum(returns#145)#98 AS returns#148, sum(profit#146)#99 AS profit#149]
 
-(91) HashAggregate [codegen id : 73]
-Input [3]: [sales#156, returns#157, profit#158]
+(85) HashAggregate [codegen id : 67]
+Input [3]: [sales#147, returns#148, profit#149]
 Keys: []
-Functions [3]: [partial_sum(sales#156), partial_sum(returns#157), partial_sum(profit#158)]
-Aggregate Attributes [6]: [sum#159, isEmpty#160, sum#161, isEmpty#162, sum#163, isEmpty#164]
-Results [6]: [sum#165, isEmpty#166, sum#167, isEmpty#168, sum#169, isEmpty#170]
+Functions [3]: [partial_sum(sales#147), partial_sum(returns#148), partial_sum(profit#149)]
+Aggregate Attributes [6]: [sum#150, isEmpty#151, sum#152, isEmpty#153, sum#154, isEmpty#155]
+Results [6]: [sum#156, isEmpty#157, sum#158, isEmpty#159, sum#160, isEmpty#161]
 
-(92) Exchange
-Input [6]: [sum#165, isEmpty#166, sum#167, isEmpty#168, sum#169, isEmpty#170]
+(86) Exchange
+Input [6]: [sum#156, isEmpty#157, sum#158, isEmpty#159, sum#160, isEmpty#161]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
 
-(93) HashAggregate [codegen id : 74]
-Input [6]: [sum#165, isEmpty#166, sum#167, isEmpty#168, sum#169, isEmpty#170]
+(87) HashAggregate [codegen id : 68]
+Input [6]: [sum#156, isEmpty#157, sum#158, isEmpty#159, sum#160, isEmpty#161]
 Keys: []
-Functions [3]: [sum(sales#156), sum(returns#157), sum(profit#158)]
-Aggregate Attributes [3]: [sum(sales#156)#171, sum(returns#157)#172, sum(profit#158)#173]
-Results [5]: [null AS channel#174, null AS id#175, sum(sales#156)#171 AS sales#176, sum(returns#157)#172 AS returns#177, sum(profit#158)#173 AS profit#178]
+Functions [3]: [sum(sales#147), sum(returns#148), sum(profit#149)]
+Aggregate Attributes [3]: [sum(sales#147)#162, sum(returns#148)#163, sum(profit#149)#164]
+Results [5]: [null AS channel#165, null AS id#166, sum(sales#147)#162 AS sales#167, sum(returns#148)#163 AS returns#168, sum(profit#149)#164 AS profit#169]
 
-(94) Union
+(88) Union
 
-(95) HashAggregate [codegen id : 75]
-Input [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
-Keys [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
+(89) HashAggregate [codegen id : 69]
+Input [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
+Keys [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
+Results [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
 
-(96) Exchange
-Input [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
-Arguments: hashpartitioning(channel#30, id#31, sales#109, returns#110, profit#111, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+(90) Exchange
+Input [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
+Arguments: hashpartitioning(channel#30, id#31, sales#100, returns#101, profit#102, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(97) HashAggregate [codegen id : 76]
-Input [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
-Keys [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
+(91) HashAggregate [codegen id : 70]
+Input [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
+Keys [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
+Results [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
 
-(98) TakeOrderedAndProject
-Input [5]: [channel#30, id#31, sales#109, returns#110, profit#111]
-Arguments: 100, [channel#30 ASC NULLS FIRST, id#31 ASC NULLS FIRST], [channel#30, id#31, sales#109, returns#110, profit#111]
+(92) TakeOrderedAndProject
+Input [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
+Arguments: 100, [channel#30 ASC NULLS FIRST, id#31 ASC NULLS FIRST], [channel#30, id#31, sales#100, returns#101, profit#102]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
-BroadcastExchange (103)
-+- * Project (102)
-   +- * Filter (101)
-      +- * ColumnarToRow (100)
-         +- Scan parquet spark_catalog.default.date_dim (99)
+BroadcastExchange (97)
++- * Project (96)
+   +- * Filter (95)
+      +- * ColumnarToRow (94)
+         +- Scan parquet spark_catalog.default.date_dim (93)
 
 
-(99) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#6, d_date#179]
+(93) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#6, d_date#170]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1998-08-04), LessThanOrEqual(d_date,1998-09-03), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(100) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#6, d_date#179]
+(94) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#6, d_date#170]
 
-(101) Filter [codegen id : 1]
-Input [2]: [d_date_sk#6, d_date#179]
-Condition : (((isnotnull(d_date#179) AND (d_date#179 >= 1998-08-04)) AND (d_date#179 <= 1998-09-03)) AND isnotnull(d_date_sk#6))
+(95) Filter [codegen id : 1]
+Input [2]: [d_date_sk#6, d_date#170]
+Condition : (((isnotnull(d_date#170) AND (d_date#170 >= 1998-08-04)) AND (d_date#170 <= 1998-09-03)) AND isnotnull(d_date_sk#6))
 
-(102) Project [codegen id : 1]
+(96) Project [codegen id : 1]
 Output [1]: [d_date_sk#6]
-Input [2]: [d_date_sk#6, d_date#179]
+Input [2]: [d_date_sk#6, d_date#170]
 
-(103) BroadcastExchange
+(97) BroadcastExchange
 Input [1]: [d_date_sk#6]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=16]
 
@@ -623,10 +583,69 @@ Subquery:2 Hosting operator id = 16 Hosting Expression = sr_returned_date_sk#19 
 
 Subquery:3 Hosting operator id = 31 Hosting Expression = cs_sold_date_sk#37 IN dynamicpruning#5
 
-Subquery:4 Hosting operator id = 40 Hosting Expression = cr_returned_date_sk#49 IN dynamicpruning#5
+Subquery:4 Hosting operator id = 41 Hosting Expression = Subquery scalar-subquery#47, [id=#7]
+* Project (106)
++- * HashAggregate (105)
+   +- Exchange (104)
+      +- * HashAggregate (103)
+         +- * Project (102)
+            +- * BroadcastHashJoin Inner BuildRight (101)
+               :- * ColumnarToRow (99)
+               :  +- Scan parquet spark_catalog.default.catalog_returns (98)
+               +- ReusedExchange (100)
 
-Subquery:5 Hosting operator id = 50 Hosting Expression = ws_sold_date_sk#65 IN dynamicpruning#5
 
-Subquery:6 Hosting operator id = 65 Hosting Expression = wr_returned_date_sk#79 IN dynamicpruning#5
+(98) Scan parquet spark_catalog.default.catalog_returns
+Output [3]: [cr_return_amount#171, cr_net_loss#172, cr_returned_date_sk#173]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cr_returned_date_sk#173), dynamicpruningexpression(cr_returned_date_sk#173 IN dynamicpruning#5)]
+ReadSchema: struct<cr_return_amount:decimal(7,2),cr_net_loss:decimal(7,2)>
+
+(99) ColumnarToRow [codegen id : 2]
+Input [3]: [cr_return_amount#171, cr_net_loss#172, cr_returned_date_sk#173]
+
+(100) ReusedExchange [Reuses operator id: 97]
+Output [1]: [d_date_sk#174]
+
+(101) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [cr_returned_date_sk#173]
+Right keys [1]: [d_date_sk#174]
+Join type: Inner
+Join condition: None
+
+(102) Project [codegen id : 2]
+Output [2]: [cr_return_amount#171, cr_net_loss#172]
+Input [4]: [cr_return_amount#171, cr_net_loss#172, cr_returned_date_sk#173, d_date_sk#174]
+
+(103) HashAggregate [codegen id : 2]
+Input [2]: [cr_return_amount#171, cr_net_loss#172]
+Keys: []
+Functions [2]: [partial_sum(UnscaledValue(cr_return_amount#171)), partial_sum(UnscaledValue(cr_net_loss#172))]
+Aggregate Attributes [2]: [sum#175, sum#176]
+Results [2]: [sum#177, sum#178]
+
+(104) Exchange
+Input [2]: [sum#177, sum#178]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
+
+(105) HashAggregate [codegen id : 3]
+Input [2]: [sum#177, sum#178]
+Keys: []
+Functions [2]: [sum(UnscaledValue(cr_return_amount#171)), sum(UnscaledValue(cr_net_loss#172))]
+Aggregate Attributes [2]: [sum(UnscaledValue(cr_return_amount#171))#179, sum(UnscaledValue(cr_net_loss#172))#180]
+Results [2]: [MakeDecimal(sum(UnscaledValue(cr_return_amount#171))#179,17,2) AS returns#48, MakeDecimal(sum(UnscaledValue(cr_net_loss#172))#180,17,2) AS profit_loss#49]
+
+(106) Project [codegen id : 3]
+Output [1]: [named_struct(returns, returns#48, profit_loss, profit_loss#49) AS mergedValue#181]
+Input [2]: [returns#48, profit_loss#49]
+
+Subquery:5 Hosting operator id = 98 Hosting Expression = cr_returned_date_sk#173 IN dynamicpruning#5
+
+Subquery:6 Hosting operator id = 41 Hosting Expression = ReusedSubquery Subquery scalar-subquery#47, [id=#7]
+
+Subquery:7 Hosting operator id = 44 Hosting Expression = ws_sold_date_sk#56 IN dynamicpruning#5
+
+Subquery:8 Hosting operator id = 59 Hosting Expression = wr_returned_date_sk#70 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/simplified.txt
@@ -1,17 +1,17 @@
 TakeOrderedAndProject [channel,id,sales,returns,profit]
-  WholeStageCodegen (76)
+  WholeStageCodegen (70)
     HashAggregate [channel,id,sales,returns,profit]
       InputAdapter
         Exchange [channel,id,sales,returns,profit] #1
-          WholeStageCodegen (75)
+          WholeStageCodegen (69)
             HashAggregate [channel,id,sales,returns,profit]
               InputAdapter
                 Union
-                  WholeStageCodegen (24)
+                  WholeStageCodegen (22)
                     HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
                         Exchange [channel,id] #2
-                          WholeStageCodegen (23)
+                          WholeStageCodegen (21)
                             HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               InputAdapter
                                 Union
@@ -69,7 +69,7 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                   ReusedExchange [d_date_sk] #4
                                                             InputAdapter
                                                               ReusedExchange [s_store_sk] #5
-                                  WholeStageCodegen (14)
+                                  WholeStageCodegen (12)
                                     Project [cs_call_center_sk,sales,returns,profit,profit_loss]
                                       BroadcastNestedLoopJoin
                                         InputAdapter
@@ -88,26 +88,32 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                   ReusedSubquery [d_date_sk] #1
                                                             InputAdapter
                                                               ReusedExchange [d_date_sk] #4
-                                        HashAggregate [sum,sum] [sum(UnscaledValue(cr_return_amount)),sum(UnscaledValue(cr_net_loss)),returns,profit_loss,sum,sum]
-                                          InputAdapter
-                                            Exchange #10
-                                              WholeStageCodegen (13)
-                                                HashAggregate [cr_return_amount,cr_net_loss] [sum,sum,sum,sum]
-                                                  Project [cr_return_amount,cr_net_loss]
-                                                    BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.catalog_returns [cr_return_amount,cr_net_loss,cr_returned_date_sk]
-                                                            ReusedSubquery [d_date_sk] #1
-                                                      InputAdapter
-                                                        ReusedExchange [d_date_sk] #4
-                                  WholeStageCodegen (22)
+                                        Project
+                                          Subquery #2
+                                            WholeStageCodegen (3)
+                                              Project [returns,profit_loss]
+                                                HashAggregate [sum,sum] [sum(UnscaledValue(cr_return_amount)),sum(UnscaledValue(cr_net_loss)),returns,profit_loss,sum,sum]
+                                                  InputAdapter
+                                                    Exchange #10
+                                                      WholeStageCodegen (2)
+                                                        HashAggregate [cr_return_amount,cr_net_loss] [sum,sum,sum,sum]
+                                                          Project [cr_return_amount,cr_net_loss]
+                                                            BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.catalog_returns [cr_return_amount,cr_net_loss,cr_returned_date_sk]
+                                                                    ReusedSubquery [d_date_sk] #1
+                                                              InputAdapter
+                                                                ReusedExchange [d_date_sk] #4
+                                          ReusedSubquery [mergedValue] #2
+                                          Scan OneRowRelation
+                                  WholeStageCodegen (20)
                                     Project [wp_web_page_sk,sales,returns,profit,profit_loss]
                                       BroadcastHashJoin [wp_web_page_sk,wp_web_page_sk]
                                         HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(ws_ext_sales_price)),sum(UnscaledValue(ws_net_profit)),sales,profit,sum,sum]
                                           InputAdapter
                                             Exchange [wp_web_page_sk] #11
-                                              WholeStageCodegen (17)
+                                              WholeStageCodegen (15)
                                                 HashAggregate [wp_web_page_sk,ws_ext_sales_price,ws_net_profit] [sum,sum,sum,sum]
                                                   Project [ws_ext_sales_price,ws_net_profit,wp_web_page_sk]
                                                     BroadcastHashJoin [ws_web_page_sk,wp_web_page_sk]
@@ -122,18 +128,18 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                             ReusedExchange [d_date_sk] #4
                                                       InputAdapter
                                                         BroadcastExchange #12
-                                                          WholeStageCodegen (16)
+                                                          WholeStageCodegen (14)
                                                             Filter [wp_web_page_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.web_page [wp_web_page_sk]
                                         InputAdapter
                                           BroadcastExchange #13
-                                            WholeStageCodegen (21)
+                                            WholeStageCodegen (19)
                                               HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(wr_return_amt)),sum(UnscaledValue(wr_net_loss)),returns,profit_loss,sum,sum]
                                                 InputAdapter
                                                   Exchange [wp_web_page_sk] #14
-                                                    WholeStageCodegen (20)
+                                                    WholeStageCodegen (18)
                                                       HashAggregate [wp_web_page_sk,wr_return_amt,wr_net_loss] [sum,sum,sum,sum]
                                                         Project [wr_return_amt,wr_net_loss,wp_web_page_sk]
                                                           BroadcastHashJoin [wr_web_page_sk,wp_web_page_sk]
@@ -148,20 +154,20 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                   ReusedExchange [d_date_sk] #4
                                                             InputAdapter
                                                               ReusedExchange [wp_web_page_sk] #12
-                  WholeStageCodegen (49)
+                  WholeStageCodegen (45)
                     HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
                         Exchange [channel] #15
-                          WholeStageCodegen (48)
+                          WholeStageCodegen (44)
                             HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 InputAdapter
                                   ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2
-                  WholeStageCodegen (74)
+                  WholeStageCodegen (68)
                     HashAggregate [sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),channel,id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
                         Exchange #16
-                          WholeStageCodegen (73)
+                          WholeStageCodegen (67)
                             HashAggregate [sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 InputAdapter


### PR DESCRIPTION
### What changes were proposed in this pull request?

`DynamicPruningSubquery.canonicalized` now normalizes `buildKeys` relative to `buildQuery.output` using `QueryPlan.normalizeExpressions` instead of calling `.canonicalized` on each key expression independently.

### Why are the changes needed?

The previous implementation called `buildKeys.map(_.canonicalized)`, which canonicalized each key expression in isolation and therefore preserved the original `ExprId` values of attribute references. When two `DynamicPruningSubquery` instances referenced the same logical build query (e.g. different copies of a CTE branch) but with different `ExprId`s, their canonical `buildKeys` differed even though the queries were semantically identical.

`QueryPlan.normalizeExpressions(key, buildQuery.output)` replaces each attribute reference with `ExprId(ordinal)` where `ordinal` is the attribute's position in `buildQuery.output`. Two copies of the same CTE branch will place the same attribute at the same ordinal, so the canonical `buildKeys` become identical regardless of the original `ExprId` values.

### Does this PR introduce _any_ user-facing change?

No. This is an internal canonicalization fix. It may improve query plans by enabling `PlanMerger` to deduplicate more `DynamicPruningSubquery` expressions, but does not change observable query results.

### How was this patch tested?

Added a unit test in `DynamicPruningSubquerySuite` that constructs two `DynamicPruningSubquery` instances with identical build query structure but fresh (distinct) `ExprId`s, and asserts that their `canonicalized` forms are equal.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 4.6
