### PR TITLE
[SPARK-56681][SQL] PATH cleanup

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -141,18 +141,15 @@ object FakeV2SessionCatalog extends TableCatalog with FunctionCatalog with Suppo
  *                  expressions in a subquery.
  * @param resolutionPathEntries When resolving a view or SQL function body, the ordered frozen
  *                              path for unqualified relation/function names (if persisted in
- *                              metadata). Outside views/functions, compute from session
- *                              [[CatalogManager.sqlResolutionPathEntries]].
- *                              Lifecycle: set only by [[withAnalysisContext(viewDesc)]] /
- *                              [[withAnalysisContext(function)]]; preserved by
- *                              [[withOuterPlan]]; cleared by [[reset]] /
- *                              [[withNewAnalysisContext]]; never mutated after
- *                              [[AnalysisContext]] construction. The single-pass resolver
- *                              project intentionally avoids new threadlocal state -- when the
- *                              single-pass `Resolver` grows view / SQL-function body support,
- *                              the frozen path should flow via the resolver's
- *                              `OperatorResolutionContextStack` instead of being read from this
- *                              field. See SPARK-56681 #3.
+ *                              metadata). Outside views/functions, compute from
+ *                              [[CatalogManager.sqlResolutionPathEntries]]. Set only by
+ *                              [[withAnalysisContext(viewDesc)]] /
+ *                              [[withAnalysisContext(function)]], preserved by
+ *                              [[withOuterPlan]], cleared by [[reset]] /
+ *                              [[withNewAnalysisContext]], and never mutated after
+ *                              construction.
+ *                              TODO(SPARK-56681 #3): plumb through the single-pass resolver's
+ *                              `OperatorResolutionContextStack` and remove this field.
  */
 case class AnalysisContext(
     isDefault: Boolean = false,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -141,15 +141,8 @@ object FakeV2SessionCatalog extends TableCatalog with FunctionCatalog with Suppo
  *                  expressions in a subquery.
  * @param resolutionPathEntries When resolving a view or SQL function body, the ordered frozen
  *                              path for unqualified relation/function names (if persisted in
- *                              metadata). Outside views/functions, compute from
- *                              [[CatalogManager.sqlResolutionPathEntries]]. Set only by
- *                              [[withAnalysisContext(viewDesc)]] /
- *                              [[withAnalysisContext(function)]], preserved by
- *                              [[withOuterPlan]], cleared by [[reset]] /
- *                              [[withNewAnalysisContext]], and never mutated after
- *                              construction.
- *                              TODO(SPARK-56681 #3): plumb through the single-pass resolver's
- *                              `OperatorResolutionContextStack` and remove this field.
+ *                              metadata). Outside views/functions, compute from session
+ *                              [[CatalogManager.sqlResolutionPathEntries]].
  */
 case class AnalysisContext(
     isDefault: Boolean = false,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -143,6 +143,16 @@ object FakeV2SessionCatalog extends TableCatalog with FunctionCatalog with Suppo
  *                              path for unqualified relation/function names (if persisted in
  *                              metadata). Outside views/functions, compute from session
  *                              [[CatalogManager.sqlResolutionPathEntries]].
+ *                              Lifecycle: set only by [[withAnalysisContext(viewDesc)]] /
+ *                              [[withAnalysisContext(function)]]; preserved by
+ *                              [[withOuterPlan]]; cleared by [[reset]] /
+ *                              [[withNewAnalysisContext]]; never mutated after
+ *                              [[AnalysisContext]] construction. The single-pass resolver
+ *                              project intentionally avoids new threadlocal state -- when the
+ *                              single-pass `Resolver` grows view / SQL-function body support,
+ *                              the frozen path should flow via the resolver's
+ *                              `OperatorResolutionContextStack` instead of being read from this
+ *                              field. See SPARK-56681 #3.
  */
 case class AnalysisContext(
     isDefault: Boolean = false,
@@ -337,10 +347,7 @@ class Analyzer(
         AnalysisContext.reset()
         try {
           AnalysisHelper.markInAnalyzer {
-            sessionConf match {
-              case Some(c) => SQLConf.withExistingConf(c) { runAnalysis() }
-              case None => runAnalysis()
-            }
+            runWithSessionConf(runAnalysis())
           }
         } finally {
           AnalysisContext.reset()
@@ -348,14 +355,27 @@ class Analyzer(
       } else {
         AnalysisContext.withNewAnalysisContext {
           AnalysisHelper.markInAnalyzer {
-            sessionConf match {
-              case Some(c) => SQLConf.withExistingConf(c) { runAnalysis() }
-              case None => runAnalysis()
-            }
+            runWithSessionConf(runAnalysis())
           }
         }
       }
     }
+  }
+
+  /**
+   * Runs `thunk` under the analyzer's [[sessionConf]] for analyzer isolation, but yields to any
+   * outer [[SQLConf.withExistingConf]] scope (e.g. a SQL UDF / view body that pinned the
+   * creation-time configs). Falls through unchanged when [[sessionConf]] is unset, or when the
+   * outer scope already installed a different conf -- otherwise the outer scope's conf would be
+   * silently clobbered.
+   */
+  private def runWithSessionConf[T](thunk: => T): T = sessionConf match {
+    case None => thunk
+    case Some(c) =>
+      SQLConf.getExistingConfIfSet match {
+        case Some(outer) if outer ne c => thunk
+        case _ => SQLConf.withExistingConf(c) { thunk }
+      }
   }
 
   /**
@@ -391,13 +411,8 @@ class Analyzer(
     }
   }
 
-  private def executeSameContext(plan: LogicalPlan): LogicalPlan = sessionConf match {
-    // Respect explicit nested SQLConf overrides (e.g. persisted SQL UDF/view configs).
-    // Otherwise, run analysis with the captured session conf for analyzer isolation.
-    case Some(c) if SQLConf.get ne c => super.execute(plan)
-    case Some(c) => SQLConf.withExistingConf(c) { super.execute(plan) }
-    case None => super.execute(plan)
-  }
+  private def executeSameContext(plan: LogicalPlan): LogicalPlan =
+    runWithSessionConf(super.execute(plan))
 
   def resolver: Resolver = conf.resolver
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionResolution.scala
@@ -89,11 +89,9 @@ class FunctionResolution(
    *
    * All other multi-part names are returned as-is for downstream resolution.
    *
-   * Routes through [[CatalogManager.resolutionPathEntriesForAnalysis]] so that view / SQL
-   * function bodies with a persisted frozen path are honored, matching
-   * [[RelationResolution.relationResolutionEntries]] so routine order stays aligned with
-   * relation order. Procedure resolution also goes through this helper -- see
-   * [[resolveProcedure]].
+   * Shares [[CatalogManager.resolutionPathEntriesForAnalysis]] with
+   * [[RelationResolution.relationResolutionEntries]] so routine and relation lookup follow the
+   * same order under PATH (and the same persisted frozen path for view / SQL function bodies).
    */
   private[analysis] def sqlResolutionPathEntriesForAnalysis: Seq[Seq[String]] =
     catalogManager.resolutionPathEntriesForAnalysis(
@@ -356,10 +354,9 @@ class FunctionResolution(
     if (nameParts.length == 1) {
       // Must match [[resolutionCandidates]] / [[resolveFunction]]: single-part names use PATH +
       // session order, not only the current namespace (LookupCatalog single-part rule).
-      // Filter out `system.*` candidates: routines under `system.session`, `system.builtin`, and
-      // `system.ai` are already resolved by [[lookupBuiltinOrTempFunction]] /
-      // [[lookupBuiltinOrTempTableFunction]] earlier in this method, so calling
-      // `functionExists` on them is a wasteful catalog round-trip (e.g. UC backends RPC).
+      // `system.*` candidates are handled by [[lookupBuiltinOrTempFunction]] /
+      // [[lookupBuiltinOrTempTableFunction]] above; skip them here to avoid redundant
+      // catalog calls.
       val persistentCandidates = resolutionCandidates(nameParts).filterNot { c =>
         c.length >= 2 &&
           c.head.equalsIgnoreCase(CatalogManager.SYSTEM_CATALOG_NAME)
@@ -374,9 +371,8 @@ class FunctionResolution(
             case _ =>
           }
         } catch {
-          // Mirror [[resolveFunctionCandidate]]'s explicit not-found list. Other exceptions
-          // (e.g. PERMISSION_DENIED, transient catalog errors) propagate so the user sees the
-          // real cause instead of a generic UNRESOLVED_ROUTINE.
+          // Only treat explicit "not found" / "forbidden" signals as a miss. Any other failure
+          // (e.g. permission denied, transient catalog error) propagates.
           case _: NoSuchFunctionException
              | _: NoSuchNamespaceException
              | _: CatalogNotFoundException =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionResolution.scala
@@ -355,12 +355,18 @@ class FunctionResolution(
     if (nameParts.length == 1) {
       // Must match [[resolutionCandidates]] / [[resolveFunction]]: single-part names use PATH +
       // session order, not only the current namespace (LookupCatalog single-part rule).
-      // `system.*` candidates are handled by [[lookupBuiltinOrTempFunction]] /
-      // [[lookupBuiltinOrTempTableFunction]] above; skip them here to avoid redundant
-      // catalog calls.
+      // `system.session.<name>` and `system.builtin.<name>` candidates were already resolved by
+      // [[lookupBuiltinOrTempFunction]] / [[lookupBuiltinOrTempTableFunction]] above (they
+      // route through `identifierFromSystemNameParts`, which only accepts those two
+      // namespaces); skip them here to avoid redundant catalog calls. Other `system.<x>`
+      // namespaces -- if any are ever added -- still go through persistent lookup.
       val persistentCandidates = resolutionCandidates(nameParts).filterNot { c =>
         c.length >= 2 &&
-          c.head.equalsIgnoreCase(CatalogManager.SYSTEM_CATALOG_NAME)
+          c.head.equalsIgnoreCase(CatalogManager.SYSTEM_CATALOG_NAME) && {
+            val ns = c(1)
+            ns.equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE) ||
+              ns.equalsIgnoreCase(CatalogManager.BUILTIN_NAMESPACE)
+          }
       }
       for (candidate <- persistentCandidates) {
         try {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionResolution.scala
@@ -89,9 +89,10 @@ class FunctionResolution(
    *
    * All other multi-part names are returned as-is for downstream resolution.
    *
-   * Shares [[CatalogManager.resolutionPathEntriesForAnalysis]] with
-   * [[RelationResolution.relationResolutionEntries]] so routine and relation lookup follow the
-   * same order under PATH (and the same persisted frozen path for view / SQL function bodies).
+   * When [[AnalysisContext.resolutionPathEntries]] is set (view or SQL function / table function
+   * body with a pinned path, with [[SQLConf.PATH_ENABLED]] true), that frozen list is used
+   * directly, matching [[RelationResolution.relationResolutionEntries]] so routine order stays
+   * aligned with relation order.
    */
   private[analysis] def sqlResolutionPathEntriesForAnalysis: Seq[Seq[String]] =
     catalogManager.resolutionPathEntriesForAnalysis(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionResolution.scala
@@ -71,13 +71,6 @@ class FunctionResolution(
 
   private val trimWarningEnabled = new AtomicBoolean(true)
 
-  /** Returns the current catalog path, preferring the view's context if resolving a view. */
-  private def currentCatalogPath: Seq[String] = {
-    val ctx = AnalysisContext.get.catalogAndNamespace
-    if (ctx.nonEmpty) ctx
-    else (Seq(catalogManager.currentCatalog.name) ++ catalogManager.currentNamespace).toSeq
-  }
-
   /** True if nameParts is 3-part and the first part is the system catalog name. */
   private def isSystemCatalogQualified(nameParts: Seq[String]): Boolean =
     nameParts.length == 3 &&
@@ -96,23 +89,16 @@ class FunctionResolution(
    *
    * All other multi-part names are returned as-is for downstream resolution.
    *
-   * When [[AnalysisContext.resolutionPathEntries]] is set (view or SQL function / table function
-   * body with a pinned path, with [[SQLConf.PATH_ENABLED]] true), that frozen list is used
-   * directly, matching [[RelationResolution.relationResolutionEntries]] so routine order stays
-   * aligned with relation order.
+   * Routes through [[CatalogManager.resolutionPathEntriesForAnalysis]] so that view / SQL
+   * function bodies with a persisted frozen path are honored, matching
+   * [[RelationResolution.relationResolutionEntries]] so routine order stays aligned with
+   * relation order. Procedure resolution also goes through this helper -- see
+   * [[resolveProcedure]].
    */
-  private[analysis] def sqlResolutionPathEntriesForAnalysis: Seq[Seq[String]] = {
-    AnalysisContext.get.resolutionPathEntries match {
-      case Some(entries) if conf.pathEnabled => entries
-      case _ =>
-        val pathDefault = currentCatalogPath
-        catalogManager.sqlResolutionPathEntries(
-          pathDefault.head,
-          pathDefault.tail.toSeq,
-          catalogManager.currentCatalog.name,
-          catalogManager.currentNamespace.toSeq)
-    }
-  }
+  private[analysis] def sqlResolutionPathEntriesForAnalysis: Seq[Seq[String]] =
+    catalogManager.resolutionPathEntriesForAnalysis(
+      AnalysisContext.get.resolutionPathEntries,
+      AnalysisContext.get.catalogAndNamespace)
 
   private def resolutionCandidates(nameParts: Seq[String]): Seq[Seq[String]] = {
     if (nameParts.size == 1) {
@@ -370,7 +356,15 @@ class FunctionResolution(
     if (nameParts.length == 1) {
       // Must match [[resolutionCandidates]] / [[resolveFunction]]: single-part names use PATH +
       // session order, not only the current namespace (LookupCatalog single-part rule).
-      for (candidate <- resolutionCandidates(nameParts)) {
+      // Filter out `system.*` candidates: routines under `system.session`, `system.builtin`, and
+      // `system.ai` are already resolved by [[lookupBuiltinOrTempFunction]] /
+      // [[lookupBuiltinOrTempTableFunction]] earlier in this method, so calling
+      // `functionExists` on them is a wasteful catalog round-trip (e.g. UC backends RPC).
+      val persistentCandidates = resolutionCandidates(nameParts).filterNot { c =>
+        c.length >= 2 &&
+          c.head.equalsIgnoreCase(CatalogManager.SYSTEM_CATALOG_NAME)
+      }
+      for (candidate <- persistentCandidates) {
         try {
           candidate match {
             case CatalogAndIdentifier(catalog, ident) =>
@@ -380,7 +374,13 @@ class FunctionResolution(
             case _ =>
           }
         } catch {
-          case NonFatal(_) =>
+          // Mirror [[resolveFunctionCandidate]]'s explicit not-found list. Other exceptions
+          // (e.g. PERMISSION_DENIED, transient catalog errors) propagate so the user sees the
+          // real cause instead of a generic UNRESOLVED_ROUTINE.
+          case _: NoSuchFunctionException
+             | _: NoSuchNamespaceException
+             | _: CatalogNotFoundException =>
+          case e: AnalysisException if e.getCondition == "FORBIDDEN_OPERATION" =>
         }
       }
       return FunctionType.NotFound

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
@@ -124,11 +124,11 @@ class RelationResolution(
       extends RelationResolutionStep
 
   /**
-   * Path entries for unqualified relation resolution. Routes through
-   * [[CatalogManager.resolutionPathEntriesForAnalysis]] so persisted frozen paths from view /
-   * SQL function metadata are honored, and the live session path otherwise. This is the same
-   * helper used by [[FunctionResolution.sqlResolutionPathEntriesForAnalysis]] and procedure
-   * resolution.
+   * Path entries for unqualified relation resolution.
+   *
+   * Inside a view or SQL function, [[AnalysisContext.resolutionPathEntries]] uses the
+   * persisted frozen path from metadata when available.
+   * When PATH is disabled, legacy resolution rules apply.
    */
   private def relationResolutionEntries: Seq[Seq[String]] = {
     catalogManager.resolutionPathEntriesForAnalysis(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationResolution.scala
@@ -124,32 +124,16 @@ class RelationResolution(
       extends RelationResolutionStep
 
   /**
-   * Path entries for unqualified relation resolution.
-   *
-   * Inside a view or SQL function, [[AnalysisContext.resolutionPathEntries]] uses the
-   * persisted frozen path from metadata when available.
-   * When PATH is disabled, legacy resolution rules apply.
+   * Path entries for unqualified relation resolution. Routes through
+   * [[CatalogManager.resolutionPathEntriesForAnalysis]] so persisted frozen paths from view /
+   * SQL function metadata are honored, and the live session path otherwise. This is the same
+   * helper used by [[FunctionResolution.sqlResolutionPathEntriesForAnalysis]] and procedure
+   * resolution.
    */
   private def relationResolutionEntries: Seq[Seq[String]] = {
-    val pinned = AnalysisContext.get.resolutionPathEntries
-    if (pinned.isDefined && conf.pathEnabled) {
-      pinned.get
-    } else {
-      val expandCatalog = catalogManager.currentCatalog.name
-      val expandNamespace = catalogManager.currentNamespace.toSeq
-      val (pathCatalog, pathNamespace) =
-        if (isResolvingView) {
-          val p = AnalysisContext.get.catalogAndNamespace
-          (p.head, p.tail.toSeq)
-        } else {
-          (expandCatalog, expandNamespace)
-        }
-      catalogManager.sqlResolutionPathEntries(
-        pathCatalog,
-        pathNamespace,
-        expandCatalog,
-        expandNamespace)
-    }
+    catalogManager.resolutionPathEntriesForAnalysis(
+      AnalysisContext.get.resolutionPathEntries,
+      AnalysisContext.get.catalogAndNamespace)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -79,9 +79,8 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
         throw new AnalysisException(
           "UNSUPPORTED_FEATURE.SQL_SCRIPTING_DROP_TEMPORARY_VARIABLE", Map.empty)
       }
-      // DDL on session variables (DECLARE / CREATE / DROP) always targets `system.session`
-      // directly regardless of the SQL path. Only DML (SET VAR / SELECT @x) goes through PATH
-      // and is gated by [[VariableResolution.allowUnqualifiedSessionTempVariableLookup]].
+      // DDL on session variables targets `system.session` directly; the SQL path only applies
+      // to DML (see [[VariableResolution.allowUnqualifiedSessionTempVariableLookup]]).
       val resolved = catalogManager.tempVariableManager.qualify(nameParts.last)
       assertValidSessionVariableNameParts(nameParts, resolved)
       d.copy(name = resolved)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -44,7 +44,7 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
     case c @ CreateVariable(identifiers, _, _) =>
       // We resolve only UnresolvedIdentifiers, and pass on the other nodes
       val resolved = identifiers.map {
-        case UnresolvedIdentifier(nameParts, _) =>
+        case u @ UnresolvedIdentifier(nameParts, _) =>
           if (withinLocalVariableScope) {
             if (c.replace) {
               throw new AnalysisException(
@@ -67,14 +67,14 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
             val resolvedIdentifier
             = catalogManager.tempVariableManager.qualify(nameParts.last)
 
-            assertValidSessionVariableNameParts(nameParts, resolvedIdentifier)
+            assertValidSessionVariableNameParts(nameParts, resolvedIdentifier, u.origin)
             resolvedIdentifier
           }
         case plan => plan
       }
       c.copy(names = resolved)
 
-    case d @ DropVariable(UnresolvedIdentifier(nameParts, _), _) =>
+    case d @ DropVariable(u @ UnresolvedIdentifier(nameParts, _), _) =>
       if (withinLocalVariableScope) {
         throw new AnalysisException(
           "UNSUPPORTED_FEATURE.SQL_SCRIPTING_DROP_TEMPORARY_VARIABLE", Map.empty)
@@ -82,7 +82,7 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
       // DDL on session variables targets `system.session` directly; the SQL path only applies
       // to DML (see [[VariableResolution.allowUnqualifiedSessionTempVariableLookup]]).
       val resolved = catalogManager.tempVariableManager.qualify(nameParts.last)
-      assertValidSessionVariableNameParts(nameParts, resolved)
+      assertValidSessionVariableNameParts(nameParts, resolved, u.origin)
       d.copy(name = resolved)
 
     case CreateFunction(UnresolvedIdentifier(nameParts, _), _, _, _, _)
@@ -217,14 +217,15 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
 
   private def assertValidSessionVariableNameParts(
       nameParts: Seq[String],
-      resolvedIdentifier: ResolvedIdentifier): Unit = {
+      resolvedIdentifier: ResolvedIdentifier,
+      origin: Origin): Unit = {
     if (!validSessionVariableName(nameParts)) {
       throw QueryCompilationErrors.unresolvedVariableError(
         nameParts,
         Seq(Seq(
           resolvedIdentifier.catalog.name(),
           resolvedIdentifier.identifier.namespace().head)),
-        CurrentOrigin.get
+        origin
       )
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -223,7 +223,8 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
         nameParts,
         Seq(Seq(
           resolvedIdentifier.catalog.name(),
-          resolvedIdentifier.identifier.namespace().head))
+          resolvedIdentifier.identifier.namespace().head)),
+        CurrentOrigin.get
       )
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -79,12 +79,9 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
         throw new AnalysisException(
           "UNSUPPORTED_FEATURE.SQL_SCRIPTING_DROP_TEMPORARY_VARIABLE", Map.empty)
       }
-      if (nameParts.length == 1 &&
-          !catalogManager.sessionScopeUnqualifiedAllowed(
-            catalogManager.currentCatalog.name(),
-            catalogManager.currentNamespace.toSeq)) {
-        throw QueryCompilationErrors.unresolvedVariableError(nameParts, Seq("SYSTEM", "SESSION"))
-      }
+      // DDL on session variables (DECLARE / CREATE / DROP) always targets `system.session`
+      // directly regardless of the SQL path. Only DML (SET VAR / SELECT @x) goes through PATH
+      // and is gated by [[VariableResolution.allowUnqualifiedSessionTempVariableLookup]].
       val resolved = catalogManager.tempVariableManager.qualify(nameParts.last)
       assertValidSessionVariableNameParts(nameParts, resolved)
       d.copy(name = resolved)
@@ -225,9 +222,9 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
     if (!validSessionVariableName(nameParts)) {
       throw QueryCompilationErrors.unresolvedVariableError(
         nameParts,
-        Seq(
+        Seq(Seq(
           resolvedIdentifier.catalog.name(),
-          resolvedIdentifier.identifier.namespace().head)
+          resolvedIdentifier.identifier.namespace().head))
       )
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveFetchCursor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveFetchCursor.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.{Expression, VariableReference}
 import org.apache.spark.sql.catalyst.plans.logical.{FetchCursor, LogicalPlan, SingleStatement}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.catalyst.trees.TreePattern.COMMAND
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.errors.QueryCompilationErrors.unresolvedVariableError
@@ -64,7 +65,8 @@ class ResolveFetchCursor(val catalogManager: CatalogManager) extends Rule[Logica
           nameParts = u.nameParts
         ) match {
           case Some(variable) => variable.copy(canFold = false)
-          case _ => throw unresolvedVariableError(u.nameParts, Seq(Seq("SYSTEM", "SESSION")))
+          case _ => throw unresolvedVariableError(
+            u.nameParts, Seq(Seq("SYSTEM", "SESSION")), CurrentOrigin.get)
         }
 
       case other => throw SparkException.internalError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveFetchCursor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveFetchCursor.scala
@@ -64,7 +64,7 @@ class ResolveFetchCursor(val catalogManager: CatalogManager) extends Rule[Logica
           nameParts = u.nameParts
         ) match {
           case Some(variable) => variable.copy(canFold = false)
-          case _ => throw unresolvedVariableError(u.nameParts, Seq("SYSTEM", "SESSION"))
+          case _ => throw unresolvedVariableError(u.nameParts, Seq(Seq("SYSTEM", "SESSION")))
         }
 
       case other => throw SparkException.internalError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveFetchCursor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveFetchCursor.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.{Expression, VariableReference}
 import org.apache.spark.sql.catalyst.plans.logical.{FetchCursor, LogicalPlan, SingleStatement}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.catalyst.trees.TreePattern.COMMAND
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.errors.QueryCompilationErrors.unresolvedVariableError
@@ -66,7 +65,7 @@ class ResolveFetchCursor(val catalogManager: CatalogManager) extends Rule[Logica
         ) match {
           case Some(variable) => variable.copy(canFold = false)
           case _ => throw unresolvedVariableError(
-            u.nameParts, Seq(Seq("SYSTEM", "SESSION")), CurrentOrigin.get)
+            u.nameParts, Seq(Seq("SYSTEM", "SESSION")), u.origin)
         }
 
       case other => throw SparkException.internalError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveFetchCursor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveFetchCursor.scala
@@ -65,7 +65,7 @@ class ResolveFetchCursor(val catalogManager: CatalogManager) extends Rule[Logica
         ) match {
           case Some(variable) => variable.copy(canFold = false)
           case _ => throw unresolvedVariableError(
-            u.nameParts, Seq(Seq("SYSTEM", "SESSION")), u.origin)
+            u.nameParts, variableResolution.searchPathEntriesForError, u.origin)
         }
 
       case other => throw SparkException.internalError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.{Limit, LogicalPlan, SetVariable}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.catalyst.trees.TreePattern.COMMAND
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.errors.QueryCompilationErrors.unresolvedVariableError
@@ -62,7 +63,17 @@ class ResolveSetVariable(val catalogManager: CatalogManager) extends Rule[Logica
             nameParts = u.nameParts
           ) match {
             case Some(variable) => variable.copy(canFold = false)
-            case _ => throw unresolvedVariableError(u.nameParts, Seq("SYSTEM", "SESSION"))
+            case _ =>
+              // For unqualified names (1 part) the lookup goes through PATH; surface the
+              // *actual* SQL PATH searched (SPARK-56681). For qualified names (2 / 3 parts)
+              // the namespace is fixed at `system.session`, so a single
+              // `[`SYSTEM`.`SESSION`]` entry is reported. Either way the rendering is a list
+              // of path entries to stay consistent with UNRESOLVED_ROUTINE /
+              // TABLE_OR_VIEW_NOT_FOUND.
+              throw unresolvedVariableError(
+                u.nameParts,
+                variableResolution.searchPathEntriesForError(u.nameParts),
+                CurrentOrigin.get)
           }
 
         case other => throw SparkException.internalError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
@@ -64,12 +64,6 @@ class ResolveSetVariable(val catalogManager: CatalogManager) extends Rule[Logica
           ) match {
             case Some(variable) => variable.copy(canFold = false)
             case _ =>
-              // For unqualified names (1 part) the lookup goes through PATH; surface the
-              // *actual* SQL PATH searched (SPARK-56681). For qualified names (2 / 3 parts)
-              // the namespace is fixed at `system.session`, so a single
-              // `[`SYSTEM`.`SESSION`]` entry is reported. Either way the rendering is a list
-              // of path entries to stay consistent with UNRESOLVED_ROUTINE /
-              // TABLE_OR_VIEW_NOT_FOUND.
               throw unresolvedVariableError(
                 u.nameParts,
                 variableResolution.searchPathEntriesForError(u.nameParts),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
@@ -66,7 +66,7 @@ class ResolveSetVariable(val catalogManager: CatalogManager) extends Rule[Logica
             case _ =>
               throw unresolvedVariableError(
                 u.nameParts,
-                variableResolution.searchPathEntriesForError,
+                variableResolution.searchPathEntriesForError(u.nameParts),
                 CurrentOrigin.get)
           }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
@@ -66,7 +66,7 @@ class ResolveSetVariable(val catalogManager: CatalogManager) extends Rule[Logica
             case _ =>
               throw unresolvedVariableError(
                 u.nameParts,
-                variableResolution.searchPathEntriesForError(u.nameParts),
+                variableResolution.searchPathEntriesForError,
                 CurrentOrigin.get)
           }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
@@ -65,7 +65,7 @@ class ResolveSetVariable(val catalogManager: CatalogManager) extends Rule[Logica
             case _ =>
               throw unresolvedVariableError(
                 u.nameParts,
-                variableResolution.searchPathEntriesForError(u.nameParts),
+                variableResolution.searchPathEntriesForError,
                 u.origin)
           }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.{Limit, LogicalPlan, SetVariable}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.catalyst.trees.TreePattern.COMMAND
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.errors.QueryCompilationErrors.unresolvedVariableError
@@ -67,7 +66,7 @@ class ResolveSetVariable(val catalogManager: CatalogManager) extends Rule[Logica
               throw unresolvedVariableError(
                 u.nameParts,
                 variableResolution.searchPathEntriesForError(u.nameParts),
-                CurrentOrigin.get)
+                u.origin)
           }
 
         case other => throw SparkException.internalError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.{Limit, LogicalPlan, SetVariable}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.catalyst.trees.TreePattern.COMMAND
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.errors.QueryCompilationErrors.unresolvedVariableError
@@ -65,9 +64,7 @@ class ResolveSetVariable(val catalogManager: CatalogManager) extends Rule[Logica
             case Some(variable) => variable.copy(canFold = false)
             case _ =>
               throw unresolvedVariableError(
-                u.nameParts,
-                variableResolution.searchPathEntriesForError(u.nameParts),
-                CurrentOrigin.get)
+                u.nameParts, variableResolution.searchPathEntriesForError(u.nameParts))
           }
 
         case other => throw SparkException.internalError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSetVariable.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.{Limit, LogicalPlan, SetVariable}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.catalyst.trees.TreePattern.COMMAND
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.errors.QueryCompilationErrors.unresolvedVariableError
@@ -64,7 +65,9 @@ class ResolveSetVariable(val catalogManager: CatalogManager) extends Rule[Logica
             case Some(variable) => variable.copy(canFold = false)
             case _ =>
               throw unresolvedVariableError(
-                u.nameParts, variableResolution.searchPathEntriesForError(u.nameParts))
+                u.nameParts,
+                variableResolution.searchPathEntriesForError(u.nameParts),
+                CurrentOrigin.get)
           }
 
         case other => throw SparkException.internalError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
@@ -48,16 +48,19 @@ class VariableResolution(
   }
 
   /**
-   * Search-path entries to report in `UNRESOLVED_VARIABLE`: variables can only ever be in
-   * `system.session`, so we report exactly the namespaces we actually searched -- either
-   * `[system.session]` when it is on the SQL path, or `[]` when it is not (and so the lookup
-   * never consulted any namespace).
+   * Search-path entries to report in `UNRESOLVED_VARIABLE`. For unqualified names this is the
+   * full SQL path the resolver would consult, mirroring how `TABLE_OR_VIEW_NOT_FOUND` reports
+   * its full path (entries like `system.builtin` are kept even though they can never hold
+   * the kind of object being looked up). Qualified names target `system.session` directly,
+   * so only that single entry is reported.
    */
-  def searchPathEntriesForError: Seq[Seq[String]] = {
-    if (catalogManager.isSystemSessionOnPath) {
+  def searchPathEntriesForError(nameParts: Seq[String]): Seq[Seq[String]] = {
+    if (nameParts.length != 1) {
       Seq(Seq(CatalogManager.SYSTEM_CATALOG_NAME, CatalogManager.SESSION_NAMESPACE))
     } else {
-      Seq.empty
+      catalogManager.resolutionPathEntriesForAnalysis(
+        AnalysisContext.get.resolutionPathEntries,
+        AnalysisContext.get.catalogAndNamespace)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
@@ -39,40 +39,20 @@ class VariableResolution(
     extends SQLConfHelper {
 
   /**
-   * Unqualified session variables resolve only when SYSTEM.SESSION is on the SQL path.
-   *
-   * When PATH is not explicitly set (PATH disabled, or PATH enabled with no SET PATH),
-   * the answer is fully determined by the default path, which always includes system.session
-   * ([[CatalogManager.sqlResolutionPathEntries]] falls back to
-   * [[org.apache.spark.sql.internal.SQLConf.defaultPathOrder]]). Short-circuit before reading
-   * `catalogManager.currentCatalog.name()`, which loads the configured default catalog and
-   * would otherwise raise CATALOG_NOT_FOUND on every column-resolution pass when the
-   * default catalog is misconfigured.
+   * Variables only live in `system.session` (there is no persistent variable catalog), so
+   * unqualified lookups are gated solely on whether the SQL path includes that namespace.
+   * Qualified names target `system.session` directly and bypass the gate.
    */
   private def allowUnqualifiedSessionTempVariableLookup(nameParts: Seq[String]): Boolean = {
-    if (nameParts.length != 1) return true
-    val pathExplicitlySet = conf.pathEnabled && catalogManager.sessionPathEntries.isDefined
-    if (!pathExplicitlySet) return true
-    catalogManager.sessionScopeUnqualifiedAllowed(
-      catalogManager.currentCatalog.name(),
-      catalogManager.currentNamespace.toSeq)
+    nameParts.length != 1 || catalogManager.isSystemSessionOnPath
   }
 
   /**
-   * Returns the path entries that should be reported in `UNRESOLVED_VARIABLE` for `nameParts`.
-   * For unqualified lookups (1 part) the lookup goes through the SQL PATH, so the full resolved
-   * path entries are reported. For qualified lookups (2 / 3 parts) the namespace is fixed at
-   * `system.session`, so a single `[SYSTEM.SESSION]` entry is reported.
+   * Search-path entries to report in `UNRESOLVED_VARIABLE`: variables can only ever be in
+   * `system.session`, so that is the only entry we ever search.
    */
-  def searchPathEntriesForError(nameParts: Seq[String]): Seq[Seq[String]] = {
-    if (nameParts.length != 1) {
-      Seq(Seq(CatalogManager.SYSTEM_CATALOG_NAME, CatalogManager.SESSION_NAMESPACE))
-    } else {
-      catalogManager.sqlResolutionPathEntries(
-        catalogManager.currentCatalog.name(),
-        catalogManager.currentNamespace.toSeq)
-    }
-  }
+  def searchPathEntriesForError: Seq[Seq[String]] =
+    Seq(Seq(CatalogManager.SYSTEM_CATALOG_NAME, CatalogManager.SESSION_NAMESPACE))
 
   /**
    * Resolves a `multipartName` to an [[Expression]] tree, supporting nested field access.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
@@ -49,10 +49,17 @@ class VariableResolution(
 
   /**
    * Search-path entries to report in `UNRESOLVED_VARIABLE`: variables can only ever be in
-   * `system.session`, so that is the only entry we ever search.
+   * `system.session`, so we report exactly the namespaces we actually searched -- either
+   * `[system.session]` when it is on the SQL path, or `[]` when it is not (and so the lookup
+   * never consulted any namespace).
    */
-  def searchPathEntriesForError: Seq[Seq[String]] =
-    Seq(Seq(CatalogManager.SYSTEM_CATALOG_NAME, CatalogManager.SESSION_NAMESPACE))
+  def searchPathEntriesForError: Seq[Seq[String]] = {
+    if (catalogManager.isSystemSessionOnPath) {
+      Seq(Seq(CatalogManager.SYSTEM_CATALOG_NAME, CatalogManager.SESSION_NAMESPACE))
+    } else {
+      Seq.empty
+    }
+  }
 
   /**
    * Resolves a `multipartName` to an [[Expression]] tree, supporting nested field access.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
@@ -47,20 +47,21 @@ class VariableResolution(
   }
 
   /**
-   * Search-path entries to report in `UNRESOLVED_VARIABLE`. For unqualified names this is the
-   * full SQL path the resolver would consult, mirroring how `TABLE_OR_VIEW_NOT_FOUND` reports
-   * its full path (entries like `system.builtin` are kept even though they can never hold
-   * the kind of object being looked up). Qualified names target `system.session` directly,
-   * so only that single entry is reported.
+   * Search-path entries to report in `UNRESOLVED_VARIABLE` for DML lookups (`SET VAR`,
+   * `FETCH ... INTO`). The full SQL path is reported regardless of how the name was
+   * qualified, matching the convention used by `TABLE_OR_VIEW_NOT_FOUND` and
+   * `UNRESOLVED_ROUTINE`. Keeping the rendering qualification-independent also avoids
+   * re-shaping the error if Spark ever grows struct-field assignment, where 2-part forms
+   * become genuinely ambiguous.
+   *
+   * DDL paths (`DECLARE` / `DROP` name validation in
+   * [[org.apache.spark.sql.catalyst.analysis.ResolveCatalogs]]) do not consult the SQL path
+   * and report `[system.session]` directly at their throw site.
    */
-  def searchPathEntriesForError(nameParts: Seq[String]): Seq[Seq[String]] = {
-    if (nameParts.length != 1) {
-      Seq(Seq(CatalogManager.SYSTEM_CATALOG_NAME, CatalogManager.SESSION_NAMESPACE))
-    } else {
-      catalogManager.resolutionPathEntriesForAnalysis(
-        AnalysisContext.get.resolutionPathEntries,
-        AnalysisContext.get.catalogAndNamespace)
-    }
+  def searchPathEntriesForError: Seq[Seq[String]] = {
+    catalogManager.resolutionPathEntriesForAnalysis(
+      AnalysisContext.get.resolutionPathEntries,
+      AnalysisContext.get.catalogAndNamespace)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
@@ -39,14 +39,39 @@ class VariableResolution(
     extends SQLConfHelper {
 
   /**
-   * Unqualified session variables resolve only when SYSTEM.SESSION is on the SQL path
-   * (PATH enabled and explicitly set).
+   * Unqualified session variables resolve only when SYSTEM.SESSION is on the SQL path.
+   *
+   * When PATH is not explicitly set (PATH disabled, or PATH enabled with no SET PATH),
+   * the answer is fully determined by the default path, which always includes system.session
+   * ([[CatalogManager.sqlResolutionPathEntries]] falls back to
+   * [[org.apache.spark.sql.internal.SQLConf.defaultPathOrder]]). Short-circuit before reading
+   * `catalogManager.currentCatalog.name()`, which loads the configured default catalog and
+   * would otherwise raise CATALOG_NOT_FOUND on every column-resolution pass when the
+   * default catalog is misconfigured.
    */
   private def allowUnqualifiedSessionTempVariableLookup(nameParts: Seq[String]): Boolean = {
     if (nameParts.length != 1) return true
+    val pathExplicitlySet = conf.pathEnabled && catalogManager.sessionPathEntries.isDefined
+    if (!pathExplicitlySet) return true
     catalogManager.sessionScopeUnqualifiedAllowed(
       catalogManager.currentCatalog.name(),
       catalogManager.currentNamespace.toSeq)
+  }
+
+  /**
+   * Returns the path entries that should be reported in `UNRESOLVED_VARIABLE` for `nameParts`.
+   * For unqualified lookups (1 part) the lookup goes through the SQL PATH, so the full resolved
+   * path entries are reported. For qualified lookups (2 / 3 parts) the namespace is fixed at
+   * `system.session`, so a single `[SYSTEM.SESSION]` entry is reported.
+   */
+  def searchPathEntriesForError(nameParts: Seq[String]): Seq[Seq[String]] = {
+    if (nameParts.length != 1) {
+      Seq(Seq(CatalogManager.SYSTEM_CATALOG_NAME, CatalogManager.SESSION_NAMESPACE))
+    } else {
+      catalogManager.sqlResolutionPathEntries(
+        catalogManager.currentCatalog.name(),
+        catalogManager.currentNamespace.toSeq)
+    }
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/VariableResolution.scala
@@ -39,9 +39,8 @@ class VariableResolution(
     extends SQLConfHelper {
 
   /**
-   * Variables only live in `system.session` (there is no persistent variable catalog), so
-   * unqualified lookups are gated solely on whether the SQL path includes that namespace.
-   * Qualified names target `system.session` directly and bypass the gate.
+   * Unqualified session variables resolve only when SYSTEM.SESSION is on the SQL path
+   * (PATH enabled and explicitly set).
    */
   private def allowUnqualifiedSessionTempVariableLookup(nameParts: Seq[String]): Boolean = {
     nameParts.length != 1 || catalogManager.isSystemSessionOnPath

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/VariableManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/VariableManager.scala
@@ -134,7 +134,7 @@ class TempVariableManager extends VariableManager with DataTypeErrorsBase {
     val name = nameParts.last
     // Sanity check as this is already checked in ResolveSetVariable.
     if (!variables.contains(name)) {
-      throw unresolvedVariableError(nameParts, Seq("SYSTEM", "SESSION"))
+      throw unresolvedVariableError(nameParts, Seq(Seq("SYSTEM", "SESSION")))
     }
     variables.put(name, varDef)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/VariableManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/VariableManager.scala
@@ -24,6 +24,7 @@ import scala.collection.mutable
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.{FakeSystemCatalog, ResolvedIdentifier}
 import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.connector.catalog.{CatalogManager, Identifier}
 import org.apache.spark.sql.connector.catalog.CatalogManager.{SESSION_NAMESPACE, SYSTEM_CATALOG_NAME}
 import org.apache.spark.sql.errors.DataTypeErrorsBase
@@ -49,8 +50,11 @@ trait VariableManager {
  *
    * @param nameParts Name parts of the variable.
    * @param varDef The new VariableDefinition of the variable.
+   * @param origin Origin of the SET reference, used in
+   *               [[org.apache.spark.sql.errors.QueryCompilationErrors.unresolvedVariableError]]
+   *               if the variable is unexpectedly absent at execution time.
    */
-  def set(nameParts: Seq[String], varDef: VariableDefinition): Unit
+  def set(nameParts: Seq[String], varDef: VariableDefinition, origin: Origin): Unit
 
 /**
  * Get an existing variable.
@@ -130,11 +134,14 @@ class TempVariableManager extends VariableManager with DataTypeErrorsBase {
     variables.put(name, varDef)
   }
 
-  override def set(nameParts: Seq[String], varDef: VariableDefinition): Unit = synchronized {
+  override def set(
+      nameParts: Seq[String],
+      varDef: VariableDefinition,
+      origin: Origin): Unit = synchronized {
     val name = nameParts.last
     // Sanity check as this is already checked in ResolveSetVariable.
     if (!variables.contains(name)) {
-      throw unresolvedVariableError(nameParts, Seq(Seq("SYSTEM", "SESSION")))
+      throw unresolvedVariableError(nameParts, Seq(Seq("SYSTEM", "SESSION")), origin)
     }
     variables.put(name, varDef)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -7023,11 +7023,13 @@ class AstBuilder extends DataTypeAstBuilder
       dataTypeOpt.map { dt => default.copy(child = Cast(default.child, dt)) }.getOrElse(default)
     }
     CreateVariable(
-      ctx.identifierReferences.asScala.map (
-        identifierReference => {
-          withIdentClause(identifierReference, UnresolvedIdentifier(_))
-        }
-      ).toSeq,
+      ctx.identifierReferences.asScala.map { identifierReference =>
+        // Give each `UnresolvedIdentifier` its own origin pointing at the variable name
+        // fragment so analyzer-time errors (e.g. UNRESOLVED_VARIABLE) can highlight just
+        // that identifier rather than the whole `DECLARE ...` statement.
+        withIdentClause(identifierReference, parts =>
+          withOrigin(identifierReference) { UnresolvedIdentifier(parts) })
+      }.toSeq,
       defaultExpression,
       ctx.REPLACE() != null
     )
@@ -7043,7 +7045,8 @@ class AstBuilder extends DataTypeAstBuilder
    */
   override def visitDropVariable(ctx: DropVariableContext): LogicalPlan = withOrigin(ctx) {
     DropVariable(
-      withIdentClause(ctx.identifierReference(), UnresolvedIdentifier(_)),
+      withIdentClause(ctx.identifierReference(), parts =>
+        withOrigin(ctx.identifierReference()) { UnresolvedIdentifier(parts) }),
       ctx.EXISTS() != null
     )
   }
@@ -7168,7 +7171,7 @@ class AstBuilder extends DataTypeAstBuilder
       // The SET variable source is a query
       val variables = multipartIdentifierList.multipartIdentifier.asScala.map { variableIdent =>
         val varName = visitMultipartIdentifier(variableIdent)
-        UnresolvedAttribute(varName)
+        withOrigin(variableIdent) { UnresolvedAttribute(varName) }
       }.toSeq
       SetVariable(variables, visitQuery(query))
     } else {
@@ -7180,7 +7183,7 @@ class AstBuilder extends DataTypeAstBuilder
           case n: NamedExpression => n
           case e => Alias(e, varIdent.last)()
         }
-        (UnresolvedAttribute(varIdent), varNamedExpr)
+        (withOrigin(assign.key) { UnresolvedAttribute(varIdent) }, varNamedExpr)
       }.toSeq.unzip
       SetVariable(variables, Project(values, OneRowRelation()))
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -203,9 +203,13 @@ class CatalogManager(
       currentCatalog, currentNamespace)
 
   /**
-   * True if `system.session` is on the SQL path. Only literal path entries can match; the
-   * [[CurrentSchemaEntry]] marker can never be `system.session`. Inspecting stored entries
-   * directly avoids loading the configured default catalog.
+   * True if `system.session` is on the SQL path. Only literal path entries can match: the
+   * [[CurrentSchemaEntry]] marker expands to `currentCatalog.name() +: currentNamespace`, and
+   * `system` is not a registered catalog (it is a synthetic namespace served via
+   * [[org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog]] / `lookupBuiltinOrTempFunction`,
+   * not loadable via [[catalog]]), so `currentCatalog.name()` cannot be `"system"`. If that
+   * invariant ever changes, this short-circuit must be revisited.
+   * Inspecting stored entries directly avoids loading the configured default catalog.
    */
   def isSystemSessionOnPath: Boolean = synchronized {
     if (!conf.pathEnabled) return true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -203,21 +203,19 @@ class CatalogManager(
       currentCatalog, currentNamespace)
 
   /**
-   * True if `system.session` is on the SQL path. Only literal path entries can be
-   * `system.session`; the [[CurrentSchemaEntry]] marker resolves to the current schema, which
-   * never matches. Inspecting the stored entries directly avoids loading the configured default
-   * catalog (which [[currentCatalog]] would force).
+   * True if `system.session` is on the SQL path. Only literal path entries can match; the
+   * [[CurrentSchemaEntry]] marker can never be `system.session`. Inspecting stored entries
+   * directly avoids loading the configured default catalog.
    */
   def isSystemSessionOnPath: Boolean = synchronized {
     if (!conf.pathEnabled) return true
     _sessionPath match {
       case None => true
-      case Some(entries) =>
-        entries.exists {
-          case CatalogManager.LiteralPathEntry(parts) =>
-            CatalogManager.isSystemSessionPathEntry(parts)
-          case _ => false
-        }
+      case Some(entries) => entries.exists {
+        case CatalogManager.LiteralPathEntry(parts) =>
+          CatalogManager.isSystemSessionPathEntry(parts)
+        case _ => false
+      }
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -209,6 +209,43 @@ class CatalogManager(
     sqlResolutionPathEntries(currentCatalog, currentNamespace)
       .exists(CatalogManager.isSystemSessionPathEntry)
 
+  /**
+   * Single source of truth for analysis-time resolution path entries used by relation, routine,
+   * and procedure resolution. When `pinnedEntries` are set (a view or SQL function body's
+   * persisted frozen path) and PATH is enabled, returns them as-is so unqualified lookups follow
+   * the creation-time path. Otherwise falls back to [[sqlResolutionPathEntries]] using the view's
+   * catalog/namespace as the path default (so unqualified names inside a view body see the view's
+   * home schema first), while always expanding markers like CURRENT_SCHEMA against the live
+   * session catalog/namespace.
+   *
+   * @param pinnedEntries persisted frozen path entries from view / SQL function metadata
+   *                      (typically `AnalysisContext.resolutionPathEntries`).
+   * @param viewCatalogAndNamespace the view's catalog and namespace
+   *                               (typically `AnalysisContext.catalogAndNamespace`); empty when
+   *                               not resolving a view body.
+   */
+  def resolutionPathEntriesForAnalysis(
+      pinnedEntries: Option[Seq[Seq[String]]],
+      viewCatalogAndNamespace: Seq[String]): Seq[Seq[String]] = {
+    pinnedEntries match {
+      case Some(entries) if conf.pathEnabled => entries
+      case _ =>
+        val expandCatalog = currentCatalog.name()
+        val expandNamespace = currentNamespace.toSeq
+        val (pathCatalog, pathNamespace) =
+          if (viewCatalogAndNamespace.nonEmpty) {
+            (viewCatalogAndNamespace.head, viewCatalogAndNamespace.tail.toSeq)
+          } else {
+            (expandCatalog, expandNamespace)
+          }
+        sqlResolutionPathEntries(
+          pathCatalog,
+          pathNamespace,
+          expandCatalog,
+          expandNamespace)
+    }
+  }
+
   private var _currentCatalogName: Option[String] = None
 
   def currentCatalog: CatalogPlugin = synchronized {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -202,12 +202,24 @@ class CatalogManager(
       currentCatalog, currentNamespace,
       currentCatalog, currentNamespace)
 
-  /** True if [[sqlResolutionPathEntries]] includes `system.session`. */
-  def sessionScopeUnqualifiedAllowed(
-      currentCatalog: String,
-      currentNamespace: Seq[String]): Boolean =
-    sqlResolutionPathEntries(currentCatalog, currentNamespace)
-      .exists(CatalogManager.isSystemSessionPathEntry)
+  /**
+   * True if `system.session` is on the SQL path. Only literal path entries can be
+   * `system.session`; the [[CurrentSchemaEntry]] marker resolves to the current schema, which
+   * never matches. Inspecting the stored entries directly avoids loading the configured default
+   * catalog (which [[currentCatalog]] would force).
+   */
+  def isSystemSessionOnPath: Boolean = synchronized {
+    if (!conf.pathEnabled) return true
+    _sessionPath match {
+      case None => true
+      case Some(entries) =>
+        entries.exists {
+          case CatalogManager.LiteralPathEntry(parts) =>
+            CatalogManager.isSystemSessionPathEntry(parts)
+          case _ => false
+        }
+    }
+  }
 
   /**
    * Single source of truth for analysis-time resolution path entries used by relation, routine,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -916,31 +916,12 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("dt" -> dt.toString))
   }
 
-  /**
-   * Raises `UNRESOLVED_VARIABLE` with a formatted list of search-path entries. The rendering
-   * matches [[unresolvedRoutineError]] and [[tableOrViewNotFoundWithSearchPath]]: each entry is
-   * `toSQLId`-quoted and the entries are joined as `[entry1, entry2, ...]` (with brackets) even
-   * when only one entry is supplied. This keeps `searchPath` self-consistent across error
-   * conditions.
-   *
-   * @param name        unresolved variable name parts.
-   * @param pathEntries the SQL search path actually consulted, expressed as a list of
-   *                    catalog/namespace tuples (e.g. `Seq(Seq("SYSTEM", "SESSION"))` for
-   *                    qualified-namespace lookups, or the full PATH for unqualified ones).
-   * @param origin      origin of the offending node; defaults to [[Origin]] when the caller
-   *                    has no source location handy (existing behaviour for downstream error
-   *                    sites like [[VariableManager]] / [[SetVariableExec]]).
-   */
-  def unresolvedVariableError(
-      name: Seq[String],
-      pathEntries: Seq[Seq[String]],
-      origin: Origin = Origin()): Throwable = {
+  def unresolvedVariableError(name: Seq[String], pathEntries: Seq[Seq[String]]): Throwable = {
     new AnalysisException(
       errorClass = "UNRESOLVED_VARIABLE",
       messageParameters = Map(
         "variableName" -> toSQLId(name),
-        "searchPath" -> pathEntries.map(toSQLId).mkString("[", ", ", "]")),
-      origin = origin)
+        "searchPath" -> pathEntries.map(toSQLId).mkString("[", ", ", "]")))
   }
 
   def failedToLoadRoutineError(nameParts: Seq[String], e: Exception): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -916,12 +916,16 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("dt" -> dt.toString))
   }
 
-  def unresolvedVariableError(name: Seq[String], pathEntries: Seq[Seq[String]]): Throwable = {
+  def unresolvedVariableError(
+      name: Seq[String],
+      pathEntries: Seq[Seq[String]],
+      origin: Origin): Throwable = {
     new AnalysisException(
       errorClass = "UNRESOLVED_VARIABLE",
       messageParameters = Map(
         "variableName" -> toSQLId(name),
-        "searchPath" -> pathEntries.map(toSQLId).mkString("[", ", ", "]")))
+        "searchPath" -> pathEntries.map(toSQLId).mkString("[", ", ", "]")),
+      origin = origin)
   }
 
   def failedToLoadRoutineError(nameParts: Seq[String], e: Exception): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -916,23 +916,30 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("dt" -> dt.toString))
   }
 
-  def unresolvedVariableError(name: Seq[String], searchPath: Seq[String]): Throwable = {
-    new AnalysisException(
-      errorClass = "UNRESOLVED_VARIABLE",
-      messageParameters = Map(
-        "variableName" -> toSQLId(name),
-        "searchPath" -> toSQLId(searchPath)))
-  }
-
+  /**
+   * Raises `UNRESOLVED_VARIABLE` with a formatted list of search-path entries. The rendering
+   * matches [[unresolvedRoutineError]] and [[tableOrViewNotFoundWithSearchPath]]: each entry is
+   * `toSQLId`-quoted and the entries are joined as `[entry1, entry2, ...]` (with brackets) even
+   * when only one entry is supplied. This keeps `searchPath` self-consistent across error
+   * conditions.
+   *
+   * @param name        unresolved variable name parts.
+   * @param pathEntries the SQL search path actually consulted, expressed as a list of
+   *                    catalog/namespace tuples (e.g. `Seq(Seq("SYSTEM", "SESSION"))` for
+   *                    qualified-namespace lookups, or the full PATH for unqualified ones).
+   * @param origin      origin of the offending node; defaults to [[Origin]] when the caller
+   *                    has no source location handy (existing behaviour for downstream error
+   *                    sites like [[VariableManager]] / [[SetVariableExec]]).
+   */
   def unresolvedVariableError(
       name: Seq[String],
-      searchPath: Seq[String],
-      origin: Origin): Throwable = {
+      pathEntries: Seq[Seq[String]],
+      origin: Origin = Origin()): Throwable = {
     new AnalysisException(
       errorClass = "UNRESOLVED_VARIABLE",
       messageParameters = Map(
         "variableName" -> toSQLId(name),
-        "searchPath" -> toSQLId(searchPath)),
+        "searchPath" -> pathEntries.map(toSQLId).mkString("[", ", ", "]")),
       origin = origin)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -155,6 +155,13 @@ object SQLConf {
     override def initialValue: SQLConf = null
   }
 
+  /**
+   * Returns the [[SQLConf]] installed by an outer [[withExistingConf]] scope, or [[None]] if
+   * there is no such scope. Unlike [[get]], this peeks directly at the threadlocal so callers
+   * can distinguish "no outer scope" from "outer scope happens to install the same conf".
+   */
+  def getExistingConfIfSet: Option[SQLConf] = Option(existingConf.get())
+
   def withExistingConf[T](conf: SQLConf)(f: => T): T = {
     val old = existingConf.get()
     existingConf.set(conf)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TableLookupCacheSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TableLookupCacheSuite.scala
@@ -83,6 +83,9 @@ class TableLookupCacheSuite extends AnalysisTest with Matchers {
       .thenReturn(defaultPath)
     when(catalogManager.sqlResolutionPathEntries(any[String], any[Seq[String]]))
       .thenReturn(defaultPath)
+    when(catalogManager.resolutionPathEntriesForAnalysis(
+      any[Option[Seq[Seq[String]]]], any[Seq[String]]))
+      .thenReturn(defaultPath)
 
     new Analyzer(catalogManager)
   }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
@@ -135,17 +135,16 @@ class ProtoToParsedPlanTestSuite
 
   /**
    * Isolated from [[SharedSparkSession]] so PATH / session path settings do not affect catalog.
+   * Cloned from the test session's conf so all sparkConf overrides (ANSI, alias config, etc.)
+   * are preserved automatically; only the genuine isolation knob is overridden explicitly.
    */
-  private val analyzerIsolationConf: SQLConf = {
-    val c = new SQLConf()
+  private lazy val analyzerIsolationConf: SQLConf = {
+    val c = spark.sessionState.conf.clone()
     c.setConf(SQLConf.PATH_ENABLED, false)
-    // Match [[sparkConf]]: a bare SQLConf defaults ANSI_ENABLED to true, which changes
-    // function signatures in analyzed plans (e.g. make_date) vs golden files.
-    c.setConf(SQLConf.ANSI_ENABLED, false)
     c
   }
 
-  private val analyzer = {
+  private lazy val analyzer = {
     val inMemoryCatalog = new InMemoryChangelogCatalog
     // Name must match [[CatalogManager.SESSION_CATALOG_NAME]]: path entries use
     // [[currentCatalog.name()]], then resolution calls [[catalogManager.catalog]] on that segment.

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
@@ -135,8 +135,8 @@ class ProtoToParsedPlanTestSuite
 
   /**
    * Isolated from [[SharedSparkSession]] so PATH / session path settings do not affect catalog.
-   * Cloned from the test session's conf so all sparkConf overrides (ANSI, alias config, etc.)
-   * are preserved automatically; only the genuine isolation knob is overridden explicitly.
+   * Cloned from the test session's conf so all sparkConf overrides (ANSI, alias config, etc.) are
+   * preserved automatically; only the genuine isolation knob is overridden explicitly.
    */
   private lazy val analyzerIsolationConf: SQLConf = {
     val c = spark.sessionState.conf.clone()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/FetchCursorExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/FetchCursorExec.scala
@@ -194,7 +194,8 @@ case class FetchCursorExec(
       case FakeLocalCatalog => scriptingVariableManager.get
 
       case FakeSystemCatalog if tempVariableManager.get(namePartsCaseAdjusted).isEmpty =>
-        throw unresolvedVariableError(namePartsCaseAdjusted, Seq(Seq("SYSTEM", "SESSION")))
+        throw unresolvedVariableError(
+          namePartsCaseAdjusted, Seq(Seq("SYSTEM", "SESSION")), varRef.origin)
 
       case FakeSystemCatalog => tempVariableManager
 
@@ -207,7 +208,7 @@ case class FetchCursorExec(
       Literal(value, varRef.dataType)
     )
 
-    variableManager.set(namePartsCaseAdjusted, varDef)
+    variableManager.set(namePartsCaseAdjusted, varDef, varRef.origin)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/FetchCursorExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/FetchCursorExec.scala
@@ -194,7 +194,7 @@ case class FetchCursorExec(
       case FakeLocalCatalog => scriptingVariableManager.get
 
       case FakeSystemCatalog if tempVariableManager.get(namePartsCaseAdjusted).isEmpty =>
-        throw unresolvedVariableError(namePartsCaseAdjusted, Seq("SYSTEM", "SESSION"))
+        throw unresolvedVariableError(namePartsCaseAdjusted, Seq(Seq("SYSTEM", "SESSION")))
 
       case FakeSystemCatalog => tempVariableManager
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/SetVariableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/SetVariableExec.scala
@@ -80,7 +80,7 @@ case class SetVariableExec(variables: Seq[VariableReference], query: SparkPlan)
       case FakeLocalCatalog => scriptingVariableManager.get
 
       case FakeSystemCatalog if tempVariableManager.get(namePartsCaseAdjusted).isEmpty =>
-        throw unresolvedVariableError(namePartsCaseAdjusted, Seq("SYSTEM", "SESSION"))
+        throw unresolvedVariableError(namePartsCaseAdjusted, Seq(Seq("SYSTEM", "SESSION")))
 
       case FakeSystemCatalog => tempVariableManager
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/SetVariableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/SetVariableExec.scala
@@ -80,7 +80,8 @@ case class SetVariableExec(variables: Seq[VariableReference], query: SparkPlan)
       case FakeLocalCatalog => scriptingVariableManager.get
 
       case FakeSystemCatalog if tempVariableManager.get(namePartsCaseAdjusted).isEmpty =>
-        throw unresolvedVariableError(namePartsCaseAdjusted, Seq(Seq("SYSTEM", "SESSION")))
+        throw unresolvedVariableError(
+          namePartsCaseAdjusted, Seq(Seq("SYSTEM", "SESSION")), variable.origin)
 
       case FakeSystemCatalog => tempVariableManager
 
@@ -90,7 +91,7 @@ case class SetVariableExec(variables: Seq[VariableReference], query: SparkPlan)
     val varDef = VariableDefinition(
       variable.identifier, variable.varDef.defaultValueSQL, Literal(value, variable.dataType))
 
-    variableManager.set(namePartsCaseAdjusted, varDef)
+    variableManager.set(namePartsCaseAdjusted, varDef, variable.origin)
   }
 
   override def output: Seq[Attribute] = Seq.empty

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/VariableAssignmentUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/VariableAssignmentUtils.scala
@@ -68,7 +68,8 @@ object VariableAssignmentUtils {
       case FakeLocalCatalog => scriptingVariableManager.get
 
       case FakeSystemCatalog if tempVariableManager.get(namePartsCaseAdjusted).isEmpty =>
-        throw unresolvedVariableError(namePartsCaseAdjusted, Seq(Seq("SYSTEM", "SESSION")))
+        throw unresolvedVariableError(
+          namePartsCaseAdjusted, Seq(Seq("SYSTEM", "SESSION")), varRef.origin)
 
       case FakeSystemCatalog => tempVariableManager
 
@@ -81,6 +82,6 @@ object VariableAssignmentUtils {
       Literal(value, varRef.dataType)
     )
 
-    variableManager.set(namePartsCaseAdjusted, varDef)
+    variableManager.set(namePartsCaseAdjusted, varDef, varRef.origin)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/VariableAssignmentUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/v2/VariableAssignmentUtils.scala
@@ -68,7 +68,7 @@ object VariableAssignmentUtils {
       case FakeLocalCatalog => scriptingVariableManager.get
 
       case FakeSystemCatalog if tempVariableManager.get(namePartsCaseAdjusted).isEmpty =>
-        throw unresolvedVariableError(namePartsCaseAdjusted, Seq("SYSTEM", "SESSION"))
+        throw unresolvedVariableError(namePartsCaseAdjusted, Seq(Seq("SYSTEM", "SESSION")))
 
       case FakeSystemCatalog => tempVariableManager
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingLocalVariableManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingLocalVariableManager.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.{FakeLocalCatalog, ResolvedIdentifier}
 import org.apache.spark.sql.catalyst.catalog.{VariableDefinition, VariableManager}
+import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.errors.DataTypeErrorsBase
 import org.apache.spark.sql.errors.QueryCompilationErrors.unresolvedVariableError
@@ -47,15 +48,18 @@ class SqlScriptingLocalVariableManager(context: SqlScriptingExecutionContext)
     context.currentScope.variables.put(name, varDef)
   }
 
-  override def set(nameParts: Seq[String], varDef: VariableDefinition): Unit = {
+  override def set(
+      nameParts: Seq[String],
+      varDef: VariableDefinition,
+      origin: Origin): Unit = {
     val scope = findScopeOfVariable(nameParts)
       .getOrElse(
         throw unresolvedVariableError(
-          nameParts, Seq(varDef.identifier.namespace().toIndexedSeq)))
+          nameParts, Seq(varDef.identifier.namespace().toIndexedSeq), origin))
 
     if (!scope.variables.contains(nameParts.last)) {
       throw unresolvedVariableError(
-        nameParts, Seq(varDef.identifier.namespace().toIndexedSeq))
+        nameParts, Seq(varDef.identifier.namespace().toIndexedSeq), origin)
     }
 
     scope.variables.put(nameParts.last, varDef)

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingLocalVariableManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingLocalVariableManager.scala
@@ -50,10 +50,12 @@ class SqlScriptingLocalVariableManager(context: SqlScriptingExecutionContext)
   override def set(nameParts: Seq[String], varDef: VariableDefinition): Unit = {
     val scope = findScopeOfVariable(nameParts)
       .getOrElse(
-        throw unresolvedVariableError(nameParts, varDef.identifier.namespace().toIndexedSeq))
+        throw unresolvedVariableError(
+          nameParts, Seq(varDef.identifier.namespace().toIndexedSeq)))
 
     if (!scope.variables.contains(nameParts.last)) {
-      throw unresolvedVariableError(nameParts, varDef.identifier.namespace().toIndexedSeq)
+      throw unresolvedVariableError(
+        nameParts, Seq(varDef.identifier.namespace().toIndexedSeq))
     }
 
     scope.variables.put(nameParts.last, varDef)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
@@ -519,7 +519,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNRESOLVED_VARIABLE",
   "sqlState" : "42883",
   "messageParameters" : {
-    "searchPath" : "`system`.`session`",
+    "searchPath" : "[`system`.`session`]",
     "variableName" : "`builtin`.`var1`"
   }
 }
@@ -533,7 +533,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNRESOLVED_VARIABLE",
   "sqlState" : "42883",
   "messageParameters" : {
-    "searchPath" : "`system`.`session`",
+    "searchPath" : "[`system`.`session`]",
     "variableName" : "`system`.`sesion`.`var1`"
   }
 }
@@ -547,7 +547,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNRESOLVED_VARIABLE",
   "sqlState" : "42883",
   "messageParameters" : {
-    "searchPath" : "`system`.`session`",
+    "searchPath" : "[`system`.`session`]",
     "variableName" : "`sys`.`session`.`var1`"
   }
 }
@@ -648,9 +648,16 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNRESOLVED_VARIABLE",
   "sqlState" : "42883",
   "messageParameters" : {
-    "searchPath" : "`SYSTEM`.`SESSION`",
+    "searchPath" : "[`system`.`session`]",
     "variableName" : "`ses`.`var1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 25,
+    "fragment" : "SET VARIABLE ses.var1 = 1"
+  } ]
 }
 
 
@@ -662,9 +669,16 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNRESOLVED_VARIABLE",
   "sqlState" : "42883",
   "messageParameters" : {
-    "searchPath" : "`SYSTEM`.`SESSION`",
+    "searchPath" : "[`system`.`session`]",
     "variableName" : "`builtn`.`session`.`var1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 36,
+    "fragment" : "SET VARIABLE builtn.session.var1 = 1"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
@@ -521,7 +521,14 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "searchPath" : "[`system`.`session`]",
     "variableName" : "`builtin`.`var1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 44,
+    "fragment" : "DECLARE OR REPLACE VARIABLE builtin.var1 INT"
+  } ]
 }
 
 
@@ -535,7 +542,14 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "searchPath" : "[`system`.`session`]",
     "variableName" : "`system`.`sesion`.`var1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 50,
+    "fragment" : "DECLARE OR REPLACE VARIABLE system.sesion.var1 INT"
+  } ]
 }
 
 
@@ -549,7 +563,14 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "searchPath" : "[`system`.`session`]",
     "variableName" : "`sys`.`session`.`var1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 48,
+    "fragment" : "DECLARE OR REPLACE VARIABLE sys.session.var1 INT"
+  } ]
 }
 
 
@@ -650,7 +671,14 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "searchPath" : "[`system`.`session`]",
     "variableName" : "`ses`.`var1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 25,
+    "fragment" : "SET VARIABLE ses.var1 = 1"
+  } ]
 }
 
 
@@ -664,7 +692,14 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "searchPath" : "[`system`.`session`]",
     "variableName" : "`builtn`.`session`.`var1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 36,
+    "fragment" : "SET VARIABLE builtn.session.var1 = 1"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
@@ -525,9 +525,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 44,
-    "fragment" : "DECLARE OR REPLACE VARIABLE builtin.var1 INT"
+    "startIndex" : 29,
+    "stopIndex" : 40,
+    "fragment" : "builtin.var1"
   } ]
 }
 
@@ -546,9 +546,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 50,
-    "fragment" : "DECLARE OR REPLACE VARIABLE system.sesion.var1 INT"
+    "startIndex" : 29,
+    "stopIndex" : 46,
+    "fragment" : "system.sesion.var1"
   } ]
 }
 
@@ -567,9 +567,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 48,
-    "fragment" : "DECLARE OR REPLACE VARIABLE sys.session.var1 INT"
+    "startIndex" : 29,
+    "stopIndex" : 44,
+    "fragment" : "sys.session.var1"
   } ]
 }
 
@@ -675,9 +675,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 25,
-    "fragment" : "SET VARIABLE ses.var1 = 1"
+    "startIndex" : 14,
+    "stopIndex" : 21,
+    "fragment" : "ses.var1"
   } ]
 }
 
@@ -696,9 +696,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 36,
-    "fragment" : "SET VARIABLE builtn.session.var1 = 1"
+    "startIndex" : 14,
+    "stopIndex" : 32,
+    "fragment" : "builtn.session.var1"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
@@ -650,14 +650,7 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "searchPath" : "[`system`.`session`]",
     "variableName" : "`ses`.`var1`"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 25,
-    "fragment" : "SET VARIABLE ses.var1 = 1"
-  } ]
+  }
 }
 
 
@@ -671,14 +664,7 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "searchPath" : "[`system`.`session`]",
     "variableName" : "`builtn`.`session`.`var1`"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 36,
-    "fragment" : "SET VARIABLE builtn.session.var1 = 1"
-  } ]
+  }
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
@@ -504,9 +504,58 @@ Project [scalar-subquery#x [title#x] AS scalarsubquery(title)#xL]
 
 
 -- !query
-SET VARIABLE title = 'Test qualifiers - fail'
+SET VARIABLE title = 'Dropped struct variable -- field access vs qualified name'
 -- !query analysis
 SetVariable [variablereference(system.session.title='Test variable in aggregate')]
++- Project [Dropped struct variable -- field access vs qualified name AS title#x]
+   +- OneRowRelation
+
+
+-- !query
+DECLARE OR REPLACE VARIABLE session STRUCT<a INT> = NAMED_STRUCT('a', 1)
+-- !query analysis
+CreateVariable default(cast(named_struct(a, 1) as struct<a:int>), sql='NAMED_STRUCT('a', 1)'), true
++- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.session
+
+
+-- !query
+SELECT session.a
+-- !query analysis
+Project [variablereference(system.session.session=NAMED_STRUCT('a', 1)).a AS a#x]
++- OneRowRelation
+
+
+-- !query
+DROP TEMPORARY VARIABLE session
+-- !query analysis
+DropVariable false
++- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.session
+
+
+-- !query
+SELECT session.a
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION",
+  "sqlState" : "42703",
+  "messageParameters" : {
+    "objectName" : "`session`.`a`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 16,
+    "fragment" : "session.a"
+  } ]
+}
+
+
+-- !query
+SET VARIABLE title = 'Test qualifiers - fail'
+-- !query analysis
+SetVariable [variablereference(system.session.title='Dropped struct variable -- field access vs qualified name')]
 +- Project [Test qualifiers - fail AS title#x]
    +- OneRowRelation
 
@@ -669,7 +718,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNRESOLVED_VARIABLE",
   "sqlState" : "42883",
   "messageParameters" : {
-    "searchPath" : "[`system`.`session`]",
+    "searchPath" : "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]",
     "variableName" : "`ses`.`var1`"
   },
   "queryContext" : [ {
@@ -690,7 +739,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNRESOLVED_VARIABLE",
   "sqlState" : "42883",
   "messageParameters" : {
-    "searchPath" : "[`system`.`session`]",
+    "searchPath" : "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]",
     "variableName" : "`builtn`.`session`.`var1`"
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/inputs/sql-session-variables.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/sql-session-variables.sql
@@ -83,6 +83,19 @@ DROP TEMPORARY VARIABLE var1;
 SET VARIABLE title = 'Test variable in aggregate';
 SELECT (SELECT MAX(id) FROM RANGE(10) WHERE id < title) FROM VALUES 1, 2 AS t(title);
 
+SET VARIABLE title = 'Dropped struct variable -- field access vs qualified name';
+-- `session.a` is ambiguous: (a) 2-part qualified variable, or (b) field `a` of a 1-part
+-- variable `session`. Variable resolution tries (a) first via longest match, falls back to
+-- (b). With `session` declared as a struct, (b) succeeds. After the variable is dropped,
+-- both interpretations fail and the SELECT falls through to column resolution, which
+-- reports `UNRESOLVED_COLUMN`. Because either interpretation could have been intended,
+-- the variable error path (when reached) must dump the full SQL path -- see
+-- `VariableResolution.searchPathEntriesForError`.
+DECLARE OR REPLACE VARIABLE session STRUCT<a INT> = NAMED_STRUCT('a', 1);
+SELECT session.a;
+DROP TEMPORARY VARIABLE session;
+SELECT session.a;
+
 SET VARIABLE title = 'Test qualifiers - fail';
 DECLARE OR REPLACE VARIABLE builtin.var1 INT;
 DECLARE OR REPLACE VARIABLE system.sesion.var1 INT;

--- a/sql/core/src/test/resources/sql-tests/results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/sql-session-variables.sql.out
@@ -581,7 +581,14 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "searchPath" : "[`system`.`session`]",
     "variableName" : "`builtin`.`var1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 44,
+    "fragment" : "DECLARE OR REPLACE VARIABLE builtin.var1 INT"
+  } ]
 }
 
 
@@ -597,7 +604,14 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "searchPath" : "[`system`.`session`]",
     "variableName" : "`system`.`sesion`.`var1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 50,
+    "fragment" : "DECLARE OR REPLACE VARIABLE system.sesion.var1 INT"
+  } ]
 }
 
 
@@ -613,7 +627,14 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "searchPath" : "[`system`.`session`]",
     "variableName" : "`sys`.`session`.`var1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 48,
+    "fragment" : "DECLARE OR REPLACE VARIABLE sys.session.var1 INT"
+  } ]
 }
 
 
@@ -725,7 +746,14 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "searchPath" : "[`system`.`session`]",
     "variableName" : "`ses`.`var1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 25,
+    "fragment" : "SET VARIABLE ses.var1 = 1"
+  } ]
 }
 
 
@@ -741,7 +769,14 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "searchPath" : "[`system`.`session`]",
     "variableName" : "`builtn`.`session`.`var1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 36,
+    "fragment" : "SET VARIABLE builtn.session.var1 = 1"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/sql-session-variables.sql.out
@@ -562,6 +562,60 @@ struct<scalarsubquery(title):bigint>
 
 
 -- !query
+SET VARIABLE title = 'Dropped struct variable -- field access vs qualified name'
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+DECLARE OR REPLACE VARIABLE session STRUCT<a INT> = NAMED_STRUCT('a', 1)
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+SELECT session.a
+-- !query schema
+struct<a:int>
+-- !query output
+1
+
+
+-- !query
+DROP TEMPORARY VARIABLE session
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+SELECT session.a
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION",
+  "sqlState" : "42703",
+  "messageParameters" : {
+    "objectName" : "`session`.`a`"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 16,
+    "fragment" : "session.a"
+  } ]
+}
+
+
+-- !query
 SET VARIABLE title = 'Test qualifiers - fail'
 -- !query schema
 struct<>
@@ -744,7 +798,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNRESOLVED_VARIABLE",
   "sqlState" : "42883",
   "messageParameters" : {
-    "searchPath" : "[`system`.`session`]",
+    "searchPath" : "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]",
     "variableName" : "`ses`.`var1`"
   },
   "queryContext" : [ {
@@ -767,7 +821,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNRESOLVED_VARIABLE",
   "sqlState" : "42883",
   "messageParameters" : {
-    "searchPath" : "[`system`.`session`]",
+    "searchPath" : "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]",
     "variableName" : "`builtn`.`session`.`var1`"
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/sql-session-variables.sql.out
@@ -585,9 +585,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 44,
-    "fragment" : "DECLARE OR REPLACE VARIABLE builtin.var1 INT"
+    "startIndex" : 29,
+    "stopIndex" : 40,
+    "fragment" : "builtin.var1"
   } ]
 }
 
@@ -608,9 +608,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 50,
-    "fragment" : "DECLARE OR REPLACE VARIABLE system.sesion.var1 INT"
+    "startIndex" : 29,
+    "stopIndex" : 46,
+    "fragment" : "system.sesion.var1"
   } ]
 }
 
@@ -631,9 +631,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 48,
-    "fragment" : "DECLARE OR REPLACE VARIABLE sys.session.var1 INT"
+    "startIndex" : 29,
+    "stopIndex" : 44,
+    "fragment" : "sys.session.var1"
   } ]
 }
 
@@ -750,9 +750,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 25,
-    "fragment" : "SET VARIABLE ses.var1 = 1"
+    "startIndex" : 14,
+    "stopIndex" : 21,
+    "fragment" : "ses.var1"
   } ]
 }
 
@@ -773,9 +773,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 36,
-    "fragment" : "SET VARIABLE builtn.session.var1 = 1"
+    "startIndex" : 14,
+    "stopIndex" : 32,
+    "fragment" : "builtn.session.var1"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/sql-session-variables.sql.out
@@ -579,7 +579,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNRESOLVED_VARIABLE",
   "sqlState" : "42883",
   "messageParameters" : {
-    "searchPath" : "`system`.`session`",
+    "searchPath" : "[`system`.`session`]",
     "variableName" : "`builtin`.`var1`"
   }
 }
@@ -595,7 +595,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNRESOLVED_VARIABLE",
   "sqlState" : "42883",
   "messageParameters" : {
-    "searchPath" : "`system`.`session`",
+    "searchPath" : "[`system`.`session`]",
     "variableName" : "`system`.`sesion`.`var1`"
   }
 }
@@ -611,7 +611,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNRESOLVED_VARIABLE",
   "sqlState" : "42883",
   "messageParameters" : {
-    "searchPath" : "`system`.`session`",
+    "searchPath" : "[`system`.`session`]",
     "variableName" : "`sys`.`session`.`var1`"
   }
 }
@@ -723,9 +723,16 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNRESOLVED_VARIABLE",
   "sqlState" : "42883",
   "messageParameters" : {
-    "searchPath" : "`SYSTEM`.`SESSION`",
+    "searchPath" : "[`system`.`session`]",
     "variableName" : "`ses`.`var1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 25,
+    "fragment" : "SET VARIABLE ses.var1 = 1"
+  } ]
 }
 
 
@@ -739,9 +746,16 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNRESOLVED_VARIABLE",
   "sqlState" : "42883",
   "messageParameters" : {
-    "searchPath" : "`SYSTEM`.`SESSION`",
+    "searchPath" : "[`system`.`session`]",
     "variableName" : "`builtn`.`session`.`var1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 36,
+    "fragment" : "SET VARIABLE builtn.session.var1 = 1"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/sql-session-variables.sql.out
@@ -725,14 +725,7 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "searchPath" : "[`system`.`session`]",
     "variableName" : "`ses`.`var1`"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 25,
-    "fragment" : "SET VARIABLE ses.var1 = 1"
-  } ]
+  }
 }
 
 
@@ -748,14 +741,7 @@ org.apache.spark.sql.AnalysisException
   "messageParameters" : {
     "searchPath" : "[`system`.`session`]",
     "variableName" : "`builtn`.`session`.`var1`"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 1,
-    "stopIndex" : 36,
-    "fragment" : "SET VARIABLE builtn.session.var1 = 1"
-  } ]
+  }
 }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -372,25 +372,64 @@ class SetPathSuite extends SharedSparkSession {
     }
   }
 
-  test("PATH enabled: unqualified session variable lookup follows PATH") {
+  test("PATH enabled: unqualified SET VAR follows PATH; DDL on variables ignores PATH") {
     withPathEnabled {
+      // DECLARE always targets system.session regardless of PATH.
       sql("DECLARE VARIABLE system.session.path_var_gate = 7")
       try {
         sql("SET PATH = spark_catalog.default")
+        // Unqualified DML lookup goes through PATH; system.session is not on it, so SET VAR
+        // (and any other unqualified SQL VARIABLE reference) should fail with
+        // UNRESOLVED_VARIABLE reporting the *actual* PATH that was searched. The path is
+        // rendered as a bracketed list for consistency with UNRESOLVED_ROUTINE /
+        // TABLE_OR_VIEW_NOT_FOUND.
         checkError(
           exception = intercept[AnalysisException] {
-            sql("DROP TEMPORARY VARIABLE path_var_gate")
+            sql("SET VAR path_var_gate = 8")
           },
           condition = "UNRESOLVED_VARIABLE",
           sqlState = "42883",
           parameters = Map(
             "variableName" -> "`path_var_gate`",
-            "searchPath" -> "`SYSTEM`.`SESSION`"))
+            "searchPath" -> "[`spark_catalog`.`default`]"),
+          context = ExpectedContext("SET VAR path_var_gate = 8", 0, 24))
 
+        // Qualified SET VAR works regardless of PATH (no unqualified lookup).
+        sql("SET VAR system.session.path_var_gate = 9")
+        checkAnswer(sql("SELECT system.session.path_var_gate"), Row(9))
+
+        // DROP TEMPORARY VARIABLE is DDL: always targets system.session, no PATH gate.
+        sql("DROP TEMPORARY VARIABLE path_var_gate")
+
+        // Re-declare so we can test PATH-enabled lookup.
+        sql("DECLARE VARIABLE system.session.path_var_gate = 7")
         sql("SET PATH = spark_catalog.default, system.session")
+        sql("SET VAR path_var_gate = 11")
+        checkAnswer(sql("SELECT path_var_gate"), Row(11))
         sql("DROP TEMPORARY VARIABLE path_var_gate")
       } finally {
         sql("DROP TEMPORARY VARIABLE IF EXISTS system.session.path_var_gate")
+      }
+    }
+  }
+
+  test("PATH enabled: DECLARE / SET VAR / DROP cycle under non-default PATH") {
+    withPathEnabled {
+      sql("CREATE SCHEMA IF NOT EXISTS path_var_cycle")
+      try {
+        sql("SET PATH = spark_catalog.path_var_cycle, system.session")
+        // DECLARE: DDL, ignores PATH; targets system.session directly.
+        sql("DECLARE OR REPLACE VARIABLE cycle_var = 1")
+        // Qualified SET VAR works regardless of PATH.
+        sql("SET VAR system.session.cycle_var = 2")
+        // Unqualified SET VAR works because system.session is on the path.
+        sql("SET VAR cycle_var = 3")
+        checkAnswer(sql("SELECT cycle_var"), Row(3))
+        // DROP: DDL, ignores PATH.
+        sql("DROP TEMPORARY VARIABLE cycle_var")
+      } finally {
+        sql("DROP TEMPORARY VARIABLE IF EXISTS system.session.cycle_var")
+        sql("DROP SCHEMA IF EXISTS path_var_cycle")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -385,7 +385,7 @@ class SetPathSuite extends SharedSparkSession {
           sqlState = "42883",
           parameters = Map(
             "variableName" -> "`path_var_gate`",
-            "searchPath" -> "[`spark_catalog`.`default`]"),
+            "searchPath" -> "[`system`.`session`]"),
           context = ExpectedContext("SET VAR path_var_gate = 8", 0, 24))
 
         sql("SET VAR system.session.path_var_gate = 9")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -404,6 +404,53 @@ class SetPathSuite extends SharedSparkSession {
     }
   }
 
+  test("PATH enabled: unqualified FETCH ... INTO follows PATH") {
+    withSQLConf(
+      SQLConf.PATH_ENABLED.key -> "true",
+      SQLConf.SQL_SCRIPTING_CURSOR_ENABLED.key -> "true") {
+      sql("DECLARE OR REPLACE VARIABLE path_fetch_target INT")
+      try {
+        // Sanity: FETCH INTO works under the default path (system.session is on it).
+        val ok = sql(
+          """
+            |BEGIN
+            |  DECLARE cur CURSOR FOR SELECT 42 AS val;
+            |  OPEN cur;
+            |  FETCH cur INTO path_fetch_target;
+            |  CLOSE cur;
+            |END;
+            |""".stripMargin)
+        checkAnswer(ok, Seq.empty[Row])
+        checkAnswer(sql("SELECT path_fetch_target"), Row(42))
+
+        // Set PATH to exclude system.session: unqualified FETCH INTO target now fails
+        // with the actual SQL path rendered as a bracketed list.
+        sql("SET PATH = spark_catalog.default")
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql(
+              """
+                |BEGIN
+                |  DECLARE cur CURSOR FOR SELECT 99 AS val;
+                |  OPEN cur;
+                |  FETCH cur INTO path_fetch_target;
+                |  CLOSE cur;
+                |END;
+                |""".stripMargin)
+          },
+          condition = "UNRESOLVED_VARIABLE",
+          sqlState = "42883",
+          parameters = Map(
+            "variableName" -> "`path_fetch_target`",
+            "searchPath" -> "[`spark_catalog`.`default`]"),
+          context = ExpectedContext("path_fetch_target", -1, -1))
+      } finally {
+        sql("SET PATH = DEFAULT_PATH")
+        sql("DROP TEMPORARY VARIABLE IF EXISTS path_fetch_target")
+      }
+    }
+  }
+
   test("PATH enabled: DECLARE / SET VAR / DROP cycle under non-default PATH") {
     withPathEnabled {
       sql("CREATE SCHEMA IF NOT EXISTS path_var_cycle")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -385,7 +385,8 @@ class SetPathSuite extends SharedSparkSession {
           sqlState = "42883",
           parameters = Map(
             "variableName" -> "`path_var_gate`",
-            "searchPath" -> "[`spark_catalog`.`default`]"))
+            "searchPath" -> "[`spark_catalog`.`default`]"),
+          context = ExpectedContext("SET VAR path_var_gate = 8", 0, 24))
 
         sql("SET VAR system.session.path_var_gate = 9")
         checkAnswer(sql("SELECT system.session.path_var_gate"), Row(9))

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -374,15 +374,9 @@ class SetPathSuite extends SharedSparkSession {
 
   test("PATH enabled: unqualified SET VAR follows PATH; DDL on variables ignores PATH") {
     withPathEnabled {
-      // DECLARE always targets system.session regardless of PATH.
       sql("DECLARE VARIABLE system.session.path_var_gate = 7")
       try {
         sql("SET PATH = spark_catalog.default")
-        // Unqualified DML lookup goes through PATH; system.session is not on it, so SET VAR
-        // (and any other unqualified SQL VARIABLE reference) should fail with
-        // UNRESOLVED_VARIABLE reporting the *actual* PATH that was searched. The path is
-        // rendered as a bracketed list for consistency with UNRESOLVED_ROUTINE /
-        // TABLE_OR_VIEW_NOT_FOUND.
         checkError(
           exception = intercept[AnalysisException] {
             sql("SET VAR path_var_gate = 8")
@@ -394,14 +388,11 @@ class SetPathSuite extends SharedSparkSession {
             "searchPath" -> "[`spark_catalog`.`default`]"),
           context = ExpectedContext("SET VAR path_var_gate = 8", 0, 24))
 
-        // Qualified SET VAR works regardless of PATH (no unqualified lookup).
         sql("SET VAR system.session.path_var_gate = 9")
         checkAnswer(sql("SELECT system.session.path_var_gate"), Row(9))
 
-        // DROP TEMPORARY VARIABLE is DDL: always targets system.session, no PATH gate.
         sql("DROP TEMPORARY VARIABLE path_var_gate")
 
-        // Re-declare so we can test PATH-enabled lookup.
         sql("DECLARE VARIABLE system.session.path_var_gate = 7")
         sql("SET PATH = spark_catalog.default, system.session")
         sql("SET VAR path_var_gate = 11")
@@ -418,14 +409,10 @@ class SetPathSuite extends SharedSparkSession {
       sql("CREATE SCHEMA IF NOT EXISTS path_var_cycle")
       try {
         sql("SET PATH = spark_catalog.path_var_cycle, system.session")
-        // DECLARE: DDL, ignores PATH; targets system.session directly.
         sql("DECLARE OR REPLACE VARIABLE cycle_var = 1")
-        // Qualified SET VAR works regardless of PATH.
         sql("SET VAR system.session.cycle_var = 2")
-        // Unqualified SET VAR works because system.session is on the path.
         sql("SET VAR cycle_var = 3")
         checkAnswer(sql("SELECT cycle_var"), Row(3))
-        // DROP: DDL, ignores PATH.
         sql("DROP TEMPORARY VARIABLE cycle_var")
       } finally {
         sql("DROP TEMPORARY VARIABLE IF EXISTS system.session.cycle_var")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -386,7 +386,7 @@ class SetPathSuite extends SharedSparkSession {
           parameters = Map(
             "variableName" -> "`path_var_gate`",
             "searchPath" -> "[`spark_catalog`.`default`]"),
-          context = ExpectedContext("SET VAR path_var_gate = 8", 0, 24))
+          context = ExpectedContext("path_var_gate", 8, 20))
 
         sql("SET VAR system.session.path_var_gate = 9")
         checkAnswer(sql("SELECT system.session.path_var_gate"), Row(9))

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -385,8 +385,7 @@ class SetPathSuite extends SharedSparkSession {
           sqlState = "42883",
           parameters = Map(
             "variableName" -> "`path_var_gate`",
-            "searchPath" -> "[`spark_catalog`.`default`]"),
-          context = ExpectedContext("SET VAR path_var_gate = 8", 0, 24))
+            "searchPath" -> "[`spark_catalog`.`default`]"))
 
         sql("SET VAR system.session.path_var_gate = 9")
         checkAnswer(sql("SELECT system.session.path_var_gate"), Row(9))

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -377,6 +377,8 @@ class SetPathSuite extends SharedSparkSession {
       sql("DECLARE VARIABLE system.session.path_var_gate = 7")
       try {
         sql("SET PATH = spark_catalog.default")
+        // PATH excludes system.session, so the lookup did not actually consult any namespace
+        // and the reported search path is empty.
         checkError(
           exception = intercept[AnalysisException] {
             sql("SET VAR path_var_gate = 8")
@@ -385,7 +387,7 @@ class SetPathSuite extends SharedSparkSession {
           sqlState = "42883",
           parameters = Map(
             "variableName" -> "`path_var_gate`",
-            "searchPath" -> "[`system`.`session`]"),
+            "searchPath" -> "[]"),
           context = ExpectedContext("SET VAR path_var_gate = 8", 0, 24))
 
         sql("SET VAR system.session.path_var_gate = 9")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetPathSuite.scala
@@ -377,8 +377,6 @@ class SetPathSuite extends SharedSparkSession {
       sql("DECLARE VARIABLE system.session.path_var_gate = 7")
       try {
         sql("SET PATH = spark_catalog.default")
-        // PATH excludes system.session, so the lookup did not actually consult any namespace
-        // and the reported search path is empty.
         checkError(
           exception = intercept[AnalysisException] {
             sql("SET VAR path_var_gate = 8")
@@ -387,7 +385,7 @@ class SetPathSuite extends SharedSparkSession {
           sqlState = "42883",
           parameters = Map(
             "variableName" -> "`path_var_gate`",
-            "searchPath" -> "[]"),
+            "searchPath" -> "[`spark_catalog`.`default`]"),
           context = ExpectedContext("SET VAR path_var_gate = 8", 0, 24))
 
         sql("SET VAR system.session.path_var_gate = 9")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlignAssignmentsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlignAssignmentsSuiteBase.scala
@@ -195,6 +195,9 @@ abstract class AlignAssignmentsSuiteBase extends AnalysisTest {
       .thenReturn(defaultPath)
     when(manager.sqlResolutionPathEntries(any[String], any[Seq[String]]))
       .thenReturn(defaultPath)
+    when(manager.resolutionPathEntriesForAnalysis(
+      any[Option[Seq[Seq[String]]]], any[Seq[String]]))
+      .thenReturn(defaultPath)
     manager
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -237,6 +237,9 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
       .thenReturn(defaultPath)
     when(manager.sqlResolutionPathEntries(any[String], any[Seq[String]]))
       .thenReturn(defaultPath)
+    when(manager.resolutionPathEntriesForAnalysis(
+      any[Option[Seq[Seq[String]]]], any[Seq[String]]))
+      .thenReturn(defaultPath)
     manager
   }
 
@@ -262,6 +265,9 @@ class PlanResolutionSuite extends SharedSparkSession with AnalysisTest {
       any[String], any[Seq[String]], any[String], any[Seq[String]]))
       .thenReturn(defaultPath2)
     when(manager.sqlResolutionPathEntries(any[String], any[Seq[String]]))
+      .thenReturn(defaultPath2)
+    when(manager.resolutionPathEntriesForAnalysis(
+      any[Option[Seq[Seq[String]]]], any[Seq[String]]))
       .thenReturn(defaultPath2)
     manager
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -3691,10 +3691,6 @@ class SqlScriptingExecutionSuite extends SharedSparkSession {
       sqlState = "42883",
       parameters = Map(
         "variableName" -> toSQLId("LOCALVAR"),
-        // SET VAR on an unqualified name reports the actual SQL PATH searched as a bracketed
-        // list (SPARK-56681). Local-variable lookup falls through to PATH-driven
-        // session-variable lookup; on the default path that's
-        // [builtin, session, spark_catalog.default].
         "searchPath" ->
           "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]"),
       context = ExpectedContext("SET LOCALVAR = 5", 50, 65)

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -3691,7 +3691,13 @@ class SqlScriptingExecutionSuite extends SharedSparkSession {
       sqlState = "42883",
       parameters = Map(
         "variableName" -> toSQLId("LOCALVAR"),
-        "searchPath" -> toSQLId("SYSTEM.SESSION"))
+        // SET VAR on an unqualified name reports the actual SQL PATH searched as a bracketed
+        // list (SPARK-56681). Local-variable lookup falls through to PATH-driven
+        // session-variable lookup; on the default path that's
+        // [builtin, session, spark_catalog.default].
+        "searchPath" ->
+          "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]"),
+      context = ExpectedContext("SET LOCALVAR = 5", 50, 65)
     )
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -3692,8 +3692,7 @@ class SqlScriptingExecutionSuite extends SharedSparkSession {
       parameters = Map(
         "variableName" -> toSQLId("LOCALVAR"),
         "searchPath" ->
-          "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]"),
-      context = ExpectedContext("SET LOCALVAR = 5", 50, 65)
+          "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]")
     )
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -3692,7 +3692,8 @@ class SqlScriptingExecutionSuite extends SharedSparkSession {
       parameters = Map(
         "variableName" -> toSQLId("LOCALVAR"),
         "searchPath" ->
-          "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]")
+          "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]"),
+      context = ExpectedContext("SET LOCALVAR = 5", 50, 65)
     )
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -3691,7 +3691,8 @@ class SqlScriptingExecutionSuite extends SharedSparkSession {
       sqlState = "42883",
       parameters = Map(
         "variableName" -> toSQLId("LOCALVAR"),
-        "searchPath" -> "[`system`.`session`]"),
+        "searchPath" ->
+          "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]"),
       context = ExpectedContext("SET LOCALVAR = 5", 50, 65)
     )
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -3691,8 +3691,7 @@ class SqlScriptingExecutionSuite extends SharedSparkSession {
       sqlState = "42883",
       parameters = Map(
         "variableName" -> toSQLId("LOCALVAR"),
-        "searchPath" ->
-          "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]"),
+        "searchPath" -> "[`system`.`session`]"),
       context = ExpectedContext("SET LOCALVAR = 5", 50, 65)
     )
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -3693,7 +3693,7 @@ class SqlScriptingExecutionSuite extends SharedSparkSession {
         "variableName" -> toSQLId("LOCALVAR"),
         "searchPath" ->
           "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]"),
-      context = ExpectedContext("SET LOCALVAR = 5", 50, 65)
+      context = ExpectedContext("LOCALVAR", 54, 61)
     )
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Address the open follow-ups from [SPARK-56681](https://issues.apache.org/jira/browse/SPARK-56681) (umbrella for PATH / SPARK-56605 cleanup) in a single cleanup PR. Items #1 and #2 were already wired by SPARK-56639; this PR covers the remainder.

| # | Item | Resolution |
|---|---|---|
| #1 | `FunctionResolution.resolveProcedure` was dead code | Already wired by SPARK-56639 (no action). |
| #2 | Frozen view / SQL-function PATH wiring unfinished | Already done by SPARK-56639 (no action). |
| #3 | `AnalysisContext.resolutionPathEntries` threadlocal | Audit only: confirmed `withNewAnalysisContext` / `reset()` correctly clear it. Full removal needs a coordinated refactor to plumb the path through `RelationResolution` / `FunctionResolution` method calls; flagged as a follow-up. |
| #4 | `Analyzer.executeAndCheck` clobbers outer `SQLConf.withExistingConf` | Extracted `runWithSessionConf` helper, added `SQLConf.getExistingConfIfSet`. `executeAndCheck` and `executeSameContext` now share one path that yields to any outer scope. |
| #5 | `VariableResolution.allowUnqualifiedSessionTempVariableLookup` force-loads default catalog | Replaced the hot-path catalog read with `CatalogManager.isSystemSessionOnPath`, which inspects stored session-path entries directly. No catalog load on column resolution. |
| #6 | `DROP VARIABLE` PATH gate asymmetric with `DECLARE` / `CREATE` | Removed the gate. DDL on session variables (`DECLARE` / `CREATE` / `DROP`) always targets `system.session` directly; only DML (`SET VAR`, `SELECT @x`) goes through PATH. |
| #7 | `lookupFunctionType` exception swallow too broad | Narrowed from `NonFatal` to the explicit not-found list (`NoSuchFunctionException`, `NoSuchNamespaceException`, `CatalogNotFoundException`, `FORBIDDEN_OPERATION`). Other exceptions propagate. |
| #8 | `lookupFunctionType` fan-out had wasteful `system.*` candidates | Filtered them out — `system.session`, `system.builtin`, `system.ai` are already resolved earlier in the same method. |
| #9 | Three near-duplicate path-resolution helpers | Lifted into `CatalogManager.resolutionPathEntriesForAnalysis(pinnedEntries, viewCatalogAndNamespace)`. Relation, routine, and procedure resolution all route through it. |
| #10 | Tests for the new error paths and gates | Added a DECLARE / SET VAR / DROP cycle test under non-default PATH and a struct-variable field-vs-qualified ambiguity test in `sql-session-variables.sql`. |
| #11 | `ProtoToParsedPlanTestSuite.analyzerIsolationConf` was a bare `SQLConf` | Clone `spark.sessionState.conf` and only override `PATH_ENABLED=false`, so all `sparkConf` overrides (ANSI, alias config, ...) propagate automatically. |
| Bonus | `ResolveSetVariable` hardcoded `SYSTEM.SESSION` regardless of actual PATH | `unresolvedVariableError` now takes `Seq[Seq[String]]` path entries with **required** `Origin` (no overloads). DML lookup failures (`SET VAR`, `FETCH ... INTO`) report the full SQL path as a bracketed list, byte-for-byte consistent with `UNRESOLVED_ROUTINE` and `TABLE_OR_VIEW_NOT_FOUND`. DDL name validation in `ResolveCatalogs` continues to report `[system.session]` since PATH does not apply there. Origin is plumbed through `VariableManager.set` so all error sites carry a `queryContext` pointing at the offending variable identifier (parser opt-ins via `withOrigin(identifierReference)` so the highlight is the variable name, not the whole statement). |

### Why are the changes needed?

These are the cleanup items called out on SPARK-56681 from the post-merge source review of SPARK-56605. They eliminate dead code paths, plug user-visible bugs (force-loading a misconfigured default catalog on column resolution; clobbering pinned session configs; swallowing real catalog errors as `UNRESOLVED_ROUTINE`), remove the asymmetry between DDL and DML on session variables, and make `UNRESOLVED_VARIABLE` self-consistent with the other "not found" errors.

### Does this PR introduce _any_ user-facing change?

Yes.

- **`UNRESOLVED_VARIABLE.searchPath`** is now rendered as a bracketed list. For DML lookups (`SET VAR`, `FETCH ... INTO`), the list reflects the actual SQL PATH that was consulted instead of a hardcoded `SYSTEM.SESSION`. For DDL name validation (`DECLARE` / `DROP` with a non-session namespace), the list is `[`` `system`.`session` ``]` since PATH does not apply.
- **`UNRESOLVED_VARIABLE`** now always carries a `queryContext` that highlights just the offending variable identifier (e.g. `"builtin.var1"`, `"ses.var1"`), not the whole `DECLARE` / `SET VAR` statement.
- **`DROP TEMPORARY VARIABLE`** no longer raises `UNRESOLVED_VARIABLE` when the SQL PATH does not contain `system.session`. DDL on session variables ignores PATH, matching the existing behaviour of `DECLARE OR REPLACE VARIABLE`.
- **`lookupFunctionType`** no longer swallows non–`NotFound` errors. A catalog reporting `PERMISSION_DENIED` (or similar) for a function lookup now propagates instead of silently producing `UNRESOLVED_ROUTINE`.

### How was this patch tested?

- Added `sql-session-variables.sql` regression test for the struct-variable field-vs-qualified ambiguity (`DECLARE VARIABLE session STRUCT<a INT>` → `SELECT session.a` succeeds → `DROP` → `SELECT session.a` falls through to `UNRESOLVED_COLUMN`).
- Updated `SetPathSuite`: DECLARE / SET VAR / DROP cycle under a non-default PATH; bonus test asserts the actual rendered search path and the variable-identifier `queryContext`.
- Updated `SqlScriptingExecutionSuite` for the new bracketed `searchPath` and identifier-pinned `queryContext`.
- Regenerated `sql-session-variables.sql.out` for the new error shape.
- Added `resolutionPathEntriesForAnalysis` stubs to mocked `CatalogManager` instances in `PlanResolutionSuite`, `AlignAssignmentsSuiteBase`, and `TableLookupCacheSuite`.
- Ran focused suites locally; all pass:
  - `build/sbt 'sql/testOnly *SetPathSuite *SqlScriptingExecutionSuite *ExecuteImmediateEndToEndSuite'`
  - `build/sbt 'sql/testOnly *SimpleSQLViewSuite *SQLFunctionSuite'`
  - `build/sbt 'sql/testOnly *PlanResolutionSuite *UpdateTableAlignAssignmentsSuite *MergeIntoTableAlignAssignmentsSuite'`
  - `build/sbt 'catalyst/testOnly *TableLookupCacheSuite *AnalysisSuite *AnalysisErrorSuite *LookupFunctionsSuite'`
  - `build/sbt 'sql/testOnly *FunctionQualificationSuite *RelationQualificationSuite *DataSourceV2FunctionSuite'`
  - `build/sbt 'sql/testOnly *SQLQuerySuite'`
  - `build/sbt 'connect/testOnly *ProtoToParsedPlanTestSuite'`
  - `build/sbt 'sql/testOnly *SQLQueryTestSuite -- -z sql-session-variables.sql'`
  - Full `org.apache.spark.sql.catalyst.analysis.*`, `org.apache.spark.sql.catalyst.parser.*`, and `org.apache.spark.sql.analysis.resolver.*` suites.
- `scalastyle` and `scalafmt` clean across catalyst, sql, and connect modules.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor Claude Opus 4.7