### PR TITLE
[SPARK-56698][PYTHON] Add Spark MCP (Model Context Protocol) server

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -620,6 +620,7 @@ pyspark_sql = Module(
         "pyspark.sql.tests.test_udf_profiler",
         "pyspark.sql.tests.test_unified_udf",
         "pyspark.sql.tests.test_udtf",
+        "pyspark.sql.tests.mcp.test_mcp_tools",
         "pyspark.sql.tests.test_tvf",
         "pyspark.sql.tests.test_utils",
         "pyspark.sql.tests.test_resources",
@@ -1214,6 +1215,7 @@ pyspark_connect = Module(
         "pyspark.sql.tests.connect.pandas.test_parity_pandas_udf_scalar",
         "pyspark.sql.tests.connect.pandas.test_parity_pandas_udf_grouped_agg",
         "pyspark.sql.tests.connect.pandas.test_parity_pandas_udf_window",
+        "pyspark.sql.tests.mcp.test_mcp_integration",
     ],
 )
 

--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -177,6 +177,12 @@ ignore_missing_imports = True
 [mypy-IPython.*]
 ignore_missing_imports = True
 
+[mypy-mcp.*]
+ignore_missing_imports = True
+
+[mypy-anyio]
+ignore_missing_imports = True
+
 ; Ignore errors for proto generated code
 [mypy-pyspark.sql.connect.proto.*, pyspark.sql.connect.proto, pyspark.sql.streaming.proto]
 ignore_errors = True

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -577,6 +577,56 @@
       "A master URL must be set in your configuration."
     ]
   },
+  "MCP_CONNECT_URL_REQUIRED": {
+    "message": [
+      "Spark Connect URL must be provided via --connect-url or the SPARK_REMOTE environment variable."
+    ]
+  },
+  "MCP_EMPTY_QUERY": {
+    "message": [
+      "Query is empty."
+    ]
+  },
+  "MCP_INVALID_ENV_INT": {
+    "message": [
+      "Environment variable `<name>` must be an integer; got <value>."
+    ]
+  },
+  "MCP_INVALID_EXPLAIN_MODE": {
+    "message": [
+      "Explain mode must be one of <allowed>; got <mode>."
+    ]
+  },
+  "MCP_PYARROW_REQUIRED": {
+    "message": [
+      "Format `<format>` requires PyArrow to be installed."
+    ]
+  },
+  "MCP_QUERY_TIMEOUT": {
+    "message": [
+      "Tool `<label>` exceeded the configured `<timeout>`s timeout."
+    ]
+  },
+  "MCP_READ_ONLY_VIOLATION": {
+    "message": [
+      "Statement type `<statement>` is not allowed in read-only mode."
+    ]
+  },
+  "MCP_TRANSPORT_NOT_IMPLEMENTED": {
+    "message": [
+      "MCP transport `<transport>` is not implemented."
+    ]
+  },
+  "MCP_UNKNOWN_TOOL": {
+    "message": [
+      "Unknown MCP tool: `<name>`."
+    ]
+  },
+  "MCP_UNSUPPORTED_FORMAT": {
+    "message": [
+      "Unsupported result format `<format>`; expected one of <allowed>."
+    ]
+  },
   "MEMORY_PROFILE_INVALID_SOURCE": {
     "message": [
       "Memory profiler can only be used on editors with line numbers."

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -597,11 +597,6 @@
       "Explain mode must be one of `<allowed>`; got `<mode>`."
     ]
   },
-  "MCP_PYARROW_REQUIRED": {
-    "message": [
-      "Format `<format>` requires PyArrow to be installed."
-    ]
-  },
   "MCP_QUERY_TIMEOUT": {
     "message": [
       "Tool `<label>` exceeded the configured timeout of `<timeout>` seconds."

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -589,12 +589,12 @@
   },
   "MCP_INVALID_ENV_INT": {
     "message": [
-      "Environment variable `<name>` must be an integer; got <value>."
+      "Environment variable `<name>` must be an integer; got `<value>`."
     ]
   },
   "MCP_INVALID_EXPLAIN_MODE": {
     "message": [
-      "Explain mode must be one of <allowed>; got <mode>."
+      "Explain mode must be one of `<allowed>`; got `<mode>`."
     ]
   },
   "MCP_PYARROW_REQUIRED": {
@@ -604,7 +604,7 @@
   },
   "MCP_QUERY_TIMEOUT": {
     "message": [
-      "Tool `<label>` exceeded the configured `<timeout>`s timeout."
+      "Tool `<label>` exceeded the configured timeout of `<timeout>` seconds."
     ]
   },
   "MCP_READ_ONLY_VIOLATION": {
@@ -624,7 +624,7 @@
   },
   "MCP_UNSUPPORTED_FORMAT": {
     "message": [
-      "Unsupported result format `<format>`; expected one of <allowed>."
+      "Unsupported result format `<format>`; expected one of `<allowed>`."
     ]
   },
   "MEMORY_PROFILE_INVALID_SOURCE": {

--- a/python/pyspark/sql/mcp/README.md
+++ b/python/pyspark/sql/mcp/README.md
@@ -4,8 +4,6 @@ A [Model Context Protocol](https://modelcontextprotocol.io) server for Apache
 Spark, implemented as a thin client over [Spark
 Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html).
 
-> Status: **early scaffold (v0.1 PoC)**. Not yet wired into Spark releases.
-
 ## Why
 
 LLM clients can already talk to MCP servers; Spark Connect already separates
@@ -33,7 +31,7 @@ python -m pyspark.sql.mcp
 The server is **read-only by default**. Pass `--no-read-only` to allow DDL/DML
 (use with care; the read-only filter is a guardrail, not a security boundary).
 
-## Tools (planned for v0.1)
+## Tools
 
 Catalog exploration, query execution, and query plans:
 
@@ -43,13 +41,12 @@ Catalog exploration, query execution, and query plans:
 - `execute_sql`, `preview_table`
 - `explain_query`, `analyze_query`
 
-See `dev/design-docs/spark-mcp-server/02-design.md` for the full design.
-
 ## Motivating example: LLM-assisted plan analysis
 
-`explain_query` and `analyze_query` are the highest-leverage tools in the
-v0.1 set: an LLM that can read a structured Spark plan can reason about
-performance the way a Spark engineer would, without running the query.
+`explain_query` and `analyze_query` are the highest-leverage tools the
+server exposes: an LLM that can read a structured Spark plan can reason
+about performance the way a Spark engineer would, without running the
+query.
 
 A user prompts an LLM client (which has the Spark MCP server attached):
 

--- a/python/pyspark/sql/mcp/README.md
+++ b/python/pyspark/sql/mcp/README.md
@@ -31,6 +31,78 @@ python -m pyspark.sql.mcp
 The server is **read-only by default**. Pass `--no-read-only` to allow DDL/DML
 (use with care; the read-only filter is a guardrail, not a security boundary).
 
+## Configuring an MCP client
+
+The server speaks `stdio` MCP transport, so a client launches it as a
+subprocess. The exact configuration step is client-specific; the moving
+parts are always:
+
+1. The command (`python -m pyspark.sql.mcp`).
+2. The Spark Connect URL, supplied via `--connect-url` or the
+   `SPARK_REMOTE` environment variable.
+3. Optionally, `--no-read-only` to permit DDL/DML.
+
+### Claude Code
+
+```bash
+claude mcp add spark \
+  -e SPARK_REMOTE=sc://localhost:15002 \
+  -- python -m pyspark.sql.mcp
+```
+
+Pass `--scope user` to register the server for all projects, or
+`--scope project` to write a shared `.mcp.json` into the current
+repository. Restart the Claude Code session and the LLM gains
+`mcp__spark__*` tools.
+
+### Claude Desktop
+
+Edit the application's `claude_desktop_config.json` (location is
+documented in the Claude Desktop docs) and add an entry under
+`mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "spark": {
+      "command": "python",
+      "args": ["-m", "pyspark.sql.mcp"],
+      "env": {
+        "SPARK_REMOTE": "sc://localhost:15002"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop.
+
+### Other MCP clients
+
+Any MCP-compliant client that can launch a stdio subprocess can use the
+same shape:
+
+```json
+{
+  "command": "python",
+  "args": ["-m", "pyspark.sql.mcp"],
+  "env": {"SPARK_REMOTE": "sc://localhost:15002"}
+}
+```
+
+### Environment variables
+
+| Variable | Meaning |
+| --- | --- |
+| `SPARK_REMOTE` | Spark Connect URL (`sc://host:port[/;params]`). |
+| `SPARK_MCP_READ_ONLY` | `true` (default) or `false`. |
+| `SPARK_MCP_USER_ID` | Optional Spark Connect session user id. |
+| `SPARK_MCP_TRANSPORT` | Reserved; only `stdio` is implemented. |
+
+To verify the wiring, ask the LLM to list catalogs, or to call
+`get_session_info` — the response should include the Spark version
+reported by the cluster.
+
 ## Tools
 
 Catalog exploration, query execution, and query plans:

--- a/python/pyspark/sql/mcp/README.md
+++ b/python/pyspark/sql/mcp/README.md
@@ -45,6 +45,66 @@ Catalog exploration, query execution, and query plans:
 
 See `dev/design-docs/spark-mcp-server/02-design.md` for the full design.
 
+## Motivating example: LLM-assisted plan analysis
+
+`explain_query` and `analyze_query` are the highest-leverage tools in the
+v0.1 set: an LLM that can read a structured Spark plan can reason about
+performance the way a Spark engineer would, without running the query.
+
+A user prompts an LLM client (which has the Spark MCP server attached):
+
+> "I want to understand the execution plan for
+> `SELECT count(*) FROM range(1000000) WHERE id % 7 = 0 GROUP BY id % 3` —
+> but **don't actually execute it**. From the plan, where is the predicate
+> handled?"
+
+The LLM calls `analyze_query`, receives the optimized logical and physical
+plans, and produces an answer like:
+
+```
+Optimized Logical Plan
+Aggregate [_groupingexpression#50L], [count(1) AS count(1)]
++- Project [(id % 3) AS _groupingexpression]
+   +- Filter ((id % 7) = 0)
+      +- Range (0, 1000000, step=1)
+
+Physical Plan
+AdaptiveSparkPlan isFinalPlan=false
++- HashAggregate(keys=[_groupingexpression], functions=[count(1)])
+   +- Exchange hashpartitioning(_groupingexpression, 200)
+      +- HashAggregate(keys=[_groupingexpression], functions=[partial_count(1)])
+         +- Project [(id % 3) AS _groupingexpression]
+            +- Filter ((id % 7) = 0)
+               +- Range (0, 1000000, step=1, splits=16)
+```
+
+> 1. **Range (splits=16)** generates 0..999999 across 16 partitions — no I/O.
+> 2. **Filter `(id % 7) = 0`** sits directly above the Range, so only ~1/7 of
+>    the rows survive; everything above it sees the smaller stream.
+> 3. **Project `id % 3`** materializes the group key once so it isn't
+>    recomputed on either side of the aggregate.
+> 4. **HashAggregate (partial_count)** does map-side combine inside each
+>    partition, emitting `(group_key, partial_count)`.
+> 5. **Exchange hashpartitioning(200)** shuffles by group key. Since the key
+>    only has 3 distinct values, only 3 reducers actually receive data.
+> 6. **HashAggregate (final count)** sums the partial counts into the final
+>    3-row result.
+> 7. **AdaptiveSparkPlan `isFinalPlan=false`** means AQE can still adjust at
+>    runtime (coalesce empty partitions, change join strategies, etc.).
+>
+> **Where is `id % 7 = 0` handled?** In the `Filter` operator immediately
+> above the source — the lowest, earliest point in the plan. The
+> `PushDownPredicates` optimizer rule moves filters as close to the source
+> as possible. `Range` isn't a file source, so there is no storage-level
+> pushdown, but the effect is identical: `id % 3`, the partial aggregate,
+> and the shuffle all see only the post-filter rows. For a Parquet source
+> the same filter would also be pushed down as a data-source filter and
+> drive partition pruning.
+
+This kind of explanation is what makes the plan tools valuable: the LLM
+turns Spark's verbose plan output into a step-by-step narrative grounded in
+operator semantics, without any of the query's data leaving the cluster.
+
 ## Dependencies
 
 - `pyspark` with the Spark Connect client extras.

--- a/python/pyspark/sql/mcp/README.md
+++ b/python/pyspark/sql/mcp/README.md
@@ -97,7 +97,12 @@ same shape:
 | `SPARK_REMOTE` | Spark Connect URL (`sc://host:port[/;params]`). |
 | `SPARK_MCP_READ_ONLY` | `true` (default) or `false`. |
 | `SPARK_MCP_USER_ID` | Optional Spark Connect session user id. |
+| `SPARK_MCP_MAX_ROWS` | Hard cap on rows returned per tool call (default `1000`). |
+| `SPARK_MCP_QUERY_TIMEOUT_SECONDS` | Wall-clock cap per tool call (default `60`; `0` disables). |
 | `SPARK_MCP_TRANSPORT` | Reserved; only `stdio` is implemented. |
+
+Equivalent CLI flags: `--user-id`, `--max-rows`, `--query-timeout-seconds`.
+CLI flags take precedence over env vars.
 
 To verify the wiring, ask the LLM to list catalogs, or to call
 `get_session_info` — the response should include the Spark version

--- a/python/pyspark/sql/mcp/README.md
+++ b/python/pyspark/sql/mcp/README.md
@@ -1,0 +1,52 @@
+# Spark MCP Server
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server for Apache
+Spark, implemented as a thin client over [Spark
+Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html).
+
+> Status: **early scaffold (v0.1 PoC)**. Not yet wired into Spark releases.
+
+## Why
+
+LLM clients can already talk to MCP servers; Spark Connect already separates
+client from cluster. This module connects the two: a Spark cluster shows up
+to an LLM as a set of safe, paginated tools — `list_tables`, `describe_table`,
+`execute_sql`, `explain_query`, etc. — without giving the LLM a JVM driver.
+
+## Run
+
+The server speaks the `stdio` MCP transport (other transports may be added
+later) and connects to a Spark cluster via Spark Connect:
+
+```bash
+python -m pyspark.sql.mcp \
+  --connect-url "sc://localhost:15002"
+```
+
+Equivalent via environment variable:
+
+```bash
+export SPARK_REMOTE="sc://localhost:15002"
+python -m pyspark.sql.mcp
+```
+
+The server is **read-only by default**. Pass `--no-read-only` to allow DDL/DML
+(use with care; the read-only filter is a guardrail, not a security boundary).
+
+## Tools (planned for v0.1)
+
+Catalog exploration, query execution, and query plans:
+
+- `get_session_info`
+- `list_catalogs`, `list_databases`, `list_tables`, `describe_table`,
+  `list_functions`
+- `execute_sql`, `preview_table`
+- `explain_query`, `analyze_query`
+
+See `dev/design-docs/spark-mcp-server/02-design.md` for the full design.
+
+## Dependencies
+
+- `pyspark` with the Spark Connect client extras.
+- The official [`mcp`](https://github.com/modelcontextprotocol/python-sdk)
+  Python SDK.

--- a/python/pyspark/sql/mcp/__init__.py
+++ b/python/pyspark/sql/mcp/__init__.py
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Spark MCP (Model Context Protocol) server.
+
+Thin client over Spark Connect that exposes Spark capabilities as MCP tools
+for LLM consumption. Catalog browsing, SQL execution, and query plan tools
+are read-only by default.
+"""
+
+from pyspark.sql.mcp.config import ServerConfig
+from pyspark.sql.mcp.server import build_server, run
+
+__all__ = ["ServerConfig", "build_server", "run"]

--- a/python/pyspark/sql/mcp/__main__.py
+++ b/python/pyspark/sql/mcp/__main__.py
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.sql.mcp.server import run
+
+if __name__ == "__main__":
+    run()

--- a/python/pyspark/sql/mcp/config.py
+++ b/python/pyspark/sql/mcp/config.py
@@ -1,0 +1,75 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+from dataclasses import dataclass, field
+from typing import Optional, Sequence
+
+
+DEFAULT_MAX_ROWS = 1000
+DEFAULT_PAGE_SIZE = 100
+DEFAULT_QUERY_TIMEOUT_SECONDS = 60
+
+
+@dataclass(frozen=True)
+class ServerConfig:
+    """Runtime configuration for the Spark MCP server.
+
+    Use :meth:`from_env` to populate from CLI args + environment variables.
+    """
+
+    connect_url: str
+    read_only: bool = True
+    allowed_catalogs: Optional[Sequence[str]] = None
+    allowed_databases: Optional[Sequence[str]] = None
+    max_rows: int = DEFAULT_MAX_ROWS
+    default_page_size: int = DEFAULT_PAGE_SIZE
+    query_timeout_seconds: int = DEFAULT_QUERY_TIMEOUT_SECONDS
+    transport: str = "stdio"
+    user_id: Optional[str] = None
+    extra_session_configs: dict = field(default_factory=dict)
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        connect_url: Optional[str] = None,
+        read_only: Optional[bool] = None,
+        transport: Optional[str] = None,
+    ) -> "ServerConfig":
+        url = connect_url or os.environ.get("SPARK_REMOTE")
+        if not url:
+            raise ValueError(
+                "Spark Connect URL must be provided via --connect-url or SPARK_REMOTE"
+            )
+        return cls(
+            connect_url=url,
+            read_only=_default(read_only, _env_bool("SPARK_MCP_READ_ONLY", True)),
+            transport=transport or os.environ.get("SPARK_MCP_TRANSPORT", "stdio"),
+            user_id=os.environ.get("SPARK_MCP_USER_ID"),
+        )
+
+
+def _default(value, fallback):
+    return fallback if value is None else value
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}

--- a/python/pyspark/sql/mcp/config.py
+++ b/python/pyspark/sql/mcp/config.py
@@ -19,6 +19,8 @@ import os
 from dataclasses import dataclass, field
 from typing import Optional
 
+from pyspark.errors import PySparkValueError
+
 
 DEFAULT_MAX_ROWS = 1000
 DEFAULT_PAGE_SIZE = 100
@@ -54,8 +56,9 @@ class ServerConfig:
     ) -> "ServerConfig":
         url = connect_url or os.environ.get("SPARK_REMOTE")
         if not url:
-            raise ValueError(
-                "Spark Connect URL must be provided via --connect-url or SPARK_REMOTE"
+            raise PySparkValueError(
+                errorClass="MCP_CONNECT_URL_REQUIRED",
+                messageParameters={},
             )
         return cls(
             connect_url=url,
@@ -90,4 +93,7 @@ def _env_int(name: str, default: int) -> int:
     try:
         return int(raw)
     except ValueError as exc:
-        raise ValueError(f"{name} must be an integer; got {raw!r}") from exc
+        raise PySparkValueError(
+            errorClass="MCP_INVALID_ENV_INT",
+            messageParameters={"name": name, "value": repr(raw)},
+        ) from exc

--- a/python/pyspark/sql/mcp/config.py
+++ b/python/pyspark/sql/mcp/config.py
@@ -63,9 +63,7 @@ class ServerConfig:
         return cls(
             connect_url=url,
             read_only=_default(read_only, _env_bool("SPARK_MCP_READ_ONLY", True)),
-            max_rows=_default(
-                max_rows, _env_int("SPARK_MCP_MAX_ROWS", DEFAULT_MAX_ROWS)
-            ),
+            max_rows=_default(max_rows, _env_int("SPARK_MCP_MAX_ROWS", DEFAULT_MAX_ROWS)),
             query_timeout_seconds=_default(
                 query_timeout_seconds,
                 _env_int("SPARK_MCP_QUERY_TIMEOUT_SECONDS", DEFAULT_QUERY_TIMEOUT_SECONDS),

--- a/python/pyspark/sql/mcp/config.py
+++ b/python/pyspark/sql/mcp/config.py
@@ -17,7 +17,7 @@
 
 import os
 from dataclasses import dataclass, field
-from typing import Optional, Sequence
+from typing import Optional
 
 
 DEFAULT_MAX_ROWS = 1000
@@ -34,8 +34,6 @@ class ServerConfig:
 
     connect_url: str
     read_only: bool = True
-    allowed_catalogs: Optional[Sequence[str]] = None
-    allowed_databases: Optional[Sequence[str]] = None
     max_rows: int = DEFAULT_MAX_ROWS
     default_page_size: int = DEFAULT_PAGE_SIZE
     query_timeout_seconds: int = DEFAULT_QUERY_TIMEOUT_SECONDS
@@ -50,6 +48,9 @@ class ServerConfig:
         connect_url: Optional[str] = None,
         read_only: Optional[bool] = None,
         transport: Optional[str] = None,
+        max_rows: Optional[int] = None,
+        query_timeout_seconds: Optional[int] = None,
+        user_id: Optional[str] = None,
     ) -> "ServerConfig":
         url = connect_url or os.environ.get("SPARK_REMOTE")
         if not url:
@@ -59,8 +60,15 @@ class ServerConfig:
         return cls(
             connect_url=url,
             read_only=_default(read_only, _env_bool("SPARK_MCP_READ_ONLY", True)),
+            max_rows=_default(
+                max_rows, _env_int("SPARK_MCP_MAX_ROWS", DEFAULT_MAX_ROWS)
+            ),
+            query_timeout_seconds=_default(
+                query_timeout_seconds,
+                _env_int("SPARK_MCP_QUERY_TIMEOUT_SECONDS", DEFAULT_QUERY_TIMEOUT_SECONDS),
+            ),
             transport=transport or os.environ.get("SPARK_MCP_TRANSPORT", "stdio"),
-            user_id=os.environ.get("SPARK_MCP_USER_ID"),
+            user_id=user_id or os.environ.get("SPARK_MCP_USER_ID"),
         )
 
 
@@ -73,3 +81,13 @@ def _env_bool(name: str, default: bool) -> bool:
     if raw is None:
         return default
     return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer; got {raw!r}") from exc

--- a/python/pyspark/sql/mcp/config.py
+++ b/python/pyspark/sql/mcp/config.py
@@ -17,7 +17,7 @@
 
 import os
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, TypeVar
 
 from pyspark.errors import PySparkValueError
 
@@ -73,7 +73,10 @@ class ServerConfig:
         )
 
 
-def _default(value, fallback):
+_T = TypeVar("_T")
+
+
+def _default(value: Optional[_T], fallback: _T) -> _T:
     return fallback if value is None else value
 
 

--- a/python/pyspark/sql/mcp/safety.py
+++ b/python/pyspark/sql/mcp/safety.py
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import re
+
+# Read-only allow-list. Comments and leading whitespace are stripped before
+# matching. We deliberately keep this conservative — anything not on the list
+# is rejected when read_only is on.
+_READ_ONLY_LEAD = re.compile(
+    r"^(select|with|show|describe|desc|explain|use|set|reset)\b",
+    re.IGNORECASE,
+)
+
+# Strip /* ... */ block comments and -- line comments before matching.
+_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+_LINE_COMMENT = re.compile(r"--[^\n]*")
+
+
+class ReadOnlyViolation(ValueError):
+    """Raised when a SQL statement violates the read-only policy."""
+
+
+def assert_read_only(query: str) -> None:
+    """Reject queries that mutate state when the server is in read-only mode.
+
+    The check is best-effort and string-based; it is a guardrail, not a
+    security boundary. Real isolation belongs at the Spark cluster (catalog
+    permissions, workspace policies, etc.).
+    """
+    stripped = _LINE_COMMENT.sub("", _BLOCK_COMMENT.sub("", query)).strip()
+    if not stripped:
+        raise ReadOnlyViolation("empty query")
+    if not _READ_ONLY_LEAD.match(stripped):
+        first_token = stripped.split(None, 1)[0]
+        raise ReadOnlyViolation(
+            f"statement type {first_token!r} is not allowed in read-only mode"
+        )

--- a/python/pyspark/sql/mcp/safety.py
+++ b/python/pyspark/sql/mcp/safety.py
@@ -17,6 +17,8 @@
 
 import re
 
+from pyspark.errors import PySparkValueError
+
 # Read-only allow-list. Comments and leading whitespace are stripped before
 # matching. We deliberately keep this conservative — anything not on the list
 # is rejected when read_only is on.
@@ -30,7 +32,7 @@ _BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
 _LINE_COMMENT = re.compile(r"--[^\n]*")
 
 
-class ReadOnlyViolation(ValueError):
+class ReadOnlyViolation(PySparkValueError):
     """Raised when a SQL statement violates the read-only policy."""
 
 
@@ -43,9 +45,13 @@ def assert_read_only(query: str) -> None:
     """
     stripped = _LINE_COMMENT.sub("", _BLOCK_COMMENT.sub("", query)).strip()
     if not stripped:
-        raise ReadOnlyViolation("empty query")
+        raise ReadOnlyViolation(
+            errorClass="MCP_EMPTY_QUERY",
+            messageParameters={},
+        )
     if not _READ_ONLY_LEAD.match(stripped):
         first_token = stripped.split(None, 1)[0]
         raise ReadOnlyViolation(
-            f"statement type {first_token!r} is not allowed in read-only mode"
+            errorClass="MCP_READ_ONLY_VIOLATION",
+            messageParameters={"statement": first_token},
         )

--- a/python/pyspark/sql/mcp/safety.py
+++ b/python/pyspark/sql/mcp/safety.py
@@ -32,10 +32,6 @@ _BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
 _LINE_COMMENT = re.compile(r"--[^\n]*")
 
 
-class ReadOnlyViolation(PySparkValueError):
-    """Raised when a SQL statement violates the read-only policy."""
-
-
 def assert_read_only(query: str) -> None:
     """Reject queries that mutate state when the server is in read-only mode.
 
@@ -45,13 +41,13 @@ def assert_read_only(query: str) -> None:
     """
     stripped = _LINE_COMMENT.sub("", _BLOCK_COMMENT.sub("", query)).strip()
     if not stripped:
-        raise ReadOnlyViolation(
+        raise PySparkValueError(
             errorClass="MCP_EMPTY_QUERY",
             messageParameters={},
         )
     if not _READ_ONLY_LEAD.match(stripped):
         first_token = stripped.split(None, 1)[0]
-        raise ReadOnlyViolation(
+        raise PySparkValueError(
             errorClass="MCP_READ_ONLY_VIOLATION",
             messageParameters={"statement": first_token},
         )

--- a/python/pyspark/sql/mcp/server.py
+++ b/python/pyspark/sql/mcp/server.py
@@ -1,0 +1,141 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Entry point for the Spark MCP server.
+
+The :func:`build_server` function is the seam used by tests; :func:`run` is
+the CLI entry point used by ``python -m pyspark.sql.mcp``.
+
+The official ``mcp`` Python SDK is imported lazily so that importing this
+module does not pull the SDK in on machines that only need the configuration
+objects (e.g. for unit testing the safety layer).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, TYPE_CHECKING
+
+from pyspark.sql.mcp.config import ServerConfig
+from pyspark.sql.mcp.session import SessionHolder
+from pyspark.sql.mcp.tools.registry import all_tools
+
+if TYPE_CHECKING:
+    from mcp.server import Server
+
+
+def build_server(config: ServerConfig) -> "Server":
+    """Build an MCP server instance bound to a Spark Connect session.
+
+    The server registers tool handlers but does not start a transport. Use
+    :func:`run` (or the SDK's transport runners) to serve.
+    """
+    from mcp.server import Server
+
+    holder = SessionHolder(config)
+    server: "Server[Any]" = Server("spark-mcp")
+    _register_tools(server, holder)
+    return server
+
+
+def _register_tools(server: "Server", holder: SessionHolder) -> None:
+    import mcp.types as types
+
+    specs = {spec.name: spec for spec in all_tools()}
+
+    @server.list_tools()
+    async def _list_tools() -> list:
+        return [
+            types.Tool(
+                name=spec.name,
+                description=spec.description,
+                inputSchema=spec.input_schema,
+            )
+            for spec in specs.values()
+        ]
+
+    @server.call_tool()
+    async def _call_tool(name: str, arguments: dict) -> list:
+        spec = specs.get(name)
+        if spec is None:
+            raise ValueError(f"unknown tool: {name}")
+        result = await spec.handler(arguments or {}, holder)
+        return [types.TextContent(type="text", text=json.dumps(result, default=str))]
+
+
+def run(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    config = ServerConfig.from_env(
+        connect_url=args.connect_url,
+        read_only=args.read_only,
+        transport=args.transport,
+    )
+    _serve(build_server(config), config)
+
+
+def _serve(server: "Server", config: ServerConfig) -> None:
+    if config.transport == "stdio":
+        import anyio
+        from mcp.server.stdio import stdio_server
+
+        async def main() -> None:
+            async with stdio_server() as (read, write):
+                await server.run(read, write, server.create_initialization_options())
+
+        anyio.run(main)
+    else:
+        raise NotImplementedError(
+            f"transport {config.transport!r} is not implemented yet"
+        )
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="python -m pyspark.sql.mcp",
+        description="Apache Spark MCP server (Spark Connect thin client).",
+    )
+    parser.add_argument(
+        "--connect-url",
+        help="Spark Connect URL (sc://host:port[/;params]). "
+        "Defaults to the SPARK_REMOTE environment variable.",
+    )
+    ro = parser.add_mutually_exclusive_group()
+    ro.add_argument(
+        "--read-only",
+        dest="read_only",
+        action="store_true",
+        default=None,
+        help="Reject DDL/DML statements (default).",
+    )
+    ro.add_argument(
+        "--no-read-only",
+        dest="read_only",
+        action="store_false",
+        help="Allow arbitrary SQL. Use with care.",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["stdio"],
+        default=None,
+        help="MCP transport (currently only stdio is implemented).",
+    )
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI wrapper
+    run()

--- a/python/pyspark/sql/mcp/server.py
+++ b/python/pyspark/sql/mcp/server.py
@@ -31,6 +31,7 @@ import argparse
 import json
 from typing import Any, TYPE_CHECKING
 
+from pyspark.errors import PySparkNotImplementedError, PySparkValueError
 from pyspark.sql.mcp.config import ServerConfig
 from pyspark.sql.mcp.session import SessionHolder
 from pyspark.sql.mcp.tools.registry import all_tools
@@ -73,7 +74,10 @@ def _register_tools(server: "Server", holder: SessionHolder) -> None:
     async def _call_tool(name: str, arguments: dict) -> list:
         spec = specs.get(name)
         if spec is None:
-            raise ValueError(f"unknown tool: {name}")
+            raise PySparkValueError(
+                errorClass="MCP_UNKNOWN_TOOL",
+                messageParameters={"name": name},
+            )
         result = await spec.handler(arguments or {}, holder)
         return [types.TextContent(type="text", text=json.dumps(result, default=str))]
 
@@ -102,8 +106,9 @@ def _serve(server: "Server", config: ServerConfig) -> None:
 
         anyio.run(main)
     else:
-        raise NotImplementedError(
-            f"transport {config.transport!r} is not implemented yet"
+        raise PySparkNotImplementedError(
+            errorClass="MCP_TRANSPORT_NOT_IMPLEMENTED",
+            messageParameters={"transport": str(config.transport)},
         )
 
 

--- a/python/pyspark/sql/mcp/server.py
+++ b/python/pyspark/sql/mcp/server.py
@@ -84,6 +84,9 @@ def run(argv: list[str] | None = None) -> None:
         connect_url=args.connect_url,
         read_only=args.read_only,
         transport=args.transport,
+        max_rows=args.max_rows,
+        query_timeout_seconds=args.query_timeout_seconds,
+        user_id=args.user_id,
     )
     _serve(build_server(config), config)
 
@@ -133,6 +136,32 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         choices=["stdio"],
         default=None,
         help="MCP transport (currently only stdio is implemented).",
+    )
+    parser.add_argument(
+        "--user-id",
+        dest="user_id",
+        default=None,
+        help="Spark Connect session user id. Defaults to $SPARK_MCP_USER_ID.",
+    )
+    parser.add_argument(
+        "--max-rows",
+        dest="max_rows",
+        default=None,
+        type=int,
+        help=(
+            "Hard cap on rows returned per row-producing tool call. Defaults "
+            "to $SPARK_MCP_MAX_ROWS or 1000."
+        ),
+    )
+    parser.add_argument(
+        "--query-timeout-seconds",
+        dest="query_timeout_seconds",
+        default=None,
+        type=int,
+        help=(
+            "Wall-clock timeout for individual tool invocations that touch "
+            "the cluster. Defaults to $SPARK_MCP_QUERY_TIMEOUT_SECONDS or 60."
+        ),
     )
     return parser.parse_args(argv)
 

--- a/python/pyspark/sql/mcp/session.py
+++ b/python/pyspark/sql/mcp/session.py
@@ -45,9 +45,7 @@ class SessionHolder:
             for key, value in self._config.extra_session_configs.items():
                 builder = builder.config(key, value)
             if self._config.user_id is not None:
-                builder = builder.config(
-                    "spark.connect.session.userId", self._config.user_id
-                )
+                builder = builder.config("spark.connect.session.userId", self._config.user_id)
             self._session = builder.getOrCreate()
         return self._session
 

--- a/python/pyspark/sql/mcp/session.py
+++ b/python/pyspark/sql/mcp/session.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Optional
 from pyspark.sql.mcp.config import ServerConfig
 
 if TYPE_CHECKING:
-    from pyspark.sql.connect.session import SparkSession
+    from pyspark.sql.session import SparkSession
 
 
 class SessionHolder:
@@ -47,6 +47,7 @@ class SessionHolder:
             if self._config.user_id is not None:
                 builder = builder.config("spark.connect.session.userId", self._config.user_id)
             self._session = builder.getOrCreate()
+        assert self._session is not None
         return self._session
 
     def close(self) -> None:

--- a/python/pyspark/sql/mcp/session.py
+++ b/python/pyspark/sql/mcp/session.py
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import TYPE_CHECKING, Optional
+
+from pyspark.sql.mcp.config import ServerConfig
+
+if TYPE_CHECKING:
+    from pyspark.sql.connect.session import SparkSession
+
+
+class SessionHolder:
+    """Lazily creates and caches a Spark Connect session for the MCP server.
+
+    One MCP client connection maps to one Spark Connect session for v0.1.
+    """
+
+    def __init__(self, config: ServerConfig):
+        self._config = config
+        self._session: Optional["SparkSession"] = None
+
+    @property
+    def config(self) -> ServerConfig:
+        return self._config
+
+    def get(self) -> "SparkSession":
+        if self._session is None:
+            from pyspark.sql import SparkSession
+
+            builder = SparkSession.builder.remote(self._config.connect_url)
+            for key, value in self._config.extra_session_configs.items():
+                builder = builder.config(key, value)
+            if self._config.user_id is not None:
+                builder = builder.config(
+                    "spark.connect.session.userId", self._config.user_id
+                )
+            self._session = builder.getOrCreate()
+        return self._session
+
+    def close(self) -> None:
+        if self._session is not None:
+            try:
+                self._session.stop()
+            finally:
+                self._session = None

--- a/python/pyspark/sql/mcp/session.py
+++ b/python/pyspark/sql/mcp/session.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 class SessionHolder:
     """Lazily creates and caches a Spark Connect session for the MCP server.
 
-    One MCP client connection maps to one Spark Connect session for v0.1.
+    One MCP client connection maps to one Spark Connect session.
     """
 
     def __init__(self, config: ServerConfig):

--- a/python/pyspark/sql/mcp/tools/__init__.py
+++ b/python/pyspark/sql/mcp/tools/__init__.py
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tool implementations for the Spark MCP server."""

--- a/python/pyspark/sql/mcp/tools/catalog.py
+++ b/python/pyspark/sql/mcp/tools/catalog.py
@@ -41,7 +41,11 @@ def _to_dict(obj: Any) -> Dict[str, Any]:
     if isinstance(obj, dict):
         return obj
     # Fallback: scrape public attributes.
-    return {k: getattr(obj, k) for k in dir(obj) if not k.startswith("_") and not callable(getattr(obj, k))}
+    return {
+        k: getattr(obj, k)
+        for k in dir(obj)
+        if not k.startswith("_") and not callable(getattr(obj, k))
+    }
 
 
 def _paginate(items: List[Any], limit: int, offset: int) -> Dict[str, Any]:

--- a/python/pyspark/sql/mcp/tools/catalog.py
+++ b/python/pyspark/sql/mcp/tools/catalog.py
@@ -34,7 +34,7 @@ from pyspark.sql.mcp.tools.registry import ToolSpec
 def _to_dict(obj: Any) -> Dict[str, Any]:
     """Best-effort conversion of catalog dataclasses (CatalogMetadata, Database,
     Table, Column, Function) into plain dicts."""
-    if is_dataclass(obj):
+    if is_dataclass(obj) and not isinstance(obj, type):
         return asdict(obj)
     if hasattr(obj, "_asdict"):  # NamedTuple
         return dict(obj._asdict())

--- a/python/pyspark/sql/mcp/tools/catalog.py
+++ b/python/pyspark/sql/mcp/tools/catalog.py
@@ -20,27 +20,10 @@
 from __future__ import annotations
 
 from dataclasses import asdict, is_dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from pyspark.sql.mcp.session import SessionHolder
 from pyspark.sql.mcp.tools.registry import ToolSpec
-
-
-# ---------------------------------------------------------------------------
-# Whitelist enforcement
-# ---------------------------------------------------------------------------
-
-
-def _check_catalog_allowed(holder: SessionHolder, catalog: Optional[str]) -> None:
-    allowed = holder.config.allowed_catalogs
-    if allowed and catalog and catalog not in allowed:
-        raise PermissionError(f"catalog {catalog!r} is not in the allow-list")
-
-
-def _check_database_allowed(holder: SessionHolder, database: Optional[str]) -> None:
-    allowed = holder.config.allowed_databases
-    if allowed and database and database not in allowed:
-        raise PermissionError(f"database {database!r} is not in the allow-list")
 
 
 # ---------------------------------------------------------------------------
@@ -83,9 +66,6 @@ def _paginate(items: List[Any], limit: int, offset: int) -> Dict[str, Any]:
 async def _handle_list_catalogs(args: Dict[str, Any], holder: SessionHolder) -> Dict[str, Any]:
     spark = holder.get()
     catalogs = list(spark.catalog.listCatalogs())
-    if holder.config.allowed_catalogs:
-        allowed = set(holder.config.allowed_catalogs)
-        catalogs = [c for c in catalogs if getattr(c, "name", None) in allowed]
     limit = int(args.get("limit", holder.config.default_page_size))
     offset = int(args.get("offset", 0))
     return _paginate(catalogs, limit, offset)
@@ -116,7 +96,6 @@ async def _handle_list_databases(args: Dict[str, Any], holder: SessionHolder) ->
     spark = holder.get()
     catalog = args.get("catalog")
     pattern = args.get("pattern")
-    _check_catalog_allowed(holder, catalog)
 
     if catalog:
         spark.catalog.setCurrentCatalog(catalog)
@@ -124,10 +103,6 @@ async def _handle_list_databases(args: Dict[str, Any], holder: SessionHolder) ->
         databases = list(spark.catalog.listDatabases(pattern))
     else:
         databases = list(spark.catalog.listDatabases())
-
-    if holder.config.allowed_databases:
-        allowed = set(holder.config.allowed_databases)
-        databases = [d for d in databases if getattr(d, "name", None) in allowed]
 
     limit = int(args.get("limit", holder.config.default_page_size))
     offset = int(args.get("offset", 0))
@@ -164,7 +139,6 @@ async def _handle_list_tables(args: Dict[str, Any], holder: SessionHolder) -> Di
     spark = holder.get()
     database = args.get("database")
     pattern = args.get("pattern")
-    _check_database_allowed(holder, database)
 
     kwargs: Dict[str, Any] = {}
     if database is not None:

--- a/python/pyspark/sql/mcp/tools/catalog.py
+++ b/python/pyspark/sql/mcp/tools/catalog.py
@@ -1,0 +1,240 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Catalog browsing tools."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from typing import Any, Dict, List, Optional
+
+from pyspark.sql.mcp.session import SessionHolder
+from pyspark.sql.mcp.tools.registry import ToolSpec
+
+
+# ---------------------------------------------------------------------------
+# Whitelist enforcement
+# ---------------------------------------------------------------------------
+
+
+def _check_catalog_allowed(holder: SessionHolder, catalog: Optional[str]) -> None:
+    allowed = holder.config.allowed_catalogs
+    if allowed and catalog and catalog not in allowed:
+        raise PermissionError(f"catalog {catalog!r} is not in the allow-list")
+
+
+def _check_database_allowed(holder: SessionHolder, database: Optional[str]) -> None:
+    allowed = holder.config.allowed_databases
+    if allowed and database and database not in allowed:
+        raise PermissionError(f"database {database!r} is not in the allow-list")
+
+
+# ---------------------------------------------------------------------------
+# Result shaping
+# ---------------------------------------------------------------------------
+
+
+def _to_dict(obj: Any) -> Dict[str, Any]:
+    """Best-effort conversion of catalog dataclasses (CatalogMetadata, Database,
+    Table, Column, Function) into plain dicts."""
+    if is_dataclass(obj):
+        return asdict(obj)
+    if hasattr(obj, "_asdict"):  # NamedTuple
+        return dict(obj._asdict())
+    if isinstance(obj, dict):
+        return obj
+    # Fallback: scrape public attributes.
+    return {k: getattr(obj, k) for k in dir(obj) if not k.startswith("_") and not callable(getattr(obj, k))}
+
+
+def _paginate(items: List[Any], limit: int, offset: int) -> Dict[str, Any]:
+    total = len(items)
+    end = offset + limit if limit is not None else total
+    page = items[offset:end]
+    return {
+        "items": [_to_dict(x) for x in page],
+        "offset": offset,
+        "limit": limit,
+        "returned": len(page),
+        "total": total,
+        "truncated": end < total,
+    }
+
+
+# ---------------------------------------------------------------------------
+# list_catalogs
+# ---------------------------------------------------------------------------
+
+
+async def _handle_list_catalogs(args: Dict[str, Any], holder: SessionHolder) -> Dict[str, Any]:
+    spark = holder.get()
+    catalogs = list(spark.catalog.listCatalogs())
+    if holder.config.allowed_catalogs:
+        allowed = set(holder.config.allowed_catalogs)
+        catalogs = [c for c in catalogs if getattr(c, "name", None) in allowed]
+    limit = int(args.get("limit", holder.config.default_page_size))
+    offset = int(args.get("offset", 0))
+    return _paginate(catalogs, limit, offset)
+
+
+def list_catalogs_spec() -> ToolSpec:
+    return ToolSpec(
+        name="list_catalogs",
+        description="List catalogs available to the current Spark session.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "minimum": 1, "maximum": 1000, "default": 100},
+                "offset": {"type": "integer", "minimum": 0, "default": 0},
+            },
+            "additionalProperties": False,
+        },
+        handler=_handle_list_catalogs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_databases
+# ---------------------------------------------------------------------------
+
+
+async def _handle_list_databases(args: Dict[str, Any], holder: SessionHolder) -> Dict[str, Any]:
+    spark = holder.get()
+    catalog = args.get("catalog")
+    pattern = args.get("pattern")
+    _check_catalog_allowed(holder, catalog)
+
+    if catalog:
+        spark.catalog.setCurrentCatalog(catalog)
+    if pattern is not None:
+        databases = list(spark.catalog.listDatabases(pattern))
+    else:
+        databases = list(spark.catalog.listDatabases())
+
+    if holder.config.allowed_databases:
+        allowed = set(holder.config.allowed_databases)
+        databases = [d for d in databases if getattr(d, "name", None) in allowed]
+
+    limit = int(args.get("limit", holder.config.default_page_size))
+    offset = int(args.get("offset", 0))
+    return _paginate(databases, limit, offset)
+
+
+def list_databases_spec() -> ToolSpec:
+    return ToolSpec(
+        name="list_databases",
+        description=(
+            "List databases (a.k.a. schemas) in the current or named catalog. "
+            "Optional name pattern uses Spark's LIKE semantics."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "catalog": {"type": "string"},
+                "pattern": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": 1000, "default": 100},
+                "offset": {"type": "integer", "minimum": 0, "default": 0},
+            },
+            "additionalProperties": False,
+        },
+        handler=_handle_list_databases,
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_tables
+# ---------------------------------------------------------------------------
+
+
+async def _handle_list_tables(args: Dict[str, Any], holder: SessionHolder) -> Dict[str, Any]:
+    spark = holder.get()
+    database = args.get("database")
+    pattern = args.get("pattern")
+    _check_database_allowed(holder, database)
+
+    kwargs: Dict[str, Any] = {}
+    if database is not None:
+        kwargs["dbName"] = database
+    if pattern is not None:
+        kwargs["pattern"] = pattern
+    tables = list(spark.catalog.listTables(**kwargs))
+
+    limit = int(args.get("limit", holder.config.default_page_size))
+    offset = int(args.get("offset", 0))
+    return _paginate(tables, limit, offset)
+
+
+def list_tables_spec() -> ToolSpec:
+    return ToolSpec(
+        name="list_tables",
+        description=(
+            "List tables and views in a database. Defaults to the current "
+            "database if 'database' is omitted. Returns each table's name, "
+            "type (TABLE/VIEW/TEMPORARY), description, and database."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "database": {"type": "string"},
+                "pattern": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": 1000, "default": 100},
+                "offset": {"type": "integer", "minimum": 0, "default": 0},
+            },
+            "additionalProperties": False,
+        },
+        handler=_handle_list_tables,
+    )
+
+
+# ---------------------------------------------------------------------------
+# describe_table
+# ---------------------------------------------------------------------------
+
+
+async def _handle_describe_table(args: Dict[str, Any], holder: SessionHolder) -> Dict[str, Any]:
+    spark = holder.get()
+    name = args["name"]
+
+    table = spark.catalog.getTable(name)
+    columns = list(spark.catalog.listColumns(name))
+    return {
+        "table": _to_dict(table),
+        "columns": [_to_dict(c) for c in columns],
+    }
+
+
+def describe_table_spec() -> ToolSpec:
+    return ToolSpec(
+        name="describe_table",
+        description=(
+            "Return a table's metadata: name, database, type, description, "
+            "and the full column list with types, nullability, and partition "
+            "flags. Accepts a fully-qualified or unqualified name."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Table name. May be qualified (catalog.db.table) or unqualified.",
+                }
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        handler=_handle_describe_table,
+    )

--- a/python/pyspark/sql/mcp/tools/query.py
+++ b/python/pyspark/sql/mcp/tools/query.py
@@ -105,7 +105,7 @@ def list_functions_spec() -> ToolSpec:
 # ---------------------------------------------------------------------------
 
 
-def _row_to_dict(row) -> Dict[str, Any]:
+def _row_to_dict(row: Any) -> Dict[str, Any]:
     if hasattr(row, "asDict"):
         return row.asDict(recursive=True)
     if hasattr(row, "_asdict"):
@@ -131,7 +131,7 @@ def _md_cell(value: Any) -> str:
     return text
 
 
-def _schema_fields(schema) -> List[str]:
+def _schema_fields(schema: Any) -> List[str]:
     try:
         return [field.name for field in schema.fields]
     except AttributeError:
@@ -206,7 +206,7 @@ async def _handle_execute_sql(args: Dict[str, Any], holder: SessionHolder) -> Di
     return payload
 
 
-def _sql(spark, query: str, sql_args: Optional[Any]):
+def _sql(spark: Any, query: str, sql_args: Optional[Any]) -> Any:
     if sql_args is None:
         return spark.sql(query)
     return spark.sql(query, args=sql_args)

--- a/python/pyspark/sql/mcp/tools/query.py
+++ b/python/pyspark/sql/mcp/tools/query.py
@@ -32,10 +32,6 @@ from pyspark.sql.mcp.tools.registry import ToolSpec
 T = TypeVar("T")
 
 
-class QueryTimeoutError(PySparkRuntimeError):
-    """Raised when a tool call exceeds ``query_timeout_seconds``."""
-
-
 async def _with_timeout(
     holder: SessionHolder, func: Callable[[], T], *, label: str
 ) -> T:
@@ -46,7 +42,7 @@ async def _with_timeout(
         try:
             return await asyncio.wait_for(coro, timeout=timeout)
         except asyncio.TimeoutError as exc:
-            raise QueryTimeoutError(
+            raise PySparkRuntimeError(
                 errorClass="MCP_QUERY_TIMEOUT",
                 messageParameters={"label": label, "timeout": str(timeout)},
             ) from exc

--- a/python/pyspark/sql/mcp/tools/query.py
+++ b/python/pyspark/sql/mcp/tools/query.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Awaitable, Callable, Dict, List, Optional, TypeVar
 
+from pyspark.errors import PySparkRuntimeError, PySparkValueError
 from pyspark.sql.mcp.safety import assert_read_only
 from pyspark.sql.mcp.session import SessionHolder
 from pyspark.sql.mcp.tools.catalog import _to_dict
@@ -31,7 +32,7 @@ from pyspark.sql.mcp.tools.registry import ToolSpec
 T = TypeVar("T")
 
 
-class QueryTimeoutError(RuntimeError):
+class QueryTimeoutError(PySparkRuntimeError):
     """Raised when a tool call exceeds ``query_timeout_seconds``."""
 
 
@@ -46,7 +47,8 @@ async def _with_timeout(
             return await asyncio.wait_for(coro, timeout=timeout)
         except asyncio.TimeoutError as exc:
             raise QueryTimeoutError(
-                f"{label} exceeded {timeout}s timeout"
+                errorClass="MCP_QUERY_TIMEOUT",
+                messageParameters={"label": label, "timeout": str(timeout)},
             ) from exc
     return await coro
 
@@ -193,13 +195,22 @@ async def _handle_execute_sql(args: Dict[str, Any], holder: SessionHolder) -> Di
         try:
             import pyarrow as pa  # noqa: F401
         except ImportError as exc:  # pragma: no cover
-            raise RuntimeError("arrow_base64 format requires pyarrow") from exc
+            raise PySparkRuntimeError(
+                errorClass="MCP_PYARROW_REQUIRED",
+                messageParameters={"format": "arrow_base64"},
+            ) from exc
         table = await _with_timeout(holder, page_df_arrow.toArrow, label="execute_sql")
         with pa.ipc.new_stream(buf, table.schema) as writer:  # type: ignore[name-defined]
             writer.write_table(table)
         payload["arrow_base64"] = base64.b64encode(buf.getvalue()).decode("ascii")
     else:
-        raise ValueError(f"unsupported format: {fmt}")
+        raise PySparkValueError(
+            errorClass="MCP_UNSUPPORTED_FORMAT",
+            messageParameters={
+                "format": str(fmt),
+                "allowed": "json, markdown, arrow_base64",
+            },
+        )
     return payload
 
 
@@ -292,7 +303,13 @@ async def _handle_explain_query(args: Dict[str, Any], holder: SessionHolder) -> 
     query = args["query"]
     mode = args.get("mode", "formatted")
     if mode not in _EXPLAIN_MODES:
-        raise ValueError(f"mode must be one of {_EXPLAIN_MODES}")
+        raise PySparkValueError(
+            errorClass="MCP_INVALID_EXPLAIN_MODE",
+            messageParameters={
+                "allowed": ", ".join(_EXPLAIN_MODES),
+                "mode": str(mode),
+            },
+        )
     if holder.config.read_only:
         assert_read_only(query)
 

--- a/python/pyspark/sql/mcp/tools/query.py
+++ b/python/pyspark/sql/mcp/tools/query.py
@@ -189,14 +189,14 @@ async def _handle_execute_sql(args: Dict[str, Any], holder: SessionHolder) -> Di
         buf = io.BytesIO()
         page_df_arrow = df.offset(offset).limit(capped_limit) if offset else df.limit(capped_limit)
         try:
-            import pyarrow as pa  # noqa: F401
+            import pyarrow as pa
         except ImportError as exc:  # pragma: no cover
             raise PySparkRuntimeError(
                 errorClass="MCP_PYARROW_REQUIRED",
                 messageParameters={"format": "arrow_base64"},
             ) from exc
         table = await _with_timeout(holder, page_df_arrow.toArrow, label="execute_sql")
-        with pa.ipc.new_stream(buf, table.schema) as writer:  # type: ignore[name-defined]
+        with pa.ipc.new_stream(buf, table.schema) as writer:
             writer.write_table(table)
         payload["arrow_base64"] = base64.b64encode(buf.getvalue()).decode("ascii")
     else:

--- a/python/pyspark/sql/mcp/tools/query.py
+++ b/python/pyspark/sql/mcp/tools/query.py
@@ -19,12 +19,36 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+import asyncio
+from typing import Any, Awaitable, Callable, Dict, List, Optional, TypeVar
 
 from pyspark.sql.mcp.safety import assert_read_only
 from pyspark.sql.mcp.session import SessionHolder
 from pyspark.sql.mcp.tools.catalog import _to_dict
 from pyspark.sql.mcp.tools.registry import ToolSpec
+
+
+T = TypeVar("T")
+
+
+class QueryTimeoutError(RuntimeError):
+    """Raised when a tool call exceeds ``query_timeout_seconds``."""
+
+
+async def _with_timeout(
+    holder: SessionHolder, func: Callable[[], T], *, label: str
+) -> T:
+    """Run a blocking Spark Connect call in a worker thread under the configured timeout."""
+    timeout = holder.config.query_timeout_seconds
+    coro: Awaitable[T] = asyncio.to_thread(func)
+    if timeout and timeout > 0:
+        try:
+            return await asyncio.wait_for(coro, timeout=timeout)
+        except asyncio.TimeoutError as exc:
+            raise QueryTimeoutError(
+                f"{label} exceeded {timeout}s timeout"
+            ) from exc
+    return await coro
 
 
 # ---------------------------------------------------------------------------
@@ -141,7 +165,8 @@ async def _handle_execute_sql(args: Dict[str, Any], holder: SessionHolder) -> Di
     schema_fields = _schema_fields(df.schema)
 
     page_df = df.offset(offset).limit(capped_limit + 1) if offset else df.limit(capped_limit + 1)
-    rows = [_row_to_dict(r) for r in page_df.collect()]
+    collected = await _with_timeout(holder, page_df.collect, label="execute_sql")
+    rows = [_row_to_dict(r) for r in collected]
     truncated = len(rows) > capped_limit
     rows = rows[:capped_limit]
 
@@ -169,7 +194,7 @@ async def _handle_execute_sql(args: Dict[str, Any], holder: SessionHolder) -> Di
             import pyarrow as pa  # noqa: F401
         except ImportError as exc:  # pragma: no cover
             raise RuntimeError("arrow_base64 format requires pyarrow") from exc
-        table = page_df_arrow.toArrow()
+        table = await _with_timeout(holder, page_df_arrow.toArrow, label="execute_sql")
         with pa.ipc.new_stream(buf, table.schema) as writer:  # type: ignore[name-defined]
             writer.write_table(table)
         payload["arrow_base64"] = base64.b64encode(buf.getvalue()).decode("ascii")
@@ -272,7 +297,9 @@ async def _handle_explain_query(args: Dict[str, Any], holder: SessionHolder) -> 
         assert_read_only(query)
 
     df = _sql(spark, query, args.get("args"))
-    plan = df._explain_string(mode=mode)
+    plan = await _with_timeout(
+        holder, lambda: df._explain_string(mode=mode), label="explain_query"
+    )
     return {"mode": mode, "plan": plan}
 
 
@@ -309,8 +336,12 @@ async def _handle_analyze_query(args: Dict[str, Any], holder: SessionHolder) -> 
         assert_read_only(query)
 
     df = _sql(spark, query, args.get("args"))
-    extended = df._explain_string(mode="extended")
-    formatted = df._explain_string(mode="formatted")
+    extended = await _with_timeout(
+        holder, lambda: df._explain_string(mode="extended"), label="analyze_query"
+    )
+    formatted = await _with_timeout(
+        holder, lambda: df._explain_string(mode="formatted"), label="analyze_query"
+    )
     schema = [
         {"name": field.name, "type": str(field.dataType), "nullable": field.nullable}
         for field in df.schema.fields

--- a/python/pyspark/sql/mcp/tools/query.py
+++ b/python/pyspark/sql/mcp/tools/query.py
@@ -1,0 +1,343 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""SQL execution and plan tools."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pyspark.sql.mcp.safety import assert_read_only
+from pyspark.sql.mcp.session import SessionHolder
+from pyspark.sql.mcp.tools.catalog import _to_dict
+from pyspark.sql.mcp.tools.registry import ToolSpec
+
+
+# ---------------------------------------------------------------------------
+# list_functions
+# ---------------------------------------------------------------------------
+
+
+async def _handle_list_functions(args: Dict[str, Any], holder: SessionHolder) -> Dict[str, Any]:
+    spark = holder.get()
+    database = args.get("database")
+    pattern = args.get("pattern")
+
+    kwargs: Dict[str, Any] = {}
+    if database is not None:
+        kwargs["dbName"] = database
+    if pattern is not None:
+        kwargs["pattern"] = pattern
+    funcs = list(spark.catalog.listFunctions(**kwargs))
+
+    limit = int(args.get("limit", holder.config.default_page_size))
+    offset = int(args.get("offset", 0))
+    total = len(funcs)
+    page = funcs[offset : offset + limit]
+    return {
+        "items": [_to_dict(f) for f in page],
+        "offset": offset,
+        "limit": limit,
+        "returned": len(page),
+        "total": total,
+        "truncated": offset + limit < total,
+    }
+
+
+def list_functions_spec() -> ToolSpec:
+    return ToolSpec(
+        name="list_functions",
+        description=(
+            "List user-defined and built-in functions visible in a database. "
+            "Useful when authoring SQL — surfaces both UDFs and the built-in "
+            "function library."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "database": {"type": "string"},
+                "pattern": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": 1000, "default": 100},
+                "offset": {"type": "integer", "minimum": 0, "default": 0},
+            },
+            "additionalProperties": False,
+        },
+        handler=_handle_list_functions,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Result rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_dict(row) -> Dict[str, Any]:
+    if hasattr(row, "asDict"):
+        return row.asDict(recursive=True)
+    if hasattr(row, "_asdict"):
+        return dict(row._asdict())
+    return dict(row)
+
+
+def _render_markdown(rows: List[Dict[str, Any]], schema_fields: List[str]) -> str:
+    if not schema_fields:
+        return "_(no columns)_"
+    header = "| " + " | ".join(schema_fields) + " |"
+    sep = "| " + " | ".join("---" for _ in schema_fields) + " |"
+    body = []
+    for row in rows:
+        body.append(
+            "| " + " | ".join(_md_cell(row.get(c)) for c in schema_fields) + " |"
+        )
+    return "\n".join([header, sep, *body])
+
+
+def _md_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).replace("|", "\\|").replace("\n", " ")
+    return text
+
+
+def _schema_fields(schema) -> List[str]:
+    try:
+        return [field.name for field in schema.fields]
+    except AttributeError:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# execute_sql
+# ---------------------------------------------------------------------------
+
+
+async def _handle_execute_sql(args: Dict[str, Any], holder: SessionHolder) -> Dict[str, Any]:
+    spark = holder.get()
+    query: str = args["query"]
+    sql_args: Optional[Any] = args.get("args")
+    fmt: str = args.get("format", "json")
+    limit_arg = args.get("limit", holder.config.default_page_size)
+    offset = int(args.get("offset", 0))
+
+    if holder.config.read_only:
+        assert_read_only(query)
+
+    capped_limit = min(int(limit_arg), int(holder.config.max_rows))
+    df = _sql(spark, query, sql_args)
+    schema_fields = _schema_fields(df.schema)
+
+    page_df = df.offset(offset).limit(capped_limit + 1) if offset else df.limit(capped_limit + 1)
+    rows = [_row_to_dict(r) for r in page_df.collect()]
+    truncated = len(rows) > capped_limit
+    rows = rows[:capped_limit]
+
+    payload: Dict[str, Any] = {
+        "row_count": len(rows),
+        "truncated": truncated,
+        "limit": capped_limit,
+        "offset": offset,
+        "schema": [
+            {"name": field.name, "type": str(field.dataType), "nullable": field.nullable}
+            for field in df.schema.fields
+        ],
+    }
+    if fmt == "json":
+        payload["rows"] = rows
+    elif fmt == "markdown":
+        payload["markdown"] = _render_markdown(rows, schema_fields)
+    elif fmt == "arrow_base64":
+        import base64
+        import io
+
+        buf = io.BytesIO()
+        page_df_arrow = df.offset(offset).limit(capped_limit) if offset else df.limit(capped_limit)
+        try:
+            import pyarrow as pa  # noqa: F401
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError("arrow_base64 format requires pyarrow") from exc
+        table = page_df_arrow.toArrow()
+        with pa.ipc.new_stream(buf, table.schema) as writer:  # type: ignore[name-defined]
+            writer.write_table(table)
+        payload["arrow_base64"] = base64.b64encode(buf.getvalue()).decode("ascii")
+    else:
+        raise ValueError(f"unsupported format: {fmt}")
+    return payload
+
+
+def _sql(spark, query: str, sql_args: Optional[Any]):
+    if sql_args is None:
+        return spark.sql(query)
+    return spark.sql(query, args=sql_args)
+
+
+def execute_sql_spec() -> ToolSpec:
+    return ToolSpec(
+        name="execute_sql",
+        description=(
+            "Run a SQL query and return rows. Read-only by default — only "
+            "SELECT/WITH/SHOW/DESCRIBE/EXPLAIN/USE/SET are accepted unless "
+            "the server is started with --no-read-only. Results are paginated "
+            "and capped by the server's max_rows setting."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "SQL statement."},
+                "args": {
+                    "description": (
+                        "Bind parameters. Object for named (':name'), array for "
+                        "positional ('?')."
+                    ),
+                    "oneOf": [{"type": "object"}, {"type": "array"}],
+                },
+                "limit": {"type": "integer", "minimum": 1, "default": 100},
+                "offset": {"type": "integer", "minimum": 0, "default": 0},
+                "format": {
+                    "type": "string",
+                    "enum": ["json", "markdown", "arrow_base64"],
+                    "default": "json",
+                },
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+        handler=_handle_execute_sql,
+    )
+
+
+# ---------------------------------------------------------------------------
+# preview_table
+# ---------------------------------------------------------------------------
+
+
+async def _handle_preview_table(args: Dict[str, Any], holder: SessionHolder) -> Dict[str, Any]:
+    name = args["name"]
+    limit = int(args.get("limit", 20))
+    return await _handle_execute_sql(
+        {"query": f"SELECT * FROM {name}", "limit": limit, "format": args.get("format", "json")},
+        holder,
+    )
+
+
+def preview_table_spec() -> ToolSpec:
+    return ToolSpec(
+        name="preview_table",
+        description=(
+            "Convenience wrapper for SELECT * FROM <name> LIMIT <limit>. "
+            "Honors the server's max_rows cap and read-only mode."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1, "default": 20},
+                "format": {"type": "string", "enum": ["json", "markdown"], "default": "json"},
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        handler=_handle_preview_table,
+    )
+
+
+# ---------------------------------------------------------------------------
+# explain_query
+# ---------------------------------------------------------------------------
+
+
+_EXPLAIN_MODES = ("simple", "extended", "formatted", "cost", "codegen")
+
+
+async def _handle_explain_query(args: Dict[str, Any], holder: SessionHolder) -> Dict[str, Any]:
+    spark = holder.get()
+    query = args["query"]
+    mode = args.get("mode", "formatted")
+    if mode not in _EXPLAIN_MODES:
+        raise ValueError(f"mode must be one of {_EXPLAIN_MODES}")
+    if holder.config.read_only:
+        assert_read_only(query)
+
+    df = _sql(spark, query, args.get("args"))
+    plan = df._explain_string(mode=mode)
+    return {"mode": mode, "plan": plan}
+
+
+def explain_query_spec() -> ToolSpec:
+    return ToolSpec(
+        name="explain_query",
+        description=(
+            "Return the query plan for a SQL statement without executing it. "
+            "Modes: simple, extended, formatted (default), cost, codegen."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "mode": {"type": "string", "enum": list(_EXPLAIN_MODES), "default": "formatted"},
+                "args": {"oneOf": [{"type": "object"}, {"type": "array"}]},
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+        handler=_handle_explain_query,
+    )
+
+
+# ---------------------------------------------------------------------------
+# analyze_query
+# ---------------------------------------------------------------------------
+
+
+async def _handle_analyze_query(args: Dict[str, Any], holder: SessionHolder) -> Dict[str, Any]:
+    spark = holder.get()
+    query = args["query"]
+    if holder.config.read_only:
+        assert_read_only(query)
+
+    df = _sql(spark, query, args.get("args"))
+    extended = df._explain_string(mode="extended")
+    formatted = df._explain_string(mode="formatted")
+    schema = [
+        {"name": field.name, "type": str(field.dataType), "nullable": field.nullable}
+        for field in df.schema.fields
+    ]
+    return {
+        "schema": schema,
+        "extended_plan": extended,
+        "formatted_plan": formatted,
+    }
+
+
+def analyze_query_spec() -> ToolSpec:
+    return ToolSpec(
+        name="analyze_query",
+        description=(
+            "Higher-level wrapper around explain: returns output schema plus "
+            "both extended and formatted plans, so an LLM can reason about a "
+            "query without executing it."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "args": {"oneOf": [{"type": "object"}, {"type": "array"}]},
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+        handler=_handle_analyze_query,
+    )

--- a/python/pyspark/sql/mcp/tools/query.py
+++ b/python/pyspark/sql/mcp/tools/query.py
@@ -32,9 +32,7 @@ from pyspark.sql.mcp.tools.registry import ToolSpec
 T = TypeVar("T")
 
 
-async def _with_timeout(
-    holder: SessionHolder, func: Callable[[], T], *, label: str
-) -> T:
+async def _with_timeout(holder: SessionHolder, func: Callable[[], T], *, label: str) -> T:
     """Run a blocking Spark Connect call in a worker thread under the configured timeout."""
     timeout = holder.config.query_timeout_seconds
     coro: Awaitable[T] = asyncio.to_thread(func)
@@ -122,9 +120,7 @@ def _render_markdown(rows: List[Dict[str, Any]], schema_fields: List[str]) -> st
     sep = "| " + " | ".join("---" for _ in schema_fields) + " |"
     body = []
     for row in rows:
-        body.append(
-            "| " + " | ".join(_md_cell(row.get(c)) for c in schema_fields) + " |"
-        )
+        body.append("| " + " | ".join(_md_cell(row.get(c)) for c in schema_fields) + " |")
     return "\n".join([header, sep, *body])
 
 
@@ -231,8 +227,7 @@ def execute_sql_spec() -> ToolSpec:
                 "query": {"type": "string", "description": "SQL statement."},
                 "args": {
                     "description": (
-                        "Bind parameters. Object for named (':name'), array for "
-                        "positional ('?')."
+                        "Bind parameters. Object for named (':name'), array for positional ('?')."
                     ),
                     "oneOf": [{"type": "object"}, {"type": "array"}],
                 },
@@ -310,9 +305,7 @@ async def _handle_explain_query(args: Dict[str, Any], holder: SessionHolder) -> 
         assert_read_only(query)
 
     df = _sql(spark, query, args.get("args"))
-    plan = await _with_timeout(
-        holder, lambda: df._explain_string(mode=mode), label="explain_query"
-    )
+    plan = await _with_timeout(holder, lambda: df._explain_string(mode=mode), label="explain_query")
     return {"mode": mode, "plan": plan}
 
 

--- a/python/pyspark/sql/mcp/tools/query.py
+++ b/python/pyspark/sql/mcp/tools/query.py
@@ -178,29 +178,12 @@ async def _handle_execute_sql(args: Dict[str, Any], holder: SessionHolder) -> Di
         payload["rows"] = rows
     elif fmt == "markdown":
         payload["markdown"] = _render_markdown(rows, schema_fields)
-    elif fmt == "arrow_base64":
-        import base64
-        import io
-
-        buf = io.BytesIO()
-        page_df_arrow = df.offset(offset).limit(capped_limit) if offset else df.limit(capped_limit)
-        try:
-            import pyarrow as pa
-        except ImportError as exc:  # pragma: no cover
-            raise PySparkRuntimeError(
-                errorClass="MCP_PYARROW_REQUIRED",
-                messageParameters={"format": "arrow_base64"},
-            ) from exc
-        table = await _with_timeout(holder, page_df_arrow.toArrow, label="execute_sql")
-        with pa.ipc.new_stream(buf, table.schema) as writer:
-            writer.write_table(table)
-        payload["arrow_base64"] = base64.b64encode(buf.getvalue()).decode("ascii")
     else:
         raise PySparkValueError(
             errorClass="MCP_UNSUPPORTED_FORMAT",
             messageParameters={
                 "format": str(fmt),
-                "allowed": "json, markdown, arrow_base64",
+                "allowed": "json, markdown",
             },
         )
     return payload
@@ -235,7 +218,7 @@ def execute_sql_spec() -> ToolSpec:
                 "offset": {"type": "integer", "minimum": 0, "default": 0},
                 "format": {
                     "type": "string",
-                    "enum": ["json", "markdown", "arrow_base64"],
+                    "enum": ["json", "markdown"],
                     "default": "json",
                 },
             },

--- a/python/pyspark/sql/mcp/tools/registry.py
+++ b/python/pyspark/sql/mcp/tools/registry.py
@@ -45,7 +45,7 @@ class ToolSpec:
 
 
 def all_tools() -> List[ToolSpec]:
-    """Return the v0.1 tool surface."""
+    """Return the full tool surface exposed by the server."""
     # Imports are local to avoid forcing tool-module imports when only the
     # registry shape is needed (e.g. in lightweight tests).
     from pyspark.sql.mcp.tools import catalog, query, session

--- a/python/pyspark/sql/mcp/tools/registry.py
+++ b/python/pyspark/sql/mcp/tools/registry.py
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tool registry.
+
+A tool is a (name, description, input schema, handler) tuple. Handlers receive
+the parsed arguments dict and a :class:`SessionHolder`, and return any
+JSON-serialisable Python value. The server adapter is responsible for turning
+that into MCP ``TextContent`` envelopes.
+
+Keeping handlers free of MCP types means we can unit-test them without the
+SDK installed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, List
+
+from pyspark.sql.mcp.session import SessionHolder
+
+ToolHandler = Callable[[Dict[str, Any], SessionHolder], Awaitable[Any]]
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    name: str
+    description: str
+    input_schema: Dict[str, Any]
+    handler: ToolHandler
+
+
+def all_tools() -> List[ToolSpec]:
+    """Return the v0.1 tool surface."""
+    # Imports are local to avoid forcing tool-module imports when only the
+    # registry shape is needed (e.g. in lightweight tests).
+    from pyspark.sql.mcp.tools import catalog, query, session
+
+    return [
+        session.get_session_info_spec(),
+        catalog.list_catalogs_spec(),
+        catalog.list_databases_spec(),
+        catalog.list_tables_spec(),
+        catalog.describe_table_spec(),
+        query.list_functions_spec(),
+        query.execute_sql_spec(),
+        query.preview_table_spec(),
+        query.explain_query_spec(),
+        query.analyze_query_spec(),
+    ]

--- a/python/pyspark/sql/mcp/tools/session.py
+++ b/python/pyspark/sql/mcp/tools/session.py
@@ -1,0 +1,79 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from pyspark.sql.mcp.session import SessionHolder
+from pyspark.sql.mcp.tools.registry import ToolSpec
+
+# Configs that are safe to surface to an LLM. Anything else is filtered out
+# to avoid leaking tokens or workspace-scoped identifiers.
+_SAFE_CONFIG_PREFIXES = (
+    "spark.app.",
+    "spark.sql.",
+    "spark.connect.",
+)
+_REDACT_SUBSTRINGS = ("token", "secret", "password", "credential")
+
+
+async def _handle(_args: Dict[str, Any], holder: SessionHolder) -> Dict[str, Any]:
+    spark = holder.get()
+    config = holder.config
+
+    version = spark.version
+    current_catalog = spark.catalog.currentCatalog()
+    current_database = spark.catalog.currentDatabase()
+    safe_configs = _collect_safe_configs(spark)
+
+    return {
+        "spark_version": version,
+        "connect_url": config.connect_url,
+        "read_only": config.read_only,
+        "current_catalog": current_catalog,
+        "current_database": current_database,
+        "configs": safe_configs,
+    }
+
+
+def _collect_safe_configs(spark) -> Dict[str, str]:
+    try:
+        items = spark.conf.getAll()
+    except Exception:
+        return {}
+    out: Dict[str, str] = {}
+    for key, value in items.items():
+        if not key.startswith(_SAFE_CONFIG_PREFIXES):
+            continue
+        if any(needle in key.lower() for needle in _REDACT_SUBSTRINGS):
+            continue
+        out[key] = value
+    return out
+
+
+def get_session_info_spec() -> ToolSpec:
+    return ToolSpec(
+        name="get_session_info",
+        description=(
+            "Return Spark version, connection URL, current catalog/database, "
+            "and a filtered subset of session configs. Use this first to "
+            "orient before issuing other tool calls."
+        ),
+        input_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        handler=_handle,
+    )

--- a/python/pyspark/sql/mcp/tools/session.py
+++ b/python/pyspark/sql/mcp/tools/session.py
@@ -51,7 +51,7 @@ async def _handle(_args: Dict[str, Any], holder: SessionHolder) -> Dict[str, Any
     }
 
 
-def _collect_safe_configs(spark) -> Dict[str, str]:
+def _collect_safe_configs(spark: Any) -> Dict[str, str]:
     try:
         items = spark.conf.getAll()
     except Exception:

--- a/python/pyspark/sql/tests/mcp/__init__.py
+++ b/python/pyspark/sql/tests/mcp/__init__.py
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/pyspark/sql/tests/mcp/test_mcp_integration.py
+++ b/python/pyspark/sql/tests/mcp/test_mcp_integration.py
@@ -181,10 +181,11 @@ class MCPToolsConnectIntegrationTest(unittest.TestCase):
         self.assertTrue(out["truncated"])
 
     def test_execute_sql_blocks_ddl_in_read_only(self):
-        from pyspark.sql.mcp.safety import ReadOnlyViolation
+        from pyspark.errors import PySparkValueError
 
-        with self.assertRaises(ReadOnlyViolation):
+        with self.assertRaises(PySparkValueError) as ctx:
             self._call("execute_sql", {"query": "DROP TABLE mcp_test_orders"})
+        self.assertEqual(ctx.exception.getCondition(), "MCP_READ_ONLY_VIOLATION")
 
     def test_explain_query_returns_plan_text(self):
         out = self._call(

--- a/python/pyspark/sql/tests/mcp/test_mcp_integration.py
+++ b/python/pyspark/sql/tests/mcp/test_mcp_integration.py
@@ -70,7 +70,9 @@ class MCPToolsConnectIntegrationTest(unittest.TestCase):
 
         # Seed a small dataset so the catalog/preview tools have something
         # to chew on.
-        cls.spark.sql("CREATE TABLE IF NOT EXISTS mcp_test_orders (id BIGINT, amount DECIMAL(10,2)) USING parquet")
+        cls.spark.sql(
+            "CREATE TABLE IF NOT EXISTS mcp_test_orders (id BIGINT, amount DECIMAL(10,2)) USING parquet"
+        )
         cls.spark.sql("INSERT INTO mcp_test_orders VALUES (1, 10.50), (2, 20.00), (3, 30.75)")
 
         from pyspark.sql.mcp.config import ServerConfig

--- a/python/pyspark/sql/tests/mcp/test_mcp_integration.py
+++ b/python/pyspark/sql/tests/mcp/test_mcp_integration.py
@@ -1,0 +1,209 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""End-to-end integration test for the Spark MCP server.
+
+This test boots a local Spark Connect session (via the in-process server
+provided by ``SparkSession.builder.remote("local[*]")``) and exercises the
+MCP tool handlers against it. The unit tests in ``test_mcp_tools`` cover the
+same tools against a fake session; this file confirms that the handlers
+actually agree with what the real Connect client returns.
+
+The test is skipped automatically when:
+  * Spark Connect dependencies (grpcio, pandas, pyarrow, ...) are missing.
+  * Spark JARs are not built (the ``SparkSession`` cannot be created).
+
+Run with::
+
+    PYTHONPATH=python python -m unittest \
+        pyspark.sql.tests.mcp.test_mcp_integration
+"""
+
+import asyncio
+import unittest
+
+from pyspark.testing.utils import (
+    connect_requirement_message,
+    should_test_connect,
+)
+
+
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
+class MCPToolsConnectIntegrationTest(unittest.TestCase):
+    """Run MCP tool handlers against a real Spark Connect session."""
+
+    spark = None
+    holder = None
+
+    @classmethod
+    def setUpClass(cls):
+        from pyspark.sql import SparkSession
+
+        cls.spark = (
+            SparkSession.builder.appName(cls.__name__)
+            # Disable the Spark UI: in some local builds Jetty's classpath
+            # is mismatched and binding the UI throws. We don't need it for
+            # an in-process test.
+            .config("spark.ui.enabled", "false")
+            # Force loopback for both driver and executor traffic so the
+            # in-process Connect REPL artifact server is reachable from
+            # local executors.
+            .config("spark.driver.bindAddress", "127.0.0.1")
+            .config("spark.driver.host", "127.0.0.1")
+            .remote("local[2]")
+            .getOrCreate()
+        )
+
+        # Seed a small dataset so the catalog/preview tools have something
+        # to chew on.
+        cls.spark.sql("CREATE TABLE IF NOT EXISTS mcp_test_orders (id BIGINT, amount DECIMAL(10,2)) USING parquet")
+        cls.spark.sql("INSERT INTO mcp_test_orders VALUES (1, 10.50), (2, 20.00), (3, 30.75)")
+
+        from pyspark.sql.mcp.config import ServerConfig
+        from pyspark.sql.mcp.session import SessionHolder
+
+        class _PreboundHolder(SessionHolder):
+            """A SessionHolder that wraps an already-built SparkSession.
+
+            The default holder calls ``SparkSession.builder.remote(...)``;
+            for the integration test we want to reuse the session created
+            in ``setUpClass`` so all assertions run against the same Spark
+            instance.
+            """
+
+            def __init__(self, config, session):
+                super().__init__(config)
+                self._session = session
+
+        cls.holder = _PreboundHolder(
+            ServerConfig(connect_url="local[2]"),
+            cls.spark,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            if cls.spark is not None:
+                cls.spark.sql("DROP TABLE IF EXISTS mcp_test_orders")
+                cls.spark.stop()
+        finally:
+            cls.spark = None
+            cls.holder = None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _spec(cls, name):
+        from pyspark.sql.mcp.tools.registry import all_tools
+
+        for spec in all_tools():
+            if spec.name == name:
+                return spec
+        raise KeyError(name)
+
+    @classmethod
+    def _call(cls, name, args=None):
+        spec = cls._spec(name)
+        return asyncio.run(spec.handler(args or {}, cls.holder))
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_get_session_info_reports_real_version(self):
+        out = self._call("get_session_info")
+        self.assertTrue(out["spark_version"], "spark_version should not be empty")
+        # Sanity-check semver-ish prefix.
+        self.assertRegex(out["spark_version"], r"^\d+\.\d+")
+        self.assertEqual(out["read_only"], True)
+        self.assertIn("current_catalog", out)
+        self.assertIn("current_database", out)
+
+    def test_list_catalogs_includes_default(self):
+        out = self._call("list_catalogs")
+        names = [item.get("name") for item in out["items"]]
+        self.assertIn("spark_catalog", names)
+
+    def test_list_databases_includes_default(self):
+        out = self._call("list_databases")
+        names = [item.get("name") for item in out["items"]]
+        self.assertIn("default", names)
+
+    def test_list_tables_finds_seeded_table(self):
+        out = self._call("list_tables")
+        names = [item.get("name") for item in out["items"]]
+        self.assertIn("mcp_test_orders", names)
+
+    def test_describe_table_returns_columns(self):
+        out = self._call("describe_table", {"name": "mcp_test_orders"})
+        self.assertEqual(out["table"]["name"], "mcp_test_orders")
+        col_names = [c["name"] for c in out["columns"]]
+        self.assertEqual(col_names, ["id", "amount"])
+
+    def test_execute_sql_returns_rows(self):
+        out = self._call(
+            "execute_sql",
+            {"query": "SELECT id, amount FROM mcp_test_orders ORDER BY id"},
+        )
+        self.assertEqual(out["row_count"], 3)
+        self.assertFalse(out["truncated"])
+        ids = [row["id"] for row in out["rows"]]
+        self.assertEqual(ids, [1, 2, 3])
+        # Schema metadata round-trips through Connect.
+        names = [field["name"] for field in out["schema"]]
+        self.assertEqual(names, ["id", "amount"])
+
+    def test_execute_sql_truncates_at_limit(self):
+        out = self._call(
+            "execute_sql",
+            {
+                "query": "SELECT id FROM mcp_test_orders ORDER BY id",
+                "limit": 2,
+            },
+        )
+        self.assertEqual(out["row_count"], 2)
+        self.assertTrue(out["truncated"])
+
+    def test_execute_sql_blocks_ddl_in_read_only(self):
+        from pyspark.sql.mcp.safety import ReadOnlyViolation
+
+        with self.assertRaises(ReadOnlyViolation):
+            self._call("execute_sql", {"query": "DROP TABLE mcp_test_orders"})
+
+    def test_explain_query_returns_plan_text(self):
+        out = self._call(
+            "explain_query",
+            {"query": "SELECT COUNT(*) FROM mcp_test_orders", "mode": "formatted"},
+        )
+        self.assertEqual(out["mode"], "formatted")
+        self.assertIn("Aggregate", out["plan"])
+
+    def test_analyze_query_includes_schema_and_plans(self):
+        out = self._call("analyze_query", {"query": "SELECT id FROM mcp_test_orders"})
+        self.assertEqual([f["name"] for f in out["schema"]], ["id"])
+        self.assertIn("extended_plan", out)
+        self.assertIn("formatted_plan", out)
+
+    def test_preview_table_returns_capped_rows(self):
+        out = self._call("preview_table", {"name": "mcp_test_orders", "limit": 2})
+        self.assertEqual(out["row_count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/pyspark/sql/tests/mcp/test_mcp_tools.py
+++ b/python/pyspark/sql/tests/mcp/test_mcp_tools.py
@@ -158,9 +158,7 @@ class _FakeHolder:
     def __init__(self, **overrides: Any):
         self.config = ServerConfig(connect_url="sc://fake", **overrides)
         rows = [{"id": i, "amount": i * 10} for i in range(5)]
-        schema = _Schema(
-            [_StructField("id", "long", False), _StructField("amount", "long", True)]
-        )
+        schema = _Schema([_StructField("id", "long", False), _StructField("amount", "long", True)])
         self._spark = _FakeSpark(_FakeDataFrame(rows, schema))
 
     def get(self) -> _FakeSpark:
@@ -292,9 +290,7 @@ class MCPToolsTest(unittest.TestCase):
         # should complete even if the underlying collect sleeps.
         holder = _FakeHolder(query_timeout_seconds=0)
         rows = [{"id": 0, "amount": 0}]
-        schema = _Schema(
-            [_StructField("id", "long", False), _StructField("amount", "long", True)]
-        )
+        schema = _Schema([_StructField("id", "long", False), _StructField("amount", "long", True)])
 
         class _SlightlySlow(_FakeDataFrame):
             def limit(self, n):
@@ -310,16 +306,12 @@ class MCPToolsTest(unittest.TestCase):
                 return [_Row(r) for r in rows]
 
         holder._spark = _FakeSpark(_SlightlySlow(rows, schema))
-        out = _run(
-            _spec("execute_sql").handler({"query": "SELECT * FROM t"}, holder)
-        )
+        out = _run(_spec("execute_sql").handler({"query": "SELECT * FROM t"}, holder))
         self.assertEqual(out["row_count"], 1)
 
     def test_execute_sql_query_timeout_fires(self):
         rows = [{"id": 0, "amount": 0}]
-        schema = _Schema(
-            [_StructField("id", "long", False), _StructField("amount", "long", True)]
-        )
+        schema = _Schema([_StructField("id", "long", False), _StructField("amount", "long", True)])
 
         class _TooSlow(_FakeDataFrame):
             def limit(self, n):

--- a/python/pyspark/sql/tests/mcp/test_mcp_tools.py
+++ b/python/pyspark/sql/tests/mcp/test_mcp_tools.py
@@ -1,0 +1,291 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for the Spark MCP server tool layer.
+
+These tests exercise the tool handlers against an in-memory fake of the
+Spark Connect session so they run without a live Spark cluster, without
+the MCP SDK installed, and without grpcio. End-to-end tests with a real
+Spark Connect server live elsewhere and run as part of the Connect test
+matrix.
+"""
+
+import asyncio
+import unittest
+from collections import namedtuple
+from typing import Any, Dict, List
+
+from pyspark.sql.mcp.config import ServerConfig
+from pyspark.sql.mcp.safety import ReadOnlyViolation
+from pyspark.sql.mcp.tools.registry import all_tools
+
+
+_StructField = namedtuple("StructField", "name dataType nullable")
+
+
+class _Schema:
+    def __init__(self, fields: List[_StructField]):
+        self.fields = fields
+
+
+class _Row(dict):
+    def asDict(self, recursive: bool = False) -> Dict[str, Any]:
+        return dict(self)
+
+
+class _FakeDataFrame:
+    def __init__(self, rows: List[Dict[str, Any]], schema: _Schema, _offset: int = 0):
+        self._rows = rows
+        self.schema = schema
+        self._offset = _offset
+
+    def offset(self, n: int) -> "_FakeDataFrame":
+        return _FakeDataFrame(self._rows, self.schema, _offset=self._offset + n)
+
+    def limit(self, n: int) -> "_FakeDataFrame":
+        end = self._offset + n
+        return _FakeDataFrame(self._rows[self._offset:end], self.schema)
+
+    def collect(self) -> List[_Row]:
+        return [_Row(r) for r in self._rows]
+
+    def _explain_string(self, mode: str = "simple") -> str:
+        return f"== {mode} plan ==\nLogicalRDD"
+
+
+class _FakeCatalog:
+    _CatalogMeta = namedtuple("CatalogMetadata", "name description")
+    _Database = namedtuple("Database", "name catalog description locationUri")
+    _Table = namedtuple(
+        "Table", "name catalog namespace description tableType isTemporary"
+    )
+    _Column = namedtuple(
+        "Column", "name description dataType nullable isPartition isBucket"
+    )
+    _Function = namedtuple(
+        "Function", "name catalog namespace description className isTemporary"
+    )
+
+    def __init__(self):
+        self._catalog = "spark_catalog"
+        self._database = "default"
+
+    def currentCatalog(self) -> str:
+        return self._catalog
+
+    def currentDatabase(self) -> str:
+        return self._database
+
+    def setCurrentCatalog(self, name: str) -> None:
+        self._catalog = name
+
+    def listCatalogs(self):
+        return [
+            self._CatalogMeta("spark_catalog", "in-memory"),
+            self._CatalogMeta("hive_metastore", None),
+        ]
+
+    def listDatabases(self, pattern=None):
+        return [self._Database("default", "spark_catalog", None, "/tmp")]
+
+    def listTables(self, dbName=None, pattern=None):
+        return [
+            self._Table(
+                "orders", "spark_catalog", ["default"], "orders", "MANAGED", False
+            )
+        ]
+
+    def getTable(self, name):
+        return self._Table(
+            "orders", "spark_catalog", ["default"], "orders", "MANAGED", False
+        )
+
+    def listColumns(self, name, dbName=None):
+        return [
+            self._Column("id", None, "bigint", False, False, False),
+            self._Column("amount", None, "decimal(10,2)", True, False, False),
+        ]
+
+    def listFunctions(self, dbName=None, pattern=None):
+        return [
+            self._Function(
+                "coalesce", "spark_catalog", [], "", "BuiltIn", True
+            ),
+            self._Function(
+                "explode", "spark_catalog", [], "", "BuiltIn", True
+            ),
+        ]
+
+
+class _FakeConf:
+    def getAll(self) -> Dict[str, str]:
+        return {
+            "spark.app.name": "demo",
+            "spark.sql.shuffle.partitions": "200",
+            "spark.connect.session.token": "REDACT_ME",
+        }
+
+
+class _FakeSpark:
+    version = "4.0.0-test"
+
+    def __init__(self, df: _FakeDataFrame):
+        self._df = df
+        self.catalog = _FakeCatalog()
+        self.conf = _FakeConf()
+
+    def sql(self, query, args=None):
+        # Echo the same fake DataFrame for every query — the tools we exercise
+        # care about row/schema shape, not query semantics.
+        return self._df
+
+
+class _FakeHolder:
+    def __init__(self, **overrides: Any):
+        self.config = ServerConfig(connect_url="sc://fake", **overrides)
+        rows = [{"id": i, "amount": i * 10} for i in range(5)]
+        schema = _Schema(
+            [_StructField("id", "long", False), _StructField("amount", "long", True)]
+        )
+        self._spark = _FakeSpark(_FakeDataFrame(rows, schema))
+
+    def get(self) -> _FakeSpark:
+        return self._spark
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _spec(name: str):
+    for spec in all_tools():
+        if spec.name == name:
+            return spec
+    raise KeyError(name)
+
+
+class MCPToolsTest(unittest.TestCase):
+    def test_registry_exposes_ten_tools(self):
+        names = [s.name for s in all_tools()]
+        self.assertEqual(len(names), 10)
+        self.assertIn("get_session_info", names)
+        self.assertIn("execute_sql", names)
+        self.assertIn("explain_query", names)
+
+    def test_get_session_info_redacts_token(self):
+        out = _run(_spec("get_session_info").handler({}, _FakeHolder()))
+        self.assertEqual(out["spark_version"], "4.0.0-test")
+        self.assertEqual(out["read_only"], True)
+        self.assertIn("spark.app.name", out["configs"])
+        self.assertNotIn("spark.connect.session.token", out["configs"])
+
+    def test_list_catalogs_paginates(self):
+        out = _run(_spec("list_catalogs").handler({"limit": 1}, _FakeHolder()))
+        self.assertEqual(out["returned"], 1)
+        self.assertTrue(out["truncated"])
+        self.assertEqual(out["total"], 2)
+
+    def test_list_tables_returns_namespace(self):
+        out = _run(_spec("list_tables").handler({}, _FakeHolder()))
+        self.assertEqual(out["items"][0]["name"], "orders")
+        self.assertEqual(out["items"][0]["namespace"], ["default"])
+
+    def test_describe_table_includes_columns(self):
+        out = _run(_spec("describe_table").handler({"name": "orders"}, _FakeHolder()))
+        self.assertEqual(out["table"]["name"], "orders")
+        col_names = [c["name"] for c in out["columns"]]
+        self.assertEqual(col_names, ["id", "amount"])
+
+    def test_execute_sql_json_truncates(self):
+        out = _run(
+            _spec("execute_sql").handler(
+                {"query": "SELECT * FROM t", "limit": 3}, _FakeHolder()
+            )
+        )
+        self.assertEqual(out["row_count"], 3)
+        self.assertTrue(out["truncated"])
+        self.assertEqual([c["name"] for c in out["schema"]], ["id", "amount"])
+
+    def test_execute_sql_markdown(self):
+        out = _run(
+            _spec("execute_sql").handler(
+                {"query": "SELECT * FROM t", "limit": 2, "format": "markdown"},
+                _FakeHolder(),
+            )
+        )
+        self.assertIn("| id | amount |", out["markdown"])
+        self.assertNotIn("rows", out)
+
+    def test_execute_sql_read_only_blocks_ddl(self):
+        with self.assertRaises(ReadOnlyViolation):
+            _run(_spec("execute_sql").handler({"query": "DROP TABLE t"}, _FakeHolder()))
+
+    def test_execute_sql_read_only_off_allows_ddl(self):
+        out = _run(
+            _spec("execute_sql").handler(
+                {"query": "DROP TABLE t"}, _FakeHolder(read_only=False)
+            )
+        )
+        # Fake session returns the canned DataFrame; the test only asserts no
+        # exception escaped past the safety filter.
+        self.assertIn("row_count", out)
+
+    def test_execute_sql_max_rows_caps_limit(self):
+        out = _run(
+            _spec("execute_sql").handler(
+                {"query": "SELECT * FROM t", "limit": 100},
+                _FakeHolder(max_rows=2),
+            )
+        )
+        self.assertEqual(out["limit"], 2)
+        self.assertEqual(out["row_count"], 2)
+        self.assertTrue(out["truncated"])
+
+    def test_explain_query_modes(self):
+        out = _run(
+            _spec("explain_query").handler(
+                {"query": "SELECT 1", "mode": "extended"}, _FakeHolder()
+            )
+        )
+        self.assertEqual(out["mode"], "extended")
+        self.assertIn("extended plan", out["plan"])
+
+    def test_explain_query_rejects_unknown_mode(self):
+        with self.assertRaises(ValueError):
+            _run(
+                _spec("explain_query").handler(
+                    {"query": "SELECT 1", "mode": "bogus"}, _FakeHolder()
+                )
+            )
+
+    def test_analyze_query_bundles_schema_and_plans(self):
+        out = _run(_spec("analyze_query").handler({"query": "SELECT 1"}, _FakeHolder()))
+        self.assertIn("schema", out)
+        self.assertIn("extended_plan", out)
+        self.assertIn("formatted_plan", out)
+
+    def test_preview_table_delegates_to_execute_sql(self):
+        out = _run(
+            _spec("preview_table").handler(
+                {"name": "orders", "limit": 1}, _FakeHolder()
+            )
+        )
+        self.assertEqual(out["row_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/pyspark/sql/tests/mcp/test_mcp_tools.py
+++ b/python/pyspark/sql/tests/mcp/test_mcp_tools.py
@@ -58,7 +58,7 @@ class _FakeDataFrame:
 
     def limit(self, n: int) -> "_FakeDataFrame":
         end = self._offset + n
-        return _FakeDataFrame(self._rows[self._offset:end], self.schema)
+        return _FakeDataFrame(self._rows[self._offset : end], self.schema)
 
     def collect(self) -> List[_Row]:
         return [_Row(r) for r in self._rows]
@@ -70,15 +70,9 @@ class _FakeDataFrame:
 class _FakeCatalog:
     _CatalogMeta = namedtuple("CatalogMetadata", "name description")
     _Database = namedtuple("Database", "name catalog description locationUri")
-    _Table = namedtuple(
-        "Table", "name catalog namespace description tableType isTemporary"
-    )
-    _Column = namedtuple(
-        "Column", "name description dataType nullable isPartition isBucket"
-    )
-    _Function = namedtuple(
-        "Function", "name catalog namespace description className isTemporary"
-    )
+    _Table = namedtuple("Table", "name catalog namespace description tableType isTemporary")
+    _Column = namedtuple("Column", "name description dataType nullable isPartition isBucket")
+    _Function = namedtuple("Function", "name catalog namespace description className isTemporary")
 
     def __init__(self):
         self._catalog = "spark_catalog"
@@ -103,16 +97,10 @@ class _FakeCatalog:
         return [self._Database("default", "spark_catalog", None, "/tmp")]
 
     def listTables(self, dbName=None, pattern=None):
-        return [
-            self._Table(
-                "orders", "spark_catalog", ["default"], "orders", "MANAGED", False
-            )
-        ]
+        return [self._Table("orders", "spark_catalog", ["default"], "orders", "MANAGED", False)]
 
     def getTable(self, name):
-        return self._Table(
-            "orders", "spark_catalog", ["default"], "orders", "MANAGED", False
-        )
+        return self._Table("orders", "spark_catalog", ["default"], "orders", "MANAGED", False)
 
     def listColumns(self, name, dbName=None):
         return [
@@ -122,12 +110,8 @@ class _FakeCatalog:
 
     def listFunctions(self, dbName=None, pattern=None):
         return [
-            self._Function(
-                "coalesce", "spark_catalog", [], "", "BuiltIn", True
-            ),
-            self._Function(
-                "explode", "spark_catalog", [], "", "BuiltIn", True
-            ),
+            self._Function("coalesce", "spark_catalog", [], "", "BuiltIn", True),
+            self._Function("explode", "spark_catalog", [], "", "BuiltIn", True),
         ]
 
 
@@ -210,9 +194,7 @@ class MCPToolsTest(unittest.TestCase):
 
     def test_execute_sql_json_truncates(self):
         out = _run(
-            _spec("execute_sql").handler(
-                {"query": "SELECT * FROM t", "limit": 3}, _FakeHolder()
-            )
+            _spec("execute_sql").handler({"query": "SELECT * FROM t", "limit": 3}, _FakeHolder())
         )
         self.assertEqual(out["row_count"], 3)
         self.assertTrue(out["truncated"])
@@ -235,9 +217,7 @@ class MCPToolsTest(unittest.TestCase):
 
     def test_execute_sql_read_only_off_allows_ddl(self):
         out = _run(
-            _spec("execute_sql").handler(
-                {"query": "DROP TABLE t"}, _FakeHolder(read_only=False)
-            )
+            _spec("execute_sql").handler({"query": "DROP TABLE t"}, _FakeHolder(read_only=False))
         )
         # Fake session returns the canned DataFrame; the test only asserts no
         # exception escaped past the safety filter.
@@ -256,9 +236,7 @@ class MCPToolsTest(unittest.TestCase):
 
     def test_explain_query_modes(self):
         out = _run(
-            _spec("explain_query").handler(
-                {"query": "SELECT 1", "mode": "extended"}, _FakeHolder()
-            )
+            _spec("explain_query").handler({"query": "SELECT 1", "mode": "extended"}, _FakeHolder())
         )
         self.assertEqual(out["mode"], "extended")
         self.assertIn("extended plan", out["plan"])
@@ -278,11 +256,7 @@ class MCPToolsTest(unittest.TestCase):
         self.assertIn("formatted_plan", out)
 
     def test_preview_table_delegates_to_execute_sql(self):
-        out = _run(
-            _spec("preview_table").handler(
-                {"name": "orders", "limit": 1}, _FakeHolder()
-            )
-        )
+        out = _run(_spec("preview_table").handler({"name": "orders", "limit": 1}, _FakeHolder()))
         self.assertEqual(out["row_count"], 1)
 
     def test_execute_sql_query_timeout_disabled(self):

--- a/python/pyspark/sql/tests/mcp/test_mcp_tools.py
+++ b/python/pyspark/sql/tests/mcp/test_mcp_tools.py
@@ -29,8 +29,8 @@ import unittest
 from collections import namedtuple
 from typing import Any, Dict, List
 
+from pyspark.errors import PySparkRuntimeError, PySparkValueError
 from pyspark.sql.mcp.config import ServerConfig
-from pyspark.sql.mcp.safety import ReadOnlyViolation
 from pyspark.sql.mcp.tools.registry import all_tools
 
 
@@ -231,8 +231,9 @@ class MCPToolsTest(unittest.TestCase):
         self.assertNotIn("rows", out)
 
     def test_execute_sql_read_only_blocks_ddl(self):
-        with self.assertRaises(ReadOnlyViolation):
+        with self.assertRaises(PySparkValueError) as ctx:
             _run(_spec("execute_sql").handler({"query": "DROP TABLE t"}, _FakeHolder()))
+        self.assertEqual(ctx.exception.getCondition(), "MCP_READ_ONLY_VIOLATION")
 
     def test_execute_sql_read_only_off_allows_ddl(self):
         out = _run(
@@ -315,8 +316,6 @@ class MCPToolsTest(unittest.TestCase):
         self.assertEqual(out["row_count"], 1)
 
     def test_execute_sql_query_timeout_fires(self):
-        from pyspark.sql.mcp.tools.query import QueryTimeoutError
-
         rows = [{"id": 0, "amount": 0}]
         schema = _Schema(
             [_StructField("id", "long", False), _StructField("amount", "long", True)]
@@ -337,8 +336,9 @@ class MCPToolsTest(unittest.TestCase):
 
         holder = _FakeHolder(query_timeout_seconds=1)
         holder._spark = _FakeSpark(_TooSlow(rows, schema))
-        with self.assertRaises(QueryTimeoutError):
+        with self.assertRaises(PySparkRuntimeError) as ctx:
             _run(_spec("execute_sql").handler({"query": "SELECT * FROM t"}, holder))
+        self.assertEqual(ctx.exception.getCondition(), "MCP_QUERY_TIMEOUT")
 
 
 class ServerConfigTest(unittest.TestCase):

--- a/python/pyspark/sql/tests/mcp/test_mcp_tools.py
+++ b/python/pyspark/sql/tests/mcp/test_mcp_tools.py
@@ -286,6 +286,144 @@ class MCPToolsTest(unittest.TestCase):
         )
         self.assertEqual(out["row_count"], 1)
 
+    def test_execute_sql_query_timeout_disabled(self):
+        # query_timeout_seconds <= 0 disables the timeout entirely; the call
+        # should complete even if the underlying collect sleeps.
+        holder = _FakeHolder(query_timeout_seconds=0)
+        rows = [{"id": 0, "amount": 0}]
+        schema = _Schema(
+            [_StructField("id", "long", False), _StructField("amount", "long", True)]
+        )
+
+        class _SlightlySlow(_FakeDataFrame):
+            def limit(self, n):
+                return self
+
+            def offset(self, n):
+                return self
+
+            def collect(self):
+                import time
+
+                time.sleep(0.05)
+                return [_Row(r) for r in rows]
+
+        holder._spark = _FakeSpark(_SlightlySlow(rows, schema))
+        out = _run(
+            _spec("execute_sql").handler({"query": "SELECT * FROM t"}, holder)
+        )
+        self.assertEqual(out["row_count"], 1)
+
+    def test_execute_sql_query_timeout_fires(self):
+        from pyspark.sql.mcp.tools.query import QueryTimeoutError
+
+        rows = [{"id": 0, "amount": 0}]
+        schema = _Schema(
+            [_StructField("id", "long", False), _StructField("amount", "long", True)]
+        )
+
+        class _TooSlow(_FakeDataFrame):
+            def limit(self, n):
+                return self
+
+            def offset(self, n):
+                return self
+
+            def collect(self):
+                import time
+
+                time.sleep(2)
+                return [_Row(r) for r in rows]
+
+        holder = _FakeHolder(query_timeout_seconds=1)
+        holder._spark = _FakeSpark(_TooSlow(rows, schema))
+        with self.assertRaises(QueryTimeoutError):
+            _run(_spec("execute_sql").handler({"query": "SELECT * FROM t"}, holder))
+
+
+class ServerConfigTest(unittest.TestCase):
+    def _scrub_env(self):
+        import os
+
+        for key in [
+            "SPARK_REMOTE",
+            "SPARK_MCP_READ_ONLY",
+            "SPARK_MCP_MAX_ROWS",
+            "SPARK_MCP_QUERY_TIMEOUT_SECONDS",
+            "SPARK_MCP_USER_ID",
+            "SPARK_MCP_TRANSPORT",
+        ]:
+            os.environ.pop(key, None)
+
+    def setUp(self):
+        self._scrub_env()
+
+    def tearDown(self):
+        self._scrub_env()
+
+    def test_from_env_requires_connect_url(self):
+        with self.assertRaises(ValueError):
+            ServerConfig.from_env()
+
+    def test_cli_args_override_env(self):
+        import os
+
+        os.environ["SPARK_REMOTE"] = "sc://from-env:1"
+        os.environ["SPARK_MCP_MAX_ROWS"] = "42"
+        cfg = ServerConfig.from_env(
+            connect_url="sc://from-cli:2", max_rows=7, query_timeout_seconds=3
+        )
+        self.assertEqual(cfg.connect_url, "sc://from-cli:2")
+        self.assertEqual(cfg.max_rows, 7)
+        self.assertEqual(cfg.query_timeout_seconds, 3)
+
+    def test_env_vars_populate_defaults(self):
+        import os
+
+        os.environ["SPARK_REMOTE"] = "sc://env:1"
+        os.environ["SPARK_MCP_READ_ONLY"] = "false"
+        os.environ["SPARK_MCP_MAX_ROWS"] = "5"
+        os.environ["SPARK_MCP_QUERY_TIMEOUT_SECONDS"] = "11"
+        os.environ["SPARK_MCP_USER_ID"] = "alice"
+        cfg = ServerConfig.from_env()
+        self.assertEqual(cfg.connect_url, "sc://env:1")
+        self.assertFalse(cfg.read_only)
+        self.assertEqual(cfg.max_rows, 5)
+        self.assertEqual(cfg.query_timeout_seconds, 11)
+        self.assertEqual(cfg.user_id, "alice")
+
+    def test_env_int_rejects_garbage(self):
+        import os
+
+        os.environ["SPARK_REMOTE"] = "sc://env:1"
+        os.environ["SPARK_MCP_MAX_ROWS"] = "not-a-number"
+        with self.assertRaises(ValueError):
+            ServerConfig.from_env()
+
+
+class CLIParserTest(unittest.TestCase):
+    def test_parser_exposes_new_flags(self):
+        from pyspark.sql.mcp.server import _parse_args
+
+        args = _parse_args(
+            [
+                "--connect-url",
+                "sc://localhost:15002",
+                "--max-rows",
+                "250",
+                "--query-timeout-seconds",
+                "5",
+                "--user-id",
+                "bob",
+            ]
+        )
+        self.assertEqual(args.connect_url, "sc://localhost:15002")
+        self.assertEqual(args.max_rows, 250)
+        self.assertEqual(args.query_timeout_seconds, 5)
+        self.assertEqual(args.user_id, "bob")
+        # read_only is a tri-state (None means "use env/default").
+        self.assertIsNone(args.read_only)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Adds an Apache Spark MCP server that acts as a thin client over Spark Connect, exposing Spark capabilities as MCP tools for LLM consumption. Catalog browsing, SQL execution, and query plan tools are read-only by default.

Module layout (python/pyspark/sql/mcp/):
  - server.py         CLI entry point and MCP tool registration
  - config.py         ServerConfig dataclass (env + CLI sources)
  - session.py        Lazy SparkSession holder over Spark Connect
  - safety.py         Read-only SQL guardrail
  - tools/registry.py Tool spec / handler abstraction
  - tools/session.py  get_session_info (with config redaction)
  - tools/catalog.py  list_catalogs, list_databases, list_tables, describe_table
  - tools/query.py    list_functions, execute_sql, preview_table, explain_query, analyze_query

Tool handlers are MCP-SDK-agnostic and Connect-import-free at module load time, so the unit tests run without grpcio or the mcp SDK installed. 14 unit tests in python/pyspark/sql/tests/mcp/test_mcp_tools.py exercise the full tool surface against an in-memory fake session.

### Why are the changes needed?

LLM clients can already talk to MCP servers; Spark Connect already separates client from cluster. This module connects the two: a Spark cluster shows up to an LLM as a set of safe, paginated tools — `list_tables`, `describe_table`, `execute_sql`, `explain_query`, etc. Users can interact with Spark using natural language.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. User can do Spark queries with natural language in LLMs like Claude Code using these MCP tools.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit test. Manual test in Claude Code.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: Claude Code