### PR TITLE
[SPARK-56699][K8S] Default `ExecutorPVCResizePlugin` interval to `5min` in 5-minute units

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1818,9 +1818,10 @@ See the [configuration page](configuration.html) for information on Spark config
 </tr>
 <tr>
   <td><code>spark.kubernetes.executor.pvc.resizeInterval</code></td>
-  <td><code>0min</code></td>
+  <td><code>5min</code></td>
   <td>
-    Interval between executor PVC resize operations. To disable, set 0 (default).
+    Interval between executor PVC resize operations, in minutes. Defaults to 5 minutes.
+    Set to 0 to disable. Must be 0 or a positive multiple of 5 minutes.
     Takes effect only when <code>org.apache.spark.scheduler.cluster.k8s.ExecutorPVCResizePlugin</code>
     is registered via <code>spark.plugins</code>.
   </td>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -264,11 +264,14 @@ private[spark] object Config extends Logging {
 
   val PVC_RESIZE_INTERVAL =
     ConfigBuilder("spark.kubernetes.executor.pvc.resizeInterval")
-      .doc("Interval between executor PVC resize operations. To disable, set 0 (default)")
+      .doc("Interval between executor PVC resize operations, in minutes. " +
+        "Defaults to 5 minutes. Set to 0 to disable. " +
+        "Must be 0 or a positive multiple of 5 minutes.")
       .version("4.2.0")
       .timeConf(TimeUnit.MINUTES)
-      .checkValue(_ >= 0, "Interval should be non-negative")
-      .createWithDefault(0)
+      .checkValue(v => v >= 0 && v % 5 == 0,
+        "Interval must be 0 or a positive multiple of 5 minutes")
+      .createWithDefault(5)
 
   val PVC_RESIZE_THRESHOLD =
     ConfigBuilder("spark.kubernetes.executor.pvc.resizeThreshold")

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPVCResizePluginSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPVCResizePluginSuite.scala
@@ -26,7 +26,8 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, never, times, verify, when}
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.{SparkContext, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.deploy.k8s.Config.PVC_RESIZE_INTERVAL
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.k8s.Fabric8Aliases._
 
@@ -274,5 +275,18 @@ class ExecutorPVCResizePluginSuite
     val plugin = createPlugin()
     assert(plugin.receive("unrelated") == null)
     assert(plugin.receive(42) == null)
+  }
+
+  test("SPARK-56699: PVC_RESIZE_INTERVAL must be 0 or a positive multiple of 5 minutes") {
+    val conf = new SparkConf(false)
+    assert(conf.get(PVC_RESIZE_INTERVAL) === 5)
+    Seq("0", "5", "10", "15", "15min").foreach { v =>
+      conf.set(PVC_RESIZE_INTERVAL.key, v)
+      assert(conf.get(PVC_RESIZE_INTERVAL) >= 0)
+    }
+    Seq("1", "7", "-5").foreach { v =>
+      conf.set(PVC_RESIZE_INTERVAL.key, v)
+      intercept[IllegalArgumentException](conf.get(PVC_RESIZE_INTERVAL))
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes `spark.kubernetes.executor.pvc.resizeInterval` to default to `5min` and to accept only `0` or a positive multiple of 5 minutes.

### Why are the changes needed?

Given that PVC expansion is a heavy operation (which typically takes over 1 minutes), restricting to 5-minute units (and defaulting to 5 minutes) gives a sensible out-of-the-box configuration once the plugin is registered, and prevents misconfigured intervals that would only add load on the K8s API server.

### Does this PR introduce _any_ user-facing change?

No (unreleased config).

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)