### PR TITLE
[SPARK-XXXXX][SQL] Public Column.toJson / Column.fromJson on the V2 catalog interface

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -60,7 +60,18 @@ object MimaExcludes {
     // [SPARK-56330][CORE] Add TaskInterruptListener to TaskContext for interrupt notifications
     ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.TaskContext.addTaskInterruptListener"),
     // [SPARK-56700][SS] Make DataStreamReader.name public
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.streaming.DataStreamReader.name")
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.streaming.DataStreamReader.name"),
+
+    // [SPARK-XXXXX][SQL] Public Column.toJson / Column.fromJson on the V2 catalog interface
+    // The new `Column.toJson` / `Column.fromJson` are backed by `private[sql]` helpers on
+    // `StructField`'s companion object (`json` / `prettyJson` / `fromJson`). Adding a
+    // `fromJson(String)` static factory to `StructField`'s companion causes scalac to drop
+    // the auto-generated `tupled` / `curried` (Function22 helpers from the case class
+    // apply) and the `AbstractFunction4` parent. None of these are documented public API;
+    // the removals are safe.
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.types.StructField.tupled"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.types.StructField.curried"),
+    ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.sql.types.StructField$")
   )
 
   // Exclude rules for 4.1.x from 4.0.0

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -311,7 +311,7 @@ object DataType {
         messageParameters = Map("invalidType" -> compact(render(other))))
   }
 
-  private def parseStructField(json: JValue): StructField = json match {
+  private[sql] def parseStructField(json: JValue): StructField = json match {
     case JSortedObject(
           ("metadata", JObject(metadataFields)),
           ("name", JString(name)),

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StructField.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StructField.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable
 import org.json4s.{JObject, JString}
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods.{compact, parse, pretty, render}
 
 import org.apache.spark.SparkException
 import org.apache.spark.annotation.Stable
@@ -74,6 +75,17 @@ case class StructField(
       ("nullable" -> nullable) ~
       ("metadata" -> metadataJson)
   }
+
+  /**
+   * Internal: compact JSON representation of this StructField (name, type, nullable,
+   * metadata). Inverse of `StructField.fromJson(String)`. Connectors should round-trip
+   * a [[org.apache.spark.sql.connector.catalog.Column]] via `Column.toJson` /
+   * `Column.fromJson` instead.
+   */
+  private[sql] def json: String = compact(render(jsonValue))
+
+  /** Internal: pretty (i.e. indented) JSON representation of this StructField. */
+  private[sql] def prettyJson: String = pretty(render(jsonValue))
 
   private[sql] def dataTypeJsonValue: JValue = {
     if (collationMetadata.isEmpty) return dataType.jsonValue
@@ -272,4 +284,19 @@ case class StructField(
     s"${QuotingUtils.quoteIfNeeded(name)} ${dataType.sql}$nullDDL" +
       s"$getDDLDefault$getDDLComment"
   }
+}
+
+/**
+ * Internal companion. Holds the `private[sql]` JSON parsing helper that powers
+ * [[org.apache.spark.sql.connector.catalog.Column.fromJson]]. Connectors should not call
+ * methods on this companion directly; use the public `Column.toJson` / `Column.fromJson`
+ * APIs instead.
+ */
+object StructField {
+
+  /**
+   * Internal: parses a JSON string produced by `StructField.json` back into a `StructField`.
+   * The JSON must encode a single field with `name`, `type`, `nullable`, and `metadata`.
+   */
+  private[sql] def fromJson(json: String): StructField = DataType.parseStructField(parse(json))
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Column.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Column.java
@@ -123,6 +123,33 @@ public interface Column {
   }
 
   /**
+   * Serializes this column to a canonical JSON form. The JSON shape is the Spark
+   * {@code StructField} JSON: {@code {"name", "type", "nullable", "metadata"}} -- wire-
+   * format compatible with what Databricks Runtime emits via {@code StructField.toJson}.
+   * The {@link #comment()} (if present) is folded into the {@code metadata} object under
+   * the {@code "comment"} key, matching the Spark {@code StructField} convention.
+   * Inverse of {@link #fromJson(String)}.
+   *
+   * @since 4.2.0
+   */
+  default String toJson() {
+    return CatalogV2Util.columnToJson(this);
+  }
+
+  /**
+   * Parses a JSON string produced by {@link #toJson()} back into a Column. The JSON must
+   * encode a single field with {@code name}, {@code type}, {@code nullable}, and
+   * {@code metadata} keys. The {@code "comment"} key (if present in the metadata object)
+   * is lifted out and exposed via the returned column's {@link #comment()} accessor;
+   * it does NOT remain in {@link #metadataInJSON()}.
+   *
+   * @since 4.2.0
+   */
+  static Column fromJson(String json) {
+    return CatalogV2Util.columnFromJson(json);
+  }
+
+  /**
    * Returns the name of this table column.
    */
   String name();

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -656,6 +656,18 @@ private[sql] object CatalogV2Util {
     f
   }
 
+  /**
+   * Backs the public [[Column#toJson]] / [[Column#fromJson]] APIs. The wire JSON is the
+   * Spark `StructField` JSON shape (`{"name", "type", "nullable", "metadata"}`), with the
+   * comment folded into `metadata` under the `"comment"` key. We compose with the existing
+   * `v2ColumnToStructField` / `structFieldToV2Column` helpers so the conversion rules
+   * (comment-vs-metadata, default-value / generation-expression / identity-spec metadata
+   * keys) stay defined in exactly one place.
+   */
+  def columnToJson(col: Column): String = v2ColumnToStructField(col).json
+
+  def columnFromJson(json: String): Column = structFieldToV2Column(StructField.fromJson(json))
+
   // For built-in file sources, we encode the default value in StructField metadata. An analyzer
   // rule will check the special metadata and change the DML input plan to fill the default value.
   private def encodeDefaultValue(defaultValue: ColumnDefaultValue, f: StructField): StructField = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogV2UtilSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogV2UtilSuite.scala
@@ -21,7 +21,7 @@ import org.mockito.Mockito.{mock, when}
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
-import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.types.{ArrayType, IntegerType, Metadata, StringType, StructField, StructType}
 
 class CatalogV2UtilSuite extends SparkFunSuite {
   test("Load relation should encode the identifiers for V2Relations") {
@@ -36,5 +36,89 @@ class CatalogV2UtilSuite extends SparkFunSuite {
     val v2Relation = r.get.asInstanceOf[DataSourceV2Relation]
     assert(v2Relation.catalog.exists(_ == testCatalog))
     assert(v2Relation.identifier.exists(_ == ident))
+  }
+
+  // -- Column.toJson / Column.fromJson round-trip --
+  //
+  // The wire shape is the Spark `StructField` JSON: `{name, type, nullable, metadata}`
+  // with the `Column.comment()` (if present) folded into `metadata` under the `"comment"`
+  // key. The conversion goes through `CatalogV2Util.{v2ColumnToStructField,
+  // structFieldToV2Column}` so the comment-vs-metadata rule, the empty-metadata-as-null
+  // rule, and any future StructField-shape evolution are all defined in one place.
+
+  test("Column.toJson / fromJson round-trips analyzer-attached metadata") {
+    val metadataJson = "{\"metric_view.type\":\"dimension\",\"metric_view.expr\":\"region\"}"
+    val input = Column.create("region", StringType, true, null, metadataJson)
+
+    val wire = input.toJson()
+    val output = Column.fromJson(wire)
+
+    assert(output.name() === "region")
+    assert(output.dataType() === StringType)
+    assert(output.nullable())
+    assert(output.comment() === null)
+    val md = Metadata.fromJson(output.metadataInJSON())
+    assert(md.getString("metric_view.type") === "dimension")
+    assert(md.getString("metric_view.expr") === "region")
+  }
+
+  test("Column.toJson / fromJson round-trips comment + metadata without duplication") {
+    val metadataJson = "{\"metric_view.type\":\"dimension\"}"
+    val input = Column.create("region", StringType, true, "the region", metadataJson)
+
+    val wire = input.toJson()
+    // Wire format: comment is folded into metadata under the "comment" key.
+    assert(wire.contains("\"comment\":\"the region\""))
+
+    val output = Column.fromJson(wire)
+    assert(output.comment() === "the region")
+    val md = Metadata.fromJson(output.metadataInJSON())
+    // Comment is exposed via Column.comment(), NOT in metadataInJSON, so the read side
+    // must strip it on the way back out -- matches `structFieldToV2Column`'s convention.
+    assert(!md.contains("comment"))
+    assert(md.getString("metric_view.type") === "dimension")
+  }
+
+  test("Column.toJson / fromJson round-trips empty metadata as null metadataInJSON") {
+    val input = Column.create("c", IntegerType, false, null, null)
+
+    val wire = input.toJson()
+    val output = Column.fromJson(wire)
+
+    assert(output.name() === "c")
+    assert(output.dataType() === IntegerType)
+    assert(!output.nullable())
+    assert(output.comment() === null)
+    // Empty metadata must round-trip as `null` (not `"{}"`), matching
+    // `structFieldToV2Column`'s `metadataAsJson` convention so consumers checking
+    // `metadataInJSON() == null` work correctly.
+    assert(output.metadataInJSON() === null)
+  }
+
+  test("Column.toJson / fromJson round-trips comment-only metadata as null metadataInJSON") {
+    val input = Column.create("c", IntegerType, true, "only comment", null)
+
+    val wire = input.toJson()
+    val output = Column.fromJson(wire)
+
+    assert(output.comment() === "only comment")
+    // After the read side strips "comment", the metadata is empty -- so `metadataInJSON`
+    // is null (not `"{}"`), consistent with the empty-metadata case above.
+    assert(output.metadataInJSON() === null)
+  }
+
+  test("Column.toJson / fromJson round-trips a complex nested type") {
+    val nested = ArrayType(
+      StructType(Seq(
+        StructField("a", IntegerType, nullable = false),
+        StructField("b", StringType, nullable = true))),
+      containsNull = true)
+    val input = Column.create("nested", nested, true, null, null)
+
+    val wire = input.toJson()
+    val output = Column.fromJson(wire)
+
+    assert(output.dataType() === nested)
+    assert(output.nullable())
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -315,6 +315,30 @@ class DataTypeSuite extends SparkFunSuite {
   checkDataTypeFromJson(structType)
   checkDataTypeFromDDL(structType)
 
+  test("StructField json round-trip preserves name, type, nullable, comment, metadata") {
+    val baseMetadata = new MetadataBuilder()
+      .putString("metric_view.type", "dimension")
+      .putString("metric_view.expr", "region")
+      .build()
+    val field = StructField("region", StringType, nullable = true, baseMetadata)
+      .withComment("dim col")
+    val parsed = StructField.fromJson(field.json)
+    assert(parsed.name == "region")
+    assert(parsed.dataType == StringType)
+    assert(parsed.nullable)
+    assert(parsed.getComment().contains("dim col"))
+    // `withComment` adds a "comment" key to metadata; it must round-trip alongside the
+    // metric_view.* keys.
+    assert(parsed.metadata.getString("metric_view.type") == "dimension")
+    assert(parsed.metadata.getString("metric_view.expr") == "region")
+  }
+
+  test("StructField json round-trip with empty metadata and no comment") {
+    val field = StructField("c", IntegerType, nullable = false)
+    val parsed = StructField.fromJson(field.json)
+    assert(parsed == field)
+  }
+
   test("fromJson throws an exception when given type string is invalid") {
     checkError(
       exception = intercept[SparkIllegalArgumentException] {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds two small public methods on the V2 catalog `Column` interface for canonical JSON
round-trip:

```java
public interface Column {
  // ...

  /** @since 4.2.0 */
  default String toJson() { ... }

  /** @since 4.2.0 */
  static Column fromJson(String json) { ... }
}
```

The wire format is the Spark `StructField` JSON shape -- `{"name", "type", "nullable",
"metadata"}` -- byte-compatible with what `StructField.toJson` emits today (and with
the per-column JSON shape Databricks Runtime stores in catalog metadata). The
`Column.comment()` (if present) is folded into the `metadata` object under the
`"comment"` key on the wire and lifted back out into the dedicated `comment()`
accessor on the read side.

**Net public surface change**: 2 new methods on the existing public `Column`
interface. Everything else is internal.

#### Implementation

`Column.toJson()` and `Column.fromJson(String)` in
`sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Column.java` are
thin wrappers that delegate to two new entry points on `CatalogV2Util`:

```scala
def columnToJson(col: Column): String =
  v2ColumnToStructField(col).json

def columnFromJson(json: String): Column =
  structFieldToV2Column(StructField.fromJson(json))
```

The composition with the existing `v2ColumnToStructField` / `structFieldToV2Column`
helpers (already used by `Table.columns()` and friends) means the conversion rules --
comment-vs-metadata, empty-metadata-as-null, and the default-value /
generation-expression / identity-spec metadata-key handling -- stay defined in
exactly one place (`structFieldToV2Column`).

`StructField.json` / `StructField.prettyJson` (instance) and
`StructField.fromJson(String)` (companion) are added as **`private[sql]`** -- internal
helpers used by `CatalogV2Util`, NOT exposed on the public Spark surface. Connectors
should use `Column.toJson` / `Column.fromJson` instead. `DataType.parseStructField` is
widened from `private` to `private[sql]` for the same reason (used internally by
`StructField.fromJson`, no external consumer).

#### MIMA exclusions

3 exclusions on the `StructField` companion object are needed because adding a
`fromJson(String)` static factory causes scalac to drop the auto-generated `tupled` /
`curried` Function22 helpers and the `AbstractFunction4` parent. None of those are
documented public API; the removals are safe.

### Why are the changes needed?

The V2 catalog `Column` interface is part of Spark's public surface for catalog
plugins. Connectors that persist column metadata to external storage one column at
a time (e.g. the Unity Catalog Spark connector, which writes each column's
`StructField`-shape JSON into UC's `ColumnInfo.type_json` field) have no public way
to round-trip a `Column` to JSON today. They reach for one of:

1. **A singleton-`StructType` wrap workaround.** Build a one-field `StructType`, call
   the public `StructType.json`, parse the result, and pluck out `.fields[0]`. Reverse
   on read. Works, but each connector reinvents the same JSON-twiddling and is prone
   to subtle bugs around the comment-in-metadata convention (the comment lives in
   `metadata["comment"]` on the wire but is exposed via `Column.comment()` in memory --
   hand-rolled inverses commonly forget to strip it on the read side, leading to
   duplicated comments).
2. **Reaching for `private[sql]` helpers** like `CatalogV2Util.structFieldToV2Column`
   (file-private inside `CatalogV2Util`) or `DataType.parseStructField` (`private[sql]`).
   Connectors built outside `org.apache.spark.sql.*` can't access these.

Spark already has the symmetric APIs for whole-DataType and whole-`Column[]` round-trip:

- `DataType.json` / `DataType.fromJson` -- entire DataType.
- `TableInfo.schema()` + `CatalogV2Util.v2ColumnsToStructType` -- entire `Column[]`
  -> `StructType`.

The single-`Column` round-trip is the gap. Filling it on `Column` itself (rather than
via `StructField`) keeps the public surface tight (2 methods instead of 3), hides
`StructField` as an implementation detail, and is forward-compatible if `Column` gains
attributes (default value, generation expression, identity spec) -- the
`v2ColumnToStructField` / `structFieldToV2Column` helpers already handle these and
the JSON helpers compose with them.

### Does this PR introduce _any_ user-facing change?

For catalog plugin developers:

- `Column.toJson()` and `Column.fromJson(String)` are new public APIs (`@since 4.2.0`)
  on the `Column` interface. Implementations of `Column` get `toJson()` for free via
  the default method.

For end users: no. The wire format for any pre-existing UC / DBR table whose columns
were stored as `StructField` JSON in `type_json` is byte-identical -- the public
`Column.toJson` produces the same shape that `StructField.toJson` did.

### How was this patch tested?

`CatalogV2UtilSuite` adds 5 round-trip tests covering the full contract:

- Analyzer-attached metadata (e.g. `metric_view.type` / `metric_view.expr`) survives
  the round trip.
- Comment + metadata round-trips without duplication: comment ends up in
  `Column.comment()`, NOT in `metadataInJSON()`.
- Empty metadata round-trips as `null` `metadataInJSON()` (not `"{}"`), matching
  `structFieldToV2Column`'s convention.
- Comment-only metadata round-trips as `null` `metadataInJSON()` after the read-side
  strip.
- Complex nested type (`array<struct<a:int, b:string>>`) round-trips via
  `DataType.fromJson` inside the helper.

The existing `StructField.json` / `StructField.fromJson` round-trip tests in
`DataTypeSuite` continue to exercise the `private[sql]` helpers directly -- still
valuable for catching regressions in the internal serialization that `Column.toJson`
delegates to.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor (Claude Sonnet 4.7)