### PR TITLE
[SPARK-56702][K8S] Restrict `ExecutorPVCResizePlugin` to `direct` pods allocator

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPVCResizePlugin.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPVCResizePlugin.scala
@@ -31,7 +31,7 @@ import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext,
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.LogKeys.{CURRENT_DISK_SIZE, ORIGINAL_DISK_SIZE, PVC_METADATA_NAME}
+import org.apache.spark.internal.LogKeys.{CONFIG, CONFIG2, CURRENT_DISK_SIZE, ORIGINAL_DISK_SIZE, PVC_METADATA_NAME}
 import org.apache.spark.util.ThreadUtils
 
 /**
@@ -74,6 +74,13 @@ class ExecutorPVCResizeDriverPlugin extends DriverPlugin with Logging {
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("pvc-resize-plugin")
 
   override def init(sc: SparkContext, ctx: PluginContext): JMap[String, String] = {
+    val allocator = sc.conf.get(KUBERNETES_ALLOCATION_PODS_ALLOCATOR)
+    if (allocator != "direct") {
+      logWarning(log"ExecutorPVCResizePlugin requires the 'direct' pods allocator; " +
+        log"${MDC(CONFIG, KUBERNETES_ALLOCATION_PODS_ALLOCATOR.key)} is " +
+        log"${MDC(CONFIG2, allocator)}. Plugin will not start.")
+      return Map.empty[String, String].asJava
+    }
     val interval = sc.conf.get(PVC_RESIZE_INTERVAL)
     if (interval <= 0) {
       logInfo("PVCResizePlugin disabled (interval <= 0).")

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPVCResizePluginSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPVCResizePluginSuite.scala
@@ -27,7 +27,8 @@ import org.mockito.Mockito.{mock, never, times, verify, when}
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
-import org.apache.spark.deploy.k8s.Config.PVC_RESIZE_INTERVAL
+import org.apache.spark.api.plugin.PluginContext
+import org.apache.spark.deploy.k8s.Config.{KUBERNETES_ALLOCATION_PODS_ALLOCATOR, PVC_RESIZE_INTERVAL}
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.k8s.Fabric8Aliases._
 
@@ -287,6 +288,20 @@ class ExecutorPVCResizePluginSuite
     Seq("1", "7", "-5").foreach { v =>
       conf.set(PVC_RESIZE_INTERVAL.key, v)
       intercept[IllegalArgumentException](conf.get(PVC_RESIZE_INTERVAL))
+    }
+  }
+
+  Seq("statefulset", "deployment").foreach { allocator =>
+    test(s"init returns early when pods allocator is '$allocator'") {
+      val plugin = new ExecutorPVCResizeDriverPlugin()
+      val sparkConf = new SparkConf().set(KUBERNETES_ALLOCATION_PODS_ALLOCATOR, allocator)
+      val sc = mock(classOf[SparkContext])
+      when(sc.conf).thenReturn(sparkConf)
+      val pluginCtx = mock(classOf[PluginContext])
+
+      val result = plugin.init(sc, pluginCtx)
+
+      assert(result.isEmpty)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR restricts `ExecutorPVCResizePlugin` to the `direct` pods allocator. When `spark.kubernetes.allocation.pods.allocator` is not `direct`, `init()` logs a warning and returns early.

### Why are the changes needed?

`ExecutorPVCResizePlugin` patches individual executor PVCs directly. This only works when Spark owns each pod and its PVCs (`direct` allocator). For `statefulset` and `deployment` allocators, PVCs are governed by the controller's `volumeClaimTemplates`, so direct patches conflict with the controller.

This mirrors SPARK-56670, which restricted the sibling `ExecutorResizePlugin` for the same reason.
- https://github.com/apache/spark/pull/55615

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with new unit tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)