### PR TITLE
[SPARK-56686][FOLLOWUP][SQL] Mark CDC streaming rewrite via attribute metadata

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveChangelogTable.scala
@@ -91,6 +91,17 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
   }
 
   /**
+   * Metadata-key marker placed on the `__spark_cdc_events` aggregate's output attribute
+   * by [[addStreamingRowLevelPostProcessing]]. Downstream rules
+   * (`UnsupportedOperationChecker`'s CDC-specific output-mode check) detect the
+   * streaming row-level rewrite by looking for this marker rather than by string-matching
+   * the helper column's name -- mirroring the existing `EventTimeWatermark.delayKey` and
+   * `SessionWindow.marker` patterns and surviving any optimization that might relabel
+   * or rewrite the alias.
+   */
+  final val streamingPostProcessingMarker = "spark.cdc.streamingPostProcessing"
+
+  /**
    * Reserved (`__spark_cdc_*`) column names used internally by net-change
    * computation; connectors must not emit columns with these names.
    */
@@ -385,23 +396,22 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
     // both inside the struct and as top-level grouping outputs; the top-level duplicates
     // are dropped via `unrequiredChildIndex` below.
     val structOfAllCols = CreateStruct(watermarked.output)
+    // Attach a metadata marker to the `__spark_cdc_events` alias so downstream rules
+    // can detect the streaming row-level rewrite by metadata rather than by helper
+    // column name (mirrors `SessionWindow.marker` / `EventTimeWatermark.delayKey`).
+    val eventsMetadata = new MetadataBuilder()
+      .putBoolean(streamingPostProcessingMarker, true)
+      .build()
     val eventsAlias = Alias(
-      new CollectList(structOfAllCols).toAggregateExpression(), HelperColumn.Events)()
+      new CollectList(structOfAllCols).toAggregateExpression(), HelperColumn.Events)(
+      explicitMetadata = Some(eventsMetadata))
 
     val aggregateExprs: Seq[NamedExpression] =
       groupingNamedExprs ++ Seq(delCntAlias, insCntAlias) ++ rvAliases :+ eventsAlias
     val aggregated = Aggregate(groupingExprs, aggregateExprs, watermarked)
 
     val filtered: LogicalPlan = if (requiresCarryOverRemoval) {
-      val delCnt = getAttribute(aggregated, HelperColumn.DelCnt)
-      val insCnt = getAttribute(aggregated, HelperColumn.InsCnt)
-      val minRv = getAttribute(aggregated, HelperColumn.MinRv)
-      val maxRv = getAttribute(aggregated, HelperColumn.MaxRv)
-      val rvCnt = getAttribute(aggregated, HelperColumn.RvCnt)
-      val isCarryoverPair = And(
-        And(EqualTo(delCnt, Literal(1L)), EqualTo(insCnt, Literal(1L))),
-        And(EqualTo(rvCnt, Literal(2L)), EqualTo(minRv, maxRv)))
-      Filter(Not(isCarryoverPair), aggregated)
+      Filter(Not(buildCarryOverPairPredicate(aggregated)), aggregated)
     } else aggregated
 
     // Inline the struct array back into rows. Drop the events column (consumed by Inline)
@@ -531,23 +541,33 @@ object ResolveChangelogTable extends Rule[LogicalPlan] {
   }
 
   /**
-   * Adds a Filter node that drops rows belonging to a CoW carry-over pair.
-   * A pair is a carry-over iff
-   * `_del_cnt = 1 AND _ins_cnt = 1 AND _rv_cnt = 2 AND _min_rv = _max_rv`.
-   * The `_rv_cnt = 2` clause guards against a NULL rowVersion silently matching
+   * Builds the carry-over pair predicate against the helper attributes exposed by
+   * `input`: a pair is a CoW carry-over iff
+   * `_del_cnt = 1 AND _ins_cnt = 1 AND _rv_cnt = 2 AND _min_rv = _max_rv`. The
+   * `_rv_cnt = 2` clause guards against a NULL rowVersion silently matching
    * `_min_rv = _max_rv` (Spark's min/max skip NULLs).
+   *
+   * Used by both the batch path (`addCarryOverPairFilter` over a Window child) and the
+   * streaming path (in `addStreamingRowLevelPostProcessing` over an Aggregate child).
+   * The helper-attribute layout is the same in both cases.
    */
-  private def addCarryOverPairFilter(input: LogicalPlan): LogicalPlan = {
+  private def buildCarryOverPairPredicate(input: LogicalPlan): Expression = {
     val delCnt = getAttribute(input, HelperColumn.DelCnt)
     val insCnt = getAttribute(input, HelperColumn.InsCnt)
     val minRv = getAttribute(input, HelperColumn.MinRv)
     val maxRv = getAttribute(input, HelperColumn.MaxRv)
     val rvCnt = getAttribute(input, HelperColumn.RvCnt)
-
-    val isCarryoverPair = And(
+    And(
       And(EqualTo(delCnt, Literal(1L)), EqualTo(insCnt, Literal(1L))),
       And(EqualTo(rvCnt, Literal(2L)), EqualTo(minRv, maxRv)))
-    Filter(Not(isCarryoverPair), input)
+  }
+
+  /**
+   * Adds a Filter node that drops rows belonging to a CoW carry-over pair, using the
+   * shared `buildCarryOverPairPredicate`.
+   */
+  private def addCarryOverPairFilter(input: LogicalPlan): LogicalPlan = {
+    Filter(Not(buildCarryOverPairPredicate(input)), input)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -284,9 +284,10 @@ object UnsupportedOperationChecker extends Logging {
     // [[ResolveChangelogTable]] are designed and validated only for Append output mode.
     // Two markers can identify a CDC-rewritten plan:
     //   - The row-level rewrite (`addStreamingRowLevelPostProcessing`) injects a
-    //     streaming Aggregate buffering input rows into the helper column
-    //     `ResolveChangelogTable.HelperColumn.Events` ("__spark_cdc_events") before
-    //     re-emitting them via `Generate(Inline(...))`.
+    //     streaming Aggregate whose `__spark_cdc_events` alias's output attribute
+    //     carries the metadata marker
+    //     `ResolveChangelogTable.streamingPostProcessingMarker` (mirrors
+    //     `SessionWindow.marker` / `EventTimeWatermark.delayKey`).
     //   - The netChanges rewrite (`addStreamingNetChangeComputation`) injects a
     //     `TransformWithState` driven by `CdcNetChangesStatefulProcessor`.
     // Under Update or Complete the Aggregate / TransformWithState would re-emit
@@ -296,9 +297,10 @@ object UnsupportedOperationChecker extends Logging {
     // netChanges-only marker is needed here primarily to catch Update mode.) Reject
     // those modes at analysis time with a clear error rather than silently producing
     // a misleading change feed.
-    val containsCdcEventsAggregate = aggregates.exists(a => a.aggregateExpressions.exists {
+    val containsCdcRowLevelRewrite = aggregates.exists(a => a.aggregateExpressions.exists {
       case ne: NamedExpression if ne.resolved =>
-        ne.name == ResolveChangelogTable.HelperColumn.Events
+        ne.metadata.contains(ResolveChangelogTable.streamingPostProcessingMarker) &&
+          ne.metadata.getBoolean(ResolveChangelogTable.streamingPostProcessingMarker)
       case _ => false
     })
     val containsCdcNetChangesProcessor = plan.exists {
@@ -307,7 +309,7 @@ object UnsupportedOperationChecker extends Logging {
       case _ => false
     }
     if (outputMode != InternalOutputModes.Append &&
-        (containsCdcEventsAggregate || containsCdcNetChangesProcessor)) {
+        (containsCdcRowLevelRewrite || containsCdcNetChangesProcessor)) {
       throw QueryCompilationErrors.unsupportedOutputModeForStreamingOperationError(
         outputMode, "Change Data Capture (CDC) streaming reads with post-processing")
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ChangelogEndToEndSuite.scala
@@ -1173,4 +1173,345 @@ class ChangelogEndToEndSuite extends SharedSparkSession {
       }
     }
   }
+
+  // ---------- Streaming: extended row-level post-processing coverage ----------
+
+  test("streaming carry-over removal with composite rowId removes pairs per (id, name)") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsCarryoverRows = true,
+      rowIdNames = Seq("id", "data"),
+      rowVersionName = Some("row_commit_version")))
+
+    catalog.addChangeRows(id, Seq(
+      // v1: insert two rows that share id=1 but different `data`. The composite rowId
+      // (id, data) means each is its own row identity.
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      ppRow(1L, "Bob", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      // v2: CoW carry-over for (1, "Alice"); real delete for (1, "Bob").
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 2L, 2000000L),
+      ppRow(1L, "Bob", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L)))
+
+    val q = spark.readStream
+      .option("startingVersion", "1")
+      .changes(fullTableName)
+      .select("id", "data", "_change_type", "_commit_version")
+      .writeStream
+      .format("memory")
+      .queryName("cdc_stream_composite_carryover")
+      .outputMode("append")
+      .start()
+    try {
+      q.processAllAvailable()
+      // (1, "Alice") carry-over is dropped; (1, "Bob") delete survives. With broken
+      // single-column rowId partitioning the four v2 rows would collapse into one
+      // partition with del_cnt=2 / ins_cnt=1 and no rows would qualify as carry-over.
+      checkAnswer(
+        spark.sql("SELECT * FROM cdc_stream_composite_carryover"),
+        Seq(
+          Row(1L, "Alice", CHANGE_TYPE_INSERT, 1L),
+          Row(1L, "Bob", CHANGE_TYPE_INSERT, 1L),
+          Row(1L, "Bob", CHANGE_TYPE_DELETE, 2L)))
+    } finally {
+      q.stop()
+    }
+  }
+
+  test("streaming update detection with composite rowId keeps different tuples raw") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      representsUpdateAsDeleteAndInsert = true,
+      rowIdNames = Seq("id", "data"),
+      rowVersionName = Some("row_commit_version")))
+
+    catalog.addChangeRows(id, Seq(
+      // v1: insert pre-existing Alice and Bob (so v2 has rows to fall through).
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      ppRow(1L, "Bob", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      // v2: delete (1, "Alice") and insert (1, "Bob"). These are DIFFERENT composite
+      // rowIds; they MUST NOT be relabeled as update.
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(1L, "Carol", 2L, CHANGE_TYPE_INSERT, 2L, 2000000L)))
+
+    val q = spark.readStream
+      .option("startingVersion", "1")
+      .option("computeUpdates", "true")
+      .option("deduplicationMode", "none")
+      .changes(fullTableName)
+      .select("id", "data", "_change_type")
+      .writeStream
+      .format("memory")
+      .queryName("cdc_stream_composite_updates")
+      .outputMode("append")
+      .start()
+    try {
+      q.processAllAvailable()
+      checkAnswer(
+        spark.sql("SELECT * FROM cdc_stream_composite_updates"),
+        Seq(
+          Row(1L, "Alice", CHANGE_TYPE_INSERT),
+          Row(1L, "Bob", CHANGE_TYPE_INSERT),
+          Row(1L, "Alice", CHANGE_TYPE_DELETE),
+          Row(1L, "Carol", CHANGE_TYPE_INSERT)))
+    } finally {
+      q.stop()
+    }
+  }
+
+  test("streaming carry-over removal and update detection across multiple commits") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsCarryoverRows = true,
+      representsUpdateAsDeleteAndInsert = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    catalog.addChangeRows(id, Seq(
+      // v1: insert 3 rows.
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      ppRow(2L, "Bob", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      ppRow(3L, "Charlie", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      // v2: real delete Alice; CoW carry-overs for Bob/Charlie.
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(2L, "Bob", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(2L, "Bob", 1L, CHANGE_TYPE_INSERT, 2L, 2000000L),
+      ppRow(3L, "Charlie", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(3L, "Charlie", 1L, CHANGE_TYPE_INSERT, 2L, 2000000L),
+      // v3: real update Bob -> Robert (rcv bumps); CoW for Charlie.
+      ppRow(2L, "Bob", 1L, CHANGE_TYPE_DELETE, 3L, 3000000L),
+      ppRow(2L, "Robert", 3L, CHANGE_TYPE_INSERT, 3L, 3000000L),
+      ppRow(3L, "Charlie", 1L, CHANGE_TYPE_DELETE, 3L, 3000000L),
+      ppRow(3L, "Charlie", 1L, CHANGE_TYPE_INSERT, 3L, 3000000L),
+      // v4: insert Diana.
+      ppRow(4L, "Diana", 4L, CHANGE_TYPE_INSERT, 4L, 4000000L)))
+
+    val q = spark.readStream
+      .option("startingVersion", "1")
+      .option("computeUpdates", "true")
+      .changes(fullTableName)
+      .select("id", "data", "_change_type", "_commit_version")
+      .writeStream
+      .format("memory")
+      .queryName("cdc_stream_multi_commit")
+      .outputMode("append")
+      .start()
+    try {
+      q.processAllAvailable()
+      val result = spark.sql(
+        "SELECT * FROM cdc_stream_multi_commit ORDER BY _commit_version, id, _change_type")
+      checkAnswer(
+        result,
+        Seq(
+          Row(1L, "Alice", CHANGE_TYPE_INSERT, 1L),
+          Row(2L, "Bob", CHANGE_TYPE_INSERT, 1L),
+          Row(3L, "Charlie", CHANGE_TYPE_INSERT, 1L),
+          // v2: only Alice's real delete survives (Bob and Charlie carry-over dropped).
+          Row(1L, "Alice", CHANGE_TYPE_DELETE, 2L),
+          // v3: Bob -> Robert relabeled as update_pre/postimage; Charlie carry-over
+          // dropped. The ORDER BY breaks ties on `_change_type` ascending where
+          // `update_postimage` < `update_preimage` alphabetically.
+          Row(2L, "Robert", CHANGE_TYPE_UPDATE_POSTIMAGE, 3L),
+          Row(2L, "Bob", CHANGE_TYPE_UPDATE_PREIMAGE, 3L),
+          // v4
+          Row(4L, "Diana", CHANGE_TYPE_INSERT, 4L)))
+    } finally {
+      q.stop()
+    }
+  }
+
+  test("streaming DELETE-all-rows: only deletes survive at the deleting commit") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsCarryoverRows = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    catalog.addChangeRows(id, Seq(
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      ppRow(2L, "Bob", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(2L, "Bob", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L)))
+
+    val q = spark.readStream
+      .option("startingVersion", "1")
+      .changes(fullTableName)
+      .select("id", "data", "_change_type", "_commit_version")
+      .writeStream
+      .format("memory")
+      .queryName("cdc_stream_delete_all")
+      .outputMode("append")
+      .start()
+    try {
+      q.processAllAvailable()
+      checkAnswer(
+        spark.sql("SELECT * FROM cdc_stream_delete_all"),
+        Seq(
+          Row(1L, "Alice", CHANGE_TYPE_INSERT, 1L),
+          Row(2L, "Bob", CHANGE_TYPE_INSERT, 1L),
+          Row(1L, "Alice", CHANGE_TYPE_DELETE, 2L),
+          Row(2L, "Bob", CHANGE_TYPE_DELETE, 2L)))
+    } finally {
+      q.stop()
+    }
+  }
+
+  test("streaming UPDATE-all-rows: every row gets update_pre/postimage") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsCarryoverRows = true,
+      representsUpdateAsDeleteAndInsert = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    catalog.addChangeRows(id, Seq(
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      ppRow(2L, "Bob", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      // v2: every row is a real update (different rcv on pre vs post).
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(1L, "AliceUpdated", 2L, CHANGE_TYPE_INSERT, 2L, 2000000L),
+      ppRow(2L, "Bob", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(2L, "BobUpdated", 2L, CHANGE_TYPE_INSERT, 2L, 2000000L)))
+
+    val q = spark.readStream
+      .option("startingVersion", "1")
+      .option("computeUpdates", "true")
+      .changes(fullTableName)
+      .select("id", "data", "_change_type", "_commit_version")
+      .writeStream
+      .format("memory")
+      .queryName("cdc_stream_update_all")
+      .outputMode("append")
+      .start()
+    try {
+      q.processAllAvailable()
+      checkAnswer(
+        spark.sql("SELECT * FROM cdc_stream_update_all"),
+        Seq(
+          Row(1L, "Alice", CHANGE_TYPE_INSERT, 1L),
+          Row(2L, "Bob", CHANGE_TYPE_INSERT, 1L),
+          Row(1L, "Alice", CHANGE_TYPE_UPDATE_PREIMAGE, 2L),
+          Row(1L, "AliceUpdated", CHANGE_TYPE_UPDATE_POSTIMAGE, 2L),
+          Row(2L, "Bob", CHANGE_TYPE_UPDATE_PREIMAGE, 2L),
+          Row(2L, "BobUpdated", CHANGE_TYPE_UPDATE_POSTIMAGE, 2L)))
+    } finally {
+      q.stop()
+    }
+  }
+
+  test("streaming append-only workload: all inserts pass through") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      // Append-only connectors typically declare no special CDC capabilities.
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    catalog.addChangeRows(id, Seq(
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      ppRow(2L, "Bob", 2L, CHANGE_TYPE_INSERT, 2L, 2000000L),
+      ppRow(3L, "Charlie", 3L, CHANGE_TYPE_INSERT, 3L, 3000000L)))
+
+    val q = spark.readStream
+      .option("startingVersion", "1")
+      .changes(fullTableName)
+      .select("id", "data", "_change_type", "_commit_version")
+      .writeStream
+      .format("memory")
+      .queryName("cdc_stream_append_only")
+      .outputMode("append")
+      .start()
+    try {
+      q.processAllAvailable()
+      checkAnswer(
+        spark.sql("SELECT * FROM cdc_stream_append_only"),
+        Seq(
+          Row(1L, "Alice", CHANGE_TYPE_INSERT, 1L),
+          Row(2L, "Bob", CHANGE_TYPE_INSERT, 2L),
+          Row(3L, "Charlie", CHANGE_TYPE_INSERT, 3L)))
+    } finally {
+      q.stop()
+    }
+  }
+
+  test("streaming no-op UPDATE is labeled as update (rcv differs on pre/post)") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsCarryoverRows = true,
+      representsUpdateAsDeleteAndInsert = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    catalog.addChangeRows(id, Seq(
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_INSERT, 1L, 1000000L),
+      // v2 no-op update: identical data, but rcv differs (Delta bumps it on every UPDATE).
+      // Carry-over filter requires _min_rv = _max_rv, which is false here, so this is
+      // correctly treated as a real update -- not a carry-over.
+      ppRow(1L, "Alice", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+      ppRow(1L, "Alice", 2L, CHANGE_TYPE_INSERT, 2L, 2000000L)))
+
+    val q = spark.readStream
+      .option("startingVersion", "1")
+      .option("computeUpdates", "true")
+      .changes(fullTableName)
+      .select("id", "data", "_change_type", "_commit_version")
+      .writeStream
+      .format("memory")
+      .queryName("cdc_stream_noop_update")
+      .outputMode("append")
+      .start()
+    try {
+      q.processAllAvailable()
+      checkAnswer(
+        spark.sql("SELECT * FROM cdc_stream_noop_update"),
+        Seq(
+          Row(1L, "Alice", CHANGE_TYPE_INSERT, 1L),
+          Row(1L, "Alice", CHANGE_TYPE_UPDATE_PREIMAGE, 2L),
+          Row(1L, "Alice", CHANGE_TYPE_UPDATE_POSTIMAGE, 2L)))
+    } finally {
+      q.stop()
+    }
+  }
+
+  test("streaming carry-over removal at scale: many CoW pairs, one real change") {
+    val id = recreateWithRowVersion()
+    catalog.setChangelogProperties(id, ChangelogProperties(
+      containsCarryoverRows = true,
+      rowIdNames = Seq("id"),
+      rowVersionName = Some("row_commit_version")))
+
+    val v1Inserts = (1 to 10).map { i =>
+      ppRow(i.toLong, ('A' + i - 1).toChar.toString, 1L,
+        CHANGE_TYPE_INSERT, 1L, 1000000L)
+    }
+    // At v2: row 5 is really deleted; the other 9 rows are CoW carry-over pairs
+    // (rcv unchanged on both sides means content unchanged).
+    val v2CarryOvers = (1 to 10).filter(_ != 5).flatMap { i =>
+      val name = ('A' + i - 1).toChar.toString
+      Seq(
+        ppRow(i.toLong, name, 1L, CHANGE_TYPE_DELETE, 2L, 2000000L),
+        ppRow(i.toLong, name, 1L, CHANGE_TYPE_INSERT, 2L, 2000000L))
+    }
+    val v2RealDelete = Seq(ppRow(5L, "E", 1L, CHANGE_TYPE_DELETE, 2L, 2000000L))
+    catalog.addChangeRows(id, v1Inserts ++ v2CarryOvers ++ v2RealDelete)
+
+    val q = spark.readStream
+      .option("startingVersion", "2")
+      .option("endingVersion", "2")
+      .changes(fullTableName)
+      .select("id", "data", "_change_type")
+      .writeStream
+      .format("memory")
+      .queryName("cdc_stream_many_carryovers")
+      .outputMode("append")
+      .start()
+    try {
+      q.processAllAvailable()
+      // 9 carry-over pairs dropped; only the real delete of row 5 survives.
+      checkAnswer(
+        spark.sql("SELECT * FROM cdc_stream_many_carryovers"),
+        Seq(Row(5L, "E", CHANGE_TYPE_DELETE)))
+    } finally {
+      q.stop()
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to #55636 addressing post-merge review comments from @zikangh:

1. **Deduplicate `isCarryoverPair`.** The carry-over predicate (`_del_cnt = 1 AND _ins_cnt = 1 AND _rv_cnt = 2 AND _min_rv = _max_rv`) was duplicated between the batch path's `addCarryOverPairFilter` and the streaming path's inline filter. Extracted a shared `buildCarryOverPairPredicate` helper and call it from both.

2. **Mark the streaming row-level rewrite via attribute metadata rather than helper column name.** `UnsupportedOperationChecker` previously detected the rewrite by string-matching the `__spark_cdc_events` aggregate alias name. Switched to a metadata marker (`ResolveChangelogTable.streamingPostProcessingMarker`) attached to the alias's output attribute -- mirroring the existing `EventTimeWatermark.delayKey` and `SessionWindow.marker` patterns. The marker travels with the attribute through optimization.

3. **Expand streaming E2E coverage.** New tests in `ChangelogEndToEndSuite`:
   - composite rowId carry-over removal,
   - composite rowId update detection (different tuples kept raw),
   - carry-over + update detection across multiple commits,
   - DELETE-all-rows and UPDATE-all-rows fixtures,
   - append-only workload pass-through,
   - no-op UPDATE labeled as update (rcv differs on pre/post),
   - large carry-over removal (9 carry-over pairs + 1 real delete).

### Why are the changes needed?

@zikangh raised these on the merged PR. Bundled together so they can be reviewed and shipped as one follow-up.

### Does this PR introduce _any_ user-facing change?

No. Internal refactor (#1, #2) and additional test coverage (#3). The behavior of streaming CDC reads is unchanged.

### How was this patch tested?

All 157 tests pass across the four CDC suites:
- `ChangelogResolutionSuite`
- `ResolveChangelogTablePostProcessingSuite`
- `ResolveChangelogTableStreamingPostProcessingSuite`
- `ChangelogEndToEndSuite`

Also confirmed:
- `UnsupportedOperationsSuite` (216 tests) still passes after the marker-based detection switch.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)