### PR TITLE
[SPARK-55872][UI] Highlight long-running SQL queries by duration

### DIFF
--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/allexecutionspage.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/allexecutionspage.js
@@ -195,7 +195,13 @@ $(document).ready(function () {
           data: "duration", name: "duration", title: "Duration",
           render: function (data, type) {
             if (type !== "display") return data;
-            return formatDurationSql(data);
+            var formatted = formatDurationSql(data);
+            if (data > 600000) {
+              return '<span class="text-danger">' + formatted + '</span>';
+            } else if (data > 60000) {
+              return '<span class="text-warning">' + formatted + '</span>';
+            }
+            return formatted;
           }
         },
         {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR modifies the SQL Executions listing table in the Spark Web UI to visually highlight long-running SQL queries ([SPARK-55872](https://issues.apache.org/jira/browse/SPARK-55872)). The duration column is now color-coded:
- Amber text (`text-warning`) for queries exceeding 1 minute (60,000 ms).
- Red text (`text-danger`) for queries exceeding 10 minutes (600,000 ms).

The change applies to Running, Completed  and Failed queries.
This is achieved purely via client-side JavaScript (allexecutionspage.js), applying the existing Bootstrap 5 utility classes already available in the Spark UI.

### Why are the changes needed?
To help users quickly identify performance bottlenecks at a glance. When analyzing jobs in production, scanning large execution tables can be cumbersome. Color-coding makes slow SQL queries immediately obvious without having to sort or parse durations manually, improving the observability and usability of the Spark Web UI.


### Does this PR introduce _any_ user-facing change?
Yes. 
The SQL listing page in the Spark Web UI will now display long durations with emphasized colors:
- **Before:** `1.2 min`, `15 min` (standard text color).
- **After:** `1.2 min` (amber text), `15 min` (red text).



### How was this patch tested?
Ran a local Spark application with simulated fast and slow queries to visually confirm that the `text-warning` and `text-danger` classes are applied perfectly based on the duration.


### Was this patch authored or co-authored using generative AI tooling?
Yes

### Screenshots

| Before |
|--------|
| <img width="1512" height="607" alt="Screenshot 2026-05-02 at 11 36 32 PM" src="https://github.com/user-attachments/assets/d6421252-700e-4adc-8b24-517a88f8b286" /> |

| After |
|--------|
| <img width="1511" height="567" alt="Screenshot 2026-05-02 at 11 35 54 PM" src="https://github.com/user-attachments/assets/2448a8ff-f6a6-4457-863c-ce3b1a90e52f" /> |
| <img width="1512" height="472" alt="sceenshot running queries" src="https://github.com/user-attachments/assets/453088b2-4e11-477f-babd-cfc28181ac41" /> |




