### PR TITLE
[SPARK-56705][PYSPARK][SS] Introduce a JVM-bridged MemoryStream wrapper for PySpark tests (Part 1 of 4)

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -703,6 +703,7 @@ pyspark_structured_streaming = Module(
         "pyspark.sql.tests.streaming.test_streaming_kafka_rtm",
         "pyspark.sql.tests.streaming.test_streaming_listener",
         "pyspark.sql.tests.streaming.test_streaming_offline_state_repartition",
+        "pyspark.sql.tests.streaming.test_stream_test_framework",
         "pyspark.sql.tests.pandas.test_pandas_grouped_map_with_state",
         "pyspark.sql.tests.pandas.streaming.test_pandas_transform_with_state",
         "pyspark.sql.tests.pandas.streaming.test_pandas_transform_with_state_checkpoint_v2",

--- a/python/pyspark/sql/tests/streaming/test_stream_test_framework.py
+++ b/python/pyspark/sql/tests/streaming/test_stream_test_framework.py
@@ -1,0 +1,184 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for the ``MemoryStream`` Python wrapper.
+
+These tests exercise ``MemoryStream`` directly against the JVM bridge,
+without depending on the (forthcoming) ``StreamTest`` driver. They verify
+that data added from Python flows through the JVM memory source and lands
+in a ``writeStream.format("memory")`` sink.
+"""
+
+import os
+import shutil
+import tempfile
+import time
+from collections import namedtuple
+
+from pyspark.sql import Row
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+from pyspark.testing.sqlutils import ReusedSQLTestCase
+from pyspark.testing.streaming import MemoryStream
+
+
+class MemoryStreamTests(ReusedSQLTestCase):
+    """Self-tests for the ``MemoryStream`` Python wrapper."""
+
+    def setUp(self):
+        super().setUp()
+        self._checkpoint = tempfile.mkdtemp(prefix="memory_stream_test_")
+        self._query_name = f"memory_stream_test_{os.getpid()}_{time.monotonic_ns()}"
+
+    def tearDown(self):
+        try:
+            for q in self.spark.streams.active:
+                if q.name == self._query_name:
+                    q.stop()
+        finally:
+            shutil.rmtree(self._checkpoint, ignore_errors=True)
+            try:
+                self.spark.sql(f"DROP TABLE IF EXISTS {self._query_name}")
+            except Exception:
+                pass
+        super().tearDown()
+
+    def _start_passthrough(self, df):
+        return (
+            df.writeStream.format("memory")
+            .queryName(self._query_name)
+            .option("checkpointLocation", self._checkpoint)
+            .trigger(processingTime="0 seconds")
+            .outputMode("append")
+            .start()
+        )
+
+    def test_simple_int_schema_round_trip(self):
+        source = MemoryStream(self.spark, "int")
+        self.assertEqual(source.schema.simpleString(), "struct<value:int>")
+        offset = source.add_data(1, 2, 3)
+        self.assertEqual(offset, 0)
+
+        query = self._start_passthrough(source.to_df())
+        try:
+            query.processAllAvailable()
+            rows = self.spark.sql(f"SELECT value FROM {self._query_name}").collect()
+            self.assertEqual(sorted(r.value for r in rows), [1, 2, 3])
+        finally:
+            query.stop()
+            query.awaitTermination(60)
+
+    def test_subsequent_add_data_advances_offset(self):
+        source = MemoryStream(self.spark, "int")
+        self.assertEqual(source.add_data(1), 0)
+        self.assertEqual(source.add_data(2, 3), 1)
+        self.assertEqual(source.add_data(4, 5, 6), 2)
+        self.assertEqual(source.current_offset, 2)
+
+    def test_empty_add_data_is_noop(self):
+        source = MemoryStream(self.spark, "int")
+        self.assertEqual(source.add_data(), -1)
+        # First real call still gets offset 0.
+        self.assertEqual(source.add_data(1), 0)
+
+    def test_struct_schema(self):
+        schema = StructType(
+            [
+                StructField("name", StringType(), True),
+                StructField("age", IntegerType(), True),
+            ]
+        )
+        source = MemoryStream(self.spark, schema)
+        source.add_data(Row(name="Alice", age=30), Row(name="Bob", age=25))
+
+        query = self._start_passthrough(source.to_df())
+        try:
+            query.processAllAvailable()
+            rows = self.spark.sql(
+                f"SELECT name, age FROM {self._query_name} ORDER BY name"
+            ).collect()
+            self.assertEqual([(r.name, r.age) for r in rows], [("Alice", 30), ("Bob", 25)])
+        finally:
+            query.stop()
+            query.awaitTermination(60)
+
+    def test_struct_schema_accepts_tuples_and_dicts(self):
+        schema = StructType(
+            [
+                StructField("name", StringType(), True),
+                StructField("age", IntegerType(), True),
+            ]
+        )
+        source = MemoryStream(self.spark, schema)
+        # Tuples positional, dicts by name.
+        source.add_data(("Alice", 30), {"name": "Bob", "age": 25})
+        query = self._start_passthrough(source.to_df())
+        try:
+            query.processAllAvailable()
+            rows = self.spark.sql(
+                f"SELECT name, age FROM {self._query_name} ORDER BY name"
+            ).collect()
+            self.assertEqual([(r.name, r.age) for r in rows], [("Alice", 30), ("Bob", 25)])
+        finally:
+            query.stop()
+            query.awaitTermination(60)
+
+    def test_unsupported_simple_type_rejected(self):
+        with self.assertRaises(ValueError):
+            MemoryStream(self.spark, "uuid")
+
+    def test_unsupported_schema_arg_type_rejected(self):
+        with self.assertRaises(TypeError):
+            MemoryStream(self.spark, schema=123)  # type: ignore[arg-type]
+
+    def test_to_df_is_streaming(self):
+        source = MemoryStream(self.spark, "int")
+        df = source.to_df()
+        self.assertTrue(df.isStreaming)
+        self.assertEqual(df.schema.simpleString(), "struct<value:int>")
+
+    def test_namedtuple_resolved_by_field_name_not_position(self):
+        """Regression: namedtuples must be matched against the schema by
+        field name, not positionally. A namedtuple whose fields are in a
+        different order than the schema would otherwise silently produce
+        mis-mapped Rows."""
+        # PT's field order is the *opposite* of the schema's. Positional
+        # mapping would put the int "30" into ``name`` and the string
+        # "Alice" into ``age``, producing a type-coercion failure or
+        # garbled output. Resolving by name yields the correct Row.
+        PT = namedtuple("PT", ["age", "name"])
+        schema = StructType(
+            [
+                StructField("name", StringType(), True),
+                StructField("age", IntegerType(), True),
+            ]
+        )
+        source = MemoryStream(self.spark, schema)
+        source.add_data(PT(age=30, name="Alice"))
+
+        query = self._start_passthrough(source.to_df())
+        try:
+            query.processAllAvailable()
+            rows = self.spark.sql(f"SELECT name, age FROM {self._query_name}").collect()
+            self.assertEqual([(r.name, r.age) for r in rows], [("Alice", 30)])
+        finally:
+            query.stop()
+            query.awaitTermination(60)
+
+
+if __name__ == "__main__":
+    from pyspark.testing import main
+
+    main()

--- a/python/pyspark/testing/streaming/__init__.py
+++ b/python/pyspark/testing/streaming/__init__.py
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Testing helpers for PySpark Structured Streaming.
+
+This package will host the Python port of Scala's ``StreamTest`` framework
+(see ``sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala``).
+The first step is a controllable in-memory streaming source: ``MemoryStream``.
+Subsequent commits add ``StreamTest``, lifecycle/assertion actions, and
+verification actions.
+"""
+
+from pyspark.testing.streaming.memory_stream import MemoryStream
+
+__all__ = ["MemoryStream"]

--- a/python/pyspark/testing/streaming/_conversions.py
+++ b/python/pyspark/testing/streaming/_conversions.py
@@ -1,0 +1,184 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Internal helpers for the PySpark StreamTest framework.
+
+These helpers are not part of the public API and may change without notice.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Union
+
+from pyspark.sql import Row
+from pyspark.sql.types import (
+    BooleanType,
+    DoubleType,
+    FloatType,
+    IntegerType,
+    LongType,
+    StringType,
+    StructField,
+    StructType,
+)
+
+
+# Simple-name shortcuts accepted by ``MemoryStream(spark, "<name>")``. Mirrors
+# the small set of primitive Encoders covered by Scala's
+# ``MemoryStream[Int]`` / ``MemoryStream[String]`` / etc.
+_SIMPLE_TYPES: Dict[str, Any] = {
+    "int": IntegerType(),
+    "integer": IntegerType(),
+    "long": LongType(),
+    "bigint": LongType(),
+    "string": StringType(),
+    "str": StringType(),
+    "double": DoubleType(),
+    "float": FloatType(),
+    "boolean": BooleanType(),
+    "bool": BooleanType(),
+}
+
+
+def resolve_schema(schema: Union[str, StructType]) -> StructType:
+    """Resolve a schema spec into a ``StructType``.
+
+    Accepts either a ``StructType`` or a simple primitive type name (e.g.
+    ``"int"``). Primitive names produce a single-column schema with a column
+    named ``value``, mirroring Scala's ``MemoryStream[Int]`` (single output
+    column ``value``).
+
+    Raises
+    ------
+    ValueError
+        If the string is not a recognized primitive name.
+    """
+    if isinstance(schema, StructType):
+        return schema
+    if not isinstance(schema, str):
+        raise TypeError(
+            f"schema must be a StructType or a primitive type name string, "
+            f"got {type(schema).__name__}"
+        )
+    name = schema.strip().lower()
+    if name not in _SIMPLE_TYPES:
+        raise ValueError(
+            f"Unsupported primitive type {schema!r}. "
+            f"Supported names: {sorted(_SIMPLE_TYPES)}. "
+            f"Pass a StructType for richer schemas."
+        )
+    return StructType([StructField("value", _SIMPLE_TYPES[name], True)])
+
+
+def _object_to_dict(obj: Any, field_names: List[str]) -> Optional[Dict[str, Any]]:
+    """Try to extract values for ``field_names`` from an arbitrary object.
+
+    Tried in order:
+
+    1. ``_asdict()`` -- namedtuples and ``typing.NamedTuple``
+    2. ``__dict__`` -- plain classes and dataclasses
+    3. ``getattr()`` -- slot-based or property-backed attributes
+
+    Returns ``None`` if no strategy yields all required field names. The
+    caller is expected to raise a descriptive ``TypeError`` in that case.
+    """
+    asdict = getattr(obj, "_asdict", None)
+    if callable(asdict):
+        d = asdict()
+        if all(name in d for name in field_names):
+            return {name: d[name] for name in field_names}
+
+    obj_dict = getattr(obj, "__dict__", None)
+    if isinstance(obj_dict, dict) and all(name in obj_dict for name in field_names):
+        return {name: obj_dict[name] for name in field_names}
+
+    try:
+        return {name: getattr(obj, name) for name in field_names}
+    except AttributeError:
+        return None
+
+
+def to_rows(items: List[Any], schema: StructType) -> List[Row]:
+    """Convert a list of input values to ``Row`` objects matching ``schema``.
+
+    This is the Python analogue of Scala's
+    ``createToExternalRowConverter[A]()`` used inside ``CheckAnswer`` /
+    ``AddData``. Accepted item types:
+
+    * ``Row`` -- kept as-is (no schema validation; the caller is expected to
+      build the Row with field names that match the schema).
+    * ``dict`` -- keys must include all schema field names.
+    * ``tuple`` / ``list`` -- values are positionally assigned to fields.
+    * Scalar (int, str, float, bool, ...) -- only valid for single-column
+      schemas; wrapped as ``Row(<field>=value)``.
+    * Arbitrary objects -- namedtuples, dataclasses, plain classes whose
+      ``_asdict()`` / ``__dict__`` / attributes expose all field names.
+
+    Raises
+    ------
+    TypeError
+        If an item cannot be converted (e.g. a scalar with a multi-column
+        schema, or an object missing required fields).
+    """
+    field_names = [f.name for f in schema.fields]
+    single_col = len(field_names) == 1
+    out: List[Row] = []
+    for item in items:
+        if isinstance(item, Row):
+            out.append(item)
+            continue
+        if isinstance(item, dict):
+            missing = [n for n in field_names if n not in item]
+            if missing:
+                raise TypeError(
+                    f"dict {item!r} is missing required fields {missing} "
+                    f"for schema {schema.simpleString()}"
+                )
+            out.append(Row(**{n: item[n] for n in field_names}))
+            continue
+        # Namedtuples are tuples but carry field names; resolve them
+        # by name so a namedtuple whose fields are in a different order
+        # than the schema doesn't silently produce mis-mapped Rows.
+        if isinstance(item, tuple) and hasattr(item, "_fields"):
+            row_dict = _object_to_dict(item, field_names)
+            if row_dict is None:
+                raise TypeError(
+                    f"namedtuple {item!r} fields {item._fields} do not "
+                    f"cover schema fields {field_names}"
+                )
+            out.append(Row(**row_dict))
+            continue
+        if isinstance(item, (tuple, list)):
+            if len(item) != len(field_names):
+                raise TypeError(
+                    f"sequence {item!r} has length {len(item)}, expected "
+                    f"{len(field_names)} for schema {schema.simpleString()}"
+                )
+            out.append(Row(**dict(zip(field_names, item))))
+            continue
+        if single_col:
+            out.append(Row(**{field_names[0]: item}))
+            continue
+
+        row_dict = _object_to_dict(item, field_names)
+        if row_dict is None:
+            raise TypeError(
+                f"Cannot convert {type(item).__name__} {item!r} to Row for "
+                f"schema {schema.simpleString()}. Pass a Row, dict, tuple, "
+                f"or an object whose attributes match {field_names}."
+            )
+        out.append(Row(**row_dict))
+    return out

--- a/python/pyspark/testing/streaming/memory_stream.py
+++ b/python/pyspark/testing/streaming/memory_stream.py
@@ -1,0 +1,123 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""A controllable in-memory streaming source for PySpark tests.
+
+``MemoryStream`` wraps the JVM ``MemoryStream[Row]`` so Python tests can
+add rows to a streaming source and obtain the corresponding streaming
+DataFrame for use in ``StreamTest`` flows.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Union
+
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import StructType
+from pyspark.testing.streaming._conversions import resolve_schema, to_rows
+
+
+class MemoryStream:
+    """A controllable streaming source backed by the JVM ``MemoryStream``.
+
+    Parameters
+    ----------
+    spark : SparkSession
+        The active SparkSession. Spark Connect sessions are not supported;
+        the Scala bridge requires JVM access.
+    schema : str or StructType, default ``"int"``
+        Either a primitive name (``"int"``, ``"long"``, ``"string"``,
+        ``"double"``, ``"float"``, ``"boolean"``) or a full ``StructType``.
+        Primitive names produce a single-column schema with a column named
+        ``value``, mirroring Scala's ``MemoryStream[Int]``.
+
+    Examples
+    --------
+    >>> source = MemoryStream(spark, "int")  # doctest: +SKIP
+    >>> source.add_data(1, 2, 3)             # doctest: +SKIP
+    0
+    >>> df = source.to_df()                  # doctest: +SKIP
+    """
+
+    def __init__(
+        self,
+        spark: SparkSession,
+        schema: Union[str, StructType] = "int",
+    ) -> None:
+        self._spark = spark
+        self._schema = resolve_schema(schema)
+        jvm = self._jvm()
+        jspark = spark._jsparkSession  # type: ignore[attr-defined]
+        jschema = jspark.parseDataType(self._schema.json())
+        py_utils = jvm.org.apache.spark.sql.api.python.PythonSQLUtils
+        self._jstream = py_utils.createMemoryStream(jspark, jschema)
+        self._current_offset = -1
+
+    def _jvm(self) -> Any:
+        jvm = getattr(self._spark, "_jvm", None)
+        if jvm is None:
+            raise RuntimeError(
+                "MemoryStream requires a JVM-backed SparkSession; "
+                "Spark Connect sessions are not supported."
+            )
+        return jvm
+
+    @property
+    def schema(self) -> StructType:
+        """The output schema of the stream."""
+        return self._schema
+
+    @property
+    def current_offset(self) -> int:
+        """The most recent offset returned by ``add_data``, or ``-1``."""
+        return self._current_offset
+
+    def add_data(self, *rows: Any) -> int:
+        """Append rows to the underlying JVM memory stream.
+
+        Each call corresponds to a single addition and produces a single
+        new offset on the JVM side. Calling with no arguments is a no-op
+        and returns the current offset.
+
+        Parameters
+        ----------
+        *rows
+            Values to add. For a single-column schema, scalars are accepted.
+            For multi-column schemas, pass ``Row`` objects, dicts, tuples,
+            or objects whose attributes match the schema field names.
+
+        Returns
+        -------
+        int
+            The new current offset after the addition.
+        """
+        if not rows:
+            return self._current_offset
+        converted = to_rows(list(rows), self._schema)
+        df = self._spark.createDataFrame(converted, schema=self._schema)
+        py_utils = self._jvm().org.apache.spark.sql.api.python.PythonSQLUtils
+        offset = py_utils.memoryStreamAddData(self._jstream, df._jdf)
+        self._current_offset = int(offset)
+        return self._current_offset
+
+    def to_df(self) -> DataFrame:
+        """Return a streaming ``DataFrame`` reading from this memory stream."""
+        py_utils = self._jvm().org.apache.spark.sql.api.python.PythonSQLUtils
+        jdf = py_utils.memoryStreamToDF(self._jstream)
+        return DataFrame(jdf, self._spark)
+
+    def __repr__(self) -> str:
+        return f"MemoryStream(schema={self._schema.simpleString()})"

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -228,6 +228,50 @@ private[sql] object PythonSQLUtils extends Logging {
     reader.asInstanceOf[ClassicDataFrameReader].xml(toStringDataset(df))
   }
 
+  /**
+   * Create a [[org.apache.spark.sql.execution.streaming.runtime.MemoryStream]] of `Row`
+   * values for use by the PySpark `StreamTest` framework. The returned object is opaque
+   * to Python; callers pass it back to [[memoryStreamAddData]] and [[memoryStreamToDF]].
+   *
+   * Test-only: not part of the public Spark API.
+   */
+  def createMemoryStream(sparkSession: SparkSession, schema: StructType): AnyRef = {
+    import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
+    implicit val enc: ExpressionEncoder[Row] = ExpressionEncoder(schema)
+    MemoryStream[Row](sparkSession)
+  }
+
+  /**
+   * Append the rows of `dataDF` to a memory stream that was previously returned from
+   * [[createMemoryStream]]. Returns the offset (as a `Long`) after the addition.
+   *
+   * Test-only: not part of the public Spark API.
+   */
+  def memoryStreamAddData(memoryStream: AnyRef, dataDF: DataFrame): Long = {
+    // Narrowed to MemoryStream[Row] (the concrete type returned by
+    // createMemoryStream) so the LongOffset assumption below is well-founded.
+    // Subclasses with non-Long offsets are intentionally not supported here.
+    import org.apache.spark.sql.execution.streaming.runtime.{LongOffset, MemoryStream}
+    val stream = memoryStream.asInstanceOf[MemoryStream[Row]]
+    val rows = dataDF.collect().toSeq
+    stream.addData(rows) match {
+      case LongOffset(v) => v
+      case other => throw new IllegalStateException(
+        s"Unexpected offset type from MemoryStream: ${other.getClass.getName}")
+    }
+  }
+
+  /**
+   * Returns a streaming [[DataFrame]] backed by the memory stream returned from
+   * [[createMemoryStream]].
+   *
+   * Test-only: not part of the public Spark API.
+   */
+  def memoryStreamToDF(memoryStream: AnyRef): DataFrame = {
+    import org.apache.spark.sql.execution.streaming.runtime.MemoryStreamBase
+    memoryStream.asInstanceOf[MemoryStreamBase[Row]].toDF()
+  }
+
   def cleanupPythonWorkerLogs(sessionUUID: String, sparkContext: SparkContext): Unit = {
     if (!sparkContext.isStopped) {
       try {


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR is the first step of porting Scala's StreamTest framework to PySpark. It adds the JVM bridge and Python wrapper that subsequent PRs build on:

- Three test-only helper methods in `PythonSQLUtils.scala`: `createMemoryStream`, `memoryStreamAddData`, `memoryStreamToDF`
- A new `pyspark.testing.streaming` package containing:
  - `MemoryStream` -- Pythonic wrapper around the JVM `MemoryStream[Row]`
  - `_conversions` -- internal helpers for normalizing Python inputs to `Row` objects (Row, dict, tuple, scalar, dataclass, namedtuple, plain objects). Used both by `MemoryStream.add_data` and (in a follow-up) by `CheckAnswer` family of actions.
- A focused test suite (`test_stream_test_framework.py`) that exercises `MemoryStream` against a vanilla `writeStream.format("memory")` query
- Module registration in `dev/sparktestsupport/modules.py`

The Python wrapper requires a JVM-backed SparkSession; Spark Connect is not supported (and explicitly raises). Scala's StreamTest is also JVM-only, so this is consistent.


Next set of PRs are the following:

PR 2:  Add StreamTest base class and lifecycle actions for PySpark 
* Adds StreamTest (extends unittest.TestCase) with the _Runner._execute_action loop, plus 8 lifecycle/assertion actions (StartStream, StopStream, AddData, ProcessAllAvailable, ExpectFailure, Assert, AssertOnQuery, Execute). Includes per-test isolation (unique query name, temp checkpoint dir, sink-table cleanup), state-dump on failure, exception-chain matching,bounded awaitTermination in teardown

PR 3:  Add CheckAnswer/CheckLastBatch/CheckNewAnswer actions to StreamTest
* The verification layer. Adds 4 Check actions (CheckAnswer, CheckLastBatch, CheckNewAnswer, CheckAnswerByFunc) plus 4 JVM-side helpers (memorySinkOf, memorySinkAllData,                    
  memorySinkDataSinceBatch, memorySinkLatestBatchId) that read the JVM MemorySink directly (preserving batch arrival order, unlike SELECT * FROM <view>). Implements row-count cumulative
  cursor for CheckNewAnswer (stable across restart) and latestBatchId-based CheckLastBatch

PR 4: Add Real-Time Mode (RTM) support to StreamTest 
*  The RTM extension. Adds LowLatencyMemoryStream and ContinuousMemorySink Python wrappers, four polling/wait actions (CheckAnswerWithTimeout, CheckAnswerContainsWithTimeout, ExternalAction,
   Sleep), 7 more JVM helpers (RTM source/sink + realTimeTrigger + startStreamingQueryWithSink), and a run_stream_test(sink=...) parameter that routes through the explicit-sink JVM bridge
  instead of writeStream. Polling loop fail-fasts on dead query, validates trigger keys (single shared _validate_trigger_keys covering both paths), rejects CheckLastBatch / CheckNewAnswer  
  on the custom-sink path with a clear message.


The overall experience is documented here:

https://github.com/jerrypeng/spark/blob/fbcf4074e280e89834628e818b70e688bc64764e/python/pyspark/testing/streaming/DESIGN.md

### Why are the changes needed?

Scala's `StreamTest` provides a declarative, action-based testing framework used by hundreds of Structured Streaming test suites. PySpark has no equivalent: streaming tests are written ad-hoc with manual `writeStream`/`processAllAvailable`/sleep loops, which is verbose and fragile. The Python port reuses Scala's `MemoryStream[Row]` (the battle-tested in-memory source) instead of reimplementing offset tracking and recovery semantics in Python. This PR establishes the bridge; follow-ups add the action API and driver loop.

### Does this PR introduce _any_ user-facing change?

No. Everything added here is test infrastructure. The new `PythonSQLUtils` methods are private to `org.apache.spark.sql` and documented as test-only.

### How was this patch tested?

Added `MemoryStreamTests` covering primitive and struct schemas, the `add_data`/`current_offset` contract, schema validation, and the streaming nature of `to_df()`. All tests pass:

    python3 -m unittest pyspark.sql.tests.streaming.test_stream_test_framework

Ran 10 tests in 7.977s — OK.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->
