### PR TITLE
[SPARK-55203][PYTHON] Support PathLike in readwriter paths

### DIFF
--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
 from typing import Dict
 from typing import Optional, Union, List, overload, Tuple, cast, Callable
 from typing import TYPE_CHECKING
@@ -34,6 +35,10 @@ from pyspark.sql.readwriter import (
     DataFrameWriter as PySparkDataFrameWriter,
     DataFrameReader as PySparkDataFrameReader,
     DataFrameWriterV2 as PySparkDataFrameWriterV2,
+    PathLikeOrString,
+    PathOrPaths,
+    _to_str_path,
+    _to_str_paths,
 )
 from pyspark.errors import (
     AnalysisException,
@@ -51,7 +56,6 @@ if TYPE_CHECKING:
 
 __all__ = ["DataFrameReader", "DataFrameWriter"]
 
-PathOrPaths = Union[str, List[str]]
 TupleOrListOfString = Union[List[str], Tuple[str, ...]]
 
 
@@ -130,15 +134,13 @@ class DataFrameReader(OptionUtils):
             self.schema(schema)
         self.options(**options)
 
-        paths = path
-        if isinstance(path, str):
-            paths = [path]
+        paths = None if path is None else _to_str_paths(path)
 
         plan = DataSource(
             format=self._format,
             schema=self._schema,
             options=self._options,
-            paths=paths,  # type: ignore[arg-type]
+            paths=paths,
         )
         return self._df(plan)
 
@@ -220,10 +222,8 @@ class DataFrameReader(OptionUtils):
             allowNonNumericNumbers=allowNonNumericNumbers,
             useUnsafeRow=useUnsafeRow,
         )
-        if isinstance(path, str):
-            path = [path]
-        if isinstance(path, list):
-            return self.load(path=path, format="json", schema=schema)
+        if isinstance(path, (str, os.PathLike, list)):
+            return self.load(path=_to_str_paths(path), format="json", schema=schema)
 
         from pyspark.sql.connect.dataframe import DataFrame
 
@@ -251,7 +251,7 @@ class DataFrameReader(OptionUtils):
 
     json.__doc__ = PySparkDataFrameReader.json.__doc__
 
-    def parquet(self, *paths: str, **options: "OptionalPrimitiveType") -> "DataFrame":
+    def parquet(self, *paths: PathLikeOrString, **options: "OptionalPrimitiveType") -> "DataFrame":
         mergeSchema = options.get("mergeSchema", None)
         pathGlobFilter = options.get("pathGlobFilter", None)
         modifiedBefore = options.get("modifiedBefore", None)
@@ -269,7 +269,7 @@ class DataFrameReader(OptionUtils):
             int96RebaseMode=int96RebaseMode,
         )
 
-        return self.load(path=list(paths), format="parquet")
+        return self.load(path=_to_str_paths(list(paths)), format="parquet")
 
     parquet.__doc__ = PySparkDataFrameReader.parquet.__doc__
 
@@ -292,9 +292,7 @@ class DataFrameReader(OptionUtils):
             modifiedAfter=modifiedAfter,
         )
 
-        if isinstance(paths, str):
-            paths = [paths]
-        return self.load(path=paths, format="text")
+        return self.load(path=_to_str_paths(paths), format="text")
 
     text.__doc__ = PySparkDataFrameReader.text.__doc__
 
@@ -369,9 +367,6 @@ class DataFrameReader(OptionUtils):
             modifiedAfter=modifiedAfter,
             unescapedQuoteHandling=unescapedQuoteHandling,
         )
-        if isinstance(path, str):
-            path = [path]
-
         from pyspark.sql.connect.dataframe import DataFrame
 
         if isinstance(path, DataFrame):
@@ -387,7 +382,16 @@ class DataFrameReader(OptionUtils):
                     options=self._options,
                 )
             )
-        return self.load(path=path, format="csv", schema=schema)
+        if isinstance(path, (str, os.PathLike, list)):
+            return self.load(path=_to_str_paths(path), format="csv", schema=schema)
+        raise PySparkTypeError(
+            errorClass="NOT_EXPECTED_TYPE",
+            messageParameters={
+                "arg_name": "path",
+                "expected_type": "str, list, or DataFrame",
+                "arg_type": type(path).__name__,
+            },
+        )
 
     csv.__doc__ = PySparkDataFrameReader.csv.__doc__
 
@@ -435,10 +439,8 @@ class DataFrameReader(OptionUtils):
             samplingRatio=samplingRatio,
             locale=locale,
         )
-        if isinstance(path, str):
-            path = [path]
-        if isinstance(path, list):
-            return self.load(path=path, format="xml", schema=schema)
+        if isinstance(path, (str, os.PathLike, list)):
+            return self.load(path=_to_str_paths(path), format="xml", schema=schema)
 
         from pyspark.sql.connect.dataframe import DataFrame
 
@@ -482,9 +484,7 @@ class DataFrameReader(OptionUtils):
             modifiedAfter=modifiedAfter,
             recursiveFileLookup=recursiveFileLookup,
         )
-        if isinstance(path, str):
-            path = [path]
-        return self.load(path=path, format="orc")
+        return self.load(path=_to_str_paths(path), format="orc")
 
     orc.__doc__ = PySparkDataFrameReader.orc.__doc__
 
@@ -747,7 +747,7 @@ class DataFrameWriter(OptionUtils):
 
     def save(
         self,
-        path: Optional[str] = None,
+        path: Optional[PathLikeOrString] = None,
         format: Optional[str] = None,
         mode: Optional[str] = None,
         partitionBy: Optional[Union[str, List[str]]] = None,
@@ -758,7 +758,7 @@ class DataFrameWriter(OptionUtils):
             self.partitionBy(partitionBy)
         if format is not None:
             self.format(format)
-        self._write.path = path
+        self._write.path = None if path is None else _to_str_path(path)
         _, _, ei = self._spark.client.execute_command(
             self._write.command(self._spark.client), self._write.observations
         )
@@ -802,7 +802,7 @@ class DataFrameWriter(OptionUtils):
 
     def json(
         self,
-        path: str,
+        path: PathLikeOrString,
         mode: Optional[str] = None,
         compression: Optional[str] = None,
         dateFormat: Optional[str] = None,
@@ -826,7 +826,7 @@ class DataFrameWriter(OptionUtils):
 
     def parquet(
         self,
-        path: str,
+        path: PathLikeOrString,
         mode: Optional[str] = None,
         partitionBy: Optional[Union[str, List[str]]] = None,
         compression: Optional[str] = None,
@@ -840,7 +840,10 @@ class DataFrameWriter(OptionUtils):
     parquet.__doc__ = PySparkDataFrameWriter.parquet.__doc__
 
     def text(
-        self, path: str, compression: Optional[str] = None, lineSep: Optional[str] = None
+        self,
+        path: PathLikeOrString,
+        compression: Optional[str] = None,
+        lineSep: Optional[str] = None,
     ) -> None:
         self._set_opts(compression=compression, lineSep=lineSep)
         self.format("text").save(path)
@@ -849,7 +852,7 @@ class DataFrameWriter(OptionUtils):
 
     def csv(
         self,
-        path: str,
+        path: PathLikeOrString,
         mode: Optional[str] = None,
         compression: Optional[str] = None,
         sep: Optional[str] = None,
@@ -893,7 +896,7 @@ class DataFrameWriter(OptionUtils):
 
     def xml(
         self,
-        path: str,
+        path: PathLikeOrString,
         rowTag: Optional[str] = None,
         mode: Optional[str] = None,
         attributePrefix: Optional[str] = None,
@@ -929,7 +932,7 @@ class DataFrameWriter(OptionUtils):
 
     def orc(
         self,
-        path: str,
+        path: PathLikeOrString,
         mode: Optional[str] = None,
         partitionBy: Optional[Union[str, List[str]]] = None,
         compression: Optional[str] = None,

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
 import sys
 from typing import cast, overload, Dict, Iterable, List, Optional, Tuple, TYPE_CHECKING, Union
 
@@ -33,8 +34,19 @@ if TYPE_CHECKING:
 
 __all__ = ["DataFrameReader", "DataFrameWriter", "DataFrameWriterV2"]
 
-PathOrPaths = Union[str, List[str]]
+PathLikeOrString = Union[str, os.PathLike[str]]
+PathOrPaths = Union[PathLikeOrString, List[str], List[PathLikeOrString]]
 TupleOrListOfString = Union[List[str], Tuple[str, ...]]
+
+
+def _to_str_path(path: PathLikeOrString) -> str:
+    return os.fsdecode(path)
+
+
+def _to_str_paths(paths: PathOrPaths) -> List[str]:
+    if isinstance(paths, (str, os.PathLike)):
+        return [_to_str_path(paths)]
+    return [_to_str_path(path) for path in paths]
 
 
 class OptionUtils:
@@ -268,8 +280,8 @@ class DataFrameReader(OptionUtils):
 
         Parameters
         ----------
-        path : str or list, optional
-            optional string or a list of string for file-system backed data sources.
+        path : str, :class:`os.PathLike`, list, optional
+            optional path or list of paths for file-system backed data sources.
         format : str, optional
             optional string for format of the data source. Default to 'parquet'.
         schema : :class:`pyspark.sql.types.StructType` or str, optional
@@ -308,19 +320,20 @@ class DataFrameReader(OptionUtils):
         if schema is not None:
             self.schema(schema)
         self.options(**options)
-        if isinstance(path, str):
-            return self._df(self._jreader.load(path))
+        if isinstance(path, (str, os.PathLike)):
+            return self._df(self._jreader.load(_to_str_path(path)))
         elif path is not None:
             if not isinstance(path, list):
                 path = [path]
             assert self._spark._sc._jvm is not None
-            return self._df(self._jreader.load(self._spark._sc._jvm.PythonUtils.toSeq(path)))
+            paths = _to_str_paths(cast(PathOrPaths, path))
+            return self._df(self._jreader.load(self._spark._sc._jvm.PythonUtils.toSeq(paths)))
         else:
             return self._df(self._jreader.load())
 
     def json(
         self,
-        path: Union[str, List[str], "RDD[str]", "DataFrame"],
+        path: Union[PathOrPaths, "RDD[str]", "DataFrame"],
         schema: Optional[Union[StructType, str]] = None,
         primitivesAsString: Optional[Union[bool, str]] = None,
         prefersDecimal: Optional[Union[bool, str]] = None,
@@ -366,8 +379,8 @@ class DataFrameReader(OptionUtils):
 
         Parameters
         ----------
-        path : str, list, :class:`RDD`, or :class:`DataFrame`
-            string represents path to the JSON dataset, or a list of paths,
+        path : str, :class:`os.PathLike`, list, :class:`RDD`, or :class:`DataFrame`
+            string or path-like object represents path to the JSON dataset, or a list of paths,
             or RDD of Strings storing JSON objects,
             or a DataFrame with a single string column containing JSON strings.
         schema : :class:`pyspark.sql.types.StructType` or str, optional
@@ -480,9 +493,10 @@ class DataFrameReader(OptionUtils):
             allowNonNumericNumbers=allowNonNumericNumbers,
             useUnsafeRow=useUnsafeRow,
         )
-        if isinstance(path, str):
-            path = [path]
+        if isinstance(path, (str, os.PathLike)):
+            path = [_to_str_path(path)]
         if isinstance(path, list):
+            path = _to_str_paths(cast(PathOrPaths, path))
             assert self._spark._sc._jvm is not None
             return self._df(self._jreader.json(self._spark._sc._jvm.PythonUtils.toSeq(path)))
 
@@ -584,7 +598,7 @@ class DataFrameReader(OptionUtils):
         """
         return self._df(self._jreader.changes(tableName))
 
-    def parquet(self, *paths: str, **options: "OptionalPrimitiveType") -> "DataFrame":
+    def parquet(self, *paths: PathLikeOrString, **options: "OptionalPrimitiveType") -> "DataFrame":
         """
         Loads Parquet files, returning the result as a :class:`DataFrame`.
 
@@ -595,7 +609,7 @@ class DataFrameReader(OptionUtils):
 
         Parameters
         ----------
-        paths : str
+        paths : str or :class:`os.PathLike`
             One or more file paths to read the Parquet files from.
 
         Other Parameters
@@ -693,7 +707,7 @@ class DataFrameReader(OptionUtils):
             int96RebaseMode=int96RebaseMode,
         )
 
-        return self._df(self._jreader.parquet(_to_seq(self._spark._sc, paths)))
+        return self._df(self._jreader.parquet(_to_seq(self._spark._sc, _to_str_paths(list(paths)))))
 
     def text(
         self,
@@ -720,8 +734,8 @@ class DataFrameReader(OptionUtils):
 
         Parameters
         ----------
-        paths : str or list
-            string, or list of strings, for input path(s).
+        paths : str, :class:`os.PathLike`, or list
+            path, or list of paths, for input path(s).
 
         Other Parameters
         ----------------
@@ -761,14 +775,13 @@ class DataFrameReader(OptionUtils):
             modifiedAfter=modifiedAfter,
         )
 
-        if isinstance(paths, str):
-            paths = [paths]
+        paths = _to_str_paths(paths)
         assert self._spark._sc._jvm is not None
         return self._df(self._jreader.text(self._spark._sc._jvm.PythonUtils.toSeq(paths)))
 
     def csv(
         self,
-        path: Union[str, List[str], "RDD[str]", "DataFrame"],
+        path: Union[PathOrPaths, "RDD[str]", "DataFrame"],
         schema: Optional[Union[StructType, str]] = None,
         sep: Optional[str] = None,
         encoding: Optional[str] = None,
@@ -819,8 +832,8 @@ class DataFrameReader(OptionUtils):
 
         Parameters
         ----------
-        path : str, list, :class:`RDD`, or :class:`DataFrame`
-            string, or list of strings, for input path(s),
+        path : str, :class:`os.PathLike`, list, :class:`RDD`, or :class:`DataFrame`
+            path, or list of paths, for input path(s),
             or RDD of Strings storing CSV rows,
             or a DataFrame with a single string column containing CSV rows.
         schema : :class:`pyspark.sql.types.StructType` or str, optional
@@ -889,9 +902,10 @@ class DataFrameReader(OptionUtils):
             modifiedAfter=modifiedAfter,
             unescapedQuoteHandling=unescapedQuoteHandling,
         )
-        if isinstance(path, str):
-            path = [path]
+        if isinstance(path, (str, os.PathLike)):
+            path = [_to_str_path(path)]
         if isinstance(path, list):
+            path = _to_str_paths(cast(PathOrPaths, path))
             assert self._spark._sc._jvm is not None
             return self._df(self._jreader.csv(self._spark._sc._jvm.PythonUtils.toSeq(path)))
 
@@ -940,7 +954,7 @@ class DataFrameReader(OptionUtils):
 
     def xml(
         self,
-        path: Union[str, List[str], "RDD[str]", "DataFrame"],
+        path: Union[PathOrPaths, "RDD[str]", "DataFrame"],
         rowTag: Optional[str] = None,
         schema: Optional[Union[StructType, str]] = None,
         excludeAttribute: Optional[Union[bool, str]] = None,
@@ -973,8 +987,8 @@ class DataFrameReader(OptionUtils):
 
         Parameters
         ----------
-        path : str, list, :class:`RDD`, or :class:`DataFrame`
-            string, or list of strings, for input path(s),
+        path : str, :class:`os.PathLike`, list, :class:`RDD`, or :class:`DataFrame`
+            path, or list of paths, for input path(s),
             or RDD of Strings storing XML rows,
             or a DataFrame with a single string column containing XML strings.
         schema : :class:`pyspark.sql.types.StructType` or str, optional
@@ -1045,9 +1059,10 @@ class DataFrameReader(OptionUtils):
             samplingRatio=samplingRatio,
             locale=locale,
         )
-        if isinstance(path, str):
-            path = [path]
+        if isinstance(path, (str, os.PathLike)):
+            path = [_to_str_path(path)]
         if isinstance(path, list):
+            path = _to_str_paths(cast(PathOrPaths, path))
             assert self._spark._sc._jvm is not None
             return self._df(self._jreader.xml(self._spark._sc._jvm.PythonUtils.toSeq(path)))
 
@@ -1111,7 +1126,8 @@ class DataFrameReader(OptionUtils):
 
         Parameters
         ----------
-        path : str or list
+        path : str, :class:`os.PathLike`, or list
+            path, or list of paths, for input path(s).
 
         Other Parameters
         ----------------
@@ -1150,9 +1166,7 @@ class DataFrameReader(OptionUtils):
             modifiedAfter=modifiedAfter,
             recursiveFileLookup=recursiveFileLookup,
         )
-        if isinstance(path, str):
-            path = [path]
-        return self._df(self._jreader.orc(_to_seq(self._spark._sc, path)))
+        return self._df(self._jreader.orc(_to_seq(self._spark._sc, _to_str_paths(path))))
 
     @overload
     def jdbc(
@@ -1769,7 +1783,7 @@ class DataFrameWriter(OptionUtils):
 
     def save(
         self,
-        path: Optional[str] = None,
+        path: Optional[PathLikeOrString] = None,
         format: Optional[str] = None,
         mode: Optional[str] = None,
         partitionBy: Optional[Union[str, List[str]]] = None,
@@ -1788,7 +1802,7 @@ class DataFrameWriter(OptionUtils):
 
         Parameters
         ----------
-        path : str, optional
+        path : str or :class:`os.PathLike`, optional
             the path in a Hadoop supported file system
         format : str, optional
             the format used to save
@@ -1832,7 +1846,7 @@ class DataFrameWriter(OptionUtils):
         if path is None:
             self._jwrite.save()
         else:
-            self._jwrite.save(path)
+            self._jwrite.save(_to_str_path(path))
 
     def insertInto(self, tableName: str, overwrite: Optional[bool] = None) -> None:
         """Inserts the content of the :class:`DataFrame` to the specified table.
@@ -1959,7 +1973,7 @@ class DataFrameWriter(OptionUtils):
 
     def json(
         self,
-        path: str,
+        path: PathLikeOrString,
         mode: Optional[str] = None,
         compression: Optional[str] = None,
         dateFormat: Optional[str] = None,
@@ -1979,7 +1993,7 @@ class DataFrameWriter(OptionUtils):
 
         Parameters
         ----------
-        path : str
+        path : str or :class:`os.PathLike`
             the path in any Hadoop supported file system
         mode : str, optional
             specifies the behavior of the save operation when data already exists.
@@ -2027,11 +2041,11 @@ class DataFrameWriter(OptionUtils):
             encoding=encoding,
             ignoreNullFields=ignoreNullFields,
         )
-        self._jwrite.json(path)
+        self._jwrite.json(_to_str_path(path))
 
     def parquet(
         self,
-        path: str,
+        path: PathLikeOrString,
         mode: Optional[str] = None,
         partitionBy: Optional[Union[str, List[str]]] = None,
         compression: Optional[str] = None,
@@ -2045,7 +2059,7 @@ class DataFrameWriter(OptionUtils):
 
         Parameters
         ----------
-        path : str
+        path : str or :class:`os.PathLike`
             the path in any Hadoop supported file system
         mode : str, optional
             specifies the behavior of the save operation when data already exists.
@@ -2090,10 +2104,13 @@ class DataFrameWriter(OptionUtils):
         if partitionBy is not None:
             self.partitionBy(partitionBy)
         self._set_opts(compression=compression)
-        self._jwrite.parquet(path)
+        self._jwrite.parquet(_to_str_path(path))
 
     def text(
-        self, path: str, compression: Optional[str] = None, lineSep: Optional[str] = None
+        self,
+        path: PathLikeOrString,
+        compression: Optional[str] = None,
+        lineSep: Optional[str] = None,
     ) -> None:
         """Saves the content of the DataFrame in a text file at the specified path.
         The text files will be encoded as UTF-8.
@@ -2105,7 +2122,7 @@ class DataFrameWriter(OptionUtils):
 
         Parameters
         ----------
-        path : str
+        path : str or :class:`os.PathLike`
             the path in any Hadoop supported file system
 
         Other Parameters
@@ -2143,11 +2160,11 @@ class DataFrameWriter(OptionUtils):
         +---------+
         """
         self._set_opts(compression=compression, lineSep=lineSep)
-        self._jwrite.text(path)
+        self._jwrite.text(_to_str_path(path))
 
     def csv(
         self,
-        path: str,
+        path: PathLikeOrString,
         mode: Optional[str] = None,
         compression: Optional[str] = None,
         sep: Optional[str] = None,
@@ -2175,7 +2192,7 @@ class DataFrameWriter(OptionUtils):
 
         Parameters
         ----------
-        path : str
+        path : str or :class:`os.PathLike`
             the path in any Hadoop supported file system
         mode : str, optional
             specifies the behavior of the save operation when data already exists.
@@ -2233,11 +2250,11 @@ class DataFrameWriter(OptionUtils):
             emptyValue=emptyValue,
             lineSep=lineSep,
         )
-        self._jwrite.csv(path)
+        self._jwrite.csv(_to_str_path(path))
 
     def xml(
         self,
-        path: str,
+        path: PathLikeOrString,
         rowTag: Optional[str] = None,
         mode: Optional[str] = None,
         attributePrefix: Optional[str] = None,
@@ -2258,7 +2275,7 @@ class DataFrameWriter(OptionUtils):
 
         Parameters
         ----------
-        path : str
+        path : str or :class:`os.PathLike`
             the path in any Hadoop supported file system
         mode : str, optional
             specifies the behavior of the save operation when data already exists.
@@ -2312,11 +2329,11 @@ class DataFrameWriter(OptionUtils):
             encoding=encoding,
             validateName=validateName,
         )
-        self._jwrite.xml(path)
+        self._jwrite.xml(_to_str_path(path))
 
     def orc(
         self,
-        path: str,
+        path: PathLikeOrString,
         mode: Optional[str] = None,
         partitionBy: Optional[Union[str, List[str]]] = None,
         compression: Optional[str] = None,
@@ -2330,7 +2347,7 @@ class DataFrameWriter(OptionUtils):
 
         Parameters
         ----------
-        path : str
+        path : str or :class:`os.PathLike`
             the path in any Hadoop supported file system
         mode : str, optional
             specifies the behavior of the save operation when data already exists.
@@ -2375,7 +2392,7 @@ class DataFrameWriter(OptionUtils):
         if partitionBy is not None:
             self.partitionBy(partitionBy)
         self._set_opts(compression=compression)
-        self._jwrite.orc(path)
+        self._jwrite.orc(_to_str_path(path))
 
     def jdbc(
         self,

--- a/python/pyspark/sql/tests/connect/test_connect_plan.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan.py
@@ -19,6 +19,7 @@ import uuid
 import datetime
 import decimal
 import math
+from pathlib import Path
 
 from pyspark.testing.connectutils import (
     PlanOnlyTestFixture,
@@ -599,6 +600,15 @@ class SparkConnectPlanTests(PlanOnlyTestFixture):
         self.assertEqual(data_source.options.get("op2"), "opv2")
         self.assertEqual(len(data_source.paths), 1)
         self.assertEqual(data_source.paths[0], "test_path")
+
+        reader = DataFrameReader(self.connect)
+        df = reader.load(
+            path=[Path("test_path1"), Path("test_path2")],
+            format="text",
+        )
+        plan = df._plan.to_proto(self.connect)
+        data_source = plan.root.read.data_source
+        self.assertEqual(list(data_source.paths), ["test_path1", "test_path2"])
 
     def test_relation_changes(self):
         reader = DataFrameReader(self.connect)

--- a/python/pyspark/sql/tests/test_readwriter.py
+++ b/python/pyspark/sql/tests/test_readwriter.py
@@ -16,6 +16,7 @@
 #
 
 import os
+from pathlib import Path
 import shutil
 import tempfile
 
@@ -105,6 +106,42 @@ class ReadwriterTestsMixin:
                 assertDataFrameEqual(df, actual)
         finally:
             shutil.rmtree(tmpPath)
+
+    def test_pathlike_paths(self):
+        df = self.df
+        with tempfile.TemporaryDirectory(prefix="pathlike") as d:
+            json_path = Path(d) / "json"
+            df.write.mode("overwrite").format("json").save(json_path)
+            assertDataFrameEqual(df, self.spark.read.format("json").load(json_path))
+            assertDataFrameEqual(df, self.spark.read.json(json_path))
+
+            json_path2 = Path(d) / "json2"
+            df.write.mode("overwrite").json(json_path2)
+            assertDataFrameEqual(df.union(df), self.spark.read.json([json_path, json_path2]))
+
+            parquet_path = Path(d) / "parquet"
+            df.write.mode("overwrite").parquet(parquet_path)
+            assertDataFrameEqual(df, self.spark.read.parquet(parquet_path))
+
+            text_df = df.select("value")
+            text_path = Path(d) / "text"
+            text_df.write.mode("overwrite").text(text_path)
+            assertDataFrameEqual(text_df, self.spark.read.text(text_path))
+
+            csv_path = Path(d) / "csv"
+            df.write.mode("overwrite").csv(csv_path)
+            assertDataFrameEqual(df, self.spark.read.csv(csv_path, schema=df.schema))
+
+            orc_path = Path(d) / "orc"
+            df.write.mode("overwrite").orc(orc_path)
+            assertDataFrameEqual(df, self.spark.read.orc(orc_path))
+
+            xml_path = Path(d) / "xml"
+            df.write.mode("overwrite").xml(xml_path, rowTag="row")
+            assertDataFrameEqual(
+                df,
+                self.spark.read.xml(xml_path, rowTag="row", schema=df.schema),
+            )
 
     def test_bucketed_write(self):
         data = [


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR allows os.PathLike path objects, such as pathlib.Path, to be passed to PySpark readwriter path APIs.

The change normalizes path-like objects with os.fsdecode before sending paths to the JVM or Spark Connect plans.

### Why are the changes needed?

Currently, several PySpark readwriter methods accept only str or list[str] paths. Python users commonly use pathlib.Path, and these objects should work for file-system backed data sources.

Closes #55203.

### Does this PR introduce any user-facing change?

Yes. Users can pass pathlib.Path / os.PathLike objects to supported readwriter APIs.

### How was this patch tested?

- ./dev/lint-python --compile
- git diff --check
- Added PySpark readwriter tests for pathlib.Path
- Added Spark Connect plan coverage for path-like path lists

Full PySpark runtime tests were not run locally because this machine does not have a Java Runtime installed.

### Was this patch authored or co-authored using generative AI tooling?

Yes. I used OpenAI Codex to help implement and test this change. I have reviewed the changes and take responsibility for them. This contribution is my original work and I license the work to the project under the project's open source license.