### PR TITLE
[SPARK-56712][SQL][DOCS] Document pushdown contract for CDC ChangelogTable

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
@@ -76,30 +76,25 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * later commit (with strictly greater `_commit_timestamp`) advances the global watermark
  * past them, or the source terminates.
  * <p>
- * <b>Predicate pushdown.</b> Connectors may implement
- * {@link org.apache.spark.sql.connector.read.SupportsPushDownFilters} or
- * {@link org.apache.spark.sql.connector.read.SupportsPushDownV2Filters} on the
+ * <b>Pushdown contract when post-processing applies.</b> When the
  * {@link org.apache.spark.sql.connector.read.ScanBuilder} returned by
- * {@link #newScanBuilder(org.apache.spark.sql.util.CaseInsensitiveStringMap)}.
- * When any post-processing pass applies (carry-over removal, update detection,
- * or netChanges) Spark will only push predicates referencing safe columns --
- * {@code _commit_version}, {@code _commit_timestamp}, and the columns named by
- * {@link #rowId()}. Predicates on {@code _change_type}, the
- * {@link #rowVersion()} column, or any data column are kept above the scan and
- * never reach {@code pushFilters} / {@code pushPredicates}, because pushing
- * them would drop a single half of a delete/insert pair within a row-identity
- * group and silently break post-processing.
- * <p>
- * This restriction is enforced by the post-processing rewrite shape:
- * the row-level rewrite places a {@code Window} (or streaming {@code Aggregate})
- * partitioned/grouped by {@code (rowId, _commit_version[, _commit_timestamp])}
- * between the relation and the user's filter, and the netChanges rewrite places
- * a {@code Window} (or {@code TransformWithState}) keyed on {@code rowId} there;
- * Spark's predicate-pushdown rules only push through these operators when every
- * referenced column is a partition / grouping key. Connectors implementing
- * pushdown therefore do not need to code this restriction themselves -- but they
- * must not bypass it (e.g. by self-applying filters from connector-specific
- * options when post-processing applies).
+ * {@link #newScanBuilder(org.apache.spark.sql.util.CaseInsensitiveStringMap)}
+ * implements {@link org.apache.spark.sql.connector.read.SupportsPushDownFilters}
+ * or {@link org.apache.spark.sql.connector.read.SupportsPushDownV2Filters},
+ * Spark only pushes predicates that reference {@code _commit_version},
+ * {@code _commit_timestamp}, or columns named by {@link #rowId()}. Predicates
+ * on {@code _change_type}, the {@link #rowVersion()} column, or data columns
+ * are kept above the scan -- pushing them would drop one half of a
+ * delete/insert pair within a row-identity group and silently break
+ * post-processing. Catalyst's pushdown rules already enforce this via the
+ * rewrite operators (a {@code Window} / {@code Aggregate} partitioned on
+ * {@code rowId, _commit_version} sits between the relation and the user
+ * filter), so connectors do not need to code the restriction themselves -- but
+ * they must not bypass it via connector-specific options.
+ * {@link org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns}
+ * is unrestricted: Spark's column pruning already respects what the rewrite
+ * operators reference, so connectors should serve whatever required-column set
+ * Spark requests.
  *
  * @since 4.2.0
  */

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
@@ -76,25 +76,22 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * later commit (with strictly greater `_commit_timestamp`) advances the global watermark
  * past them, or the source terminates.
  * <p>
- * <b>Pushdown contract when post-processing applies.</b> When the
- * {@link org.apache.spark.sql.connector.read.ScanBuilder} returned by
- * {@link #newScanBuilder(org.apache.spark.sql.util.CaseInsensitiveStringMap)}
- * implements {@link org.apache.spark.sql.connector.read.SupportsPushDownFilters}
- * or {@link org.apache.spark.sql.connector.read.SupportsPushDownV2Filters},
- * Spark only pushes predicates that reference {@code _commit_version},
- * {@code _commit_timestamp}, or columns named by {@link #rowId()}. Predicates
- * on {@code _change_type}, the {@link #rowVersion()} column, or data columns
- * are kept above the scan -- pushing them would drop one half of a
- * delete/insert pair within a row-identity group and silently break
- * post-processing. Catalyst's pushdown rules already enforce this via the
- * rewrite operators (a {@code Window} / {@code Aggregate} partitioned on
- * {@code rowId, _commit_version} sits between the relation and the user
- * filter), so connectors do not need to code the restriction themselves -- but
- * they must not bypass it via connector-specific options.
+ * <b>Pushdown contract.</b> When any post-processing pass applies (carry-over
+ * removal, update detection, or netChanges), Spark only pushes predicates
+ * that reference {@code _commit_version}, {@code _commit_timestamp}, or
+ * columns named by {@link #rowId()} to the connector's
+ * {@link org.apache.spark.sql.connector.read.SupportsPushDownFilters} /
+ * {@link org.apache.spark.sql.connector.read.SupportsPushDownV2Filters}.
+ * Predicates on {@code _change_type}, the {@link #rowVersion()} column, or
+ * data columns are kept above the scan: pushing them would drop one half of
+ * a delete/insert pair within a row-identity group and silently break
+ * post-processing. Catalyst's pushdown rules enforce this via the rewrite
+ * operators, so connectors do not need to code the restriction themselves --
+ * but must not bypass it via connector-specific options. When no
+ * post-processing pass applies, pushdown is unrestricted.
  * {@link org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns}
- * is unrestricted: Spark's column pruning already respects what the rewrite
- * operators reference, so connectors should serve whatever required-column set
- * Spark requests.
+ * (column pruning) is unrestricted in either case: Spark's pruning already
+ * respects what the rewrite operators reference.
  *
  * @since 4.2.0
  */

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
@@ -75,6 +75,31 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * row identities only touched in the latest observed commit are held back until either a
  * later commit (with strictly greater `_commit_timestamp`) advances the global watermark
  * past them, or the source terminates.
+ * <p>
+ * <b>Predicate pushdown.</b> Connectors may implement
+ * {@link org.apache.spark.sql.connector.read.SupportsPushDownFilters} or
+ * {@link org.apache.spark.sql.connector.read.SupportsPushDownV2Filters} on the
+ * {@link org.apache.spark.sql.connector.read.ScanBuilder} returned by
+ * {@link #newScanBuilder(org.apache.spark.sql.util.CaseInsensitiveStringMap)}.
+ * When any post-processing pass applies (carry-over removal, update detection,
+ * or netChanges) Spark will only push predicates referencing safe columns --
+ * {@code _commit_version}, {@code _commit_timestamp}, and the columns named by
+ * {@link #rowId()}. Predicates on {@code _change_type}, the
+ * {@link #rowVersion()} column, or any data column are kept above the scan and
+ * never reach {@code pushFilters} / {@code pushPredicates}, because pushing
+ * them would drop a single half of a delete/insert pair within a row-identity
+ * group and silently break post-processing.
+ * <p>
+ * This restriction is enforced by the post-processing rewrite shape:
+ * the row-level rewrite places a {@code Window} (or streaming {@code Aggregate})
+ * partitioned/grouped by {@code (rowId, _commit_version[, _commit_timestamp])}
+ * between the relation and the user's filter, and the netChanges rewrite places
+ * a {@code Window} (or {@code TransformWithState}) keyed on {@code rowId} there;
+ * Spark's predicate-pushdown rules only push through these operators when every
+ * referenced column is a partition / grouping key. Connectors implementing
+ * pushdown therefore do not need to code this restriction themselves -- but they
+ * must not bypass it (e.g. by self-applying filters from connector-specific
+ * options when post-processing applies).
  *
  * @since 4.2.0
  */

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
@@ -83,12 +83,13 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * {@link org.apache.spark.sql.connector.read.SupportsPushDownFilters} /
  * {@link org.apache.spark.sql.connector.read.SupportsPushDownV2Filters}.
  * Predicates on {@code _change_type}, the {@link #rowVersion()} column, or
- * data columns are kept above the scan: pushing them would drop one half of
- * a delete/insert pair within a row-identity group and silently break
- * post-processing. Catalyst's pushdown rules enforce this via the rewrite
- * operators, so connectors do not need to code the restriction themselves --
- * but must not bypass it via connector-specific options. When no
- * post-processing pass applies, pushdown is unrestricted.
+ * non-rowId data columns are kept above the scan: pushing them would drop
+ * one half of a delete/insert pair within a row-identity group and silently
+ * break post-processing. Catalyst's pushdown rules enforce this via the
+ * rewrite operators, so connectors do not need to code the restriction
+ * themselves -- but must not bypass it via connector-specific options. When
+ * no post-processing pass applies, Spark does not impose any CDC-specific
+ * predicate-pushdown restriction.
  * {@link org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns}
  * (column pruning) is unrestricted in either case: Spark's pruning already
  * respects what the rewrite operators reference.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Document the predicate pushdown and column pruning contract for CDC `Changelog` connectors in the `Changelog` Javadoc.

When any post-processing pass applies (carry-over removal, update detection, or netChanges):
- Spark only pushes predicates that reference `_commit_version`, `_commit_timestamp`, or columns named by `rowId()` to the connector's `SupportsPushDownFilters` / `SupportsPushDownV2Filters`.
- Predicates on `_change_type`, the `rowVersion()` column, or data columns are kept above the scan; pushing them would drop one half of a delete/insert pair within a row-identity group and silently break post-processing.

When no post-processing pass applies, pushdown is unrestricted.

`SupportsPushDownRequiredColumns` (column pruning) is unrestricted in either case — Spark's pruning already respects what the rewrite operators reference, so connectors should serve whatever required-column set Spark requests.

The restriction is enforced by the rewrite shape itself: a `Window` / `Aggregate` / `TransformWithState` keyed on the safe columns sits between the relation and the user's filter, so Catalyst's predicate-pushdown rules naturally block unsafe pushes. Connectors do not need to code this restriction themselves but must not bypass it (e.g. by self-applying filters from connector-specific options).

This is a sub-task of SPARK-55668.

### Why are the changes needed?

The contract was implicit. A connector author reading the Javadoc could reasonably implement `SupportsPushDownFilters` and accept all predicates, including unsafe ones, expecting Spark to handle the rest. Spelling out which predicates the connector actually needs to handle (and why others are intentionally never delivered) prevents accidental misuse and explains the asymmetry to anyone debugging an unexpected post-scan filter. Documenting the column pruning side keeps the two related contracts in one place.

### Does this PR introduce _any_ user-facing change?

Documentation only. No behavior change.

### How was this patch tested?

`Xdoclint:html,syntax,accessibility` is clean on `Changelog.java`. No code changed; existing CDC test suites unaffected.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude opus-4-7