### PR TITLE
[SPARK-54419][SQL] Avoid expanding expensive alias chains in optimizer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -83,6 +83,7 @@ trait PythonFuncExpression extends NonSQLExpression with UserDefinedExpression {
   def resultId: ExprId
 
   override lazy val deterministic: Boolean = udfDeterministic && children.forall(_.deterministic)
+  override def expensive: Boolean = true
 
   override def toString: String = s"$name(${children.mkString(", ")})#${resultId.id}$typeSuffix"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1369,6 +1369,7 @@ object CollapseProject extends Rule[LogicalPlan] with AliasHelper {
     producers.foreach {
       case a: Alias =>
         producerReferences.get(a.toAttribute).foreach { case (count, relatedConsumers) =>
+          lazy val canInlineProducer = count == 1 || cheapToInlineProducer(a, relatedConsumers)
           lazy val containsUDF = a.child.exists {
             case udf: PythonUDF =>
               isScalarPythonUDF(udf) &&
@@ -1379,9 +1380,11 @@ object CollapseProject extends Rule[LogicalPlan] with AliasHelper {
 
           if (!a.child.deterministic) {
             neverInlines += a
-          } else if (alwaysInline || containsUDF) {
+          } else if (alwaysInline) {
             mustInlines += a
-          } else if (count == 1 || cheapToInlineProducer(a, relatedConsumers)) {
+          } else if (containsUDF && canInlineProducer) {
+            mustInlines += a
+          } else if (canInlineProducer) {
             maybeInlines += a
           } else {
             neverInlines += a
@@ -2115,17 +2118,19 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
       } else {
         // Break up the filter into its respective components by &&s.
         val splitCondition = splitConjunctivePredicates(condition)
-        // Find the different aliases each component of the filter uses.
-        val originalAndRewrittenConditionsWithUsedAlias = splitCondition.map { cond =>
-          // Here we get which aliases were used in a given filter so we can see if the filter
-          // referenced an expensive alias v.s. just checking if the filter is expensive.
-          val (replaced, usedAliases) = replaceAliasWhileTracking(cond, aliasMap)
-          (cond, usedAliases, replaced)
+        // Find the different aliases each component of the filter uses before expanding them.
+        // This avoids inlining long chains of expensive aliases just to discover that the
+        // predicate should stay above the projection.
+        val originalConditionsWithUsedAlias = splitCondition.map { cond =>
+          val usedAliases = AttributeMap(cond.references.toSeq.flatMap { attr =>
+            aliasMap.get(attr).map(alias => attr -> alias)
+          })
+          (cond, usedAliases)
         }
         // Split the filter's components into cheap and expensive while keeping track of
         // what each references from the projection.
-        val (cheapWithUsed, expensiveWithUsed) = originalAndRewrittenConditionsWithUsedAlias
-          .partition { case (cond, used, replaced) =>
+        val (cheapWithUsed, expensiveWithUsed) = originalConditionsWithUsedAlias
+          .partition { case (cond, used) =>
             // Didn't use anything? We're good
             if (used.isEmpty) {
               true
@@ -2142,7 +2147,9 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
         if (cheapWithUsed.isEmpty) {
           f
         } else {
-          val cheap: Seq[Expression] = cheapWithUsed.map(_._3)
+          val cheap: Seq[Expression] = cheapWithUsed.map { case (cond, _) =>
+            replaceAlias(cond, aliasMap)
+          }
           // Make a base instance which has all of the cheap filters pushed down.
           // For all filter which do not reference any expensive aliases then
           // just push the filter while resolving the non-expensive aliases.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -251,6 +251,39 @@ class FilterPushdownSuite extends PlanTest {
     comparePlans(optimized, originalQuery)
   }
 
+  test("SPARK-54419: avoid expanding expensive alias chains that stay above projects") {
+    object StressOptimize extends RuleExecutor[LogicalPlan] {
+      val batches =
+        Batch("Filter Pushdown", FixedPoint(100),
+          CombineFilters,
+          PushPredicateThroughNonJoin,
+          BooleanSimplification,
+          PushPredicateThroughJoin,
+          CollapseProject) :: Nil
+    }
+
+    def expensivePredicate(input: Expression): PythonUDF = PythonUDF("pythonUDF", null,
+      BooleanType, Seq(input), PythonEvalType.SQL_BATCHED_UDF, udfDeterministic = true)
+
+    var plan: LogicalPlan = LocalRelation(attrE)
+    (1 to 30).foreach { _ =>
+      val currentAttr = plan.output.head
+      plan = Project(
+        Seq(Alias(CaseWhen(Seq(expensivePredicate(currentAttr) -> currentAttr), Some(currentAttr)),
+          currentAttr.name)()),
+        plan)
+    }
+
+    val originalQuery = Filter(expensivePredicate(plan.output.head), plan).analyze
+    val optimized = StressOptimize.execute(originalQuery)
+
+    optimized match {
+      case Filter(_: Expression, _: Project) =>
+      case other =>
+        fail(s"Expected expensive filter to stay above the projection chain, but got:\n$other")
+    }
+  }
+
   // Combined case 1, 2, and 3 filter pushdown
   test("SPARK-47672: Case 1, 2, and 3 make sure we leave up and push down correctly.") {
     val originalQuery = testStringRelation


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR avoids eagerly expanding expensive projection aliases during predicate pushdown, and prevents `CollapseProject` from force-inlining multi-use expensive Python-UDF-containing aliases just to merge adjacent Python UDF projections.

It also adds a regression test for the deep `withColumn` rewrite pattern reported in SPARK-54419.

### Why are the changes needed?

The optimizer could blow up on deep iterative `withColumn` rewrites when a filter above the projection chain referenced an expensive alias. We were expanding those aliases before deciding whether the predicate could stay above the project, and then `CollapseProject` could still force-inline the expensive chain while merging Python UDF projections.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified locally:
- `./build/sbt "catalyst/testOnly org.apache.spark.sql.catalyst.optimizer.FilterPushdownSuite org.apache.spark.sql.catalyst.optimizer.CollapseProjectSuite"`
- `git diff --check`
