### PR TITLE
[SPARK-50610][SQL] Fix decimal precision in HiveInspectors.toInspector

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -839,8 +839,9 @@ private[hive] trait HiveInspectors {
       PrimitiveObjectInspectorFactory.javaHiveIntervalDayTimeObjectInspector
     case _: YearMonthIntervalType =>
       PrimitiveObjectInspectorFactory.javaHiveIntervalYearMonthObjectInspector
-    // TODO decimal precision?
-    case DecimalType() => PrimitiveObjectInspectorFactory.javaHiveDecimalObjectInspector
+    case DecimalType.Fixed(precision, scale) =>
+      PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector(
+        new DecimalTypeInfo(precision, scale))
     case StructType(fields) =>
       ObjectInspectorFactory.getStandardStructObjectInspector(
         java.util.Arrays.asList(fields.map(f => f.name) : _*),

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -881,8 +881,8 @@ private[hive] trait HiveInspectors {
       getDateWritableConstantObjectInspector(value)
     case Literal(value, TimestampType) =>
       getTimestampWritableConstantObjectInspector(value)
-    case Literal(value, DecimalType()) =>
-      getDecimalWritableConstantObjectInspector(value)
+    case Literal(value, DecimalType.Fixed(precision, scale)) =>
+      getDecimalWritableConstantObjectInspector(value, precision, scale)
     case Literal(_, NullType) =>
       getPrimitiveNullWritableConstantObjectInspector
     case Literal(_, _: DayTimeIntervalType) =>
@@ -1036,9 +1036,10 @@ private[hive] trait HiveInspectors {
     PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
       TypeInfoFactory.timestampTypeInfo, getTimestampWritable(value))
 
-  private def getDecimalWritableConstantObjectInspector(value: Any): ObjectInspector =
+  private def getDecimalWritableConstantObjectInspector(
+      value: Any, precision: Int, scale: Int): ObjectInspector =
     PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-      TypeInfoFactory.decimalTypeInfo, getDecimalWritable(value))
+      new DecimalTypeInfo(precision, scale), getDecimalWritable(value))
 
   private def getPrimitiveNullWritableConstantObjectInspector: ObjectInspector =
     PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveInspectorSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveInspectorSuite.scala
@@ -21,9 +21,10 @@ import java.util
 
 import org.apache.hadoop.hive.ql.udf.UDAFPercentile
 import org.apache.hadoop.hive.serde2.io.DoubleWritable
-import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspector, ObjectInspectorFactory, StructObjectInspector}
+import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspector, ObjectInspectorFactory, PrimitiveObjectInspector, StructObjectInspector}
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.ObjectInspectorOptions
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo
 import org.apache.hadoop.io.LongWritable
 
 import org.apache.spark.SparkFunSuite
@@ -250,5 +251,27 @@ class HiveInspectorSuite extends SparkFunSuite with HiveInspectors {
     checkValue(d,
       unwrap(wrap(null, toInspector(Literal.create(d, dt)), dt),
         toInspector(Literal.create(d, dt))))
+  }
+
+  test("SPARK-50610: toInspector should preserve decimal precision and scale") {
+    val dt = DecimalType(18, 10)
+    val oi = toInspector(dt).asInstanceOf[PrimitiveObjectInspector]
+    val typeInfo = oi.getTypeInfo.asInstanceOf[DecimalTypeInfo]
+    assert(typeInfo.precision() === 18)
+    assert(typeInfo.scale() === 10)
+
+    // Also verify non-default precision/scale combinations
+    val dt2 = DecimalType(10, 2)
+    val oi2 = toInspector(dt2).asInstanceOf[PrimitiveObjectInspector]
+    val typeInfo2 = oi2.getTypeInfo.asInstanceOf[DecimalTypeInfo]
+    assert(typeInfo2.precision() === 10)
+    assert(typeInfo2.scale() === 2)
+
+    // Verify the default DecimalType also works
+    val dt3 = DecimalType.SYSTEM_DEFAULT
+    val oi3 = toInspector(dt3).asInstanceOf[PrimitiveObjectInspector]
+    val typeInfo3 = oi3.getTypeInfo.asInstanceOf[DecimalTypeInfo]
+    assert(typeInfo3.precision() === DecimalType.MAX_PRECISION)
+    assert(typeInfo3.scale() === DecimalType.DEFAULT_SCALE)
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveInspectorSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveInspectorSuite.scala
@@ -253,7 +253,7 @@ class HiveInspectorSuite extends SparkFunSuite with HiveInspectors {
         toInspector(Literal.create(d, dt))))
   }
 
-  test("SPARK-50610: toInspector should preserve decimal precision and scale") {
+  test("SPARK-50610: toInspector(dataType) should preserve decimal precision and scale") {
     val dt = DecimalType(18, 10)
     val oi = toInspector(dt).asInstanceOf[PrimitiveObjectInspector]
     val typeInfo = oi.getTypeInfo.asInstanceOf[DecimalTypeInfo]
@@ -273,5 +273,22 @@ class HiveInspectorSuite extends SparkFunSuite with HiveInspectors {
     val typeInfo3 = oi3.getTypeInfo.asInstanceOf[DecimalTypeInfo]
     assert(typeInfo3.precision() === DecimalType.MAX_PRECISION)
     assert(typeInfo3.scale() === DecimalType.DEFAULT_SCALE)
+  }
+
+  test("SPARK-50610: toInspector(expr) should preserve decimal precision and scale for literals") {
+    val decimal = Decimal(BigDecimal("123.45"))
+    val dt = DecimalType(10, 2)
+    val literal = Literal.create(decimal, dt)
+    val oi = toInspector(literal).asInstanceOf[PrimitiveObjectInspector]
+    val typeInfo = oi.getTypeInfo.asInstanceOf[DecimalTypeInfo]
+    assert(typeInfo.precision() === 10)
+    assert(typeInfo.scale() === 2)
+
+    // Null literal should still preserve type info
+    val nullLiteral = Literal.create(null, DecimalType(18, 10))
+    val oi2 = toInspector(nullLiteral).asInstanceOf[PrimitiveObjectInspector]
+    val typeInfo2 = oi2.getTypeInfo.asInstanceOf[DecimalTypeInfo]
+    assert(typeInfo2.precision() === 18)
+    assert(typeInfo2.scale() === 10)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix `toInspector(dataType: DataType)` and `toInspector(expr: Expression)` in HiveInspectors to preserve the actual decimal precision and scale instead of always using `Hive's default precision (38, 18)`.  

Column-reference path (toInspector(dataType)): The existing code had a // TODO decimal precision? comment and always returned `javaHiveDecimalObjectInspector`. This replaces it with `getPrimitiveJavaObjectInspector(new DecimalTypeInfo(precision, scale))`.

Literal-expression path (toInspector(expr)): `getDecimalWritableConstantObjectInspector` hardcoded `TypeInfoFactory.decimalTypeInfo` (the (38, 18) singleton). Now extracts precision/scale from the literal's DecimalType and passes it through.

Both fixes align with the existing `typeInfoConversions` precedent in the same file, which already uses new `DecimalTypeInfo(precision, scale)`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When a Hive UDF (e.g., mask) operates on a Decimal(18, 10) column or receives a decimal literal argument, the result incorrectly has scale 18 instead of 10, because the inspector always reports (38, 18) regardless of the actual type. The fix is generic - it correctly handles all decimal precisions and scales, not just a specific case.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Hive UDFs operating on decimal columns and decimal literal arguments will now return results with the correct precision and scale, matching the input type.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added tests in `HiveInspectorSuite` verifying that both `toInspector(dataType)` and `toInspector(expr)` preserve precision/scale for `DecimalType(18, 10)`, `DecimalType(10, 2)`, `DecimalType.SYSTEM_DEFAULT`, and `null literals`.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes.