### PR TITLE
[SPARK-46912][CORE] Preserve local environment variables' precedence

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/CommandUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/CommandUtils.scala
@@ -20,6 +20,7 @@ package org.apache.spark.deploy.worker
 import java.io.{File, FileOutputStream, InputStream, IOException}
 
 import scala.collection.Map
+import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.{SecurityManager, SSLOptions}
@@ -39,13 +40,13 @@ object CommandUtils extends Logging {
    * The `env` argument is exposed for testing.
    */
   def buildProcessBuilder(
-      command: Command,
-      securityMgr: SecurityManager,
-      memory: Int,
-      sparkHome: String,
-      substituteArguments: String => String,
-      classPaths: Seq[String] = Seq.empty,
-      env: Map[String, String] = sys.env): ProcessBuilder = {
+                           command: Command,
+                           securityMgr: SecurityManager,
+                           memory: Int,
+                           sparkHome: String,
+                           substituteArguments: String => String,
+                           classPaths: Seq[String] = Seq.empty,
+                           env: Map[String, String] = sys.env): ProcessBuilder = {
     val localCommand = buildLocalCommand(
       command, securityMgr, substituteArguments, classPaths, env)
     val commandSeq = buildCommandSeq(localCommand, memory, sparkHome)
@@ -70,29 +71,33 @@ object CommandUtils extends Logging {
    * any extra class paths.
    */
   private def buildLocalCommand(
-      command: Command,
-      securityMgr: SecurityManager,
-      substituteArguments: String => String,
-      classPath: Seq[String] = Seq.empty,
-      env: Map[String, String]): Command = {
+                                 command: Command,
+                                 securityMgr: SecurityManager,
+                                 substituteArguments: String => String,
+                                 classPath: Seq[String] = Seq.empty,
+                                 env: Map[String, String]): Command = {
     val libraryPathName = Utils.libraryPathEnvName
     val libraryPathEntries = command.libraryPathEntries
     val cmdLibraryPath = command.environment.get(libraryPathName)
 
-    var newEnvironment = if (libraryPathEntries.nonEmpty && libraryPathName.nonEmpty) {
+    val newEnvironment = new mutable.HashMap[String, String]()
+    newEnvironment.addAll(env)
+
+    if (libraryPathEntries.nonEmpty && libraryPathName.nonEmpty) {
       val libraryPaths = libraryPathEntries ++ cmdLibraryPath ++ env.get(libraryPathName)
-      command.environment ++ Map(libraryPathName -> libraryPaths.mkString(File.pathSeparator))
-    } else {
-      command.environment
+      newEnvironment.put(libraryPathName, libraryPaths.mkString(File.pathSeparator))
+    }
+
+    for ((k, v) <- command.environment) {
+      newEnvironment.getOrElseUpdate(k, v)
     }
 
     // set auth secret to env variable if needed
     if (securityMgr.isAuthenticationEnabled()) {
-      newEnvironment = newEnvironment ++
-        Map(SecurityManager.ENV_AUTH_SECRET -> securityMgr.getSecretKey())
+      newEnvironment.put(SecurityManager.ENV_AUTH_SECRET, securityMgr.getSecretKey())
     }
     // set SSL env variables if needed
-    newEnvironment ++= securityMgr.getEnvironmentForSslRpcPasswords
+    newEnvironment.addAll(securityMgr.getEnvironmentForSslRpcPasswords)
 
     Command(
       command.mainClass,
@@ -103,9 +108,9 @@ object CommandUtils extends Logging {
       // filter out secrets from java options
       command.javaOpts.filterNot(opts =>
         opts.startsWith("-D" + SecurityManager.SPARK_AUTH_SECRET_CONF) ||
-        SSLOptions.SPARK_RPC_SSL_PASSWORD_FIELDS.exists(
-          field => opts.startsWith("-D" + field)
-        )
+          SSLOptions.SPARK_RPC_SSL_PASSWORD_FIELDS.exists(
+            field => opts.startsWith("-D" + field)
+          )
       ))
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fixing environment for stand alone cluster when launching driver/executor processes.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fixing a bug when submitting to a standalone cluster from a machine which has different envs and paths
Closes #51314 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. According to https://issues.apache.org/jira/browse/SPARK-46912 when submitting to stand alone cluster in cluster mode, driver was trying to launch java on the path from JAVA_HOME, which, in turn, was taken from "submitter" machine not from the worker one. And java.IOException with "Cannot run program /${wrongPath}" is thrown.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests.
Submitting to upgraded custom Stand Alone cluster from a docker container which has a different environment than cluster.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No