### PR TITLE
[SPARK-56720][SS] Fail subsequent async log writes after a prior failure in async progress tracking

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncCommitLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncCommitLog.scala
@@ -19,13 +19,13 @@ package org.apache.spark.sql.execution.streaming.checkpointing
 
 import java.io.OutputStream
 import java.util.concurrent.{CompletableFuture, ConcurrentLinkedDeque, ThreadPoolExecutor}
-import java.util.concurrent.atomic.AtomicReference
 
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.internal.LogKeys
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.execution.streaming.runtime.ErrorNotifier
 
 /**
  * Implementation of CommitLog to perform asynchronous writes to storage
@@ -34,7 +34,7 @@ class AsyncCommitLog(
     sparkSession: SparkSession,
     path: String,
     executorService: ThreadPoolExecutor,
-    asyncWriteError: AtomicReference[Throwable] = new AtomicReference[Throwable]())
+    errorNotifier: ErrorNotifier = new ErrorNotifier())
   extends CommitLog(sparkSession, path) {
 
   // the cache needs to be enabled because we may not be persisting every entry to durable storage
@@ -113,7 +113,7 @@ class AsyncCommitLog(
     } else {
       executorService.submit(new Runnable {
         override def run(): Unit = {
-          val priorError = asyncWriteError.get()
+          val priorError = errorNotifier.getError().orNull
           if (priorError != null) {
             logWarning(log"Skipping async commit write for batch " +
               log"${MDC(LogKeys.BATCH_ID, batchId)} because a previous async " +
@@ -141,7 +141,7 @@ class AsyncCommitLog(
             case e: Throwable =>
               logError(log"Encountered error while writing batch " +
                 log"${MDC(LogKeys.BATCH_ID, batchId)} to commit log", e)
-              asyncWriteError.compareAndSet(null, e)
+              errorNotifier.markError(e)
               future.completeExceptionally(e)
           }
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncCommitLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncCommitLog.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.streaming.checkpointing
 
 import java.io.OutputStream
 import java.util.concurrent.{CompletableFuture, ConcurrentLinkedDeque, ThreadPoolExecutor}
+import java.util.concurrent.atomic.AtomicReference
 
 import scala.jdk.CollectionConverters._
 
@@ -29,7 +30,11 @@ import org.apache.spark.sql.errors.QueryExecutionErrors
 /**
  * Implementation of CommitLog to perform asynchronous writes to storage
  */
-class AsyncCommitLog(sparkSession: SparkSession, path: String, executorService: ThreadPoolExecutor)
+class AsyncCommitLog(
+    sparkSession: SparkSession,
+    path: String,
+    executorService: ThreadPoolExecutor,
+    asyncWriteError: AtomicReference[Throwable] = new AtomicReference[Throwable]())
   extends CommitLog(sparkSession, path) {
 
   // the cache needs to be enabled because we may not be persisting every entry to durable storage
@@ -108,6 +113,14 @@ class AsyncCommitLog(sparkSession: SparkSession, path: String, executorService: 
     } else {
       executorService.submit(new Runnable {
         override def run(): Unit = {
+          val priorError = asyncWriteError.get()
+          if (priorError != null) {
+            logWarning(log"Skipping async commit write for batch " +
+              log"${MDC(LogKeys.BATCH_ID, batchId)} because a previous async " +
+              log"write task already failed", priorError)
+            future.completeExceptionally(priorError)
+            return
+          }
           try {
             if (fileManager.exists(batchMetadataFile)) {
               future.complete(false)
@@ -128,6 +141,7 @@ class AsyncCommitLog(sparkSession: SparkSession, path: String, executorService: 
             case e: Throwable =>
               logError(log"Encountered error while writing batch " +
                 log"${MDC(LogKeys.BATCH_ID, batchId)} to commit log", e)
+              asyncWriteError.compareAndSet(null, e)
               future.completeExceptionally(e)
           }
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncCommitLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncCommitLog.scala
@@ -113,15 +113,15 @@ class AsyncCommitLog(
     } else {
       executorService.submit(new Runnable {
         override def run(): Unit = {
-          val priorError = errorNotifier.getError().orNull
-          if (priorError != null) {
-            logWarning(log"Skipping async commit write for batch " +
-              log"${MDC(LogKeys.BATCH_ID, batchId)} because a previous async " +
-              log"write task already failed", priorError)
-            future.completeExceptionally(priorError)
-            return
-          }
           try {
+            val priorError = errorNotifier.getError().orNull
+            if (priorError != null) {
+              logWarning(log"Skipping async commit write for batch " +
+                log"${MDC(LogKeys.BATCH_ID, batchId)} because a previous async " +
+                log"write task already failed", priorError)
+              future.completeExceptionally(priorError)
+              return
+            }
             if (fileManager.exists(batchMetadataFile)) {
               future.complete(false)
             } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncCommitLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncCommitLog.scala
@@ -141,7 +141,6 @@ class AsyncCommitLog(
             case e: Throwable =>
               logError(log"Encountered error while writing batch " +
                 log"${MDC(LogKeys.BATCH_ID, batchId)} to commit log", e)
-              errorNotifier.markError(e)
               future.completeExceptionally(e)
           }
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncOffsetSeqLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncOffsetSeqLog.scala
@@ -19,13 +19,14 @@ package org.apache.spark.sql.execution.streaming.checkpointing
 
 import java.io.OutputStream
 import java.util.concurrent._
-import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
+import java.util.concurrent.atomic.AtomicLong
 
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.internal.{LogKeys}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.execution.streaming.runtime.ErrorNotifier
 import org.apache.spark.util.{Clock, SystemClock}
 
 /**
@@ -37,7 +38,7 @@ class AsyncOffsetSeqLog(
     executorService: ThreadPoolExecutor,
     offsetCommitIntervalMs: Long,
     clock: Clock = new SystemClock(),
-    asyncWriteError: AtomicReference[Throwable] = new AtomicReference[Throwable]())
+    errorNotifier: ErrorNotifier = new ErrorNotifier())
   extends OffsetSeqLog(sparkSession, path) {
 
   // the cache needs to be enabled because we may not be persisting every entry to durable storage
@@ -143,7 +144,7 @@ class AsyncOffsetSeqLog(
     } else {
       executorService.submit(new Runnable {
         override def run(): Unit = {
-          val priorError = asyncWriteError.get()
+          val priorError = errorNotifier.getError().orNull
           if (priorError != null) {
             logWarning(log"Skipping async offset write for batch " +
               log"${MDC(LogKeys.BATCH_ID, batchId)} because a previous async " +
@@ -171,7 +172,7 @@ class AsyncOffsetSeqLog(
             case e: Throwable =>
               logError(log"Encountered error while writing batch " +
                 log"${MDC(LogKeys.BATCH_ID, batchId)} to offset log", e)
-              asyncWriteError.compareAndSet(null, e)
+              errorNotifier.markError(e)
               future.completeExceptionally(e)
           }
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncOffsetSeqLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncOffsetSeqLog.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.streaming.checkpointing
 
 import java.io.OutputStream
 import java.util.concurrent._
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 
 import scala.jdk.CollectionConverters._
 
@@ -36,7 +36,8 @@ class AsyncOffsetSeqLog(
     path: String,
     executorService: ThreadPoolExecutor,
     offsetCommitIntervalMs: Long,
-    clock: Clock = new SystemClock())
+    clock: Clock = new SystemClock(),
+    asyncWriteError: AtomicReference[Throwable] = new AtomicReference[Throwable]())
   extends OffsetSeqLog(sparkSession, path) {
 
   // the cache needs to be enabled because we may not be persisting every entry to durable storage
@@ -142,6 +143,17 @@ class AsyncOffsetSeqLog(
     } else {
       executorService.submit(new Runnable {
         override def run(): Unit = {
+          // If a previous async write task already failed, short-circuit
+          // without writing anything so we don't introduce gaps on durable
+          // storage (e.g. offset N missing while offset N+1 is present).
+          val priorError = asyncWriteError.get()
+          if (priorError != null) {
+            logWarning(log"Skipping async offset write for batch " +
+              log"${MDC(LogKeys.BATCH_ID, batchId)} because a previous async " +
+              log"write task already failed", priorError)
+            future.completeExceptionally(priorError)
+            return
+          }
           try {
             if (fileManager.exists(batchMetadataFile)) {
               future.complete(false)
@@ -162,6 +174,7 @@ class AsyncOffsetSeqLog(
             case e: Throwable =>
               logError(log"Encountered error while writing batch " +
                 log"${MDC(LogKeys.BATCH_ID, batchId)} to offset log", e)
+              asyncWriteError.compareAndSet(null, e)
               future.completeExceptionally(e)
           }
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncOffsetSeqLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncOffsetSeqLog.scala
@@ -172,7 +172,6 @@ class AsyncOffsetSeqLog(
             case e: Throwable =>
               logError(log"Encountered error while writing batch " +
                 log"${MDC(LogKeys.BATCH_ID, batchId)} to offset log", e)
-              errorNotifier.markError(e)
               future.completeExceptionally(e)
           }
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncOffsetSeqLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncOffsetSeqLog.scala
@@ -144,15 +144,15 @@ class AsyncOffsetSeqLog(
     } else {
       executorService.submit(new Runnable {
         override def run(): Unit = {
-          val priorError = errorNotifier.getError().orNull
-          if (priorError != null) {
-            logWarning(log"Skipping async offset write for batch " +
-              log"${MDC(LogKeys.BATCH_ID, batchId)} because a previous async " +
-              log"write task already failed", priorError)
-            future.completeExceptionally(priorError)
-            return
-          }
           try {
+            val priorError = errorNotifier.getError().orNull
+            if (priorError != null) {
+              logWarning(log"Skipping async offset write for batch " +
+                log"${MDC(LogKeys.BATCH_ID, batchId)} because a previous async " +
+                log"write task already failed", priorError)
+              future.completeExceptionally(priorError)
+              return
+            }
             if (fileManager.exists(batchMetadataFile)) {
               future.complete(false)
             } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncOffsetSeqLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/AsyncOffsetSeqLog.scala
@@ -143,9 +143,6 @@ class AsyncOffsetSeqLog(
     } else {
       executorService.submit(new Runnable {
         override def run(): Unit = {
-          // If a previous async write task already failed, short-circuit
-          // without writing anything so we don't introduce gaps on durable
-          // storage (e.g. offset N missing while offset N+1 is present).
           val priorError = asyncWriteError.get()
           if (priorError != null) {
             logWarning(log"Skipping async offset write for batch " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/AsyncProgressTrackingMicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/AsyncProgressTrackingMicroBatchExecution.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.streaming.runtime
 
 import java.util.concurrent._
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 
 import org.apache.spark.internal.LogKeys.{BATCH_ID, PRETTY_ID_STRING}
 import org.apache.spark.sql.catalyst.streaming.WriteToStream
@@ -57,6 +57,13 @@ class AsyncProgressTrackingMicroBatchExecution(
   // used to check during the first batch if the pipeline is stateful
   private var isFirstBatch: Boolean = true
 
+  // Records the first error seen by any async log write task. Subsequent async
+  // log writes short-circuit by failing with this error before touching storage.
+  // This prevents creating gaps on durable storage (e.g. offset N missing while
+  // offset N+1 is present, or commit N+1 written without offset N) when an
+  // earlier async write has already failed.
+  private val firstAsyncWriteError = new AtomicReference[Throwable]()
+
   // thread pool is only one thread because we want offset
   // writes to execute in order in a serialized fashion
   protected val asyncWritesExecutorService
@@ -94,7 +101,8 @@ class AsyncProgressTrackingMicroBatchExecution(
       resolvedCheckpointRoot,
       asyncWritesExecutorService,
       asyncProgressTrackingCheckpointingIntervalMs,
-      triggerClock
+      triggerClock,
+      firstAsyncWriteError
     )
 
   override lazy val offsetLog: AsyncOffsetSeqLog = asyncCheckpointMetadata.offsetLog
@@ -176,7 +184,7 @@ class AsyncProgressTrackingMicroBatchExecution(
       .exceptionally((th: Throwable) => {
         logError(log"Encountered error while performing async offset write for batch " +
           log"${MDC(BATCH_ID, execCtx.batchId)}", th)
-        errorNotifier.markError(th)
+        recordAsyncWriteError(th)
         return
       })
 
@@ -208,7 +216,7 @@ class AsyncProgressTrackingMicroBatchExecution(
           .exceptionally((th: Throwable) => {
             logError(log"Got exception during async write to commit log for batch " +
               log"${MDC(BATCH_ID, execCtx.batchId)}", th)
-            errorNotifier.markError(th)
+            recordAsyncWriteError(th)
             return
           })
       } else {
@@ -293,6 +301,11 @@ class AsyncProgressTrackingMicroBatchExecution(
         )
       case _ => throw new IllegalStateException(s"Unknown type of trigger: $trigger")
     }
+  }
+
+  private def recordAsyncWriteError(th: Throwable): Unit = {
+    firstAsyncWriteError.compareAndSet(null, th)
+    errorNotifier.markError(th)
   }
 
   private def checkNotStatefulStreamingQuery: Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/AsyncProgressTrackingMicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/AsyncProgressTrackingMicroBatchExecution.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.streaming.runtime
 
 import java.util.concurrent._
-import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
+import java.util.concurrent.atomic.AtomicLong
 
 import org.apache.spark.internal.LogKeys.{BATCH_ID, PRETTY_ID_STRING}
 import org.apache.spark.sql.catalyst.streaming.WriteToStream
@@ -56,13 +56,6 @@ class AsyncProgressTrackingMicroBatchExecution(
 
   // used to check during the first batch if the pipeline is stateful
   private var isFirstBatch: Boolean = true
-
-  // Records the first error seen by any async log write task. Subsequent async
-  // log writes short-circuit by failing with this error before touching storage.
-  // This prevents creating gaps on durable storage (e.g. offset N missing while
-  // offset N+1 is present, or commit N+1 written without offset N) when an
-  // earlier async write has already failed.
-  private val firstAsyncWriteError = new AtomicReference[Throwable]()
 
   // thread pool is only one thread because we want offset
   // writes to execute in order in a serialized fashion
@@ -102,7 +95,7 @@ class AsyncProgressTrackingMicroBatchExecution(
       asyncWritesExecutorService,
       asyncProgressTrackingCheckpointingIntervalMs,
       triggerClock,
-      firstAsyncWriteError
+      errorNotifier
     )
 
   override lazy val offsetLog: AsyncOffsetSeqLog = asyncCheckpointMetadata.offsetLog
@@ -184,7 +177,7 @@ class AsyncProgressTrackingMicroBatchExecution(
       .exceptionally((th: Throwable) => {
         logError(log"Encountered error while performing async offset write for batch " +
           log"${MDC(BATCH_ID, execCtx.batchId)}", th)
-        recordAsyncWriteError(th)
+        errorNotifier.markError(th)
         return
       })
 
@@ -216,7 +209,7 @@ class AsyncProgressTrackingMicroBatchExecution(
           .exceptionally((th: Throwable) => {
             logError(log"Got exception during async write to commit log for batch " +
               log"${MDC(BATCH_ID, execCtx.batchId)}", th)
-            recordAsyncWriteError(th)
+            errorNotifier.markError(th)
             return
           })
       } else {
@@ -301,11 +294,6 @@ class AsyncProgressTrackingMicroBatchExecution(
         )
       case _ => throw new IllegalStateException(s"Unknown type of trigger: $trigger")
     }
-  }
-
-  private def recordAsyncWriteError(th: Throwable): Unit = {
-    firstAsyncWriteError.compareAndSet(null, th)
-    errorNotifier.markError(th)
   }
 
   private def checkNotStatefulStreamingQuery: Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/AsyncStreamingQueryCheckpointMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/AsyncStreamingQueryCheckpointMetadata.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution.streaming.runtime
 
 import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.atomic.AtomicReference
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.checkpointing.{AsyncCommitLog, AsyncOffsetSeqLog}
@@ -30,13 +31,17 @@ import org.apache.spark.util.Clock
  * @param asyncWritesExecutorService The executor service for async writes
  * @param asyncProgressTrackingCheckpointingIntervalMs The interval for async progress
  * @param triggerClock The clock to use for trigger time
+ * @param asyncWriteError Shared first-error reference between the offset and commit logs.
+ *                       Once set, any subsequent async write task short-circuits and
+ *                       fails with the recorded error instead of writing to storage.
  */
 class AsyncStreamingQueryCheckpointMetadata(
     sparkSession: SparkSession,
     resolvedCheckpointRoot: String,
     asyncWritesExecutorService: ThreadPoolExecutor,
     asyncProgressTrackingCheckpointingIntervalMs: Long,
-    triggerClock: Clock)
+    triggerClock: Clock,
+    asyncWriteError: AtomicReference[Throwable])
   extends StreamingQueryCheckpointMetadata(sparkSession, resolvedCheckpointRoot) {
 
   override lazy val offsetLog = new AsyncOffsetSeqLog(
@@ -44,13 +49,15 @@ class AsyncStreamingQueryCheckpointMetadata(
     checkpointFile(StreamingCheckpointConstants.DIR_NAME_OFFSETS),
     asyncWritesExecutorService,
     asyncProgressTrackingCheckpointingIntervalMs,
-    clock = triggerClock
+    clock = triggerClock,
+    asyncWriteError = asyncWriteError
   )
 
   override lazy val commitLog = new AsyncCommitLog(
     sparkSession,
     checkpointFile(StreamingCheckpointConstants.DIR_NAME_COMMITS),
-    asyncWritesExecutorService
+    asyncWritesExecutorService,
+    asyncWriteError = asyncWriteError
   )
 
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/AsyncStreamingQueryCheckpointMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/AsyncStreamingQueryCheckpointMetadata.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.execution.streaming.runtime
 
 import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.atomic.AtomicReference
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.checkpointing.{AsyncCommitLog, AsyncOffsetSeqLog}
@@ -31,9 +30,9 @@ import org.apache.spark.util.Clock
  * @param asyncWritesExecutorService The executor service for async writes
  * @param asyncProgressTrackingCheckpointingIntervalMs The interval for async progress
  * @param triggerClock The clock to use for trigger time
- * @param asyncWriteError Shared first-error reference between the offset and commit logs.
- *                       Once set, any subsequent async write task short-circuits and
- *                       fails with the recorded error instead of writing to storage.
+ * @param errorNotifier Shared error sink between the offset and commit logs. Once a
+ *                      first error is recorded, subsequent async write tasks short-circuit
+ *                      with that error instead of writing to durable storage.
  */
 class AsyncStreamingQueryCheckpointMetadata(
     sparkSession: SparkSession,
@@ -41,7 +40,7 @@ class AsyncStreamingQueryCheckpointMetadata(
     asyncWritesExecutorService: ThreadPoolExecutor,
     asyncProgressTrackingCheckpointingIntervalMs: Long,
     triggerClock: Clock,
-    asyncWriteError: AtomicReference[Throwable])
+    errorNotifier: ErrorNotifier)
   extends StreamingQueryCheckpointMetadata(sparkSession, resolvedCheckpointRoot) {
 
   override lazy val offsetLog = new AsyncOffsetSeqLog(
@@ -50,14 +49,14 @@ class AsyncStreamingQueryCheckpointMetadata(
     asyncWritesExecutorService,
     asyncProgressTrackingCheckpointingIntervalMs,
     clock = triggerClock,
-    asyncWriteError = asyncWriteError
+    errorNotifier = errorNotifier
   )
 
   override lazy val commitLog = new AsyncCommitLog(
     sparkSession,
     checkpointFile(StreamingCheckpointConstants.DIR_NAME_COMMITS),
     asyncWritesExecutorService,
-    asyncWriteError = asyncWriteError
+    errorNotifier = errorNotifier
   )
 
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/ErrorNotifier.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/ErrorNotifier.scala
@@ -28,10 +28,14 @@ class ErrorNotifier extends Logging {
 
   private val error = new AtomicReference[Throwable]
 
-  /** To indicate any errors that have occurred */
+  /**
+   * Record a fatal error. Only the first error is retained — subsequent calls
+   * are no-ops so cascading failures cannot mask the original cause.
+   */
   def markError(th: Throwable): Unit = {
-    logError("A fatal error has occurred.", th)
-    error.set(th)
+    if (error.compareAndSet(null, th)) {
+      logError("A fatal error has occurred.", th)
+    }
   }
 
   /** Get any errors that have occurred */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/ErrorNotifier.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/ErrorNotifier.scala
@@ -29,12 +29,18 @@ class ErrorNotifier extends Logging {
   private val error = new AtomicReference[Throwable]
 
   /**
-   * Record a fatal error. Only the first error is retained — subsequent calls
+   * Record a fatal error. Only the first error is retained - subsequent calls
    * are no-ops so cascading failures cannot mask the original cause.
    */
   def markError(th: Throwable): Unit = {
     if (error.compareAndSet(null, th)) {
       logError("A fatal error has occurred.", th)
+    } else {
+      // Attach subsequent errors as suppressed so they're not silently lost.
+      val existing = error.get()
+      if (existing != null && existing != th) {
+        existing.addSuppressed(th)
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.streaming
 
 import java.io.File
 import java.util.concurrent.{CountDownLatch, ExecutionException, Semaphore, TimeUnit}
-import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.mutable.ListBuffer
 
@@ -31,7 +30,7 @@ import org.apache.spark.TestUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.connector.read.streaming
 import org.apache.spark.sql.execution.streaming.checkpointing.{AsyncCommitLog, AsyncOffsetSeqLog, CommitMetadata, OffsetSeq}
-import org.apache.spark.sql.execution.streaming.runtime.{AsyncProgressTrackingMicroBatchExecution, LongOffset, MemoryStream, StreamExecution}
+import org.apache.spark.sql.execution.streaming.runtime.{AsyncProgressTrackingMicroBatchExecution, ErrorNotifier, LongOffset, MemoryStream, StreamExecution}
 import org.apache.spark.sql.execution.streaming.runtime.AsyncProgressTrackingMicroBatchExecution.{ASYNC_PROGRESS_TRACKING_CHECKPOINTING_INTERVAL_MS, ASYNC_PROGRESS_TRACKING_ENABLED, ASYNC_PROGRESS_TRACKING_OVERRIDE_SINK_SUPPORT_CHECK}
 import org.apache.spark.sql.functions.{column, window}
 import org.apache.spark.sql.internal.SQLConf
@@ -750,7 +749,7 @@ class AsyncProgressTrackingMicroBatchExecutionSuite
               val e = intercept[StreamingQueryException] {
                 q.processAllAvailable()
               }
-              e.getCause.getCause.getMessage should include("Permission denied")
+              TestUtils.assertExceptionMsg(e, "Permission denied")
             }
         }
       )
@@ -783,48 +782,35 @@ class AsyncProgressTrackingMicroBatchExecutionSuite
 
     val executor = ThreadUtils.newDaemonSingleThreadExecutor("async-log-write-test")
     try {
-      val sharedError = new AtomicReference[Throwable]()
+      val sharedNotifier = new ErrorNotifier()
       val offsetLog = new AsyncOffsetSeqLog(
         spark, offsetsDir.getAbsolutePath, executor, offsetCommitIntervalMs = 0,
-        asyncWriteError = sharedError)
+        errorNotifier = sharedNotifier)
       val commitLog = new AsyncCommitLog(
-        spark, commitsDir, executor, asyncWriteError = sharedError)
+        spark, commitsDir, executor, errorNotifier = sharedNotifier)
 
-      // Make the offsets dir read-only so the first write fails.
       offsetsDir.setReadOnly()
       try {
         val firstFuture = offsetLog.addAsync(0L, OffsetSeq.fill(LongOffset(0)))
         val firstEx = intercept[ExecutionException] {
           firstFuture.get(5, TimeUnit.SECONDS)
         }
-        // Sanity: the actual failure was recorded in the shared ref.
-        assert(sharedError.get() ne null,
-          "expected first async write failure to populate shared error ref")
-        assert(sharedError.get() eq firstEx.getCause)
-        val firstError = sharedError.get()
+        assert(sharedNotifier.getError().contains(firstEx.getCause))
+        val firstError = sharedNotifier.getError().get
 
-        // A subsequent commit-log write must short-circuit with that same
-        // error instance (and must not produce a commit file).
         val commitFuture = commitLog.addAsync(0L, CommitMetadata())
         val commitEx = intercept[ExecutionException] {
           commitFuture.get(5, TimeUnit.SECONDS)
         }
-        assert(commitEx.getCause eq firstError,
-          "expected commit-log write to short-circuit with the shared first error")
-        assert(getListOfFiles(commitsDir).isEmpty,
-          s"expected no commit files but found: ${getListOfFiles(commitsDir)}")
+        assert(commitEx.getCause eq firstError)
+        assert(getListOfFiles(commitsDir).isEmpty)
 
-        // A subsequent offset-log write must also short-circuit with the same
-        // first error (compareAndSet semantics preserve it across cascading
-        // failures).
         val secondOffsetFuture = offsetLog.addAsync(1L, OffsetSeq.fill(LongOffset(1)))
         val secondOffsetEx = intercept[ExecutionException] {
           secondOffsetFuture.get(5, TimeUnit.SECONDS)
         }
-        assert(secondOffsetEx.getCause eq firstError,
-          "expected later offset-log write to short-circuit with the shared first error")
-        assert(sharedError.get() eq firstError,
-          "shared error must still hold the first error after later short-circuits")
+        assert(secondOffsetEx.getCause eq firstError)
+        assert(sharedNotifier.getError().contains(firstError))
       } finally {
         offsetsDir.setWritable(true)
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
@@ -795,7 +795,9 @@ class AsyncProgressTrackingMicroBatchExecutionSuite
         val firstEx = intercept[ExecutionException] {
           firstFuture.get(5, TimeUnit.SECONDS)
         }
-        assert(sharedNotifier.getError().contains(firstEx.getCause))
+        // In production this is done by the `.exceptionally` chain in
+        // AsyncProgressTrackingMicroBatchExecution.
+        sharedNotifier.markError(firstEx.getCause)
         val firstError = sharedNotifier.getError().get
 
         val commitFuture = commitLog.addAsync(0L, CommitMetadata())

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
@@ -775,12 +775,6 @@ class AsyncProgressTrackingMicroBatchExecutionSuite
     testAsyncWriteErrorsPermissionsIssue("/commits")
   }
 
-  // Regression test: once a previous async log write fails, the shared
-  // first-error reference is populated and any subsequent task scheduled on
-  // the shared executor (offset or commit) short-circuits with that *same*
-  // error instead of writing anything to durable storage. This prevents gaps
-  // such as offset N missing while offset N+1 is present, or a commit-log
-  // entry written without its corresponding offset-log entry.
   test("async log writes record first error and gate subsequent writes") {
     val checkpointLocation = Utils.createTempDir(namePrefix = "streaming.metadata").getCanonicalPath
     val offsetsDir = new File(checkpointLocation + "/offsets")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
@@ -18,7 +18,8 @@
 package org.apache.spark.sql.execution.streaming
 
 import java.io.File
-import java.util.concurrent.{CountDownLatch, Semaphore, TimeUnit}
+import java.util.concurrent.{CountDownLatch, ExecutionException, Semaphore, TimeUnit}
+import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.mutable.ListBuffer
 
@@ -29,14 +30,14 @@ import org.scalatest.time.{Seconds, Span}
 import org.apache.spark.TestUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.connector.read.streaming
-import org.apache.spark.sql.execution.streaming.checkpointing.{AsyncCommitLog, AsyncOffsetSeqLog}
-import org.apache.spark.sql.execution.streaming.runtime.{AsyncProgressTrackingMicroBatchExecution, MemoryStream, StreamExecution}
+import org.apache.spark.sql.execution.streaming.checkpointing.{AsyncCommitLog, AsyncOffsetSeqLog, CommitMetadata, OffsetSeq}
+import org.apache.spark.sql.execution.streaming.runtime.{AsyncProgressTrackingMicroBatchExecution, LongOffset, MemoryStream, StreamExecution}
 import org.apache.spark.sql.execution.streaming.runtime.AsyncProgressTrackingMicroBatchExecution.{ASYNC_PROGRESS_TRACKING_CHECKPOINTING_INTERVAL_MS, ASYNC_PROGRESS_TRACKING_ENABLED, ASYNC_PROGRESS_TRACKING_OVERRIDE_SINK_SUPPORT_CHECK}
 import org.apache.spark.sql.functions.{column, window}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException, StreamTest, Trigger}
 import org.apache.spark.sql.streaming.util.StreamManualClock
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{ThreadUtils, Utils}
 
 class AsyncProgressTrackingMicroBatchExecutionSuite
   extends StreamTest with BeforeAndAfter with Matchers {
@@ -772,6 +773,70 @@ class AsyncProgressTrackingMicroBatchExecutionSuite
   test("bubble up async commit log write errors 2" +
     ": commit file already exists for a batch") {
     testAsyncWriteErrorsPermissionsIssue("/commits")
+  }
+
+  // Regression test: once a previous async log write fails, the shared
+  // first-error reference is populated and any subsequent task scheduled on
+  // the shared executor (offset or commit) short-circuits with that *same*
+  // error instead of writing anything to durable storage. This prevents gaps
+  // such as offset N missing while offset N+1 is present, or a commit-log
+  // entry written without its corresponding offset-log entry.
+  test("async log writes record first error and gate subsequent writes") {
+    val checkpointLocation = Utils.createTempDir(namePrefix = "streaming.metadata").getCanonicalPath
+    val offsetsDir = new File(checkpointLocation + "/offsets")
+    val commitsDir = checkpointLocation + "/commits"
+    offsetsDir.mkdirs()
+
+    val executor = ThreadUtils.newDaemonSingleThreadExecutor("async-log-write-test")
+    try {
+      val sharedError = new AtomicReference[Throwable]()
+      val offsetLog = new AsyncOffsetSeqLog(
+        spark, offsetsDir.getAbsolutePath, executor, offsetCommitIntervalMs = 0,
+        asyncWriteError = sharedError)
+      val commitLog = new AsyncCommitLog(
+        spark, commitsDir, executor, asyncWriteError = sharedError)
+
+      // Make the offsets dir read-only so the first write fails.
+      offsetsDir.setReadOnly()
+      try {
+        val firstFuture = offsetLog.addAsync(0L, OffsetSeq.fill(LongOffset(0)))
+        val firstEx = intercept[ExecutionException] {
+          firstFuture.get(5, TimeUnit.SECONDS)
+        }
+        // Sanity: the actual failure was recorded in the shared ref.
+        assert(sharedError.get() ne null,
+          "expected first async write failure to populate shared error ref")
+        assert(sharedError.get() eq firstEx.getCause)
+        val firstError = sharedError.get()
+
+        // A subsequent commit-log write must short-circuit with that same
+        // error instance (and must not produce a commit file).
+        val commitFuture = commitLog.addAsync(0L, CommitMetadata())
+        val commitEx = intercept[ExecutionException] {
+          commitFuture.get(5, TimeUnit.SECONDS)
+        }
+        assert(commitEx.getCause eq firstError,
+          "expected commit-log write to short-circuit with the shared first error")
+        assert(getListOfFiles(commitsDir).isEmpty,
+          s"expected no commit files but found: ${getListOfFiles(commitsDir)}")
+
+        // A subsequent offset-log write must also short-circuit with the same
+        // first error (compareAndSet semantics preserve it across cascading
+        // failures).
+        val secondOffsetFuture = offsetLog.addAsync(1L, OffsetSeq.fill(LongOffset(1)))
+        val secondOffsetEx = intercept[ExecutionException] {
+          secondOffsetFuture.get(5, TimeUnit.SECONDS)
+        }
+        assert(secondOffsetEx.getCause eq firstError,
+          "expected later offset-log write to short-circuit with the shared first error")
+        assert(sharedError.get() eq firstError,
+          "shared error must still hold the first error after later short-circuits")
+      } finally {
+        offsetsDir.setWritable(true)
+      }
+    } finally {
+      executor.shutdownNow()
+    }
   }
 
   test("commit intervals happy path") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Pass the shared error recorder ErrorNotifier to both `AsyncOffsetSeqLog` and `AsyncCommitLog`. Once the first failure is recorded:

- Subsequent offset and commit log write tasks short-circuit by failing with the original error without touching durable storage.
- The first error is preserved via `compareAndSet(null, err)` so it is not overwritten by later cascading failures.

The shared reference is owned by `AsyncProgressTrackingMicroBatchExecution` and threaded through `AsyncStreamingQueryCheckpointMetadata` to both async logs. The existing `.exceptionally` handlers in `markMicroBatchStart` / `markMicroBatchEnd` are routed through a new `recordAsyncWriteError` helper so the shared ref is also populated when the failure originates from `addAsync`'s own `thenApply` (e.g. `concurrentStreamLogUpdate`).

### Why are the changes needed?

When async progress tracking is enabled, offset and commit log writes are submitted to a single-threaded executor service. If one async write task fails, follow-up writes already queued (or queued shortly afterward) can still proceed and persist files to durable storage, leaving inconsistent state on disk — for example a commit-log entry written without its corresponding offset-log entry.

The original error can also be overwritten in the `ErrorNotifier` by a later cascading failure, so the user-visible exception masks the root cause (e.g. surfacing `concurrentStreamLogUpdate` instead of the actual `Permission denied` / IOException that started the cascade).

### Does this PR introduce _any_ user-facing change?

No. Async-progress-tracking queries that hit a write failure will now surface the root cause instead of a later cascading error, but the failure mode (query termination with a `StreamingQueryException`) is unchanged.

### How was this patch tested?

Added a regression test in `AsyncProgressTrackingMicroBatchExecutionSuite` that triggers a real I/O failure on the first offset write and verifies:

1. The shared first-error reference is populated.
2. A follow-up commit-log write short-circuits with the original error and produces no commit file.
3. A follow-up offset-log write for the next batch also short-circuits with the same first error.
4. The shared error reference is not overwritten by later cascading failures.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor (Claude Opus 4.7)