### PR TITLE
[MINOR][DOCS] Clarify when to ask the user before running tests in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Avoid introducing non-ASCII characters in code or comments. String literals may 
 
 ## Build and Test
 
-Build and tests can take a long time. Before running tests, ask the user if they have more changes to make.
+Build and tests can take a long time. If the user explicitly asked to run tests, run them. Otherwise (you are running tests on your own to verify a change), first ask the user if they have more changes to make.
 
 Prefer SBT over Maven for faster incremental compilation. Module names are defined in `project/SparkBuild.scala`.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Tighten the wording in `AGENTS.md` that tells coding agents to ask the user about pending changes before running tests. The previous wording fired even when the user explicitly asked for a test run.

Before:
> Build and tests can take a long time. Before running tests, ask the user if they have more changes to make.

After:
> Build and tests can take a long time. If the user explicitly asked to run tests, run them. Otherwise (you are running tests on your own to verify a change), first ask the user if they have more changes to make.

### Why are the changes needed?

The intent of the original instruction was to avoid kicking off a long, agent-initiated test run when the user has more edits coming. But as written, it also applies when the user explicitly requests a test run, which makes the prompt redundant and annoying. Spelling out both branches makes it easier for LLMs to follow the rule correctly.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only update for coding agent instructions.

### How was this patch tested?

N/A — documentation only.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.7)