### PR TITLE
[SPARK-56395][FOLLOWUP][SQL] Reject NearestByJoin when spark.sql.crossJoin.enabled is false

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5324,6 +5324,11 @@
       "Invalid nearest-by join."
     ],
     "subClass" : {
+      "CROSS_JOIN_NOT_ENABLED" : {
+        "message" : [
+          "Nearest-by join is implemented as a bounded cross-product internally and is therefore rejected when `spark.sql.crossJoin.enabled = false`. Set `spark.sql.crossJoin.enabled = true` to permit it, or rewrite the query without nearest-by."
+        ]
+      },
       "EXACT_WITH_NONDETERMINISTIC_EXPRESSION" : {
         "message" : [
           "EXACT nearest-by join is incompatible with the nondeterministic ranking expression <expression>. Use APPROX, or replace the expression with a deterministic one."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -671,6 +671,11 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
               errorClass = "NEAREST_BY_JOIN.STREAMING_NOT_SUPPORTED",
               messageParameters = Map.empty)
 
+          case j: NearestByJoin if !conf.crossJoinEnabled =>
+            j.failAnalysis(
+              errorClass = "NEAREST_BY_JOIN.CROSS_JOIN_NOT_ENABLED",
+              messageParameters = Map.empty)
+
           case j @ NearestByJoin(_, _, _, _, _, rankingExpression, _)
               if !RowOrdering.isOrderable(rankingExpression.dataType) =>
             j.failAnalysis(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -938,6 +938,21 @@ class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {
       expectedMessageParameters = Map.empty)
   }
 
+  test("NearestByJoin is rejected when spark.sql.crossJoin.enabled is false") {
+    val left = LocalRelation(AttributeReference("a", IntegerType)())
+    val right = LocalRelation(AttributeReference("b", IntegerType)())
+    val nearestBy = NearestByJoin(
+      left, right, Inner, approx = true, numResults = 1,
+      rankingExpression = left.output.head + right.output.head,
+      direction = NearestBySimilarity)
+    withSQLConf(SQLConf.CROSS_JOINS_ENABLED.key -> "false") {
+      assertAnalysisErrorCondition(
+        nearestBy,
+        expectedErrorCondition = "NEAREST_BY_JOIN.CROSS_JOIN_NOT_ENABLED",
+        expectedMessageParameters = Map.empty)
+    }
+  }
+
   test("check grouping expression data types") {
     def checkDataType(dataType: DataType): Unit = {
       val plan =

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/join-nearest-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/join-nearest-by.sql.out
@@ -348,18 +348,18 @@ SELECT u.user_id, p.product
 FROM users u JOIN products p
   APPROX NEAREST 1 BY SIMILARITY -abs(u.score - p.pscore)
 -- !query analysis
-Project [user_id#x, product#x]
-+- NearestByJoin Inner, true, 1, -abs((score#x - pscore#x)), NearestBySimilarity
-   :- SubqueryAlias u
-   :  +- SubqueryAlias spark_catalog.default.users
-   :     +- View (`spark_catalog`.`default`.`users`, [user_id#x, score#x])
-   :        +- Project [cast(col1#x as int) AS user_id#x, cast(col2#x as decimal(3,1)) AS score#x]
-   :           +- LocalRelation [col1#x, col2#x]
-   +- SubqueryAlias p
-      +- SubqueryAlias spark_catalog.default.products
-         +- View (`spark_catalog`.`default`.`products`, [product#x, pscore#x])
-            +- Project [cast(col1#x as string) AS product#x, cast(col2#x as decimal(3,1)) AS pscore#x]
-               +- LocalRelation [col1#x, col2#x]
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "NEAREST_BY_JOIN.CROSS_JOIN_NOT_ENABLED",
+  "sqlState" : "42604",
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 42,
+    "stopIndex" : 114,
+    "fragment" : "JOIN products p\n  APPROX NEAREST 1 BY SIMILARITY -abs(u.score - p.pscore)"
+  } ]
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/join-nearest-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/join-nearest-by.sql.out
@@ -365,14 +365,17 @@ FROM users u JOIN products p
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.AnalysisException
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1211",
-  "messageParameters" : {
-    "joinType" : "LEFT OUTER",
-    "leftPlan" : "Project [col1#x AS user_id#x, col2#x AS score#x, uuid(Some(x)) AS __qid#x]\n+- LocalRelation [col1#x, col2#x]",
-    "rightPlan" : "Project [col1#x AS product#x, col2#x AS pscore#x]\n+- LocalRelation [col1#x, col2#x]"
-  }
+  "errorClass" : "NEAREST_BY_JOIN.CROSS_JOIN_NOT_ENABLED",
+  "sqlState" : "42604",
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 42,
+    "stopIndex" : 114,
+    "fragment" : "JOIN products p\n  APPROX NEAREST 1 BY SIMILARITY -abs(u.score - p.pscore)"
+  } ]
 }
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Followup of #55629, addressing the review comment at https://github.com/apache/spark/pull/55629#discussion_r3185614384.

Adds a dedicated `CheckAnalysis` case that fails with `NEAREST_BY_JOIN.CROSS_JOIN_NOT_ENABLED` when a nearest-by join is attempted while `spark.sql.crossJoin.enabled = false`. Previously the query fell through to the generic cross-join check and produced a confusing, unrelated error.

### Why are the changes needed?

The nearest-by join is internally implemented as a bounded cross-product. Without this guard a user gets the misleading `_LEGACY_ERROR_TEMP_1211` cross-join error rather than a clear message explaining the relationship to `spark.sql.crossJoin.enabled`.

### Does this PR introduce _any_ user-facing change?

Yes. Users who run a nearest-by join with `spark.sql.crossJoin.enabled = false` now receive the structured error `NEAREST_BY_JOIN.CROSS_JOIN_NOT_ENABLED` with an actionable message instead of a generic cross-join error.

### How was this patch tested?

- New unit test in `AnalysisErrorSuite` (`NearestByJoin is rejected when spark.sql.crossJoin.enabled is false`)
- Updated SQL golden files (`join-nearest-by.sql.out`) regenerated to reflect the new error

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-sonnet-4-6)