### PR TITLE
[SPARK-56729][SQL] ReplaceData and WriteDelta should implement SupportsNonDeterministicExpression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -347,7 +347,10 @@ case class ReplaceData(
     originalTable: NamedRelation,
     projections: ReplaceDataProjections,
     groupFilterCondition: Option[Expression] = None,
-    write: Option[Write] = None) extends RowLevelWrite {
+    write: Option[Write] = None)
+    extends RowLevelWrite with SupportsNonDeterministicExpression {
+
+  override def allowNonDeterministicExpression: Boolean = true
 
   override val isByName: Boolean = false
   override val withSchemaEvolution: Boolean = false
@@ -435,7 +438,9 @@ case class WriteDelta(
     originalTable: NamedRelation,
     projections: WriteDeltaProjections,
     groupFilterCondition: Option[Expression] = None,
-    write: Option[DeltaWrite] = None) extends RowLevelWrite {
+    write: Option[DeltaWrite] = None) extends RowLevelWrite with SupportsNonDeterministicExpression {
+
+  override def allowNonDeterministicExpression: Boolean = true
 
   override val isByName: Boolean = false
   override val withSchemaEvolution: Boolean = false

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -1330,4 +1330,11 @@ class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {
       "INVALID_NON_DETERMINISTIC_EXPRESSIONS" :: Nil
     )
   }
+
+  test("SPARK-56729: ReplaceData and WriteDelta allow non-deterministic expressions") {
+    assert(classOf[SupportsNonDeterministicExpression].isAssignableFrom(classOf[ReplaceData]),
+      "ReplaceData should implement SupportsNonDeterministicExpression")
+    assert(classOf[SupportsNonDeterministicExpression].isAssignableFrom(classOf[WriteDelta]),
+      "WriteDelta should implement SupportsNonDeterministicExpression")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`ReplaceData` and `WriteDelta` now implement the `SupportsNonDeterministicExpression` trait (introduced in SPARK-48871). This fixes `INVALID_NON_DETERMINISTIC_EXPRESSIONS` errors when running `MERGE INTO` on DSv2 tables (e.g. Apache Iceberg) where the source plan contains non-deterministic expressions such as `uuid()`, `current_timestamp()`, or `input_file_name()`.

### Why are the changes needed?

In Spark 3.5, `RewriteMergeIntoTable` wraps the source plan in an `Exists` subquery stored as `groupFilterCondition` on `ReplaceData`. If the source plan contains any non-deterministic expression, the `Exists` becomes non-deterministic and `CheckAnalysis` rejects the query. The `SupportsNonDeterministicExpression` trait was introduced in SPARK-48871 for exactly this situation, but was never applied to `ReplaceData` or `WriteDelta`. This is a regression from Spark 3.3, where these queries worked correctly.

Root cause analysis by @DaxterXS in [apache/iceberg#14585](https://github.com/apache/iceberg/issues/14585). Multiple users affected across AWS Glue 4/5 with Iceberg 1.7–1.10.

### Does this PR introduce _any_ user-facing change?

Yes. `MERGE INTO` queries with non-deterministic expressions in the source plan will no longer fail with `INVALID_NON_DETERMINISTIC_EXPRESSIONS`.

### How was this patch tested?

Added unit tests in `AnalysisErrorSuite` verifying that `ReplaceData` and `WriteDelta` implement `SupportsNonDeterministicExpression`.

### Was this patch authored or co-authored using generative AI tooling?

No.