### PR TITLE
[MINOR][PYTHON][TESTS] Rename `test_utils` to `test_parity_utils` for Connect parity convention

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -1188,7 +1188,7 @@ pyspark_connect = Module(
         "pyspark.sql.tests.connect.test_parity_python_datasource",
         "pyspark.sql.tests.connect.test_parity_frame_plot",
         "pyspark.sql.tests.connect.test_parity_frame_plot_plotly",
-        "pyspark.sql.tests.connect.test_utils",
+        "pyspark.sql.tests.connect.test_parity_utils",
         "pyspark.sql.tests.connect.client.test_artifact",
         "pyspark.sql.tests.connect.client.test_artifact_localcluster",
         "pyspark.sql.tests.connect.client.test_client",

--- a/python/pyspark/sql/tests/connect/test_parity_utils.py
+++ b/python/pyspark/sql/tests/connect/test_parity_utils.py
@@ -19,7 +19,7 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.sql.tests.test_utils import UtilsTestsMixin
 
 
-class ConnectUtilsTests(UtilsTestsMixin, ReusedConnectTestCase):
+class UtilsParityTests(UtilsTestsMixin, ReusedConnectTestCase):
     pass
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

The Connect parity test file `python/pyspark/sql/tests/connect/test_utils.py` and its class `ConnectUtilsTests` don't follow the naming convention used by 200+ other parity tests in `python/pyspark/sql/tests/connect/`:

- Filename should be `test_parity_<name>.py`.
- Class name should be `<Name>ParityTests`.

This PR renames:
- `python/pyspark/sql/tests/connect/test_utils.py` -> `python/pyspark/sql/tests/connect/test_parity_utils.py`
- `ConnectUtilsTests` -> `UtilsParityTests`

The reference to the old module path is updated in `dev/sparktestsupport/modules.py`.

### Why are the changes needed?

Consistency. The `test_parity_*` filename and `*ParityTests` class name are the established convention across the Connect parity test suite; this rename brings the utils parity test in line and makes it easier to locate and identify parity tests at a glance.

### Does this PR introduce _any_ user-facing change?

No. Test-only change with no behavioral impact.

### How was this patch tested?

Existing tests; only filename and class name changed. The test module is still discovered through `dev/sparktestsupport/modules.py`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)