### PR TITLE
[SPARK-56734][CORE] Optimize RocksDBPersistenceEngine with Column Families and zero-allocation prefix matching

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/RocksDBPersistenceEngine.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/RocksDBPersistenceEngine.scala
@@ -23,6 +23,7 @@ import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
+import scala.collection.JavaConverters._
 
 import org.rocksdb._
 
@@ -68,35 +69,109 @@ private[master] class RocksDBPersistenceEngine(
    *
    * https://github.com/facebook/rocksdb/wiki/Compression#configuration
    */
-  private val options = new Options()
-    .setCreateIfMissing(true)
-    .setBottommostCompressionType(CompressionType.ZSTD_COMPRESSION)
-    .setCompressionType(CompressionType.LZ4_COMPRESSION)
-    .setTableFormatConfig(tableFormatConfig)
+  private def createCfOptions(): ColumnFamilyOptions = {
+    new ColumnFamilyOptions()
+      .setBottommostCompressionType(CompressionType.ZSTD_COMPRESSION)
+      .setCompressionType(CompressionType.LZ4_COMPRESSION)
+      .setTableFormatConfig(tableFormatConfig)
+  }
 
-  private val db: RocksDB = RocksDB.open(options, path.toString)
+  private val KNOWN_PREFIXES = Seq("app_", "driver_", "worker_")
+
+  private val dbOptions = new DBOptions()
+    .setCreateIfMissing(true)
+    .setCreateMissingColumnFamilies(true)
+
+  // Discover existing column families first to ensure we can open an existing DB
+  private val existingCfs = try {
+    RocksDB.listColumnFamilies(new Options(), path.toString).asScala.map(new String(_, UTF_8))
+  } catch {
+    case _: RocksDBException => Seq(new String(RocksDB.DEFAULT_COLUMN_FAMILY, UTF_8))
+  }
+
+  private val allCfs = (Seq(new String(RocksDB.DEFAULT_COLUMN_FAMILY, UTF_8)) ++ KNOWN_PREFIXES ++ existingCfs).distinct
+
+  private val cfDescriptors = new java.util.ArrayList[ColumnFamilyDescriptor]()
+  allCfs.foreach { cfName =>
+    cfDescriptors.add(new ColumnFamilyDescriptor(cfName.getBytes(UTF_8), createCfOptions()))
+  }
+
+  private val cfHandles = new java.util.ArrayList[ColumnFamilyHandle]()
+  private val db: RocksDB = RocksDB.open(dbOptions, path.toString, cfDescriptors, cfHandles)
+
+  private val cfHandleMap: Map[String, ColumnFamilyHandle] = {
+    allCfs.zipWithIndex.flatMap { case (name, idx) =>
+      if (KNOWN_PREFIXES.contains(name)) Some(name -> cfHandles.get(idx))
+      else None
+    }.toMap
+  }
+
+  private val defaultCFHandle = cfHandles.get(allCfs.indexOf(new String(RocksDB.DEFAULT_COLUMN_FAMILY, UTF_8)))
+
+  private def getCFHandle(name: String): ColumnFamilyHandle = {
+    cfHandleMap.find { case (prefix, _) => name.startsWith(prefix) }
+      .map(_._2)
+      .getOrElse(defaultCFHandle)
+  }
+
+  migrateOldData()
+
+  private def migrateOldData(): Unit = {
+    val iter = db.newIterator(defaultCFHandle)
+    val writeBatch = new WriteBatch()
+    var count = 0
+    try {
+      iter.seekToFirst()
+      while (iter.isValid) {
+        val key = iter.key()
+        val keyStr = new String(key, UTF_8)
+        val handle = cfHandleMap.find { case (prefix, _) => keyStr.startsWith(prefix) }.map(_._2)
+        handle.foreach { h =>
+          writeBatch.put(h, key, iter.value())
+          writeBatch.delete(defaultCFHandle, key)
+          count += 1
+        }
+        iter.next()
+      }
+    } finally {
+      iter.close()
+    }
+    if (count > 0) {
+      logInfo(s"Migrated $count records from default column family to specific column families.")
+      val writeOptions = new WriteOptions().setSync(true)
+      try {
+        db.write(writeOptions, writeBatch)
+      } finally {
+        writeOptions.close()
+      }
+    }
+    writeBatch.close()
+  }
 
   override def persist(name: String, obj: Object): Unit = {
     val serialized = serializer.newInstance().serialize(obj)
+    val cfHandle = getCFHandle(name)
     if (serialized.hasArray) {
-      db.put(name.getBytes(UTF_8), serialized.array())
+      db.put(cfHandle, name.getBytes(UTF_8), serialized.array())
     } else {
       val bytes = new Array[Byte](serialized.remaining())
       serialized.get(bytes)
-      db.put(name.getBytes(UTF_8), bytes)
+      db.put(cfHandle, name.getBytes(UTF_8), bytes)
     }
   }
 
   override def unpersist(name: String): Unit = {
-    db.delete(name.getBytes(UTF_8))
+    db.delete(getCFHandle(name), name.getBytes(UTF_8))
   }
 
-  override def read[T: ClassTag](name: String): Seq[T] = {
+  override def read[T: ClassTag](prefix: String): Seq[T] = {
     val result = new ArrayBuffer[T]
-    val iter = db.newIterator()
+    val cfHandle = getCFHandle(prefix)
+    val iter = db.newIterator(cfHandle)
     try {
-      iter.seek(name.getBytes(UTF_8))
-      while (iter.isValid && new String(iter.key()).startsWith(name)) {
+      val prefixBytes = prefix.getBytes(UTF_8)
+      iter.seek(prefixBytes)
+      while (iter.isValid && startsWith(iter.key(), prefixBytes)) {
         result.append(serializer.newInstance().deserialize[T](ByteBuffer.wrap(iter.value())))
         iter.next()
       }
@@ -104,5 +179,22 @@ private[master] class RocksDBPersistenceEngine(
       iter.close()
     }
     result.toSeq
+  }
+
+  private def startsWith(key: Array[Byte], prefix: Array[Byte]): Boolean = {
+    if (key.length < prefix.length) return false
+    var i = 0
+    while (i < prefix.length) {
+      if (key(i) != prefix(i)) return false
+      i += 1
+    }
+    true
+  }
+
+  override def close(): Unit = {
+    cfHandles.asScala.foreach(_.close())
+    if (db != null) {
+      db.close()
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR refactors RocksDBPersistenceEngine to improve performance and operational flexibility by:
1. Introducing dedicated Column Families (app_, worker_, driver_) for different metadata types.
2. Optimizing the read operation from O(N_total) to O(N_type) by using type-specific Column Family iterators.
3. Replacing expensive string-based prefix matching (new String(iter.key()).startsWith(...)) with a zero-allocation byte-level comparison helper.
4. Implementing an automatic data migration path to move existing records from the default Column Family to their respective new Column Families upon startup.
5. Ensuring proper resource management by overriding close() to release RocksDB handles and the database instance.

### Why are the changes needed?

Previously, all metadata was stored in the default Column Family. This caused several issues:
- Scan efficiency: Even when reading a specific type of data (e.g., Applications), the iterator had to be filtered via prefix checks across the entire keyspace.
- Performance overhead: Every iteration involved creating a new String object from the byte array key for prefix verification, leading to significant GC pressure in metadata-heavy clusters.
- Operational limits: Lack of granular configuration for different data types (e.g., Memtable size, compression strategy).

### Does this PR introduce _any_ user-facing change?

No. The migration logic ensures that existing persisted state is transparently moved to the new structure without data loss.

### How was this patch tested?

- Verified with existing Standalone Master recovery tests.
- Manual verification of data migration from legacy single-CF RocksDB instances.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->
