### PR TITLE
[SPARK-56736][K8S] Add `sparkVersion` method to `KubernetesConf` abstract class

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -49,6 +49,8 @@ private[spark] abstract class KubernetesConf(val sparkConf: SparkConf) {
 
   def appName: String = get("spark.app.name", "spark")
 
+  def sparkVersion: String = SPARK_VERSION
+
   def namespace: String = get(KUBERNETES_NAMESPACE)
 
   def imagePullPolicy: String = get(CONTAINER_IMAGE_PULL_POLICY)
@@ -122,7 +124,7 @@ class KubernetesDriverConf(
 
   override def labels: Map[String, String] = {
     val presetLabels = Map(
-      SPARK_VERSION_LABEL -> SPARK_VERSION,
+      SPARK_VERSION_LABEL -> sparkVersion,
       SPARK_APP_ID_LABEL -> appId,
       SPARK_APP_NAME_LABEL -> KubernetesConf.getAppNameLabel(appName),
       SPARK_ROLE_LABEL -> SPARK_POD_DRIVER_ROLE)
@@ -199,7 +201,7 @@ private[spark] class KubernetesExecutorConf(
 
   override def labels: Map[String, String] = {
     val presetLabels = Map(
-      SPARK_VERSION_LABEL -> SPARK_VERSION,
+      SPARK_VERSION_LABEL -> sparkVersion,
       SPARK_EXECUTOR_ID_LABEL -> executorId,
       SPARK_APP_ID_LABEL -> appId,
       SPARK_APP_NAME_LABEL -> KubernetesConf.getAppNameLabel(appName),

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -298,6 +298,31 @@ class KubernetesConfSuite extends SparkFunSuite {
     }
   }
 
+  test("SPARK-56736: sparkVersion returns the runtime Spark version for driver and executor") {
+    val sparkConf = new SparkConf(false)
+    val driverConf = KubernetesTestConf.createDriverConf(sparkConf)
+    val execConf = KubernetesTestConf.createExecutorConf(sparkConf)
+    assert(driverConf.sparkVersion === SPARK_VERSION)
+    assert(execConf.sparkVersion === SPARK_VERSION)
+    assert(driverConf.labels(SPARK_VERSION_LABEL) === SPARK_VERSION)
+    assert(execConf.labels(SPARK_VERSION_LABEL) === SPARK_VERSION)
+  }
+
+  test("SPARK-56736: KubernetesDriverConf subclass can override sparkVersion") {
+    val customVersion = "9.9.9-custom"
+    val customConf = new KubernetesDriverConf(
+      new SparkConf(false),
+      KubernetesTestConf.APP_ID,
+      JavaMainAppResource(None),
+      KubernetesTestConf.MAIN_CLASS,
+      APP_ARGS,
+      None) {
+      override def sparkVersion: String = customVersion
+    }
+    assert(customConf.sparkVersion === customVersion)
+    assert(customConf.labels(SPARK_VERSION_LABEL) === customVersion)
+  }
+
   test("SPARK-52902: K8s image configs support {{SPARK_VERSION}} placeholder") {
     val sparkConf = new SparkConf(false)
     sparkConf.set(CONTAINER_IMAGE, "apache/spark:{{SPARK_VERSION}}")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a `sparkVersion: String` method on `KubernetesConf` and uses it in `KubernetesDriverConf.labels` and `KubernetesExecutorConf.labels` instead of referencing the `SPARK_VERSION` constant directly.

### Why are the changes needed?

Exposing the version through an overridable method gives subclasses (e.g., the Spark K8s operator) a single extension point to customize the `SPARK_VERSION_LABEL` value.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)