### PR TITLE
fix: the hive thrift server's ldap authentication pr... in...

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
@@ -65,14 +65,14 @@ public class LdapAuthenticationProviderImpl implements PasswdAuthenticationProvi
     List<String> candidatePrincipals = new ArrayList<>();
     if (Utils.isBlank(userDNPattern)) {
       if (Utils.isNotBlank(baseDN)) {
-        String pattern = "uid=" + user + "," + baseDN;
+        String pattern = "uid=" + escapeLdapDN(user) + "," + baseDN;
         candidatePrincipals.add(pattern);
       }
     } else {
       String[] patterns = userDNPattern.split(":");
       for (String pattern : patterns) {
         if (pattern.contains(",") && pattern.contains("=")) {
-          candidatePrincipals.add(pattern.replaceAll("%s", user));
+          candidatePrincipals.add(pattern.replace("%s", escapeLdapDN(user)));
         }
       }
     }
@@ -107,5 +107,28 @@ public class LdapAuthenticationProviderImpl implements PasswdAuthenticationProvi
 
   private boolean hasDomain(String userName) {
     return (ServiceUtils.indexOfDomainMatch(userName) > 0);
+  }
+
+  /**
+   * Escapes special characters in an LDAP DN attribute value per RFC 4514
+   * to prevent LDAP injection attacks.
+   */
+  private static String escapeLdapDN(String value) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '\\': sb.append("\\\\"); break;
+        case ',':  sb.append("\\,");  break;
+        case '+':  sb.append("\\+");  break;
+        case '"':  sb.append("\\\""); break;
+        case '<':  sb.append("\\<");  break;
+        case '>':  sb.append("\\>");  break;
+        case ';':  sb.append("\\;");  break;
+        case '\0': sb.append("\\00"); break;
+        default:   sb.append(c);      break;
+      }
+    }
+    return sb.toString();
   }
 }


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java:97` |

**Description**: The Hive Thrift Server's LDAP authentication provider constructs LDAP directory queries using user-supplied credentials (username) without sanitizing LDAP special characters. An attacker can supply a crafted username such as 'admin)(|(uid=*))' to modify the LDAP filter logic, potentially bypassing the password check entirely or enumerating LDAP directory entries. The InitialDirContext at line 97 is initialized with environment properties that include unsanitized user-supplied values, and any LDAP search filters built from the username are vulnerable to injection.

## Changes
- `sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
