### PR TITLE
[SPARK-56744][INFRA] Document test base class hierarchy in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,17 +53,6 @@ Each class-bearing test base above pairs `SparkFunSuite` with a style-agnostic `
 | `SharedSparkSession` | `sql/core` | `QueryTest` -> `SparkFunSuite` | Classic in-process `SparkSession`. Default for tests under `sql/core`. |
 | `TestHiveSingleton` | `sql/hive` | `SparkFunSuite` | Hive-backed session (`TestHive`). Used by tests under `sql/hive`. |
 
-A handful of suites (e.g. `MapStatusEndToEndSuite`, `ExecutorSideSQLConfSuite`) override `spark` directly and manage the session lifecycle themselves; reach for that pattern only when none of the providers above fit (e.g. local-cluster mode, custom builder configs).
-
-Helper traits like `ParquetTest`, `OrcTest`, `FileBasedDataSourceTest`, `DDLCommandTestUtils` already extend `QueryTest` but do NOT supply a session. Combine them with one of the session providers above (e.g. `extends ParquetTest with SharedSparkSession`, `extends QueryTest with TestHiveSingleton`).
-
-Common mistakes in the `extends` clause:
-- `extends QueryTest with SharedSparkSession` — `QueryTest` is redundant (`SharedSparkSession` already extends it). Use `extends SharedSparkSession`.
-- `extends QueryTest with ParquetTest` / `with FileBasedDataSourceTest` / `with OrcTest` — `QueryTest` is redundant; these helper traits all extend `QueryTest`.
-- `extends OrcTest with QueryTestBase` — `OrcTest -> QueryTest -> QueryTestBase` already.
-- `extends QueryTest with CommandSuiteBase with DDLCommandTestUtils` — both `CommandSuiteBase` (via `SharedSparkSession`) and `DDLCommandTestUtils` extend `QueryTest`, so `QueryTest` is redundant.
-- `extends ParquetTest with SharedSparkSession` is NOT redundant — the format helper trait and the session trait bring different things.
-
 Linearization gotcha: the first item in the `extends` clause must transitively extend a class (i.e. carry a non-`Object` superclass). Of the bases above, `SparkFunSuite`, `PlanTest`, `QueryTest`, and `SharedSparkSession` all carry the `SparkFunSuite` -> `AnyFunSuite` chain. `SparkTestSuite` is a pure trait and does NOT — if you use it directly you must put a ScalaTest style class first (e.g. `class X extends AnyWordSpec with SparkTestSuite`). The same applies to other "pure helper" traits (`*ErrorsBase`, `*Helper`): if you put one first, mix in a class-bearing trait immediately after, or compilation fails with `superclass Object is not a subclass of the superclass SparkFunSuite of the mixin trait ...`. Quick check: `grep "^trait <Name>"` — if it ends in `extends DataTypeErrorsBase` or another pure trait, it does not carry the class chain.
 
 ## Build and Test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,6 @@ When writing a new Scala test suite, pick the lowest base class that provides wh
 |---|---|---|---|
 | `SharedSparkSession` | `sql/core` | `QueryTest` -> `SparkFunSuite` | Classic in-process `SparkSession`. Default for tests under `sql/core`. |
 | `TestHiveSingleton` | `sql/hive` | `SparkFunSuite` | Hive-backed session (`TestHive`). Used by tests under `sql/hive`. |
-| `RemoteSparkSession` | `sql/connect/client/jvm` | `AnyFunSuite` (NOT `SparkFunSuite`) | Spark Connect client session. Used by Connect client tests. |
-
-`RemoteSparkSession` is the odd one out: it directly extends `AnyFunSuite` (with `// scalastyle:ignore funsuite`) instead of going through `SparkFunSuite`, so on its own it lacks SparkFunSuite-only features (per-test timeout, `gridTest`, `retry`, log-capture). Connect client suites therefore combine it with `QueryTest` (e.g. `class DataFrameSuite extends QueryTest with RemoteSparkSession`) to bring the `SparkFunSuite` chain back in.
 
 A handful of suites (e.g. `MapStatusEndToEndSuite`, `ExecutorSideSQLConfSuite`) override `spark` directly and manage the session lifecycle themselves; reach for that pattern only when none of the providers above fit (e.g. local-cluster mode, custom builder configs).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,6 @@ When writing a new Scala test suite, pick the lowest base class that provides wh
 | `SharedSparkSession` | `sql/core` | Itself extends `QueryTest`, so concrete suites just `extends SharedSparkSession`. Default for tests under `sql/core`. |
 | `TestHiveSingleton` | `sql/hive` | Mixed in alongside `QueryTest`, e.g. `class X extends QueryTest with TestHiveSingleton`. Used by tests under `sql/hive`. |
 
-Linearization gotcha: the first item in the `extends` clause must transitively extend a class (i.e. carry a non-`Object` superclass). All three bases above plus `SharedSparkSession` carry the `SparkFunSuite` chain, so any of them can appear first. A "pure helper" trait (e.g. `*ErrorsBase`, `*Helper`) does not — if you put one first, mix in a class-bearing trait immediately after, or compilation fails with `superclass Object is not a subclass of the superclass SparkFunSuite of the mixin trait ...`. Quick check: `grep "^trait <Name>"` — if it ends in `extends DataTypeErrorsBase` or another pure trait, it does not carry the class chain.
-
 ## Build and Test
 
 Build and tests can take a long time. If the user explicitly asked to run tests, run them. Otherwise (you are running tests on your own to verify a change), first ask the user if they have more changes to make.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ When writing a new Scala test suite, pick the lowest base class that provides wh
 
 | Session provider | Module / location | Typical usage |
 |---|---|---|
-| `SharedSparkSession` | `sql/core` | Itself extends `QueryTest`, so concrete suites just `extends SharedSparkSession`. Default for tests under `sql/core`. |
+| `SharedSparkSession` | `sql/core` | Already extends `QueryTest` for historical reasons, but still mix in `QueryTest` explicitly, e.g. `class X extends QueryTest with SharedSparkSession`. Default for tests under `sql/core`. |
 | `TestHiveSingleton` | `sql/hive` | Mixed in alongside `QueryTest`, e.g. `class X extends QueryTest with TestHiveSingleton`. Used by tests under `sql/hive`. |
 
 ## Build and Test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,10 +33,20 @@ When writing a new Scala test suite, pick the lowest base class that provides wh
 |------------|------|-------|
 | Plain JVM/Scala — no Spark SQL | `SparkFunSuite` | `core` utilities, RDD, network, util classes, etc. Adds per-test timeout, retry, `gridTest`. |
 | Catalyst plan tests — no `SparkSession` | `PlanTest` | Adds `comparePlans`, `normalizePlan`, `normalizeExprIds`. For analyzer / optimizer / planner rule tests. |
-| DataFrame helpers — no session | `QueryTest` | Rarely used on its own; mostly a building block for other traits (e.g. `FileBasedDataSourceTest`). |
-| SQL/DataFrame integration tests — needs a session | `SharedSparkSession` | The default for most SQL suites. Provides a shared `TestSparkSession`, `testImplicits`, plus `checkAnswer` from `QueryTest`. |
+| SQL/DataFrame helpers — abstract `spark` | `QueryTest` | Adds `checkAnswer`, codegen-on/off helpers. Cannot be instantiated alone — `spark` is abstract and must be supplied by a session-providing trait. |
+| SQL/DataFrame integration tests — provides a session | `SharedSparkSession` | The default for most SQL suites. Provides a shared classic `TestSparkSession`, `testImplicits`, plus `checkAnswer` from `QueryTest`. |
 
-Helper traits like `ParquetTest`, `OrcTest`, `FileBasedDataSourceTest`, `DDLCommandTestUtils` already extend `QueryTest` but do NOT provide a `SparkSession`. Combine with `SharedSparkSession` when a session is needed (e.g. `extends ParquetTest with SharedSparkSession`).
+`QueryTest` declares `spark: SparkSession` abstractly via `SparkSessionProvider`. To run a concrete suite, mix in a session-providing trait. The common providers in this repo are:
+
+| Session provider | Module / location | Use case |
+|---|---|---|
+| `SharedSparkSession` | `sql/core` | Classic in-process `SparkSession`. Default for tests under `sql/core`. |
+| `TestHiveSingleton` | `sql/hive` | Hive-backed session (`TestHive`). Used by tests under `sql/hive`. |
+| `RemoteSparkSession` | `sql/connect/client/jvm` | Spark Connect client session. Used by Connect client tests. |
+
+A handful of suites (e.g. `MapStatusEndToEndSuite`, `ExecutorSideSQLConfSuite`) override `spark` directly and manage the session lifecycle themselves; reach for that pattern only when none of the providers above fit (e.g. local-cluster mode, custom builder configs).
+
+Helper traits like `ParquetTest`, `OrcTest`, `FileBasedDataSourceTest`, `DDLCommandTestUtils` already extend `QueryTest` but do NOT supply a session. Combine them with one of the session providers above (e.g. `extends ParquetTest with SharedSparkSession`, `extends QueryTest with TestHiveSingleton`).
 
 Common mistakes in the `extends` clause:
 - `extends QueryTest with SharedSparkSession` — `QueryTest` is redundant (`SharedSparkSession` already extends it). Use `extends SharedSparkSession`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@ When writing a new Scala test suite, pick the lowest base class that provides wh
     SparkTestSuite                                                          (core; style-agnostic foundation)
       <- SparkFunSuite = AnyFunSuite + SparkTestSuite                       (core; pins the FunSuite style — the default)
         <- PlanTest = SparkFunSuite + PlanTestBase                          (sql/catalyst)
-        <- QueryTest = SparkFunSuite + QueryTestBase + PlanTest             (sql/core)
-          <- SharedSparkSession = QueryTest + SharedSparkSessionBase        (sql/core)
+          <- QueryTest = PlanTest + QueryTestBase                           (sql/core)
+            <- SharedSparkSession = QueryTest + SharedSparkSessionBase      (sql/core)
 
 | Test scope | Base | Notes |
 |------------|------|-------|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,23 +27,27 @@ When writing a new Scala test suite, pick the lowest base class that provides wh
     SparkFunSuite                                                           (core)
       <- PlanTest                                                           (sql/catalyst)
         <- QueryTest                                                        (sql/core)
-          <- SharedSparkSession                                             (sql/core)
 
 | Test scope | Base | Notes |
 |------------|------|-------|
 | Plain JVM/Scala — no Spark SQL | `SparkFunSuite` | `core` utilities, RDD, network, util classes, etc. Adds per-test timeout, `testRetry`, `gridTest`, thread audit, fixed timezone/locale, `withTempDir`, `withLogAppender`, `checkError`. |
 | Catalyst plan tests — no `SparkSession` | `PlanTest` | Adds `comparePlans`, `normalizePlan`, `normalizeExprIds`. For analyzer / optimizer / planner rule tests. |
-| SQL/DataFrame helpers — abstract `spark` | `QueryTest` | Adds `checkAnswer`, codegen-on/off helpers. Cannot be instantiated alone — `spark` is abstract and must be supplied by a session-providing trait. |
-| SQL/DataFrame integration tests — provides a session | `SharedSparkSession` | The default for most SQL suites. Provides a shared classic `TestSparkSession`, `testImplicits`, plus `checkAnswer` from `QueryTest`. |
+| SQL/DataFrame tests — needs a `SparkSession` | `QueryTest` | Adds `checkAnswer`, codegen-on/off helpers. `spark: SparkSession` is abstract and must be supplied by a session-providing trait (see below). |
 
-`QueryTest` declares `spark: SparkSession` abstractly via `SparkSessionProvider`. To run a concrete suite, mix in a session-providing trait. The common providers in this repo are:
+### Providing a `SparkSession` for `QueryTest`
 
-| Session provider | Module / location | Use case |
+`QueryTest` declares `spark: SparkSession` abstractly via `SparkSessionProvider`, so it cannot be instantiated on its own. A concrete suite mixes in one of the session-providing traits below:
+
+    QueryTest                                                               (abstract `spark`)
+      + SharedSparkSession (sql/core)        -> classic in-process `TestSparkSession`
+      + TestHiveSingleton  (sql/hive)        -> Hive-backed `TestHive` session
+
+| Session provider | Module / location | Typical usage |
 |---|---|---|
-| `SharedSparkSession` | `sql/core` | Classic in-process `SparkSession`. Default for tests under `sql/core`. |
-| `TestHiveSingleton` | `sql/hive` | Hive-backed session (`TestHive`). Used by tests under `sql/hive`. |
+| `SharedSparkSession` | `sql/core` | Itself extends `QueryTest`, so concrete suites just `extends SharedSparkSession`. Default for tests under `sql/core`. |
+| `TestHiveSingleton` | `sql/hive` | Mixed in alongside `QueryTest`, e.g. `class X extends QueryTest with TestHiveSingleton`. Used by tests under `sql/hive`. |
 
-Linearization gotcha: the first item in the `extends` clause must transitively extend a class (i.e. carry a non-`Object` superclass). The four bases above all carry the `SparkFunSuite` chain, so they can appear first. A "pure helper" trait (e.g. `*ErrorsBase`, `*Helper`) does not — if you put one first, mix in a class-bearing trait immediately after, or compilation fails with `superclass Object is not a subclass of the superclass SparkFunSuite of the mixin trait ...`. Quick check: `grep "^trait <Name>"` — if it ends in `extends DataTypeErrorsBase` or another pure trait, it does not carry the class chain.
+Linearization gotcha: the first item in the `extends` clause must transitively extend a class (i.e. carry a non-`Object` superclass). All three bases above plus `SharedSparkSession` carry the `SparkFunSuite` chain, so any of them can appear first. A "pure helper" trait (e.g. `*ErrorsBase`, `*Helper`) does not — if you put one first, mix in a class-bearing trait immediately after, or compilation fails with `superclass Object is not a subclass of the superclass SparkFunSuite of the mixin trait ...`. Quick check: `grep "^trait <Name>"` — if it ends in `extends DataTypeErrorsBase` or another pure trait, it does not carry the class chain.
 
 ## Build and Test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,11 +38,13 @@ When writing a new Scala test suite, pick the lowest base class that provides wh
 
 `QueryTest` declares `spark: SparkSession` abstractly via `SparkSessionProvider`. To run a concrete suite, mix in a session-providing trait. The common providers in this repo are:
 
-| Session provider | Module / location | Use case |
-|---|---|---|
-| `SharedSparkSession` | `sql/core` | Classic in-process `SparkSession`. Default for tests under `sql/core`. |
-| `TestHiveSingleton` | `sql/hive` | Hive-backed session (`TestHive`). Used by tests under `sql/hive`. |
-| `RemoteSparkSession` | `sql/connect/client/jvm` | Spark Connect client session. Used by Connect client tests. |
+| Session provider | Module / location | Base chain | Use case |
+|---|---|---|---|
+| `SharedSparkSession` | `sql/core` | `QueryTest` -> `SparkFunSuite` | Classic in-process `SparkSession`. Default for tests under `sql/core`. |
+| `TestHiveSingleton` | `sql/hive` | `SparkFunSuite` | Hive-backed session (`TestHive`). Used by tests under `sql/hive`. |
+| `RemoteSparkSession` | `sql/connect/client/jvm` | `AnyFunSuite` (NOT `SparkFunSuite`) | Spark Connect client session. Used by Connect client tests. |
+
+`RemoteSparkSession` is the odd one out: it directly extends `AnyFunSuite` (with `// scalastyle:ignore funsuite`) instead of going through `SparkFunSuite`, so on its own it lacks SparkFunSuite-only features (per-test timeout, `gridTest`, `retry`, log-capture). Connect client suites therefore combine it with `QueryTest` (e.g. `class DataFrameSuite extends QueryTest with RemoteSparkSession`) to bring the `SparkFunSuite` chain back in.
 
 A handful of suites (e.g. `MapStatusEndToEndSuite`, `ExecutorSideSQLConfSuite`) override `spark` directly and manage the session lifecycle themselves; reach for that pattern only when none of the providers above fit (e.g. local-cluster mode, custom builder configs).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,14 @@ When writing a new Scala test suite, pick the lowest base class that provides wh
           <- QueryTest = PlanTest + QueryTestBase                           (sql/core)
             <- SharedSparkSession = QueryTest + SharedSparkSessionBase      (sql/core)
 
+Each class-bearing test base above pairs `SparkFunSuite` with a style-agnostic `*Base` trait that actually holds the helpers. Those `*Base` traits form a parallel chain:
+
+    PlanTestBase                                                            (sql/catalyst; pure trait — plan-comparison helpers)
+      <- QueryTestBase                                                      (sql/core; adds SQL/DataFrame helpers + abstract `spark`)
+        <- SharedSparkSessionBase                                           (sql/core; provides the actual `TestSparkSession`)
+
+`PlanTest`, `QueryTest`, and `SharedSparkSession` are the FunSuite-flavored bundles built on top of these (analogous to how `SparkFunSuite` = `AnyFunSuite` + `SparkTestSuite`).
+
 | Test scope | Base | Notes |
 |------------|------|-------|
 | Non-FunSuite ScalaTest style (rare) | `SparkTestSuite` | Style-agnostic trait holding the common Spark test functionality (thread audit, fixed timezone/locale, `withTempDir`, `withLogAppender`, `checkError`, etc.). Mix with any ScalaTest style — see `core/src/test/scala/org/apache/spark/{WordSpec,FunSpec,FlatSpec,...}SparkTestSuite.scala` for examples. Real Spark tests should use `SparkFunSuite` instead. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,14 +24,16 @@ Avoid introducing non-ASCII characters in code or comments. String literals may 
 
 When writing a new Scala test suite, pick the lowest base class that provides what the test actually needs. The chain is layered — each adds capability on top of the previous:
 
-    SparkFunSuite                                                           (core)
-      <- PlanTest = SparkFunSuite + PlanTestBase                            (sql/catalyst)
-      <- QueryTest = SparkFunSuite + QueryTestBase + PlanTest               (sql/core)
-        <- SharedSparkSession = QueryTest + SharedSparkSessionBase          (sql/core)
+    SparkTestSuite                                                          (core; style-agnostic foundation)
+      <- SparkFunSuite = AnyFunSuite + SparkTestSuite                       (core; pins the FunSuite style — the default)
+        <- PlanTest = SparkFunSuite + PlanTestBase                          (sql/catalyst)
+        <- QueryTest = SparkFunSuite + QueryTestBase + PlanTest             (sql/core)
+          <- SharedSparkSession = QueryTest + SharedSparkSessionBase        (sql/core)
 
 | Test scope | Base | Notes |
 |------------|------|-------|
-| Plain JVM/Scala — no Spark SQL | `SparkFunSuite` | `core` utilities, RDD, network, util classes, etc. Adds per-test timeout, retry, `gridTest`. |
+| Non-FunSuite ScalaTest style (rare) | `SparkTestSuite` | Style-agnostic trait holding the common Spark test functionality (thread audit, fixed timezone/locale, `withTempDir`, `withLogAppender`, `checkError`, etc.). Mix with any ScalaTest style — see `core/src/test/scala/org/apache/spark/{WordSpec,FunSpec,FlatSpec,...}SparkTestSuite.scala` for examples. Real Spark tests should use `SparkFunSuite` instead. |
+| Plain JVM/Scala — no Spark SQL | `SparkFunSuite` | `core` utilities, RDD, network, util classes, etc. = `AnyFunSuite + SparkTestSuite`. Adds per-test timeout, `testRetry`, `gridTest` on top of `SparkTestSuite`. |
 | Catalyst plan tests — no `SparkSession` | `PlanTest` | Adds `comparePlans`, `normalizePlan`, `normalizeExprIds`. For analyzer / optimizer / planner rule tests. |
 | SQL/DataFrame helpers — abstract `spark` | `QueryTest` | Adds `checkAnswer`, codegen-on/off helpers. Cannot be instantiated alone — `spark` is abstract and must be supplied by a session-providing trait. |
 | SQL/DataFrame integration tests — provides a session | `SharedSparkSession` | The default for most SQL suites. Provides a shared classic `TestSparkSession`, `testImplicits`, plus `checkAnswer` from `QueryTest`. |
@@ -57,7 +59,7 @@ Common mistakes in the `extends` clause:
 - `extends QueryTest with CommandSuiteBase with DDLCommandTestUtils` — both `CommandSuiteBase` (via `SharedSparkSession`) and `DDLCommandTestUtils` extend `QueryTest`, so `QueryTest` is redundant.
 - `extends ParquetTest with SharedSparkSession` is NOT redundant — the format helper trait and the session trait bring different things.
 
-Linearization gotcha: the first item in the `extends` clause must transitively extend `SparkFunSuite` (an `abstract class`, not a trait). All four bases above carry that chain. A "pure helper" trait (e.g. `*ErrorsBase`, `*Helper`) does not — if you put one first, mix in a class-bearing trait immediately after, or compilation fails with `superclass Object is not a subclass of the superclass SparkFunSuite of the mixin trait ...`. Quick check: `grep "^trait <Name>"` — if it ends in `extends DataTypeErrorsBase` or another pure trait, it does not carry the class chain.
+Linearization gotcha: the first item in the `extends` clause must transitively extend a class (i.e. carry a non-`Object` superclass). Of the bases above, `SparkFunSuite`, `PlanTest`, `QueryTest`, and `SharedSparkSession` all carry the `SparkFunSuite` -> `AnyFunSuite` chain. `SparkTestSuite` is a pure trait and does NOT — if you use it directly you must put a ScalaTest style class first (e.g. `class X extends AnyWordSpec with SparkTestSuite`). The same applies to other "pure helper" traits (`*ErrorsBase`, `*Helper`): if you put one first, mix in a class-bearing trait immediately after, or compilation fails with `superclass Object is not a subclass of the superclass SparkFunSuite of the mixin trait ...`. Quick check: `grep "^trait <Name>"` — if it ends in `extends DataTypeErrorsBase` or another pure trait, it does not carry the class chain.
 
 ## Build and Test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Spark Connect protocol is defined in proto files under `sql/connect/common/src/m
 
 Avoid introducing non-ASCII characters in code or comments. String literals may contain non-ASCII when the content requires it (error messages, test data, etc.). Identifiers are ASCII by convention. The common failure mode is typographic characters (em-dash, smart quotes, ellipsis, non-breaking space) sneaking into comments; scalastyle flags some of these. Spot-check before committing: `grep -rn -P "[^\x00-\x7F]" <files>`.
 
-## Test Base Classes
+## Scala Test Base Classes
 
 When writing a new Scala test suite, pick the lowest base class that provides what the test actually needs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,33 @@ Spark Connect protocol is defined in proto files under `sql/connect/common/src/m
 
 Avoid introducing non-ASCII characters in code or comments. String literals may contain non-ASCII when the content requires it (error messages, test data, etc.). Identifiers are ASCII by convention. The common failure mode is typographic characters (em-dash, smart quotes, ellipsis, non-breaking space) sneaking into comments; scalastyle flags some of these. Spot-check before committing: `grep -rn -P "[^\x00-\x7F]" <files>`.
 
+## Test Base Classes
+
+When writing a new Scala test suite, pick the lowest base class that provides what the test actually needs. The chain is layered — each adds capability on top of the previous:
+
+    SparkFunSuite                                                           (core)
+      <- PlanTest = SparkFunSuite + PlanTestBase                            (sql/catalyst)
+      <- QueryTest = SparkFunSuite + QueryTestBase + PlanTest               (sql/core)
+        <- SharedSparkSession = QueryTest + SharedSparkSessionBase          (sql/core)
+
+| Test scope | Base | Notes |
+|------------|------|-------|
+| Plain JVM/Scala — no Spark SQL | `SparkFunSuite` | `core` utilities, RDD, network, util classes, etc. Adds per-test timeout, retry, `gridTest`. |
+| Catalyst plan tests — no `SparkSession` | `PlanTest` | Adds `comparePlans`, `normalizePlan`, `normalizeExprIds`. For analyzer / optimizer / planner rule tests. |
+| DataFrame helpers — no session | `QueryTest` | Rarely used on its own; mostly a building block for other traits (e.g. `FileBasedDataSourceTest`). |
+| SQL/DataFrame integration tests — needs a session | `SharedSparkSession` | The default for most SQL suites. Provides a shared `TestSparkSession`, `testImplicits`, plus `checkAnswer` from `QueryTest`. |
+
+Helper traits like `ParquetTest`, `OrcTest`, `FileBasedDataSourceTest`, `DDLCommandTestUtils` already extend `QueryTest` but do NOT provide a `SparkSession`. Combine with `SharedSparkSession` when a session is needed (e.g. `extends ParquetTest with SharedSparkSession`).
+
+Common mistakes in the `extends` clause:
+- `extends QueryTest with SharedSparkSession` — `QueryTest` is redundant (`SharedSparkSession` already extends it). Use `extends SharedSparkSession`.
+- `extends QueryTest with ParquetTest` / `with FileBasedDataSourceTest` / `with OrcTest` — `QueryTest` is redundant; these helper traits all extend `QueryTest`.
+- `extends OrcTest with QueryTestBase` — `OrcTest -> QueryTest -> QueryTestBase` already.
+- `extends QueryTest with CommandSuiteBase with DDLCommandTestUtils` — both `CommandSuiteBase` (via `SharedSparkSession`) and `DDLCommandTestUtils` extend `QueryTest`, so `QueryTest` is redundant.
+- `extends ParquetTest with SharedSparkSession` is NOT redundant — the format helper trait and the session trait bring different things.
+
+Linearization gotcha: the first item in the `extends` clause must transitively extend `SparkFunSuite` (an `abstract class`, not a trait). All four bases above carry that chain. A "pure helper" trait (e.g. `*ErrorsBase`, `*Helper`) does not — if you put one first, mix in a class-bearing trait immediately after, or compilation fails with `superclass Object is not a subclass of the superclass SparkFunSuite of the mixin trait ...`. Quick check: `grep "^trait <Name>"` — if it ends in `extends DataTypeErrorsBase` or another pure trait, it does not carry the class chain.
+
 ## Build and Test
 
 Build and tests can take a long time. If the user explicitly asked to run tests, run them. Otherwise (you are running tests on your own to verify a change), first ask the user if they have more changes to make.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,38 +22,28 @@ Avoid introducing non-ASCII characters in code or comments. String literals may 
 
 ## Scala Test Base Classes
 
-When writing a new Scala test suite, pick the lowest base class that provides what the test actually needs.
+When writing a new Scala test suite, pick the lowest base class that provides what the test actually needs. Spark uses the `AnyFunSuite` ScalaTest style throughout, so the bases below are the chain to choose from. Each adds capability on top of the previous:
 
-The actual test helpers live in style-agnostic traits that do not commit to a ScalaTest style:
-
-    SparkTestSuite                                                          (core; thread audit, fixed timezone/locale, withTempDir, withLogAppender, checkError)
-    PlanTestBase                                                            (sql/catalyst; plan-comparison helpers — comparePlans, normalizePlan)
-      <- QueryTestBase                                                      (sql/core; adds SQL/DataFrame helpers + abstract `spark` via `SparkSessionProvider`)
-        <- SharedSparkSessionBase                                           (sql/core; provides the actual `TestSparkSession`)
-
-The class-bearing test bases bundle each style-agnostic helper with `AnyFunSuite` (the default ScalaTest style) so concrete suites can extend them directly. They form a layered chain — each adds capability on top of the previous:
-
-    SparkFunSuite = AnyFunSuite + SparkTestSuite                            (core; pins the FunSuite style — the default)
-      <- PlanTest = SparkFunSuite + PlanTestBase                            (sql/catalyst)
-        <- QueryTest = PlanTest + QueryTestBase                             (sql/core)
-          <- SharedSparkSession = QueryTest + SharedSparkSessionBase        (sql/core)
+    SparkFunSuite                                                           (core)
+      <- PlanTest                                                           (sql/catalyst)
+        <- QueryTest                                                        (sql/core)
+          <- SharedSparkSession                                             (sql/core)
 
 | Test scope | Base | Notes |
 |------------|------|-------|
-| Non-FunSuite ScalaTest style (rare) | `SparkTestSuite` | Style-agnostic trait holding the common Spark test functionality (thread audit, fixed timezone/locale, `withTempDir`, `withLogAppender`, `checkError`, etc.). Mix with any ScalaTest style — see `core/src/test/scala/org/apache/spark/{WordSpec,FunSpec,FlatSpec,...}SparkTestSuite.scala` for examples. Real Spark tests should use `SparkFunSuite` instead. |
-| Plain JVM/Scala — no Spark SQL | `SparkFunSuite` | `core` utilities, RDD, network, util classes, etc. = `AnyFunSuite + SparkTestSuite`. Adds per-test timeout, `testRetry`, `gridTest` on top of `SparkTestSuite`. |
+| Plain JVM/Scala — no Spark SQL | `SparkFunSuite` | `core` utilities, RDD, network, util classes, etc. Adds per-test timeout, `testRetry`, `gridTest`, thread audit, fixed timezone/locale, `withTempDir`, `withLogAppender`, `checkError`. |
 | Catalyst plan tests — no `SparkSession` | `PlanTest` | Adds `comparePlans`, `normalizePlan`, `normalizeExprIds`. For analyzer / optimizer / planner rule tests. |
 | SQL/DataFrame helpers — abstract `spark` | `QueryTest` | Adds `checkAnswer`, codegen-on/off helpers. Cannot be instantiated alone — `spark` is abstract and must be supplied by a session-providing trait. |
 | SQL/DataFrame integration tests — provides a session | `SharedSparkSession` | The default for most SQL suites. Provides a shared classic `TestSparkSession`, `testImplicits`, plus `checkAnswer` from `QueryTest`. |
 
 `QueryTest` declares `spark: SparkSession` abstractly via `SparkSessionProvider`. To run a concrete suite, mix in a session-providing trait. The common providers in this repo are:
 
-| Session provider | Module / location | Base chain | Use case |
-|---|---|---|---|
-| `SharedSparkSession` | `sql/core` | `QueryTest` -> `SparkFunSuite` | Classic in-process `SparkSession`. Default for tests under `sql/core`. |
-| `TestHiveSingleton` | `sql/hive` | `SparkFunSuite` | Hive-backed session (`TestHive`). Used by tests under `sql/hive`. |
+| Session provider | Module / location | Use case |
+|---|---|---|
+| `SharedSparkSession` | `sql/core` | Classic in-process `SparkSession`. Default for tests under `sql/core`. |
+| `TestHiveSingleton` | `sql/hive` | Hive-backed session (`TestHive`). Used by tests under `sql/hive`. |
 
-Linearization gotcha: the first item in the `extends` clause must transitively extend a class (i.e. carry a non-`Object` superclass). Of the bases above, `SparkFunSuite`, `PlanTest`, `QueryTest`, and `SharedSparkSession` all carry the `SparkFunSuite` -> `AnyFunSuite` chain. `SparkTestSuite` is a pure trait and does NOT — if you use it directly you must put a ScalaTest style class first (e.g. `class X extends AnyWordSpec with SparkTestSuite`). The same applies to other "pure helper" traits (`*ErrorsBase`, `*Helper`): if you put one first, mix in a class-bearing trait immediately after, or compilation fails with `superclass Object is not a subclass of the superclass SparkFunSuite of the mixin trait ...`. Quick check: `grep "^trait <Name>"` — if it ends in `extends DataTypeErrorsBase` or another pure trait, it does not carry the class chain.
+Linearization gotcha: the first item in the `extends` clause must transitively extend a class (i.e. carry a non-`Object` superclass). The four bases above all carry the `SparkFunSuite` chain, so they can appear first. A "pure helper" trait (e.g. `*ErrorsBase`, `*Helper`) does not — if you put one first, mix in a class-bearing trait immediately after, or compilation fails with `superclass Object is not a subclass of the superclass SparkFunSuite of the mixin trait ...`. Quick check: `grep "^trait <Name>"` — if it ends in `extends DataTypeErrorsBase` or another pure trait, it does not carry the class chain.
 
 ## Build and Test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,21 +22,21 @@ Avoid introducing non-ASCII characters in code or comments. String literals may 
 
 ## Test Base Classes
 
-When writing a new Scala test suite, pick the lowest base class that provides what the test actually needs. The chain is layered — each adds capability on top of the previous:
+When writing a new Scala test suite, pick the lowest base class that provides what the test actually needs.
 
-    SparkTestSuite                                                          (core; style-agnostic foundation)
-      <- SparkFunSuite = AnyFunSuite + SparkTestSuite                       (core; pins the FunSuite style — the default)
-        <- PlanTest = SparkFunSuite + PlanTestBase                          (sql/catalyst)
-          <- QueryTest = PlanTest + QueryTestBase                           (sql/core)
-            <- SharedSparkSession = QueryTest + SharedSparkSessionBase      (sql/core)
+The actual test helpers live in style-agnostic traits that do not commit to a ScalaTest style:
 
-Each class-bearing test base above pairs `SparkFunSuite` with a style-agnostic `*Base` trait that actually holds the helpers. Those `*Base` traits form a parallel chain:
-
-    PlanTestBase                                                            (sql/catalyst; pure trait — plan-comparison helpers)
-      <- QueryTestBase                                                      (sql/core; adds SQL/DataFrame helpers + abstract `spark`)
+    SparkTestSuite                                                          (core; thread audit, fixed timezone/locale, withTempDir, withLogAppender, checkError)
+    PlanTestBase                                                            (sql/catalyst; plan-comparison helpers — comparePlans, normalizePlan)
+      <- QueryTestBase                                                      (sql/core; adds SQL/DataFrame helpers + abstract `spark` via `SparkSessionProvider`)
         <- SharedSparkSessionBase                                           (sql/core; provides the actual `TestSparkSession`)
 
-`PlanTest`, `QueryTest`, and `SharedSparkSession` are the FunSuite-flavored bundles built on top of these (analogous to how `SparkFunSuite` = `AnyFunSuite` + `SparkTestSuite`).
+The class-bearing test bases bundle each style-agnostic helper with `AnyFunSuite` (the default ScalaTest style) so concrete suites can extend them directly. They form a layered chain — each adds capability on top of the previous:
+
+    SparkFunSuite = AnyFunSuite + SparkTestSuite                            (core; pins the FunSuite style — the default)
+      <- PlanTest = SparkFunSuite + PlanTestBase                            (sql/catalyst)
+        <- QueryTest = PlanTest + QueryTestBase                             (sql/core)
+          <- SharedSparkSession = QueryTest + SharedSparkSessionBase        (sql/core)
 
 | Test scope | Base | Notes |
 |------------|------|-------|


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a `Scala Test Base Classes` section to `AGENTS.md` that documents the layered Scala test base hierarchy in this repo and how to pick a base class for a new test suite. Spark uses the `AnyFunSuite` ScalaTest style throughout, and the chain is:

    SparkFunSuite                                                           (core)
      <- PlanTest                                                           (sql/catalyst)
        <- QueryTest                                                        (sql/core)

`QueryTest` declares `spark: SparkSession` abstractly via `SparkSessionProvider`, so a concrete SQL test suite mixes in one of the session-providing traits:

    QueryTest                                                               (abstract `spark`)
      + SharedSparkSession (sql/core)        -> classic in-process `TestSparkSession`
      + TestHiveSingleton  (sql/hive)        -> Hive-backed `TestHive` session

The new section also includes:
- A decision table mapping test scope (plain JVM, Catalyst plans, SQL/DataFrame with a session) to the right base.
- A session-provider table noting that `SharedSparkSession` itself extends `QueryTest` (so concrete suites just `extends SharedSparkSession`), while `TestHiveSingleton` is mixed in alongside `QueryTest`.
- A linearization gotcha: the first item in an `extends` clause must transitively extend a class. Pure helper traits (`*ErrorsBase`, `*Helper`) cannot be put first.

`CLAUDE.md` is a symlink to `AGENTS.md`, so this change is picked up by both AI agent toolchains.

### Why are the changes needed?

Picking the wrong test base class (e.g. extending `QueryTest` directly when a session is needed, or `SparkFunSuite` when `PlanTest` would do) is a common stumble when adding new Scala test suites. The information is currently spread across the source of `SparkFunSuite`, `PlanTest`, `QueryTest`, and the session-providing traits, with no single place that summarizes when to use which. Documenting it in `AGENTS.md` gives both contributors and AI coding agents a quick reference.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only change to a developer/agent guide file.

### How was this patch tested?

N/A. Documentation-only change; no code or tests are affected.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude opus-4-7