### PR TITLE
[SPARK-56746][SQL][TESTS] Drop redundant PlanTest/SQLHelper trait mixins

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/ClientE2ETestSuite.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.connect.ConnectConversions._
 import org.apache.spark.sql.connect.client.{PlanCompressionOptions, RetryPolicy, SparkConnectClient, SparkResult}
-import org.apache.spark.sql.connect.test.{ConnectFunSuite, IntegrationTestUtils, QueryTest, RemoteSparkSession, SQLHelper}
+import org.apache.spark.sql.connect.test.{ConnectFunSuite, IntegrationTestUtils, QueryTest, RemoteSparkSession}
 import org.apache.spark.sql.connect.test.SparkConnectServerUtils.{createSparkSession, port}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SqlApiConf
@@ -53,7 +53,6 @@ class ClientE2ETestSuite
     extends QueryTest
     with ConnectFunSuite
     with RemoteSparkSession
-    with SQLHelper
     with PrivateMethodTester {
 
   test("throw SparkException with null filename in stack trace elements") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -714,7 +714,7 @@ trait QueryTestBase
  * Subclasses should *not* create `SparkSession`s in the test suite constructor, which is
  * prone to leaving multiple overlapping [[org.apache.spark.SparkContext]]s in the same JVM.
  */
-trait QueryTest extends SparkFunSuite with QueryTestBase with PlanTest {
+trait QueryTest extends SparkFunSuite with QueryTestBase {
 
   /**
    * Creates a temporary directory, which is then passed to `f` and will be deleted after `f`

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -25,7 +25,6 @@ import java.util.Locale
 import org.apache.spark.{SparkConf, TestUtils}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator
 import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.NANOS_PER_SECOND
@@ -153,7 +152,7 @@ import org.apache.spark.util.Utils
  */
 // scalastyle:on line.size.limit
 @ExtendedSQLTest
-class SQLQueryTestSuite extends SharedSparkSession with SQLHelper
+class SQLQueryTestSuite extends SharedSparkSession
     with SQLQueryTestHelper with TPCDSSchema {
 
   import IntegratedUDFTestUtils._

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Final, Max, Partial}
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParserInterface}
-import org.apache.spark.sql.catalyst.plans.{PlanTest, SQLHelper}
+import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, AggregateHint, ColumnStat, Limit, LocalRelation, LogicalPlan, Project, Range, Sort, SortHint, Statistics, UnresolvedHint}
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning, SinglePartition}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -58,7 +58,7 @@ import org.apache.spark.unsafe.types.UTF8String
 /**
  * Test cases for the [[SparkSessionExtensions]].
  */
-class SparkSessionExtensionSuite extends PlanTest with SQLHelper with AdaptiveSparkPlanHelper {
+class SparkSessionExtensionSuite extends PlanTest with AdaptiveSparkPlanHelper {
   private def create(
       builder: SparkSessionExtensionsProvider): Seq[SparkSessionExtensionsProvider] = Seq(builder)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -20,13 +20,12 @@ package org.apache.spark.sql.errors
 import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLId
 import org.apache.spark.sql.test.SharedSparkSession
 
 // Turn of the length check because most of the tests check entire error messages
 // scalastyle:off line.size.limit
-class QueryParsingErrorsSuite extends SharedSparkSession with SQLHelper {
+class QueryParsingErrorsSuite extends SharedSparkSession {
 
   private def parseException(sqlText: String): SparkThrowable = {
     intercept[ParseException](sql(sqlText).collect())

--- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceWithActualMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceWithActualMetricsSuite.scala
@@ -30,7 +30,6 @@ import org.apache.spark.SparkConf
 import org.apache.spark.deploy.history.HistoryServerSuite.getContentAndCode
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
-import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.execution.metric.SQLMetricsTestUtils
 import org.apache.spark.sql.internal.SQLConf.ADAPTIVE_EXECUTION_ENABLED
 import org.apache.spark.sql.test.SharedSparkSession
@@ -42,7 +41,7 @@ case class Salary(personId: Int, salary: Double)
  * Sql Resource Public API Unit Tests running query and extracting the metrics.
  */
 class SqlResourceWithActualMetricsSuite
-  extends SharedSparkSession with SQLMetricsTestUtils with SQLHelper {
+  extends SharedSparkSession with SQLMetricsTestUtils {
 
   import testImplicits._
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removes a few redundant trait mixins in the test hierarchy:

1. `trait QueryTest extends SparkFunSuite with QueryTestBase with PlanTest` — drop `with PlanTest`. `PlanTest` is `SparkFunSuite with PlanTestBase`, both already in the linearization (`SparkFunSuite` is the first parent; `QueryTestBase` already extends `PlanTestBase`). The mixin contributes nothing.

2. Concrete suites that already inherit `SQLHelper` transitively but redeclared it:
   - `SqlResourceWithActualMetricsSuite` (via `SharedSparkSession`)
   - `SparkSessionExtensionSuite` (via `PlanTest`)
   - `SQLQueryTestSuite` (via `SharedSparkSession`)
   - `QueryParsingErrorsSuite` (via `SharedSparkSession`)
   - `ClientE2ETestSuite` (via Connect's `QueryTest`)

The now-unused `SQLHelper` imports are also removed.

### Why are the changes needed?

Cleanup. Redundant mixins make the trait hierarchy harder to read and signal confusion about where helpers come from.

### Does this PR introduce _any_ user-facing change?

No. Test-only refactor.

### How was this patch tested?

`build/sbt sql/Test/compile connect-client-jvm/Test/compile` succeeds. No behavior change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)