### PR TITLE
[SPARK-56749][BUILD] Upgrade PostgreSQL JDBC driver to 42.7.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -341,7 +341,7 @@
     </extraJavaTestArgs>
     <mariadb.java.client.version>3.5.7</mariadb.java.client.version>
     <mysql.connector.version>9.6.0</mysql.connector.version>
-    <postgresql.version>42.7.10</postgresql.version>
+    <postgresql.version>42.7.11</postgresql.version>
     <db2.jcc.version>11.5.9.0</db2.jcc.version>
     <mssql.jdbc.version>13.2.1.jre11</mssql.jdbc.version>
     <ojdbc17.version>23.26.1.0.0</ojdbc17.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade the test dependency `PostgreSQL` JDBC driver to `42.7.11` which was released on 2026-04-28. The one-week dependency-update grace-period passed.

- https://github.com/apache/spark/security/dependabot/186

### Why are the changes needed?

To maintain `PostgreSQL` JDBC driver test coverage up-to-date.
- https://jdbc.postgresql.org/changelogs/2026-04-28-42/ (42.7.11)
  - Security: Limit SCRAM PBKDF2 iterations accepted from the server (new `scramMaxIterations` property capped at 100,000) to mitigate DoS by malicious servers.
  - Feature: Support for `require_auth` connection property (libpq-aligned authentication requirement validation).
  - Fixes: extended-protocol `Sync` handling, cursor-based fetching when SQL initiates transactions, SSL fallback/retry across `sslMode` values, connect timeout honored during retries, JSONB returned as `PGObject` instead of `String`, thread safety on concurrent connection close, unsigned `LogSequenceNumber` comparison, `COPY` lock release on I/O error.

### Does this PR introduce _any_ user-facing change?

No, this is a test dependency.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Claude Opus 4.7 (1M context)`