### PR TITLE
[SPARK-55910][SQL][TESTS][FOLLOW-UP] Inline unnecessary asInstanceOf[classic.SparkSession] cast in QueryTest

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -1073,14 +1073,13 @@ object QueryTest extends Assertions {
       }
     }
 
-    val classicSession = spark.asInstanceOf[classic.SparkSession]
-    classicSession.sparkContext.listenerBus.waitUntilEmpty(15000)
-    classicSession.listenerManager.register(listener)
+    spark.sparkContext.listenerBus.waitUntilEmpty(15000)
+    spark.listenerManager.register(listener)
     try {
       thunk
-      classicSession.sparkContext.listenerBus.waitUntilEmpty(15000)
+      spark.sparkContext.listenerBus.waitUntilEmpty(15000)
     } finally {
-      classicSession.listenerManager.unregister(listener)
+      spark.listenerManager.unregister(listener)
     }
 
     capturedQueryExecutions


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `QueryTest.withQueryExecutionsCaptured`, the local alias `classicSession = spark.asInstanceOf[classic.SparkSession]` is replaced with direct uses of `spark`. The cast is not needed: `sparkContext` (`api/SparkSession.scala:72`) and `listenerManager` (`api/SparkSession.scala:144`) are both declared on the abstract `org.apache.spark.sql.SparkSession`, so they are accessible without converting to the classic implementation.

### Why are the changes needed?

Cleanup follow-up to #55339, which removed unnecessary `asInstanceOf[classic.Dataset]` casts in `QueryTest`. The same criterion applies here: when the called API is already on the abstract type, the explicit classic cast adds noise and obscures which code paths actually depend on classic-only functionality.

### Does this PR introduce _any_ user-facing change?

No. Test-only.

### How was this patch tested?

`build/sbt sql/Test/compile` succeeds.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)