### PR TITLE
[SPARK-56768][PYTHON][INFRA] Share SBT compile artifact across pyspark CI jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -801,28 +801,6 @@ jobs:
         name: unit-tests-log-${{ matrix.modules }}--${{ matrix.java }}-${{ inputs.hadoop }}-hive2.3-${{ env.PYTHON_TO_TEST }}
         path: "**/target/unit-tests.log"
 
-  precompile-cleanup:
-    needs: [precompile, pyspark]
-    if: always() && needs.precompile.result == 'success'
-    name: "Delete precompile artifact"
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-    - name: Delete artifact
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        artifact_id=$(gh api \
-          repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-          --jq '.artifacts[] | select(.name=="spark-compile-${{ github.run_id }}") | .id')
-        if [ -n "$artifact_id" ]; then
-          gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$artifact_id
-          echo "Deleted artifact $artifact_id"
-        else
-          echo "No precompile artifact found to delete"
-        fi
-
   sparkr:
     needs: [precondition, infra-image]
     # always run if sparkr == 'true', even infra-image is skip (such as non-master job)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -745,14 +745,14 @@ jobs:
       run: |
         tar -xzf compile-artifact.tar.gz
         rm compile-artifact.tar.gz
-    - name: Set SKIP_SCALA_BUILD when precompiled artifact is usable
-      if: steps.extract-precompiled.outcome == 'success'
-      run: echo "SKIP_SCALA_BUILD=true" >> $GITHUB_ENV
     # Run the tests.
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
       shell: 'script -q -e -c "bash {0}"'
       run: |
+        if [ "${{ steps.extract-precompiled.outcome }}" = "success" ]; then
+          export SKIP_SCALA_BUILD=true
+        fi
         if [[ "$MODULES_TO_TEST" == *"pyspark-pipelines"* ]]; then
           export SKIP_PACKAGING=false
           echo "Python Packaging Tests Enabled!"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -547,6 +547,9 @@ jobs:
     name: "Precompile Spark"
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Optional optimization: if this job fails or is cancelled, the pyspark
+    # matrix entries fall back to running the SBT build locally as before.
+    continue-on-error: true
     env:
       HADOOP_PROFILE: ${{ inputs.hadoop }}
       HIVE_PROFILE: hive2.3
@@ -669,7 +672,6 @@ jobs:
       SKIP_UNIDOC: true
       SKIP_MIMA: true
       SKIP_PACKAGING: true
-      SKIP_BUILD: true
       METASPACE_SIZE: 1g
       BRANCH: ${{ inputs.branch }}
       PYSPARK_TEST_TIMEOUT: 450
@@ -730,13 +732,22 @@ jobs:
           echo ""
         done
     - name: Download precompiled artifact
+      id: download-precompiled
+      if: needs.precompile.result == 'success'
+      continue-on-error: true
       uses: actions/download-artifact@v6
       with:
         name: spark-compile-${{ github.run_id }}
     - name: Extract precompiled artifact
+      id: extract-precompiled
+      if: steps.download-precompiled.outcome == 'success'
+      continue-on-error: true
       run: |
         tar -xjf compile-artifact.tar.bz2
         rm compile-artifact.tar.bz2
+    - name: Set SKIP_SCALA_BUILD when precompiled artifact is usable
+      if: steps.extract-precompiled.outcome == 'success'
+      run: echo "SKIP_SCALA_BUILD=true" >> $GITHUB_ENV
     # Run the tests.
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -542,7 +542,8 @@ jobs:
     if: >-
       (!cancelled()) && (
         fromJson(needs.precondition.outputs.required).pyspark == 'true' ||
-        fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true')
+        fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true' ||
+        fromJson(needs.precondition.outputs.required).pyspark-install == 'true')
     name: "Precompile Spark"
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -537,8 +537,82 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/apache/spark/apache-spark-github-action-image-pyspark-${{ env.PYSPARK_IMAGE_TO_TEST }}-cache:${{ inputs.branch }}
 
 
+  precompile-pyspark:
+    needs: precondition
+    if: >-
+      (!cancelled()) && (
+        fromJson(needs.precondition.outputs.required).pyspark == 'true' ||
+        fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true' ||
+        fromJson(needs.precondition.outputs.required).sparkr == 'true')
+    name: "Precompile Spark for pyspark/sparkr"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      HADOOP_PROFILE: ${{ inputs.hadoop }}
+      HIVE_PROFILE: hive2.3
+      GITHUB_PREV_SHA: ${{ github.event.before }}
+    steps:
+    - name: Checkout Spark repository
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        repository: apache/spark
+        ref: ${{ inputs.branch }}
+    - name: Sync the current branch with the latest in Apache Spark
+      if: github.repository != 'apache/spark'
+      run: |
+        echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
+        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
+        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+    - name: Cache SBT and Maven
+      uses: actions/cache@v5
+      with:
+        path: |
+          build/apache-maven-*
+          build/*.jar
+          ~/.sbt
+        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        restore-keys: |
+          build-
+    - name: Cache Coursier local repository
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/coursier
+        key: precompile-pyspark-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+        restore-keys: |
+          precompile-pyspark-coursier-
+    - name: Free up disk space
+      run: |
+        if [ -f ./dev/free_disk_space ]; then
+          ./dev/free_disk_space
+        fi
+    - name: Install Java ${{ inputs.java }}
+      uses: actions/setup-java@v5
+      with:
+        distribution: zulu
+        java-version: ${{ inputs.java }}
+    - name: Build Spark
+      run: |
+        ./build/sbt -Phadoop-3 -Pyarn -Pspark-ganglia-lgpl -Phadoop-cloud -Phive \
+          -Pkubernetes -Pjvm-profiler -Pkinesis-asl -Phive-thriftserver \
+          -Pdocker-integration-tests -Pvolcano \
+          Test/package streaming-kinesis-asl-assembly/assembly connect/assembly assembly/package
+    - name: Package compile output
+      run: |
+        find . -type d -name target -not -path './build/*' -not -path './.git/*' -print0 \
+          | tar --null --use-compress-program='zstd -3 -T0' -cf compile-artifact.tar.zst -T -
+        ls -lh compile-artifact.tar.zst
+    - name: Upload compile artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: spark-compile-${{ github.run_id }}
+        path: compile-artifact.tar.zst
+        retention-days: 1
+        if-no-files-found: error
+
   pyspark:
-    needs: [precondition, infra-image]
+    needs: [precondition, infra-image, precompile-pyspark]
     # always run if pyspark == 'true', even infra-image is skip (such as non-master job)
     if: (!cancelled()) && (fromJson(needs.precondition.outputs.required).pyspark == 'true' || fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true')
     name: "Build modules: ${{ matrix.modules }}"
@@ -600,6 +674,7 @@ jobs:
       SKIP_UNIDOC: true
       SKIP_MIMA: true
       SKIP_PACKAGING: true
+      SKIP_BUILD: true
       METASPACE_SIZE: 1g
       BRANCH: ${{ inputs.branch }}
       PYSPARK_TEST_TIMEOUT: 450
@@ -659,6 +734,14 @@ jobs:
           $py -m pip list
           echo ""
         done
+    - name: Download precompiled artifact
+      uses: actions/download-artifact@v6
+      with:
+        name: spark-compile-${{ github.run_id }}
+    - name: Extract precompiled artifact
+      run: |
+        tar --use-compress-program=zstd -xf compile-artifact.tar.zst
+        rm compile-artifact.tar.zst
     # Run the tests.
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
@@ -719,7 +802,7 @@ jobs:
         path: "**/target/unit-tests.log"
 
   sparkr:
-    needs: [precondition, infra-image]
+    needs: [precondition, infra-image, precompile-pyspark]
     # always run if sparkr == 'true', even infra-image is skip (such as non-master job)
     if: (!cancelled()) && fromJson(needs.precondition.outputs.required).sparkr == 'true'
     name: "Build modules: sparkr"
@@ -735,6 +818,7 @@ jobs:
       SKIP_UNIDOC: true
       SKIP_MIMA: true
       SKIP_PACKAGING: true
+      SKIP_BUILD: true
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v6
@@ -778,6 +862,14 @@ jobs:
       with:
         distribution: zulu
         java-version: ${{ inputs.java }}
+    - name: Download precompiled artifact
+      uses: actions/download-artifact@v6
+      with:
+        name: spark-compile-${{ github.run_id }}
+    - name: Extract precompiled artifact
+      run: |
+        tar --use-compress-program=zstd -xf compile-artifact.tar.zst
+        rm compile-artifact.tar.zst
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -752,6 +752,7 @@ jobs:
       run: |
         if [ "${{ steps.extract-precompiled.outcome }}" = "success" ]; then
           export SKIP_SCALA_BUILD=true
+          echo "Reusing precompiled artifact, skipping local SBT build."
         fi
         if [[ "$MODULES_TO_TEST" == *"pyspark-pipelines"* ]]; then
           export SKIP_PACKAGING=false

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -582,11 +582,6 @@ jobs:
         key: precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           precompile-coursier-
-    - name: Free up disk space
-      run: |
-        if [ -f ./dev/free_disk_space ]; then
-          ./dev/free_disk_space
-        fi
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v5
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -166,6 +166,9 @@ jobs:
               \"ui\" : \"$ui\",
             }"
           echo $precondition # For debugging
+          # TEMP for PR #55726: only run pyspark + pyspark-pandas. REVERT BEFORE MERGE.
+          precondition='{ "build": "false", "pyspark": "true", "pyspark-pandas": "true", "pyspark-install": "false", "sparkr": "false", "tpcds-1g": "false", "docker-integration-tests": "false", "lint" : "false", "java17" : "false", "java25" : "false", "docs" : "false", "yarn" : "false", "k8s-integration-tests" : "false", "buf" : "false", "ui" : "false" }'
+          echo "TEMP override: $precondition"
           # Remove `\n` to avoid "Invalid format" error
           precondition="${precondition//$'\n'/}"
           echo "required=$precondition" >> $GITHUB_OUTPUT

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -601,13 +601,13 @@ jobs:
     - name: Package compile output
       run: |
         find . -type d -name target -not -path './build/*' -not -path './.git/*' -print0 \
-          | tar --null --use-compress-program='zstd -3 -T0' -cf compile-artifact.tar.zst -T -
-        ls -lh compile-artifact.tar.zst
+          | XZ_OPT='-T0 -9' tar --null -cJf compile-artifact.tar.xz -T -
+        ls -lh compile-artifact.tar.xz
     - name: Upload compile artifact
       uses: actions/upload-artifact@v6
       with:
         name: spark-compile-${{ github.run_id }}
-        path: compile-artifact.tar.zst
+        path: compile-artifact.tar.xz
         retention-days: 1
         if-no-files-found: error
 
@@ -740,8 +740,8 @@ jobs:
         name: spark-compile-${{ github.run_id }}
     - name: Extract precompiled artifact
       run: |
-        tar --use-compress-program=zstd -xf compile-artifact.tar.zst
-        rm compile-artifact.tar.zst
+        tar -xJf compile-artifact.tar.xz
+        rm compile-artifact.tar.xz
     # Run the tests.
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
@@ -868,8 +868,8 @@ jobs:
         name: spark-compile-${{ github.run_id }}
     - name: Extract precompiled artifact
       run: |
-        tar --use-compress-program=zstd -xf compile-artifact.tar.zst
-        rm compile-artifact.tar.zst
+        tar -xJf compile-artifact.tar.xz
+        rm compile-artifact.tar.xz
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -166,9 +166,6 @@ jobs:
               \"ui\" : \"$ui\",
             }"
           echo $precondition # For debugging
-          # TEMP for PR #55726: only run pyspark + pyspark-pandas + pyspark-install. REVERT BEFORE MERGE.
-          precondition='{ "build": "false", "pyspark": "true", "pyspark-pandas": "true", "pyspark-install": "true", "sparkr": "false", "tpcds-1g": "false", "docker-integration-tests": "false", "lint" : "false", "java17" : "false", "java25" : "false", "docs" : "false", "yarn" : "false", "k8s-integration-tests" : "false", "buf" : "false", "ui" : "false" }'
-          echo "TEMP override: $precondition"
           # Remove `\n` to avoid "Invalid format" error
           precondition="${precondition//$'\n'/}"
           echo "required=$precondition" >> $GITHUB_OUTPUT
@@ -607,7 +604,7 @@ jobs:
     - name: Upload compile artifact
       uses: actions/upload-artifact@v6
       with:
-        name: spark-compile-${{ github.run_id }}
+        name: spark-compile-${{ inputs.branch }}-${{ github.run_id }}
         path: compile-artifact.tar.gz
         retention-days: 1
         if-no-files-found: error
@@ -740,7 +737,7 @@ jobs:
       continue-on-error: true
       uses: actions/download-artifact@v6
       with:
-        name: spark-compile-${{ github.run_id }}
+        name: spark-compile-${{ inputs.branch }}-${{ github.run_id }}
     - name: Extract precompiled artifact
       id: extract-precompiled
       if: steps.download-precompiled.outcome == 'success'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -599,13 +599,13 @@ jobs:
     - name: Package compile output
       run: |
         find . -type d -name target -not -path './build/*' -not -path './.git/*' -print0 \
-          | tar --null -cjf compile-artifact.tar.bz2 -T -
-        ls -lh compile-artifact.tar.bz2
+          | tar --null -czf compile-artifact.tar.gz -T -
+        ls -lh compile-artifact.tar.gz
     - name: Upload compile artifact
       uses: actions/upload-artifact@v6
       with:
         name: spark-compile-${{ github.run_id }}
-        path: compile-artifact.tar.bz2
+        path: compile-artifact.tar.gz
         retention-days: 1
         if-no-files-found: error
 
@@ -743,8 +743,8 @@ jobs:
       if: steps.download-precompiled.outcome == 'success'
       continue-on-error: true
       run: |
-        tar -xjf compile-artifact.tar.bz2
-        rm compile-artifact.tar.bz2
+        tar -xzf compile-artifact.tar.gz
+        rm compile-artifact.tar.gz
     - name: Set SKIP_SCALA_BUILD when precompiled artifact is usable
       if: steps.extract-precompiled.outcome == 'success'
       run: echo "SKIP_SCALA_BUILD=true" >> $GITHUB_ENV

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -545,8 +545,7 @@ jobs:
     if: >-
       (!cancelled()) && (
         fromJson(needs.precondition.outputs.required).pyspark == 'true' ||
-        fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true' ||
-        fromJson(needs.precondition.outputs.required).sparkr == 'true')
+        fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true')
     name: "Precompile Spark"
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -805,7 +804,7 @@ jobs:
         path: "**/target/unit-tests.log"
 
   sparkr:
-    needs: [precondition, infra-image, precompile]
+    needs: [precondition, infra-image]
     # always run if sparkr == 'true', even infra-image is skip (such as non-master job)
     if: (!cancelled()) && fromJson(needs.precondition.outputs.required).sparkr == 'true'
     name: "Build modules: sparkr"
@@ -821,7 +820,6 @@ jobs:
       SKIP_UNIDOC: true
       SKIP_MIMA: true
       SKIP_PACKAGING: true
-      SKIP_BUILD: true
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v6
@@ -865,14 +863,6 @@ jobs:
       with:
         distribution: zulu
         java-version: ${{ inputs.java }}
-    - name: Download precompiled artifact
-      uses: actions/download-artifact@v6
-      with:
-        name: spark-compile-${{ github.run_id }}
-    - name: Extract precompiled artifact
-      run: |
-        tar -xjf compile-artifact.tar.bz2
-        rm compile-artifact.tar.bz2
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -601,13 +601,13 @@ jobs:
     - name: Package compile output
       run: |
         find . -type d -name target -not -path './build/*' -not -path './.git/*' -print0 \
-          | XZ_OPT='-T0 -9' tar --null -cJf compile-artifact.tar.xz -T -
-        ls -lh compile-artifact.tar.xz
+          | tar --null -cjf compile-artifact.tar.bz2 -T -
+        ls -lh compile-artifact.tar.bz2
     - name: Upload compile artifact
       uses: actions/upload-artifact@v6
       with:
         name: spark-compile-${{ github.run_id }}
-        path: compile-artifact.tar.xz
+        path: compile-artifact.tar.bz2
         retention-days: 1
         if-no-files-found: error
 
@@ -740,8 +740,8 @@ jobs:
         name: spark-compile-${{ github.run_id }}
     - name: Extract precompiled artifact
       run: |
-        tar -xJf compile-artifact.tar.xz
-        rm compile-artifact.tar.xz
+        tar -xjf compile-artifact.tar.bz2
+        rm compile-artifact.tar.bz2
     # Run the tests.
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
@@ -868,8 +868,8 @@ jobs:
         name: spark-compile-${{ github.run_id }}
     - name: Extract precompiled artifact
       run: |
-        tar -xJf compile-artifact.tar.xz
-        rm compile-artifact.tar.xz
+        tar -xjf compile-artifact.tar.bz2
+        rm compile-artifact.tar.bz2
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -537,14 +537,14 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/apache/spark/apache-spark-github-action-image-pyspark-${{ env.PYSPARK_IMAGE_TO_TEST }}-cache:${{ inputs.branch }}
 
 
-  precompile-pyspark:
+  precompile:
     needs: precondition
     if: >-
       (!cancelled()) && (
         fromJson(needs.precondition.outputs.required).pyspark == 'true' ||
         fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true' ||
         fromJson(needs.precondition.outputs.required).sparkr == 'true')
-    name: "Precompile Spark for pyspark/sparkr"
+    name: "Precompile Spark"
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -579,9 +579,9 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.cache/coursier
-        key: precompile-pyspark-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+        key: precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
-          precompile-pyspark-coursier-
+          precompile-coursier-
     - name: Free up disk space
       run: |
         if [ -f ./dev/free_disk_space ]; then
@@ -612,7 +612,7 @@ jobs:
         if-no-files-found: error
 
   pyspark:
-    needs: [precondition, infra-image, precompile-pyspark]
+    needs: [precondition, infra-image, precompile]
     # always run if pyspark == 'true', even infra-image is skip (such as non-master job)
     if: (!cancelled()) && (fromJson(needs.precondition.outputs.required).pyspark == 'true' || fromJson(needs.precondition.outputs.required).pyspark-pandas == 'true')
     name: "Build modules: ${{ matrix.modules }}"
@@ -802,7 +802,7 @@ jobs:
         path: "**/target/unit-tests.log"
 
   sparkr:
-    needs: [precondition, infra-image, precompile-pyspark]
+    needs: [precondition, infra-image, precompile]
     # always run if sparkr == 'true', even infra-image is skip (such as non-master job)
     if: (!cancelled()) && fromJson(needs.precondition.outputs.required).sparkr == 'true'
     name: "Build modules: sparkr"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -166,9 +166,6 @@ jobs:
               \"ui\" : \"$ui\",
             }"
           echo $precondition # For debugging
-          # TEMP for PR #55726: only run pyspark + pyspark-pandas. REVERT BEFORE MERGE.
-          precondition='{ "build": "false", "pyspark": "true", "pyspark-pandas": "true", "pyspark-install": "false", "sparkr": "false", "tpcds-1g": "false", "docker-integration-tests": "false", "lint" : "false", "java17" : "false", "java25" : "false", "docs" : "false", "yarn" : "false", "k8s-integration-tests" : "false", "buf" : "false", "ui" : "false" }'
-          echo "TEMP override: $precondition"
           # Remove `\n` to avoid "Invalid format" error
           precondition="${precondition//$'\n'/}"
           echo "required=$precondition" >> $GITHUB_OUTPUT

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -801,6 +801,28 @@ jobs:
         name: unit-tests-log-${{ matrix.modules }}--${{ matrix.java }}-${{ inputs.hadoop }}-hive2.3-${{ env.PYTHON_TO_TEST }}
         path: "**/target/unit-tests.log"
 
+  precompile-cleanup:
+    needs: [precompile, pyspark]
+    if: always() && needs.precompile.result == 'success'
+    name: "Delete precompile artifact"
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+    - name: Delete artifact
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        artifact_id=$(gh api \
+          repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
+          --jq '.artifacts[] | select(.name=="spark-compile-${{ github.run_id }}") | .id')
+        if [ -n "$artifact_id" ]; then
+          gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$artifact_id
+          echo "Deleted artifact $artifact_id"
+        else
+          echo "No precompile artifact found to delete"
+        fi
+
   sparkr:
     needs: [precondition, infra-image]
     # always run if sparkr == 'true', even infra-image is skip (such as non-master job)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -166,8 +166,8 @@ jobs:
               \"ui\" : \"$ui\",
             }"
           echo $precondition # For debugging
-          # TEMP for PR #55726: only run pyspark + pyspark-pandas. REVERT BEFORE MERGE.
-          precondition='{ "build": "false", "pyspark": "true", "pyspark-pandas": "true", "pyspark-install": "false", "sparkr": "false", "tpcds-1g": "false", "docker-integration-tests": "false", "lint" : "false", "java17" : "false", "java25" : "false", "docs" : "false", "yarn" : "false", "k8s-integration-tests" : "false", "buf" : "false", "ui" : "false" }'
+          # TEMP for PR #55726: only run pyspark + pyspark-pandas + pyspark-install. REVERT BEFORE MERGE.
+          precondition='{ "build": "false", "pyspark": "true", "pyspark-pandas": "true", "pyspark-install": "true", "sparkr": "false", "tpcds-1g": "false", "docker-integration-tests": "false", "lint" : "false", "java17" : "false", "java25" : "false", "docs" : "false", "yarn" : "false", "k8s-integration-tests" : "false", "buf" : "false", "ui" : "false" }'
           echo "TEMP override: $precondition"
           # Remove `\n` to avoid "Invalid format" error
           precondition="${precondition//$'\n'/}"

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -644,7 +644,8 @@ def main():
         run_build_tests()
 
     # spark build
-    build_apache_spark(build_tool, extra_profiles)
+    if not os.environ.get("SKIP_BUILD"):
+        build_apache_spark(build_tool, extra_profiles)
 
     # backwards compatibility checks
     if build_tool == "sbt":
@@ -653,7 +654,8 @@ def main():
             detect_binary_inop_with_mima(extra_profiles)
         # Since we did not build assembly/package before running dev/mima, we need to
         # do it here because the tests still rely on it; see SPARK-13294 for details.
-        build_spark_assembly_sbt(extra_profiles, should_run_java_style_checks)
+        if not os.environ.get("SKIP_BUILD"):
+            build_spark_assembly_sbt(extra_profiles, should_run_java_style_checks)
 
     # run the test suites
     run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags, included_tags)

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -644,7 +644,7 @@ def main():
         run_build_tests()
 
     # spark build
-    if not os.environ.get("SKIP_BUILD"):
+    if not os.environ.get("SKIP_SCALA_BUILD"):
         build_apache_spark(build_tool, extra_profiles)
 
     # backwards compatibility checks
@@ -654,7 +654,7 @@ def main():
             detect_binary_inop_with_mima(extra_profiles)
         # Since we did not build assembly/package before running dev/mima, we need to
         # do it here because the tests still rely on it; see SPARK-13294 for details.
-        if not os.environ.get("SKIP_BUILD"):
+        if not os.environ.get("SKIP_SCALA_BUILD"):
             build_spark_assembly_sbt(extra_profiles, should_run_java_style_checks)
 
     # run the test suites

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -644,7 +644,7 @@ def main():
         run_build_tests()
 
     # spark build
-    if not os.environ.get("SKIP_SCALA_BUILD"):
+    if os.environ.get("SKIP_SCALA_BUILD", "false") != "true":
         build_apache_spark(build_tool, extra_profiles)
 
     # backwards compatibility checks
@@ -654,7 +654,7 @@ def main():
             detect_binary_inop_with_mima(extra_profiles)
         # Since we did not build assembly/package before running dev/mima, we need to
         # do it here because the tests still rely on it; see SPARK-13294 for details.
-        if not os.environ.get("SKIP_SCALA_BUILD"):
+        if os.environ.get("SKIP_SCALA_BUILD", "false") != "true":
             build_spark_assembly_sbt(extra_profiles, should_run_java_style_checks)
 
     # run the test suites


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a single shared `precompile` CI job that runs Spark's SBT build once and uploads the resulting `target/` trees as a GitHub Actions artifact. The 8 pyspark matrix entries plus the optional `pyspark-install` entry now consume that artifact instead of re-running the same SBT build themselves. The job is named generically because the same artifact can be reused by sparkr, R, or documentation jobs in follow-ups.

Concretely:

- New `precompile` job in `.github/workflows/build_and_test.yml` runs the SBT build:
  ```
  ./build/sbt -Phadoop-3 -Pyarn -Pspark-ganglia-lgpl -Phadoop-cloud -Phive \
    -Pkubernetes -Pjvm-profiler -Pkinesis-asl -Phive-thriftserver \
    -Pdocker-integration-tests -Pvolcano \
    Test/package streaming-kinesis-asl-assembly/assembly connect/assembly assembly/package
  ```
  It tars every `target/` directory (excluding `./build/` and `./.git/`) with `tar -czf` (gzip), uploads as `spark-compile-<branch>-<run_id>` with `retention-days: 1` so storage is reclaimed within 24h.
  The job's `if:` gate fires when any of `pyspark`, `pyspark-pandas`, or `pyspark-install` is true in the precondition output, so the artifact is always available for any matrix entry that needs it (including via `inputs.jobs` overrides used by scheduled / dispatched workflows).
- The `pyspark` matrix job adds `precompile` to `needs:`, downloads and extracts the artifact (with graceful fallback - see below), and exports `SKIP_SCALA_BUILD=true` for `dev/run-tests.py` only when the artifact was successfully extracted.
- `dev/run-tests.py` reads `SKIP_SCALA_BUILD` and skips `build_apache_spark` and `build_spark_assembly_sbt` when it equals `"true"`, matching the existing `SKIP_PACKAGING` idiom in the same file.

### Optional: graceful fallback if precompile fails

The precompile job is treated as an optimization, not a hard prerequisite:

- `precompile` has `continue-on-error: true` - a failed or cancelled precompile does not fail the workflow run.
- The pyspark matrix's "Download precompiled artifact" step is gated on `needs.precompile.result == 'success'` and itself has `continue-on-error: true`.
- The "Extract precompiled artifact" step is gated on the download succeeding, and also has `continue-on-error: true`.
- Inside the "Run tests" bash block, `SKIP_SCALA_BUILD=true` is exported only when `steps.extract-precompiled.outcome == 'success'`. Otherwise it stays unset and `dev/run-tests.py` falls back to the original local SBT build.

So the worst case for a precompile failure is degraded to the pre-PR behavior, not a workflow failure.

### SBT invocations: before vs. after

Every pyspark matrix entry today drives `dev/run-tests.py`, which makes two SBT calls back-to-back (`build_spark_sbt` at `dev/run-tests.py:647` then `build_spark_assembly_sbt` at `dev/run-tests.py:656`):

```
# build_spark_sbt
./build/sbt <11 profiles> Test/package streaming-kinesis-asl-assembly/assembly connect/assembly
# build_spark_assembly_sbt
./build/sbt <11 profiles> assembly/package
```

The 11 profiles, identical across all 8 entries: `-Phadoop-3 -Pyarn -Phive -Phive-thriftserver -Pkubernetes -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl -Pdocker-integration-tests -Pvolcano`.

After this PR, when the artifact is usable, both calls are gated off via `SKIP_SCALA_BUILD=true`; no SBT compile runs in the matrix entry. The new `precompile` job runs one SBT invocation that combines all four goals (safe because `SKIP_MIMA=true` in the pyspark job, so the original split for `dev/mima` is moot here):

| | SBT compile invocations per pyspark matrix entry | Total SBT compile invocations across the matrix |
|---|--:|--:|
| Before | 2 | 16 |
| After  | 0 (artifact reused) or 2 (fallback) | 1 (in `precompile`, all 4 goals combined), plus 0 or 16 (fallback) |

The produced `target/` is byte-equivalent - same goals, same profiles, same Scala/Java/Hadoop versions.

### Measured savings

Comparing two real CI runs of the same workflow on the same fork:

- **BEFORE** ([run 25432660319](https://github.com/zhengruifeng/spark/actions/runs/25432660319), without this PR)
- **AFTER** ([run 25532354044](https://github.com/zhengruifeng/spark/actions/runs/25532354044), with this PR active; pyspark-only iteration)

Per-matrix-entry wall time:

| Matrix entry | Before | After | Saved |
|---|--:|--:|--:|
| pyspark-sql / resource / testing / core / errors / logger | 69m34s | 64m26s | 5m08s |
| pyspark-mllib / ml / ml-connect / pipelines | 73m36s | 54m34s | 19m02s |
| pyspark-streaming / structured-streaming / structured-streaming-connect | 57m31s | 41m31s | 16m00s |
| pyspark-connect | 60m26s | 48m01s | 12m25s |
| pyspark-pandas | 71m26s | 56m45s | 14m41s |
| pyspark-pandas-slow | 67m21s | 49m04s | 18m17s |
| pyspark-pandas-connect | 71m57s | 58m54s | 13m03s |
| pyspark-pandas-slow-connect | 72m28s | 59m09s | 13m19s |
| **Sum (8 matrix entries)** | **544m19s** | **432m24s** | **111m55s** |

CI compute totals:

| | Per-run CI time |
|---|---:|
| Sum of 8 matrix entries before | 544m19s |
| Sum of 8 matrix entries after  | 432m24s |
| Add the new `precompile` job   | +16m14s |
| **Net CI compute saved per run** | **~95m41s (~14% of total ~700m)** |

Wall clock (workflow critical path):

| | Critical path |
|---|---:|
| Before (longest matrix entry: pyspark-mllib/...) | 73m36s |
| After (precompile 16m14s + longest matrix entry: pyspark-sql/... 64m26s) | ~79m40s |

A roughly +6m wall-clock cost in exchange for ~96m of CI compute savings: the build was previously parallel-hidden inside each matrix runner; sharing it serializes one ~16m build before the matrix, but the slowest matrix runner shrinks by roughly the same amount. Net wall-clock change is small.

### Does this PR introduce _any_ user-facing change?

No. CI infrastructure change only.

### How was this patch tested?

The change is exercised by the CI run of this PR itself:
- If `precompile` succeeds and produces an artifact of reasonable size, the build phase works.
- If the pyspark matrix completes normally on top of the downloaded artifact, the artifact is sufficient and `SKIP_SCALA_BUILD` is correctly skipping the local compile. The "Run tests" step logs `Reusing precompiled artifact, skipping local SBT build.` to make this visible per matrix entry.
- If the precompile job is forced to fail (or its artifact is missing), the matrix entries should still pass via the fallback path.

A few things to watch in the first run:
- **Artifact size.** Spark's combined `target/` is roughly 1-3 GB raw; expect ~1-1.5 GB after gzip. The "Package compile output" step prints the size with `ls -lh`. If it ever gets close to GHA's 10 GB per-artifact cap we should slim the find pattern (e.g., exclude `target/streams` and intermediate scaladoc).
- **`gzip` in the test images.** The pyspark Docker images need `gzip` for the extract step. It is in the `gzip` package and present in every standard Ubuntu base image.

The doctests in `dev/sparktestsupport/utils.py` continue to pass; no logic in `is-changed.py` or the module graph was changed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)