### PR TITLE
[SPARK-56770][DOCS] Update PROJ version to 9.8.1 in the documentation for geospatial types

### DIFF
--- a/docs/sql-ref-geospatial-types.md
+++ b/docs/sql-ref-geospatial-types.md
@@ -155,7 +155,7 @@ Spark includes a pre-built SRID registry that combines coordinate systems from t
 
 | Spark Version | PROJ Version |
 |---------------|--------------|
-| 4.2.0 | 9.8.1        |
+| 4.2.0 | 9.8.1 |
 
 The SRID registry is pinned to the PROJ version shown above and is not synced live with external databases.
 

--- a/docs/sql-ref-geospatial-types.md
+++ b/docs/sql-ref-geospatial-types.md
@@ -155,7 +155,7 @@ Spark includes a pre-built SRID registry that combines coordinate systems from t
 
 | Spark Version | PROJ Version |
 |---------------|--------------|
-| 4.2.0 | 9.7.1 |
+| 4.2.0 | 9.8.1        |
 
 The SRID registry is pinned to the PROJ version shown above and is not synced live with external databases.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/55207 added the documentation for standard spatial reference systems, but PROJ was upgraded from 9.7 to 9.8 in https://github.com/apache/spark/pull/55525. This PR updates the docs accordingly.


### Why are the changes needed?
Make the geospatial type documentation precise for Spark 4.2.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Only Doc Changes.


### Was this patch authored or co-authored using generative AI tooling?
No.
