### PR TITLE
[SPARK-56771][SQL] Enable geospatial support by default

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -630,7 +630,7 @@ object SQLConf {
       .doc("When true, enables geospatial types (GEOGRAPHY/GEOMETRY) and ST functions.")
       .version("4.1.0")
       .booleanConf
-      .createWithDefaultFunction(() => Utils.isTesting)
+      .createWithDefault(true)
 
   val TYPES_FRAMEWORK_ENABLED =
     buildConf("spark.sql.types.framework.enabled")


### PR DESCRIPTION
### What changes were proposed in this pull request?
With geospatial types implemented in Spark (https://issues.apache.org/jira/browse/SPARK-51658), we can now enable the corresponding SQL config by default.


### Why are the changes needed?
Enable geospatial support by default in Spark 4.2.


### Does this PR introduce _any_ user-facing change?
Yes, geospatial types and expressions are now enabled by default.


### How was this patch tested?
Existing tests suffice, this is a config-only change.


### Was this patch authored or co-authored using generative AI tooling?
No.
