### PR TITLE
[SPARK-56769][SQL] Add fast path for date_trunc WEEK/MONTH/QUARTER/YEAR

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -497,7 +497,9 @@ object DateTimeUtils extends SparkDateTimeUtils {
       case TRUNC_TO_WEEK => getNextDateForDayOfWeek(days - 7, MONDAY)
       case TRUNC_TO_MONTH => days - getDayOfMonth(days) + 1
       case TRUNC_TO_QUARTER =>
-        localDateToDays(daysToLocalDate(days).`with`(IsoFields.DAY_OF_QUARTER, 1L))
+        val ld = daysToLocalDate(days)
+        val firstMonthOfQuarter = ((ld.getMonthValue - 1) / 3) * 3 + 1
+        localDateToDays(ld.withMonth(firstMonthOfQuarter).withDayOfMonth(1))
       case TRUNC_TO_YEAR => days - getDayInYear(days) + 1
       case _ =>
         // caller make sure that this should never be reached
@@ -511,23 +513,41 @@ object DateTimeUtils extends SparkDateTimeUtils {
   }
 
   /**
-   * Fast path for truncating to MINUTE/HOUR/DAY using offset arithmetic instead of
-   * allocating a `ZonedDateTime` per row. The offset is resolved once for `micros`; the
-   * truncation then runs as `floorMod` in local time. We fall back to [[truncToUnit]] when
-   * the offset at the candidate truncated instant differs from the offset at `micros`,
-   * which means the truncation crosses a DST/historical transition and the local-time
-   * alignment we computed is no longer valid (see SPARK-30766/30857). The check is
-   * skipped for fixed-offset zones. Sub-minute offsets (e.g. America/Los_Angeles LMT
-   * -07:52:58, see SPARK-33404) and 30/45-minute offsets (Asia/Kolkata +05:30, Asia/Kathmandu
-   * +05:45) are handled correctly by this path because the offset is applied as part of
-   * the arithmetic; no offset-alignment guard is needed.
+   * Returns the trunc date time from original date time and trunc level.
+   * Trunc level should be generated using `parseTruncLevel()`, should be between 0 and 9.
    *
-   * `unitMicros` must evenly divide `MICROS_PER_DAY`; otherwise wall-clock unit
-   * boundaries do not align to multiples of `unitMicros` in the shifted-local frame
-   * and the `floorMod` truncation is unsafe.
+   * Uses an offset-arithmetic fast path: the zone offset at `micros` is resolved once,
+   * truncation runs in the shifted-local frame, and the result is shifted back to UTC
+   * micros. Falls back to [[truncTimestampSlow]] when the offset at the candidate
+   * truncated instant differs from the offset at `micros` (DST/historical transition
+   * spans the candidate; SPARK-30766/30857) or on arithmetic overflow.
+   *
+   * Sub-minute LMT offsets (e.g. America/Los_Angeles -07:52:58 pre-1883, see
+   * SPARK-33404) and 30/45-minute offsets (Asia/Kolkata +05:30, Asia/Kathmandu +05:45)
+   * are handled correctly because the offset is applied as part of the arithmetic; no
+   * offset-alignment guard is needed.
+   *
+   * The local-frame truncation is selected by `level`:
+   *   - MICROSECOND/MILLISECOND/SECOND: no zone information needed (zone offsets have
+   *     at most second precision, see `java.time.ZoneOffset`); reduces to pure UTC
+   *     `floorMod`.
+   *   - MINUTE/HOUR/DAY: `floorMod` against the corresponding `unitMicros`. The unit
+   *     must evenly divide `MICROS_PER_DAY`, which holds for all three; otherwise
+   *     wall-clock unit boundaries would not align to multiples of `unitMicros` in
+   *     the shifted-local frame.
+   *   - WEEK/MONTH/QUARTER/YEAR: convert local micros to local epoch-day, run
+   *     [[truncDate]] in the local-day frame, multiply back to local micros.
    */
-  private def truncToUnitFast(
-      micros: Long, zoneId: ZoneId, unitMicros: Long, fallbackUnit: ChronoUnit): Long = {
+  def truncTimestamp(micros: Long, level: Int, zoneId: ZoneId): Long = {
+    // MICROSECOND / MILLISECOND / SECOND don't need zone information.
+    level match {
+      case TRUNC_TO_MICROSECOND => return micros
+      case TRUNC_TO_MILLISECOND =>
+        return Math.subtractExact(micros, Math.floorMod(micros, MICROS_PER_MILLIS))
+      case TRUNC_TO_SECOND =>
+        return Math.subtractExact(micros, Math.floorMod(micros, MICROS_PER_SECOND))
+      case _ =>
+    }
     val rules = zoneId.getRules
     val originalSec = Math.floorDiv(micros, MICROS_PER_SECOND)
     val originalOffsetSec =
@@ -535,45 +555,49 @@ object DateTimeUtils extends SparkDateTimeUtils {
     val offsetMicros = originalOffsetSec * MICROS_PER_SECOND
     try {
       val local = Math.addExact(micros, offsetMicros)
-      val truncatedLocal = Math.subtractExact(local, Math.floorMod(local, unitMicros))
+      val truncatedLocal = level match {
+        case TRUNC_TO_MINUTE =>
+          Math.subtractExact(local, Math.floorMod(local, MICROS_PER_MINUTE))
+        case TRUNC_TO_HOUR =>
+          Math.subtractExact(local, Math.floorMod(local, MICROS_PER_HOUR))
+        case TRUNC_TO_DAY =>
+          Math.subtractExact(local, Math.floorMod(local, MICROS_PER_DAY))
+        case _ => // Date-level truncation: WEEK / MONTH / QUARTER / YEAR.
+          val localDays = Math.floorDiv(local, MICROS_PER_DAY).toInt
+          Math.multiplyExact(truncDate(localDays, level).toLong, MICROS_PER_DAY)
+      }
       val candidate = Math.subtractExact(truncatedLocal, offsetMicros)
       if (!rules.isFixedOffset) {
         val candidateSec = Math.floorDiv(candidate, MICROS_PER_SECOND)
         val candidateOffsetSec =
           rules.getOffset(Instant.ofEpochSecond(candidateSec)).getTotalSeconds.toLong
         if (candidateOffsetSec != originalOffsetSec) {
-          return truncToUnit(micros, zoneId, fallbackUnit)
+          return truncTimestampSlow(micros, level, zoneId)
         }
       }
       candidate
     } catch {
-      case _: ArithmeticException => truncToUnit(micros, zoneId, fallbackUnit)
+      case _: ArithmeticException => truncTimestampSlow(micros, level, zoneId)
     }
   }
 
   /**
-   * Returns the trunc date time from original date time and trunc level.
-   * Trunc level should be generated using `parseTruncLevel()`, should be between 0 and 9.
+   * Slow-path reference implementation: equivalent to [[truncTimestamp]] without the
+   * offset-arithmetic fast path. Invoked from [[truncTimestamp]] on DST-cross or
+   * arithmetic overflow. It is also a complete handler for every supported `level`, so
+   * the fast path's correctness can be verified against this method case-by-case.
    */
-  def truncTimestamp(micros: Long, level: Int, zoneId: ZoneId): Long = {
-    // Time zone offsets have a maximum precision of seconds (see `java.time.ZoneOffset`). Hence
-    // truncation to microsecond, millisecond, and second can be done
-    // without using time zone information. This results in a performance improvement.
+  private def truncTimestampSlow(micros: Long, level: Int, zoneId: ZoneId): Long = {
     level match {
       case TRUNC_TO_MICROSECOND => micros
       case TRUNC_TO_MILLISECOND =>
         Math.subtractExact(micros, Math.floorMod(micros, MICROS_PER_MILLIS))
       case TRUNC_TO_SECOND =>
         Math.subtractExact(micros, Math.floorMod(micros, MICROS_PER_SECOND))
-      case TRUNC_TO_MINUTE =>
-        truncToUnitFast(micros, zoneId, MICROS_PER_MINUTE, ChronoUnit.MINUTES)
-      case TRUNC_TO_HOUR =>
-        truncToUnitFast(micros, zoneId, MICROS_PER_HOUR, ChronoUnit.HOURS)
-      case TRUNC_TO_DAY =>
-        truncToUnitFast(micros, zoneId, MICROS_PER_DAY, ChronoUnit.DAYS)
-      case _ => // Try to truncate date levels
-        val dDays = microsToDays(micros, zoneId)
-        daysToMicros(truncDate(dDays, level), zoneId)
+      case TRUNC_TO_MINUTE => truncToUnit(micros, zoneId, ChronoUnit.MINUTES)
+      case TRUNC_TO_HOUR => truncToUnit(micros, zoneId, ChronoUnit.HOURS)
+      case TRUNC_TO_DAY => truncToUnit(micros, zoneId, ChronoUnit.DAYS)
+      case _ => daysToMicros(truncDate(microsToDays(micros, zoneId), level), zoneId)
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -724,6 +724,10 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       withDefaultTimeZone(zid) {
         val inputTS = DateTimeUtils.stringToTimestamp(
           UTF8String.fromString("1769-10-17T17:10:02.123456"), defaultZoneId)
+        testTrunc(DateTimeUtils.TRUNC_TO_YEAR, "1769-01-01T00:00:00", inputTS.get, zid)
+        testTrunc(DateTimeUtils.TRUNC_TO_QUARTER, "1769-10-01T00:00:00", inputTS.get, zid)
+        testTrunc(DateTimeUtils.TRUNC_TO_MONTH, "1769-10-01T00:00:00", inputTS.get, zid)
+        testTrunc(DateTimeUtils.TRUNC_TO_WEEK, "1769-10-16T00:00:00", inputTS.get, zid)
         testTrunc(DateTimeUtils.TRUNC_TO_DAY, "1769-10-17T00:00:00", inputTS.get, zid)
         testTrunc(DateTimeUtils.TRUNC_TO_HOUR, "1769-10-17T17:00:00", inputTS.get, zid)
         testTrunc(DateTimeUtils.TRUNC_TO_MINUTE, "1769-10-17T17:10:00", inputTS.get, zid)
@@ -873,6 +877,29 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
     val expected = DateTimeUtils.stringToTimestamp(
       UTF8String.fromString("2018-11-04T01:00:00-02:00"), zone).get
     assert(DateTimeUtils.truncTimestamp(ts, DateTimeUtils.TRUNC_TO_DAY, zone) === expected)
+  }
+
+  test("truncTimestamp date-level units across DST boundaries") {
+    val la = getZoneId("America/Los_Angeles")
+    // YEAR / QUARTER truncation of an instant in March (post-spring-forward) crosses
+    // the DST boundary: Jan 1 is in PST, March is in PDT, so the offset at the
+    // candidate (Jan 1 wall-clock) differs from the offset at the original. The fast
+    // path falls back to the slow path, which resolves Jan 1 00:00 in PST.
+    val mar = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-03-15T12:00:00-07:00"), la).get
+    val expectedYear = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-01-01T00:00:00-08:00"), la).get
+    assert(DateTimeUtils.truncTimestamp(mar, DateTimeUtils.TRUNC_TO_YEAR, la) === expectedYear)
+    val expectedQuarter = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-01-01T00:00:00-08:00"), la).get
+    assert(
+      DateTimeUtils.truncTimestamp(mar, DateTimeUtils.TRUNC_TO_QUARTER, la) === expectedQuarter)
+    // MONTH where original and candidate are both in PDT: April fully in DST, no cross.
+    val apr = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-04-15T12:00:00-07:00"), la).get
+    val expectedMonth = DateTimeUtils.stringToTimestamp(
+      UTF8String.fromString("2024-04-01T00:00:00-07:00"), la).get
+    assert(DateTimeUtils.truncTimestamp(apr, DateTimeUtils.TRUNC_TO_MONTH, la) === expectedMonth)
   }
 
   test("truncTimestamp at Pacific/Apia after the 2011 calendar shift") {

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk21-results.txt
@@ -2,460 +2,460 @@
 datetime +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  937            951          18         10.7          93.7       1.0X
-date + interval(m, d)                               889            904          19         11.2          88.9       1.1X
-date + interval(m, d, ms)                          3636           3671          49          2.8         363.6       0.3X
-date - interval(m)                                  821            828           8         12.2          82.1       1.1X
-date - interval(m, d)                               850            858           9         11.8          85.0       1.1X
-date - interval(m, d, ms)                          3613           3614           2          2.8         361.3       0.3X
-timestamp + interval(m)                            1543           1547           6          6.5         154.3       0.6X
-timestamp + interval(m, d)                         1590           1595           8          6.3         159.0       0.6X
-timestamp + interval(m, d, ms)                     2052           2055           5          4.9         205.2       0.5X
-timestamp - interval(m)                            1847           1849           3          5.4         184.7       0.5X
-timestamp - interval(m, d)                         1897           1908          16          5.3         189.7       0.5X
-timestamp - interval(m, d, ms)                     2057           2063           7          4.9         205.7       0.5X
+date + interval(m)                                  737            781          66         13.6          73.7       1.0X
+date + interval(m, d)                               738            742           6         13.6          73.8       1.0X
+date + interval(m, d, ms)                          2887           2902          21          3.5         288.7       0.3X
+date - interval(m)                                  709            716           7         14.1          70.9       1.0X
+date - interval(m, d)                               713            719           5         14.0          71.3       1.0X
+date - interval(m, d, ms)                          2908           2914           8          3.4         290.8       0.3X
+timestamp + interval(m)                            1457           1458           2          6.9         145.7       0.5X
+timestamp + interval(m, d)                         1476           1476           0          6.8         147.6       0.5X
+timestamp + interval(m, d, ms)                     1562           1564           3          6.4         156.2       0.5X
+timestamp - interval(m)                            1397           1401           5          7.2         139.7       0.5X
+timestamp - interval(m, d)                         1442           1446           5          6.9         144.2       0.5X
+timestamp - interval(m, d, ms)                     1564           1566           3          6.4         156.4       0.5X
 
 
 ================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    203            208           7         49.1          20.3       1.0X
-cast to timestamp wholestage on                     219            222           4         45.8          21.9       0.9X
+cast to timestamp wholestage off                    169            169           1         59.3          16.9       1.0X
+cast to timestamp wholestage on                     176            178           2         56.9          17.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    626            626           1         16.0          62.6       1.0X
-year of timestamp wholestage on                     640            646           9         15.6          64.0       1.0X
+year of timestamp wholestage off                    525            538          18         19.0          52.5       1.0X
+year of timestamp wholestage on                     533            539           7         18.8          53.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 659            663           5         15.2          65.9       1.0X
-quarter of timestamp wholestage on                  665            671           6         15.0          66.5       1.0X
+quarter of timestamp wholestage off                 556            558           2         18.0          55.6       1.0X
+quarter of timestamp wholestage on                  565            567           2         17.7          56.5       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   644            647           3         15.5          64.4       1.0X
-month of timestamp wholestage on                    648            651           2         15.4          64.8       1.0X
+month of timestamp wholestage off                   543            547           6         18.4          54.3       1.0X
+month of timestamp wholestage on                    550            551           1         18.2          55.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1037           1038           1          9.6         103.7       1.0X
-weekofyear of timestamp wholestage on              1012           1022           9          9.9         101.2       1.0X
+weekofyear of timestamp wholestage off              775            782           9         12.9          77.5       1.0X
+weekofyear of timestamp wholestage on               854            856           2         11.7          85.4       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     648            651           4         15.4          64.8       1.0X
-day of timestamp wholestage on                      653            661           9         15.3          65.3       1.0X
+day of timestamp wholestage off                     551            552           2         18.1          55.1       1.0X
+day of timestamp wholestage on                      553            562          15         18.1          55.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               684            696          17         14.6          68.4       1.0X
-dayofyear of timestamp wholestage on                685            688           5         14.6          68.5       1.0X
+dayofyear of timestamp wholestage off               568            570           3         17.6          56.8       1.0X
+dayofyear of timestamp wholestage on                581            584           2         17.2          58.1       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              659            660           2         15.2          65.9       1.0X
-dayofmonth of timestamp wholestage on               649            654           5         15.4          64.9       1.0X
+dayofmonth of timestamp wholestage off              563            597          48         17.8          56.3       1.0X
+dayofmonth of timestamp wholestage on               555            562          11         18.0          55.5       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               815            821           8         12.3          81.5       1.0X
-dayofweek of timestamp wholestage on                817            820           2         12.2          81.7       1.0X
+dayofweek of timestamp wholestage off               674            675           1         14.8          67.4       1.0X
+dayofweek of timestamp wholestage on                677            684           6         14.8          67.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 747            749           4         13.4          74.7       1.0X
-weekday of timestamp wholestage on                  755            757           1         13.2          75.5       1.0X
+weekday of timestamp wholestage off                 628            629           1         15.9          62.8       1.0X
+weekday of timestamp wholestage on                  637            643          11         15.7          63.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    552            556           5         18.1          55.2       1.0X
-hour of timestamp wholestage on                     573            577           5         17.4          57.3       1.0X
+hour of timestamp wholestage off                    509            509           0         19.7          50.9       1.0X
+hour of timestamp wholestage on                     514            519           8         19.5          51.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  547            549           3         18.3          54.7       1.0X
-minute of timestamp wholestage on                   561            565           3         17.8          56.1       1.0X
+minute of timestamp wholestage off                  516            517           1         19.4          51.6       1.0X
+minute of timestamp wholestage on                   514            517           4         19.5          51.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  546            549           5         18.3          54.6       1.0X
-second of timestamp wholestage on                   561            570          13         17.8          56.1       1.0X
+second of timestamp wholestage off                  511            512           1         19.6          51.1       1.0X
+second of timestamp wholestage on                   516            521           3         19.4          51.6       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         182            182           0         55.1          18.2       1.0X
-current_date wholestage on                          218            227          12         45.9          21.8       0.8X
+current_date wholestage off                         150            150           0         66.6          15.0       1.0X
+current_date wholestage on                          177            181           4         56.4          17.7       0.8X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    192            205          18         52.1          19.2       1.0X
-current_timestamp wholestage on                     231            240           9         43.3          23.1       0.8X
+current_timestamp wholestage off                    165            175          15         60.7          16.5       1.0X
+current_timestamp wholestage on                     184            192          10         54.4          18.4       0.9X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         603            604           2         16.6          60.3       1.0X
-cast to date wholestage on                          611            614           3         16.4          61.1       1.0X
+cast to date wholestage off                         503            504           1         19.9          50.3       1.0X
+cast to date wholestage on                          508            515          12         19.7          50.8       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             668            668           1         15.0          66.8       1.0X
-last_day wholestage on                              681            688          13         14.7          68.1       1.0X
+last_day wholestage off                             566            568           3         17.7          56.6       1.0X
+last_day wholestage on                              591            593           2         16.9          59.1       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             641            648          10         15.6          64.1       1.0X
-next_day wholestage on                              644            647           3         15.5          64.4       1.0X
+next_day wholestage off                             541            552          16         18.5          54.1       1.0X
+next_day wholestage on                              544            546           3         18.4          54.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             587            588           2         17.0          58.7       1.0X
-date_add wholestage on                              609            611           2         16.4          60.9       1.0X
+date_add wholestage off                             494            499           8         20.2          49.4       1.0X
+date_add wholestage on                              510            517          10         19.6          51.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             585            586           1         17.1          58.5       1.0X
-date_sub wholestage on                              607            617          16         16.5          60.7       1.0X
+date_sub wholestage off                             495            499           6         20.2          49.5       1.0X
+date_sub wholestage on                              509            514           6         19.7          50.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           803            805           3         12.4          80.3       1.0X
-add_months wholestage on                            829            844          17         12.1          82.9       1.0X
+add_months wholestage off                           692            692           0         14.5          69.2       1.0X
+add_months wholestage on                            696            706          15         14.4          69.6       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3114           3175          85          3.2         311.4       1.0X
-format date wholestage on                          3127           3152          37          3.2         312.7       1.0X
+format date wholestage off                         2342           2346           6          4.3         234.2       1.0X
+format date wholestage on                          2349           2357          12          4.3         234.9       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       2821           2821           0          3.5         282.1       1.0X
-from_unixtime wholestage on                        2858           2871          12          3.5         285.8       1.0X
+from_unixtime wholestage off                       2054           2055           1          4.9         205.4       1.0X
+from_unixtime wholestage on                        2089           2096           9          4.8         208.9       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   745            746           0         13.4          74.5       1.0X
-from_utc_timestamp wholestage on                    783            788           6         12.8          78.3       1.0X
+from_utc_timestamp wholestage off                   616            619           4         16.2          61.6       1.0X
+from_utc_timestamp wholestage on                    662            664           3         15.1          66.2       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                     886            886           1         11.3          88.6       1.0X
-to_utc_timestamp wholestage on                      946            951           4         10.6          94.6       0.9X
+to_utc_timestamp wholestage off                     667            670           5         15.0          66.7       1.0X
+to_utc_timestamp wholestage on                      681            687           5         14.7          68.1       1.0X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        235            235           1         42.6          23.5       1.0X
-cast interval wholestage on                         221            223           3         45.3          22.1       1.1X
+cast interval wholestage off                        181            182           0         55.1          18.1       1.0X
+cast interval wholestage on                         179            184           3         55.8          17.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                             990           1000          13         10.1          99.0       1.0X
-datediff wholestage on                              991            995           3         10.1          99.1       1.0X
+datediff wholestage off                             827            846          27         12.1          82.7       1.0X
+datediff wholestage on                              825            833          14         12.1          82.5       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      3178           3181           4          3.1         317.8       1.0X
-months_between wholestage on                       3256           3269          17          3.1         325.6       1.0X
+months_between wholestage off                      2538           2540           2          3.9         253.8       1.0X
+months_between wholestage on                       2590           2607          17          3.9         259.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               597            616          28          1.7         596.8       1.0X
-window wholestage on                                657            686          16          1.5         656.8       0.9X
+window wholestage off                               457            477          28          2.2         457.5       1.0X
+window wholestage on                                494            502          10          2.0         494.3       0.9X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                      724            726           3         13.8          72.4       1.0X
-date_trunc YEAR wholestage on                       698            703           6         14.3          69.8       1.0X
+date_trunc YEAR wholestage off                      628            630           3         15.9          62.8       1.0X
+date_trunc YEAR wholestage on                       632            643          14         15.8          63.2       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                      723            733          14         13.8          72.3       1.0X
-date_trunc YYYY wholestage on                       699            703           4         14.3          69.9       1.0X
+date_trunc YYYY wholestage off                      626            632           9         16.0          62.6       1.0X
+date_trunc YYYY wholestage on                       632            635           3         15.8          63.2       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                        719            734          22         13.9          71.9       1.0X
-date_trunc YY wholestage on                         697            704           4         14.3          69.7       1.0X
+date_trunc YY wholestage off                        628            629           2         15.9          62.8       1.0X
+date_trunc YY wholestage on                         631            632           1         15.8          63.1       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                       734            735           2         13.6          73.4       1.0X
-date_trunc MON wholestage on                        714            716           3         14.0          71.4       1.0X
+date_trunc MON wholestage off                       634            635           2         15.8          63.4       1.0X
+date_trunc MON wholestage on                        616            619           3         16.2          61.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                     730            734           6         13.7          73.0       1.0X
-date_trunc MONTH wholestage on                      713            724          13         14.0          71.3       1.0X
+date_trunc MONTH wholestage off                     635            636           1         15.8          63.5       1.0X
+date_trunc MONTH wholestage on                      616            640          34         16.2          61.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                        728            731           4         13.7          72.8       1.0X
-date_trunc MM wholestage on                         716            719           2         14.0          71.6       1.0X
+date_trunc MM wholestage off                        638            639           2         15.7          63.8       1.0X
+date_trunc MM wholestage on                         615            621           6         16.3          61.5       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       574            577           5         17.4          57.4       1.0X
-date_trunc DAY wholestage on                        572            576           3         17.5          57.2       1.0X
+date_trunc DAY wholestage off                       503            503           0         19.9          50.3       1.0X
+date_trunc DAY wholestage on                        487            492           7         20.5          48.7       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        580            580           1         17.3          58.0       1.0X
-date_trunc DD wholestage on                         572            576           5         17.5          57.2       1.0X
+date_trunc DD wholestage off                        500            502           3         20.0          50.0       1.0X
+date_trunc DD wholestage on                         485            487           2         20.6          48.5       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      652            653           1         15.3          65.2       1.0X
-date_trunc HOUR wholestage on                       565            571          10         17.7          56.5       1.2X
+date_trunc HOUR wholestage off                      527            528           1         19.0          52.7       1.0X
+date_trunc HOUR wholestage on                       501            503           2         19.9          50.1       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    612            612           1         16.3          61.2       1.0X
-date_trunc MINUTE wholestage on                     574            576           2         17.4          57.4       1.1X
+date_trunc MINUTE wholestage off                    505            518          19         19.8          50.5       1.0X
+date_trunc MINUTE wholestage on                     481            483           3         20.8          48.1       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    329            331           3         30.4          32.9       1.0X
-date_trunc SECOND wholestage on                     284            286           2         35.2          28.4       1.2X
+date_trunc SECOND wholestage off                    258            259           1         38.8          25.8       1.0X
+date_trunc SECOND wholestage on                     221            223           2         45.2          22.1       1.2X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                      669            671           2         14.9          66.9       1.0X
-date_trunc WEEK wholestage on                       649            651           2         15.4          64.9       1.0X
+date_trunc WEEK wholestage off                      534            536           3         18.7          53.4       1.0X
+date_trunc WEEK wholestage on                       512            514           2         19.5          51.2       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                   875            882           9         11.4          87.5       1.0X
-date_trunc QUARTER wholestage on                    833            834           1         12.0          83.3       1.1X
+date_trunc QUARTER wholestage off                   714            716           3         14.0          71.4       1.0X
+date_trunc QUARTER wholestage on                    693            696           3         14.4          69.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           800            801           1         12.5          80.0       1.0X
-trunc year wholestage on                            763            766           3         13.1          76.3       1.0X
+trunc year wholestage off                           666            673           9         15.0          66.6       1.0X
+trunc year wholestage on                            632            633           1         15.8          63.2       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           799            802           4         12.5          79.9       1.0X
-trunc yyyy wholestage on                            765            775          17         13.1          76.5       1.0X
+trunc yyyy wholestage off                           669            669           1         15.0          66.9       1.0X
+trunc yyyy wholestage on                            633            637           4         15.8          63.3       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             802            802           1         12.5          80.2       1.0X
-trunc yy wholestage on                              766            768           2         13.1          76.6       1.0X
+trunc yy wholestage off                             673            679           7         14.9          67.3       1.0X
+trunc yy wholestage on                              636            642          12         15.7          63.6       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            759            763           6         13.2          75.9       1.0X
-trunc mon wholestage on                             722            724           2         13.9          72.2       1.1X
+trunc mon wholestage off                            633            633           1         15.8          63.3       1.0X
+trunc mon wholestage on                             599            603           3         16.7          59.9       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          754            756           3         13.3          75.4       1.0X
-trunc month wholestage on                           721            727           7         13.9          72.1       1.0X
+trunc month wholestage off                          626            627           1         16.0          62.6       1.0X
+trunc month wholestage on                           601            610          18         16.7          60.1       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             760            762           2         13.2          76.0       1.0X
-trunc mm wholestage on                              722            727           5         13.9          72.2       1.1X
+trunc mm wholestage off                             627            632           7         15.9          62.7       1.0X
+trunc mm wholestage on                              599            602           3         16.7          59.9       1.0X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     102            104           2          9.8         102.1       1.0X
-to timestamp str wholestage on                      109            111           1          9.2         108.8       0.9X
+to timestamp str wholestage off                      77             80           4         12.9          77.3       1.0X
+to timestamp str wholestage on                       79             81           3         12.7          78.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         705            705           0          1.4         705.4       1.0X
-to_timestamp wholestage on                          697            701           6          1.4         697.0       1.0X
+to_timestamp wholestage off                         457            458           0          2.2         457.4       1.0X
+to_timestamp wholestage on                          455            456           1          2.2         454.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    705            707           3          1.4         705.5       1.0X
-to_unix_timestamp wholestage on                     700            704           3          1.4         700.3       1.0X
+to_unix_timestamp wholestage off                    459            460           1          2.2         459.4       1.0X
+to_unix_timestamp wholestage on                     445            446           1          2.2         444.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          137            140           5          7.3         136.6       1.0X
-to date str wholestage on                           131            133           2          7.6         131.4       1.0X
+to date str wholestage off                          108            108           0          9.3         107.5       1.0X
+to date str wholestage on                           102            104           2          9.8         102.0       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              627            627           0          1.6         627.3       1.0X
-to_date wholestage on                               635            637           2          1.6         634.6       1.0X
+to_date wholestage off                              472            473           1          2.1         472.0       1.0X
+to_date wholestage on                               455            465          20          2.2         454.9       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  285            286           1         17.6          56.9       1.0X
-From java.time.LocalDate                            231            232           1         21.6          46.3       1.2X
-Collect java.sql.Date                              1098           1282         166          4.6         219.6       0.3X
-Collect java.time.LocalDate                         902            962          66          5.5         180.5       0.3X
-From java.sql.Timestamp                             240            249           7         20.8          48.1       1.2X
-From java.time.Instant                              224            257          50         22.3          44.8       1.3X
-Collect longs                                       882            999         187          5.7         176.5       0.3X
-Collect java.sql.Timestamp                          979           1070          82          5.1         195.8       0.3X
-Collect java.time.Instant                           846           1058         201          5.9         169.3       0.3X
-java.sql.Date to Hive string                       4645           4692          61          1.1         929.1       0.1X
-java.time.LocalDate to Hive string                 3572           3672          89          1.4         714.5       0.1X
-java.sql.Timestamp to Hive string                  7028           7180         135          0.7        1405.5       0.0X
-java.time.Instant to Hive string                   4729           4824          94          1.1         945.9       0.1X
+From java.sql.Date                                  246            249           4         20.3          49.2       1.0X
+From java.time.LocalDate                            170            172           2         29.4          34.0       1.4X
+Collect java.sql.Date                              1034           1087          61          4.8         206.9       0.2X
+Collect java.time.LocalDate                         701            803         158          7.1         140.1       0.4X
+From java.sql.Timestamp                             173            203          32         29.0          34.5       1.4X
+From java.time.Instant                              133            135           3         37.5          26.6       1.8X
+Collect longs                                       749            785          61          6.7         149.9       0.3X
+Collect java.sql.Timestamp                          869            925          84          5.8         173.7       0.3X
+Collect java.time.Instant                           734            860         125          6.8         146.8       0.3X
+java.sql.Date to Hive string                       3281           3391         127          1.5         656.2       0.1X
+java.time.LocalDate to Hive string                 2410           2458          52          2.1         481.9       0.1X
+java.sql.Timestamp to Hive string                  5030           5142         156          1.0        1006.1       0.0X
+java.time.Instant to Hive string                   3179           3225          48          1.6         635.8       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk21-results.txt
@@ -3,21 +3,21 @@ datetime +/- interval
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  826            872          75         12.1          82.6       1.0X
-date + interval(m, d)                               822            856          33         12.2          82.2       1.0X
-date + interval(m, d, ms)                          3529           3537          11          2.8         352.9       0.2X
-date - interval(m)                                  791            799           8         12.6          79.1       1.0X
-date - interval(m, d)                               823            837          12         12.2          82.3       1.0X
-date - interval(m, d, ms)                          3537           3555          25          2.8         353.7       0.2X
-timestamp + interval(m)                            1842           1857          22          5.4         184.2       0.4X
-timestamp + interval(m, d)                         1886           1889           5          5.3         188.6       0.4X
-timestamp + interval(m, d, ms)                     1934           1942          11          5.2         193.4       0.4X
-timestamp - interval(m)                            1708           1715          11          5.9         170.8       0.5X
-timestamp - interval(m, d)                         1747           1748           2          5.7         174.7       0.5X
-timestamp - interval(m, d, ms)                     1896           1905          13          5.3         189.6       0.4X
+date + interval(m)                                  937            951          18         10.7          93.7       1.0X
+date + interval(m, d)                               889            904          19         11.2          88.9       1.1X
+date + interval(m, d, ms)                          3636           3671          49          2.8         363.6       0.3X
+date - interval(m)                                  821            828           8         12.2          82.1       1.1X
+date - interval(m, d)                               850            858           9         11.8          85.0       1.1X
+date - interval(m, d, ms)                          3613           3614           2          2.8         361.3       0.3X
+timestamp + interval(m)                            1543           1547           6          6.5         154.3       0.6X
+timestamp + interval(m, d)                         1590           1595           8          6.3         159.0       0.6X
+timestamp + interval(m, d, ms)                     2052           2055           5          4.9         205.2       0.5X
+timestamp - interval(m)                            1847           1849           3          5.4         184.7       0.5X
+timestamp - interval(m, d)                         1897           1908          16          5.3         189.7       0.5X
+timestamp - interval(m, d, ms)                     2057           2063           7          4.9         205.7       0.5X
 
 
 ================================================================================================
@@ -25,95 +25,95 @@ Extract components
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    213            220          10         47.0          21.3       1.0X
-cast to timestamp wholestage on                     204            207           5         49.1          20.4       1.0X
+cast to timestamp wholestage off                    203            208           7         49.1          20.3       1.0X
+cast to timestamp wholestage on                     219            222           4         45.8          21.9       0.9X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    634            640           9         15.8          63.4       1.0X
-year of timestamp wholestage on                     636            646           9         15.7          63.6       1.0X
+year of timestamp wholestage off                    626            626           1         16.0          62.6       1.0X
+year of timestamp wholestage on                     640            646           9         15.6          64.0       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 672            675           4         14.9          67.2       1.0X
-quarter of timestamp wholestage on                  684            692           6         14.6          68.4       1.0X
+quarter of timestamp wholestage off                 659            663           5         15.2          65.9       1.0X
+quarter of timestamp wholestage on                  665            671           6         15.0          66.5       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   671            680          13         14.9          67.1       1.0X
-month of timestamp wholestage on                    672            680          10         14.9          67.2       1.0X
+month of timestamp wholestage off                   644            647           3         15.5          64.4       1.0X
+month of timestamp wholestage on                    648            651           2         15.4          64.8       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off              960            962           4         10.4          96.0       1.0X
-weekofyear of timestamp wholestage on               970            988          13         10.3          97.0       1.0X
+weekofyear of timestamp wholestage off             1037           1038           1          9.6         103.7       1.0X
+weekofyear of timestamp wholestage on              1012           1022           9          9.9         101.2       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     656            657           1         15.3          65.6       1.0X
-day of timestamp wholestage on                      663            670           5         15.1          66.3       1.0X
+day of timestamp wholestage off                     648            651           4         15.4          64.8       1.0X
+day of timestamp wholestage on                      653            661           9         15.3          65.3       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               677            684          10         14.8          67.7       1.0X
-dayofyear of timestamp wholestage on                700            704           4         14.3          70.0       1.0X
+dayofyear of timestamp wholestage off               684            696          17         14.6          68.4       1.0X
+dayofyear of timestamp wholestage on                685            688           5         14.6          68.5       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              666            671           7         15.0          66.6       1.0X
-dayofmonth of timestamp wholestage on               658            666           6         15.2          65.8       1.0X
+dayofmonth of timestamp wholestage off              659            660           2         15.2          65.9       1.0X
+dayofmonth of timestamp wholestage on               649            654           5         15.4          64.9       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               777            796          27         12.9          77.7       1.0X
-dayofweek of timestamp wholestage on                788            796          10         12.7          78.8       1.0X
+dayofweek of timestamp wholestage off               815            821           8         12.3          81.5       1.0X
+dayofweek of timestamp wholestage on                817            820           2         12.2          81.7       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 747            748           0         13.4          74.7       1.0X
-weekday of timestamp wholestage on                  762            770           9         13.1          76.2       1.0X
+weekday of timestamp wholestage off                 747            749           4         13.4          74.7       1.0X
+weekday of timestamp wholestage on                  755            757           1         13.2          75.5       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    589            590           1         17.0          58.9       1.0X
-hour of timestamp wholestage on                     598            604           7         16.7          59.8       1.0X
+hour of timestamp wholestage off                    552            556           5         18.1          55.2       1.0X
+hour of timestamp wholestage on                     573            577           5         17.4          57.3       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  617            618           1         16.2          61.7       1.0X
-minute of timestamp wholestage on                   596            603           8         16.8          59.6       1.0X
+minute of timestamp wholestage off                  547            549           3         18.3          54.7       1.0X
+minute of timestamp wholestage on                   561            565           3         17.8          56.1       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  595            612          24         16.8          59.5       1.0X
-second of timestamp wholestage on                   599            610           9         16.7          59.9       1.0X
+second of timestamp wholestage off                  546            549           5         18.3          54.6       1.0X
+second of timestamp wholestage on                   561            570          13         17.8          56.1       1.0X
 
 
 ================================================================================================
@@ -121,18 +121,18 @@ Current date and time
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         181            187           8         55.2          18.1       1.0X
-current_date wholestage on                          201            211          14         49.7          20.1       0.9X
+current_date wholestage off                         182            182           0         55.1          18.2       1.0X
+current_date wholestage on                          218            227          12         45.9          21.8       0.8X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    193            198           6         51.7          19.3       1.0X
-current_timestamp wholestage on                     212            223          17         47.1          21.2       0.9X
+current_timestamp wholestage off                    192            205          18         52.1          19.2       1.0X
+current_timestamp wholestage on                     231            240           9         43.3          23.1       0.8X
 
 
 ================================================================================================
@@ -140,46 +140,46 @@ Date arithmetic
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         611            628          23         16.4          61.1       1.0X
-cast to date wholestage on                          609            617           5         16.4          60.9       1.0X
+cast to date wholestage off                         603            604           2         16.6          60.3       1.0X
+cast to date wholestage on                          611            614           3         16.4          61.1       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             674            678           7         14.8          67.4       1.0X
-last_day wholestage on                              683            692           9         14.6          68.3       1.0X
+last_day wholestage off                             668            668           1         15.0          66.8       1.0X
+last_day wholestage on                              681            688          13         14.7          68.1       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             650            653           4         15.4          65.0       1.0X
-next_day wholestage on                              638            641           5         15.7          63.8       1.0X
+next_day wholestage off                             641            648          10         15.6          64.1       1.0X
+next_day wholestage on                              644            647           3         15.5          64.4       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             596            602           9         16.8          59.6       1.0X
-date_add wholestage on                              595            602           9         16.8          59.5       1.0X
+date_add wholestage off                             587            588           2         17.0          58.7       1.0X
+date_add wholestage on                              609            611           2         16.4          60.9       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             599            607          11         16.7          59.9       1.0X
-date_sub wholestage on                              602            607           8         16.6          60.2       1.0X
+date_sub wholestage off                             585            586           1         17.1          58.5       1.0X
+date_sub wholestage on                              607            617          16         16.5          60.7       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           817            818           1         12.2          81.7       1.0X
-add_months wholestage on                            811            818           8         12.3          81.1       1.0X
+add_months wholestage off                           803            805           3         12.4          80.3       1.0X
+add_months wholestage on                            829            844          17         12.1          82.9       1.0X
 
 
 ================================================================================================
@@ -187,11 +187,11 @@ Formatting dates
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         2731           2744          19          3.7         273.1       1.0X
-format date wholestage on                          2750           2785          45          3.6         275.0       1.0X
+format date wholestage off                         3114           3175          85          3.2         311.4       1.0X
+format date wholestage on                          3127           3152          37          3.2         312.7       1.0X
 
 
 ================================================================================================
@@ -199,11 +199,11 @@ Formatting timestamps
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       2936           2939           4          3.4         293.6       1.0X
-from_unixtime wholestage on                        2766           2779          15          3.6         276.6       1.1X
+from_unixtime wholestage off                       2821           2821           0          3.5         282.1       1.0X
+from_unixtime wholestage on                        2858           2871          12          3.5         285.8       1.0X
 
 
 ================================================================================================
@@ -211,18 +211,18 @@ Convert timestamps
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   729            731           4         13.7          72.9       1.0X
-from_utc_timestamp wholestage on                    790            799           7         12.7          79.0       0.9X
+from_utc_timestamp wholestage off                   745            746           0         13.4          74.5       1.0X
+from_utc_timestamp wholestage on                    783            788           6         12.8          78.3       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                     860            864           6         11.6          86.0       1.0X
-to_utc_timestamp wholestage on                      870            878           7         11.5          87.0       1.0X
+to_utc_timestamp wholestage off                     886            886           1         11.3          88.6       1.0X
+to_utc_timestamp wholestage on                      946            951           4         10.6          94.6       0.9X
 
 
 ================================================================================================
@@ -230,32 +230,32 @@ Intervals
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        219            239          28         45.6          21.9       1.0X
-cast interval wholestage on                         212            220           6         47.2          21.2       1.0X
+cast interval wholestage off                        235            235           1         42.6          23.5       1.0X
+cast interval wholestage on                         221            223           3         45.3          22.1       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1033           1035           3          9.7         103.3       1.0X
-datediff wholestage on                             1047           1053           6          9.6         104.7       1.0X
+datediff wholestage off                             990           1000          13         10.1          99.0       1.0X
+datediff wholestage on                              991            995           3         10.1          99.1       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      3185           3191           8          3.1         318.5       1.0X
-months_between wholestage on                       3224           3231           9          3.1         322.4       1.0X
+months_between wholestage off                      3178           3181           4          3.1         317.8       1.0X
+months_between wholestage on                       3256           3269          17          3.1         325.6       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               529            538          12          1.9         529.2       1.0X
-window wholestage on                                659            668           9          1.5         658.8       0.8X
+window wholestage off                               597            616          28          1.7         596.8       1.0X
+window wholestage on                                657            686          16          1.5         656.8       0.9X
 
 
 ================================================================================================
@@ -263,137 +263,137 @@ Truncation
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     1667           1671           6          6.0         166.7       1.0X
-date_trunc YEAR wholestage on                      1664           1670           6          6.0         166.4       1.0X
+date_trunc YEAR wholestage off                      724            726           3         13.8          72.4       1.0X
+date_trunc YEAR wholestage on                       698            703           6         14.3          69.8       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     1663           1665           3          6.0         166.3       1.0X
-date_trunc YYYY wholestage on                      1655           1666          10          6.0         165.5       1.0X
+date_trunc YYYY wholestage off                      723            733          14         13.8          72.3       1.0X
+date_trunc YYYY wholestage on                       699            703           4         14.3          69.9       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       1666           1670           6          6.0         166.6       1.0X
-date_trunc YY wholestage on                        1660           1674          14          6.0         166.0       1.0X
+date_trunc YY wholestage off                        719            734          22         13.9          71.9       1.0X
+date_trunc YY wholestage on                         697            704           4         14.3          69.7       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      1697           1700           5          5.9         169.7       1.0X
-date_trunc MON wholestage on                       1678           1696          24          6.0         167.8       1.0X
+date_trunc MON wholestage off                       734            735           2         13.6          73.4       1.0X
+date_trunc MON wholestage on                        714            716           3         14.0          71.4       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    1709           1716          10          5.9         170.9       1.0X
-date_trunc MONTH wholestage on                     1671           1678           7          6.0         167.1       1.0X
+date_trunc MONTH wholestage off                     730            734           6         13.7          73.0       1.0X
+date_trunc MONTH wholestage on                      713            724          13         14.0          71.3       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       1710           1717          11          5.8         171.0       1.0X
-date_trunc MM wholestage on                        1670           1679           5          6.0         167.0       1.0X
+date_trunc MM wholestage off                        728            731           4         13.7          72.8       1.0X
+date_trunc MM wholestage on                         716            719           2         14.0          71.6       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       636            638           3         15.7          63.6       1.0X
-date_trunc DAY wholestage on                        585            589           5         17.1          58.5       1.1X
+date_trunc DAY wholestage off                       574            577           5         17.4          57.4       1.0X
+date_trunc DAY wholestage on                        572            576           3         17.5          57.2       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        635            648          18         15.7          63.5       1.0X
-date_trunc DD wholestage on                         581            587           5         17.2          58.1       1.1X
+date_trunc DD wholestage off                        580            580           1         17.3          58.0       1.0X
+date_trunc DD wholestage on                         572            576           5         17.5          57.2       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      614            617           5         16.3          61.4       1.0X
-date_trunc HOUR wholestage on                       575            579           2         17.4          57.5       1.1X
+date_trunc HOUR wholestage off                      652            653           1         15.3          65.2       1.0X
+date_trunc HOUR wholestage on                       565            571          10         17.7          56.5       1.2X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    617            619           2         16.2          61.7       1.0X
-date_trunc MINUTE wholestage on                     579            589          16         17.3          57.9       1.1X
+date_trunc MINUTE wholestage off                    612            612           1         16.3          61.2       1.0X
+date_trunc MINUTE wholestage on                     574            576           2         17.4          57.4       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    302            302           1         33.2          30.2       1.0X
-date_trunc SECOND wholestage on                     273            279           7         36.7          27.3       1.1X
+date_trunc SECOND wholestage off                    329            331           3         30.4          32.9       1.0X
+date_trunc SECOND wholestage on                     284            286           2         35.2          28.4       1.2X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     1623           1631          12          6.2         162.3       1.0X
-date_trunc WEEK wholestage on                      1580           1597          17          6.3         158.0       1.0X
+date_trunc WEEK wholestage off                      669            671           2         14.9          66.9       1.0X
+date_trunc WEEK wholestage on                       649            651           2         15.4          64.9       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  2020           2025           6          4.9         202.0       1.0X
-date_trunc QUARTER wholestage on                   1958           1970           8          5.1         195.8       1.0X
+date_trunc QUARTER wholestage off                   875            882           9         11.4          87.5       1.0X
+date_trunc QUARTER wholestage on                    833            834           1         12.0          83.3       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           792            802          14         12.6          79.2       1.0X
-trunc year wholestage on                            744            750          11         13.4          74.4       1.1X
+trunc year wholestage off                           800            801           1         12.5          80.0       1.0X
+trunc year wholestage on                            763            766           3         13.1          76.3       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           798            801           4         12.5          79.8       1.0X
-trunc yyyy wholestage on                            743            761          18         13.5          74.3       1.1X
+trunc yyyy wholestage off                           799            802           4         12.5          79.9       1.0X
+trunc yyyy wholestage on                            765            775          17         13.1          76.5       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             792            802          14         12.6          79.2       1.0X
-trunc yy wholestage on                              744            755          14         13.4          74.4       1.1X
+trunc yy wholestage off                             802            802           1         12.5          80.2       1.0X
+trunc yy wholestage on                              766            768           2         13.1          76.6       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            768            771           3         13.0          76.8       1.0X
-trunc mon wholestage on                             721            731          10         13.9          72.1       1.1X
+trunc mon wholestage off                            759            763           6         13.2          75.9       1.0X
+trunc mon wholestage on                             722            724           2         13.9          72.2       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          774            781           9         12.9          77.4       1.0X
-trunc month wholestage on                           723            728           6         13.8          72.3       1.1X
+trunc month wholestage off                          754            756           3         13.3          75.4       1.0X
+trunc month wholestage on                           721            727           7         13.9          72.1       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             766            770           5         13.0          76.6       1.0X
-trunc mm wholestage on                              724            732           9         13.8          72.4       1.1X
+trunc mm wholestage off                             760            762           2         13.2          76.0       1.0X
+trunc mm wholestage on                              722            727           5         13.9          72.2       1.1X
 
 
 ================================================================================================
@@ -401,39 +401,39 @@ Parsing
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     107            107           0          9.3         107.0       1.0X
-to timestamp str wholestage on                      123            127           4          8.1         122.9       0.9X
+to timestamp str wholestage off                     102            104           2          9.8         102.1       1.0X
+to timestamp str wholestage on                      109            111           1          9.2         108.8       0.9X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         643            650           9          1.6         643.1       1.0X
-to_timestamp wholestage on                          659            669          11          1.5         659.2       1.0X
+to_timestamp wholestage off                         705            705           0          1.4         705.4       1.0X
+to_timestamp wholestage on                          697            701           6          1.4         697.0       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    660            660           1          1.5         659.5       1.0X
-to_unix_timestamp wholestage on                     660            666           5          1.5         659.6       1.0X
+to_unix_timestamp wholestage off                    705            707           3          1.4         705.5       1.0X
+to_unix_timestamp wholestage on                     700            704           3          1.4         700.3       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          163            163           1          6.1         162.9       1.0X
-to date str wholestage on                           169            172           5          5.9         168.7       1.0X
+to date str wholestage off                          137            140           5          7.3         136.6       1.0X
+to date str wholestage on                           131            133           2          7.6         131.4       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              654            658           5          1.5         654.5       1.0X
-to_date wholestage on                               656            662           4          1.5         656.5       1.0X
+to_date wholestage off                              627            627           0          1.6         627.3       1.0X
+to_date wholestage on                               635            637           2          1.6         634.6       1.0X
 
 
 ================================================================================================
@@ -441,21 +441,21 @@ Conversion from/to external types
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  317            319           4         15.8          63.3       1.0X
-From java.time.LocalDate                            235            235           1         21.3          46.9       1.3X
-Collect java.sql.Date                              1550           1622          77          3.2         310.1       0.2X
-Collect java.time.LocalDate                        1021           1145         108          4.9         204.2       0.3X
-From java.sql.Timestamp                             241            257          15         20.8          48.1       1.3X
-From java.time.Instant                              206            215          13         24.2          41.3       1.5X
-Collect longs                                      1065           1186         205          4.7         213.0       0.3X
-Collect java.sql.Timestamp                         1330           1414          73          3.8         266.1       0.2X
-Collect java.time.Instant                          1180           1303         107          4.2         236.0       0.3X
-java.sql.Date to Hive string                       5630           5668          38          0.9        1125.9       0.1X
-java.time.LocalDate to Hive string                 4147           4197          67          1.2         829.3       0.1X
-java.sql.Timestamp to Hive string                  7441           7609         160          0.7        1488.1       0.0X
-java.time.Instant to Hive string                   5179           5237          94          1.0        1035.8       0.1X
+From java.sql.Date                                  285            286           1         17.6          56.9       1.0X
+From java.time.LocalDate                            231            232           1         21.6          46.3       1.2X
+Collect java.sql.Date                              1098           1282         166          4.6         219.6       0.3X
+Collect java.time.LocalDate                         902            962          66          5.5         180.5       0.3X
+From java.sql.Timestamp                             240            249           7         20.8          48.1       1.2X
+From java.time.Instant                              224            257          50         22.3          44.8       1.3X
+Collect longs                                       882            999         187          5.7         176.5       0.3X
+Collect java.sql.Timestamp                          979           1070          82          5.1         195.8       0.3X
+Collect java.time.Instant                           846           1058         201          5.9         169.3       0.3X
+java.sql.Date to Hive string                       4645           4692          61          1.1         929.1       0.1X
+java.time.LocalDate to Hive string                 3572           3672          89          1.4         714.5       0.1X
+java.sql.Timestamp to Hive string                  7028           7180         135          0.7        1405.5       0.0X
+java.time.Instant to Hive string                   4729           4824          94          1.1         945.9       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk25-results.txt
@@ -6,18 +6,18 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  836            853          23         12.0          83.6       1.0X
-date + interval(m, d)                               827            891         101         12.1          82.7       1.0X
-date + interval(m, d, ms)                          3338           3343           7          3.0         333.8       0.3X
-date - interval(m)                                  805            808           4         12.4          80.5       1.0X
-date - interval(m, d)                               823            826           4         12.1          82.3       1.0X
-date - interval(m, d, ms)                          3338           3344           8          3.0         333.8       0.3X
-timestamp + interval(m)                            1697           1700           4          5.9         169.7       0.5X
-timestamp + interval(m, d)                         1757           1761           5          5.7         175.7       0.5X
-timestamp + interval(m, d, ms)                     2124           2125           1          4.7         212.4       0.4X
-timestamp - interval(m)                            1861           1868          11          5.4         186.1       0.4X
-timestamp - interval(m, d)                         1940           1941           1          5.2         194.0       0.4X
-timestamp - interval(m, d, ms)                     2120           2124           5          4.7         212.0       0.4X
+date + interval(m)                                  926            960          49         10.8          92.6       1.0X
+date + interval(m, d)                               915            924           8         10.9          91.5       1.0X
+date + interval(m, d, ms)                          3248           3305          80          3.1         324.8       0.3X
+date - interval(m)                                  830            832           2         12.1          83.0       1.1X
+date - interval(m, d)                               847            848           1         11.8          84.7       1.1X
+date - interval(m, d, ms)                          3278           3285          10          3.1         327.8       0.3X
+timestamp + interval(m)                            1670           1686          22          6.0         167.0       0.6X
+timestamp + interval(m, d)                         1737           1737           1          5.8         173.7       0.5X
+timestamp + interval(m, d, ms)                     2086           2087           2          4.8         208.6       0.4X
+timestamp - interval(m)                            1875           1875           0          5.3         187.5       0.5X
+timestamp - interval(m, d)                         1925           1927           2          5.2         192.5       0.5X
+timestamp - interval(m, d, ms)                     2086           2089           4          4.8         208.6       0.4X
 
 
 ================================================================================================
@@ -28,92 +28,92 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    199            200           1         50.2          19.9       1.0X
-cast to timestamp wholestage on                     214            228          26         46.8          21.4       0.9X
+cast to timestamp wholestage off                    202            204           2         49.4          20.2       1.0X
+cast to timestamp wholestage on                     207            216           6         48.4          20.7       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    604            605           1         16.6          60.4       1.0X
-year of timestamp wholestage on                     609            616           7         16.4          60.9       1.0X
+year of timestamp wholestage off                    624            624           0         16.0          62.4       1.0X
+year of timestamp wholestage on                     626            628           2         16.0          62.6       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 656            665          13         15.3          65.6       1.0X
-quarter of timestamp wholestage on                  640            649           7         15.6          64.0       1.0X
+quarter of timestamp wholestage off                 675            681           9         14.8          67.5       1.0X
+quarter of timestamp wholestage on                  662            664           2         15.1          66.2       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   626            626           1         16.0          62.6       1.0X
-month of timestamp wholestage on                    620            625           3         16.1          62.0       1.0X
+month of timestamp wholestage off                   654            656           2         15.3          65.4       1.0X
+month of timestamp wholestage on                    640            643           2         15.6          64.0       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1028           1029           1          9.7         102.8       1.0X
-weekofyear of timestamp wholestage on              1032           1040           9          9.7         103.2       1.0X
+weekofyear of timestamp wholestage off              918            920           3         10.9          91.8       1.0X
+weekofyear of timestamp wholestage on               913            922          13         11.0          91.3       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     640            642           3         15.6          64.0       1.0X
-day of timestamp wholestage on                      626            630           4         16.0          62.6       1.0X
+day of timestamp wholestage off                     645            648           4         15.5          64.5       1.0X
+day of timestamp wholestage on                      641            647           9         15.6          64.1       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               666            674          11         15.0          66.6       1.0X
-dayofyear of timestamp wholestage on                665            670           5         15.0          66.5       1.0X
+dayofyear of timestamp wholestage off               687            693           8         14.5          68.7       1.0X
+dayofyear of timestamp wholestage on                683            686           3         14.6          68.3       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              638            638           0         15.7          63.8       1.0X
-dayofmonth of timestamp wholestage on               623            635          12         16.1          62.3       1.0X
+dayofmonth of timestamp wholestage off              645            646           2         15.5          64.5       1.0X
+dayofmonth of timestamp wholestage on               641            648           7         15.6          64.1       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               796            797           1         12.6          79.6       1.0X
-dayofweek of timestamp wholestage on                798            802           2         12.5          79.8       1.0X
+dayofweek of timestamp wholestage off               826            827           2         12.1          82.6       1.0X
+dayofweek of timestamp wholestage on                812            815           4         12.3          81.2       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 732            732           1         13.7          73.2       1.0X
-weekday of timestamp wholestage on                  736            738           2         13.6          73.6       1.0X
+weekday of timestamp wholestage off                 750            750           1         13.3          75.0       1.0X
+weekday of timestamp wholestage on                  750            753           4         13.3          75.0       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    533            534           2         18.8          53.3       1.0X
-hour of timestamp wholestage on                     545            547           2         18.3          54.5       1.0X
+hour of timestamp wholestage off                    542            551          12         18.5          54.2       1.0X
+hour of timestamp wholestage on                     542            544           2         18.4          54.2       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  535            539           5         18.7          53.5       1.0X
-minute of timestamp wholestage on                   545            547           3         18.4          54.5       1.0X
+minute of timestamp wholestage off                  559            561           2         17.9          55.9       1.0X
+minute of timestamp wholestage on                   543            548           3         18.4          54.3       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  537            541           6         18.6          53.7       1.0X
-second of timestamp wholestage on                   547            552           5         18.3          54.7       1.0X
+second of timestamp wholestage off                  553            557           5         18.1          55.3       1.0X
+second of timestamp wholestage on                   543            545           1         18.4          54.3       1.0X
 
 
 ================================================================================================
@@ -124,15 +124,15 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         192            201          13         52.2          19.2       1.0X
-current_date wholestage on                          208            212           5         48.1          20.8       0.9X
+current_date wholestage off                         193            196           4         51.8          19.3       1.0X
+current_date wholestage on                          209            215           4         47.8          20.9       0.9X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
 current_timestamp wholestage off                    202            205           5         49.6          20.2       1.0X
-current_timestamp wholestage on                     212            217           5         47.2          21.2       1.0X
+current_timestamp wholestage on                     216            222           5         46.3          21.6       0.9X
 
 
 ================================================================================================
@@ -143,43 +143,43 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         591            591           1         16.9          59.1       1.0X
-cast to date wholestage on                          584            586           1         17.1          58.4       1.0X
+cast to date wholestage off                         608            612           6         16.5          60.8       1.0X
+cast to date wholestage on                          611            614           3         16.4          61.1       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             651            653           3         15.4          65.1       1.0X
-last_day wholestage on                              672            678           6         14.9          67.2       1.0X
+last_day wholestage off                             680            681           1         14.7          68.0       1.0X
+last_day wholestage on                              699            702           3         14.3          69.9       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             622            623           2         16.1          62.2       1.0X
-next_day wholestage on                              611            617           4         16.4          61.1       1.0X
+next_day wholestage off                             652            652           0         15.3          65.2       1.0X
+next_day wholestage on                              629            632           3         15.9          62.9       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             564            569           8         17.7          56.4       1.0X
-date_add wholestage on                              564            570           4         17.7          56.4       1.0X
+date_add wholestage off                             579            580           2         17.3          57.9       1.0X
+date_add wholestage on                              586            587           1         17.1          58.6       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             568            568           1         17.6          56.8       1.0X
-date_sub wholestage on                              573            575           2         17.4          57.3       1.0X
+date_sub wholestage off                             581            581           1         17.2          58.1       1.0X
+date_sub wholestage on                              589            590           1         17.0          58.9       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           799            809          15         12.5          79.9       1.0X
-add_months wholestage on                            805            814          14         12.4          80.5       1.0X
+add_months wholestage off                           820            820           0         12.2          82.0       1.0X
+add_months wholestage on                            810            815           7         12.4          81.0       1.0X
 
 
 ================================================================================================
@@ -190,8 +190,8 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         2907           2981         104          3.4         290.7       1.0X
-format date wholestage on                          2902           2909           9          3.4         290.2       1.0X
+format date wholestage off                         2984           2985           0          3.4         298.4       1.0X
+format date wholestage on                          2917           2921           4          3.4         291.7       1.0X
 
 
 ================================================================================================
@@ -202,8 +202,8 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       2825           2825           0          3.5         282.5       1.0X
-from_unixtime wholestage on                        2667           2673           6          3.8         266.7       1.1X
+from_unixtime wholestage off                       2539           2541           3          3.9         253.9       1.0X
+from_unixtime wholestage on                        2608           2615           8          3.8         260.8       1.0X
 
 
 ================================================================================================
@@ -214,15 +214,15 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   733            733           1         13.6          73.3       1.0X
-from_utc_timestamp wholestage on                    698            701           8         14.3          69.8       1.1X
+from_utc_timestamp wholestage off                   653            654           2         15.3          65.3       1.0X
+from_utc_timestamp wholestage on                    689            691           2         14.5          68.9       0.9X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                     863            866           4         11.6          86.3       1.0X
-to_utc_timestamp wholestage on                      873            876           2         11.5          87.3       1.0X
+to_utc_timestamp wholestage off                     855            857           2         11.7          85.5       1.0X
+to_utc_timestamp wholestage on                      862            865           3         11.6          86.2       1.0X
 
 
 ================================================================================================
@@ -233,29 +233,29 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        285            286           1         35.1          28.5       1.0X
-cast interval wholestage on                         208            211           3         48.1          20.8       1.4X
+cast interval wholestage off                        258            265          10         38.8          25.8       1.0X
+cast interval wholestage on                         207            213           7         48.3          20.7       1.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                             943            943           0         10.6          94.3       1.0X
-datediff wholestage on                              940            945           4         10.6          94.0       1.0X
+datediff wholestage off                             991            996           8         10.1          99.1       1.0X
+datediff wholestage on                             1016           1018           2          9.8         101.6       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      3189           3192           5          3.1         318.9       1.0X
-months_between wholestage on                       3184           3191           5          3.1         318.4       1.0X
+months_between wholestage off                      3277           3278           2          3.1         327.7       1.0X
+months_between wholestage on                       3284           3288           4          3.0         328.4       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               574            586          17          1.7         573.6       1.0X
-window wholestage on                                686            714          26          1.5         685.8       0.8X
+window wholestage off                               588            600          16          1.7         588.4       1.0X
+window wholestage on                                692            711          24          1.4         692.1       0.9X
 
 
 ================================================================================================
@@ -266,134 +266,134 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     1705           1708           4          5.9         170.5       1.0X
-date_trunc YEAR wholestage on                      1635           1639           3          6.1         163.5       1.0X
+date_trunc YEAR wholestage off                      774            775           1         12.9          77.4       1.0X
+date_trunc YEAR wholestage on                       688            692           4         14.5          68.8       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     1709           1710           2          5.9         170.9       1.0X
-date_trunc YYYY wholestage on                      1636           1639           3          6.1         163.6       1.0X
+date_trunc YYYY wholestage off                      770            772           3         13.0          77.0       1.0X
+date_trunc YYYY wholestage on                       686            694           7         14.6          68.6       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       1708           1710           2          5.9         170.8       1.0X
-date_trunc YY wholestage on                        1635           1637           2          6.1         163.5       1.0X
+date_trunc YY wholestage off                        771            772           1         13.0          77.1       1.0X
+date_trunc YY wholestage on                         688            691           4         14.5          68.8       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      1795           1797           3          5.6         179.5       1.0X
-date_trunc MON wholestage on                       1633           1636           3          6.1         163.3       1.1X
+date_trunc MON wholestage off                       829            837          12         12.1          82.9       1.0X
+date_trunc MON wholestage on                        661            666           5         15.1          66.1       1.3X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    1795           1795           0          5.6         179.5       1.0X
-date_trunc MONTH wholestage on                     1632           1633           1          6.1         163.2       1.1X
+date_trunc MONTH wholestage off                     819            831          18         12.2          81.9       1.0X
+date_trunc MONTH wholestage on                      658            663           3         15.2          65.8       1.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       1797           1798           0          5.6         179.7       1.0X
-date_trunc MM wholestage on                        1633           1635           3          6.1         163.3       1.1X
+date_trunc MM wholestage off                        822            829           9         12.2          82.2       1.0X
+date_trunc MM wholestage on                         661            662           2         15.1          66.1       1.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       571            572           1         17.5          57.1       1.0X
-date_trunc DAY wholestage on                        541            546           5         18.5          54.1       1.1X
+date_trunc DAY wholestage off                       743            744           2         13.5          74.3       1.0X
+date_trunc DAY wholestage on                        551            553           2         18.1          55.1       1.3X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        572            572           0         17.5          57.2       1.0X
-date_trunc DD wholestage on                         543            550           5         18.4          54.3       1.1X
+date_trunc DD wholestage off                        742            756          20         13.5          74.2       1.0X
+date_trunc DD wholestage on                         550            554           3         18.2          55.0       1.3X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      546            547           1         18.3          54.6       1.0X
-date_trunc HOUR wholestage on                       516            518           2         19.4          51.6       1.1X
+date_trunc HOUR wholestage off                      768            776          11         13.0          76.8       1.0X
+date_trunc HOUR wholestage on                       553            556           2         18.1          55.3       1.4X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    547            552           7         18.3          54.7       1.0X
-date_trunc MINUTE wholestage on                     498            502           3         20.1          49.8       1.1X
+date_trunc MINUTE wholestage off                    762            765           4         13.1          76.2       1.0X
+date_trunc MINUTE wholestage on                     542            546           5         18.5          54.2       1.4X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    308            308           0         32.4          30.8       1.0X
-date_trunc SECOND wholestage on                     269            273           3         37.1          26.9       1.1X
+date_trunc SECOND wholestage off                    541            541           1         18.5          54.1       1.0X
+date_trunc SECOND wholestage on                     261            264           2         38.3          26.1       2.1X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     1619           1622           4          6.2         161.9       1.0X
-date_trunc WEEK wholestage on                      1547           1551           3          6.5         154.7       1.0X
+date_trunc WEEK wholestage off                      793            793           0         12.6          79.3       1.0X
+date_trunc WEEK wholestage on                       588            591           3         17.0          58.8       1.4X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  2163           2171          12          4.6         216.3       1.0X
-date_trunc QUARTER wholestage on                   2016           2040          16          5.0         201.6       1.1X
+date_trunc QUARTER wholestage off                  1076           1077           2          9.3         107.6       1.0X
+date_trunc QUARTER wholestage on                    797            802           3         12.5          79.7       1.3X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           781            782           1         12.8          78.1       1.0X
-trunc year wholestage on                            736            739           2         13.6          73.6       1.1X
+trunc year wholestage off                           881            887           8         11.3          88.1       1.0X
+trunc year wholestage on                            757            760           2         13.2          75.7       1.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           783            783           0         12.8          78.3       1.0X
-trunc yyyy wholestage on                            735            738           2         13.6          73.5       1.1X
+trunc yyyy wholestage off                           879            880           2         11.4          87.9       1.0X
+trunc yyyy wholestage on                            755            758           2         13.2          75.5       1.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             782            785           3         12.8          78.2       1.0X
-trunc yy wholestage on                              737            739           2         13.6          73.7       1.1X
+trunc yy wholestage off                             878            880           3         11.4          87.8       1.0X
+trunc yy wholestage on                              755            757           1         13.3          75.5       1.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            750            750           0         13.3          75.0       1.0X
-trunc mon wholestage on                             688            689           2         14.5          68.8       1.1X
+trunc mon wholestage off                            827            828           2         12.1          82.7       1.0X
+trunc mon wholestage on                             706            708           2         14.2          70.6       1.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          751            765          20         13.3          75.1       1.0X
-trunc month wholestage on                           686            689           3         14.6          68.6       1.1X
+trunc month wholestage off                          828            830           2         12.1          82.8       1.0X
+trunc month wholestage on                           705            707           3         14.2          70.5       1.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             751            751           1         13.3          75.1       1.0X
-trunc mm wholestage on                              685            688           4         14.6          68.5       1.1X
+trunc mm wholestage off                             834            834           0         12.0          83.4       1.0X
+trunc mm wholestage on                              705            708           2         14.2          70.5       1.2X
 
 
 ================================================================================================
@@ -404,36 +404,36 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                      92             93           2         10.9          91.9       1.0X
-to timestamp str wholestage on                       84             86           1         11.9          83.9       1.1X
+to timestamp str wholestage off                      98             99           2         10.2          97.8       1.0X
+to timestamp str wholestage on                       82             89           9         12.1          82.3       1.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         611            611           1          1.6         610.9       1.0X
-to_timestamp wholestage on                          601            603           2          1.7         601.3       1.0X
+to_timestamp wholestage off                         621            625           5          1.6         621.3       1.0X
+to_timestamp wholestage on                          599            602           2          1.7         599.3       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    609            611           4          1.6         608.6       1.0X
-to_unix_timestamp wholestage on                     593            595           2          1.7         593.4       1.0X
+to_unix_timestamp wholestage off                    603            612          12          1.7         603.1       1.0X
+to_unix_timestamp wholestage on                     602            602           0          1.7         601.8       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          111            114           4          9.0         110.9       1.0X
-to date str wholestage on                           110            112           2          9.1         109.9       1.0X
+to date str wholestage off                          117            122           7          8.5         117.0       1.0X
+to date str wholestage on                           108            110           2          9.3         107.6       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              620            622           3          1.6         620.0       1.0X
-to_date wholestage on                               611            613           2          1.6         611.3       1.0X
+to_date wholestage off                              593            595           2          1.7         593.2       1.0X
+to_date wholestage on                               583            587           4          1.7         583.3       1.0X
 
 
 ================================================================================================
@@ -444,18 +444,18 @@ OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  290            291           1         17.2          58.1       1.0X
-From java.time.LocalDate                            224            227           2         22.3          44.8       1.3X
-Collect java.sql.Date                              1274           1300          30          3.9         254.8       0.2X
-Collect java.time.LocalDate                         939           1088         158          5.3         187.9       0.3X
-From java.sql.Timestamp                             248            257           8         20.2          49.6       1.2X
-From java.time.Instant                              195            205          16         25.7          38.9       1.5X
-Collect longs                                      1042           1067          22          4.8         208.3       0.3X
-Collect java.sql.Timestamp                         1136           1226          84          4.4         227.3       0.3X
-Collect java.time.Instant                           925           1042         101          5.4         185.0       0.3X
-java.sql.Date to Hive string                       4507           4562          81          1.1         901.3       0.1X
-java.time.LocalDate to Hive string                 3638           3757         103          1.4         727.6       0.1X
-java.sql.Timestamp to Hive string                  7280           7445         169          0.7        1456.0       0.0X
-java.time.Instant to Hive string                   4745           4883         136          1.1         949.1       0.1X
+From java.sql.Date                                  278            281           3         18.0          55.5       1.0X
+From java.time.LocalDate                            216            222           5         23.1          43.2       1.3X
+Collect java.sql.Date                              1247           1317          69          4.0         249.5       0.2X
+Collect java.time.LocalDate                         868           1052         186          5.8         173.7       0.3X
+From java.sql.Timestamp                             216            246          34         23.2          43.2       1.3X
+From java.time.Instant                              180            195          22         27.7          36.1       1.5X
+Collect longs                                       808           1028         206          6.2         161.6       0.3X
+Collect java.sql.Timestamp                         1210           1262          63          4.1         242.0       0.2X
+Collect java.time.Instant                           984           1067          78          5.1         196.7       0.3X
+java.sql.Date to Hive string                       4481           4583         122          1.1         896.2       0.1X
+java.time.LocalDate to Hive string                 3656           3719          87          1.4         731.2       0.1X
+java.sql.Timestamp to Hive string                  7237           7325         114          0.7        1447.5       0.0X
+java.time.Instant to Hive string                   4862           4897          39          1.0         972.5       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-jdk25-results.txt
@@ -2,460 +2,460 @@
 datetime +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                  926            960          49         10.8          92.6       1.0X
-date + interval(m, d)                               915            924           8         10.9          91.5       1.0X
-date + interval(m, d, ms)                          3248           3305          80          3.1         324.8       0.3X
-date - interval(m)                                  830            832           2         12.1          83.0       1.1X
-date - interval(m, d)                               847            848           1         11.8          84.7       1.1X
-date - interval(m, d, ms)                          3278           3285          10          3.1         327.8       0.3X
-timestamp + interval(m)                            1670           1686          22          6.0         167.0       0.6X
-timestamp + interval(m, d)                         1737           1737           1          5.8         173.7       0.5X
-timestamp + interval(m, d, ms)                     2086           2087           2          4.8         208.6       0.4X
-timestamp - interval(m)                            1875           1875           0          5.3         187.5       0.5X
-timestamp - interval(m, d)                         1925           1927           2          5.2         192.5       0.5X
-timestamp - interval(m, d, ms)                     2086           2089           4          4.8         208.6       0.4X
+date + interval(m)                                  915            954          67         10.9          91.5       1.0X
+date + interval(m, d)                               903            916          13         11.1          90.3       1.0X
+date + interval(m, d, ms)                          3520           3548          40          2.8         352.0       0.3X
+date - interval(m)                                  893            896           4         11.2          89.3       1.0X
+date - interval(m, d)                               900            901           1         11.1          90.0       1.0X
+date - interval(m, d, ms)                          3547           3556          13          2.8         354.7       0.3X
+timestamp + interval(m)                            1909           1910           1          5.2         190.9       0.5X
+timestamp + interval(m, d)                         1946           1948           3          5.1         194.6       0.5X
+timestamp + interval(m, d, ms)                     2071           2075           6          4.8         207.1       0.4X
+timestamp - interval(m)                            1844           1845           2          5.4         184.4       0.5X
+timestamp - interval(m, d)                         1922           1927           6          5.2         192.2       0.5X
+timestamp - interval(m, d, ms)                     2070           2071           2          4.8         207.0       0.4X
 
 
 ================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    202            204           2         49.4          20.2       1.0X
-cast to timestamp wholestage on                     207            216           6         48.4          20.7       1.0X
+cast to timestamp wholestage off                    213            215           2         46.9          21.3       1.0X
+cast to timestamp wholestage on                     220            225           3         45.5          22.0       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    624            624           0         16.0          62.4       1.0X
-year of timestamp wholestage on                     626            628           2         16.0          62.6       1.0X
+year of timestamp wholestage off                    667            673           8         15.0          66.7       1.0X
+year of timestamp wholestage on                     686            689           4         14.6          68.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 675            681           9         14.8          67.5       1.0X
-quarter of timestamp wholestage on                  662            664           2         15.1          66.2       1.0X
+quarter of timestamp wholestage off                 712            714           4         14.1          71.2       1.0X
+quarter of timestamp wholestage on                  721            724           4         13.9          72.1       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   654            656           2         15.3          65.4       1.0X
-month of timestamp wholestage on                    640            643           2         15.6          64.0       1.0X
+month of timestamp wholestage off                   690            692           3         14.5          69.0       1.0X
+month of timestamp wholestage on                    706            726          17         14.2          70.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off              918            920           3         10.9          91.8       1.0X
-weekofyear of timestamp wholestage on               913            922          13         11.0          91.3       1.0X
+weekofyear of timestamp wholestage off              998           1005          10         10.0          99.8       1.0X
+weekofyear of timestamp wholestage on              1036           1039           3          9.6         103.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     645            648           4         15.5          64.5       1.0X
-day of timestamp wholestage on                      641            647           9         15.6          64.1       1.0X
+day of timestamp wholestage off                     701            703           2         14.3          70.1       1.0X
+day of timestamp wholestage on                      715            722           5         14.0          71.5       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               687            693           8         14.5          68.7       1.0X
-dayofyear of timestamp wholestage on                683            686           3         14.6          68.3       1.0X
+dayofyear of timestamp wholestage off               742            748           9         13.5          74.2       1.0X
+dayofyear of timestamp wholestage on                748            754           5         13.4          74.8       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              645            646           2         15.5          64.5       1.0X
-dayofmonth of timestamp wholestage on               641            648           7         15.6          64.1       1.0X
+dayofmonth of timestamp wholestage off              706            714          12         14.2          70.6       1.0X
+dayofmonth of timestamp wholestage on               713            718           3         14.0          71.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               826            827           2         12.1          82.6       1.0X
-dayofweek of timestamp wholestage on                812            815           4         12.3          81.2       1.0X
+dayofweek of timestamp wholestage off               858            860           3         11.7          85.8       1.0X
+dayofweek of timestamp wholestage on                864            868           6         11.6          86.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 750            750           1         13.3          75.0       1.0X
-weekday of timestamp wholestage on                  750            753           4         13.3          75.0       1.0X
+weekday of timestamp wholestage off                 818            830          17         12.2          81.8       1.0X
+weekday of timestamp wholestage on                  826            829           2         12.1          82.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    542            551          12         18.5          54.2       1.0X
-hour of timestamp wholestage on                     542            544           2         18.4          54.2       1.0X
+hour of timestamp wholestage off                    594            595           1         16.8          59.4       1.0X
+hour of timestamp wholestage on                     600            605           4         16.7          60.0       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  559            561           2         17.9          55.9       1.0X
-minute of timestamp wholestage on                   543            548           3         18.4          54.3       1.0X
+minute of timestamp wholestage off                  594            596           3         16.8          59.4       1.0X
+minute of timestamp wholestage on                   600            602           1         16.7          60.0       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  553            557           5         18.1          55.3       1.0X
-second of timestamp wholestage on                   543            545           1         18.4          54.3       1.0X
+second of timestamp wholestage off                  590            591           1         16.9          59.0       1.0X
+second of timestamp wholestage on                   601            604           3         16.6          60.1       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         193            196           4         51.8          19.3       1.0X
-current_date wholestage on                          209            215           4         47.8          20.9       0.9X
+current_date wholestage off                         212            215           3         47.1          21.2       1.0X
+current_date wholestage on                          216            222           6         46.2          21.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    202            205           5         49.6          20.2       1.0X
-current_timestamp wholestage on                     216            222           5         46.3          21.6       0.9X
+current_timestamp wholestage off                    218            223           7         45.9          21.8       1.0X
+current_timestamp wholestage on                     223            235          18         44.8          22.3       1.0X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         608            612           6         16.5          60.8       1.0X
-cast to date wholestage on                          611            614           3         16.4          61.1       1.0X
+cast to date wholestage off                         642            643           2         15.6          64.2       1.0X
+cast to date wholestage on                          643            647           5         15.5          64.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             680            681           1         14.7          68.0       1.0X
-last_day wholestage on                              699            702           3         14.3          69.9       1.0X
+last_day wholestage off                             729            738          13         13.7          72.9       1.0X
+last_day wholestage on                              733            737           3         13.6          73.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             652            652           0         15.3          65.2       1.0X
-next_day wholestage on                              629            632           3         15.9          62.9       1.0X
+next_day wholestage off                             676            677           1         14.8          67.6       1.0X
+next_day wholestage on                              683            687           4         14.6          68.3       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             579            580           2         17.3          57.9       1.0X
-date_add wholestage on                              586            587           1         17.1          58.6       1.0X
+date_add wholestage off                             632            633           1         15.8          63.2       1.0X
+date_add wholestage on                              644            648           3         15.5          64.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             581            581           1         17.2          58.1       1.0X
-date_sub wholestage on                              589            590           1         17.0          58.9       1.0X
+date_sub wholestage off                             627            628           1         15.9          62.7       1.0X
+date_sub wholestage on                              641            646           8         15.6          64.1       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           820            820           0         12.2          82.0       1.0X
-add_months wholestage on                            810            815           7         12.4          81.0       1.0X
+add_months wholestage off                           892            893           1         11.2          89.2       1.0X
+add_months wholestage on                            915            916           1         10.9          91.5       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         2984           2985           0          3.4         298.4       1.0X
-format date wholestage on                          2917           2921           4          3.4         291.7       1.0X
+format date wholestage off                         2791           2805          20          3.6         279.1       1.0X
+format date wholestage on                          2756           2760           6          3.6         275.6       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       2539           2541           3          3.9         253.9       1.0X
-from_unixtime wholestage on                        2608           2615           8          3.8         260.8       1.0X
+from_unixtime wholestage off                       2574           2578           5          3.9         257.4       1.0X
+from_unixtime wholestage on                        2595           2612          12          3.9         259.5       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   653            654           2         15.3          65.3       1.0X
-from_utc_timestamp wholestage on                    689            691           2         14.5          68.9       0.9X
+from_utc_timestamp wholestage off                   718            732          21         13.9          71.8       1.0X
+from_utc_timestamp wholestage on                    746            755          16         13.4          74.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                     855            857           2         11.7          85.5       1.0X
-to_utc_timestamp wholestage on                      862            865           3         11.6          86.2       1.0X
+to_utc_timestamp wholestage off                     940            946           9         10.6          94.0       1.0X
+to_utc_timestamp wholestage on                      963            975          14         10.4          96.3       1.0X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        258            265          10         38.8          25.8       1.0X
-cast interval wholestage on                         207            213           7         48.3          20.7       1.2X
+cast interval wholestage off                        253            256           4         39.5          25.3       1.0X
+cast interval wholestage on                         218            220           2         45.8          21.8       1.2X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                             991            996           8         10.1          99.1       1.0X
-datediff wholestage on                             1016           1018           2          9.8         101.6       1.0X
+datediff wholestage off                            1054           1056           2          9.5         105.4       1.0X
+datediff wholestage on                             1044           1060          26          9.6         104.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      3277           3278           2          3.1         327.7       1.0X
-months_between wholestage on                       3284           3288           4          3.0         328.4       1.0X
+months_between wholestage off                      2945           2948           4          3.4         294.5       1.0X
+months_between wholestage on                       2926           2935          11          3.4         292.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               588            600          16          1.7         588.4       1.0X
-window wholestage on                                692            711          24          1.4         692.1       0.9X
+window wholestage off                               618            619           1          1.6         618.2       1.0X
+window wholestage on                                662            672           8          1.5         661.8       0.9X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                      774            775           1         12.9          77.4       1.0X
-date_trunc YEAR wholestage on                       688            692           4         14.5          68.8       1.1X
+date_trunc YEAR wholestage off                      795            799           5         12.6          79.5       1.0X
+date_trunc YEAR wholestage on                       769            774          10         13.0          76.9       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                      770            772           3         13.0          77.0       1.0X
-date_trunc YYYY wholestage on                       686            694           7         14.6          68.6       1.1X
+date_trunc YYYY wholestage off                      795            801          10         12.6          79.5       1.0X
+date_trunc YYYY wholestage on                       768            773           5         13.0          76.8       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                        771            772           1         13.0          77.1       1.0X
-date_trunc YY wholestage on                         688            691           4         14.5          68.8       1.1X
+date_trunc YY wholestage off                        792            798           8         12.6          79.2       1.0X
+date_trunc YY wholestage on                         769            770           0         13.0          76.9       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                       829            837          12         12.1          82.9       1.0X
-date_trunc MON wholestage on                        661            666           5         15.1          66.1       1.3X
+date_trunc MON wholestage off                       789            790           1         12.7          78.9       1.0X
+date_trunc MON wholestage on                        737            741           4         13.6          73.7       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                     819            831          18         12.2          81.9       1.0X
-date_trunc MONTH wholestage on                      658            663           3         15.2          65.8       1.2X
+date_trunc MONTH wholestage off                     791            794           5         12.6          79.1       1.0X
+date_trunc MONTH wholestage on                      735            737           1         13.6          73.5       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                        822            829           9         12.2          82.2       1.0X
-date_trunc MM wholestage on                         661            662           2         15.1          66.1       1.2X
+date_trunc MM wholestage off                        789            797          11         12.7          78.9       1.0X
+date_trunc MM wholestage on                         733            737           3         13.6          73.3       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       743            744           2         13.5          74.3       1.0X
-date_trunc DAY wholestage on                        551            553           2         18.1          55.1       1.3X
+date_trunc DAY wholestage off                       655            660           6         15.3          65.5       1.0X
+date_trunc DAY wholestage on                        620            623           5         16.1          62.0       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        742            756          20         13.5          74.2       1.0X
-date_trunc DD wholestage on                         550            554           3         18.2          55.0       1.3X
+date_trunc DD wholestage off                        665            668           4         15.0          66.5       1.0X
+date_trunc DD wholestage on                         619            624           4         16.2          61.9       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      768            776          11         13.0          76.8       1.0X
-date_trunc HOUR wholestage on                       553            556           2         18.1          55.3       1.4X
+date_trunc HOUR wholestage off                      649            654           8         15.4          64.9       1.0X
+date_trunc HOUR wholestage on                       614            616           2         16.3          61.4       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    762            765           4         13.1          76.2       1.0X
-date_trunc MINUTE wholestage on                     542            546           5         18.5          54.2       1.4X
+date_trunc MINUTE wholestage off                    628            631           4         15.9          62.8       1.0X
+date_trunc MINUTE wholestage on                     590            591           1         17.0          59.0       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    541            541           1         18.5          54.1       1.0X
-date_trunc SECOND wholestage on                     261            264           2         38.3          26.1       2.1X
+date_trunc SECOND wholestage off                    365            367           2         27.4          36.5       1.0X
+date_trunc SECOND wholestage on                     314            317           3         31.9          31.4       1.2X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                      793            793           0         12.6          79.3       1.0X
-date_trunc WEEK wholestage on                       588            591           3         17.0          58.8       1.4X
+date_trunc WEEK wholestage off                      720            720           0         13.9          72.0       1.0X
+date_trunc WEEK wholestage on                       664            668           4         15.1          66.4       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  1076           1077           2          9.3         107.6       1.0X
-date_trunc QUARTER wholestage on                    797            802           3         12.5          79.7       1.3X
+date_trunc QUARTER wholestage off                   925            925           0         10.8          92.5       1.0X
+date_trunc QUARTER wholestage on                    880            882           2         11.4          88.0       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           881            887           8         11.3          88.1       1.0X
-trunc year wholestage on                            757            760           2         13.2          75.7       1.2X
+trunc year wholestage off                           870            874           5         11.5          87.0       1.0X
+trunc year wholestage on                            826            831           4         12.1          82.6       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           879            880           2         11.4          87.9       1.0X
-trunc yyyy wholestage on                            755            758           2         13.2          75.5       1.2X
+trunc yyyy wholestage off                           870            871           0         11.5          87.0       1.0X
+trunc yyyy wholestage on                            829            831           2         12.1          82.9       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             878            880           3         11.4          87.8       1.0X
-trunc yy wholestage on                              755            757           1         13.3          75.5       1.2X
+trunc yy wholestage off                             870            873           4         11.5          87.0       1.0X
+trunc yy wholestage on                              826            838          23         12.1          82.6       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            827            828           2         12.1          82.7       1.0X
-trunc mon wholestage on                             706            708           2         14.2          70.6       1.2X
+trunc mon wholestage off                            826            837          15         12.1          82.6       1.0X
+trunc mon wholestage on                             784            787           2         12.8          78.4       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          828            830           2         12.1          82.8       1.0X
-trunc month wholestage on                           705            707           3         14.2          70.5       1.2X
+trunc month wholestage off                          826            832           8         12.1          82.6       1.0X
+trunc month wholestage on                           785            789           2         12.7          78.5       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             834            834           0         12.0          83.4       1.0X
-trunc mm wholestage on                              705            708           2         14.2          70.5       1.2X
+trunc mm wholestage off                             823            825           3         12.1          82.3       1.0X
+trunc mm wholestage on                              783            788           4         12.8          78.3       1.1X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                      98             99           2         10.2          97.8       1.0X
-to timestamp str wholestage on                       82             89           9         12.1          82.3       1.2X
+to timestamp str wholestage off                      93             96           5         10.8          92.6       1.0X
+to timestamp str wholestage on                       87             90           2         11.4          87.4       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         621            625           5          1.6         621.3       1.0X
-to_timestamp wholestage on                          599            602           2          1.7         599.3       1.0X
+to_timestamp wholestage off                         592            594           4          1.7         591.7       1.0X
+to_timestamp wholestage on                          569            574           4          1.8         569.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    603            612          12          1.7         603.1       1.0X
-to_unix_timestamp wholestage on                     602            602           0          1.7         601.8       1.0X
+to_unix_timestamp wholestage off                    573            576           5          1.7         572.9       1.0X
+to_unix_timestamp wholestage on                     571            575           3          1.8         570.6       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          117            122           7          8.5         117.0       1.0X
-to date str wholestage on                           108            110           2          9.3         107.6       1.1X
+to date str wholestage off                          112            113           2          9.0         111.6       1.0X
+to date str wholestage on                           115            116           1          8.7         114.7       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              593            595           2          1.7         593.2       1.0X
-to_date wholestage on                               583            587           4          1.7         583.3       1.0X
+to_date wholestage off                              544            545           2          1.8         543.6       1.0X
+to_date wholestage on                               548            549           1          1.8         548.1       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  278            281           3         18.0          55.5       1.0X
-From java.time.LocalDate                            216            222           5         23.1          43.2       1.3X
-Collect java.sql.Date                              1247           1317          69          4.0         249.5       0.2X
-Collect java.time.LocalDate                         868           1052         186          5.8         173.7       0.3X
-From java.sql.Timestamp                             216            246          34         23.2          43.2       1.3X
-From java.time.Instant                              180            195          22         27.7          36.1       1.5X
-Collect longs                                       808           1028         206          6.2         161.6       0.3X
-Collect java.sql.Timestamp                         1210           1262          63          4.1         242.0       0.2X
-Collect java.time.Instant                           984           1067          78          5.1         196.7       0.3X
-java.sql.Date to Hive string                       4481           4583         122          1.1         896.2       0.1X
-java.time.LocalDate to Hive string                 3656           3719          87          1.4         731.2       0.1X
-java.sql.Timestamp to Hive string                  7237           7325         114          0.7        1447.5       0.0X
-java.time.Instant to Hive string                   4862           4897          39          1.0         972.5       0.1X
+From java.sql.Date                                  320            325           6         15.6          64.1       1.0X
+From java.time.LocalDate                            243            251          11         20.6          48.5       1.3X
+Collect java.sql.Date                              1303           1415         110          3.8         260.7       0.2X
+Collect java.time.LocalDate                         944           1113         147          5.3         188.7       0.3X
+From java.sql.Timestamp                             276            278           3         18.1          55.2       1.2X
+From java.time.Instant                              209            229          18         23.9          41.8       1.5X
+Collect longs                                       935           1058         107          5.4         186.9       0.3X
+Collect java.sql.Timestamp                         1294           1361          66          3.9         258.9       0.2X
+Collect java.time.Instant                           826           1140         295          6.1         165.1       0.4X
+java.sql.Date to Hive string                       3915           3966          45          1.3         782.9       0.1X
+java.time.LocalDate to Hive string                 3063           3290         198          1.6         612.5       0.1X
+java.sql.Timestamp to Hive string                  6790           6889         109          0.7        1358.1       0.0X
+java.time.Instant to Hive string                   4080           4120          41          1.2         816.1       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -2,460 +2,460 @@
 datetime +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                 1035           1084          69          9.7         103.5       1.0X
-date + interval(m, d)                              1022           1136         161          9.8         102.2       1.0X
-date + interval(m, d, ms)                          3712           3820         154          2.7         371.2       0.3X
-date - interval(m)                                 1183           1185           2          8.5         118.3       0.9X
-date - interval(m, d)                              1038           1068          43          9.6         103.8       1.0X
-date - interval(m, d, ms)                          3727           3729           3          2.7         372.7       0.3X
-timestamp + interval(m)                            1936           1952          22          5.2         193.6       0.5X
-timestamp + interval(m, d)                         1996           2008          17          5.0         199.6       0.5X
-timestamp + interval(m, d, ms)                     2075           2077           3          4.8         207.5       0.5X
-timestamp - interval(m)                            1833           1846          18          5.5         183.3       0.6X
-timestamp - interval(m, d)                         1905           1905           1          5.3         190.5       0.5X
-timestamp - interval(m, d, ms)                     2075           2104          40          4.8         207.5       0.5X
+date + interval(m)                                 1246           1282          51          8.0         124.6       1.0X
+date + interval(m, d)                              1244           1251          11          8.0         124.4       1.0X
+date + interval(m, d, ms)                          3756           3761           8          2.7         375.6       0.3X
+date - interval(m)                                 1071           1074           5          9.3         107.1       1.2X
+date - interval(m, d)                              1099           1117          26          9.1         109.9       1.1X
+date - interval(m, d, ms)                          3787           3791           5          2.6         378.7       0.3X
+timestamp + interval(m)                            1819           1823           6          5.5         181.9       0.7X
+timestamp + interval(m, d)                         1871           1882          16          5.3         187.1       0.7X
+timestamp + interval(m, d, ms)                     2046           2062          23          4.9         204.6       0.6X
+timestamp - interval(m)                            1829           1830           2          5.5         182.9       0.7X
+timestamp - interval(m, d)                         1883           1885           3          5.3         188.3       0.7X
+timestamp - interval(m, d, ms)                     2057           2058           1          4.9         205.7       0.6X
 
 
 ================================================================================================
 Extract components
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    196            197           2         51.0          19.6       1.0X
-cast to timestamp wholestage on                     220            266          38         45.5          22.0       0.9X
+cast to timestamp wholestage off                    212            212           0         47.1          21.2       1.0X
+cast to timestamp wholestage on                     219            226          11         45.6          21.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    780            780           0         12.8          78.0       1.0X
-year of timestamp wholestage on                     786            843          91         12.7          78.6       1.0X
+year of timestamp wholestage off                    872            873           2         11.5          87.2       1.0X
+year of timestamp wholestage on                     873            877           4         11.5          87.3       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 804            851          66         12.4          80.4       1.0X
-quarter of timestamp wholestage on                  803            821          36         12.5          80.3       1.0X
+quarter of timestamp wholestage off                 888            892           6         11.3          88.8       1.0X
+quarter of timestamp wholestage on                  893            911          23         11.2          89.3       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   976            982           8         10.2          97.6       1.0X
-month of timestamp wholestage on                    802            911          69         12.5          80.2       1.2X
+month of timestamp wholestage off                   876            877           1         11.4          87.6       1.0X
+month of timestamp wholestage on                    873            887          19         11.5          87.3       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1328           1346          26          7.5         132.8       1.0X
-weekofyear of timestamp wholestage on              1314           1347          47          7.6         131.4       1.0X
+weekofyear of timestamp wholestage off             1159           1211          74          8.6         115.9       1.0X
+weekofyear of timestamp wholestage on              1271           1277           4          7.9         127.1       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     837            900          88         11.9          83.7       1.0X
-day of timestamp wholestage on                      816            834          12         12.3          81.6       1.0X
+day of timestamp wholestage off                     863            866           4         11.6          86.3       1.0X
+day of timestamp wholestage on                      874            884           7         11.4          87.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               986            997          16         10.1          98.6       1.0X
-dayofyear of timestamp wholestage on                956            993          30         10.5          95.6       1.0X
+dayofyear of timestamp wholestage off               909            932          32         11.0          90.9       1.0X
+dayofyear of timestamp wholestage on                907            916           9         11.0          90.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              972            985          18         10.3          97.2       1.0X
-dayofmonth of timestamp wholestage on               925            943          22         10.8          92.5       1.1X
+dayofmonth of timestamp wholestage off              871            871           1         11.5          87.1       1.0X
+dayofmonth of timestamp wholestage on               876            879           2         11.4          87.6       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off              1124           1126           2          8.9         112.4       1.0X
-dayofweek of timestamp wholestage on               1096           1122          23          9.1         109.6       1.0X
+dayofweek of timestamp wholestage off              1038           1052          20          9.6         103.8       1.0X
+dayofweek of timestamp wholestage on               1028           1028           1          9.7         102.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                1035           1062          39          9.7         103.5       1.0X
-weekday of timestamp wholestage on                 1017           1043          18          9.8         101.7       1.0X
+weekday of timestamp wholestage off                1003           1007           5         10.0         100.3       1.0X
+weekday of timestamp wholestage on                  988            993           4         10.1          98.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    638            648          13         15.7          63.8       1.0X
-hour of timestamp wholestage on                     646            693          29         15.5          64.6       1.0X
+hour of timestamp wholestage off                    659            660           2         15.2          65.9       1.0X
+hour of timestamp wholestage on                     660            663           3         15.2          66.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  625            634          13         16.0          62.5       1.0X
-minute of timestamp wholestage on                   638            650          15         15.7          63.8       1.0X
+minute of timestamp wholestage off                  659            661           2         15.2          65.9       1.0X
+minute of timestamp wholestage on                   665            666           2         15.0          66.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  610            612           2         16.4          61.0       1.0X
-second of timestamp wholestage on                   615            668          84         16.3          61.5       1.0X
+second of timestamp wholestage off                  662            663           1         15.1          66.2       1.0X
+second of timestamp wholestage on                   667            682          15         15.0          66.7       1.0X
 
 
 ================================================================================================
 Current date and time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         183            184           1         54.5          18.3       1.0X
-current_date wholestage on                          214            221           8         46.7          21.4       0.9X
+current_date wholestage off                         203            203           0         49.3          20.3       1.0X
+current_date wholestage on                          223            226           2         44.8          22.3       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    197            199           2         50.7          19.7       1.0X
-current_timestamp wholestage on                     224            248          23         44.7          22.4       0.9X
+current_timestamp wholestage off                    213            218           7         47.0          21.3       1.0X
+current_timestamp wholestage on                     232            248          25         43.2          23.2       0.9X
 
 
 ================================================================================================
 Date arithmetic
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         685            687           2         14.6          68.5       1.0X
-cast to date wholestage on                          687            708          26         14.6          68.7       1.0X
+cast to date wholestage off                         753            753           0         13.3          75.3       1.0X
+cast to date wholestage on                          753            758           6         13.3          75.3       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             794            795           1         12.6          79.4       1.0X
-last_day wholestage on                              802            814          13         12.5          80.2       1.0X
+last_day wholestage off                             897            900           3         11.1          89.7       1.0X
+last_day wholestage on                              900            903           2         11.1          90.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             724            744          29         13.8          72.4       1.0X
-next_day wholestage on                              712            717           3         14.0          71.2       1.0X
+next_day wholestage off                             780            784           5         12.8          78.0       1.0X
+next_day wholestage on                              797            804          10         12.5          79.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             665            690          36         15.0          66.5       1.0X
-date_add wholestage on                              691            777         102         14.5          69.1       1.0X
+date_add wholestage off                             802            833          45         12.5          80.2       1.0X
+date_add wholestage on                              743            747           6         13.5          74.3       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             730            806         108         13.7          73.0       1.0X
-date_sub wholestage on                              692            765          85         14.5          69.2       1.1X
+date_sub wholestage off                             754            757           3         13.3          75.4       1.0X
+date_sub wholestage on                              746            752           5         13.4          74.6       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                          1122           1133          16          8.9         112.2       1.0X
-add_months wholestage on                            932           1053         107         10.7          93.2       1.2X
+add_months wholestage off                          1038           1038           1          9.6         103.8       1.0X
+add_months wholestage on                           1042           1049           7          9.6         104.2       1.0X
 
 
 ================================================================================================
 Formatting dates
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         4073           4103          42          2.5         407.3       1.0X
-format date wholestage on                          3526           3611          74          2.8         352.6       1.2X
+format date wholestage off                         3136           3152          23          3.2         313.6       1.0X
+format date wholestage on                          3129           3142          12          3.2         312.9       1.0X
 
 
 ================================================================================================
 Formatting timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       3940           4049         154          2.5         394.0       1.0X
-from_unixtime wholestage on                        3779           3898         119          2.6         377.9       1.0X
+from_unixtime wholestage off                       3504           3516          18          2.9         350.4       1.0X
+from_unixtime wholestage on                        3537           3542           5          2.8         353.7       1.0X
 
 
 ================================================================================================
 Convert timestamps
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   733            735           3         13.6          73.3       1.0X
-from_utc_timestamp wholestage on                    887           1007          84         11.3          88.7       0.8X
+from_utc_timestamp wholestage off                   798            807          13         12.5          79.8       1.0X
+from_utc_timestamp wholestage on                    850            855           6         11.8          85.0       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1135           1207         102          8.8         113.5       1.0X
-to_utc_timestamp wholestage on                     1114           1201         115          9.0         111.4       1.0X
+to_utc_timestamp wholestage off                    1066           1066           1          9.4         106.6       1.0X
+to_utc_timestamp wholestage on                     1080           1086           8          9.3         108.0       1.0X
 
 
 ================================================================================================
 Intervals
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        226            227           1         44.2          22.6       1.0X
-cast interval wholestage on                         217            220           4         46.1          21.7       1.0X
+cast interval wholestage off                        234            235           1         42.7          23.4       1.0X
+cast interval wholestage on                         226            228           3         44.2          22.6       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1156           1162           9          8.7         115.6       1.0X
-datediff wholestage on                             1149           1166          21          8.7         114.9       1.0X
+datediff wholestage off                            1282           1285           4          7.8         128.2       1.0X
+datediff wholestage on                             1254           1261          10          8.0         125.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      3261           3447         263          3.1         326.1       1.0X
-months_between wholestage on                       3359           3620         284          3.0         335.9       1.0X
+months_between wholestage off                      3158           3160           3          3.2         315.8       1.0X
+months_between wholestage on                       3172           3187          15          3.2         317.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               825            829           5          1.2         825.1       1.0X
-window wholestage on                                815            882          58          1.2         815.4       1.0X
+window wholestage off                               571            573           3          1.8         570.7       1.0X
+window wholestage on                                649            657           7          1.5         649.0       0.9X
 
 
 ================================================================================================
 Truncation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                      808            814           9         12.4          80.8       1.0X
-date_trunc YEAR wholestage on                       783            880          64         12.8          78.3       1.0X
+date_trunc YEAR wholestage off                      872            879          10         11.5          87.2       1.0X
+date_trunc YEAR wholestage on                       827            830           3         12.1          82.7       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     1013           1028          21          9.9         101.3       1.0X
-date_trunc YYYY wholestage on                       772            774           1         12.9          77.2       1.3X
+date_trunc YYYY wholestage off                      875            877           2         11.4          87.5       1.0X
+date_trunc YYYY wholestage on                       825            841          16         12.1          82.5       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                        879            891          17         11.4          87.9       1.0X
-date_trunc YY wholestage on                         773            778           7         12.9          77.3       1.1X
+date_trunc YY wholestage off                        879            879           0         11.4          87.9       1.0X
+date_trunc YY wholestage on                         825            834          14         12.1          82.5       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                       794            812          26         12.6          79.4       1.0X
-date_trunc MON wholestage on                        749            800          49         13.4          74.9       1.1X
+date_trunc MON wholestage off                       856            858           3         11.7          85.6       1.0X
+date_trunc MON wholestage on                        813            819           5         12.3          81.3       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                     801            806           6         12.5          80.1       1.0X
-date_trunc MONTH wholestage on                      748            754          10         13.4          74.8       1.1X
+date_trunc MONTH wholestage off                     857            858           2         11.7          85.7       1.0X
+date_trunc MONTH wholestage on                      814            825          13         12.3          81.4       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                        868            876          12         11.5          86.8       1.0X
-date_trunc MM wholestage on                         746            751           4         13.4          74.6       1.2X
+date_trunc MM wholestage off                        858            864           9         11.7          85.8       1.0X
+date_trunc MM wholestage on                         816            819           3         12.3          81.6       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       610            612           2         16.4          61.0       1.0X
-date_trunc DAY wholestage on                        615            617           2         16.3          61.5       1.0X
+date_trunc DAY wholestage off                       670            684          20         14.9          67.0       1.0X
+date_trunc DAY wholestage on                        628            636           9         15.9          62.8       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        610            611           1         16.4          61.0       1.0X
-date_trunc DD wholestage on                         615            618           5         16.3          61.5       1.0X
+date_trunc DD wholestage off                        671            680          13         14.9          67.1       1.0X
+date_trunc DD wholestage on                         630            638          11         15.9          63.0       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      634            665          45         15.8          63.4       1.0X
-date_trunc HOUR wholestage on                       561            563           2         17.8          56.1       1.1X
+date_trunc HOUR wholestage off                      660            660           1         15.2          66.0       1.0X
+date_trunc HOUR wholestage on                       621            622           1         16.1          62.1       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    680            683           5         14.7          68.0       1.0X
-date_trunc MINUTE wholestage on                     573            622          65         17.5          57.3       1.2X
+date_trunc MINUTE wholestage off                    706            707           1         14.2          70.6       1.0X
+date_trunc MINUTE wholestage on                     672            677           6         14.9          67.2       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    336            385          70         29.8          33.6       1.0X
-date_trunc SECOND wholestage on                     275            278           2         36.4          27.5       1.2X
+date_trunc SECOND wholestage off                    346            347           1         28.9          34.6       1.0X
+date_trunc SECOND wholestage on                     302            308           6         33.2          30.2       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                      663            665           3         15.1          66.3       1.0X
-date_trunc WEEK wholestage on                       639            714          76         15.6          63.9       1.0X
+date_trunc WEEK wholestage off                      732            733           1         13.7          73.2       1.0X
+date_trunc WEEK wholestage on                       690            698          12         14.5          69.0       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                   924            932          12         10.8          92.4       1.0X
-date_trunc QUARTER wholestage on                    871            921          67         11.5          87.1       1.1X
+date_trunc QUARTER wholestage off                  1030           1032           2          9.7         103.0       1.0X
+date_trunc QUARTER wholestage on                    989            992           3         10.1          98.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           945            947           2         10.6          94.5       1.0X
-trunc year wholestage on                            903            963         107         11.1          90.3       1.0X
+trunc year wholestage off                          1054           1057           4          9.5         105.4       1.0X
+trunc year wholestage on                           1003           1004           1         10.0         100.3       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           944           1052         152         10.6          94.4       1.0X
-trunc yyyy wholestage on                            900            947          98         11.1          90.0       1.0X
+trunc yyyy wholestage off                          1054           1056           3          9.5         105.4       1.0X
+trunc yyyy wholestage on                           1004           1008           3         10.0         100.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                            1014           1071          81          9.9         101.4       1.0X
-trunc yy wholestage on                              900           1057          89         11.1          90.0       1.1X
+trunc yy wholestage off                            1054           1054           1          9.5         105.4       1.0X
+trunc yy wholestage on                             1002           1007           3         10.0         100.2       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                           1143           1158          22          8.8         114.3       1.0X
-trunc mon wholestage on                            1048           1079          22          9.5         104.8       1.1X
+trunc mon wholestage off                           1022           1039          24          9.8         102.2       1.0X
+trunc mon wholestage on                             965            971           7         10.4          96.5       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                         1097           1118          30          9.1         109.7       1.0X
-trunc month wholestage on                           874            965          91         11.4          87.4       1.3X
+trunc month wholestage off                         1013           1033          28          9.9         101.3       1.0X
+trunc month wholestage on                           966            974          11         10.4          96.6       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             923            935          16         10.8          92.3       1.0X
-trunc mm wholestage on                              871            873           4         11.5          87.1       1.1X
+trunc mm wholestage off                            1007           1008           2          9.9         100.7       1.0X
+trunc mm wholestage on                              963            966           2         10.4          96.3       1.0X
 
 
 ================================================================================================
 Parsing
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     102            103           2          9.8         102.3       1.0X
-to timestamp str wholestage on                      100            104           4         10.0         100.5       1.0X
+to timestamp str wholestage off                     104            106           2          9.6         104.1       1.0X
+to timestamp str wholestage on                      108            110           1          9.2         108.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         727            745          26          1.4         727.0       1.0X
-to_timestamp wholestage on                          726            728           2          1.4         726.2       1.0X
+to_timestamp wholestage off                         666            667           2          1.5         666.1       1.0X
+to_timestamp wholestage on                          688            692           7          1.5         687.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    739            758          27          1.4         739.2       1.0X
-to_unix_timestamp wholestage on                     726            775          87          1.4         726.3       1.0X
+to_unix_timestamp wholestage off                    678            678           1          1.5         677.8       1.0X
+to_unix_timestamp wholestage on                     660            664           5          1.5         660.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          136            139           4          7.3         136.2       1.0X
-to date str wholestage on                           135            137           3          7.4         134.8       1.0X
+to date str wholestage off                          141            141           0          7.1         141.2       1.0X
+to date str wholestage on                           138            139           1          7.3         137.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              641            642           1          1.6         641.4       1.0X
-to_date wholestage on                               632            634           2          1.6         632.0       1.0X
+to_date wholestage off                              602            603           2          1.7         601.7       1.0X
+to_date wholestage on                               587            590           3          1.7         587.1       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  285            296          18         17.6          56.9       1.0X
-From java.time.LocalDate                            247            249           2         20.2          49.4       1.2X
-Collect java.sql.Date                              1079           1222         125          4.6         215.8       0.3X
-Collect java.time.LocalDate                         954           1074         115          5.2         190.8       0.3X
-From java.sql.Timestamp                             200            204           7         25.0          39.9       1.4X
-From java.time.Instant                              202            209           7         24.8          40.4       1.4X
-Collect longs                                       979           1207         227          5.1         195.8       0.3X
-Collect java.sql.Timestamp                         1064           1316         262          4.7         212.9       0.3X
-Collect java.time.Instant                          1049           1071          24          4.8         209.7       0.3X
-java.sql.Date to Hive string                       4763           5185         438          1.0         952.5       0.1X
-java.time.LocalDate to Hive string                 3939           4019          69          1.3         787.8       0.1X
-java.sql.Timestamp to Hive string                  7164           7642         430          0.7        1432.7       0.0X
-java.time.Instant to Hive string                   5565           5830         307          0.9        1113.0       0.1X
+From java.sql.Date                                  313            315           1         16.0          62.7       1.0X
+From java.time.LocalDate                            268            270           2         18.6          53.6       1.2X
+Collect java.sql.Date                              1300           1380         100          3.8         259.9       0.2X
+Collect java.time.LocalDate                        1074           1134          94          4.7         214.8       0.3X
+From java.sql.Timestamp                             223            245          19         22.4          44.7       1.4X
+From java.time.Instant                              225            241          14         22.2          45.0       1.4X
+Collect longs                                       805            893          99          6.2         161.0       0.4X
+Collect java.sql.Timestamp                          979           1167         189          5.1         195.8       0.3X
+Collect java.time.Instant                           960           1062         107          5.2         192.1       0.3X
+java.sql.Date to Hive string                       3913           4064         209          1.3         782.5       0.1X
+java.time.LocalDate to Hive string                 3145           3256         108          1.6         629.0       0.1X
+java.sql.Timestamp to Hive string                  6279           6307          26          0.8        1255.8       0.0X
+java.time.Instant to Hive string                   4770           4858         111          1.0         954.0       0.1X
 
 

--- a/sql/core/benchmarks/DateTimeBenchmark-results.txt
+++ b/sql/core/benchmarks/DateTimeBenchmark-results.txt
@@ -6,18 +6,18 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 datetime +/- interval:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date + interval(m)                                 1027           1051          34          9.7         102.7       1.0X
-date + interval(m, d)                               996            996           1         10.0          99.6       1.0X
-date + interval(m, d, ms)                          4122           4129          10          2.4         412.2       0.2X
-date - interval(m)                                  974            981           5         10.3          97.4       1.1X
-date - interval(m, d)                              1001           1006           7         10.0         100.1       1.0X
-date - interval(m, d, ms)                          4146           4161          22          2.4         414.6       0.2X
-timestamp + interval(m)                            1819           1819           0          5.5         181.9       0.6X
-timestamp + interval(m, d)                         1866           1868           4          5.4         186.6       0.6X
-timestamp + interval(m, d, ms)                     2113           2117           5          4.7         211.3       0.5X
-timestamp - interval(m)                            1826           1834          11          5.5         182.6       0.6X
-timestamp - interval(m, d)                         1904           1905           1          5.3         190.4       0.5X
-timestamp - interval(m, d, ms)                     2110           2111           1          4.7         211.0       0.5X
+date + interval(m)                                 1035           1084          69          9.7         103.5       1.0X
+date + interval(m, d)                              1022           1136         161          9.8         102.2       1.0X
+date + interval(m, d, ms)                          3712           3820         154          2.7         371.2       0.3X
+date - interval(m)                                 1183           1185           2          8.5         118.3       0.9X
+date - interval(m, d)                              1038           1068          43          9.6         103.8       1.0X
+date - interval(m, d, ms)                          3727           3729           3          2.7         372.7       0.3X
+timestamp + interval(m)                            1936           1952          22          5.2         193.6       0.5X
+timestamp + interval(m, d)                         1996           2008          17          5.0         199.6       0.5X
+timestamp + interval(m, d, ms)                     2075           2077           3          4.8         207.5       0.5X
+timestamp - interval(m)                            1833           1846          18          5.5         183.3       0.6X
+timestamp - interval(m, d)                         1905           1905           1          5.3         190.5       0.5X
+timestamp - interval(m, d, ms)                     2075           2104          40          4.8         207.5       0.5X
 
 
 ================================================================================================
@@ -28,92 +28,92 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 cast to timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp wholestage off                    198            198           0         50.4          19.8       1.0X
-cast to timestamp wholestage on                     213            224          16         47.0          21.3       0.9X
+cast to timestamp wholestage off                    196            197           2         51.0          19.6       1.0X
+cast to timestamp wholestage on                     220            266          38         45.5          22.0       0.9X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 year of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-year of timestamp wholestage off                    761            764           4         13.1          76.1       1.0X
-year of timestamp wholestage on                     759            764           5         13.2          75.9       1.0X
+year of timestamp wholestage off                    780            780           0         12.8          78.0       1.0X
+year of timestamp wholestage on                     786            843          91         12.7          78.6       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 quarter of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-quarter of timestamp wholestage off                 783            784           1         12.8          78.3       1.0X
-quarter of timestamp wholestage on                  787            794           6         12.7          78.7       1.0X
+quarter of timestamp wholestage off                 804            851          66         12.4          80.4       1.0X
+quarter of timestamp wholestage on                  803            821          36         12.5          80.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 month of timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-month of timestamp wholestage off                   767            767           0         13.0          76.7       1.0X
-month of timestamp wholestage on                    771            773           1         13.0          77.1       1.0X
+month of timestamp wholestage off                   976            982           8         10.2          97.6       1.0X
+month of timestamp wholestage on                    802            911          69         12.5          80.2       1.2X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 weekofyear of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekofyear of timestamp wholestage off             1030           1041          16          9.7         103.0       1.0X
-weekofyear of timestamp wholestage on              1041           1052          12          9.6         104.1       1.0X
+weekofyear of timestamp wholestage off             1328           1346          26          7.5         132.8       1.0X
+weekofyear of timestamp wholestage on              1314           1347          47          7.6         131.4       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 day of timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-day of timestamp wholestage off                     761            765           6         13.1          76.1       1.0X
-day of timestamp wholestage on                      760            763           2         13.2          76.0       1.0X
+day of timestamp wholestage off                     837            900          88         11.9          83.7       1.0X
+day of timestamp wholestage on                      816            834          12         12.3          81.6       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 dayofyear of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofyear of timestamp wholestage off               798            798           0         12.5          79.8       1.0X
-dayofyear of timestamp wholestage on                799            802           3         12.5          79.9       1.0X
+dayofyear of timestamp wholestage off               986            997          16         10.1          98.6       1.0X
+dayofyear of timestamp wholestage on                956            993          30         10.5          95.6       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 dayofmonth of timestamp:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofmonth of timestamp wholestage off              772            774           2         12.9          77.2       1.0X
-dayofmonth of timestamp wholestage on               763            770           9         13.1          76.3       1.0X
+dayofmonth of timestamp wholestage off              972            985          18         10.3          97.2       1.0X
+dayofmonth of timestamp wholestage on               925            943          22         10.8          92.5       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 dayofweek of timestamp:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-dayofweek of timestamp wholestage off               903            904           1         11.1          90.3       1.0X
-dayofweek of timestamp wholestage on                910            915           5         11.0          91.0       1.0X
+dayofweek of timestamp wholestage off              1124           1126           2          8.9         112.4       1.0X
+dayofweek of timestamp wholestage on               1096           1122          23          9.1         109.6       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 weekday of timestamp:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-weekday of timestamp wholestage off                 861            862           2         11.6          86.1       1.0X
-weekday of timestamp wholestage on                  869            880          16         11.5          86.9       1.0X
+weekday of timestamp wholestage off                1035           1062          39          9.7         103.5       1.0X
+weekday of timestamp wholestage on                 1017           1043          18          9.8         101.7       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 hour of timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of timestamp wholestage off                    598            600           4         16.7          59.8       1.0X
-hour of timestamp wholestage on                     602            609           6         16.6          60.2       1.0X
+hour of timestamp wholestage off                    638            648          13         15.7          63.8       1.0X
+hour of timestamp wholestage on                     646            693          29         15.5          64.6       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 minute of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of timestamp wholestage off                  598            599           1         16.7          59.8       1.0X
-minute of timestamp wholestage on                   603            611          11         16.6          60.3       1.0X
+minute of timestamp wholestage off                  625            634          13         16.0          62.5       1.0X
+minute of timestamp wholestage on                   638            650          15         15.7          63.8       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 second of timestamp:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of timestamp wholestage off                  604            604           0         16.6          60.4       1.0X
-second of timestamp wholestage on                   604            609           4         16.6          60.4       1.0X
+second of timestamp wholestage off                  610            612           2         16.4          61.0       1.0X
+second of timestamp wholestage on                   615            668          84         16.3          61.5       1.0X
 
 
 ================================================================================================
@@ -124,15 +124,15 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 current_date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_date wholestage off                         182            182           0         55.0          18.2       1.0X
-current_date wholestage on                          213            217           3         47.0          21.3       0.9X
+current_date wholestage off                         183            184           1         54.5          18.3       1.0X
+current_date wholestage on                          214            221           8         46.7          21.4       0.9X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 current_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_timestamp wholestage off                    190            193           4         52.7          19.0       1.0X
-current_timestamp wholestage on                     216            232          12         46.4          21.6       0.9X
+current_timestamp wholestage off                    197            199           2         50.7          19.7       1.0X
+current_timestamp wholestage on                     224            248          23         44.7          22.4       0.9X
 
 
 ================================================================================================
@@ -143,43 +143,43 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 cast to date:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date wholestage off                         659            661           4         15.2          65.9       1.0X
-cast to date wholestage on                          672            675           4         14.9          67.2       1.0X
+cast to date wholestage off                         685            687           2         14.6          68.5       1.0X
+cast to date wholestage on                          687            708          26         14.6          68.7       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 last_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-last_day wholestage off                             770            771           2         13.0          77.0       1.0X
-last_day wholestage on                              772            777           5         13.0          77.2       1.0X
+last_day wholestage off                             794            795           1         12.6          79.4       1.0X
+last_day wholestage on                              802            814          13         12.5          80.2       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 next_day:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-next_day wholestage off                             690            703          18         14.5          69.0       1.0X
-next_day wholestage on                              706            709           2         14.2          70.6       1.0X
+next_day wholestage off                             724            744          29         13.8          72.4       1.0X
+next_day wholestage on                              712            717           3         14.0          71.2       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_add:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_add wholestage off                             644            645           1         15.5          64.4       1.0X
-date_add wholestage on                              645            648           2         15.5          64.5       1.0X
+date_add wholestage off                             665            690          36         15.0          66.5       1.0X
+date_add wholestage on                              691            777         102         14.5          69.1       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_sub:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_sub wholestage off                             637            640           4         15.7          63.7       1.0X
-date_sub wholestage on                              650            657           8         15.4          65.0       1.0X
+date_sub wholestage off                             730            806         108         13.7          73.0       1.0X
+date_sub wholestage on                              692            765          85         14.5          69.2       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 add_months:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-add_months wholestage off                           908            916          12         11.0          90.8       1.0X
-add_months wholestage on                            911            915           5         11.0          91.1       1.0X
+add_months wholestage off                          1122           1133          16          8.9         112.2       1.0X
+add_months wholestage on                            932           1053         107         10.7          93.2       1.2X
 
 
 ================================================================================================
@@ -190,8 +190,8 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 format date:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-format date wholestage off                         3288           3294           8          3.0         328.8       1.0X
-format date wholestage on                          3324           3363          51          3.0         332.4       1.0X
+format date wholestage off                         4073           4103          42          2.5         407.3       1.0X
+format date wholestage on                          3526           3611          74          2.8         352.6       1.2X
 
 
 ================================================================================================
@@ -202,8 +202,8 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 from_unixtime:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_unixtime wholestage off                       3654           3656           2          2.7         365.4       1.0X
-from_unixtime wholestage on                        3622           3633          12          2.8         362.2       1.0X
+from_unixtime wholestage off                       3940           4049         154          2.5         394.0       1.0X
+from_unixtime wholestage on                        3779           3898         119          2.6         377.9       1.0X
 
 
 ================================================================================================
@@ -214,15 +214,15 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 from_utc_timestamp:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-from_utc_timestamp wholestage off                   721            724           5         13.9          72.1       1.0X
-from_utc_timestamp wholestage on                    842            843           1         11.9          84.2       0.9X
+from_utc_timestamp wholestage off                   733            735           3         13.6          73.3       1.0X
+from_utc_timestamp wholestage on                    887           1007          84         11.3          88.7       0.8X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_utc_timestamp:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_utc_timestamp wholestage off                    1175           1186          17          8.5         117.5       1.0X
-to_utc_timestamp wholestage on                     1081           1092          14          9.3         108.1       1.1X
+to_utc_timestamp wholestage off                    1135           1207         102          8.8         113.5       1.0X
+to_utc_timestamp wholestage on                     1114           1201         115          9.0         111.4       1.0X
 
 
 ================================================================================================
@@ -233,29 +233,29 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 cast interval:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast interval wholestage off                        230            231           2         43.5          23.0       1.0X
-cast interval wholestage on                         212            215           4         47.2          21.2       1.1X
+cast interval wholestage off                        226            227           1         44.2          22.6       1.0X
+cast interval wholestage on                         217            220           4         46.1          21.7       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 datediff:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-datediff wholestage off                            1118           1121           4          8.9         111.8       1.0X
-datediff wholestage on                             1174           1185          20          8.5         117.4       1.0X
+datediff wholestage off                            1156           1162           9          8.7         115.6       1.0X
+datediff wholestage on                             1149           1166          21          8.7         114.9       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 months_between:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-months_between wholestage off                      3213           3217           5          3.1         321.3       1.0X
-months_between wholestage on                       3238           3248          16          3.1         323.8       1.0X
+months_between wholestage off                      3261           3447         263          3.1         326.1       1.0X
+months_between wholestage on                       3359           3620         284          3.0         335.9       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 window:                                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-window wholestage off                               632            647          21          1.6         632.3       1.0X
-window wholestage on                                629            652          17          1.6         629.0       1.0X
+window wholestage off                               825            829           5          1.2         825.1       1.0X
+window wholestage on                                815            882          58          1.2         815.4       1.0X
 
 
 ================================================================================================
@@ -266,134 +266,134 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YEAR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YEAR wholestage off                     1686           1687           1          5.9         168.6       1.0X
-date_trunc YEAR wholestage on                      1747           1749           2          5.7         174.7       1.0X
+date_trunc YEAR wholestage off                      808            814           9         12.4          80.8       1.0X
+date_trunc YEAR wholestage on                       783            880          64         12.8          78.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YYYY:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YYYY wholestage off                     1682           1684           2          5.9         168.2       1.0X
-date_trunc YYYY wholestage on                      1746           1749           2          5.7         174.6       1.0X
+date_trunc YYYY wholestage off                     1013           1028          21          9.9         101.3       1.0X
+date_trunc YYYY wholestage on                       772            774           1         12.9          77.2       1.3X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc YY:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc YY wholestage off                       1683           1683           1          5.9         168.3       1.0X
-date_trunc YY wholestage on                        1747           1749           3          5.7         174.7       1.0X
+date_trunc YY wholestage off                        879            891          17         11.4          87.9       1.0X
+date_trunc YY wholestage on                         773            778           7         12.9          77.3       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MON:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MON wholestage off                      1718           1727          13          5.8         171.8       1.0X
-date_trunc MON wholestage on                       1710           1716           6          5.8         171.0       1.0X
+date_trunc MON wholestage off                       794            812          26         12.6          79.4       1.0X
+date_trunc MON wholestage on                        749            800          49         13.4          74.9       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MONTH:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MONTH wholestage off                    1721           1723           3          5.8         172.1       1.0X
-date_trunc MONTH wholestage on                     1710           1730          32          5.8         171.0       1.0X
+date_trunc MONTH wholestage off                     801            806           6         12.5          80.1       1.0X
+date_trunc MONTH wholestage on                      748            754          10         13.4          74.8       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MM:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MM wholestage off                       1721           1721           0          5.8         172.1       1.0X
-date_trunc MM wholestage on                        1710           1719          10          5.8         171.0       1.0X
+date_trunc MM wholestage off                        868            876          12         11.5          86.8       1.0X
+date_trunc MM wholestage on                         746            751           4         13.4          74.6       1.2X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DAY:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DAY wholestage off                       603            627          33         16.6          60.3       1.0X
-date_trunc DAY wholestage on                        561            567           9         17.8          56.1       1.1X
+date_trunc DAY wholestage off                       610            612           2         16.4          61.0       1.0X
+date_trunc DAY wholestage on                        615            617           2         16.3          61.5       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc DD:                            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc DD wholestage off                        605            609           5         16.5          60.5       1.0X
-date_trunc DD wholestage on                         562            563           1         17.8          56.2       1.1X
+date_trunc DD wholestage off                        610            611           1         16.4          61.0       1.0X
+date_trunc DD wholestage on                         615            618           5         16.3          61.5       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc HOUR wholestage off                      605            608           4         16.5          60.5       1.0X
-date_trunc HOUR wholestage on                       563            570          12         17.8          56.3       1.1X
+date_trunc HOUR wholestage off                      634            665          45         15.8          63.4       1.0X
+date_trunc HOUR wholestage on                       561            563           2         17.8          56.1       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc MINUTE wholestage off                    605            605           0         16.5          60.5       1.0X
-date_trunc MINUTE wholestage on                     560            561           1         17.9          56.0       1.1X
+date_trunc MINUTE wholestage off                    680            683           5         14.7          68.0       1.0X
+date_trunc MINUTE wholestage on                     573            622          65         17.5          57.3       1.2X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc SECOND wholestage off                    325            326           1         30.8          32.5       1.0X
-date_trunc SECOND wholestage on                     281            284           2         35.6          28.1       1.2X
+date_trunc SECOND wholestage off                    336            385          70         29.8          33.6       1.0X
+date_trunc SECOND wholestage on                     275            278           2         36.4          27.5       1.2X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc WEEK:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc WEEK wholestage off                     1580           1583           4          6.3         158.0       1.0X
-date_trunc WEEK wholestage on                      1599           1601           2          6.3         159.9       1.0X
+date_trunc WEEK wholestage off                      663            665           3         15.1          66.3       1.0X
+date_trunc WEEK wholestage on                       639            714          76         15.6          63.9       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 date_trunc QUARTER:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-date_trunc QUARTER wholestage off                  2158           2168          13          4.6         215.8       1.0X
-date_trunc QUARTER wholestage on                   2138           2140           1          4.7         213.8       1.0X
+date_trunc QUARTER wholestage off                   924            932          12         10.8          92.4       1.0X
+date_trunc QUARTER wholestage on                    871            921          67         11.5          87.1       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc year:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc year wholestage off                           913            914           2         11.0          91.3       1.0X
-trunc year wholestage on                            910            917           8         11.0          91.0       1.0X
+trunc year wholestage off                           945            947           2         10.6          94.5       1.0X
+trunc year wholestage on                            903            963         107         11.1          90.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc yyyy:                               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yyyy wholestage off                           913            914           1         11.0          91.3       1.0X
-trunc yyyy wholestage on                            913            921           7         10.9          91.3       1.0X
+trunc yyyy wholestage off                           944           1052         152         10.6          94.4       1.0X
+trunc yyyy wholestage on                            900            947          98         11.1          90.0       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc yy:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc yy wholestage off                             912            913           1         11.0          91.2       1.0X
-trunc yy wholestage on                              911            913           2         11.0          91.1       1.0X
+trunc yy wholestage off                            1014           1071          81          9.9         101.4       1.0X
+trunc yy wholestage on                              900           1057          89         11.1          90.0       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc mon:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mon wholestage off                            889            890           1         11.2          88.9       1.0X
-trunc mon wholestage on                             869            879          19         11.5          86.9       1.0X
+trunc mon wholestage off                           1143           1158          22          8.8         114.3       1.0X
+trunc mon wholestage on                            1048           1079          22          9.5         104.8       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc month:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc month wholestage off                          889            890           2         11.2          88.9       1.0X
-trunc month wholestage on                           869            873           4         11.5          86.9       1.0X
+trunc month wholestage off                         1097           1118          30          9.1         109.7       1.0X
+trunc month wholestage on                           874            965          91         11.4          87.4       1.3X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 trunc mm:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-trunc mm wholestage off                             888            900          17         11.3          88.8       1.0X
-trunc mm wholestage on                              870            876           6         11.5          87.0       1.0X
+trunc mm wholestage off                             923            935          16         10.8          92.3       1.0X
+trunc mm wholestage on                              871            873           4         11.5          87.1       1.1X
 
 
 ================================================================================================
@@ -404,36 +404,36 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to timestamp str:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to timestamp str wholestage off                     105            105           1          9.6         104.6       1.0X
-to timestamp str wholestage on                      100            104           6         10.0          99.9       1.0X
+to timestamp str wholestage off                     102            103           2          9.8         102.3       1.0X
+to timestamp str wholestage on                      100            104           4         10.0         100.5       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_timestamp:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_timestamp wholestage off                         796            800           6          1.3         795.8       1.0X
-to_timestamp wholestage on                          780            782           2          1.3         779.8       1.0X
+to_timestamp wholestage off                         727            745          26          1.4         727.0       1.0X
+to_timestamp wholestage on                          726            728           2          1.4         726.2       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_unix_timestamp:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_unix_timestamp wholestage off                    789            789           0          1.3         788.8       1.0X
-to_unix_timestamp wholestage on                     765            766           2          1.3         764.9       1.0X
+to_unix_timestamp wholestage off                    739            758          27          1.4         739.2       1.0X
+to_unix_timestamp wholestage on                     726            775          87          1.4         726.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to date str:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to date str wholestage off                          133            134           1          7.5         133.5       1.0X
-to date str wholestage on                           132            135           2          7.6         131.6       1.0X
+to date str wholestage off                          136            139           4          7.3         136.2       1.0X
+to date str wholestage on                           135            137           3          7.4         134.8       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 to_date:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_date wholestage off                              671            672           1          1.5         671.1       1.0X
-to_date wholestage on                               668            679          20          1.5         667.5       1.0X
+to_date wholestage off                              641            642           1          1.6         641.4       1.0X
+to_date wholestage on                               632            634           2          1.6         632.0       1.0X
 
 
 ================================================================================================
@@ -444,18 +444,18 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
 AMD EPYC 7763 64-Core Processor
 To/from Java's date-time:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.sql.Date                                  288            289           1         17.4          57.6       1.0X
-From java.time.LocalDate                            244            246           2         20.5          48.9       1.2X
-Collect java.sql.Date                              1255           1337          72          4.0         251.0       0.2X
-Collect java.time.LocalDate                        1077           1099          20          4.6         215.3       0.3X
-From java.sql.Timestamp                             236            238           3         21.2          47.2       1.2X
-From java.time.Instant                              183            185           2         27.4          36.6       1.6X
-Collect longs                                       952           1050          98          5.3         190.3       0.3X
-Collect java.sql.Timestamp                         1002           1113          96          5.0         200.5       0.3X
-Collect java.time.Instant                           950           1050         124          5.3         190.0       0.3X
-java.sql.Date to Hive string                       4735           4742          10          1.1         946.9       0.1X
-java.time.LocalDate to Hive string                 3939           4073         160          1.3         787.7       0.1X
-java.sql.Timestamp to Hive string                  7243           7246           3          0.7        1448.6       0.0X
-java.time.Instant to Hive string                   5813           5958         141          0.9        1162.5       0.0X
+From java.sql.Date                                  285            296          18         17.6          56.9       1.0X
+From java.time.LocalDate                            247            249           2         20.2          49.4       1.2X
+Collect java.sql.Date                              1079           1222         125          4.6         215.8       0.3X
+Collect java.time.LocalDate                         954           1074         115          5.2         190.8       0.3X
+From java.sql.Timestamp                             200            204           7         25.0          39.9       1.4X
+From java.time.Instant                              202            209           7         24.8          40.4       1.4X
+Collect longs                                       979           1207         227          5.1         195.8       0.3X
+Collect java.sql.Timestamp                         1064           1316         262          4.7         212.9       0.3X
+Collect java.time.Instant                          1049           1071          24          4.8         209.7       0.3X
+java.sql.Date to Hive string                       4763           5185         438          1.0         952.5       0.1X
+java.time.LocalDate to Hive string                 3939           4019          69          1.3         787.8       0.1X
+java.sql.Timestamp to Hive string                  7164           7642         430          0.7        1432.7       0.0X
+java.time.Instant to Hive string                   5565           5830         307          0.9        1113.0       0.1X
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extends the offset-arithmetic + DST-equality-guard fast path introduced in SPARK-56663 from MIN/HR/DAY to the date-level units WEEK / MONTH / QUARTER / YEAR.

The framework for offset-based truncation -- resolve offset once, apply, truncate in the local frame, re-apply, DST guard, fall back on DST-cross or arithmetic overflow -- is identical for every level above SECOND. Only the "truncate in local frame" step varies. This PR inlines SPARK-56663's `truncToUnitFast` together with the new date-level path directly into `truncTimestamp`, and keeps a single private `truncTimestampSlow` as a complete reference implementation that the fast path falls back to:

```scala
def truncTimestamp(micros: Long, level: Int, zoneId: ZoneId): Long = {
  // MICROSECOND / MILLISECOND / SECOND short-circuits (no zone work).
  // Offset arithmetic for every other level.
  // DST guard, fallback to truncTimestampSlow.
}

private def truncTimestampSlow(micros: Long, level: Int, zoneId: ZoneId): Long
```

The local-frame truncation step is the only thing the fast path branches on:

- `MICROSECOND` / `MILLISECOND` / `SECOND` - pure UTC `floorMod` (zone offsets have at most second precision per `java.time.ZoneOffset`; no zone information needed).
- `MINUTE` / `HOUR` / `DAY` - shifted-local `floorMod` against the unit micros.
- `WEEK` / `MONTH` / `QUARTER` / `YEAR` - compute local epoch-day by integer division, run `truncDate` in the local-day frame, multiply back to local micros.

Everything else (offset resolve via `rules.getOffset`, `addExact` / `subtractExact`, DST guard via offset-equality at the candidate, slow-path fallback) is shared.

The DST guard fires correctly for the new date-level cases - for example, YEAR truncation of a March instant in `America/Los_Angeles` produces a candidate at Jan 1 (which is in PST, offset -8) while the original is in PDT (offset -7); the offsets differ, so the path falls back to the slow `microsToDays` / `daysToMicros` route which uses `ZonedDateTime.resolveLocal` to land on Jan 1 00:00 PST.

This PR also rewrites `TRUNC_TO_QUARTER` from `IsoFields.DAY_OF_QUARTER` (a `TemporalAdjuster` that produces a fresh `LocalDate`) to a direct `withMonth(firstMonthOfQuarter).withDayOfMonth(1)` chain on the existing `LocalDate`. Saves one allocation + the adjuster overhead per call.

`truncTimestampSlow` covers every level explicitly so it serves as a self-contained reference implementation - the fast path's correctness can be verified against it case-by-case.

### Why are the changes needed?

SPARK-33404 (Nov 2020) routed every `date_trunc` level above SECOND through `microsToInstant().atZone(zoneId).truncatedTo(unit)` for correctness, costing ~5.5× throughput per the follow-up benchmark PR (apache/spark#30338). SPARK-56663 recovered most of that for MIN/HR/DAY using the offset-arithmetic + DST-guard pattern. This PR extends the same recovery to WEEK / MONTH / QUARTER / YEAR - the levels that drive monthly/quarterly aggregations in analytics workloads.

`DateTimeBenchmark` Truncation results, wholestage on, ns/row on a 12th Gen Intel i7-1260P (master = pre-SPARK-56663):

| level   | master baseline | this PR | speedup |
|---------|---------------:|--------:|--------:|
| WEEK    | 165.2 |  78.2 | 2.11× |
| MONTH   | 181.9 |  92.2 | 1.97× |
| MM      | 182.2 |  92.5 | 1.97× |
| MON     | 182.9 |  92.7 | 1.97× |
| QUARTER | 216.8 | 108.8 | 1.99× |
| YEAR    | 205.2 |  96.7 | 2.12× |
| YYYY    | 205.8 |  96.9 | 2.12× |
| YY      | 206.3 |  96.0 | 2.15× |

Time-level units (MIN/HR/DAY/SECOND) and `trunc(date, ...)` are unchanged within noise; the hot path for those levels is byte-identical to SPARK-56663 after the unification.

### Does this PR introduce _any_ user-facing change?

No. The output of `date_trunc` is identical to master in all cases, including DST-spanning truncations (verified by the offset-equality guard + slow-path fallback, plus the new tests). Only the internal implementation changes.

### How was this patch tested?

- `DateTimeUtilsSuite` - all 66 tests pass, including:
  - `SPARK-33404: test truncTimestamp when time zone offset from UTC has a granularity of seconds`, extended to also exercise WEEK / MONTH / QUARTER / YEAR with the 1769-10-17 LMT timestamp across **every** available zone (the existing loop already covered SECOND/MILLI/MICRO; SPARK-56663 added HOUR/DAY; this PR completes the matrix).
  - The existing `truncTimestamp` test, which loops WEEK / MONTH / QUARTER / YEAR for 2015 timestamps across every zone.
  - New test `truncTimestamp date-level units across DST boundaries` - covers YEAR / QUARTER truncation that crosses the LA spring-forward (DST guard fires, fallback path runs) and MONTH truncation entirely within DST (fast path stays).
- `DateExpressionsSuite` - all tests pass (no changes to expression-level code, only the underlying `DateTimeUtils` helpers).
- `DateTimeBenchmark` re-run via the GitHub Actions `Run benchmarks` workflow on this fork for JDK 17, 21, and 25; results committed back to the branch.

### Was this patch authored or co-authored using generative AI tooling?

Yes, co-authored with Claude Code.
