### PR TITLE
[SPARK-53327] Update DataSketches Java to 9.0.0 version

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -326,7 +326,6 @@ org.apache.derby:derby
 org.apache.derby:derbyshared
 org.apache.derby:derbytools
 org.apache.datasketches:datasketches-java
-org.apache.datasketches:datasketches-memory
 org.apache.hadoop:hadoop-client-api
 org.apache.hadoop:hadoop-client-runtime
 org.apache.hive:hive-beeline

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -57,8 +57,7 @@ curator-recipes/5.9.0//curator-recipes-5.9.0.jar
 datanucleus-api-jdo/4.2.4//datanucleus-api-jdo-4.2.4.jar
 datanucleus-core/4.1.17//datanucleus-core-4.1.17.jar
 datanucleus-rdbms/4.1.19//datanucleus-rdbms-4.1.19.jar
-datasketches-java/6.2.0//datasketches-java-6.2.0.jar
-datasketches-memory/3.0.2//datasketches-memory-3.0.2.jar
+datasketches-java/9.0.0//datasketches-java-9.0.0.jar
 derby/10.16.1.1//derby-10.16.1.1.jar
 derbyshared/10.16.1.1//derbyshared-10.16.1.1.jar
 derbytools/10.16.1.1//derbytools-10.16.1.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
     <commons-cli.version>1.11.0</commons-cli.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <tink.version>1.20.0</tink.version>
-    <datasketches.version>6.2.0</datasketches.version>
+    <datasketches.version>9.0.0</datasketches.version>
     <netty.version>4.2.12.Final</netty.version>
     <netty-tcnative.version>2.0.76.Final</netty-tcnative.version>
     <icu4j.version>78.3</icu4j.version>


### PR DESCRIPTION


### What changes were proposed in this pull request?

Update DataSketches to the 9.0.0 version

### Why are the changes needed?

It's necessary for Java 25 support: https://github.com/apache/datasketches-java/releases/tag/9.0.0

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

CI

### Was this patch authored or co-authored using generative AI tooling?

No