### PR TITLE
[SPARK-56765][PYTHON] Suppress pyarrow.compute mypy attr-defined errors

### DIFF
--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -1406,7 +1406,7 @@ class ArrowArrayConversion:
             # arr = pc.local_timestamp(arr)
             # arr[0]
             # <pyarrow.TimestampScalar: '2022-01-05T15:00:01.000000'>
-            return pc.local_timestamp(arr)
+            return pc.local_timestamp(arr)  # type: ignore[attr-defined, unused-ignore]
 
         return cls.convert(
             arr,
@@ -1436,7 +1436,7 @@ class ArrowArrayConversion:
             pa_type = arr.type
 
             if pa_type.tz is not None:
-                arr = pc.local_timestamp(arr)
+                arr = pc.local_timestamp(arr)  # type: ignore[attr-defined, unused-ignore]
             if pa_type.unit != "ns":
                 arr = pc.cast(arr, target_type=pa.timestamp("ns", tz=None))
             return arr

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -543,14 +543,14 @@ def _check_arrow_array_timestamps_localize(
         )
 
     if types.is_timestamp(a.type) and truncate and a.type.unit == "ns":
-        a = pc.floor_temporal(a, unit="microsecond")
+        a = pc.floor_temporal(a, unit="microsecond")  # type: ignore[attr-defined, unused-ignore]
 
     if types.is_timestamp(a.type) and a.type.tz is None and isinstance(dt, TimestampType):
         assert timezone is not None
 
         # Only localize timestamps that will become Spark TimestampType columns.
         # Do not localize timestamps that will become Spark TimestampNTZType columns.
-        return pc.assume_timezone(a, timezone)
+        return pc.assume_timezone(a, timezone)  # type: ignore[attr-defined, unused-ignore]
     if types.is_list(a.type):
         # Return the ListArray as-is if it contains no nested fields or timestamps
         if not types.is_nested(a.type.value_type) and not types.is_timestamp(a.type.value_type):


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds narrow `# type: ignore[attr-defined]` annotations for `pyarrow.compute` calls whose symbols are missing from the PyArrow 24.0.0 stubs: `floor_temporal`, `assume_timezone`, and `local_timestamp`.

### Why are the changes needed?
PyArrow 24.0.0 still exposes these compute kernels at runtime, but its type stubs do not expose them to mypy. This currently breaks PySpark lint with `attr-defined` errors.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- `PYTHON_EXECUTABLE=/tmp/spark-56765-mypy-venv/bin/python ./dev/lint-python --compile`
- `/tmp/spark-56765-mypy-venv/bin/ruff format --check python/pyspark/sql/pandas/types.py python/pyspark/sql/conversion.py`
- `git diff --check`
- Targeted mypy with `pyarrow==24.0.0` confirmed these `pyarrow.compute` `attr-defined` errors are suppressed.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: OpenAI Codex (GPT-5)
