### PR TITLE
[SPARK-56760][PYTHON] Remove dead numpy version check in pandas typehints

### DIFF
--- a/python/pyspark/pandas/tests/computation/test_apply_func.py
+++ b/python/pyspark/pandas/tests/computation/test_apply_func.py
@@ -262,20 +262,18 @@ class FrameApplyFunctionMixin:
         actual.columns = ["a", "b"]
         self.assert_eq(normalize_array_values(actual._to_pandas()), normalize_array_values(pdf))
 
-        # For NumPy typing, NumPy version should be 1.21+
-        if LooseVersion(np.__version__) >= LooseVersion("1.21"):
-            import numpy.typing as ntp
+        import numpy.typing as ntp
 
-            psdf = ps.from_pandas(pdf)
+        psdf = ps.from_pandas(pdf)
 
-            def identify4(
-                x,
-            ) -> ps.DataFrame[float, [int, ntp.NDArray[int]]]:
-                return x
+        def identify4(
+            x,
+        ) -> ps.DataFrame[float, [int, ntp.NDArray[int]]]:
+            return x
 
-            actual = psdf.pandas_on_spark.apply_batch(identify4)
-            actual.columns = ["a", "b"]
-            self.assert_eq(normalize_array_values(actual._to_pandas()), normalize_array_values(pdf))
+        actual = psdf.pandas_on_spark.apply_batch(identify4)
+        actual.columns = ["a", "b"]
+        self.assert_eq(normalize_array_values(actual._to_pandas()), normalize_array_values(pdf))
 
         arrays = [[1, 2, 3, 4, 5, 6, 7, 8, 9], ["a", "b", "c", "d", "e", "f", "g", "h", "i"]]
         idx = pd.MultiIndex.from_arrays(arrays, names=("number", "color"))

--- a/python/pyspark/pandas/tests/test_typedef.py
+++ b/python/pyspark/pandas/tests/test_typedef.py
@@ -407,17 +407,15 @@ class TypeHintTestsMixin:
                 (np.dtype("object"), ArrayType(spark_type)),
             )
 
-            # For NumPy typing, NumPy version should be 1.21+
-            if LooseVersion(np.__version__) >= LooseVersion("1.21"):
-                import numpy.typing as ntp
+            import numpy.typing as ntp
 
-                self.assertEqual(
-                    as_spark_type(ntp.NDArray[numpy_or_python_type]), ArrayType(spark_type)
-                )
-                self.assertEqual(
-                    pandas_on_spark_type(ntp.NDArray[numpy_or_python_type]),
-                    (np.dtype("object"), ArrayType(spark_type)),
-                )
+            self.assertEqual(
+                as_spark_type(ntp.NDArray[numpy_or_python_type]), ArrayType(spark_type)
+            )
+            self.assertEqual(
+                pandas_on_spark_type(ntp.NDArray[numpy_or_python_type]),
+                (np.dtype("object"), ArrayType(spark_type)),
+            )
 
         with self.assertRaisesRegex(TypeError, "Type uint64 was not understood."):
             as_spark_type(np.dtype("uint64"))

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -150,18 +150,14 @@ def as_spark_type(
     - dictionaries of field_name -> type
     - Python3's typing system
     """
-    # For NumPy typing, NumPy version should be 1.21+
-    if LooseVersion(np.__version__) >= LooseVersion("1.21"):
-        if (
-            hasattr(tpe, "__origin__")
-            and tpe.__origin__ is np.ndarray
-            and hasattr(tpe, "__args__")
-            and len(tpe.__args__) > 1
-        ):
-            # numpy.typing.NDArray
-            return types.ArrayType(
-                as_spark_type(tpe.__args__[1].__args__[0], raise_error=raise_error)
-            )
+    if (
+        hasattr(tpe, "__origin__")
+        and tpe.__origin__ is np.ndarray
+        and hasattr(tpe, "__args__")
+        and len(tpe.__args__) > 1
+    ):
+        # numpy.typing.NDArray
+        return types.ArrayType(as_spark_type(tpe.__args__[1].__args__[0], raise_error=raise_error))
 
     if isinstance(tpe, np.dtype) and tpe == np.dtype("object"):
         pass


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the obsolete NumPy version guard around `numpy.typing.NDArray` handling in pandas-on-Spark type hints. The current minimum NumPy version is already newer than 1.21, so the branch is always enabled.

The associated typedef test now imports `numpy.typing` directly and continues to assert `NDArray[...]` conversion.

### Why are the changes needed?

The version check is dead code now that PySpark requires NumPy 1.22 or newer. Removing it simplifies the type hint path without changing behavior.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified locally:

- `SPARK_HOME=/tmp/spark_codex_56760 ./python/run-tests.py --python-executables python3 --testnames pyspark.pandas.tests.test_typedef`
- `SPARK_HOME=/tmp/spark_codex_56760 PYTHON_EXECUTABLE=python3 ./dev/lint-python --compile`
- `git diff --check`

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)