### PR TITLE
[SPARK-56790][PYTHON][TESTS] Remove duplicated test cases for test_data_source_segfault

### DIFF
--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -849,32 +849,6 @@ class BasePythonDataSourceTestsMixin:
                     with self.assertRaisesRegex(Exception, expected):
                         self.spark.read.format("test").load().show()
 
-                with self.subTest(worker="pyspark.sql.worker.plan_data_source_read"):
-
-                    class TestDataSource(DataSource):
-                        @classmethod
-                        def name(cls):
-                            return "test"
-
-                        def schema(self):
-                            return "x string"
-
-                        def reader(self, schema):
-                            return TestReader()
-
-                    class TestReader(DataSourceReader):
-                        def partitions(self):
-                            ctypes.string_at(0)
-                            return []
-
-                        def read(self, partition):
-                            return []
-
-                    self.spark.dataSource.register(TestDataSource)
-
-                    with self.assertRaisesRegex(Exception, expected):
-                        self.spark.read.format("test").load().show()
-
                 with self.subTest(worker="pyspark.worker"):
 
                     class TestDataSource(DataSource):
@@ -897,50 +871,6 @@ class BasePythonDataSourceTestsMixin:
 
                     with self.assertRaisesRegex(Exception, expected):
                         self.spark.read.format("test").load().show()
-
-                with self.subTest(worker="pyspark.sql.worker.write_into_data_source"):
-
-                    class TestDataSource(DataSource):
-                        @classmethod
-                        def name(cls):
-                            return "test"
-
-                        def writer(self, schema, overwrite):
-                            return TestWriter()
-
-                    class TestWriter(DataSourceWriter):
-                        def write(self, iterator):
-                            ctypes.string_at(0)
-                            return WriterCommitMessage()
-
-                    self.spark.dataSource.register(TestDataSource)
-
-                    with tempfile.TemporaryDirectory(prefix="test_segfault_") as d:
-                        with self.assertRaisesRegex(Exception, expected):
-                            self.spark.range(10).write.format("test").mode("append").save(d)
-
-                with self.subTest(worker="pyspark.sql.worker.commit_data_source_write"):
-
-                    class TestDataSource(DataSource):
-                        @classmethod
-                        def name(cls):
-                            return "test"
-
-                        def writer(self, schema, overwrite):
-                            return TestWriter2()
-
-                    class TestWriter2(DataSourceWriter):
-                        def write(self, iterator):
-                            return WriterCommitMessage()
-
-                        def commit(self, messages):
-                            ctypes.string_at(0)
-
-                    self.spark.dataSource.register(TestDataSource)
-
-                    with tempfile.TemporaryDirectory(prefix="test_segfault_") as d:
-                        with self.assertRaisesRegex(Exception, expected):
-                            self.spark.range(10).write.format("test").mode("append").save(d)
 
     @unittest.skipIf(is_remote_only(), "Requires JVM access")
     def test_data_source_reader_with_logging(self):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Remove some unnecessary test cases in `test_data_source_segfault`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

After we re-organize the planner worker code, all planner workers that data source uses are using the exact same code path for `faulthandler`. The test is pretty expensive because it needs to spawn a new process (it segfaults so not reusable). We don't need to test it on different planner workers. I kept one of the planner worker and the one that segfaults on an actual Python UDF worker. This should save us about 30s.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

CI.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.