### PR TITLE
[SPARK-56763][INFRA] Fix docker image build failures on branch-3.5

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -67,7 +67,7 @@ RUN Rscript -e "remotes::install_version('roxygen2', version='7.2.0', repos='htt
 ENV R_LIBS_SITE "/usr/local/lib/R/site-library:${R_LIBS_SITE}:/usr/lib/R/library"
 
 RUN pypy3 -m pip install numpy coverage matplotlib
-RUN python3.9 -m pip install 'numpy==1.25.1' 'pyarrow==12.0.1' 'pandas<=2.0.3' scipy unittest-xml-reporting plotly>=4.8 'mlflow>=2.3.1' coverage 'matplotlib==3.7.2' openpyxl 'memory-profiler==0.60.0' 'scikit-learn==1.1.*'
+RUN python3.9 -m pip install 'numpy==1.25.1' 'pyarrow==12.0.1' 'pandas<=2.0.3' 'scipy==1.11.4' unittest-xml-reporting 'plotly>=4.8,<=5.17.0' 'mlflow>=2.3.1' coverage 'matplotlib==3.7.2' openpyxl 'memory-profiler==0.60.0' 'scikit-learn==1.1.*'
 
 # Add Python deps for Spark Connect.
 RUN python3.9 -m pip install 'grpcio>=1.48,<1.57' 'grpcio-status>=1.48,<1.57' 'protobuf==3.20.3' 'googleapis-common-protos==1.56.4'

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update
 RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget openjdk-8-jdk libpython3-dev python3-pip python3-setuptools python3.8 python3.9
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
+RUN curl -sS https://bootstrap.pypa.io/pip/3.9/get-pip.py | python3.9
 
 RUN add-apt-repository ppa:pypy/ppa
 RUN apt update
@@ -43,12 +43,12 @@ RUN mkdir -p /usr/local/pypy/pypy3.8 && \
     ln -sf /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     ln -sf /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3
 
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
+RUN curl -sS https://bootstrap.pypa.io/pip/3.8/get-pip.py | pypy3
 
 RUN $APT_INSTALL gnupg ca-certificates pandoc
 RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/' >> /etc/apt/sources.list
-RUN gpg --keyserver hkps://keyserver.ubuntu.com --recv-key E298A3A825C0D65DFD57CBB651716619E084DAB9
-RUN gpg -a --export E084DAB9 | apt-key add -
+RUN curl -fsSL https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc \
+    -o /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
 RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/'
 RUN apt update
 RUN $APT_INSTALL r-base libcurl4-openssl-dev qpdf libssl-dev zlib1g-dev
@@ -64,7 +64,7 @@ RUN Rscript -e "remotes::install_version('roxygen2', version='7.2.0', repos='htt
 # See more in SPARK-39735
 ENV R_LIBS_SITE "/usr/local/lib/R/site-library:${R_LIBS_SITE}:/usr/lib/R/library"
 
-RUN pypy3 -m pip install numpy 'pandas<=2.0.3' scipy coverage matplotlib
+RUN pypy3 -m pip install numpy coverage matplotlib
 RUN python3.9 -m pip install 'numpy==1.25.1' 'pyarrow==12.0.1' 'pandas<=2.0.3' scipy unittest-xml-reporting plotly>=4.8 'mlflow>=2.3.1' coverage 'matplotlib==3.7.2' openpyxl 'memory-profiler==0.60.0' 'scikit-learn==1.1.*'
 
 # Add Python deps for Spark Connect.

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -52,7 +52,9 @@ RUN curl -fsSL https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc 
 RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/'
 RUN apt update
 RUN $APT_INSTALL r-base libcurl4-openssl-dev qpdf libssl-dev zlib1g-dev
-RUN Rscript -e "install.packages(c('remotes', 'knitr', 'markdown', 'rmarkdown', 'testthat', 'e1071', 'survival', 'arrow', 'roxygen2', 'xml2'), repos='https://cloud.r-project.org/')"
+RUN Rscript -e "install.packages(c('remotes', 'knitr', 'markdown', 'rmarkdown', 'testthat', 'e1071', 'survival', 'roxygen2', 'xml2'), repos='https://cloud.r-project.org/')"
+# See more in SPARK-56763, arrow < 23.0.0
+RUN Rscript -e "remotes::install_version('arrow', version='22.0.0', repos='https://cloud.r-project.org')"
 
 # See more in SPARK-39959, roxygen2 < 7.2.1
 RUN apt-get install -y libcurl4-openssl-dev libgit2-dev libssl-dev libxml2-dev \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update Dockerfile to fix build error:

- Fix get-pip.py URLs to use versioned paths for Python 3.9 and PyPy 3.8
- Replace the gpg keyserver commands for the CRAN GPG key with a single `curl` command. gpg keyserver command is now not recommended way and the command doesn't work with `http_proxy` env var under proxy environment.
- Remove `scipy` and `pandas` from the PyPy 3.8 pip install: neither can be installed in this environment. scipy >=1.8.0 fails due to a pythran/beniget/gast incompatibility; scipy <1.8.0 fails because numpy.distutils cannot locate Python.h at PyPy's non-standard header path. pandas has C++ extensions that trigger a PyPy 3.8 linker detection bug in setuptools (TypeError: 'NoneType' object is not subscriptable). Both scipy and pandas remain on the python3.9 install.

### Why are the changes needed?

The build failure described in SPARK-56763 started to occur after https://github.com/apache/spark/commit/2a56312aeb1665b72c608e14926f5d69fd3a17bc. Before this commit, the build cache https://github.com/apache/spark/pkgs/container/spark%2Fapache-spark-github-action-image-cache/193506527?tag=branch-3.5 was used and the build was successful.

- Before: https://github.com/apache/spark/actions/runs/24451638562/job/71441880373
- After: https://github.com/apache/spark/actions/runs/24562361796/job/71814012404

Without cache, the docker build fails due to a different error related to Python 3.8/3.9 EoLs. This commit fix the errors.

### Does this PR introduce _any_ user-facing change?

scipy and pandas will be removed from PyPy 3.8 environment in the branch-3.5 base image

### How was this patch tested?

Verified by running `docker build .` in `dev/infra/`. Testing in #55764 because it also requires #55757 

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Sonnet 4.6)