### PR TITLE
[SPARK-56540][INFRA][3.5] Add libuv1-dev to CI Docker images to fix R package fs build failure

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile.base
+++ b/dev/create-release/spark-rm/Dockerfile.base
@@ -61,6 +61,7 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     libssl-dev \
     libtiff5-dev \
+    libuv1-dev \
     libwebp-dev \
     libxml2-dev \
     msmtp \

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -51,7 +51,7 @@ RUN gpg --keyserver hkps://keyserver.ubuntu.com --recv-key E298A3A825C0D65DFD57C
 RUN gpg -a --export E084DAB9 | apt-key add -
 RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/'
 RUN apt update
-RUN $APT_INSTALL r-base libcurl4-openssl-dev qpdf libssl-dev zlib1g-dev
+RUN $APT_INSTALL r-base libcurl4-openssl-dev qpdf libuv1-dev libssl-dev zlib1g-dev
 RUN Rscript -e "install.packages(c('remotes', 'knitr', 'markdown', 'rmarkdown', 'testthat', 'e1071', 'survival', 'arrow', 'roxygen2', 'xml2'), repos='https://cloud.r-project.org/')"
 
 # See more in SPARK-39959, roxygen2 < 7.2.1


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add libuv1-dev to the apt-get install list in all two CI Dockerfiles that install R packages:

* `dev/infra/Dockerfile`
* `dev/create-release/spark-rm/Dockerfile.base`

### Why are the changes needed?

The R package `fs` now requires system library libuv (`uv.h`). `fs` is a transitive dependency of both `rmarkdown` (via `sass` → `bslib`) and `testthat` (via `pkgload`).

When the Docker layer cache is valid, the pre-built R packages are reused and everything works fine. But when the cache is invalidated (e.g. base image digest changes), the R packages are compiled from source. Without `libuv1-dev` installed, `fs` fails to configure:

```
Configuration failed because libuv was not found. Try installing:
 * deb: libuv1-dev (Debian, Ubuntu, etc)
...
<stdin>:1:10: fatal error: uv.h: No such file or directory
ERROR: configuration failed for package 'fs'
```

This triggers a cascade:

```
fs (missing libuv) → FAIL
  └→ sass → FAIL
       └→ bslib → FAIL
            └→ rmarkdown → FAIL
  └→ pkgload → FAIL
       └→ testthat → FAIL
```

The image build itself still "succeeds" because `install.packages()` in R does not return a non-zero exit code when individual packages fail to install -- it logs warnings but continues. So the Docker image gets pushed with rmarkdown and testthat missing, and the SparkR job fails at test time:

```
Error in library(testthat) : there is no package called 'testthat'
```
```
Error: processing vignette 'sparkr-vignettes.Rmd' failed with diagnostics:
there is no package called 'rmarkdown'
```
Example failure in branch-3.5 with several fixes (#55753): https://github.com/aajisaka/spark/actions/runs/25539393002/job/74963287548

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Verified the fix in a separate PR #55764. This is because now this backport PR itself cannot fix the build error. Now we need to apply both this PR and #55753.

### Was this patch authored or co-authored using generative AI tooling?

No