### PR TITLE
[SPARK-56805][SQL] Enable `spark.sql.codegen.wholeStage.union.enabled` by default

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,7 +43,7 @@ on:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
         type: string
-        default: '{"PYSPARK_IMAGE_TO_TEST": "python-312", "PYTHON_TO_TEST": "python3.12", "SPARK_SQL_WSCG_UNION_ENABLED": "true"}'
+        default: '{"PYSPARK_IMAGE_TO_TEST": "python-312", "PYTHON_TO_TEST": "python3.12"}'
       jobs:
         description: >-
           Jobs to run, and should be in JSON format. The values should be matched with the job's key defined
@@ -1417,7 +1417,6 @@ jobs:
         SPARK_TPCDS_DATA=`pwd`/tpcds-sf-1 build/sbt "sql/testOnly org.apache.spark.sql.TPCDSQueryTestSuite"
       env:
         SPARK_ANSI_SQL_MODE: ${{ fromJSON(inputs.envs).SPARK_ANSI_SQL_MODE }}
-        SPARK_SQL_WSCG_UNION_ENABLED: ${{ fromJSON(inputs.envs).SPARK_SQL_WSCG_UNION_ENABLED }}
         SPARK_TPCDS_JOIN_CONF: |
           spark.sql.autoBroadcastJoinThreshold=-1
           spark.sql.join.preferSortMergeJoin=true
@@ -1426,7 +1425,6 @@ jobs:
         SPARK_TPCDS_DATA=`pwd`/tpcds-sf-1 build/sbt "sql/testOnly org.apache.spark.sql.TPCDSQueryTestSuite"
       env:
         SPARK_ANSI_SQL_MODE: ${{ fromJSON(inputs.envs).SPARK_ANSI_SQL_MODE }}
-        SPARK_SQL_WSCG_UNION_ENABLED: ${{ fromJSON(inputs.envs).SPARK_SQL_WSCG_UNION_ENABLED }}
         SPARK_TPCDS_JOIN_CONF: |
           spark.sql.autoBroadcastJoinThreshold=10485760
     - name: Run TPC-DS queries (Shuffled hash join)
@@ -1434,7 +1432,6 @@ jobs:
         SPARK_TPCDS_DATA=`pwd`/tpcds-sf-1 build/sbt "sql/testOnly org.apache.spark.sql.TPCDSQueryTestSuite"
       env:
         SPARK_ANSI_SQL_MODE: ${{ fromJSON(inputs.envs).SPARK_ANSI_SQL_MODE }}
-        SPARK_SQL_WSCG_UNION_ENABLED: ${{ fromJSON(inputs.envs).SPARK_SQL_WSCG_UNION_ENABLED }}
         SPARK_TPCDS_JOIN_CONF: |
           spark.sql.autoBroadcastJoinThreshold=-1
           spark.sql.join.forceApplyShuffledHashJoin=true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,7 +43,7 @@ on:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
         type: string
-        default: '{"PYSPARK_IMAGE_TO_TEST": "python-312", "PYTHON_TO_TEST": "python3.12"}'
+        default: '{"PYSPARK_IMAGE_TO_TEST": "python-312", "PYTHON_TO_TEST": "python3.12", "SPARK_SQL_WSCG_UNION_ENABLED": "true"}'
       jobs:
         description: >-
           Jobs to run, and should be in JSON format. The values should be matched with the job's key defined
@@ -1417,6 +1417,7 @@ jobs:
         SPARK_TPCDS_DATA=`pwd`/tpcds-sf-1 build/sbt "sql/testOnly org.apache.spark.sql.TPCDSQueryTestSuite"
       env:
         SPARK_ANSI_SQL_MODE: ${{ fromJSON(inputs.envs).SPARK_ANSI_SQL_MODE }}
+        SPARK_SQL_WSCG_UNION_ENABLED: ${{ fromJSON(inputs.envs).SPARK_SQL_WSCG_UNION_ENABLED }}
         SPARK_TPCDS_JOIN_CONF: |
           spark.sql.autoBroadcastJoinThreshold=-1
           spark.sql.join.preferSortMergeJoin=true
@@ -1425,6 +1426,7 @@ jobs:
         SPARK_TPCDS_DATA=`pwd`/tpcds-sf-1 build/sbt "sql/testOnly org.apache.spark.sql.TPCDSQueryTestSuite"
       env:
         SPARK_ANSI_SQL_MODE: ${{ fromJSON(inputs.envs).SPARK_ANSI_SQL_MODE }}
+        SPARK_SQL_WSCG_UNION_ENABLED: ${{ fromJSON(inputs.envs).SPARK_SQL_WSCG_UNION_ENABLED }}
         SPARK_TPCDS_JOIN_CONF: |
           spark.sql.autoBroadcastJoinThreshold=10485760
     - name: Run TPC-DS queries (Shuffled hash join)
@@ -1432,6 +1434,7 @@ jobs:
         SPARK_TPCDS_DATA=`pwd`/tpcds-sf-1 build/sbt "sql/testOnly org.apache.spark.sql.TPCDSQueryTestSuite"
       env:
         SPARK_ANSI_SQL_MODE: ${{ fromJSON(inputs.envs).SPARK_ANSI_SQL_MODE }}
+        SPARK_SQL_WSCG_UNION_ENABLED: ${{ fromJSON(inputs.envs).SPARK_SQL_WSCG_UNION_ENABLED }}
         SPARK_TPCDS_JOIN_CONF: |
           spark.sql.autoBroadcastJoinThreshold=-1
           spark.sql.join.forceApplyShuffledHashJoin=true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2526,7 +2526,7 @@ object SQLConf {
       .version("4.2.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(sys.env.get("SPARK_SQL_WSCG_UNION_ENABLED").contains("true"))
 
   val WHOLESTAGE_UNION_MAX_CHILDREN =
     buildConf("spark.sql.codegen.wholeStage.union.maxChildren")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2526,7 +2526,7 @@ object SQLConf {
       .version("4.2.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .booleanConf
-      .createWithDefault(sys.env.get("SPARK_SQL_WSCG_UNION_ENABLED").contains("true"))
+      .createWithDefault(true)
 
   val WHOLESTAGE_UNION_MAX_CHILDREN =
     buildConf("spark.sql.codegen.wholeStage.union.maxChildren")

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -211,7 +211,7 @@ struct<plan:string>
 * HashAggregate (10)
 +- Exchange (9)
    +- * HashAggregate (8)
-      +- Union (7)
+      +- * Union (7)
          :- * Filter (3)
          :  +- * ColumnarToRow (2)
          :     +- Scan parquet spark_catalog.default.explain_temp1 (1)
@@ -241,16 +241,16 @@ Location [not included in comparison]/{warehouse_dir}/explain_temp1]
 PushedFilters: [IsNotNull(key), GreaterThan(key,1)]
 ReadSchema: struct<key:int,val:int>
 
-(5) ColumnarToRow [codegen id : 2]
+(5) ColumnarToRow
 Input [2]: [key#x, val#x]
 
-(6) Filter [codegen id : 2]
+(6) Filter
 Input [2]: [key#x, val#x]
 Condition : (isnotnull(key#x) AND (key#x > 1))
 
-(7) Union
+(7) Union [codegen id : 1]
 
-(8) HashAggregate [codegen id : 3]
+(8) HashAggregate [codegen id : 1]
 Input [2]: [key#x, val#x]
 Keys [2]: [key#x, val#x]
 Functions: []
@@ -261,7 +261,7 @@ Results [2]: [key#x, val#x]
 Input [2]: [key#x, val#x]
 Arguments: hashpartitioning(key#x, val#x, 4), ENSURE_REQUIREMENTS, [plan_id=x]
 
-(10) HashAggregate [codegen id : 4]
+(10) HashAggregate [codegen id : 2]
 Input [2]: [key#x, val#x]
 Keys [2]: [key#x, val#x]
 Functions: []

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/explain.txt
@@ -18,7 +18,7 @@ TakeOrderedAndProject (48)
                :        :     :  :           +- Scan parquet spark_catalog.default.customer (1)
                :        :     :  +- * Sort (20)
                :        :     :     +- Exchange (19)
-               :        :     :        +- Union (18)
+               :        :     :        +- * Union (18)
                :        :     :           :- * Project (11)
                :        :     :           :  +- * BroadcastHashJoin Inner BuildRight (10)
                :        :     :           :     :- * Filter (8)
@@ -79,23 +79,23 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#6), dynamicpruningexpression(ws_sol
 PushedFilters: [IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
-(7) ColumnarToRow [codegen id : 4]
+(7) ColumnarToRow [codegen id : 5]
 Input [2]: [ws_bill_customer_sk#5, ws_sold_date_sk#6]
 
-(8) Filter [codegen id : 4]
+(8) Filter [codegen id : 5]
 Input [2]: [ws_bill_customer_sk#5, ws_sold_date_sk#6]
 Condition : isnotnull(ws_bill_customer_sk#5)
 
 (9) ReusedExchange [Reuses operator id: 60]
 Output [1]: [d_date_sk#8]
 
-(10) BroadcastHashJoin [codegen id : 4]
+(10) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_sold_date_sk#6]
 Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
-(11) Project [codegen id : 4]
+(11) Project [codegen id : 5]
 Output [1]: [ws_bill_customer_sk#5 AS customer_sk#9]
 Input [3]: [ws_bill_customer_sk#5, ws_sold_date_sk#6, d_date_sk#8]
 
@@ -107,37 +107,37 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#11), dynamicpruningexpression(cs_so
 PushedFilters: [IsNotNull(cs_ship_customer_sk)]
 ReadSchema: struct<cs_ship_customer_sk:int>
 
-(13) ColumnarToRow [codegen id : 6]
+(13) ColumnarToRow
 Input [2]: [cs_ship_customer_sk#10, cs_sold_date_sk#11]
 
-(14) Filter [codegen id : 6]
+(14) Filter
 Input [2]: [cs_ship_customer_sk#10, cs_sold_date_sk#11]
 Condition : isnotnull(cs_ship_customer_sk#10)
 
 (15) ReusedExchange [Reuses operator id: 60]
 Output [1]: [d_date_sk#12]
 
-(16) BroadcastHashJoin [codegen id : 6]
+(16) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#11]
 Right keys [1]: [d_date_sk#12]
 Join type: Inner
 Join condition: None
 
-(17) Project [codegen id : 6]
+(17) Project
 Output [1]: [cs_ship_customer_sk#10 AS customer_sk#13]
 Input [3]: [cs_ship_customer_sk#10, cs_sold_date_sk#11, d_date_sk#12]
 
-(18) Union
+(18) Union [codegen id : 5]
 
 (19) Exchange
 Input [1]: [customer_sk#9]
 Arguments: hashpartitioning(customer_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(20) Sort [codegen id : 7]
+(20) Sort [codegen id : 6]
 Input [1]: [customer_sk#9]
 Arguments: [customer_sk#9 ASC NULLS FIRST], false, 0
 
-(21) SortMergeJoin [codegen id : 8]
+(21) SortMergeJoin [codegen id : 7]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customer_sk#9]
 Join type: LeftSemi
@@ -151,23 +151,23 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#15), dynamicpruningexpression(ss_so
 PushedFilters: [IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int>
 
-(23) ColumnarToRow [codegen id : 10]
+(23) ColumnarToRow [codegen id : 9]
 Input [2]: [ss_customer_sk#14, ss_sold_date_sk#15]
 
-(24) Filter [codegen id : 10]
+(24) Filter [codegen id : 9]
 Input [2]: [ss_customer_sk#14, ss_sold_date_sk#15]
 Condition : isnotnull(ss_customer_sk#14)
 
 (25) ReusedExchange [Reuses operator id: 60]
 Output [1]: [d_date_sk#16]
 
-(26) BroadcastHashJoin [codegen id : 10]
+(26) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_sold_date_sk#15]
 Right keys [1]: [d_date_sk#16]
 Join type: Inner
 Join condition: None
 
-(27) Project [codegen id : 10]
+(27) Project [codegen id : 9]
 Output [1]: [ss_customer_sk#14 AS customer_sk#17]
 Input [3]: [ss_customer_sk#14, ss_sold_date_sk#15, d_date_sk#16]
 
@@ -175,17 +175,17 @@ Input [3]: [ss_customer_sk#14, ss_sold_date_sk#15, d_date_sk#16]
 Input [1]: [customer_sk#17]
 Arguments: hashpartitioning(customer_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(29) Sort [codegen id : 11]
+(29) Sort [codegen id : 10]
 Input [1]: [customer_sk#17]
 Arguments: [customer_sk#17 ASC NULLS FIRST], false, 0
 
-(30) SortMergeJoin [codegen id : 13]
+(30) SortMergeJoin [codegen id : 12]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customer_sk#17]
 Join type: LeftSemi
 Join condition: None
 
-(31) Project [codegen id : 13]
+(31) Project [codegen id : 12]
 Output [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
@@ -196,14 +196,14 @@ Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(33) ColumnarToRow [codegen id : 12]
+(33) ColumnarToRow [codegen id : 11]
 Input [2]: [ca_address_sk#18, ca_county#19]
 
-(34) Filter [codegen id : 12]
+(34) Filter [codegen id : 11]
 Input [2]: [ca_address_sk#18, ca_county#19]
 Condition : (ca_county#19 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#18))
 
-(35) Project [codegen id : 12]
+(35) Project [codegen id : 11]
 Output [1]: [ca_address_sk#18]
 Input [2]: [ca_address_sk#18, ca_county#19]
 
@@ -211,13 +211,13 @@ Input [2]: [ca_address_sk#18, ca_county#19]
 Input [1]: [ca_address_sk#18]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
-(37) BroadcastHashJoin [codegen id : 13]
+(37) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#18]
 Join type: Inner
 Join condition: None
 
-(38) Project [codegen id : 13]
+(38) Project [codegen id : 12]
 Output [1]: [c_current_cdemo_sk#2]
 Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#18]
 
@@ -239,17 +239,17 @@ Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_stat
 Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Condition : isnotnull(cd_demo_sk#20)
 
-(43) BroadcastHashJoin [codegen id : 14]
+(43) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#20]
 Join type: Inner
 Join condition: None
 
-(44) Project [codegen id : 14]
+(44) Project [codegen id : 13]
 Output [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Input [10]: [c_current_cdemo_sk#2, cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 
-(45) HashAggregate [codegen id : 14]
+(45) HashAggregate [codegen id : 13]
 Input [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Functions [1]: [partial_count(1)]
@@ -260,7 +260,7 @@ Results [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_pur
 Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
 Arguments: hashpartitioning(cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(47) HashAggregate [codegen id : 15]
+(47) HashAggregate [codegen id : 14]
 Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
 Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Functions [1]: [count(1)]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/simplified.txt
@@ -1,21 +1,21 @@
 TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,cnt1,cnt2,cnt3,cnt4,cnt5,cnt6]
-  WholeStageCodegen (15)
+  WholeStageCodegen (14)
     HashAggregate [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,count] [count(1),cnt1,cnt2,cnt3,cnt4,cnt5,cnt6,count]
       InputAdapter
         Exchange [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] #1
-          WholeStageCodegen (14)
+          WholeStageCodegen (13)
             HashAggregate [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] [count,count]
               Project [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
                 BroadcastHashJoin [c_current_cdemo_sk,cd_demo_sk]
                   InputAdapter
                     BroadcastExchange #2
-                      WholeStageCodegen (13)
+                      WholeStageCodegen (12)
                         Project [c_current_cdemo_sk]
                           BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
                             Project [c_current_cdemo_sk,c_current_addr_sk]
                               SortMergeJoin [c_customer_sk,customer_sk]
                                 InputAdapter
-                                  WholeStageCodegen (8)
+                                  WholeStageCodegen (7)
                                     SortMergeJoin [c_customer_sk,customer_sk]
                                       InputAdapter
                                         WholeStageCodegen (2)
@@ -38,12 +38,12 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
                                       InputAdapter
-                                        WholeStageCodegen (7)
+                                        WholeStageCodegen (6)
                                           Sort [customer_sk]
                                             InputAdapter
                                               Exchange [customer_sk] #5
-                                                Union
-                                                  WholeStageCodegen (4)
+                                                WholeStageCodegen (5)
+                                                  Union
                                                     Project [ws_bill_customer_sk]
                                                       BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                         Filter [ws_bill_customer_sk]
@@ -60,7 +60,6 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                                               Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                                         InputAdapter
                                                           ReusedExchange [d_date_sk] #6
-                                                  WholeStageCodegen (6)
                                                     Project [cs_ship_customer_sk]
                                                       BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                         Filter [cs_ship_customer_sk]
@@ -71,11 +70,11 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                         InputAdapter
                                                           ReusedExchange [d_date_sk] #6
                                 InputAdapter
-                                  WholeStageCodegen (11)
+                                  WholeStageCodegen (10)
                                     Sort [customer_sk]
                                       InputAdapter
                                         Exchange [customer_sk] #7
-                                          WholeStageCodegen (10)
+                                          WholeStageCodegen (9)
                                             Project [ss_customer_sk]
                                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                 Filter [ss_customer_sk]
@@ -87,7 +86,7 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                   ReusedExchange [d_date_sk] #6
                             InputAdapter
                               BroadcastExchange #8
-                                WholeStageCodegen (12)
+                                WholeStageCodegen (11)
                                   Project [ca_address_sk]
                                     Filter [ca_county,ca_address_sk]
                                       ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10/explain.txt
@@ -14,7 +14,7 @@ TakeOrderedAndProject (44)
                :     :     :  :  +- * ColumnarToRow (2)
                :     :     :  :     +- Scan parquet spark_catalog.default.customer (1)
                :     :     :  +- BroadcastExchange (17)
-               :     :     :     +- Union (16)
+               :     :     :     +- * Union (16)
                :     :     :        :- * Project (9)
                :     :     :        :  +- * BroadcastHashJoin Inner BuildRight (8)
                :     :     :        :     :- * Filter (6)
@@ -52,10 +52,10 @@ Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk), IsNotNull(c_current_cdemo_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int>
 
-(2) ColumnarToRow [codegen id : 9]
+(2) ColumnarToRow [codegen id : 8]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
-(3) Filter [codegen id : 9]
+(3) Filter [codegen id : 8]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 Condition : ((isnotnull(c_customer_sk#1) AND isnotnull(c_current_addr_sk#3)) AND isnotnull(c_current_cdemo_sk#2))
 
@@ -67,23 +67,23 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#5), dynamicpruningexpression(ws_sol
 PushedFilters: [IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
-(5) ColumnarToRow [codegen id : 2]
+(5) ColumnarToRow [codegen id : 3]
 Input [2]: [ws_bill_customer_sk#4, ws_sold_date_sk#5]
 
-(6) Filter [codegen id : 2]
+(6) Filter [codegen id : 3]
 Input [2]: [ws_bill_customer_sk#4, ws_sold_date_sk#5]
 Condition : isnotnull(ws_bill_customer_sk#4)
 
 (7) ReusedExchange [Reuses operator id: 49]
 Output [1]: [d_date_sk#7]
 
-(8) BroadcastHashJoin [codegen id : 2]
+(8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
 Join type: Inner
 Join condition: None
 
-(9) Project [codegen id : 2]
+(9) Project [codegen id : 3]
 Output [1]: [ws_bill_customer_sk#4 AS customer_sk#8]
 Input [3]: [ws_bill_customer_sk#4, ws_sold_date_sk#5, d_date_sk#7]
 
@@ -95,33 +95,33 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#10), dynamicpruningexpression(cs_so
 PushedFilters: [IsNotNull(cs_ship_customer_sk)]
 ReadSchema: struct<cs_ship_customer_sk:int>
 
-(11) ColumnarToRow [codegen id : 4]
+(11) ColumnarToRow
 Input [2]: [cs_ship_customer_sk#9, cs_sold_date_sk#10]
 
-(12) Filter [codegen id : 4]
+(12) Filter
 Input [2]: [cs_ship_customer_sk#9, cs_sold_date_sk#10]
 Condition : isnotnull(cs_ship_customer_sk#9)
 
 (13) ReusedExchange [Reuses operator id: 49]
 Output [1]: [d_date_sk#11]
 
-(14) BroadcastHashJoin [codegen id : 4]
+(14) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#10]
 Right keys [1]: [d_date_sk#11]
 Join type: Inner
 Join condition: None
 
-(15) Project [codegen id : 4]
+(15) Project
 Output [1]: [cs_ship_customer_sk#9 AS customer_sk#12]
 Input [3]: [cs_ship_customer_sk#9, cs_sold_date_sk#10, d_date_sk#11]
 
-(16) Union
+(16) Union [codegen id : 3]
 
 (17) BroadcastExchange
 Input [1]: [customer_sk#8]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(18) BroadcastHashJoin [codegen id : 9]
+(18) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customer_sk#8]
 Join type: LeftSemi
@@ -135,23 +135,23 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#14), dynamicpruningexpression(ss_so
 PushedFilters: [IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int>
 
-(20) ColumnarToRow [codegen id : 6]
+(20) ColumnarToRow [codegen id : 5]
 Input [2]: [ss_customer_sk#13, ss_sold_date_sk#14]
 
-(21) Filter [codegen id : 6]
+(21) Filter [codegen id : 5]
 Input [2]: [ss_customer_sk#13, ss_sold_date_sk#14]
 Condition : isnotnull(ss_customer_sk#13)
 
 (22) ReusedExchange [Reuses operator id: 49]
 Output [1]: [d_date_sk#15]
 
-(23) BroadcastHashJoin [codegen id : 6]
+(23) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#14]
 Right keys [1]: [d_date_sk#15]
 Join type: Inner
 Join condition: None
 
-(24) Project [codegen id : 6]
+(24) Project [codegen id : 5]
 Output [1]: [ss_customer_sk#13 AS customer_sk#16]
 Input [3]: [ss_customer_sk#13, ss_sold_date_sk#14, d_date_sk#15]
 
@@ -159,13 +159,13 @@ Input [3]: [ss_customer_sk#13, ss_sold_date_sk#14, d_date_sk#15]
 Input [1]: [customer_sk#16]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
-(26) BroadcastHashJoin [codegen id : 9]
+(26) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customer_sk#16]
 Join type: LeftSemi
 Join condition: None
 
-(27) Project [codegen id : 9]
+(27) Project [codegen id : 8]
 Output [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
@@ -176,14 +176,14 @@ Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(29) ColumnarToRow [codegen id : 7]
+(29) ColumnarToRow [codegen id : 6]
 Input [2]: [ca_address_sk#17, ca_county#18]
 
-(30) Filter [codegen id : 7]
+(30) Filter [codegen id : 6]
 Input [2]: [ca_address_sk#17, ca_county#18]
 Condition : (ca_county#18 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#17))
 
-(31) Project [codegen id : 7]
+(31) Project [codegen id : 6]
 Output [1]: [ca_address_sk#17]
 Input [2]: [ca_address_sk#17, ca_county#18]
 
@@ -191,13 +191,13 @@ Input [2]: [ca_address_sk#17, ca_county#18]
 Input [1]: [ca_address_sk#17]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
 
-(33) BroadcastHashJoin [codegen id : 9]
+(33) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#17]
 Join type: Inner
 Join condition: None
 
-(34) Project [codegen id : 9]
+(34) Project [codegen id : 8]
 Output [1]: [c_current_cdemo_sk#2]
 Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#17]
 
@@ -208,10 +208,10 @@ Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
-(36) ColumnarToRow [codegen id : 8]
+(36) ColumnarToRow [codegen id : 7]
 Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 
-(37) Filter [codegen id : 8]
+(37) Filter [codegen id : 7]
 Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Condition : isnotnull(cd_demo_sk#19)
 
@@ -219,17 +219,17 @@ Condition : isnotnull(cd_demo_sk#19)
 Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
-(39) BroadcastHashJoin [codegen id : 9]
+(39) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#19]
 Join type: Inner
 Join condition: None
 
-(40) Project [codegen id : 9]
+(40) Project [codegen id : 8]
 Output [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Input [10]: [c_current_cdemo_sk#2, cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 
-(41) HashAggregate [codegen id : 9]
+(41) HashAggregate [codegen id : 8]
 Input [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Keys [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Functions [1]: [partial_count(1)]
@@ -240,7 +240,7 @@ Results [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_pur
 Input [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
 Arguments: hashpartitioning(cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(43) HashAggregate [codegen id : 10]
+(43) HashAggregate [codegen id : 9]
 Input [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
 Keys [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Functions [1]: [count(1)]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10/simplified.txt
@@ -1,9 +1,9 @@
 TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,cnt1,cnt2,cnt3,cnt4,cnt5,cnt6]
-  WholeStageCodegen (10)
+  WholeStageCodegen (9)
     HashAggregate [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,count] [count(1),cnt1,cnt2,cnt3,cnt4,cnt5,cnt6,count]
       InputAdapter
         Exchange [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] #1
-          WholeStageCodegen (9)
+          WholeStageCodegen (8)
             HashAggregate [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] [count,count]
               Project [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
                 BroadcastHashJoin [c_current_cdemo_sk,cd_demo_sk]
@@ -18,8 +18,8 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                   Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
                             InputAdapter
                               BroadcastExchange #2
-                                Union
-                                  WholeStageCodegen (2)
+                                WholeStageCodegen (3)
+                                  Union
                                     Project [ws_bill_customer_sk]
                                       BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                         Filter [ws_bill_customer_sk]
@@ -36,7 +36,6 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                               Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                         InputAdapter
                                           ReusedExchange [d_date_sk] #3
-                                  WholeStageCodegen (4)
                                     Project [cs_ship_customer_sk]
                                       BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                         Filter [cs_ship_customer_sk]
@@ -48,7 +47,7 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                           ReusedExchange [d_date_sk] #3
                           InputAdapter
                             BroadcastExchange #4
-                              WholeStageCodegen (6)
+                              WholeStageCodegen (5)
                                 Project [ss_customer_sk]
                                   BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                     Filter [ss_customer_sk]
@@ -60,7 +59,7 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                       ReusedExchange [d_date_sk] #3
                       InputAdapter
                         BroadcastExchange #5
-                          WholeStageCodegen (7)
+                          WholeStageCodegen (6)
                             Project [ca_address_sk]
                               Filter [ca_county,ca_address_sk]
                                 ColumnarToRow
@@ -68,7 +67,7 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                     Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
                   InputAdapter
                     BroadcastExchange #6
-                      WholeStageCodegen (8)
+                      WholeStageCodegen (7)
                         Filter [cd_demo_sk]
                           ColumnarToRow
                             InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27.sf100/explain.txt
@@ -1,6 +1,6 @@
 == Physical Plan ==
 TakeOrderedAndProject (73)
-+- Union (72)
++- * Union (72)
    :- * HashAggregate (28)
    :  +- Exchange (27)
    :     +- * HashAggregate (26)
@@ -201,7 +201,7 @@ Results [10]: [i_item_id#18, s_state#16, sum#31, count#32, sum#33, count#34, sum
 Input [10]: [i_item_id#18, s_state#16, sum#31, count#32, sum#33, count#34, sum#35, count#36, sum#37, count#38]
 Arguments: hashpartitioning(i_item_id#18, s_state#16, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(28) HashAggregate [codegen id : 6]
+(28) HashAggregate [codegen id : 16]
 Input [10]: [i_item_id#18, s_state#16, sum#31, count#32, sum#33, count#34, sum#35, count#36, sum#37, count#38]
 Keys [2]: [i_item_id#18, s_state#16]
 Functions [4]: [avg(agg1#19), avg(UnscaledValue(agg2#20)), avg(UnscaledValue(agg3#21)), avg(UnscaledValue(agg4#22))]
@@ -216,23 +216,23 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#55), (ss_sold_date_sk#55 >= 2451545
 PushedFilters: [IsNotNull(ss_cdemo_sk), IsNotNull(ss_store_sk), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_cdemo_sk:int,ss_store_sk:int,ss_quantity:int,ss_list_price:decimal(7,2),ss_sales_price:decimal(7,2),ss_coupon_amt:decimal(7,2)>
 
-(30) ColumnarToRow [codegen id : 11]
+(30) ColumnarToRow [codegen id : 10]
 Input [8]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
 
-(31) Filter [codegen id : 11]
+(31) Filter [codegen id : 10]
 Input [8]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
 Condition : ((isnotnull(ss_cdemo_sk#49) AND isnotnull(ss_store_sk#50)) AND isnotnull(ss_item_sk#48))
 
 (32) ReusedExchange [Reuses operator id: 78]
 Output [1]: [d_date_sk#56]
 
-(33) BroadcastHashJoin [codegen id : 11]
+(33) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#55]
 Right keys [1]: [d_date_sk#56]
 Join type: Inner
 Join condition: None
 
-(34) Project [codegen id : 11]
+(34) Project [codegen id : 10]
 Output [7]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54]
 Input [9]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55, d_date_sk#56]
 
@@ -243,14 +243,14 @@ Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [In(s_state, [AL,SD,TN]), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_state:string>
 
-(36) ColumnarToRow [codegen id : 8]
+(36) ColumnarToRow [codegen id : 7]
 Input [2]: [s_store_sk#57, s_state#58]
 
-(37) Filter [codegen id : 8]
+(37) Filter [codegen id : 7]
 Input [2]: [s_store_sk#57, s_state#58]
 Condition : (s_state#58 IN (TN,AL,SD) AND isnotnull(s_store_sk#57))
 
-(38) Project [codegen id : 8]
+(38) Project [codegen id : 7]
 Output [1]: [s_store_sk#57]
 Input [2]: [s_store_sk#57, s_state#58]
 
@@ -258,43 +258,43 @@ Input [2]: [s_store_sk#57, s_state#58]
 Input [1]: [s_store_sk#57]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
-(40) BroadcastHashJoin [codegen id : 11]
+(40) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#50]
 Right keys [1]: [s_store_sk#57]
 Join type: Inner
 Join condition: None
 
-(41) Project [codegen id : 11]
+(41) Project [codegen id : 10]
 Output [6]: [ss_item_sk#48, ss_cdemo_sk#49, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54]
 Input [8]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, s_store_sk#57]
 
 (42) ReusedExchange [Reuses operator id: 11]
 Output [1]: [cd_demo_sk#59]
 
-(43) BroadcastHashJoin [codegen id : 11]
+(43) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_cdemo_sk#49]
 Right keys [1]: [cd_demo_sk#59]
 Join type: Inner
 Join condition: None
 
-(44) Project [codegen id : 11]
+(44) Project [codegen id : 10]
 Output [5]: [ss_item_sk#48, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54]
 Input [7]: [ss_item_sk#48, ss_cdemo_sk#49, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, cd_demo_sk#59]
 
 (45) ReusedExchange [Reuses operator id: 23]
 Output [2]: [i_item_sk#60, i_item_id#61]
 
-(46) BroadcastHashJoin [codegen id : 11]
+(46) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_item_sk#48]
 Right keys [1]: [i_item_sk#60]
 Join type: Inner
 Join condition: None
 
-(47) Project [codegen id : 11]
+(47) Project [codegen id : 10]
 Output [5]: [i_item_id#61, ss_quantity#51 AS agg1#62, ss_list_price#52 AS agg2#63, ss_coupon_amt#54 AS agg3#64, ss_sales_price#53 AS agg4#65]
 Input [7]: [ss_item_sk#48, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, i_item_sk#60, i_item_id#61]
 
-(48) HashAggregate [codegen id : 11]
+(48) HashAggregate [codegen id : 10]
 Input [5]: [i_item_id#61, agg1#62, agg2#63, agg3#64, agg4#65]
 Keys [1]: [i_item_id#61]
 Functions [4]: [partial_avg(agg1#62), partial_avg(UnscaledValue(agg2#63)), partial_avg(UnscaledValue(agg3#64)), partial_avg(UnscaledValue(agg4#65))]
@@ -305,7 +305,7 @@ Results [9]: [i_item_id#61, sum#74, count#75, sum#76, count#77, sum#78, count#79
 Input [9]: [i_item_id#61, sum#74, count#75, sum#76, count#77, sum#78, count#79, sum#80, count#81]
 Arguments: hashpartitioning(i_item_id#61, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(50) HashAggregate [codegen id : 12]
+(50) HashAggregate
 Input [9]: [i_item_id#61, sum#74, count#75, sum#76, count#77, sum#78, count#79, sum#80, count#81]
 Keys [1]: [i_item_id#61]
 Functions [4]: [avg(agg1#62), avg(UnscaledValue(agg2#63)), avg(UnscaledValue(agg3#64)), avg(UnscaledValue(agg4#65))]
@@ -320,49 +320,49 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#99), (ss_sold_date_sk#99 >= 2451545
 PushedFilters: [IsNotNull(ss_cdemo_sk), IsNotNull(ss_store_sk), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_cdemo_sk:int,ss_store_sk:int,ss_quantity:int,ss_list_price:decimal(7,2),ss_sales_price:decimal(7,2),ss_coupon_amt:decimal(7,2)>
 
-(52) ColumnarToRow [codegen id : 17]
+(52) ColumnarToRow [codegen id : 15]
 Input [8]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
 
-(53) Filter [codegen id : 17]
+(53) Filter [codegen id : 15]
 Input [8]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
 Condition : ((isnotnull(ss_cdemo_sk#93) AND isnotnull(ss_store_sk#94)) AND isnotnull(ss_item_sk#92))
 
 (54) ReusedExchange [Reuses operator id: 78]
 Output [1]: [d_date_sk#100]
 
-(55) BroadcastHashJoin [codegen id : 17]
+(55) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_sold_date_sk#99]
 Right keys [1]: [d_date_sk#100]
 Join type: Inner
 Join condition: None
 
-(56) Project [codegen id : 17]
+(56) Project [codegen id : 15]
 Output [7]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98]
 Input [9]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99, d_date_sk#100]
 
 (57) ReusedExchange [Reuses operator id: 39]
 Output [1]: [s_store_sk#101]
 
-(58) BroadcastHashJoin [codegen id : 17]
+(58) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_store_sk#94]
 Right keys [1]: [s_store_sk#101]
 Join type: Inner
 Join condition: None
 
-(59) Project [codegen id : 17]
+(59) Project [codegen id : 15]
 Output [6]: [ss_item_sk#92, ss_cdemo_sk#93, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98]
 Input [8]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, s_store_sk#101]
 
 (60) ReusedExchange [Reuses operator id: 11]
 Output [1]: [cd_demo_sk#102]
 
-(61) BroadcastHashJoin [codegen id : 17]
+(61) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_cdemo_sk#93]
 Right keys [1]: [cd_demo_sk#102]
 Join type: Inner
 Join condition: None
 
-(62) Project [codegen id : 17]
+(62) Project [codegen id : 15]
 Output [5]: [ss_item_sk#92, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98]
 Input [7]: [ss_item_sk#92, ss_cdemo_sk#93, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, cd_demo_sk#102]
 
@@ -373,10 +373,10 @@ Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int>
 
-(64) ColumnarToRow [codegen id : 16]
+(64) ColumnarToRow [codegen id : 14]
 Input [1]: [i_item_sk#103]
 
-(65) Filter [codegen id : 16]
+(65) Filter [codegen id : 14]
 Input [1]: [i_item_sk#103]
 Condition : isnotnull(i_item_sk#103)
 
@@ -384,17 +384,17 @@ Condition : isnotnull(i_item_sk#103)
 Input [1]: [i_item_sk#103]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(67) BroadcastHashJoin [codegen id : 17]
+(67) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_item_sk#92]
 Right keys [1]: [i_item_sk#103]
 Join type: Inner
 Join condition: None
 
-(68) Project [codegen id : 17]
+(68) Project [codegen id : 15]
 Output [4]: [ss_quantity#95 AS agg1#104, ss_list_price#96 AS agg2#105, ss_coupon_amt#98 AS agg3#106, ss_sales_price#97 AS agg4#107]
 Input [6]: [ss_item_sk#92, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, i_item_sk#103]
 
-(69) HashAggregate [codegen id : 17]
+(69) HashAggregate [codegen id : 15]
 Input [4]: [agg1#104, agg2#105, agg3#106, agg4#107]
 Keys: []
 Functions [4]: [partial_avg(agg1#104), partial_avg(UnscaledValue(agg2#105)), partial_avg(UnscaledValue(agg3#106)), partial_avg(UnscaledValue(agg4#107))]
@@ -405,14 +405,14 @@ Results [8]: [sum#116, count#117, sum#118, count#119, sum#120, count#121, sum#12
 Input [8]: [sum#116, count#117, sum#118, count#119, sum#120, count#121, sum#122, count#123]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(71) HashAggregate [codegen id : 18]
+(71) HashAggregate
 Input [8]: [sum#116, count#117, sum#118, count#119, sum#120, count#121, sum#122, count#123]
 Keys: []
 Functions [4]: [avg(agg1#104), avg(UnscaledValue(agg2#105)), avg(UnscaledValue(agg3#106)), avg(UnscaledValue(agg4#107))]
 Aggregate Attributes [4]: [avg(agg1#104)#124, avg(UnscaledValue(agg2#105))#125, avg(UnscaledValue(agg3#106))#126, avg(UnscaledValue(agg4#107))#127]
 Results [7]: [null AS i_item_id#128, null AS s_state#129, 1 AS g_state#130, avg(agg1#104)#124 AS agg1#131, cast((avg(UnscaledValue(agg2#105))#125 / 100.0) as decimal(11,6)) AS agg2#132, cast((avg(UnscaledValue(agg3#106))#126 / 100.0) as decimal(11,6)) AS agg3#133, cast((avg(UnscaledValue(agg4#107))#127 / 100.0) as decimal(11,6)) AS agg4#134]
 
-(72) Union
+(72) Union [codegen id : 16]
 
 (73) TakeOrderedAndProject
 Input [7]: [i_item_id#18, s_state#16, g_state#43, agg1#44, agg2#45, agg3#46, agg4#47]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27.sf100/simplified.txt
@@ -1,6 +1,6 @@
 TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
-  Union
-    WholeStageCodegen (6)
+  WholeStageCodegen (16)
+    Union
       HashAggregate [i_item_id,s_state,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(UnscaledValue(agg2)),avg(UnscaledValue(agg3)),avg(UnscaledValue(agg4)),g_state,agg1,agg2,agg3,agg4,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange [i_item_id,s_state] #1
@@ -50,11 +50,10 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                             ColumnarToRow
                               InputAdapter
                                 Scan parquet spark_catalog.default.item [i_item_sk,i_item_id]
-    WholeStageCodegen (12)
       HashAggregate [i_item_id,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(UnscaledValue(agg2)),avg(UnscaledValue(agg3)),avg(UnscaledValue(agg4)),s_state,g_state,agg1,agg2,agg3,agg4,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange [i_item_id] #6
-            WholeStageCodegen (11)
+            WholeStageCodegen (10)
               HashAggregate [i_item_id,agg1,agg2,agg3,agg4] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [i_item_id,ss_quantity,ss_list_price,ss_coupon_amt,ss_sales_price]
                   BroadcastHashJoin [ss_item_sk,i_item_sk]
@@ -73,7 +72,7 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                                   ReusedExchange [d_date_sk] #2
                             InputAdapter
                               BroadcastExchange #7
-                                WholeStageCodegen (8)
+                                WholeStageCodegen (7)
                                   Project [s_store_sk]
                                     Filter [s_state,s_store_sk]
                                       ColumnarToRow
@@ -83,11 +82,10 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                           ReusedExchange [cd_demo_sk] #3
                     InputAdapter
                       ReusedExchange [i_item_sk,i_item_id] #5
-    WholeStageCodegen (18)
       HashAggregate [sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(UnscaledValue(agg2)),avg(UnscaledValue(agg3)),avg(UnscaledValue(agg4)),i_item_id,s_state,g_state,agg1,agg2,agg3,agg4,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange #8
-            WholeStageCodegen (17)
+            WholeStageCodegen (15)
               HashAggregate [agg1,agg2,agg3,agg4] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [ss_quantity,ss_list_price,ss_coupon_amt,ss_sales_price]
                   BroadcastHashJoin [ss_item_sk,i_item_sk]
@@ -110,7 +108,7 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                           ReusedExchange [cd_demo_sk] #3
                     InputAdapter
                       BroadcastExchange #9
-                        WholeStageCodegen (16)
+                        WholeStageCodegen (14)
                           Filter [i_item_sk]
                             ColumnarToRow
                               InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27/explain.txt
@@ -1,6 +1,6 @@
 == Physical Plan ==
 TakeOrderedAndProject (73)
-+- Union (72)
++- * Union (72)
    :- * HashAggregate (28)
    :  +- Exchange (27)
    :     +- * HashAggregate (26)
@@ -201,7 +201,7 @@ Results [10]: [i_item_id#18, s_state#16, sum#31, count#32, sum#33, count#34, sum
 Input [10]: [i_item_id#18, s_state#16, sum#31, count#32, sum#33, count#34, sum#35, count#36, sum#37, count#38]
 Arguments: hashpartitioning(i_item_id#18, s_state#16, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(28) HashAggregate [codegen id : 6]
+(28) HashAggregate [codegen id : 16]
 Input [10]: [i_item_id#18, s_state#16, sum#31, count#32, sum#33, count#34, sum#35, count#36, sum#37, count#38]
 Keys [2]: [i_item_id#18, s_state#16]
 Functions [4]: [avg(agg1#19), avg(UnscaledValue(agg2#20)), avg(UnscaledValue(agg3#21)), avg(UnscaledValue(agg4#22))]
@@ -216,36 +216,36 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#55), (ss_sold_date_sk#55 >= 2451545
 PushedFilters: [IsNotNull(ss_cdemo_sk), IsNotNull(ss_store_sk), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_cdemo_sk:int,ss_store_sk:int,ss_quantity:int,ss_list_price:decimal(7,2),ss_sales_price:decimal(7,2),ss_coupon_amt:decimal(7,2)>
 
-(30) ColumnarToRow [codegen id : 11]
+(30) ColumnarToRow [codegen id : 10]
 Input [8]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
 
-(31) Filter [codegen id : 11]
+(31) Filter [codegen id : 10]
 Input [8]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
 Condition : ((isnotnull(ss_cdemo_sk#49) AND isnotnull(ss_store_sk#50)) AND isnotnull(ss_item_sk#48))
 
 (32) ReusedExchange [Reuses operator id: 8]
 Output [1]: [cd_demo_sk#56]
 
-(33) BroadcastHashJoin [codegen id : 11]
+(33) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_cdemo_sk#49]
 Right keys [1]: [cd_demo_sk#56]
 Join type: Inner
 Join condition: None
 
-(34) Project [codegen id : 11]
+(34) Project [codegen id : 10]
 Output [7]: [ss_item_sk#48, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
 Input [9]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55, cd_demo_sk#56]
 
 (35) ReusedExchange [Reuses operator id: 78]
 Output [1]: [d_date_sk#57]
 
-(36) BroadcastHashJoin [codegen id : 11]
+(36) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#55]
 Right keys [1]: [d_date_sk#57]
 Join type: Inner
 Join condition: None
 
-(37) Project [codegen id : 11]
+(37) Project [codegen id : 10]
 Output [6]: [ss_item_sk#48, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54]
 Input [8]: [ss_item_sk#48, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55, d_date_sk#57]
 
@@ -256,14 +256,14 @@ Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [In(s_state, [AL,SD,TN]), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_state:string>
 
-(39) ColumnarToRow [codegen id : 9]
+(39) ColumnarToRow [codegen id : 8]
 Input [2]: [s_store_sk#58, s_state#59]
 
-(40) Filter [codegen id : 9]
+(40) Filter [codegen id : 8]
 Input [2]: [s_store_sk#58, s_state#59]
 Condition : (s_state#59 IN (TN,AL,SD) AND isnotnull(s_store_sk#58))
 
-(41) Project [codegen id : 9]
+(41) Project [codegen id : 8]
 Output [1]: [s_store_sk#58]
 Input [2]: [s_store_sk#58, s_state#59]
 
@@ -271,30 +271,30 @@ Input [2]: [s_store_sk#58, s_state#59]
 Input [1]: [s_store_sk#58]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
-(43) BroadcastHashJoin [codegen id : 11]
+(43) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#50]
 Right keys [1]: [s_store_sk#58]
 Join type: Inner
 Join condition: None
 
-(44) Project [codegen id : 11]
+(44) Project [codegen id : 10]
 Output [5]: [ss_item_sk#48, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54]
 Input [7]: [ss_item_sk#48, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, s_store_sk#58]
 
 (45) ReusedExchange [Reuses operator id: 23]
 Output [2]: [i_item_sk#60, i_item_id#61]
 
-(46) BroadcastHashJoin [codegen id : 11]
+(46) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_item_sk#48]
 Right keys [1]: [i_item_sk#60]
 Join type: Inner
 Join condition: None
 
-(47) Project [codegen id : 11]
+(47) Project [codegen id : 10]
 Output [5]: [i_item_id#61, ss_quantity#51 AS agg1#62, ss_list_price#52 AS agg2#63, ss_coupon_amt#54 AS agg3#64, ss_sales_price#53 AS agg4#65]
 Input [7]: [ss_item_sk#48, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, i_item_sk#60, i_item_id#61]
 
-(48) HashAggregate [codegen id : 11]
+(48) HashAggregate [codegen id : 10]
 Input [5]: [i_item_id#61, agg1#62, agg2#63, agg3#64, agg4#65]
 Keys [1]: [i_item_id#61]
 Functions [4]: [partial_avg(agg1#62), partial_avg(UnscaledValue(agg2#63)), partial_avg(UnscaledValue(agg3#64)), partial_avg(UnscaledValue(agg4#65))]
@@ -305,7 +305,7 @@ Results [9]: [i_item_id#61, sum#74, count#75, sum#76, count#77, sum#78, count#79
 Input [9]: [i_item_id#61, sum#74, count#75, sum#76, count#77, sum#78, count#79, sum#80, count#81]
 Arguments: hashpartitioning(i_item_id#61, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(50) HashAggregate [codegen id : 12]
+(50) HashAggregate
 Input [9]: [i_item_id#61, sum#74, count#75, sum#76, count#77, sum#78, count#79, sum#80, count#81]
 Keys [1]: [i_item_id#61]
 Functions [4]: [avg(agg1#62), avg(UnscaledValue(agg2#63)), avg(UnscaledValue(agg3#64)), avg(UnscaledValue(agg4#65))]
@@ -320,49 +320,49 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#99), (ss_sold_date_sk#99 >= 2451545
 PushedFilters: [IsNotNull(ss_cdemo_sk), IsNotNull(ss_store_sk), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_cdemo_sk:int,ss_store_sk:int,ss_quantity:int,ss_list_price:decimal(7,2),ss_sales_price:decimal(7,2),ss_coupon_amt:decimal(7,2)>
 
-(52) ColumnarToRow [codegen id : 17]
+(52) ColumnarToRow [codegen id : 15]
 Input [8]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
 
-(53) Filter [codegen id : 17]
+(53) Filter [codegen id : 15]
 Input [8]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
 Condition : ((isnotnull(ss_cdemo_sk#93) AND isnotnull(ss_store_sk#94)) AND isnotnull(ss_item_sk#92))
 
 (54) ReusedExchange [Reuses operator id: 8]
 Output [1]: [cd_demo_sk#100]
 
-(55) BroadcastHashJoin [codegen id : 17]
+(55) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_cdemo_sk#93]
 Right keys [1]: [cd_demo_sk#100]
 Join type: Inner
 Join condition: None
 
-(56) Project [codegen id : 17]
+(56) Project [codegen id : 15]
 Output [7]: [ss_item_sk#92, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
 Input [9]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99, cd_demo_sk#100]
 
 (57) ReusedExchange [Reuses operator id: 78]
 Output [1]: [d_date_sk#101]
 
-(58) BroadcastHashJoin [codegen id : 17]
+(58) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_sold_date_sk#99]
 Right keys [1]: [d_date_sk#101]
 Join type: Inner
 Join condition: None
 
-(59) Project [codegen id : 17]
+(59) Project [codegen id : 15]
 Output [6]: [ss_item_sk#92, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98]
 Input [8]: [ss_item_sk#92, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99, d_date_sk#101]
 
 (60) ReusedExchange [Reuses operator id: 42]
 Output [1]: [s_store_sk#102]
 
-(61) BroadcastHashJoin [codegen id : 17]
+(61) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_store_sk#94]
 Right keys [1]: [s_store_sk#102]
 Join type: Inner
 Join condition: None
 
-(62) Project [codegen id : 17]
+(62) Project [codegen id : 15]
 Output [5]: [ss_item_sk#92, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98]
 Input [7]: [ss_item_sk#92, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, s_store_sk#102]
 
@@ -373,10 +373,10 @@ Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int>
 
-(64) ColumnarToRow [codegen id : 16]
+(64) ColumnarToRow [codegen id : 14]
 Input [1]: [i_item_sk#103]
 
-(65) Filter [codegen id : 16]
+(65) Filter [codegen id : 14]
 Input [1]: [i_item_sk#103]
 Condition : isnotnull(i_item_sk#103)
 
@@ -384,17 +384,17 @@ Condition : isnotnull(i_item_sk#103)
 Input [1]: [i_item_sk#103]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(67) BroadcastHashJoin [codegen id : 17]
+(67) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_item_sk#92]
 Right keys [1]: [i_item_sk#103]
 Join type: Inner
 Join condition: None
 
-(68) Project [codegen id : 17]
+(68) Project [codegen id : 15]
 Output [4]: [ss_quantity#95 AS agg1#104, ss_list_price#96 AS agg2#105, ss_coupon_amt#98 AS agg3#106, ss_sales_price#97 AS agg4#107]
 Input [6]: [ss_item_sk#92, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, i_item_sk#103]
 
-(69) HashAggregate [codegen id : 17]
+(69) HashAggregate [codegen id : 15]
 Input [4]: [agg1#104, agg2#105, agg3#106, agg4#107]
 Keys: []
 Functions [4]: [partial_avg(agg1#104), partial_avg(UnscaledValue(agg2#105)), partial_avg(UnscaledValue(agg3#106)), partial_avg(UnscaledValue(agg4#107))]
@@ -405,14 +405,14 @@ Results [8]: [sum#116, count#117, sum#118, count#119, sum#120, count#121, sum#12
 Input [8]: [sum#116, count#117, sum#118, count#119, sum#120, count#121, sum#122, count#123]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(71) HashAggregate [codegen id : 18]
+(71) HashAggregate
 Input [8]: [sum#116, count#117, sum#118, count#119, sum#120, count#121, sum#122, count#123]
 Keys: []
 Functions [4]: [avg(agg1#104), avg(UnscaledValue(agg2#105)), avg(UnscaledValue(agg3#106)), avg(UnscaledValue(agg4#107))]
 Aggregate Attributes [4]: [avg(agg1#104)#124, avg(UnscaledValue(agg2#105))#125, avg(UnscaledValue(agg3#106))#126, avg(UnscaledValue(agg4#107))#127]
 Results [7]: [null AS i_item_id#128, null AS s_state#129, 1 AS g_state#130, avg(agg1#104)#124 AS agg1#131, cast((avg(UnscaledValue(agg2#105))#125 / 100.0) as decimal(11,6)) AS agg2#132, cast((avg(UnscaledValue(agg3#106))#126 / 100.0) as decimal(11,6)) AS agg3#133, cast((avg(UnscaledValue(agg4#107))#127 / 100.0) as decimal(11,6)) AS agg4#134]
 
-(72) Union
+(72) Union [codegen id : 16]
 
 (73) TakeOrderedAndProject
 Input [7]: [i_item_id#18, s_state#16, g_state#43, agg1#44, agg2#45, agg3#46, agg4#47]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27/simplified.txt
@@ -1,6 +1,6 @@
 TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
-  Union
-    WholeStageCodegen (6)
+  WholeStageCodegen (16)
+    Union
       HashAggregate [i_item_id,s_state,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(UnscaledValue(agg2)),avg(UnscaledValue(agg3)),avg(UnscaledValue(agg4)),g_state,agg1,agg2,agg3,agg4,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange [i_item_id,s_state] #1
@@ -50,11 +50,10 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                             ColumnarToRow
                               InputAdapter
                                 Scan parquet spark_catalog.default.item [i_item_sk,i_item_id]
-    WholeStageCodegen (12)
       HashAggregate [i_item_id,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(UnscaledValue(agg2)),avg(UnscaledValue(agg3)),avg(UnscaledValue(agg4)),s_state,g_state,agg1,agg2,agg3,agg4,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange [i_item_id] #6
-            WholeStageCodegen (11)
+            WholeStageCodegen (10)
               HashAggregate [i_item_id,agg1,agg2,agg3,agg4] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [i_item_id,ss_quantity,ss_list_price,ss_coupon_amt,ss_sales_price]
                   BroadcastHashJoin [ss_item_sk,i_item_sk]
@@ -75,7 +74,7 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                               ReusedExchange [d_date_sk] #2
                         InputAdapter
                           BroadcastExchange #7
-                            WholeStageCodegen (9)
+                            WholeStageCodegen (8)
                               Project [s_store_sk]
                                 Filter [s_state,s_store_sk]
                                   ColumnarToRow
@@ -83,11 +82,10 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                                       Scan parquet spark_catalog.default.store [s_store_sk,s_state]
                     InputAdapter
                       ReusedExchange [i_item_sk,i_item_id] #5
-    WholeStageCodegen (18)
       HashAggregate [sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(UnscaledValue(agg2)),avg(UnscaledValue(agg3)),avg(UnscaledValue(agg4)),i_item_id,s_state,g_state,agg1,agg2,agg3,agg4,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange #8
-            WholeStageCodegen (17)
+            WholeStageCodegen (15)
               HashAggregate [agg1,agg2,agg3,agg4] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [ss_quantity,ss_list_price,ss_coupon_amt,ss_sales_price]
                   BroadcastHashJoin [ss_item_sk,i_item_sk]
@@ -110,7 +108,7 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                           ReusedExchange [s_store_sk] #7
                     InputAdapter
                       BroadcastExchange #9
-                        WholeStageCodegen (16)
+                        WholeStageCodegen (14)
                           Filter [i_item_sk]
                             ColumnarToRow
                               InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
@@ -642,7 +642,7 @@ Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquer
 * HashAggregate (130)
 +- Exchange (129)
    +- * HashAggregate (128)
-      +- Union (127)
+      +- * Union (127)
          :- * Project (116)
          :  +- * BroadcastHashJoin Inner BuildRight (115)
          :     :- * ColumnarToRow (113)
@@ -667,19 +667,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ss_sold_date_sk#115), dynamicpruningexpression(ss_sold_date_sk#115 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(113) ColumnarToRow [codegen id : 2]
+(113) ColumnarToRow [codegen id : 4]
 Input [3]: [ss_quantity#113, ss_list_price#114, ss_sold_date_sk#115]
 
 (114) ReusedExchange [Reuses operator id: 140]
 Output [1]: [d_date_sk#116]
 
-(115) BroadcastHashJoin [codegen id : 2]
+(115) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#115]
 Right keys [1]: [d_date_sk#116]
 Join type: Inner
 Join condition: None
 
-(116) Project [codegen id : 2]
+(116) Project [codegen id : 4]
 Output [2]: [ss_quantity#113 AS quantity#117, ss_list_price#114 AS list_price#118]
 Input [4]: [ss_quantity#113, ss_list_price#114, ss_sold_date_sk#115, d_date_sk#116]
 
@@ -690,19 +690,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#121), dynamicpruningexpression(cs_sold_date_sk#121 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(118) ColumnarToRow [codegen id : 4]
+(118) ColumnarToRow
 Input [3]: [cs_quantity#119, cs_list_price#120, cs_sold_date_sk#121]
 
 (119) ReusedExchange [Reuses operator id: 140]
 Output [1]: [d_date_sk#122]
 
-(120) BroadcastHashJoin [codegen id : 4]
+(120) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#121]
 Right keys [1]: [d_date_sk#122]
 Join type: Inner
 Join condition: None
 
-(121) Project [codegen id : 4]
+(121) Project
 Output [2]: [cs_quantity#119 AS quantity#123, cs_list_price#120 AS list_price#124]
 Input [4]: [cs_quantity#119, cs_list_price#120, cs_sold_date_sk#121, d_date_sk#122]
 
@@ -713,25 +713,25 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#127), dynamicpruningexpression(ws_sold_date_sk#127 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(123) ColumnarToRow [codegen id : 6]
+(123) ColumnarToRow
 Input [3]: [ws_quantity#125, ws_list_price#126, ws_sold_date_sk#127]
 
 (124) ReusedExchange [Reuses operator id: 140]
 Output [1]: [d_date_sk#128]
 
-(125) BroadcastHashJoin [codegen id : 6]
+(125) BroadcastHashJoin
 Left keys [1]: [ws_sold_date_sk#127]
 Right keys [1]: [d_date_sk#128]
 Join type: Inner
 Join condition: None
 
-(126) Project [codegen id : 6]
+(126) Project
 Output [2]: [ws_quantity#125 AS quantity#129, ws_list_price#126 AS list_price#130]
 Input [4]: [ws_quantity#125, ws_list_price#126, ws_sold_date_sk#127, d_date_sk#128]
 
-(127) Union
+(127) Union [codegen id : 4]
 
-(128) HashAggregate [codegen id : 7]
+(128) HashAggregate [codegen id : 4]
 Input [2]: [quantity#117, list_price#118]
 Keys: []
 Functions [1]: [partial_avg((cast(quantity#117 as decimal(10,0)) * list_price#118))]
@@ -742,7 +742,7 @@ Results [2]: [sum#133, count#134]
 Input [2]: [sum#133, count#134]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=16]
 
-(130) HashAggregate [codegen id : 8]
+(130) HashAggregate [codegen id : 5]
 Input [2]: [sum#133, count#134]
 Keys: []
 Functions [1]: [avg((cast(quantity#117 as decimal(10,0)) * list_price#118))]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/simplified.txt
@@ -12,41 +12,37 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum(sales),su
                       Project [sales,number_sales,i_brand_id,i_class_id,i_category_id]
                         Filter [sales]
                           Subquery #3
-                            WholeStageCodegen (8)
+                            WholeStageCodegen (5)
                               HashAggregate [sum,count] [avg((cast(quantity as decimal(10,0)) * list_price)),average_sales,sum,count]
                                 InputAdapter
                                   Exchange #15
-                                    WholeStageCodegen (7)
+                                    WholeStageCodegen (4)
                                       HashAggregate [quantity,list_price] [sum,count,sum,count]
-                                        InputAdapter
-                                          Union
-                                            WholeStageCodegen (2)
-                                              Project [ss_quantity,ss_list_price]
-                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #2
-                                                  InputAdapter
-                                                    ReusedExchange [d_date_sk] #8
-                                            WholeStageCodegen (4)
-                                              Project [cs_quantity,cs_list_price]
-                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #2
-                                                  InputAdapter
-                                                    ReusedExchange [d_date_sk] #8
-                                            WholeStageCodegen (6)
-                                              Project [ws_quantity,ws_list_price]
-                                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #2
-                                                  InputAdapter
-                                                    ReusedExchange [d_date_sk] #8
+                                        Union
+                                          Project [ss_quantity,ss_list_price]
+                                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
+                                                    ReusedSubquery [d_date_sk] #2
+                                              InputAdapter
+                                                ReusedExchange [d_date_sk] #8
+                                          Project [cs_quantity,cs_list_price]
+                                            BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
+                                                    ReusedSubquery [d_date_sk] #2
+                                              InputAdapter
+                                                ReusedExchange [d_date_sk] #8
+                                          Project [ws_quantity,ws_list_price]
+                                            BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
+                                                    ReusedSubquery [d_date_sk] #2
+                                              InputAdapter
+                                                ReusedExchange [d_date_sk] #8
                           HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum((cast(ss_quantity as decimal(10,0)) * ss_list_price)),count(1),sales,number_sales,sum,isEmpty,count]
                             InputAdapter
                               Exchange [i_brand_id,i_class_id,i_category_id] #2

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/explain.txt
@@ -612,7 +612,7 @@ Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquer
 * HashAggregate (124)
 +- Exchange (123)
    +- * HashAggregate (122)
-      +- Union (121)
+      +- * Union (121)
          :- * Project (110)
          :  +- * BroadcastHashJoin Inner BuildRight (109)
          :     :- * ColumnarToRow (107)
@@ -637,19 +637,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ss_sold_date_sk#115), dynamicpruningexpression(ss_sold_date_sk#115 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(107) ColumnarToRow [codegen id : 2]
+(107) ColumnarToRow [codegen id : 4]
 Input [3]: [ss_quantity#113, ss_list_price#114, ss_sold_date_sk#115]
 
 (108) ReusedExchange [Reuses operator id: 134]
 Output [1]: [d_date_sk#116]
 
-(109) BroadcastHashJoin [codegen id : 2]
+(109) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#115]
 Right keys [1]: [d_date_sk#116]
 Join type: Inner
 Join condition: None
 
-(110) Project [codegen id : 2]
+(110) Project [codegen id : 4]
 Output [2]: [ss_quantity#113 AS quantity#117, ss_list_price#114 AS list_price#118]
 Input [4]: [ss_quantity#113, ss_list_price#114, ss_sold_date_sk#115, d_date_sk#116]
 
@@ -660,19 +660,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#121), dynamicpruningexpression(cs_sold_date_sk#121 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(112) ColumnarToRow [codegen id : 4]
+(112) ColumnarToRow
 Input [3]: [cs_quantity#119, cs_list_price#120, cs_sold_date_sk#121]
 
 (113) ReusedExchange [Reuses operator id: 134]
 Output [1]: [d_date_sk#122]
 
-(114) BroadcastHashJoin [codegen id : 4]
+(114) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#121]
 Right keys [1]: [d_date_sk#122]
 Join type: Inner
 Join condition: None
 
-(115) Project [codegen id : 4]
+(115) Project
 Output [2]: [cs_quantity#119 AS quantity#123, cs_list_price#120 AS list_price#124]
 Input [4]: [cs_quantity#119, cs_list_price#120, cs_sold_date_sk#121, d_date_sk#122]
 
@@ -683,25 +683,25 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#127), dynamicpruningexpression(ws_sold_date_sk#127 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(117) ColumnarToRow [codegen id : 6]
+(117) ColumnarToRow
 Input [3]: [ws_quantity#125, ws_list_price#126, ws_sold_date_sk#127]
 
 (118) ReusedExchange [Reuses operator id: 134]
 Output [1]: [d_date_sk#128]
 
-(119) BroadcastHashJoin [codegen id : 6]
+(119) BroadcastHashJoin
 Left keys [1]: [ws_sold_date_sk#127]
 Right keys [1]: [d_date_sk#128]
 Join type: Inner
 Join condition: None
 
-(120) Project [codegen id : 6]
+(120) Project
 Output [2]: [ws_quantity#125 AS quantity#129, ws_list_price#126 AS list_price#130]
 Input [4]: [ws_quantity#125, ws_list_price#126, ws_sold_date_sk#127, d_date_sk#128]
 
-(121) Union
+(121) Union [codegen id : 4]
 
-(122) HashAggregate [codegen id : 7]
+(122) HashAggregate [codegen id : 4]
 Input [2]: [quantity#117, list_price#118]
 Keys: []
 Functions [1]: [partial_avg((cast(quantity#117 as decimal(10,0)) * list_price#118))]
@@ -712,7 +712,7 @@ Results [2]: [sum#133, count#134]
 Input [2]: [sum#133, count#134]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
 
-(124) HashAggregate [codegen id : 8]
+(124) HashAggregate [codegen id : 5]
 Input [2]: [sum#133, count#134]
 Keys: []
 Functions [1]: [avg((cast(quantity#117 as decimal(10,0)) * list_price#118))]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/simplified.txt
@@ -12,41 +12,37 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum(sales),su
                       Project [sales,number_sales,i_brand_id,i_class_id,i_category_id]
                         Filter [sales]
                           Subquery #3
-                            WholeStageCodegen (8)
+                            WholeStageCodegen (5)
                               HashAggregate [sum,count] [avg((cast(quantity as decimal(10,0)) * list_price)),average_sales,sum,count]
                                 InputAdapter
                                   Exchange #13
-                                    WholeStageCodegen (7)
+                                    WholeStageCodegen (4)
                                       HashAggregate [quantity,list_price] [sum,count,sum,count]
-                                        InputAdapter
-                                          Union
-                                            WholeStageCodegen (2)
-                                              Project [ss_quantity,ss_list_price]
-                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #2
-                                                  InputAdapter
-                                                    ReusedExchange [d_date_sk] #7
-                                            WholeStageCodegen (4)
-                                              Project [cs_quantity,cs_list_price]
-                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #2
-                                                  InputAdapter
-                                                    ReusedExchange [d_date_sk] #7
-                                            WholeStageCodegen (6)
-                                              Project [ws_quantity,ws_list_price]
-                                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #2
-                                                  InputAdapter
-                                                    ReusedExchange [d_date_sk] #7
+                                        Union
+                                          Project [ss_quantity,ss_list_price]
+                                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
+                                                    ReusedSubquery [d_date_sk] #2
+                                              InputAdapter
+                                                ReusedExchange [d_date_sk] #7
+                                          Project [cs_quantity,cs_list_price]
+                                            BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
+                                                    ReusedSubquery [d_date_sk] #2
+                                              InputAdapter
+                                                ReusedExchange [d_date_sk] #7
+                                          Project [ws_quantity,ws_list_price]
+                                            BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
+                                                    ReusedSubquery [d_date_sk] #2
+                                              InputAdapter
+                                                ReusedExchange [d_date_sk] #7
                           HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum((cast(ss_quantity as decimal(10,0)) * ss_list_price)),count(1),sales,number_sales,sum,isEmpty,count]
                             InputAdapter
                               Exchange [i_brand_id,i_class_id,i_category_id] #2

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
@@ -523,7 +523,7 @@ Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquer
 * HashAggregate (109)
 +- Exchange (108)
    +- * HashAggregate (107)
-      +- Union (106)
+      +- * Union (106)
          :- * Project (95)
          :  +- * BroadcastHashJoin Inner BuildRight (94)
          :     :- * ColumnarToRow (92)
@@ -548,19 +548,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ss_sold_date_sk#77), dynamicpruningexpression(ss_sold_date_sk#77 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(92) ColumnarToRow [codegen id : 2]
+(92) ColumnarToRow [codegen id : 4]
 Input [3]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77]
 
 (93) ReusedExchange [Reuses operator id: 123]
 Output [1]: [d_date_sk#78]
 
-(94) BroadcastHashJoin [codegen id : 2]
+(94) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#77]
 Right keys [1]: [d_date_sk#78]
 Join type: Inner
 Join condition: None
 
-(95) Project [codegen id : 2]
+(95) Project [codegen id : 4]
 Output [2]: [ss_quantity#75 AS quantity#79, ss_list_price#76 AS list_price#80]
 Input [4]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77, d_date_sk#78]
 
@@ -571,19 +571,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#83), dynamicpruningexpression(cs_sold_date_sk#83 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(97) ColumnarToRow [codegen id : 4]
+(97) ColumnarToRow
 Input [3]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83]
 
 (98) ReusedExchange [Reuses operator id: 123]
 Output [1]: [d_date_sk#84]
 
-(99) BroadcastHashJoin [codegen id : 4]
+(99) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#83]
 Right keys [1]: [d_date_sk#84]
 Join type: Inner
 Join condition: None
 
-(100) Project [codegen id : 4]
+(100) Project
 Output [2]: [cs_quantity#81 AS quantity#85, cs_list_price#82 AS list_price#86]
 Input [4]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83, d_date_sk#84]
 
@@ -594,25 +594,25 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#89), dynamicpruningexpression(ws_sold_date_sk#89 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(102) ColumnarToRow [codegen id : 6]
+(102) ColumnarToRow
 Input [3]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89]
 
 (103) ReusedExchange [Reuses operator id: 123]
 Output [1]: [d_date_sk#90]
 
-(104) BroadcastHashJoin [codegen id : 6]
+(104) BroadcastHashJoin
 Left keys [1]: [ws_sold_date_sk#89]
 Right keys [1]: [d_date_sk#90]
 Join type: Inner
 Join condition: None
 
-(105) Project [codegen id : 6]
+(105) Project
 Output [2]: [ws_quantity#87 AS quantity#91, ws_list_price#88 AS list_price#92]
 Input [4]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89, d_date_sk#90]
 
-(106) Union
+(106) Union [codegen id : 4]
 
-(107) HashAggregate [codegen id : 7]
+(107) HashAggregate [codegen id : 4]
 Input [2]: [quantity#79, list_price#80]
 Keys: []
 Functions [1]: [partial_avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]
@@ -623,7 +623,7 @@ Results [2]: [sum#95, count#96]
 Input [2]: [sum#95, count#96]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
 
-(109) HashAggregate [codegen id : 8]
+(109) HashAggregate [codegen id : 5]
 Input [2]: [sum#95, count#96]
 Keys: []
 Functions [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/simplified.txt
@@ -3,41 +3,37 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
     BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
       Filter [sales]
         Subquery #4
-          WholeStageCodegen (8)
+          WholeStageCodegen (5)
             HashAggregate [sum,count] [avg((cast(quantity as decimal(10,0)) * list_price)),average_sales,sum,count]
               InputAdapter
                 Exchange #14
-                  WholeStageCodegen (7)
+                  WholeStageCodegen (4)
                     HashAggregate [quantity,list_price] [sum,count,sum,count]
-                      InputAdapter
-                        Union
-                          WholeStageCodegen (2)
-                            Project [ss_quantity,ss_list_price]
-                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
-                                      ReusedSubquery [d_date_sk] #3
-                                InputAdapter
-                                  ReusedExchange [d_date_sk] #7
-                          WholeStageCodegen (4)
-                            Project [cs_quantity,cs_list_price]
-                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
-                                      ReusedSubquery [d_date_sk] #3
-                                InputAdapter
-                                  ReusedExchange [d_date_sk] #7
-                          WholeStageCodegen (6)
-                            Project [ws_quantity,ws_list_price]
-                              BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
-                                      ReusedSubquery [d_date_sk] #3
-                                InputAdapter
-                                  ReusedExchange [d_date_sk] #7
+                      Union
+                        Project [ss_quantity,ss_list_price]
+                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
+                                  ReusedSubquery [d_date_sk] #3
+                            InputAdapter
+                              ReusedExchange [d_date_sk] #7
+                        Project [cs_quantity,cs_list_price]
+                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
+                                  ReusedSubquery [d_date_sk] #3
+                            InputAdapter
+                              ReusedExchange [d_date_sk] #7
+                        Project [ws_quantity,ws_list_price]
+                          BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
+                                  ReusedSubquery [d_date_sk] #3
+                            InputAdapter
+                              ReusedExchange [d_date_sk] #7
         HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum((cast(ss_quantity as decimal(10,0)) * ss_list_price)),count(1),channel,sales,number_sales,sum,isEmpty,count]
           InputAdapter
             Exchange [i_brand_id,i_class_id,i_category_id] #1

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/explain.txt
@@ -493,7 +493,7 @@ Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquer
 * HashAggregate (103)
 +- Exchange (102)
    +- * HashAggregate (101)
-      +- Union (100)
+      +- * Union (100)
          :- * Project (89)
          :  +- * BroadcastHashJoin Inner BuildRight (88)
          :     :- * ColumnarToRow (86)
@@ -518,19 +518,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ss_sold_date_sk#77), dynamicpruningexpression(ss_sold_date_sk#77 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(86) ColumnarToRow [codegen id : 2]
+(86) ColumnarToRow [codegen id : 4]
 Input [3]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77]
 
 (87) ReusedExchange [Reuses operator id: 117]
 Output [1]: [d_date_sk#78]
 
-(88) BroadcastHashJoin [codegen id : 2]
+(88) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#77]
 Right keys [1]: [d_date_sk#78]
 Join type: Inner
 Join condition: None
 
-(89) Project [codegen id : 2]
+(89) Project [codegen id : 4]
 Output [2]: [ss_quantity#75 AS quantity#79, ss_list_price#76 AS list_price#80]
 Input [4]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77, d_date_sk#78]
 
@@ -541,19 +541,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#83), dynamicpruningexpression(cs_sold_date_sk#83 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(91) ColumnarToRow [codegen id : 4]
+(91) ColumnarToRow
 Input [3]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83]
 
 (92) ReusedExchange [Reuses operator id: 117]
 Output [1]: [d_date_sk#84]
 
-(93) BroadcastHashJoin [codegen id : 4]
+(93) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#83]
 Right keys [1]: [d_date_sk#84]
 Join type: Inner
 Join condition: None
 
-(94) Project [codegen id : 4]
+(94) Project
 Output [2]: [cs_quantity#81 AS quantity#85, cs_list_price#82 AS list_price#86]
 Input [4]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83, d_date_sk#84]
 
@@ -564,25 +564,25 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#89), dynamicpruningexpression(ws_sold_date_sk#89 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(96) ColumnarToRow [codegen id : 6]
+(96) ColumnarToRow
 Input [3]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89]
 
 (97) ReusedExchange [Reuses operator id: 117]
 Output [1]: [d_date_sk#90]
 
-(98) BroadcastHashJoin [codegen id : 6]
+(98) BroadcastHashJoin
 Left keys [1]: [ws_sold_date_sk#89]
 Right keys [1]: [d_date_sk#90]
 Join type: Inner
 Join condition: None
 
-(99) Project [codegen id : 6]
+(99) Project
 Output [2]: [ws_quantity#87 AS quantity#91, ws_list_price#88 AS list_price#92]
 Input [4]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89, d_date_sk#90]
 
-(100) Union
+(100) Union [codegen id : 4]
 
-(101) HashAggregate [codegen id : 7]
+(101) HashAggregate [codegen id : 4]
 Input [2]: [quantity#79, list_price#80]
 Keys: []
 Functions [1]: [partial_avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]
@@ -593,7 +593,7 @@ Results [2]: [sum#95, count#96]
 Input [2]: [sum#95, count#96]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
 
-(103) HashAggregate [codegen id : 8]
+(103) HashAggregate [codegen id : 5]
 Input [2]: [sum#95, count#96]
 Keys: []
 Functions [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/simplified.txt
@@ -3,41 +3,37 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
     BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
       Filter [sales]
         Subquery #4
-          WholeStageCodegen (8)
+          WholeStageCodegen (5)
             HashAggregate [sum,count] [avg((cast(quantity as decimal(10,0)) * list_price)),average_sales,sum,count]
               InputAdapter
                 Exchange #12
-                  WholeStageCodegen (7)
+                  WholeStageCodegen (4)
                     HashAggregate [quantity,list_price] [sum,count,sum,count]
-                      InputAdapter
-                        Union
-                          WholeStageCodegen (2)
-                            Project [ss_quantity,ss_list_price]
-                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
-                                      ReusedSubquery [d_date_sk] #3
-                                InputAdapter
-                                  ReusedExchange [d_date_sk] #6
-                          WholeStageCodegen (4)
-                            Project [cs_quantity,cs_list_price]
-                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
-                                      ReusedSubquery [d_date_sk] #3
-                                InputAdapter
-                                  ReusedExchange [d_date_sk] #6
-                          WholeStageCodegen (6)
-                            Project [ws_quantity,ws_list_price]
-                              BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
-                                      ReusedSubquery [d_date_sk] #3
-                                InputAdapter
-                                  ReusedExchange [d_date_sk] #6
+                      Union
+                        Project [ss_quantity,ss_list_price]
+                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
+                                  ReusedSubquery [d_date_sk] #3
+                            InputAdapter
+                              ReusedExchange [d_date_sk] #6
+                        Project [cs_quantity,cs_list_price]
+                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
+                                  ReusedSubquery [d_date_sk] #3
+                            InputAdapter
+                              ReusedExchange [d_date_sk] #6
+                        Project [ws_quantity,ws_list_price]
+                          BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
+                                  ReusedSubquery [d_date_sk] #3
+                            InputAdapter
+                              ReusedExchange [d_date_sk] #6
         HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum((cast(ss_quantity as decimal(10,0)) * ss_list_price)),count(1),channel,sales,number_sales,sum,isEmpty,count]
           InputAdapter
             Exchange [i_brand_id,i_class_id,i_category_id] #1

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/explain.txt
@@ -10,7 +10,7 @@
          :     :     +- * HashAggregate (14)
          :     :        +- * Project (13)
          :     :           +- * BroadcastHashJoin Inner BuildRight (12)
-         :     :              :- Union (7)
+         :     :              :- * Union (7)
          :     :              :  :- * Project (3)
          :     :              :  :  +- * ColumnarToRow (2)
          :     :              :  :     +- Scan parquet spark_catalog.default.web_sales (1)
@@ -34,7 +34,7 @@
                   :     +- * HashAggregate (37)
                   :        +- * Project (36)
                   :           +- * BroadcastHashJoin Inner BuildRight (35)
-                  :              :- Union (30)
+                  :              :- * Union (30)
                   :              :  :- * Project (26)
                   :              :  :  +- * ColumnarToRow (25)
                   :              :  :     +- Scan parquet spark_catalog.default.web_sales (24)
@@ -59,10 +59,10 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#2)]
 ReadSchema: struct<ws_ext_sales_price:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 1]
+(2) ColumnarToRow [codegen id : 2]
 Input [2]: [ws_ext_sales_price#1, ws_sold_date_sk#2]
 
-(3) Project [codegen id : 1]
+(3) Project [codegen id : 2]
 Output [2]: [ws_sold_date_sk#2 AS sold_date_sk#3, ws_ext_sales_price#1 AS sales_price#4]
 Input [2]: [ws_ext_sales_price#1, ws_sold_date_sk#2]
 
@@ -73,14 +73,14 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#6)]
 ReadSchema: struct<cs_ext_sales_price:decimal(7,2)>
 
-(5) ColumnarToRow [codegen id : 2]
+(5) ColumnarToRow
 Input [2]: [cs_ext_sales_price#5, cs_sold_date_sk#6]
 
-(6) Project [codegen id : 2]
+(6) Project
 Output [2]: [cs_sold_date_sk#6 AS sold_date_sk#7, cs_ext_sales_price#5 AS sales_price#8]
 Input [2]: [cs_ext_sales_price#5, cs_sold_date_sk#6]
 
-(7) Union
+(7) Union [codegen id : 2]
 
 (8) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
@@ -89,10 +89,10 @@ Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int,d_day_name:string>
 
-(9) ColumnarToRow [codegen id : 3]
+(9) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
 
-(10) Filter [codegen id : 3]
+(10) Filter [codegen id : 1]
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
 Condition : ((isnotnull(d_date_sk#9) AND isnotnull(d_week_seq#10)) AND might_contain(Subquery scalar-subquery#12, [id=#1], xxhash64(d_week_seq#10, 42)))
 
@@ -100,17 +100,17 @@ Condition : ((isnotnull(d_date_sk#9) AND isnotnull(d_week_seq#10)) AND might_con
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
-(12) BroadcastHashJoin [codegen id : 4]
+(12) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [sold_date_sk#3]
 Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
-(13) Project [codegen id : 4]
+(13) Project [codegen id : 2]
 Output [3]: [sales_price#4, d_week_seq#10, d_day_name#11]
 Input [5]: [sold_date_sk#3, sales_price#4, d_date_sk#9, d_week_seq#10, d_day_name#11]
 
-(14) HashAggregate [codegen id : 4]
+(14) HashAggregate [codegen id : 2]
 Input [3]: [sales_price#4, d_week_seq#10, d_day_name#11]
 Keys [1]: [d_week_seq#10]
 Functions [7]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Sunday   ) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Monday   ) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Tuesday  ) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Wednesday) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Thursday ) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Friday   ) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Saturday ) THEN sales_price#4 END))]
@@ -121,7 +121,7 @@ Results [8]: [d_week_seq#10, sum#20, sum#21, sum#22, sum#23, sum#24, sum#25, sum
 Input [8]: [d_week_seq#10, sum#20, sum#21, sum#22, sum#23, sum#24, sum#25, sum#26]
 Arguments: hashpartitioning(d_week_seq#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(16) HashAggregate [codegen id : 12]
+(16) HashAggregate [codegen id : 8]
 Input [8]: [d_week_seq#10, sum#20, sum#21, sum#22, sum#23, sum#24, sum#25, sum#26]
 Keys [1]: [d_week_seq#10]
 Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#11 = Sunday   ) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Monday   ) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Tuesday  ) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Wednesday) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Thursday ) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Friday   ) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Saturday ) THEN sales_price#4 END))]
@@ -135,14 +135,14 @@ Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_week_seq:int,d_year:int>
 
-(18) ColumnarToRow [codegen id : 5]
+(18) ColumnarToRow [codegen id : 3]
 Input [2]: [d_week_seq#41, d_year#42]
 
-(19) Filter [codegen id : 5]
+(19) Filter [codegen id : 3]
 Input [2]: [d_week_seq#41, d_year#42]
 Condition : ((isnotnull(d_year#42) AND (d_year#42 = 2001)) AND isnotnull(d_week_seq#41))
 
-(20) Project [codegen id : 5]
+(20) Project [codegen id : 3]
 Output [1]: [d_week_seq#41]
 Input [2]: [d_week_seq#41, d_year#42]
 
@@ -150,13 +150,13 @@ Input [2]: [d_week_seq#41, d_year#42]
 Input [1]: [d_week_seq#41]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
-(22) BroadcastHashJoin [codegen id : 12]
+(22) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [d_week_seq#10]
 Right keys [1]: [d_week_seq#41]
 Join type: Inner
 Join condition: None
 
-(23) Project [codegen id : 12]
+(23) Project [codegen id : 8]
 Output [8]: [d_week_seq#10 AS d_week_seq1#43, sun_sales#34 AS sun_sales1#44, mon_sales#35 AS mon_sales1#45, tue_sales#36 AS tue_sales1#46, wed_sales#37 AS wed_sales1#47, thu_sales#38 AS thu_sales1#48, fri_sales#39 AS fri_sales1#49, sat_sales#40 AS sat_sales1#50]
 Input [9]: [d_week_seq#10, sun_sales#34, mon_sales#35, tue_sales#36, wed_sales#37, thu_sales#38, fri_sales#39, sat_sales#40, d_week_seq#41]
 
@@ -167,10 +167,10 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#52)]
 ReadSchema: struct<ws_ext_sales_price:decimal(7,2)>
 
-(25) ColumnarToRow [codegen id : 6]
+(25) ColumnarToRow [codegen id : 5]
 Input [2]: [ws_ext_sales_price#51, ws_sold_date_sk#52]
 
-(26) Project [codegen id : 6]
+(26) Project [codegen id : 5]
 Output [2]: [ws_sold_date_sk#52 AS sold_date_sk#53, ws_ext_sales_price#51 AS sales_price#54]
 Input [2]: [ws_ext_sales_price#51, ws_sold_date_sk#52]
 
@@ -181,14 +181,14 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#56)]
 ReadSchema: struct<cs_ext_sales_price:decimal(7,2)>
 
-(28) ColumnarToRow [codegen id : 7]
+(28) ColumnarToRow
 Input [2]: [cs_ext_sales_price#55, cs_sold_date_sk#56]
 
-(29) Project [codegen id : 7]
+(29) Project
 Output [2]: [cs_sold_date_sk#56 AS sold_date_sk#57, cs_ext_sales_price#55 AS sales_price#58]
 Input [2]: [cs_ext_sales_price#55, cs_sold_date_sk#56]
 
-(30) Union
+(30) Union [codegen id : 5]
 
 (31) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#59, d_week_seq#60, d_day_name#61]
@@ -197,10 +197,10 @@ Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int,d_day_name:string>
 
-(32) ColumnarToRow [codegen id : 8]
+(32) ColumnarToRow [codegen id : 4]
 Input [3]: [d_date_sk#59, d_week_seq#60, d_day_name#61]
 
-(33) Filter [codegen id : 8]
+(33) Filter [codegen id : 4]
 Input [3]: [d_date_sk#59, d_week_seq#60, d_day_name#61]
 Condition : ((isnotnull(d_date_sk#59) AND isnotnull(d_week_seq#60)) AND might_contain(Subquery scalar-subquery#62, [id=#5], xxhash64(d_week_seq#60, 42)))
 
@@ -208,17 +208,17 @@ Condition : ((isnotnull(d_date_sk#59) AND isnotnull(d_week_seq#60)) AND might_co
 Input [3]: [d_date_sk#59, d_week_seq#60, d_day_name#61]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=6]
 
-(35) BroadcastHashJoin [codegen id : 9]
+(35) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [sold_date_sk#53]
 Right keys [1]: [d_date_sk#59]
 Join type: Inner
 Join condition: None
 
-(36) Project [codegen id : 9]
+(36) Project [codegen id : 5]
 Output [3]: [sales_price#54, d_week_seq#60, d_day_name#61]
 Input [5]: [sold_date_sk#53, sales_price#54, d_date_sk#59, d_week_seq#60, d_day_name#61]
 
-(37) HashAggregate [codegen id : 9]
+(37) HashAggregate [codegen id : 5]
 Input [3]: [sales_price#54, d_week_seq#60, d_day_name#61]
 Keys [1]: [d_week_seq#60]
 Functions [7]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Sunday   ) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Monday   ) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Tuesday  ) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Wednesday) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Thursday ) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Friday   ) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Saturday ) THEN sales_price#54 END))]
@@ -229,7 +229,7 @@ Results [8]: [d_week_seq#60, sum#70, sum#71, sum#72, sum#73, sum#74, sum#75, sum
 Input [8]: [d_week_seq#60, sum#70, sum#71, sum#72, sum#73, sum#74, sum#75, sum#76]
 Arguments: hashpartitioning(d_week_seq#60, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(39) HashAggregate [codegen id : 11]
+(39) HashAggregate [codegen id : 7]
 Input [8]: [d_week_seq#60, sum#70, sum#71, sum#72, sum#73, sum#74, sum#75, sum#76]
 Keys [1]: [d_week_seq#60]
 Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#61 = Sunday   ) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Monday   ) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Tuesday  ) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Wednesday) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Thursday ) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Friday   ) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Saturday ) THEN sales_price#54 END))]
@@ -243,14 +243,14 @@ Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_week_seq:int,d_year:int>
 
-(41) ColumnarToRow [codegen id : 10]
+(41) ColumnarToRow [codegen id : 6]
 Input [2]: [d_week_seq#84, d_year#85]
 
-(42) Filter [codegen id : 10]
+(42) Filter [codegen id : 6]
 Input [2]: [d_week_seq#84, d_year#85]
 Condition : ((isnotnull(d_year#85) AND (d_year#85 = 2002)) AND isnotnull(d_week_seq#84))
 
-(43) Project [codegen id : 10]
+(43) Project [codegen id : 6]
 Output [1]: [d_week_seq#84]
 Input [2]: [d_week_seq#84, d_year#85]
 
@@ -258,13 +258,13 @@ Input [2]: [d_week_seq#84, d_year#85]
 Input [1]: [d_week_seq#84]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
-(45) BroadcastHashJoin [codegen id : 11]
+(45) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [d_week_seq#60]
 Right keys [1]: [d_week_seq#84]
 Join type: Inner
 Join condition: None
 
-(46) Project [codegen id : 11]
+(46) Project [codegen id : 7]
 Output [8]: [d_week_seq#60 AS d_week_seq2#86, sun_sales#77 AS sun_sales2#87, mon_sales#78 AS mon_sales2#88, tue_sales#79 AS tue_sales2#89, wed_sales#80 AS wed_sales2#90, thu_sales#81 AS thu_sales2#91, fri_sales#82 AS fri_sales2#92, sat_sales#83 AS sat_sales2#93]
 Input [9]: [d_week_seq#60, sun_sales#77, mon_sales#78, tue_sales#79, wed_sales#80, thu_sales#81, fri_sales#82, sat_sales#83, d_week_seq#84]
 
@@ -272,13 +272,13 @@ Input [9]: [d_week_seq#60, sun_sales#77, mon_sales#78, tue_sales#79, wed_sales#8
 Input [8]: [d_week_seq2#86, sun_sales2#87, mon_sales2#88, tue_sales2#89, wed_sales2#90, thu_sales2#91, fri_sales2#92, sat_sales2#93]
 Arguments: HashedRelationBroadcastMode(List(cast((input[0, int, true] - 53) as bigint)),false), [plan_id=9]
 
-(48) BroadcastHashJoin [codegen id : 12]
+(48) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [d_week_seq1#43]
 Right keys [1]: [(d_week_seq2#86 - 53)]
 Join type: Inner
 Join condition: None
 
-(49) Project [codegen id : 12]
+(49) Project [codegen id : 8]
 Output [8]: [d_week_seq1#43, round((sun_sales1#44 / sun_sales2#87), 2) AS round((sun_sales1 / sun_sales2), 2)#94, round((mon_sales1#45 / mon_sales2#88), 2) AS round((mon_sales1 / mon_sales2), 2)#95, round((tue_sales1#46 / tue_sales2#89), 2) AS round((tue_sales1 / tue_sales2), 2)#96, round((wed_sales1#47 / wed_sales2#90), 2) AS round((wed_sales1 / wed_sales2), 2)#97, round((thu_sales1#48 / thu_sales2#91), 2) AS round((thu_sales1 / thu_sales2), 2)#98, round((fri_sales1#49 / fri_sales2#92), 2) AS round((fri_sales1 / fri_sales2), 2)#99, round((sat_sales1#50 / sat_sales2#93), 2) AS round((sat_sales1 / sat_sales2), 2)#100]
 Input [16]: [d_week_seq1#43, sun_sales1#44, mon_sales1#45, tue_sales1#46, wed_sales1#47, thu_sales1#48, fri_sales1#49, sat_sales1#50, d_week_seq2#86, sun_sales2#87, mon_sales2#88, tue_sales2#89, wed_sales2#90, thu_sales2#91, fri_sales2#92, sat_sales2#93]
 
@@ -286,7 +286,7 @@ Input [16]: [d_week_seq1#43, sun_sales1#44, mon_sales1#45, tue_sales1#46, wed_sa
 Input [8]: [d_week_seq1#43, round((sun_sales1 / sun_sales2), 2)#94, round((mon_sales1 / mon_sales2), 2)#95, round((tue_sales1 / tue_sales2), 2)#96, round((wed_sales1 / wed_sales2), 2)#97, round((thu_sales1 / thu_sales2), 2)#98, round((fri_sales1 / fri_sales2), 2)#99, round((sat_sales1 / sat_sales2), 2)#100]
 Arguments: rangepartitioning(d_week_seq1#43 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(51) Sort [codegen id : 13]
+(51) Sort [codegen id : 9]
 Input [8]: [d_week_seq1#43, round((sun_sales1 / sun_sales2), 2)#94, round((mon_sales1 / mon_sales2), 2)#95, round((tue_sales1 / tue_sales2), 2)#96, round((wed_sales1 / wed_sales2), 2)#97, round((thu_sales1 / thu_sales2), 2)#98, round((fri_sales1 / fri_sales2), 2)#99, round((sat_sales1 / sat_sales2), 2)#100]
 Arguments: [d_week_seq1#43 ASC NULLS FIRST], true, 0
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/simplified.txt
@@ -1,8 +1,8 @@
-WholeStageCodegen (13)
+WholeStageCodegen (9)
   Sort [d_week_seq1]
     InputAdapter
       Exchange [d_week_seq1] #1
-        WholeStageCodegen (12)
+        WholeStageCodegen (8)
           Project [d_week_seq1,sun_sales1,sun_sales2,mon_sales1,mon_sales2,tue_sales1,tue_sales2,wed_sales1,wed_sales2,thu_sales1,thu_sales2,fri_sales1,fri_sales2,sat_sales1,sat_sales2]
             BroadcastHashJoin [d_week_seq1,d_week_seq2]
               Project [d_week_seq,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales]
@@ -10,25 +10,22 @@ WholeStageCodegen (13)
                   HashAggregate [d_week_seq,sum,sum,sum,sum,sum,sum,sum] [sum(UnscaledValue(CASE WHEN (d_day_name = Sunday   ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Monday   ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Tuesday  ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Wednesday) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Thursday ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Friday   ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Saturday ) THEN sales_price END)),sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,sum,sum,sum,sum,sum,sum,sum]
                     InputAdapter
                       Exchange [d_week_seq] #2
-                        WholeStageCodegen (4)
+                        WholeStageCodegen (2)
                           HashAggregate [d_week_seq,d_day_name,sales_price] [sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum]
                             Project [sales_price,d_week_seq,d_day_name]
                               BroadcastHashJoin [sold_date_sk,d_date_sk]
-                                InputAdapter
-                                  Union
-                                    WholeStageCodegen (1)
-                                      Project [ws_sold_date_sk,ws_ext_sales_price]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.web_sales [ws_ext_sales_price,ws_sold_date_sk]
-                                    WholeStageCodegen (2)
-                                      Project [cs_sold_date_sk,cs_ext_sales_price]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.catalog_sales [cs_ext_sales_price,cs_sold_date_sk]
+                                Union
+                                  Project [ws_sold_date_sk,ws_ext_sales_price]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet spark_catalog.default.web_sales [ws_ext_sales_price,ws_sold_date_sk]
+                                  Project [cs_sold_date_sk,cs_ext_sales_price]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet spark_catalog.default.catalog_sales [cs_ext_sales_price,cs_sold_date_sk]
                                 InputAdapter
                                   BroadcastExchange #3
-                                    WholeStageCodegen (3)
+                                    WholeStageCodegen (1)
                                       Filter [d_date_sk,d_week_seq]
                                         Subquery #1
                                           ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 362, 9656, 0, 0),bloomFilter,buf]
@@ -45,7 +42,7 @@ WholeStageCodegen (13)
                                             Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
                   InputAdapter
                     BroadcastExchange #5
-                      WholeStageCodegen (5)
+                      WholeStageCodegen (3)
                         Project [d_week_seq]
                           Filter [d_year,d_week_seq]
                             ColumnarToRow
@@ -53,31 +50,28 @@ WholeStageCodegen (13)
                                 Scan parquet spark_catalog.default.date_dim [d_week_seq,d_year]
               InputAdapter
                 BroadcastExchange #6
-                  WholeStageCodegen (11)
+                  WholeStageCodegen (7)
                     Project [d_week_seq,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales]
                       BroadcastHashJoin [d_week_seq,d_week_seq]
                         HashAggregate [d_week_seq,sum,sum,sum,sum,sum,sum,sum] [sum(UnscaledValue(CASE WHEN (d_day_name = Sunday   ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Monday   ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Tuesday  ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Wednesday) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Thursday ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Friday   ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Saturday ) THEN sales_price END)),sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,sum,sum,sum,sum,sum,sum,sum]
                           InputAdapter
                             Exchange [d_week_seq] #7
-                              WholeStageCodegen (9)
+                              WholeStageCodegen (5)
                                 HashAggregate [d_week_seq,d_day_name,sales_price] [sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum]
                                   Project [sales_price,d_week_seq,d_day_name]
                                     BroadcastHashJoin [sold_date_sk,d_date_sk]
-                                      InputAdapter
-                                        Union
-                                          WholeStageCodegen (6)
-                                            Project [ws_sold_date_sk,ws_ext_sales_price]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet spark_catalog.default.web_sales [ws_ext_sales_price,ws_sold_date_sk]
-                                          WholeStageCodegen (7)
-                                            Project [cs_sold_date_sk,cs_ext_sales_price]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet spark_catalog.default.catalog_sales [cs_ext_sales_price,cs_sold_date_sk]
+                                      Union
+                                        Project [ws_sold_date_sk,ws_ext_sales_price]
+                                          ColumnarToRow
+                                            InputAdapter
+                                              Scan parquet spark_catalog.default.web_sales [ws_ext_sales_price,ws_sold_date_sk]
+                                        Project [cs_sold_date_sk,cs_ext_sales_price]
+                                          ColumnarToRow
+                                            InputAdapter
+                                              Scan parquet spark_catalog.default.catalog_sales [cs_ext_sales_price,cs_sold_date_sk]
                                       InputAdapter
                                         BroadcastExchange #8
-                                          WholeStageCodegen (8)
+                                          WholeStageCodegen (4)
                                             Filter [d_date_sk,d_week_seq]
                                               Subquery #2
                                                 ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 362, 9656, 0, 0),bloomFilter,buf]
@@ -94,7 +88,7 @@ WholeStageCodegen (13)
                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
                         InputAdapter
                           BroadcastExchange #10
-                            WholeStageCodegen (10)
+                            WholeStageCodegen (6)
                               Project [d_week_seq]
                                 Filter [d_year,d_week_seq]
                                   ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2/explain.txt
@@ -10,7 +10,7 @@
          :     :     +- * HashAggregate (14)
          :     :        +- * Project (13)
          :     :           +- * BroadcastHashJoin Inner BuildRight (12)
-         :     :              :- Union (7)
+         :     :              :- * Union (7)
          :     :              :  :- * Project (3)
          :     :              :  :  +- * ColumnarToRow (2)
          :     :              :  :     +- Scan parquet spark_catalog.default.web_sales (1)
@@ -45,10 +45,10 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#2)]
 ReadSchema: struct<ws_ext_sales_price:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 1]
+(2) ColumnarToRow [codegen id : 2]
 Input [2]: [ws_ext_sales_price#1, ws_sold_date_sk#2]
 
-(3) Project [codegen id : 1]
+(3) Project [codegen id : 2]
 Output [2]: [ws_sold_date_sk#2 AS sold_date_sk#3, ws_ext_sales_price#1 AS sales_price#4]
 Input [2]: [ws_ext_sales_price#1, ws_sold_date_sk#2]
 
@@ -59,14 +59,14 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#6)]
 ReadSchema: struct<cs_ext_sales_price:decimal(7,2)>
 
-(5) ColumnarToRow [codegen id : 2]
+(5) ColumnarToRow
 Input [2]: [cs_ext_sales_price#5, cs_sold_date_sk#6]
 
-(6) Project [codegen id : 2]
+(6) Project
 Output [2]: [cs_sold_date_sk#6 AS sold_date_sk#7, cs_ext_sales_price#5 AS sales_price#8]
 Input [2]: [cs_ext_sales_price#5, cs_sold_date_sk#6]
 
-(7) Union
+(7) Union [codegen id : 2]
 
 (8) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
@@ -75,10 +75,10 @@ Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int,d_day_name:string>
 
-(9) ColumnarToRow [codegen id : 3]
+(9) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
 
-(10) Filter [codegen id : 3]
+(10) Filter [codegen id : 1]
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
 Condition : (isnotnull(d_date_sk#9) AND isnotnull(d_week_seq#10))
 
@@ -86,17 +86,17 @@ Condition : (isnotnull(d_date_sk#9) AND isnotnull(d_week_seq#10))
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(12) BroadcastHashJoin [codegen id : 4]
+(12) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [sold_date_sk#3]
 Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
-(13) Project [codegen id : 4]
+(13) Project [codegen id : 2]
 Output [3]: [sales_price#4, d_week_seq#10, d_day_name#11]
 Input [5]: [sold_date_sk#3, sales_price#4, d_date_sk#9, d_week_seq#10, d_day_name#11]
 
-(14) HashAggregate [codegen id : 4]
+(14) HashAggregate [codegen id : 2]
 Input [3]: [sales_price#4, d_week_seq#10, d_day_name#11]
 Keys [1]: [d_week_seq#10]
 Functions [7]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Sunday   ) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Monday   ) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Tuesday  ) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Wednesday) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Thursday ) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Friday   ) THEN sales_price#4 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#11 = Saturday ) THEN sales_price#4 END))]
@@ -107,7 +107,7 @@ Results [8]: [d_week_seq#10, sum#19, sum#20, sum#21, sum#22, sum#23, sum#24, sum
 Input [8]: [d_week_seq#10, sum#19, sum#20, sum#21, sum#22, sum#23, sum#24, sum#25]
 Arguments: hashpartitioning(d_week_seq#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(16) HashAggregate [codegen id : 12]
+(16) HashAggregate [codegen id : 8]
 Input [8]: [d_week_seq#10, sum#19, sum#20, sum#21, sum#22, sum#23, sum#24, sum#25]
 Keys [1]: [d_week_seq#10]
 Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#11 = Sunday   ) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Monday   ) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Tuesday  ) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Wednesday) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Thursday ) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Friday   ) THEN sales_price#4 END)), sum(UnscaledValue(CASE WHEN (d_day_name#11 = Saturday ) THEN sales_price#4 END))]
@@ -121,14 +121,14 @@ Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_week_seq:int,d_year:int>
 
-(18) ColumnarToRow [codegen id : 5]
+(18) ColumnarToRow [codegen id : 3]
 Input [2]: [d_week_seq#40, d_year#41]
 
-(19) Filter [codegen id : 5]
+(19) Filter [codegen id : 3]
 Input [2]: [d_week_seq#40, d_year#41]
 Condition : ((isnotnull(d_year#41) AND (d_year#41 = 2001)) AND isnotnull(d_week_seq#40))
 
-(20) Project [codegen id : 5]
+(20) Project [codegen id : 3]
 Output [1]: [d_week_seq#40]
 Input [2]: [d_week_seq#40, d_year#41]
 
@@ -136,20 +136,20 @@ Input [2]: [d_week_seq#40, d_year#41]
 Input [1]: [d_week_seq#40]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
 
-(22) BroadcastHashJoin [codegen id : 12]
+(22) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [d_week_seq#10]
 Right keys [1]: [d_week_seq#40]
 Join type: Inner
 Join condition: None
 
-(23) Project [codegen id : 12]
+(23) Project [codegen id : 8]
 Output [8]: [d_week_seq#10 AS d_week_seq1#42, sun_sales#33 AS sun_sales1#43, mon_sales#34 AS mon_sales1#44, tue_sales#35 AS tue_sales1#45, wed_sales#36 AS wed_sales1#46, thu_sales#37 AS thu_sales1#47, fri_sales#38 AS fri_sales1#48, sat_sales#39 AS sat_sales1#49]
 Input [9]: [d_week_seq#10, sun_sales#33, mon_sales#34, tue_sales#35, wed_sales#36, thu_sales#37, fri_sales#38, sat_sales#39, d_week_seq#40]
 
 (24) ReusedExchange [Reuses operator id: 15]
 Output [8]: [d_week_seq#50, sum#51, sum#52, sum#53, sum#54, sum#55, sum#56, sum#57]
 
-(25) HashAggregate [codegen id : 11]
+(25) HashAggregate [codegen id : 7]
 Input [8]: [d_week_seq#50, sum#51, sum#52, sum#53, sum#54, sum#55, sum#56, sum#57]
 Keys [1]: [d_week_seq#50]
 Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#58 = Sunday   ) THEN sales_price#59 END)), sum(UnscaledValue(CASE WHEN (d_day_name#58 = Monday   ) THEN sales_price#59 END)), sum(UnscaledValue(CASE WHEN (d_day_name#58 = Tuesday  ) THEN sales_price#59 END)), sum(UnscaledValue(CASE WHEN (d_day_name#58 = Wednesday) THEN sales_price#59 END)), sum(UnscaledValue(CASE WHEN (d_day_name#58 = Thursday ) THEN sales_price#59 END)), sum(UnscaledValue(CASE WHEN (d_day_name#58 = Friday   ) THEN sales_price#59 END)), sum(UnscaledValue(CASE WHEN (d_day_name#58 = Saturday ) THEN sales_price#59 END))]
@@ -163,14 +163,14 @@ Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_week_seq:int,d_year:int>
 
-(27) ColumnarToRow [codegen id : 10]
+(27) ColumnarToRow [codegen id : 6]
 Input [2]: [d_week_seq#67, d_year#68]
 
-(28) Filter [codegen id : 10]
+(28) Filter [codegen id : 6]
 Input [2]: [d_week_seq#67, d_year#68]
 Condition : ((isnotnull(d_year#68) AND (d_year#68 = 2002)) AND isnotnull(d_week_seq#67))
 
-(29) Project [codegen id : 10]
+(29) Project [codegen id : 6]
 Output [1]: [d_week_seq#67]
 Input [2]: [d_week_seq#67, d_year#68]
 
@@ -178,13 +178,13 @@ Input [2]: [d_week_seq#67, d_year#68]
 Input [1]: [d_week_seq#67]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
-(31) BroadcastHashJoin [codegen id : 11]
+(31) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [d_week_seq#50]
 Right keys [1]: [d_week_seq#67]
 Join type: Inner
 Join condition: None
 
-(32) Project [codegen id : 11]
+(32) Project [codegen id : 7]
 Output [8]: [d_week_seq#50 AS d_week_seq2#69, sun_sales#60 AS sun_sales2#70, mon_sales#61 AS mon_sales2#71, tue_sales#62 AS tue_sales2#72, wed_sales#63 AS wed_sales2#73, thu_sales#64 AS thu_sales2#74, fri_sales#65 AS fri_sales2#75, sat_sales#66 AS sat_sales2#76]
 Input [9]: [d_week_seq#50, sun_sales#60, mon_sales#61, tue_sales#62, wed_sales#63, thu_sales#64, fri_sales#65, sat_sales#66, d_week_seq#67]
 
@@ -192,13 +192,13 @@ Input [9]: [d_week_seq#50, sun_sales#60, mon_sales#61, tue_sales#62, wed_sales#6
 Input [8]: [d_week_seq2#69, sun_sales2#70, mon_sales2#71, tue_sales2#72, wed_sales2#73, thu_sales2#74, fri_sales2#75, sat_sales2#76]
 Arguments: HashedRelationBroadcastMode(List(cast((input[0, int, true] - 53) as bigint)),false), [plan_id=5]
 
-(34) BroadcastHashJoin [codegen id : 12]
+(34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [d_week_seq1#42]
 Right keys [1]: [(d_week_seq2#69 - 53)]
 Join type: Inner
 Join condition: None
 
-(35) Project [codegen id : 12]
+(35) Project [codegen id : 8]
 Output [8]: [d_week_seq1#42, round((sun_sales1#43 / sun_sales2#70), 2) AS round((sun_sales1 / sun_sales2), 2)#77, round((mon_sales1#44 / mon_sales2#71), 2) AS round((mon_sales1 / mon_sales2), 2)#78, round((tue_sales1#45 / tue_sales2#72), 2) AS round((tue_sales1 / tue_sales2), 2)#79, round((wed_sales1#46 / wed_sales2#73), 2) AS round((wed_sales1 / wed_sales2), 2)#80, round((thu_sales1#47 / thu_sales2#74), 2) AS round((thu_sales1 / thu_sales2), 2)#81, round((fri_sales1#48 / fri_sales2#75), 2) AS round((fri_sales1 / fri_sales2), 2)#82, round((sat_sales1#49 / sat_sales2#76), 2) AS round((sat_sales1 / sat_sales2), 2)#83]
 Input [16]: [d_week_seq1#42, sun_sales1#43, mon_sales1#44, tue_sales1#45, wed_sales1#46, thu_sales1#47, fri_sales1#48, sat_sales1#49, d_week_seq2#69, sun_sales2#70, mon_sales2#71, tue_sales2#72, wed_sales2#73, thu_sales2#74, fri_sales2#75, sat_sales2#76]
 
@@ -206,7 +206,7 @@ Input [16]: [d_week_seq1#42, sun_sales1#43, mon_sales1#44, tue_sales1#45, wed_sa
 Input [8]: [d_week_seq1#42, round((sun_sales1 / sun_sales2), 2)#77, round((mon_sales1 / mon_sales2), 2)#78, round((tue_sales1 / tue_sales2), 2)#79, round((wed_sales1 / wed_sales2), 2)#80, round((thu_sales1 / thu_sales2), 2)#81, round((fri_sales1 / fri_sales2), 2)#82, round((sat_sales1 / sat_sales2), 2)#83]
 Arguments: rangepartitioning(d_week_seq1#42 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(37) Sort [codegen id : 13]
+(37) Sort [codegen id : 9]
 Input [8]: [d_week_seq1#42, round((sun_sales1 / sun_sales2), 2)#77, round((mon_sales1 / mon_sales2), 2)#78, round((tue_sales1 / tue_sales2), 2)#79, round((wed_sales1 / wed_sales2), 2)#80, round((thu_sales1 / thu_sales2), 2)#81, round((fri_sales1 / fri_sales2), 2)#82, round((sat_sales1 / sat_sales2), 2)#83]
 Arguments: [d_week_seq1#42 ASC NULLS FIRST], true, 0
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2/simplified.txt
@@ -1,8 +1,8 @@
-WholeStageCodegen (13)
+WholeStageCodegen (9)
   Sort [d_week_seq1]
     InputAdapter
       Exchange [d_week_seq1] #1
-        WholeStageCodegen (12)
+        WholeStageCodegen (8)
           Project [d_week_seq1,sun_sales1,sun_sales2,mon_sales1,mon_sales2,tue_sales1,tue_sales2,wed_sales1,wed_sales2,thu_sales1,thu_sales2,fri_sales1,fri_sales2,sat_sales1,sat_sales2]
             BroadcastHashJoin [d_week_seq1,d_week_seq2]
               Project [d_week_seq,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales]
@@ -10,32 +10,29 @@ WholeStageCodegen (13)
                   HashAggregate [d_week_seq,sum,sum,sum,sum,sum,sum,sum] [sum(UnscaledValue(CASE WHEN (d_day_name = Sunday   ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Monday   ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Tuesday  ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Wednesday) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Thursday ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Friday   ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Saturday ) THEN sales_price END)),sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,sum,sum,sum,sum,sum,sum,sum]
                     InputAdapter
                       Exchange [d_week_seq] #2
-                        WholeStageCodegen (4)
+                        WholeStageCodegen (2)
                           HashAggregate [d_week_seq,d_day_name,sales_price] [sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum]
                             Project [sales_price,d_week_seq,d_day_name]
                               BroadcastHashJoin [sold_date_sk,d_date_sk]
-                                InputAdapter
-                                  Union
-                                    WholeStageCodegen (1)
-                                      Project [ws_sold_date_sk,ws_ext_sales_price]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.web_sales [ws_ext_sales_price,ws_sold_date_sk]
-                                    WholeStageCodegen (2)
-                                      Project [cs_sold_date_sk,cs_ext_sales_price]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.catalog_sales [cs_ext_sales_price,cs_sold_date_sk]
+                                Union
+                                  Project [ws_sold_date_sk,ws_ext_sales_price]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet spark_catalog.default.web_sales [ws_ext_sales_price,ws_sold_date_sk]
+                                  Project [cs_sold_date_sk,cs_ext_sales_price]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet spark_catalog.default.catalog_sales [cs_ext_sales_price,cs_sold_date_sk]
                                 InputAdapter
                                   BroadcastExchange #3
-                                    WholeStageCodegen (3)
+                                    WholeStageCodegen (1)
                                       Filter [d_date_sk,d_week_seq]
                                         ColumnarToRow
                                           InputAdapter
                                             Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
                   InputAdapter
                     BroadcastExchange #4
-                      WholeStageCodegen (5)
+                      WholeStageCodegen (3)
                         Project [d_week_seq]
                           Filter [d_year,d_week_seq]
                             ColumnarToRow
@@ -43,7 +40,7 @@ WholeStageCodegen (13)
                                 Scan parquet spark_catalog.default.date_dim [d_week_seq,d_year]
               InputAdapter
                 BroadcastExchange #5
-                  WholeStageCodegen (11)
+                  WholeStageCodegen (7)
                     Project [d_week_seq,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales]
                       BroadcastHashJoin [d_week_seq,d_week_seq]
                         HashAggregate [d_week_seq,sum,sum,sum,sum,sum,sum,sum] [sum(UnscaledValue(CASE WHEN (d_day_name = Sunday   ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Monday   ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Tuesday  ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Wednesday) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Thursday ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Friday   ) THEN sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Saturday ) THEN sales_price END)),sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,sum,sum,sum,sum,sum,sum,sum]
@@ -51,7 +48,7 @@ WholeStageCodegen (13)
                             ReusedExchange [d_week_seq,sum,sum,sum,sum,sum,sum,sum] #2
                         InputAdapter
                           BroadcastExchange #6
-                            WholeStageCodegen (10)
+                            WholeStageCodegen (6)
                               Project [d_week_seq]
                                 Filter [d_year,d_week_seq]
                                   ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5.sf100/explain.txt
@@ -12,7 +12,7 @@ TakeOrderedAndProject (77)
                :           +- * BroadcastHashJoin Inner BuildRight (17)
                :              :- * Project (12)
                :              :  +- * BroadcastHashJoin Inner BuildRight (11)
-               :              :     :- Union (9)
+               :              :     :- * Union (9)
                :              :     :  :- * Project (4)
                :              :     :  :  +- * Filter (3)
                :              :     :  :     +- * ColumnarToRow (2)
@@ -33,7 +33,7 @@ TakeOrderedAndProject (77)
                :           +- * BroadcastHashJoin Inner BuildRight (38)
                :              :- * Project (33)
                :              :  +- * BroadcastHashJoin Inner BuildRight (32)
-               :              :     :- Union (30)
+               :              :     :- * Union (30)
                :              :     :  :- * Project (25)
                :              :     :  :  +- * Filter (24)
                :              :     :  :     +- * ColumnarToRow (23)
@@ -86,14 +86,14 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#4), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_store_sk:int,ss_ext_sales_price:decimal(7,2),ss_net_profit:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 1]
+(2) ColumnarToRow [codegen id : 3]
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 
-(3) Filter [codegen id : 1]
+(3) Filter [codegen id : 3]
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 Condition : isnotnull(ss_store_sk#1)
 
-(4) Project [codegen id : 1]
+(4) Project [codegen id : 3]
 Output [6]: [ss_store_sk#1 AS store_sk#6, ss_sold_date_sk#4 AS date_sk#7, ss_ext_sales_price#2 AS sales_price#8, ss_net_profit#3 AS profit#9, 0.00 AS return_amt#10, 0.00 AS net_loss#11]
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 
@@ -105,29 +105,29 @@ PartitionFilters: [isnotnull(sr_returned_date_sk#15), dynamicpruningexpression(s
 PushedFilters: [IsNotNull(sr_store_sk)]
 ReadSchema: struct<sr_store_sk:int,sr_return_amt:decimal(7,2),sr_net_loss:decimal(7,2)>
 
-(6) ColumnarToRow [codegen id : 2]
+(6) ColumnarToRow
 Input [4]: [sr_store_sk#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 
-(7) Filter [codegen id : 2]
+(7) Filter
 Input [4]: [sr_store_sk#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 Condition : isnotnull(sr_store_sk#12)
 
-(8) Project [codegen id : 2]
+(8) Project
 Output [6]: [sr_store_sk#12 AS store_sk#16, sr_returned_date_sk#15 AS date_sk#17, 0.00 AS sales_price#18, 0.00 AS profit#19, sr_return_amt#13 AS return_amt#20, sr_net_loss#14 AS net_loss#21]
 Input [4]: [sr_store_sk#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 
-(9) Union
+(9) Union [codegen id : 3]
 
 (10) ReusedExchange [Reuses operator id: 82]
 Output [1]: [d_date_sk#22]
 
-(11) BroadcastHashJoin [codegen id : 5]
+(11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [date_sk#7]
 Right keys [1]: [d_date_sk#22]
 Join type: Inner
 Join condition: None
 
-(12) Project [codegen id : 5]
+(12) Project [codegen id : 3]
 Output [5]: [store_sk#6, sales_price#8, profit#9, return_amt#10, net_loss#11]
 Input [7]: [store_sk#6, date_sk#7, sales_price#8, profit#9, return_amt#10, net_loss#11, d_date_sk#22]
 
@@ -138,10 +138,10 @@ Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
-(14) ColumnarToRow [codegen id : 4]
+(14) ColumnarToRow [codegen id : 2]
 Input [2]: [s_store_sk#23, s_store_id#24]
 
-(15) Filter [codegen id : 4]
+(15) Filter [codegen id : 2]
 Input [2]: [s_store_sk#23, s_store_id#24]
 Condition : isnotnull(s_store_sk#23)
 
@@ -149,17 +149,17 @@ Condition : isnotnull(s_store_sk#23)
 Input [2]: [s_store_sk#23, s_store_id#24]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(17) BroadcastHashJoin [codegen id : 5]
+(17) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [store_sk#6]
 Right keys [1]: [s_store_sk#23]
 Join type: Inner
 Join condition: None
 
-(18) Project [codegen id : 5]
+(18) Project [codegen id : 3]
 Output [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#24]
 Input [7]: [store_sk#6, sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_sk#23, s_store_id#24]
 
-(19) HashAggregate [codegen id : 5]
+(19) HashAggregate [codegen id : 3]
 Input [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#24]
 Keys [1]: [s_store_id#24]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#8)), partial_sum(UnscaledValue(return_amt#10)), partial_sum(UnscaledValue(profit#9)), partial_sum(UnscaledValue(net_loss#11))]
@@ -170,7 +170,7 @@ Results [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
 Input [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
 Arguments: hashpartitioning(s_store_id#24, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(21) HashAggregate [codegen id : 6]
+(21) HashAggregate [codegen id : 4]
 Input [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
 Keys [1]: [s_store_id#24]
 Functions [4]: [sum(UnscaledValue(sales_price#8)), sum(UnscaledValue(return_amt#10)), sum(UnscaledValue(profit#9)), sum(UnscaledValue(net_loss#11))]
@@ -204,29 +204,29 @@ PartitionFilters: [isnotnull(cr_returned_date_sk#55), dynamicpruningexpression(c
 PushedFilters: [IsNotNull(cr_catalog_page_sk)]
 ReadSchema: struct<cr_catalog_page_sk:int,cr_return_amount:decimal(7,2),cr_net_loss:decimal(7,2)>
 
-(27) ColumnarToRow [codegen id : 8]
+(27) ColumnarToRow
 Input [4]: [cr_catalog_page_sk#52, cr_return_amount#53, cr_net_loss#54, cr_returned_date_sk#55]
 
-(28) Filter [codegen id : 8]
+(28) Filter
 Input [4]: [cr_catalog_page_sk#52, cr_return_amount#53, cr_net_loss#54, cr_returned_date_sk#55]
 Condition : isnotnull(cr_catalog_page_sk#52)
 
-(29) Project [codegen id : 8]
+(29) Project
 Output [6]: [cr_catalog_page_sk#52 AS page_sk#56, cr_returned_date_sk#55 AS date_sk#57, 0.00 AS sales_price#58, 0.00 AS profit#59, cr_return_amount#53 AS return_amt#60, cr_net_loss#54 AS net_loss#61]
 Input [4]: [cr_catalog_page_sk#52, cr_return_amount#53, cr_net_loss#54, cr_returned_date_sk#55]
 
-(30) Union
+(30) Union [codegen id : 7]
 
 (31) ReusedExchange [Reuses operator id: 82]
 Output [1]: [d_date_sk#62]
 
-(32) BroadcastHashJoin [codegen id : 11]
+(32) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [date_sk#47]
 Right keys [1]: [d_date_sk#62]
 Join type: Inner
 Join condition: None
 
-(33) Project [codegen id : 11]
+(33) Project [codegen id : 7]
 Output [5]: [page_sk#46, sales_price#48, profit#49, return_amt#50, net_loss#51]
 Input [7]: [page_sk#46, date_sk#47, sales_price#48, profit#49, return_amt#50, net_loss#51, d_date_sk#62]
 
@@ -237,10 +237,10 @@ Location [not included in comparison]/{warehouse_dir}/catalog_page]
 PushedFilters: [IsNotNull(cp_catalog_page_sk)]
 ReadSchema: struct<cp_catalog_page_sk:int,cp_catalog_page_id:string>
 
-(35) ColumnarToRow [codegen id : 10]
+(35) ColumnarToRow [codegen id : 6]
 Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 
-(36) Filter [codegen id : 10]
+(36) Filter [codegen id : 6]
 Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 Condition : isnotnull(cp_catalog_page_sk#63)
 
@@ -248,17 +248,17 @@ Condition : isnotnull(cp_catalog_page_sk#63)
 Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
-(38) BroadcastHashJoin [codegen id : 11]
+(38) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [page_sk#46]
 Right keys [1]: [cp_catalog_page_sk#63]
 Join type: Inner
 Join condition: None
 
-(39) Project [codegen id : 11]
+(39) Project [codegen id : 7]
 Output [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#64]
 Input [7]: [page_sk#46, sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_sk#63, cp_catalog_page_id#64]
 
-(40) HashAggregate [codegen id : 11]
+(40) HashAggregate [codegen id : 7]
 Input [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#64]
 Keys [1]: [cp_catalog_page_id#64]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#48)), partial_sum(UnscaledValue(return_amt#50)), partial_sum(UnscaledValue(profit#49)), partial_sum(UnscaledValue(net_loss#51))]
@@ -269,7 +269,7 @@ Results [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
 Input [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
 Arguments: hashpartitioning(cp_catalog_page_id#64, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(42) HashAggregate [codegen id : 12]
+(42) HashAggregate [codegen id : 8]
 Input [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
 Keys [1]: [cp_catalog_page_id#64]
 Functions [4]: [sum(UnscaledValue(sales_price#48)), sum(UnscaledValue(return_amt#50)), sum(UnscaledValue(profit#49)), sum(UnscaledValue(net_loss#51))]
@@ -284,14 +284,14 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#85), dynamicpruningexpression(ws_so
 PushedFilters: [IsNotNull(ws_web_site_sk)]
 ReadSchema: struct<ws_web_site_sk:int,ws_ext_sales_price:decimal(7,2),ws_net_profit:decimal(7,2)>
 
-(44) ColumnarToRow [codegen id : 13]
+(44) ColumnarToRow [codegen id : 9]
 Input [4]: [ws_web_site_sk#82, ws_ext_sales_price#83, ws_net_profit#84, ws_sold_date_sk#85]
 
-(45) Filter [codegen id : 13]
+(45) Filter [codegen id : 9]
 Input [4]: [ws_web_site_sk#82, ws_ext_sales_price#83, ws_net_profit#84, ws_sold_date_sk#85]
 Condition : isnotnull(ws_web_site_sk#82)
 
-(46) Project [codegen id : 13]
+(46) Project [codegen id : 9]
 Output [6]: [ws_web_site_sk#82 AS wsr_web_site_sk#86, ws_sold_date_sk#85 AS date_sk#87, ws_ext_sales_price#83 AS sales_price#88, ws_net_profit#84 AS profit#89, 0.00 AS return_amt#90, 0.00 AS net_loss#91]
 Input [4]: [ws_web_site_sk#82, ws_ext_sales_price#83, ws_net_profit#84, ws_sold_date_sk#85]
 
@@ -302,14 +302,14 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(wr_returned_date_sk#96), dynamicpruningexpression(wr_returned_date_sk#96 IN dynamicpruning#5)]
 ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_amt:decimal(7,2),wr_net_loss:decimal(7,2)>
 
-(48) ColumnarToRow [codegen id : 14]
+(48) ColumnarToRow [codegen id : 10]
 Input [5]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95, wr_returned_date_sk#96]
 
 (49) Exchange
 Input [5]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95, wr_returned_date_sk#96]
 Arguments: hashpartitioning(wr_item_sk#92, wr_order_number#93, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(50) Sort [codegen id : 15]
+(50) Sort [codegen id : 11]
 Input [5]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95, wr_returned_date_sk#96]
 Arguments: [wr_item_sk#92 ASC NULLS FIRST, wr_order_number#93 ASC NULLS FIRST], false, 0
 
@@ -320,14 +320,14 @@ Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_order_number), IsNotNull(ws_web_site_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_web_site_sk:int,ws_order_number:int>
 
-(52) ColumnarToRow [codegen id : 16]
+(52) ColumnarToRow [codegen id : 12]
 Input [4]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99, ws_sold_date_sk#100]
 
-(53) Filter [codegen id : 16]
+(53) Filter [codegen id : 12]
 Input [4]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99, ws_sold_date_sk#100]
 Condition : ((isnotnull(ws_item_sk#97) AND isnotnull(ws_order_number#99)) AND isnotnull(ws_web_site_sk#98))
 
-(54) Project [codegen id : 16]
+(54) Project [codegen id : 12]
 Output [3]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99]
 Input [4]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99, ws_sold_date_sk#100]
 
@@ -335,17 +335,17 @@ Input [4]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99, ws_sold_date_s
 Input [3]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99]
 Arguments: hashpartitioning(ws_item_sk#97, ws_order_number#99, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(56) Sort [codegen id : 17]
+(56) Sort [codegen id : 13]
 Input [3]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99]
 Arguments: [ws_item_sk#97 ASC NULLS FIRST, ws_order_number#99 ASC NULLS FIRST], false, 0
 
-(57) SortMergeJoin [codegen id : 18]
+(57) SortMergeJoin [codegen id : 14]
 Left keys [2]: [wr_item_sk#92, wr_order_number#93]
 Right keys [2]: [ws_item_sk#97, ws_order_number#99]
 Join type: Inner
 Join condition: None
 
-(58) Project [codegen id : 18]
+(58) Project [codegen id : 14]
 Output [6]: [ws_web_site_sk#98 AS wsr_web_site_sk#101, wr_returned_date_sk#96 AS date_sk#102, 0.00 AS sales_price#103, 0.00 AS profit#104, wr_return_amt#94 AS return_amt#105, wr_net_loss#95 AS net_loss#106]
 Input [8]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95, wr_returned_date_sk#96, ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99]
 
@@ -354,13 +354,13 @@ Input [8]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95,
 (60) ReusedExchange [Reuses operator id: 82]
 Output [1]: [d_date_sk#107]
 
-(61) BroadcastHashJoin [codegen id : 21]
+(61) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [date_sk#87]
 Right keys [1]: [d_date_sk#107]
 Join type: Inner
 Join condition: None
 
-(62) Project [codegen id : 21]
+(62) Project [codegen id : 17]
 Output [5]: [wsr_web_site_sk#86, sales_price#88, profit#89, return_amt#90, net_loss#91]
 Input [7]: [wsr_web_site_sk#86, date_sk#87, sales_price#88, profit#89, return_amt#90, net_loss#91, d_date_sk#107]
 
@@ -371,10 +371,10 @@ Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_site_id:string>
 
-(64) ColumnarToRow [codegen id : 20]
+(64) ColumnarToRow [codegen id : 16]
 Input [2]: [web_site_sk#108, web_site_id#109]
 
-(65) Filter [codegen id : 20]
+(65) Filter [codegen id : 16]
 Input [2]: [web_site_sk#108, web_site_id#109]
 Condition : isnotnull(web_site_sk#108)
 
@@ -382,17 +382,17 @@ Condition : isnotnull(web_site_sk#108)
 Input [2]: [web_site_sk#108, web_site_id#109]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(67) BroadcastHashJoin [codegen id : 21]
+(67) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [wsr_web_site_sk#86]
 Right keys [1]: [web_site_sk#108]
 Join type: Inner
 Join condition: None
 
-(68) Project [codegen id : 21]
+(68) Project [codegen id : 17]
 Output [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#109]
 Input [7]: [wsr_web_site_sk#86, sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_sk#108, web_site_id#109]
 
-(69) HashAggregate [codegen id : 21]
+(69) HashAggregate [codegen id : 17]
 Input [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#109]
 Keys [1]: [web_site_id#109]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#88)), partial_sum(UnscaledValue(return_amt#90)), partial_sum(UnscaledValue(profit#89)), partial_sum(UnscaledValue(net_loss#91))]
@@ -403,7 +403,7 @@ Results [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
 Input [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
 Arguments: hashpartitioning(web_site_id#109, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(71) HashAggregate [codegen id : 22]
+(71) HashAggregate [codegen id : 18]
 Input [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
 Keys [1]: [web_site_id#109]
 Functions [4]: [sum(UnscaledValue(sales_price#88)), sum(UnscaledValue(return_amt#90)), sum(UnscaledValue(profit#89)), sum(UnscaledValue(net_loss#91))]
@@ -412,11 +412,11 @@ Results [5]: [MakeDecimal(sum(UnscaledValue(sales_price#88))#118,17,2) AS sales#
 
 (72) Union
 
-(73) Expand [codegen id : 23]
+(73) Expand [codegen id : 19]
 Input [5]: [sales#37, returns#38, profit#39, channel#40, id#41]
 Arguments: [[sales#37, returns#38, profit#39, channel#40, id#41, 0], [sales#37, returns#38, profit#39, channel#40, null, 1], [sales#37, returns#38, profit#39, null, null, 3]], [sales#37, returns#38, profit#39, channel#127, id#128, spark_grouping_id#129]
 
-(74) HashAggregate [codegen id : 23]
+(74) HashAggregate [codegen id : 19]
 Input [6]: [sales#37, returns#38, profit#39, channel#127, id#128, spark_grouping_id#129]
 Keys [3]: [channel#127, id#128, spark_grouping_id#129]
 Functions [3]: [partial_sum(sales#37), partial_sum(returns#38), partial_sum(profit#39)]
@@ -427,7 +427,7 @@ Results [9]: [channel#127, id#128, spark_grouping_id#129, sum#136, isEmpty#137, 
 Input [9]: [channel#127, id#128, spark_grouping_id#129, sum#136, isEmpty#137, sum#138, isEmpty#139, sum#140, isEmpty#141]
 Arguments: hashpartitioning(channel#127, id#128, spark_grouping_id#129, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(76) HashAggregate [codegen id : 24]
+(76) HashAggregate [codegen id : 20]
 Input [9]: [channel#127, id#128, spark_grouping_id#129, sum#136, isEmpty#137, sum#138, isEmpty#139, sum#140, isEmpty#141]
 Keys [3]: [channel#127, id#128, spark_grouping_id#129]
 Functions [3]: [sum(sales#37), sum(returns#38), sum(profit#39)]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5.sf100/simplified.txt
@@ -1,95 +1,89 @@
 TakeOrderedAndProject [channel,id,sales,returns,profit]
-  WholeStageCodegen (24)
+  WholeStageCodegen (20)
     HashAggregate [channel,id,spark_grouping_id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
       InputAdapter
         Exchange [channel,id,spark_grouping_id] #1
-          WholeStageCodegen (23)
+          WholeStageCodegen (19)
             HashAggregate [channel,id,spark_grouping_id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
               Expand [sales,returns,profit,channel,id]
                 InputAdapter
                   Union
-                    WholeStageCodegen (6)
+                    WholeStageCodegen (4)
                       HashAggregate [s_store_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),sales,returns,profit,channel,id,sum,sum,sum,sum]
                         InputAdapter
                           Exchange [s_store_id] #2
-                            WholeStageCodegen (5)
+                            WholeStageCodegen (3)
                               HashAggregate [s_store_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                 Project [sales_price,profit,return_amt,net_loss,s_store_id]
                                   BroadcastHashJoin [store_sk,s_store_sk]
                                     Project [store_sk,sales_price,profit,return_amt,net_loss]
                                       BroadcastHashJoin [date_sk,d_date_sk]
-                                        InputAdapter
-                                          Union
-                                            WholeStageCodegen (1)
-                                              Project [ss_store_sk,ss_sold_date_sk,ss_ext_sales_price,ss_net_profit]
-                                                Filter [ss_store_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
-                                                        SubqueryBroadcast [d_date_sk] #1
-                                                          BroadcastExchange #3
-                                                            WholeStageCodegen (1)
-                                                              Project [d_date_sk]
-                                                                Filter [d_date,d_date_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
-                                            WholeStageCodegen (2)
-                                              Project [sr_store_sk,sr_returned_date_sk,sr_return_amt,sr_net_loss]
-                                                Filter [sr_store_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
-                                                        ReusedSubquery [d_date_sk] #1
+                                        Union
+                                          Project [ss_store_sk,ss_sold_date_sk,ss_ext_sales_price,ss_net_profit]
+                                            Filter [ss_store_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
+                                                    SubqueryBroadcast [d_date_sk] #1
+                                                      BroadcastExchange #3
+                                                        WholeStageCodegen (1)
+                                                          Project [d_date_sk]
+                                                            Filter [d_date,d_date_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                                          Project [sr_store_sk,sr_returned_date_sk,sr_return_amt,sr_net_loss]
+                                            Filter [sr_store_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
+                                                    ReusedSubquery [d_date_sk] #1
                                         InputAdapter
                                           ReusedExchange [d_date_sk] #3
                                     InputAdapter
                                       BroadcastExchange #4
-                                        WholeStageCodegen (4)
+                                        WholeStageCodegen (2)
                                           Filter [s_store_sk]
                                             ColumnarToRow
                                               InputAdapter
                                                 Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
-                    WholeStageCodegen (12)
+                    WholeStageCodegen (8)
                       HashAggregate [cp_catalog_page_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),sales,returns,profit,channel,id,sum,sum,sum,sum]
                         InputAdapter
                           Exchange [cp_catalog_page_id] #5
-                            WholeStageCodegen (11)
+                            WholeStageCodegen (7)
                               HashAggregate [cp_catalog_page_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                 Project [sales_price,profit,return_amt,net_loss,cp_catalog_page_id]
                                   BroadcastHashJoin [page_sk,cp_catalog_page_sk]
                                     Project [page_sk,sales_price,profit,return_amt,net_loss]
                                       BroadcastHashJoin [date_sk,d_date_sk]
-                                        InputAdapter
-                                          Union
-                                            WholeStageCodegen (7)
-                                              Project [cs_catalog_page_sk,cs_sold_date_sk,cs_ext_sales_price,cs_net_profit]
-                                                Filter [cs_catalog_page_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.catalog_sales [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #1
-                                            WholeStageCodegen (8)
-                                              Project [cr_catalog_page_sk,cr_returned_date_sk,cr_return_amount,cr_net_loss]
-                                                Filter [cr_catalog_page_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.catalog_returns [cr_catalog_page_sk,cr_return_amount,cr_net_loss,cr_returned_date_sk]
-                                                        ReusedSubquery [d_date_sk] #1
+                                        Union
+                                          Project [cs_catalog_page_sk,cs_sold_date_sk,cs_ext_sales_price,cs_net_profit]
+                                            Filter [cs_catalog_page_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.catalog_sales [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
+                                                    ReusedSubquery [d_date_sk] #1
+                                          Project [cr_catalog_page_sk,cr_returned_date_sk,cr_return_amount,cr_net_loss]
+                                            Filter [cr_catalog_page_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.catalog_returns [cr_catalog_page_sk,cr_return_amount,cr_net_loss,cr_returned_date_sk]
+                                                    ReusedSubquery [d_date_sk] #1
                                         InputAdapter
                                           ReusedExchange [d_date_sk] #3
                                     InputAdapter
                                       BroadcastExchange #6
-                                        WholeStageCodegen (10)
+                                        WholeStageCodegen (6)
                                           Filter [cp_catalog_page_sk]
                                             ColumnarToRow
                                               InputAdapter
                                                 Scan parquet spark_catalog.default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
-                    WholeStageCodegen (22)
+                    WholeStageCodegen (18)
                       HashAggregate [web_site_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),sales,returns,profit,channel,id,sum,sum,sum,sum]
                         InputAdapter
                           Exchange [web_site_id] #7
-                            WholeStageCodegen (21)
+                            WholeStageCodegen (17)
                               HashAggregate [web_site_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                 Project [sales_price,profit,return_amt,net_loss,web_site_id]
                                   BroadcastHashJoin [wsr_web_site_sk,web_site_sk]
@@ -97,32 +91,32 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                       BroadcastHashJoin [date_sk,d_date_sk]
                                         InputAdapter
                                           Union
-                                            WholeStageCodegen (13)
+                                            WholeStageCodegen (9)
                                               Project [ws_web_site_sk,ws_sold_date_sk,ws_ext_sales_price,ws_net_profit]
                                                 Filter [ws_web_site_sk]
                                                   ColumnarToRow
                                                     InputAdapter
                                                       Scan parquet spark_catalog.default.web_sales [ws_web_site_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
                                                         ReusedSubquery [d_date_sk] #1
-                                            WholeStageCodegen (18)
+                                            WholeStageCodegen (14)
                                               Project [ws_web_site_sk,wr_returned_date_sk,wr_return_amt,wr_net_loss]
                                                 SortMergeJoin [wr_item_sk,wr_order_number,ws_item_sk,ws_order_number]
                                                   InputAdapter
-                                                    WholeStageCodegen (15)
+                                                    WholeStageCodegen (11)
                                                       Sort [wr_item_sk,wr_order_number]
                                                         InputAdapter
                                                           Exchange [wr_item_sk,wr_order_number] #8
-                                                            WholeStageCodegen (14)
+                                                            WholeStageCodegen (10)
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss,wr_returned_date_sk]
                                                                     ReusedSubquery [d_date_sk] #1
                                                   InputAdapter
-                                                    WholeStageCodegen (17)
+                                                    WholeStageCodegen (13)
                                                       Sort [ws_item_sk,ws_order_number]
                                                         InputAdapter
                                                           Exchange [ws_item_sk,ws_order_number] #9
-                                                            WholeStageCodegen (16)
+                                                            WholeStageCodegen (12)
                                                               Project [ws_item_sk,ws_web_site_sk,ws_order_number]
                                                                 Filter [ws_item_sk,ws_order_number,ws_web_site_sk]
                                                                   ColumnarToRow
@@ -132,7 +126,7 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                           ReusedExchange [d_date_sk] #3
                                     InputAdapter
                                       BroadcastExchange #10
-                                        WholeStageCodegen (20)
+                                        WholeStageCodegen (16)
                                           Filter [web_site_sk]
                                             ColumnarToRow
                                               InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5/explain.txt
@@ -12,7 +12,7 @@ TakeOrderedAndProject (74)
                :           +- * BroadcastHashJoin Inner BuildRight (17)
                :              :- * Project (12)
                :              :  +- * BroadcastHashJoin Inner BuildRight (11)
-               :              :     :- Union (9)
+               :              :     :- * Union (9)
                :              :     :  :- * Project (4)
                :              :     :  :  +- * Filter (3)
                :              :     :  :     +- * ColumnarToRow (2)
@@ -33,7 +33,7 @@ TakeOrderedAndProject (74)
                :           +- * BroadcastHashJoin Inner BuildRight (38)
                :              :- * Project (33)
                :              :  +- * BroadcastHashJoin Inner BuildRight (32)
-               :              :     :- Union (30)
+               :              :     :- * Union (30)
                :              :     :  :- * Project (25)
                :              :     :  :  +- * Filter (24)
                :              :     :  :     +- * ColumnarToRow (23)
@@ -54,7 +54,7 @@ TakeOrderedAndProject (74)
                            +- * BroadcastHashJoin Inner BuildRight (64)
                               :- * Project (59)
                               :  +- * BroadcastHashJoin Inner BuildRight (58)
-                              :     :- Union (56)
+                              :     :- * Union (56)
                               :     :  :- * Project (46)
                               :     :  :  +- * Filter (45)
                               :     :  :     +- * ColumnarToRow (44)
@@ -83,14 +83,14 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#4), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_store_sk:int,ss_ext_sales_price:decimal(7,2),ss_net_profit:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 1]
+(2) ColumnarToRow [codegen id : 3]
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 
-(3) Filter [codegen id : 1]
+(3) Filter [codegen id : 3]
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 Condition : isnotnull(ss_store_sk#1)
 
-(4) Project [codegen id : 1]
+(4) Project [codegen id : 3]
 Output [6]: [ss_store_sk#1 AS store_sk#6, ss_sold_date_sk#4 AS date_sk#7, ss_ext_sales_price#2 AS sales_price#8, ss_net_profit#3 AS profit#9, 0.00 AS return_amt#10, 0.00 AS net_loss#11]
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 
@@ -102,29 +102,29 @@ PartitionFilters: [isnotnull(sr_returned_date_sk#15), dynamicpruningexpression(s
 PushedFilters: [IsNotNull(sr_store_sk)]
 ReadSchema: struct<sr_store_sk:int,sr_return_amt:decimal(7,2),sr_net_loss:decimal(7,2)>
 
-(6) ColumnarToRow [codegen id : 2]
+(6) ColumnarToRow
 Input [4]: [sr_store_sk#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 
-(7) Filter [codegen id : 2]
+(7) Filter
 Input [4]: [sr_store_sk#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 Condition : isnotnull(sr_store_sk#12)
 
-(8) Project [codegen id : 2]
+(8) Project
 Output [6]: [sr_store_sk#12 AS store_sk#16, sr_returned_date_sk#15 AS date_sk#17, 0.00 AS sales_price#18, 0.00 AS profit#19, sr_return_amt#13 AS return_amt#20, sr_net_loss#14 AS net_loss#21]
 Input [4]: [sr_store_sk#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 
-(9) Union
+(9) Union [codegen id : 3]
 
 (10) ReusedExchange [Reuses operator id: 79]
 Output [1]: [d_date_sk#22]
 
-(11) BroadcastHashJoin [codegen id : 5]
+(11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [date_sk#7]
 Right keys [1]: [d_date_sk#22]
 Join type: Inner
 Join condition: None
 
-(12) Project [codegen id : 5]
+(12) Project [codegen id : 3]
 Output [5]: [store_sk#6, sales_price#8, profit#9, return_amt#10, net_loss#11]
 Input [7]: [store_sk#6, date_sk#7, sales_price#8, profit#9, return_amt#10, net_loss#11, d_date_sk#22]
 
@@ -135,10 +135,10 @@ Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
-(14) ColumnarToRow [codegen id : 4]
+(14) ColumnarToRow [codegen id : 2]
 Input [2]: [s_store_sk#23, s_store_id#24]
 
-(15) Filter [codegen id : 4]
+(15) Filter [codegen id : 2]
 Input [2]: [s_store_sk#23, s_store_id#24]
 Condition : isnotnull(s_store_sk#23)
 
@@ -146,17 +146,17 @@ Condition : isnotnull(s_store_sk#23)
 Input [2]: [s_store_sk#23, s_store_id#24]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(17) BroadcastHashJoin [codegen id : 5]
+(17) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [store_sk#6]
 Right keys [1]: [s_store_sk#23]
 Join type: Inner
 Join condition: None
 
-(18) Project [codegen id : 5]
+(18) Project [codegen id : 3]
 Output [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#24]
 Input [7]: [store_sk#6, sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_sk#23, s_store_id#24]
 
-(19) HashAggregate [codegen id : 5]
+(19) HashAggregate [codegen id : 3]
 Input [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#24]
 Keys [1]: [s_store_id#24]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#8)), partial_sum(UnscaledValue(return_amt#10)), partial_sum(UnscaledValue(profit#9)), partial_sum(UnscaledValue(net_loss#11))]
@@ -167,7 +167,7 @@ Results [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
 Input [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
 Arguments: hashpartitioning(s_store_id#24, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(21) HashAggregate [codegen id : 6]
+(21) HashAggregate [codegen id : 4]
 Input [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
 Keys [1]: [s_store_id#24]
 Functions [4]: [sum(UnscaledValue(sales_price#8)), sum(UnscaledValue(return_amt#10)), sum(UnscaledValue(profit#9)), sum(UnscaledValue(net_loss#11))]
@@ -201,29 +201,29 @@ PartitionFilters: [isnotnull(cr_returned_date_sk#55), dynamicpruningexpression(c
 PushedFilters: [IsNotNull(cr_catalog_page_sk)]
 ReadSchema: struct<cr_catalog_page_sk:int,cr_return_amount:decimal(7,2),cr_net_loss:decimal(7,2)>
 
-(27) ColumnarToRow [codegen id : 8]
+(27) ColumnarToRow
 Input [4]: [cr_catalog_page_sk#52, cr_return_amount#53, cr_net_loss#54, cr_returned_date_sk#55]
 
-(28) Filter [codegen id : 8]
+(28) Filter
 Input [4]: [cr_catalog_page_sk#52, cr_return_amount#53, cr_net_loss#54, cr_returned_date_sk#55]
 Condition : isnotnull(cr_catalog_page_sk#52)
 
-(29) Project [codegen id : 8]
+(29) Project
 Output [6]: [cr_catalog_page_sk#52 AS page_sk#56, cr_returned_date_sk#55 AS date_sk#57, 0.00 AS sales_price#58, 0.00 AS profit#59, cr_return_amount#53 AS return_amt#60, cr_net_loss#54 AS net_loss#61]
 Input [4]: [cr_catalog_page_sk#52, cr_return_amount#53, cr_net_loss#54, cr_returned_date_sk#55]
 
-(30) Union
+(30) Union [codegen id : 7]
 
 (31) ReusedExchange [Reuses operator id: 79]
 Output [1]: [d_date_sk#62]
 
-(32) BroadcastHashJoin [codegen id : 11]
+(32) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [date_sk#47]
 Right keys [1]: [d_date_sk#62]
 Join type: Inner
 Join condition: None
 
-(33) Project [codegen id : 11]
+(33) Project [codegen id : 7]
 Output [5]: [page_sk#46, sales_price#48, profit#49, return_amt#50, net_loss#51]
 Input [7]: [page_sk#46, date_sk#47, sales_price#48, profit#49, return_amt#50, net_loss#51, d_date_sk#62]
 
@@ -234,10 +234,10 @@ Location [not included in comparison]/{warehouse_dir}/catalog_page]
 PushedFilters: [IsNotNull(cp_catalog_page_sk)]
 ReadSchema: struct<cp_catalog_page_sk:int,cp_catalog_page_id:string>
 
-(35) ColumnarToRow [codegen id : 10]
+(35) ColumnarToRow [codegen id : 6]
 Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 
-(36) Filter [codegen id : 10]
+(36) Filter [codegen id : 6]
 Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 Condition : isnotnull(cp_catalog_page_sk#63)
 
@@ -245,17 +245,17 @@ Condition : isnotnull(cp_catalog_page_sk#63)
 Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
-(38) BroadcastHashJoin [codegen id : 11]
+(38) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [page_sk#46]
 Right keys [1]: [cp_catalog_page_sk#63]
 Join type: Inner
 Join condition: None
 
-(39) Project [codegen id : 11]
+(39) Project [codegen id : 7]
 Output [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#64]
 Input [7]: [page_sk#46, sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_sk#63, cp_catalog_page_id#64]
 
-(40) HashAggregate [codegen id : 11]
+(40) HashAggregate [codegen id : 7]
 Input [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#64]
 Keys [1]: [cp_catalog_page_id#64]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#48)), partial_sum(UnscaledValue(return_amt#50)), partial_sum(UnscaledValue(profit#49)), partial_sum(UnscaledValue(net_loss#51))]
@@ -266,7 +266,7 @@ Results [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
 Input [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
 Arguments: hashpartitioning(cp_catalog_page_id#64, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(42) HashAggregate [codegen id : 12]
+(42) HashAggregate [codegen id : 8]
 Input [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
 Keys [1]: [cp_catalog_page_id#64]
 Functions [4]: [sum(UnscaledValue(sales_price#48)), sum(UnscaledValue(return_amt#50)), sum(UnscaledValue(profit#49)), sum(UnscaledValue(net_loss#51))]
@@ -281,14 +281,14 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#85), dynamicpruningexpression(ws_so
 PushedFilters: [IsNotNull(ws_web_site_sk)]
 ReadSchema: struct<ws_web_site_sk:int,ws_ext_sales_price:decimal(7,2),ws_net_profit:decimal(7,2)>
 
-(44) ColumnarToRow [codegen id : 13]
+(44) ColumnarToRow [codegen id : 12]
 Input [4]: [ws_web_site_sk#82, ws_ext_sales_price#83, ws_net_profit#84, ws_sold_date_sk#85]
 
-(45) Filter [codegen id : 13]
+(45) Filter [codegen id : 12]
 Input [4]: [ws_web_site_sk#82, ws_ext_sales_price#83, ws_net_profit#84, ws_sold_date_sk#85]
 Condition : isnotnull(ws_web_site_sk#82)
 
-(46) Project [codegen id : 13]
+(46) Project [codegen id : 12]
 Output [6]: [ws_web_site_sk#82 AS wsr_web_site_sk#86, ws_sold_date_sk#85 AS date_sk#87, ws_ext_sales_price#83 AS sales_price#88, ws_net_profit#84 AS profit#89, 0.00 AS return_amt#90, 0.00 AS net_loss#91]
 Input [4]: [ws_web_site_sk#82, ws_ext_sales_price#83, ws_net_profit#84, ws_sold_date_sk#85]
 
@@ -299,7 +299,7 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(wr_returned_date_sk#96), dynamicpruningexpression(wr_returned_date_sk#96 IN dynamicpruning#5)]
 ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_amt:decimal(7,2),wr_net_loss:decimal(7,2)>
 
-(48) ColumnarToRow [codegen id : 14]
+(48) ColumnarToRow [codegen id : 9]
 Input [5]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95, wr_returned_date_sk#96]
 
 (49) BroadcastExchange
@@ -324,28 +324,28 @@ Condition : ((isnotnull(ws_item_sk#97) AND isnotnull(ws_order_number#99)) AND is
 Output [3]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99]
 Input [4]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99, ws_sold_date_sk#100]
 
-(54) BroadcastHashJoin [codegen id : 15]
+(54) BroadcastHashJoin
 Left keys [2]: [wr_item_sk#92, wr_order_number#93]
 Right keys [2]: [ws_item_sk#97, ws_order_number#99]
 Join type: Inner
 Join condition: None
 
-(55) Project [codegen id : 15]
+(55) Project
 Output [6]: [ws_web_site_sk#98 AS wsr_web_site_sk#101, wr_returned_date_sk#96 AS date_sk#102, 0.00 AS sales_price#103, 0.00 AS profit#104, wr_return_amt#94 AS return_amt#105, wr_net_loss#95 AS net_loss#106]
 Input [8]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95, wr_returned_date_sk#96, ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99]
 
-(56) Union
+(56) Union [codegen id : 12]
 
 (57) ReusedExchange [Reuses operator id: 79]
 Output [1]: [d_date_sk#107]
 
-(58) BroadcastHashJoin [codegen id : 18]
+(58) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [date_sk#87]
 Right keys [1]: [d_date_sk#107]
 Join type: Inner
 Join condition: None
 
-(59) Project [codegen id : 18]
+(59) Project [codegen id : 12]
 Output [5]: [wsr_web_site_sk#86, sales_price#88, profit#89, return_amt#90, net_loss#91]
 Input [7]: [wsr_web_site_sk#86, date_sk#87, sales_price#88, profit#89, return_amt#90, net_loss#91, d_date_sk#107]
 
@@ -356,10 +356,10 @@ Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_site_id:string>
 
-(61) ColumnarToRow [codegen id : 17]
+(61) ColumnarToRow [codegen id : 11]
 Input [2]: [web_site_sk#108, web_site_id#109]
 
-(62) Filter [codegen id : 17]
+(62) Filter [codegen id : 11]
 Input [2]: [web_site_sk#108, web_site_id#109]
 Condition : isnotnull(web_site_sk#108)
 
@@ -367,17 +367,17 @@ Condition : isnotnull(web_site_sk#108)
 Input [2]: [web_site_sk#108, web_site_id#109]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=6]
 
-(64) BroadcastHashJoin [codegen id : 18]
+(64) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [wsr_web_site_sk#86]
 Right keys [1]: [web_site_sk#108]
 Join type: Inner
 Join condition: None
 
-(65) Project [codegen id : 18]
+(65) Project [codegen id : 12]
 Output [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#109]
 Input [7]: [wsr_web_site_sk#86, sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_sk#108, web_site_id#109]
 
-(66) HashAggregate [codegen id : 18]
+(66) HashAggregate [codegen id : 12]
 Input [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#109]
 Keys [1]: [web_site_id#109]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#88)), partial_sum(UnscaledValue(return_amt#90)), partial_sum(UnscaledValue(profit#89)), partial_sum(UnscaledValue(net_loss#91))]
@@ -388,7 +388,7 @@ Results [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
 Input [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
 Arguments: hashpartitioning(web_site_id#109, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(68) HashAggregate [codegen id : 19]
+(68) HashAggregate [codegen id : 13]
 Input [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
 Keys [1]: [web_site_id#109]
 Functions [4]: [sum(UnscaledValue(sales_price#88)), sum(UnscaledValue(return_amt#90)), sum(UnscaledValue(profit#89)), sum(UnscaledValue(net_loss#91))]
@@ -397,11 +397,11 @@ Results [5]: [MakeDecimal(sum(UnscaledValue(sales_price#88))#118,17,2) AS sales#
 
 (69) Union
 
-(70) Expand [codegen id : 20]
+(70) Expand [codegen id : 14]
 Input [5]: [sales#37, returns#38, profit#39, channel#40, id#41]
 Arguments: [[sales#37, returns#38, profit#39, channel#40, id#41, 0], [sales#37, returns#38, profit#39, channel#40, null, 1], [sales#37, returns#38, profit#39, null, null, 3]], [sales#37, returns#38, profit#39, channel#127, id#128, spark_grouping_id#129]
 
-(71) HashAggregate [codegen id : 20]
+(71) HashAggregate [codegen id : 14]
 Input [6]: [sales#37, returns#38, profit#39, channel#127, id#128, spark_grouping_id#129]
 Keys [3]: [channel#127, id#128, spark_grouping_id#129]
 Functions [3]: [partial_sum(sales#37), partial_sum(returns#38), partial_sum(profit#39)]
@@ -412,7 +412,7 @@ Results [9]: [channel#127, id#128, spark_grouping_id#129, sum#136, isEmpty#137, 
 Input [9]: [channel#127, id#128, spark_grouping_id#129, sum#136, isEmpty#137, sum#138, isEmpty#139, sum#140, isEmpty#141]
 Arguments: hashpartitioning(channel#127, id#128, spark_grouping_id#129, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(73) HashAggregate [codegen id : 21]
+(73) HashAggregate [codegen id : 15]
 Input [9]: [channel#127, id#128, spark_grouping_id#129, sum#136, isEmpty#137, sum#138, isEmpty#139, sum#140, isEmpty#141]
 Keys [3]: [channel#127, id#128, spark_grouping_id#129]
 Functions [3]: [sum(sales#37), sum(returns#38), sum(profit#39)]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5/simplified.txt
@@ -1,129 +1,120 @@
 TakeOrderedAndProject [channel,id,sales,returns,profit]
-  WholeStageCodegen (21)
+  WholeStageCodegen (15)
     HashAggregate [channel,id,spark_grouping_id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
       InputAdapter
         Exchange [channel,id,spark_grouping_id] #1
-          WholeStageCodegen (20)
+          WholeStageCodegen (14)
             HashAggregate [channel,id,spark_grouping_id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
               Expand [sales,returns,profit,channel,id]
                 InputAdapter
                   Union
-                    WholeStageCodegen (6)
+                    WholeStageCodegen (4)
                       HashAggregate [s_store_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),sales,returns,profit,channel,id,sum,sum,sum,sum]
                         InputAdapter
                           Exchange [s_store_id] #2
-                            WholeStageCodegen (5)
+                            WholeStageCodegen (3)
                               HashAggregate [s_store_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                 Project [sales_price,profit,return_amt,net_loss,s_store_id]
                                   BroadcastHashJoin [store_sk,s_store_sk]
                                     Project [store_sk,sales_price,profit,return_amt,net_loss]
                                       BroadcastHashJoin [date_sk,d_date_sk]
-                                        InputAdapter
-                                          Union
-                                            WholeStageCodegen (1)
-                                              Project [ss_store_sk,ss_sold_date_sk,ss_ext_sales_price,ss_net_profit]
-                                                Filter [ss_store_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
-                                                        SubqueryBroadcast [d_date_sk] #1
-                                                          BroadcastExchange #3
-                                                            WholeStageCodegen (1)
-                                                              Project [d_date_sk]
-                                                                Filter [d_date,d_date_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
-                                            WholeStageCodegen (2)
-                                              Project [sr_store_sk,sr_returned_date_sk,sr_return_amt,sr_net_loss]
-                                                Filter [sr_store_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
-                                                        ReusedSubquery [d_date_sk] #1
+                                        Union
+                                          Project [ss_store_sk,ss_sold_date_sk,ss_ext_sales_price,ss_net_profit]
+                                            Filter [ss_store_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
+                                                    SubqueryBroadcast [d_date_sk] #1
+                                                      BroadcastExchange #3
+                                                        WholeStageCodegen (1)
+                                                          Project [d_date_sk]
+                                                            Filter [d_date,d_date_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                                          Project [sr_store_sk,sr_returned_date_sk,sr_return_amt,sr_net_loss]
+                                            Filter [sr_store_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
+                                                    ReusedSubquery [d_date_sk] #1
                                         InputAdapter
                                           ReusedExchange [d_date_sk] #3
                                     InputAdapter
                                       BroadcastExchange #4
-                                        WholeStageCodegen (4)
+                                        WholeStageCodegen (2)
                                           Filter [s_store_sk]
                                             ColumnarToRow
                                               InputAdapter
                                                 Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
-                    WholeStageCodegen (12)
+                    WholeStageCodegen (8)
                       HashAggregate [cp_catalog_page_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),sales,returns,profit,channel,id,sum,sum,sum,sum]
                         InputAdapter
                           Exchange [cp_catalog_page_id] #5
-                            WholeStageCodegen (11)
+                            WholeStageCodegen (7)
                               HashAggregate [cp_catalog_page_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                 Project [sales_price,profit,return_amt,net_loss,cp_catalog_page_id]
                                   BroadcastHashJoin [page_sk,cp_catalog_page_sk]
                                     Project [page_sk,sales_price,profit,return_amt,net_loss]
                                       BroadcastHashJoin [date_sk,d_date_sk]
-                                        InputAdapter
-                                          Union
-                                            WholeStageCodegen (7)
-                                              Project [cs_catalog_page_sk,cs_sold_date_sk,cs_ext_sales_price,cs_net_profit]
-                                                Filter [cs_catalog_page_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.catalog_sales [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #1
-                                            WholeStageCodegen (8)
-                                              Project [cr_catalog_page_sk,cr_returned_date_sk,cr_return_amount,cr_net_loss]
-                                                Filter [cr_catalog_page_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.catalog_returns [cr_catalog_page_sk,cr_return_amount,cr_net_loss,cr_returned_date_sk]
-                                                        ReusedSubquery [d_date_sk] #1
+                                        Union
+                                          Project [cs_catalog_page_sk,cs_sold_date_sk,cs_ext_sales_price,cs_net_profit]
+                                            Filter [cs_catalog_page_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.catalog_sales [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
+                                                    ReusedSubquery [d_date_sk] #1
+                                          Project [cr_catalog_page_sk,cr_returned_date_sk,cr_return_amount,cr_net_loss]
+                                            Filter [cr_catalog_page_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.catalog_returns [cr_catalog_page_sk,cr_return_amount,cr_net_loss,cr_returned_date_sk]
+                                                    ReusedSubquery [d_date_sk] #1
                                         InputAdapter
                                           ReusedExchange [d_date_sk] #3
                                     InputAdapter
                                       BroadcastExchange #6
-                                        WholeStageCodegen (10)
+                                        WholeStageCodegen (6)
                                           Filter [cp_catalog_page_sk]
                                             ColumnarToRow
                                               InputAdapter
                                                 Scan parquet spark_catalog.default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
-                    WholeStageCodegen (19)
+                    WholeStageCodegen (13)
                       HashAggregate [web_site_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),sales,returns,profit,channel,id,sum,sum,sum,sum]
                         InputAdapter
                           Exchange [web_site_id] #7
-                            WholeStageCodegen (18)
+                            WholeStageCodegen (12)
                               HashAggregate [web_site_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                 Project [sales_price,profit,return_amt,net_loss,web_site_id]
                                   BroadcastHashJoin [wsr_web_site_sk,web_site_sk]
                                     Project [wsr_web_site_sk,sales_price,profit,return_amt,net_loss]
                                       BroadcastHashJoin [date_sk,d_date_sk]
-                                        InputAdapter
-                                          Union
-                                            WholeStageCodegen (13)
-                                              Project [ws_web_site_sk,ws_sold_date_sk,ws_ext_sales_price,ws_net_profit]
-                                                Filter [ws_web_site_sk]
+                                        Union
+                                          Project [ws_web_site_sk,ws_sold_date_sk,ws_ext_sales_price,ws_net_profit]
+                                            Filter [ws_web_site_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.web_sales [ws_web_site_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
+                                                    ReusedSubquery [d_date_sk] #1
+                                          Project [ws_web_site_sk,wr_returned_date_sk,wr_return_amt,wr_net_loss]
+                                            BroadcastHashJoin [wr_item_sk,wr_order_number,ws_item_sk,ws_order_number]
+                                              InputAdapter
+                                                BroadcastExchange #8
+                                                  WholeStageCodegen (9)
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss,wr_returned_date_sk]
+                                                          ReusedSubquery [d_date_sk] #1
+                                              Project [ws_item_sk,ws_web_site_sk,ws_order_number]
+                                                Filter [ws_item_sk,ws_order_number,ws_web_site_sk]
                                                   ColumnarToRow
                                                     InputAdapter
-                                                      Scan parquet spark_catalog.default.web_sales [ws_web_site_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #1
-                                            WholeStageCodegen (15)
-                                              Project [ws_web_site_sk,wr_returned_date_sk,wr_return_amt,wr_net_loss]
-                                                BroadcastHashJoin [wr_item_sk,wr_order_number,ws_item_sk,ws_order_number]
-                                                  InputAdapter
-                                                    BroadcastExchange #8
-                                                      WholeStageCodegen (14)
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss,wr_returned_date_sk]
-                                                              ReusedSubquery [d_date_sk] #1
-                                                  Project [ws_item_sk,ws_web_site_sk,ws_order_number]
-                                                    Filter [ws_item_sk,ws_order_number,ws_web_site_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_web_site_sk,ws_order_number,ws_sold_date_sk]
+                                                      Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_web_site_sk,ws_order_number,ws_sold_date_sk]
                                         InputAdapter
                                           ReusedExchange [d_date_sk] #3
                                     InputAdapter
                                       BroadcastExchange #9
-                                        WholeStageCodegen (17)
+                                        WholeStageCodegen (11)
                                           Filter [web_site_sk]
                                             ColumnarToRow
                                               InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
@@ -33,7 +33,7 @@ TakeOrderedAndProject (56)
                         :     :                       :     +- * BroadcastHashJoin Inner BuildRight (28)
                         :     :                       :        :- * Project (26)
                         :     :                       :        :  +- * BroadcastHashJoin Inner BuildRight (25)
-                        :     :                       :        :     :- Union (19)
+                        :     :                       :        :     :- * Union (19)
                         :     :                       :        :     :  :- * Project (14)
                         :     :                       :        :     :  :  +- * Filter (13)
                         :     :                       :        :     :  :     +- * ColumnarToRow (12)
@@ -111,14 +111,14 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#8), dynamicpruningexpression(cs_sol
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_bill_customer_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int>
 
-(12) ColumnarToRow [codegen id : 3]
+(12) ColumnarToRow [codegen id : 5]
 Input [3]: [cs_bill_customer_sk#6, cs_item_sk#7, cs_sold_date_sk#8]
 
-(13) Filter [codegen id : 3]
+(13) Filter [codegen id : 5]
 Input [3]: [cs_bill_customer_sk#6, cs_item_sk#7, cs_sold_date_sk#8]
 Condition : (isnotnull(cs_item_sk#7) AND isnotnull(cs_bill_customer_sk#6))
 
-(14) Project [codegen id : 3]
+(14) Project [codegen id : 5]
 Output [3]: [cs_sold_date_sk#8 AS sold_date_sk#10, cs_bill_customer_sk#6 AS customer_sk#11, cs_item_sk#7 AS item_sk#12]
 Input [3]: [cs_bill_customer_sk#6, cs_item_sk#7, cs_sold_date_sk#8]
 
@@ -130,18 +130,18 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#15), dynamicpruningexpression(ws_so
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_bill_customer_sk:int>
 
-(16) ColumnarToRow [codegen id : 4]
+(16) ColumnarToRow
 Input [3]: [ws_item_sk#13, ws_bill_customer_sk#14, ws_sold_date_sk#15]
 
-(17) Filter [codegen id : 4]
+(17) Filter
 Input [3]: [ws_item_sk#13, ws_bill_customer_sk#14, ws_sold_date_sk#15]
 Condition : (isnotnull(ws_item_sk#13) AND isnotnull(ws_bill_customer_sk#14))
 
-(18) Project [codegen id : 4]
+(18) Project
 Output [3]: [ws_sold_date_sk#15 AS sold_date_sk#16, ws_bill_customer_sk#14 AS customer_sk#17, ws_item_sk#13 AS item_sk#18]
 Input [3]: [ws_item_sk#13, ws_bill_customer_sk#14, ws_sold_date_sk#15]
 
-(19) Union
+(19) Union [codegen id : 5]
 
 (20) Scan parquet spark_catalog.default.item
 Output [3]: [i_item_sk#19, i_class#20, i_category#21]
@@ -150,14 +150,14 @@ Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_category), IsNotNull(i_class), EqualTo(i_category,Women                                             ), EqualTo(i_class,maternity                                         ), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_class:string,i_category:string>
 
-(21) ColumnarToRow [codegen id : 5]
+(21) ColumnarToRow [codegen id : 3]
 Input [3]: [i_item_sk#19, i_class#20, i_category#21]
 
-(22) Filter [codegen id : 5]
+(22) Filter [codegen id : 3]
 Input [3]: [i_item_sk#19, i_class#20, i_category#21]
 Condition : ((((isnotnull(i_category#21) AND isnotnull(i_class#20)) AND (i_category#21 = Women                                             )) AND (i_class#20 = maternity                                         )) AND isnotnull(i_item_sk#19))
 
-(23) Project [codegen id : 5]
+(23) Project [codegen id : 3]
 Output [1]: [i_item_sk#19]
 Input [3]: [i_item_sk#19, i_class#20, i_category#21]
 
@@ -165,26 +165,26 @@ Input [3]: [i_item_sk#19, i_class#20, i_category#21]
 Input [1]: [i_item_sk#19]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
 
-(25) BroadcastHashJoin [codegen id : 7]
+(25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [item_sk#12]
 Right keys [1]: [i_item_sk#19]
 Join type: Inner
 Join condition: None
 
-(26) Project [codegen id : 7]
+(26) Project [codegen id : 5]
 Output [2]: [sold_date_sk#10, customer_sk#11]
 Input [4]: [sold_date_sk#10, customer_sk#11, item_sk#12, i_item_sk#19]
 
 (27) ReusedExchange [Reuses operator id: 61]
 Output [1]: [d_date_sk#22]
 
-(28) BroadcastHashJoin [codegen id : 7]
+(28) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [sold_date_sk#10]
 Right keys [1]: [d_date_sk#22]
 Join type: Inner
 Join condition: None
 
-(29) Project [codegen id : 7]
+(29) Project [codegen id : 5]
 Output [1]: [customer_sk#11]
 Input [3]: [sold_date_sk#10, customer_sk#11, d_date_sk#22]
 
@@ -206,17 +206,17 @@ Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Condition : (isnotnull(c_customer_sk#23) AND isnotnull(c_current_addr_sk#24))
 
-(34) BroadcastHashJoin [codegen id : 8]
+(34) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [customer_sk#11]
 Right keys [1]: [c_customer_sk#23]
 Join type: Inner
 Join condition: None
 
-(35) Project [codegen id : 8]
+(35) Project [codegen id : 6]
 Output [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Input [3]: [customer_sk#11, c_customer_sk#23, c_current_addr_sk#24]
 
-(36) HashAggregate [codegen id : 8]
+(36) HashAggregate [codegen id : 6]
 Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Keys [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Functions: []
@@ -234,13 +234,13 @@ Functions: []
 Aggregate Attributes: []
 Results [2]: [c_customer_sk#23, c_current_addr_sk#24]
 
-(39) BroadcastHashJoin [codegen id : 9]
+(39) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ca_address_sk#1]
 Right keys [1]: [c_current_addr_sk#24]
 Join type: Inner
 Join condition: None
 
-(40) Project [codegen id : 9]
+(40) Project [codegen id : 7]
 Output [1]: [c_customer_sk#23]
 Input [3]: [ca_address_sk#1, c_customer_sk#23, c_current_addr_sk#24]
 
@@ -263,30 +263,30 @@ Input [3]: [ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27]
 Input [3]: [ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27]
 Condition : isnotnull(ss_customer_sk#25)
 
-(45) BroadcastHashJoin [codegen id : 11]
+(45) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#23]
 Right keys [1]: [ss_customer_sk#25]
 Join type: Inner
 Join condition: None
 
-(46) Project [codegen id : 11]
+(46) Project [codegen id : 9]
 Output [3]: [c_customer_sk#23, ss_ext_sales_price#26, ss_sold_date_sk#27]
 Input [4]: [c_customer_sk#23, ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27]
 
 (47) ReusedExchange [Reuses operator id: 66]
 Output [1]: [d_date_sk#29]
 
-(48) BroadcastHashJoin [codegen id : 11]
+(48) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_sold_date_sk#27]
 Right keys [1]: [d_date_sk#29]
 Join type: Inner
 Join condition: None
 
-(49) Project [codegen id : 11]
+(49) Project [codegen id : 9]
 Output [2]: [c_customer_sk#23, ss_ext_sales_price#26]
 Input [4]: [c_customer_sk#23, ss_ext_sales_price#26, ss_sold_date_sk#27, d_date_sk#29]
 
-(50) HashAggregate [codegen id : 11]
+(50) HashAggregate [codegen id : 9]
 Input [2]: [c_customer_sk#23, ss_ext_sales_price#26]
 Keys [1]: [c_customer_sk#23]
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#26))]
@@ -297,14 +297,14 @@ Results [2]: [c_customer_sk#23, sum#31]
 Input [2]: [c_customer_sk#23, sum#31]
 Arguments: hashpartitioning(c_customer_sk#23, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(52) HashAggregate [codegen id : 12]
+(52) HashAggregate [codegen id : 10]
 Input [2]: [c_customer_sk#23, sum#31]
 Keys [1]: [c_customer_sk#23]
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#26))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#26))#32]
 Results [1]: [cast((MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#26))#32,17,2) / 50) as int) AS segment#33]
 
-(53) HashAggregate [codegen id : 12]
+(53) HashAggregate [codegen id : 10]
 Input [1]: [segment#33]
 Keys [1]: [segment#33]
 Functions [1]: [partial_count(1)]
@@ -315,7 +315,7 @@ Results [2]: [segment#33, count#35]
 Input [2]: [segment#33, count#35]
 Arguments: hashpartitioning(segment#33, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(55) HashAggregate [codegen id : 13]
+(55) HashAggregate [codegen id : 11]
 Input [2]: [segment#33, count#35]
 Keys [1]: [segment#33]
 Functions [1]: [count(1)]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/simplified.txt
@@ -1,14 +1,14 @@
 TakeOrderedAndProject [segment,num_customers,segment_base]
-  WholeStageCodegen (13)
+  WholeStageCodegen (11)
     HashAggregate [segment,count] [count(1),num_customers,segment_base,count]
       InputAdapter
         Exchange [segment] #1
-          WholeStageCodegen (12)
+          WholeStageCodegen (10)
             HashAggregate [segment] [count,count]
               HashAggregate [c_customer_sk,sum] [sum(UnscaledValue(ss_ext_sales_price)),segment,sum]
                 InputAdapter
                   Exchange [c_customer_sk] #2
-                    WholeStageCodegen (11)
+                    WholeStageCodegen (9)
                       HashAggregate [c_customer_sk,ss_ext_sales_price] [sum,sum]
                         Project [c_customer_sk,ss_ext_sales_price]
                           BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
@@ -16,7 +16,7 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                               BroadcastHashJoin [c_customer_sk,ss_customer_sk]
                                 InputAdapter
                                   BroadcastExchange #3
-                                    WholeStageCodegen (9)
+                                    WholeStageCodegen (7)
                                       Project [c_customer_sk]
                                         BroadcastHashJoin [ca_address_sk,c_current_addr_sk]
                                           InputAdapter
@@ -38,43 +38,40 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                           HashAggregate [c_customer_sk,c_current_addr_sk]
                                             InputAdapter
                                               Exchange [c_customer_sk,c_current_addr_sk] #6
-                                                WholeStageCodegen (8)
+                                                WholeStageCodegen (6)
                                                   HashAggregate [c_customer_sk,c_current_addr_sk]
                                                     Project [c_customer_sk,c_current_addr_sk]
                                                       BroadcastHashJoin [customer_sk,c_customer_sk]
                                                         InputAdapter
                                                           BroadcastExchange #7
-                                                            WholeStageCodegen (7)
+                                                            WholeStageCodegen (5)
                                                               Project [customer_sk]
                                                                 BroadcastHashJoin [sold_date_sk,d_date_sk]
                                                                   Project [sold_date_sk,customer_sk]
                                                                     BroadcastHashJoin [item_sk,i_item_sk]
-                                                                      InputAdapter
-                                                                        Union
-                                                                          WholeStageCodegen (3)
-                                                                            Project [cs_sold_date_sk,cs_bill_customer_sk,cs_item_sk]
-                                                                              Filter [cs_item_sk,cs_bill_customer_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_sold_date_sk]
-                                                                                      SubqueryBroadcast [d_date_sk] #1
-                                                                                        BroadcastExchange #8
-                                                                                          WholeStageCodegen (1)
-                                                                                            Project [d_date_sk]
-                                                                                              Filter [d_moy,d_year,d_date_sk]
-                                                                                                ColumnarToRow
-                                                                                                  InputAdapter
-                                                                                                    Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                                                                          WholeStageCodegen (4)
-                                                                            Project [ws_sold_date_sk,ws_bill_customer_sk,ws_item_sk]
-                                                                              Filter [ws_item_sk,ws_bill_customer_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_sold_date_sk]
-                                                                                      ReusedSubquery [d_date_sk] #1
+                                                                      Union
+                                                                        Project [cs_sold_date_sk,cs_bill_customer_sk,cs_item_sk]
+                                                                          Filter [cs_item_sk,cs_bill_customer_sk]
+                                                                            ColumnarToRow
+                                                                              InputAdapter
+                                                                                Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_sold_date_sk]
+                                                                                  SubqueryBroadcast [d_date_sk] #1
+                                                                                    BroadcastExchange #8
+                                                                                      WholeStageCodegen (1)
+                                                                                        Project [d_date_sk]
+                                                                                          Filter [d_moy,d_year,d_date_sk]
+                                                                                            ColumnarToRow
+                                                                                              InputAdapter
+                                                                                                Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                                        Project [ws_sold_date_sk,ws_bill_customer_sk,ws_item_sk]
+                                                                          Filter [ws_item_sk,ws_bill_customer_sk]
+                                                                            ColumnarToRow
+                                                                              InputAdapter
+                                                                                Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_sold_date_sk]
+                                                                                  ReusedSubquery [d_date_sk] #1
                                                                       InputAdapter
                                                                         BroadcastExchange #9
-                                                                          WholeStageCodegen (5)
+                                                                          WholeStageCodegen (3)
                                                                             Project [i_item_sk]
                                                                               Filter [i_category,i_class,i_item_sk]
                                                                                 ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54/explain.txt
@@ -23,7 +23,7 @@ TakeOrderedAndProject (56)
                         :     :     :     :              :  +- * BroadcastHashJoin Inner BuildRight (18)
                         :     :     :     :              :     :- * Project (16)
                         :     :     :     :              :     :  +- * BroadcastHashJoin Inner BuildRight (15)
-                        :     :     :     :              :     :     :- Union (9)
+                        :     :     :     :              :     :     :- * Union (9)
                         :     :     :     :              :     :     :  :- * Project (4)
                         :     :     :     :              :     :     :  :  +- * Filter (3)
                         :     :     :     :              :     :     :  :     +- * ColumnarToRow (2)
@@ -65,14 +65,14 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#3), dynamicpruningexpression(cs_sol
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_bill_customer_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int>
 
-(2) ColumnarToRow [codegen id : 1]
+(2) ColumnarToRow [codegen id : 4]
 Input [3]: [cs_bill_customer_sk#1, cs_item_sk#2, cs_sold_date_sk#3]
 
-(3) Filter [codegen id : 1]
+(3) Filter [codegen id : 4]
 Input [3]: [cs_bill_customer_sk#1, cs_item_sk#2, cs_sold_date_sk#3]
 Condition : (isnotnull(cs_item_sk#2) AND isnotnull(cs_bill_customer_sk#1))
 
-(4) Project [codegen id : 1]
+(4) Project [codegen id : 4]
 Output [3]: [cs_sold_date_sk#3 AS sold_date_sk#5, cs_bill_customer_sk#1 AS customer_sk#6, cs_item_sk#2 AS item_sk#7]
 Input [3]: [cs_bill_customer_sk#1, cs_item_sk#2, cs_sold_date_sk#3]
 
@@ -84,18 +84,18 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#10), dynamicpruningexpression(ws_so
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_bill_customer_sk:int>
 
-(6) ColumnarToRow [codegen id : 2]
+(6) ColumnarToRow
 Input [3]: [ws_item_sk#8, ws_bill_customer_sk#9, ws_sold_date_sk#10]
 
-(7) Filter [codegen id : 2]
+(7) Filter
 Input [3]: [ws_item_sk#8, ws_bill_customer_sk#9, ws_sold_date_sk#10]
 Condition : (isnotnull(ws_item_sk#8) AND isnotnull(ws_bill_customer_sk#9))
 
-(8) Project [codegen id : 2]
+(8) Project
 Output [3]: [ws_sold_date_sk#10 AS sold_date_sk#11, ws_bill_customer_sk#9 AS customer_sk#12, ws_item_sk#8 AS item_sk#13]
 Input [3]: [ws_item_sk#8, ws_bill_customer_sk#9, ws_sold_date_sk#10]
 
-(9) Union
+(9) Union [codegen id : 4]
 
 (10) Scan parquet spark_catalog.default.item
 Output [3]: [i_item_sk#14, i_class#15, i_category#16]
@@ -104,14 +104,14 @@ Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_category), IsNotNull(i_class), EqualTo(i_category,Women                                             ), EqualTo(i_class,maternity                                         ), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_class:string,i_category:string>
 
-(11) ColumnarToRow [codegen id : 3]
+(11) ColumnarToRow [codegen id : 1]
 Input [3]: [i_item_sk#14, i_class#15, i_category#16]
 
-(12) Filter [codegen id : 3]
+(12) Filter [codegen id : 1]
 Input [3]: [i_item_sk#14, i_class#15, i_category#16]
 Condition : ((((isnotnull(i_category#16) AND isnotnull(i_class#15)) AND (i_category#16 = Women                                             )) AND (i_class#15 = maternity                                         )) AND isnotnull(i_item_sk#14))
 
-(13) Project [codegen id : 3]
+(13) Project [codegen id : 1]
 Output [1]: [i_item_sk#14]
 Input [3]: [i_item_sk#14, i_class#15, i_category#16]
 
@@ -119,26 +119,26 @@ Input [3]: [i_item_sk#14, i_class#15, i_category#16]
 Input [1]: [i_item_sk#14]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(15) BroadcastHashJoin [codegen id : 6]
+(15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [item_sk#7]
 Right keys [1]: [i_item_sk#14]
 Join type: Inner
 Join condition: None
 
-(16) Project [codegen id : 6]
+(16) Project [codegen id : 4]
 Output [2]: [sold_date_sk#5, customer_sk#6]
 Input [4]: [sold_date_sk#5, customer_sk#6, item_sk#7, i_item_sk#14]
 
 (17) ReusedExchange [Reuses operator id: 61]
 Output [1]: [d_date_sk#17]
 
-(18) BroadcastHashJoin [codegen id : 6]
+(18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [sold_date_sk#5]
 Right keys [1]: [d_date_sk#17]
 Join type: Inner
 Join condition: None
 
-(19) Project [codegen id : 6]
+(19) Project [codegen id : 4]
 Output [1]: [customer_sk#6]
 Input [3]: [sold_date_sk#5, customer_sk#6, d_date_sk#17]
 
@@ -149,10 +149,10 @@ Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
 
-(21) ColumnarToRow [codegen id : 5]
+(21) ColumnarToRow [codegen id : 3]
 Input [2]: [c_customer_sk#18, c_current_addr_sk#19]
 
-(22) Filter [codegen id : 5]
+(22) Filter [codegen id : 3]
 Input [2]: [c_customer_sk#18, c_current_addr_sk#19]
 Condition : (isnotnull(c_customer_sk#18) AND isnotnull(c_current_addr_sk#19))
 
@@ -160,17 +160,17 @@ Condition : (isnotnull(c_customer_sk#18) AND isnotnull(c_current_addr_sk#19))
 Input [2]: [c_customer_sk#18, c_current_addr_sk#19]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
-(24) BroadcastHashJoin [codegen id : 6]
+(24) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [customer_sk#6]
 Right keys [1]: [c_customer_sk#18]
 Join type: Inner
 Join condition: None
 
-(25) Project [codegen id : 6]
+(25) Project [codegen id : 4]
 Output [2]: [c_customer_sk#18, c_current_addr_sk#19]
 Input [3]: [customer_sk#6, c_customer_sk#18, c_current_addr_sk#19]
 
-(26) HashAggregate [codegen id : 6]
+(26) HashAggregate [codegen id : 4]
 Input [2]: [c_customer_sk#18, c_current_addr_sk#19]
 Keys [2]: [c_customer_sk#18, c_current_addr_sk#19]
 Functions: []
@@ -181,7 +181,7 @@ Results [2]: [c_customer_sk#18, c_current_addr_sk#19]
 Input [2]: [c_customer_sk#18, c_current_addr_sk#19]
 Arguments: hashpartitioning(c_customer_sk#18, c_current_addr_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(28) HashAggregate [codegen id : 11]
+(28) HashAggregate [codegen id : 9]
 Input [2]: [c_customer_sk#18, c_current_addr_sk#19]
 Keys [2]: [c_customer_sk#18, c_current_addr_sk#19]
 Functions: []
@@ -196,10 +196,10 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#22), dynamicpruningexpression(ss_so
 PushedFilters: [IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(30) ColumnarToRow [codegen id : 7]
+(30) ColumnarToRow [codegen id : 5]
 Input [3]: [ss_customer_sk#20, ss_ext_sales_price#21, ss_sold_date_sk#22]
 
-(31) Filter [codegen id : 7]
+(31) Filter [codegen id : 5]
 Input [3]: [ss_customer_sk#20, ss_ext_sales_price#21, ss_sold_date_sk#22]
 Condition : isnotnull(ss_customer_sk#20)
 
@@ -207,13 +207,13 @@ Condition : isnotnull(ss_customer_sk#20)
 Input [3]: [ss_customer_sk#20, ss_ext_sales_price#21, ss_sold_date_sk#22]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
-(33) BroadcastHashJoin [codegen id : 11]
+(33) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#18]
 Right keys [1]: [ss_customer_sk#20]
 Join type: Inner
 Join condition: None
 
-(34) Project [codegen id : 11]
+(34) Project [codegen id : 9]
 Output [4]: [c_customer_sk#18, c_current_addr_sk#19, ss_ext_sales_price#21, ss_sold_date_sk#22]
 Input [5]: [c_customer_sk#18, c_current_addr_sk#19, ss_customer_sk#20, ss_ext_sales_price#21, ss_sold_date_sk#22]
 
@@ -224,10 +224,10 @@ Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_county), IsNotNull(ca_state)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string,ca_state:string>
 
-(36) ColumnarToRow [codegen id : 8]
+(36) ColumnarToRow [codegen id : 6]
 Input [3]: [ca_address_sk#24, ca_county#25, ca_state#26]
 
-(37) Filter [codegen id : 8]
+(37) Filter [codegen id : 6]
 Input [3]: [ca_address_sk#24, ca_county#25, ca_state#26]
 Condition : ((isnotnull(ca_address_sk#24) AND isnotnull(ca_county#25)) AND isnotnull(ca_state#26))
 
@@ -235,13 +235,13 @@ Condition : ((isnotnull(ca_address_sk#24) AND isnotnull(ca_county#25)) AND isnot
 Input [3]: [ca_address_sk#24, ca_county#25, ca_state#26]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
 
-(39) BroadcastHashJoin [codegen id : 11]
+(39) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#19]
 Right keys [1]: [ca_address_sk#24]
 Join type: Inner
 Join condition: None
 
-(40) Project [codegen id : 11]
+(40) Project [codegen id : 9]
 Output [5]: [c_customer_sk#18, ss_ext_sales_price#21, ss_sold_date_sk#22, ca_county#25, ca_state#26]
 Input [7]: [c_customer_sk#18, c_current_addr_sk#19, ss_ext_sales_price#21, ss_sold_date_sk#22, ca_address_sk#24, ca_county#25, ca_state#26]
 
@@ -252,10 +252,10 @@ Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_county), IsNotNull(s_state)]
 ReadSchema: struct<s_county:string,s_state:string>
 
-(42) ColumnarToRow [codegen id : 9]
+(42) ColumnarToRow [codegen id : 7]
 Input [2]: [s_county#27, s_state#28]
 
-(43) Filter [codegen id : 9]
+(43) Filter [codegen id : 7]
 Input [2]: [s_county#27, s_state#28]
 Condition : (isnotnull(s_county#27) AND isnotnull(s_state#28))
 
@@ -263,30 +263,30 @@ Condition : (isnotnull(s_county#27) AND isnotnull(s_state#28))
 Input [2]: [s_county#27, s_state#28]
 Arguments: HashedRelationBroadcastMode(List(input[0, string, false], input[1, string, false]),false), [plan_id=6]
 
-(45) BroadcastHashJoin [codegen id : 11]
+(45) BroadcastHashJoin [codegen id : 9]
 Left keys [2]: [ca_county#25, ca_state#26]
 Right keys [2]: [s_county#27, s_state#28]
 Join type: Inner
 Join condition: None
 
-(46) Project [codegen id : 11]
+(46) Project [codegen id : 9]
 Output [3]: [c_customer_sk#18, ss_ext_sales_price#21, ss_sold_date_sk#22]
 Input [7]: [c_customer_sk#18, ss_ext_sales_price#21, ss_sold_date_sk#22, ca_county#25, ca_state#26, s_county#27, s_state#28]
 
 (47) ReusedExchange [Reuses operator id: 66]
 Output [1]: [d_date_sk#29]
 
-(48) BroadcastHashJoin [codegen id : 11]
+(48) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_sold_date_sk#22]
 Right keys [1]: [d_date_sk#29]
 Join type: Inner
 Join condition: None
 
-(49) Project [codegen id : 11]
+(49) Project [codegen id : 9]
 Output [2]: [c_customer_sk#18, ss_ext_sales_price#21]
 Input [4]: [c_customer_sk#18, ss_ext_sales_price#21, ss_sold_date_sk#22, d_date_sk#29]
 
-(50) HashAggregate [codegen id : 11]
+(50) HashAggregate [codegen id : 9]
 Input [2]: [c_customer_sk#18, ss_ext_sales_price#21]
 Keys [1]: [c_customer_sk#18]
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#21))]
@@ -297,14 +297,14 @@ Results [2]: [c_customer_sk#18, sum#31]
 Input [2]: [c_customer_sk#18, sum#31]
 Arguments: hashpartitioning(c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(52) HashAggregate [codegen id : 12]
+(52) HashAggregate [codegen id : 10]
 Input [2]: [c_customer_sk#18, sum#31]
 Keys [1]: [c_customer_sk#18]
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#21))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#21))#32]
 Results [1]: [cast((MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#21))#32,17,2) / 50) as int) AS segment#33]
 
-(53) HashAggregate [codegen id : 12]
+(53) HashAggregate [codegen id : 10]
 Input [1]: [segment#33]
 Keys [1]: [segment#33]
 Functions [1]: [partial_count(1)]
@@ -315,7 +315,7 @@ Results [2]: [segment#33, count#35]
 Input [2]: [segment#33, count#35]
 Arguments: hashpartitioning(segment#33, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(55) HashAggregate [codegen id : 13]
+(55) HashAggregate [codegen id : 11]
 Input [2]: [segment#33, count#35]
 Keys [1]: [segment#33]
 Functions [1]: [count(1)]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54/simplified.txt
@@ -1,14 +1,14 @@
 TakeOrderedAndProject [segment,num_customers,segment_base]
-  WholeStageCodegen (13)
+  WholeStageCodegen (11)
     HashAggregate [segment,count] [count(1),num_customers,segment_base,count]
       InputAdapter
         Exchange [segment] #1
-          WholeStageCodegen (12)
+          WholeStageCodegen (10)
             HashAggregate [segment] [count,count]
               HashAggregate [c_customer_sk,sum] [sum(UnscaledValue(ss_ext_sales_price)),segment,sum]
                 InputAdapter
                   Exchange [c_customer_sk] #2
-                    WholeStageCodegen (11)
+                    WholeStageCodegen (9)
                       HashAggregate [c_customer_sk,ss_ext_sales_price] [sum,sum]
                         Project [c_customer_sk,ss_ext_sales_price]
                           BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
@@ -21,7 +21,7 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                         HashAggregate [c_customer_sk,c_current_addr_sk]
                                           InputAdapter
                                             Exchange [c_customer_sk,c_current_addr_sk] #3
-                                              WholeStageCodegen (6)
+                                              WholeStageCodegen (4)
                                                 HashAggregate [c_customer_sk,c_current_addr_sk]
                                                   Project [c_customer_sk,c_current_addr_sk]
                                                     BroadcastHashJoin [customer_sk,c_customer_sk]
@@ -29,32 +29,29 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                                         BroadcastHashJoin [sold_date_sk,d_date_sk]
                                                           Project [sold_date_sk,customer_sk]
                                                             BroadcastHashJoin [item_sk,i_item_sk]
-                                                              InputAdapter
-                                                                Union
-                                                                  WholeStageCodegen (1)
-                                                                    Project [cs_sold_date_sk,cs_bill_customer_sk,cs_item_sk]
-                                                                      Filter [cs_item_sk,cs_bill_customer_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_sold_date_sk]
-                                                                              SubqueryBroadcast [d_date_sk] #1
-                                                                                BroadcastExchange #4
-                                                                                  WholeStageCodegen (1)
-                                                                                    Project [d_date_sk]
-                                                                                      Filter [d_moy,d_year,d_date_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                                                                  WholeStageCodegen (2)
-                                                                    Project [ws_sold_date_sk,ws_bill_customer_sk,ws_item_sk]
-                                                                      Filter [ws_item_sk,ws_bill_customer_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_sold_date_sk]
-                                                                              ReusedSubquery [d_date_sk] #1
+                                                              Union
+                                                                Project [cs_sold_date_sk,cs_bill_customer_sk,cs_item_sk]
+                                                                  Filter [cs_item_sk,cs_bill_customer_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_sold_date_sk]
+                                                                          SubqueryBroadcast [d_date_sk] #1
+                                                                            BroadcastExchange #4
+                                                                              WholeStageCodegen (1)
+                                                                                Project [d_date_sk]
+                                                                                  Filter [d_moy,d_year,d_date_sk]
+                                                                                    ColumnarToRow
+                                                                                      InputAdapter
+                                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                                Project [ws_sold_date_sk,ws_bill_customer_sk,ws_item_sk]
+                                                                  Filter [ws_item_sk,ws_bill_customer_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_sold_date_sk]
+                                                                          ReusedSubquery [d_date_sk] #1
                                                               InputAdapter
                                                                 BroadcastExchange #5
-                                                                  WholeStageCodegen (3)
+                                                                  WholeStageCodegen (1)
                                                                     Project [i_item_sk]
                                                                       Filter [i_category,i_class,i_item_sk]
                                                                         ColumnarToRow
@@ -64,14 +61,14 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                                             ReusedExchange [d_date_sk] #4
                                                       InputAdapter
                                                         BroadcastExchange #6
-                                                          WholeStageCodegen (5)
+                                                          WholeStageCodegen (3)
                                                             Filter [c_customer_sk,c_current_addr_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
                                         InputAdapter
                                           BroadcastExchange #7
-                                            WholeStageCodegen (7)
+                                            WholeStageCodegen (5)
                                               Filter [ss_customer_sk]
                                                 ColumnarToRow
                                                   InputAdapter
@@ -112,14 +109,14 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                                                                             Scan parquet spark_catalog.default.date_dim [d_month_seq,d_year,d_moy]
                                     InputAdapter
                                       BroadcastExchange #11
-                                        WholeStageCodegen (8)
+                                        WholeStageCodegen (6)
                                           Filter [ca_address_sk,ca_county,ca_state]
                                             ColumnarToRow
                                               InputAdapter
                                                 Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county,ca_state]
                                 InputAdapter
                                   BroadcastExchange #12
-                                    WholeStageCodegen (9)
+                                    WholeStageCodegen (7)
                                       Filter [s_county,s_state]
                                         ColumnarToRow
                                           InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71.sf100/explain.txt
@@ -13,7 +13,7 @@
                   :     :     +- * Filter (3)
                   :     :        +- * ColumnarToRow (2)
                   :     :           +- Scan parquet spark_catalog.default.item (1)
-                  :     +- Union (24)
+                  :     +- * Union (24)
                   :        :- * Project (11)
                   :        :  +- * BroadcastHashJoin Inner BuildRight (10)
                   :        :     :- * Filter (8)
@@ -69,23 +69,23 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#8), dynamicpruningexpression(ws_sol
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_time_sk)]
 ReadSchema: struct<ws_sold_time_sk:int,ws_item_sk:int,ws_ext_sales_price:decimal(7,2)>
 
-(7) ColumnarToRow [codegen id : 3]
+(7) ColumnarToRow
 Input [4]: [ws_sold_time_sk#5, ws_item_sk#6, ws_ext_sales_price#7, ws_sold_date_sk#8]
 
-(8) Filter [codegen id : 3]
+(8) Filter
 Input [4]: [ws_sold_time_sk#5, ws_item_sk#6, ws_ext_sales_price#7, ws_sold_date_sk#8]
 Condition : (isnotnull(ws_item_sk#6) AND isnotnull(ws_sold_time_sk#5))
 
 (9) ReusedExchange [Reuses operator id: 43]
 Output [1]: [d_date_sk#10]
 
-(10) BroadcastHashJoin [codegen id : 3]
+(10) BroadcastHashJoin
 Left keys [1]: [ws_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
 Join type: Inner
 Join condition: None
 
-(11) Project [codegen id : 3]
+(11) Project
 Output [3]: [ws_ext_sales_price#7 AS ext_price#11, ws_item_sk#6 AS sold_item_sk#12, ws_sold_time_sk#5 AS time_sk#13]
 Input [5]: [ws_sold_time_sk#5, ws_item_sk#6, ws_ext_sales_price#7, ws_sold_date_sk#8, d_date_sk#10]
 
@@ -97,23 +97,23 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#17), dynamicpruningexpression(cs_so
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_sold_time_sk)]
 ReadSchema: struct<cs_sold_time_sk:int,cs_item_sk:int,cs_ext_sales_price:decimal(7,2)>
 
-(13) ColumnarToRow [codegen id : 5]
+(13) ColumnarToRow
 Input [4]: [cs_sold_time_sk#14, cs_item_sk#15, cs_ext_sales_price#16, cs_sold_date_sk#17]
 
-(14) Filter [codegen id : 5]
+(14) Filter
 Input [4]: [cs_sold_time_sk#14, cs_item_sk#15, cs_ext_sales_price#16, cs_sold_date_sk#17]
 Condition : (isnotnull(cs_item_sk#15) AND isnotnull(cs_sold_time_sk#14))
 
 (15) ReusedExchange [Reuses operator id: 43]
 Output [1]: [d_date_sk#18]
 
-(16) BroadcastHashJoin [codegen id : 5]
+(16) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#17]
 Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
-(17) Project [codegen id : 5]
+(17) Project
 Output [3]: [cs_ext_sales_price#16 AS ext_price#19, cs_item_sk#15 AS sold_item_sk#20, cs_sold_time_sk#14 AS time_sk#21]
 Input [5]: [cs_sold_time_sk#14, cs_item_sk#15, cs_ext_sales_price#16, cs_sold_date_sk#17, d_date_sk#18]
 
@@ -125,35 +125,35 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#25), dynamicpruningexpression(ss_so
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_sold_time_sk)]
 ReadSchema: struct<ss_sold_time_sk:int,ss_item_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(19) ColumnarToRow [codegen id : 7]
+(19) ColumnarToRow
 Input [4]: [ss_sold_time_sk#22, ss_item_sk#23, ss_ext_sales_price#24, ss_sold_date_sk#25]
 
-(20) Filter [codegen id : 7]
+(20) Filter
 Input [4]: [ss_sold_time_sk#22, ss_item_sk#23, ss_ext_sales_price#24, ss_sold_date_sk#25]
 Condition : (isnotnull(ss_item_sk#23) AND isnotnull(ss_sold_time_sk#22))
 
 (21) ReusedExchange [Reuses operator id: 43]
 Output [1]: [d_date_sk#26]
 
-(22) BroadcastHashJoin [codegen id : 7]
+(22) BroadcastHashJoin
 Left keys [1]: [ss_sold_date_sk#25]
 Right keys [1]: [d_date_sk#26]
 Join type: Inner
 Join condition: None
 
-(23) Project [codegen id : 7]
+(23) Project
 Output [3]: [ss_ext_sales_price#24 AS ext_price#27, ss_item_sk#23 AS sold_item_sk#28, ss_sold_time_sk#22 AS time_sk#29]
 Input [5]: [ss_sold_time_sk#22, ss_item_sk#23, ss_ext_sales_price#24, ss_sold_date_sk#25, d_date_sk#26]
 
 (24) Union
 
-(25) BroadcastHashJoin [codegen id : 9]
+(25) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [sold_item_sk#12]
 Join type: Inner
 Join condition: None
 
-(26) Project [codegen id : 9]
+(26) Project [codegen id : 6]
 Output [4]: [i_brand_id#2, i_brand#3, ext_price#11, time_sk#13]
 Input [6]: [i_item_sk#1, i_brand_id#2, i_brand#3, ext_price#11, sold_item_sk#12, time_sk#13]
 
@@ -164,14 +164,14 @@ Location [not included in comparison]/{warehouse_dir}/time_dim]
 PushedFilters: [Or(EqualTo(t_meal_time,breakfast           ),EqualTo(t_meal_time,dinner              )), IsNotNull(t_time_sk)]
 ReadSchema: struct<t_time_sk:int,t_hour:int,t_minute:int,t_meal_time:string>
 
-(28) ColumnarToRow [codegen id : 8]
+(28) ColumnarToRow [codegen id : 5]
 Input [4]: [t_time_sk#30, t_hour#31, t_minute#32, t_meal_time#33]
 
-(29) Filter [codegen id : 8]
+(29) Filter [codegen id : 5]
 Input [4]: [t_time_sk#30, t_hour#31, t_minute#32, t_meal_time#33]
 Condition : (((t_meal_time#33 = breakfast           ) OR (t_meal_time#33 = dinner              )) AND isnotnull(t_time_sk#30))
 
-(30) Project [codegen id : 8]
+(30) Project [codegen id : 5]
 Output [3]: [t_time_sk#30, t_hour#31, t_minute#32]
 Input [4]: [t_time_sk#30, t_hour#31, t_minute#32, t_meal_time#33]
 
@@ -179,17 +179,17 @@ Input [4]: [t_time_sk#30, t_hour#31, t_minute#32, t_meal_time#33]
 Input [3]: [t_time_sk#30, t_hour#31, t_minute#32]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
-(32) BroadcastHashJoin [codegen id : 9]
+(32) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [time_sk#13]
 Right keys [1]: [t_time_sk#30]
 Join type: Inner
 Join condition: None
 
-(33) Project [codegen id : 9]
+(33) Project [codegen id : 6]
 Output [5]: [i_brand_id#2, i_brand#3, ext_price#11, t_hour#31, t_minute#32]
 Input [7]: [i_brand_id#2, i_brand#3, ext_price#11, time_sk#13, t_time_sk#30, t_hour#31, t_minute#32]
 
-(34) HashAggregate [codegen id : 9]
+(34) HashAggregate [codegen id : 6]
 Input [5]: [i_brand_id#2, i_brand#3, ext_price#11, t_hour#31, t_minute#32]
 Keys [4]: [i_brand#3, i_brand_id#2, t_hour#31, t_minute#32]
 Functions [1]: [partial_sum(UnscaledValue(ext_price#11))]
@@ -200,7 +200,7 @@ Results [5]: [i_brand#3, i_brand_id#2, t_hour#31, t_minute#32, sum#35]
 Input [5]: [i_brand#3, i_brand_id#2, t_hour#31, t_minute#32, sum#35]
 Arguments: hashpartitioning(i_brand#3, i_brand_id#2, t_hour#31, t_minute#32, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(36) HashAggregate [codegen id : 10]
+(36) HashAggregate [codegen id : 7]
 Input [5]: [i_brand#3, i_brand_id#2, t_hour#31, t_minute#32, sum#35]
 Keys [4]: [i_brand#3, i_brand_id#2, t_hour#31, t_minute#32]
 Functions [1]: [sum(UnscaledValue(ext_price#11))]
@@ -211,7 +211,7 @@ Results [5]: [i_brand_id#2 AS brand_id#37, i_brand#3 AS brand#38, t_hour#31, t_m
 Input [5]: [brand_id#37, brand#38, t_hour#31, t_minute#32, ext_price#39]
 Arguments: rangepartitioning(ext_price#39 DESC NULLS LAST, brand_id#37 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(38) Sort [codegen id : 11]
+(38) Sort [codegen id : 8]
 Input [5]: [brand_id#37, brand#38, t_hour#31, t_minute#32, ext_price#39]
 Arguments: [ext_price#39 DESC NULLS LAST, brand_id#37 ASC NULLS FIRST], true, 0
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71.sf100/simplified.txt
@@ -1,12 +1,12 @@
-WholeStageCodegen (11)
+WholeStageCodegen (8)
   Sort [ext_price,brand_id]
     InputAdapter
       Exchange [ext_price,brand_id] #1
-        WholeStageCodegen (10)
+        WholeStageCodegen (7)
           HashAggregate [i_brand,i_brand_id,t_hour,t_minute,sum] [sum(UnscaledValue(ext_price)),brand_id,brand,ext_price,sum]
             InputAdapter
               Exchange [i_brand,i_brand_id,t_hour,t_minute] #2
-                WholeStageCodegen (9)
+                WholeStageCodegen (6)
                   HashAggregate [i_brand,i_brand_id,t_hour,t_minute,ext_price] [sum,sum]
                     Project [i_brand_id,i_brand,ext_price,t_hour,t_minute]
                       BroadcastHashJoin [time_sk,t_time_sk]
@@ -20,48 +20,44 @@ WholeStageCodegen (11)
                                       ColumnarToRow
                                         InputAdapter
                                           Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_brand,i_manager_id]
-                            InputAdapter
-                              Union
-                                WholeStageCodegen (3)
-                                  Project [ws_ext_sales_price,ws_item_sk,ws_sold_time_sk]
-                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                      Filter [ws_item_sk,ws_sold_time_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.web_sales [ws_sold_time_sk,ws_item_sk,ws_ext_sales_price,ws_sold_date_sk]
-                                              SubqueryBroadcast [d_date_sk] #1
-                                                BroadcastExchange #4
-                                                  WholeStageCodegen (1)
-                                                    Project [d_date_sk]
-                                                      Filter [d_moy,d_year,d_date_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                            Union
+                              Project [ws_ext_sales_price,ws_item_sk,ws_sold_time_sk]
+                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                  Filter [ws_item_sk,ws_sold_time_sk]
+                                    ColumnarToRow
                                       InputAdapter
-                                        ReusedExchange [d_date_sk] #4
-                                WholeStageCodegen (5)
-                                  Project [cs_ext_sales_price,cs_item_sk,cs_sold_time_sk]
-                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                      Filter [cs_item_sk,cs_sold_time_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.catalog_sales [cs_sold_time_sk,cs_item_sk,cs_ext_sales_price,cs_sold_date_sk]
-                                              ReusedSubquery [d_date_sk] #1
+                                        Scan parquet spark_catalog.default.web_sales [ws_sold_time_sk,ws_item_sk,ws_ext_sales_price,ws_sold_date_sk]
+                                          SubqueryBroadcast [d_date_sk] #1
+                                            BroadcastExchange #4
+                                              WholeStageCodegen (1)
+                                                Project [d_date_sk]
+                                                  Filter [d_moy,d_year,d_date_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                  InputAdapter
+                                    ReusedExchange [d_date_sk] #4
+                              Project [cs_ext_sales_price,cs_item_sk,cs_sold_time_sk]
+                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                  Filter [cs_item_sk,cs_sold_time_sk]
+                                    ColumnarToRow
                                       InputAdapter
-                                        ReusedExchange [d_date_sk] #4
-                                WholeStageCodegen (7)
-                                  Project [ss_ext_sales_price,ss_item_sk,ss_sold_time_sk]
-                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                      Filter [ss_item_sk,ss_sold_time_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.store_sales [ss_sold_time_sk,ss_item_sk,ss_ext_sales_price,ss_sold_date_sk]
-                                              ReusedSubquery [d_date_sk] #1
+                                        Scan parquet spark_catalog.default.catalog_sales [cs_sold_time_sk,cs_item_sk,cs_ext_sales_price,cs_sold_date_sk]
+                                          ReusedSubquery [d_date_sk] #1
+                                  InputAdapter
+                                    ReusedExchange [d_date_sk] #4
+                              Project [ss_ext_sales_price,ss_item_sk,ss_sold_time_sk]
+                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                  Filter [ss_item_sk,ss_sold_time_sk]
+                                    ColumnarToRow
                                       InputAdapter
-                                        ReusedExchange [d_date_sk] #4
+                                        Scan parquet spark_catalog.default.store_sales [ss_sold_time_sk,ss_item_sk,ss_ext_sales_price,ss_sold_date_sk]
+                                          ReusedSubquery [d_date_sk] #1
+                                  InputAdapter
+                                    ReusedExchange [d_date_sk] #4
                         InputAdapter
                           BroadcastExchange #5
-                            WholeStageCodegen (8)
+                            WholeStageCodegen (5)
                               Project [t_time_sk,t_hour,t_minute]
                                 Filter [t_meal_time,t_time_sk]
                                   ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71/explain.txt
@@ -13,7 +13,7 @@
                   :     :     +- * Filter (3)
                   :     :        +- * ColumnarToRow (2)
                   :     :           +- Scan parquet spark_catalog.default.item (1)
-                  :     +- Union (24)
+                  :     +- * Union (24)
                   :        :- * Project (11)
                   :        :  +- * BroadcastHashJoin Inner BuildRight (10)
                   :        :     :- * Filter (8)
@@ -69,23 +69,23 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#8), dynamicpruningexpression(ws_sol
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_sold_time_sk)]
 ReadSchema: struct<ws_sold_time_sk:int,ws_item_sk:int,ws_ext_sales_price:decimal(7,2)>
 
-(7) ColumnarToRow [codegen id : 3]
+(7) ColumnarToRow
 Input [4]: [ws_sold_time_sk#5, ws_item_sk#6, ws_ext_sales_price#7, ws_sold_date_sk#8]
 
-(8) Filter [codegen id : 3]
+(8) Filter
 Input [4]: [ws_sold_time_sk#5, ws_item_sk#6, ws_ext_sales_price#7, ws_sold_date_sk#8]
 Condition : (isnotnull(ws_item_sk#6) AND isnotnull(ws_sold_time_sk#5))
 
 (9) ReusedExchange [Reuses operator id: 43]
 Output [1]: [d_date_sk#10]
 
-(10) BroadcastHashJoin [codegen id : 3]
+(10) BroadcastHashJoin
 Left keys [1]: [ws_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
 Join type: Inner
 Join condition: None
 
-(11) Project [codegen id : 3]
+(11) Project
 Output [3]: [ws_ext_sales_price#7 AS ext_price#11, ws_item_sk#6 AS sold_item_sk#12, ws_sold_time_sk#5 AS time_sk#13]
 Input [5]: [ws_sold_time_sk#5, ws_item_sk#6, ws_ext_sales_price#7, ws_sold_date_sk#8, d_date_sk#10]
 
@@ -97,23 +97,23 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#17), dynamicpruningexpression(cs_so
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_sold_time_sk)]
 ReadSchema: struct<cs_sold_time_sk:int,cs_item_sk:int,cs_ext_sales_price:decimal(7,2)>
 
-(13) ColumnarToRow [codegen id : 5]
+(13) ColumnarToRow
 Input [4]: [cs_sold_time_sk#14, cs_item_sk#15, cs_ext_sales_price#16, cs_sold_date_sk#17]
 
-(14) Filter [codegen id : 5]
+(14) Filter
 Input [4]: [cs_sold_time_sk#14, cs_item_sk#15, cs_ext_sales_price#16, cs_sold_date_sk#17]
 Condition : (isnotnull(cs_item_sk#15) AND isnotnull(cs_sold_time_sk#14))
 
 (15) ReusedExchange [Reuses operator id: 43]
 Output [1]: [d_date_sk#18]
 
-(16) BroadcastHashJoin [codegen id : 5]
+(16) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#17]
 Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
-(17) Project [codegen id : 5]
+(17) Project
 Output [3]: [cs_ext_sales_price#16 AS ext_price#19, cs_item_sk#15 AS sold_item_sk#20, cs_sold_time_sk#14 AS time_sk#21]
 Input [5]: [cs_sold_time_sk#14, cs_item_sk#15, cs_ext_sales_price#16, cs_sold_date_sk#17, d_date_sk#18]
 
@@ -125,35 +125,35 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#25), dynamicpruningexpression(ss_so
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_sold_time_sk)]
 ReadSchema: struct<ss_sold_time_sk:int,ss_item_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(19) ColumnarToRow [codegen id : 7]
+(19) ColumnarToRow
 Input [4]: [ss_sold_time_sk#22, ss_item_sk#23, ss_ext_sales_price#24, ss_sold_date_sk#25]
 
-(20) Filter [codegen id : 7]
+(20) Filter
 Input [4]: [ss_sold_time_sk#22, ss_item_sk#23, ss_ext_sales_price#24, ss_sold_date_sk#25]
 Condition : (isnotnull(ss_item_sk#23) AND isnotnull(ss_sold_time_sk#22))
 
 (21) ReusedExchange [Reuses operator id: 43]
 Output [1]: [d_date_sk#26]
 
-(22) BroadcastHashJoin [codegen id : 7]
+(22) BroadcastHashJoin
 Left keys [1]: [ss_sold_date_sk#25]
 Right keys [1]: [d_date_sk#26]
 Join type: Inner
 Join condition: None
 
-(23) Project [codegen id : 7]
+(23) Project
 Output [3]: [ss_ext_sales_price#24 AS ext_price#27, ss_item_sk#23 AS sold_item_sk#28, ss_sold_time_sk#22 AS time_sk#29]
 Input [5]: [ss_sold_time_sk#22, ss_item_sk#23, ss_ext_sales_price#24, ss_sold_date_sk#25, d_date_sk#26]
 
 (24) Union
 
-(25) BroadcastHashJoin [codegen id : 9]
+(25) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [sold_item_sk#12]
 Join type: Inner
 Join condition: None
 
-(26) Project [codegen id : 9]
+(26) Project [codegen id : 6]
 Output [4]: [i_brand_id#2, i_brand#3, ext_price#11, time_sk#13]
 Input [6]: [i_item_sk#1, i_brand_id#2, i_brand#3, ext_price#11, sold_item_sk#12, time_sk#13]
 
@@ -164,14 +164,14 @@ Location [not included in comparison]/{warehouse_dir}/time_dim]
 PushedFilters: [Or(EqualTo(t_meal_time,breakfast           ),EqualTo(t_meal_time,dinner              )), IsNotNull(t_time_sk)]
 ReadSchema: struct<t_time_sk:int,t_hour:int,t_minute:int,t_meal_time:string>
 
-(28) ColumnarToRow [codegen id : 8]
+(28) ColumnarToRow [codegen id : 5]
 Input [4]: [t_time_sk#30, t_hour#31, t_minute#32, t_meal_time#33]
 
-(29) Filter [codegen id : 8]
+(29) Filter [codegen id : 5]
 Input [4]: [t_time_sk#30, t_hour#31, t_minute#32, t_meal_time#33]
 Condition : (((t_meal_time#33 = breakfast           ) OR (t_meal_time#33 = dinner              )) AND isnotnull(t_time_sk#30))
 
-(30) Project [codegen id : 8]
+(30) Project [codegen id : 5]
 Output [3]: [t_time_sk#30, t_hour#31, t_minute#32]
 Input [4]: [t_time_sk#30, t_hour#31, t_minute#32, t_meal_time#33]
 
@@ -179,17 +179,17 @@ Input [4]: [t_time_sk#30, t_hour#31, t_minute#32, t_meal_time#33]
 Input [3]: [t_time_sk#30, t_hour#31, t_minute#32]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
-(32) BroadcastHashJoin [codegen id : 9]
+(32) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [time_sk#13]
 Right keys [1]: [t_time_sk#30]
 Join type: Inner
 Join condition: None
 
-(33) Project [codegen id : 9]
+(33) Project [codegen id : 6]
 Output [5]: [i_brand_id#2, i_brand#3, ext_price#11, t_hour#31, t_minute#32]
 Input [7]: [i_brand_id#2, i_brand#3, ext_price#11, time_sk#13, t_time_sk#30, t_hour#31, t_minute#32]
 
-(34) HashAggregate [codegen id : 9]
+(34) HashAggregate [codegen id : 6]
 Input [5]: [i_brand_id#2, i_brand#3, ext_price#11, t_hour#31, t_minute#32]
 Keys [4]: [i_brand#3, i_brand_id#2, t_hour#31, t_minute#32]
 Functions [1]: [partial_sum(UnscaledValue(ext_price#11))]
@@ -200,7 +200,7 @@ Results [5]: [i_brand#3, i_brand_id#2, t_hour#31, t_minute#32, sum#35]
 Input [5]: [i_brand#3, i_brand_id#2, t_hour#31, t_minute#32, sum#35]
 Arguments: hashpartitioning(i_brand#3, i_brand_id#2, t_hour#31, t_minute#32, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(36) HashAggregate [codegen id : 10]
+(36) HashAggregate [codegen id : 7]
 Input [5]: [i_brand#3, i_brand_id#2, t_hour#31, t_minute#32, sum#35]
 Keys [4]: [i_brand#3, i_brand_id#2, t_hour#31, t_minute#32]
 Functions [1]: [sum(UnscaledValue(ext_price#11))]
@@ -211,7 +211,7 @@ Results [5]: [i_brand_id#2 AS brand_id#37, i_brand#3 AS brand#38, t_hour#31, t_m
 Input [5]: [brand_id#37, brand#38, t_hour#31, t_minute#32, ext_price#39]
 Arguments: rangepartitioning(ext_price#39 DESC NULLS LAST, brand_id#37 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(38) Sort [codegen id : 11]
+(38) Sort [codegen id : 8]
 Input [5]: [brand_id#37, brand#38, t_hour#31, t_minute#32, ext_price#39]
 Arguments: [ext_price#39 DESC NULLS LAST, brand_id#37 ASC NULLS FIRST], true, 0
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71/simplified.txt
@@ -1,12 +1,12 @@
-WholeStageCodegen (11)
+WholeStageCodegen (8)
   Sort [ext_price,brand_id]
     InputAdapter
       Exchange [ext_price,brand_id] #1
-        WholeStageCodegen (10)
+        WholeStageCodegen (7)
           HashAggregate [i_brand,i_brand_id,t_hour,t_minute,sum] [sum(UnscaledValue(ext_price)),brand_id,brand,ext_price,sum]
             InputAdapter
               Exchange [i_brand,i_brand_id,t_hour,t_minute] #2
-                WholeStageCodegen (9)
+                WholeStageCodegen (6)
                   HashAggregate [i_brand,i_brand_id,t_hour,t_minute,ext_price] [sum,sum]
                     Project [i_brand_id,i_brand,ext_price,t_hour,t_minute]
                       BroadcastHashJoin [time_sk,t_time_sk]
@@ -20,48 +20,44 @@ WholeStageCodegen (11)
                                       ColumnarToRow
                                         InputAdapter
                                           Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_brand,i_manager_id]
-                            InputAdapter
-                              Union
-                                WholeStageCodegen (3)
-                                  Project [ws_ext_sales_price,ws_item_sk,ws_sold_time_sk]
-                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                      Filter [ws_item_sk,ws_sold_time_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.web_sales [ws_sold_time_sk,ws_item_sk,ws_ext_sales_price,ws_sold_date_sk]
-                                              SubqueryBroadcast [d_date_sk] #1
-                                                BroadcastExchange #4
-                                                  WholeStageCodegen (1)
-                                                    Project [d_date_sk]
-                                                      Filter [d_moy,d_year,d_date_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                            Union
+                              Project [ws_ext_sales_price,ws_item_sk,ws_sold_time_sk]
+                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                  Filter [ws_item_sk,ws_sold_time_sk]
+                                    ColumnarToRow
                                       InputAdapter
-                                        ReusedExchange [d_date_sk] #4
-                                WholeStageCodegen (5)
-                                  Project [cs_ext_sales_price,cs_item_sk,cs_sold_time_sk]
-                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                      Filter [cs_item_sk,cs_sold_time_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.catalog_sales [cs_sold_time_sk,cs_item_sk,cs_ext_sales_price,cs_sold_date_sk]
-                                              ReusedSubquery [d_date_sk] #1
+                                        Scan parquet spark_catalog.default.web_sales [ws_sold_time_sk,ws_item_sk,ws_ext_sales_price,ws_sold_date_sk]
+                                          SubqueryBroadcast [d_date_sk] #1
+                                            BroadcastExchange #4
+                                              WholeStageCodegen (1)
+                                                Project [d_date_sk]
+                                                  Filter [d_moy,d_year,d_date_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                  InputAdapter
+                                    ReusedExchange [d_date_sk] #4
+                              Project [cs_ext_sales_price,cs_item_sk,cs_sold_time_sk]
+                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                  Filter [cs_item_sk,cs_sold_time_sk]
+                                    ColumnarToRow
                                       InputAdapter
-                                        ReusedExchange [d_date_sk] #4
-                                WholeStageCodegen (7)
-                                  Project [ss_ext_sales_price,ss_item_sk,ss_sold_time_sk]
-                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                      Filter [ss_item_sk,ss_sold_time_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.store_sales [ss_sold_time_sk,ss_item_sk,ss_ext_sales_price,ss_sold_date_sk]
-                                              ReusedSubquery [d_date_sk] #1
+                                        Scan parquet spark_catalog.default.catalog_sales [cs_sold_time_sk,cs_item_sk,cs_ext_sales_price,cs_sold_date_sk]
+                                          ReusedSubquery [d_date_sk] #1
+                                  InputAdapter
+                                    ReusedExchange [d_date_sk] #4
+                              Project [ss_ext_sales_price,ss_item_sk,ss_sold_time_sk]
+                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                  Filter [ss_item_sk,ss_sold_time_sk]
+                                    ColumnarToRow
                                       InputAdapter
-                                        ReusedExchange [d_date_sk] #4
+                                        Scan parquet spark_catalog.default.store_sales [ss_sold_time_sk,ss_item_sk,ss_ext_sales_price,ss_sold_date_sk]
+                                          ReusedSubquery [d_date_sk] #1
+                                  InputAdapter
+                                    ReusedExchange [d_date_sk] #4
                         InputAdapter
                           BroadcastExchange #5
-                            WholeStageCodegen (8)
+                            WholeStageCodegen (5)
                               Project [t_time_sk,t_hour,t_minute]
                                 Filter [t_meal_time,t_time_sk]
                                   ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76.sf100/explain.txt
@@ -3,7 +3,7 @@ TakeOrderedAndProject (44)
 +- * HashAggregate (43)
    +- Exchange (42)
       +- * HashAggregate (41)
-         +- Union (40)
+         +- * Union (40)
             :- * Project (15)
             :  +- * BroadcastHashJoin Inner BuildRight (14)
             :     :- * Project (9)
@@ -53,10 +53,10 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#4)]
 PushedFilters: [IsNull(ss_store_sk), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 3]
+(2) ColumnarToRow [codegen id : 7]
 Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_sold_date_sk#4]
 
-(3) Filter [codegen id : 3]
+(3) Filter [codegen id : 7]
 Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_sold_date_sk#4]
 Condition : (isnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1))
 
@@ -78,13 +78,13 @@ Condition : isnotnull(d_date_sk#5)
 Input [3]: [d_date_sk#5, d_year#6, d_qoy#7]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(8) BroadcastHashJoin [codegen id : 3]
+(8) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#5]
 Join type: Inner
 Join condition: None
 
-(9) Project [codegen id : 3]
+(9) Project [codegen id : 7]
 Output [5]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, d_year#6, d_qoy#7]
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_sold_date_sk#4, d_date_sk#5, d_year#6, d_qoy#7]
 
@@ -106,13 +106,13 @@ Condition : isnotnull(i_item_sk#8)
 Input [2]: [i_item_sk#8, i_category#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
-(14) BroadcastHashJoin [codegen id : 3]
+(14) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#8]
 Join type: Inner
 Join condition: None
 
-(15) Project [codegen id : 3]
+(15) Project [codegen id : 7]
 Output [6]: [store AS channel#10, ss_store_sk#2 AS col_name#11, d_year#6, d_qoy#7, i_category#9, ss_ext_sales_price#3 AS ext_sales_price#12]
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, d_year#6, d_qoy#7, i_item_sk#8, i_category#9]
 
@@ -124,10 +124,10 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#16)]
 PushedFilters: [IsNull(ws_ship_customer_sk), IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_ship_customer_sk:int,ws_ext_sales_price:decimal(7,2)>
 
-(17) ColumnarToRow [codegen id : 4]
+(17) ColumnarToRow [codegen id : 3]
 Input [4]: [ws_item_sk#13, ws_ship_customer_sk#14, ws_ext_sales_price#15, ws_sold_date_sk#16]
 
-(18) Filter [codegen id : 4]
+(18) Filter [codegen id : 3]
 Input [4]: [ws_item_sk#13, ws_ship_customer_sk#14, ws_ext_sales_price#15, ws_sold_date_sk#16]
 Condition : (isnull(ws_ship_customer_sk#14) AND isnotnull(ws_item_sk#13))
 
@@ -149,13 +149,13 @@ Input [3]: [d_date_sk#17, d_year#18, d_qoy#19]
 Input [3]: [d_date_sk#17, d_year#18, d_qoy#19]
 Condition : isnotnull(d_date_sk#17)
 
-(23) BroadcastHashJoin [codegen id : 5]
+(23) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_sold_date_sk#16]
 Right keys [1]: [d_date_sk#17]
 Join type: Inner
 Join condition: None
 
-(24) Project [codegen id : 5]
+(24) Project [codegen id : 4]
 Output [5]: [ws_item_sk#13, ws_ship_customer_sk#14, ws_ext_sales_price#15, d_year#18, d_qoy#19]
 Input [7]: [ws_item_sk#13, ws_ship_customer_sk#14, ws_ext_sales_price#15, ws_sold_date_sk#16, d_date_sk#17, d_year#18, d_qoy#19]
 
@@ -177,13 +177,13 @@ Input [2]: [i_item_sk#20, i_category#21]
 Input [2]: [i_item_sk#20, i_category#21]
 Condition : isnotnull(i_item_sk#20)
 
-(29) BroadcastHashJoin [codegen id : 6]
+(29) BroadcastHashJoin
 Left keys [1]: [ws_item_sk#13]
 Right keys [1]: [i_item_sk#20]
 Join type: Inner
 Join condition: None
 
-(30) Project [codegen id : 6]
+(30) Project
 Output [6]: [web AS channel#22, ws_ship_customer_sk#14 AS col_name#23, d_year#18, d_qoy#19, i_category#21, ws_ext_sales_price#15 AS ext_sales_price#24]
 Input [7]: [ws_item_sk#13, ws_ship_customer_sk#14, ws_ext_sales_price#15, d_year#18, d_qoy#19, i_item_sk#20, i_category#21]
 
@@ -195,42 +195,42 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#28)]
 PushedFilters: [IsNull(cs_ship_addr_sk), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_ship_addr_sk:int,cs_item_sk:int,cs_ext_sales_price:decimal(7,2)>
 
-(32) ColumnarToRow [codegen id : 9]
+(32) ColumnarToRow
 Input [4]: [cs_ship_addr_sk#25, cs_item_sk#26, cs_ext_sales_price#27, cs_sold_date_sk#28]
 
-(33) Filter [codegen id : 9]
+(33) Filter
 Input [4]: [cs_ship_addr_sk#25, cs_item_sk#26, cs_ext_sales_price#27, cs_sold_date_sk#28]
 Condition : (isnull(cs_ship_addr_sk#25) AND isnotnull(cs_item_sk#26))
 
 (34) ReusedExchange [Reuses operator id: 7]
 Output [3]: [d_date_sk#29, d_year#30, d_qoy#31]
 
-(35) BroadcastHashJoin [codegen id : 9]
+(35) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#28]
 Right keys [1]: [d_date_sk#29]
 Join type: Inner
 Join condition: None
 
-(36) Project [codegen id : 9]
+(36) Project
 Output [5]: [cs_ship_addr_sk#25, cs_item_sk#26, cs_ext_sales_price#27, d_year#30, d_qoy#31]
 Input [7]: [cs_ship_addr_sk#25, cs_item_sk#26, cs_ext_sales_price#27, cs_sold_date_sk#28, d_date_sk#29, d_year#30, d_qoy#31]
 
 (37) ReusedExchange [Reuses operator id: 13]
 Output [2]: [i_item_sk#32, i_category#33]
 
-(38) BroadcastHashJoin [codegen id : 9]
+(38) BroadcastHashJoin
 Left keys [1]: [cs_item_sk#26]
 Right keys [1]: [i_item_sk#32]
 Join type: Inner
 Join condition: None
 
-(39) Project [codegen id : 9]
+(39) Project
 Output [6]: [catalog AS channel#34, cs_ship_addr_sk#25 AS col_name#35, d_year#30, d_qoy#31, i_category#33, cs_ext_sales_price#27 AS ext_sales_price#36]
 Input [7]: [cs_ship_addr_sk#25, cs_item_sk#26, cs_ext_sales_price#27, d_year#30, d_qoy#31, i_item_sk#32, i_category#33]
 
-(40) Union
+(40) Union [codegen id : 7]
 
-(41) HashAggregate [codegen id : 10]
+(41) HashAggregate [codegen id : 7]
 Input [6]: [channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9, ext_sales_price#12]
 Keys [5]: [channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9]
 Functions [2]: [partial_count(1), partial_sum(UnscaledValue(ext_sales_price#12))]
@@ -241,7 +241,7 @@ Results [7]: [channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9, count#39
 Input [7]: [channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9, count#39, sum#40]
 Arguments: hashpartitioning(channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(43) HashAggregate [codegen id : 11]
+(43) HashAggregate [codegen id : 8]
 Input [7]: [channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9, count#39, sum#40]
 Keys [5]: [channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9]
 Functions [2]: [count(1), sum(UnscaledValue(ext_sales_price#12))]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76.sf100/simplified.txt
@@ -1,68 +1,64 @@
 TakeOrderedAndProject [channel,col_name,d_year,d_qoy,i_category,sales_cnt,sales_amt]
-  WholeStageCodegen (11)
+  WholeStageCodegen (8)
     HashAggregate [channel,col_name,d_year,d_qoy,i_category,count,sum] [count(1),sum(UnscaledValue(ext_sales_price)),sales_cnt,sales_amt,count,sum]
       InputAdapter
         Exchange [channel,col_name,d_year,d_qoy,i_category] #1
-          WholeStageCodegen (10)
+          WholeStageCodegen (7)
             HashAggregate [channel,col_name,d_year,d_qoy,i_category,ext_sales_price] [count,sum,count,sum]
-              InputAdapter
-                Union
-                  WholeStageCodegen (3)
-                    Project [ss_store_sk,d_year,d_qoy,i_category,ss_ext_sales_price]
-                      BroadcastHashJoin [ss_item_sk,i_item_sk]
-                        Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,d_year,d_qoy]
-                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                            Filter [ss_store_sk,ss_item_sk]
-                              ColumnarToRow
-                                InputAdapter
-                                  Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk]
-                            InputAdapter
-                              BroadcastExchange #2
-                                WholeStageCodegen (1)
-                                  Filter [d_date_sk]
-                                    ColumnarToRow
-                                      InputAdapter
-                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
-                        InputAdapter
-                          BroadcastExchange #3
-                            WholeStageCodegen (2)
-                              Filter [i_item_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.item [i_item_sk,i_category]
-                  WholeStageCodegen (6)
-                    Project [ws_ship_customer_sk,d_year,d_qoy,i_category,ws_ext_sales_price]
-                      BroadcastHashJoin [ws_item_sk,i_item_sk]
-                        InputAdapter
-                          BroadcastExchange #4
-                            WholeStageCodegen (5)
-                              Project [ws_item_sk,ws_ship_customer_sk,ws_ext_sales_price,d_year,d_qoy]
-                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                  InputAdapter
-                                    BroadcastExchange #5
-                                      WholeStageCodegen (4)
-                                        Filter [ws_ship_customer_sk,ws_item_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_ship_customer_sk,ws_ext_sales_price,ws_sold_date_sk]
-                                  Filter [d_date_sk]
-                                    ColumnarToRow
-                                      InputAdapter
-                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
-                        Filter [i_item_sk]
+              Union
+                Project [ss_store_sk,d_year,d_qoy,i_category,ss_ext_sales_price]
+                  BroadcastHashJoin [ss_item_sk,i_item_sk]
+                    Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,d_year,d_qoy]
+                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                        Filter [ss_store_sk,ss_item_sk]
                           ColumnarToRow
                             InputAdapter
-                              Scan parquet spark_catalog.default.item [i_item_sk,i_category]
-                  WholeStageCodegen (9)
-                    Project [cs_ship_addr_sk,d_year,d_qoy,i_category,cs_ext_sales_price]
-                      BroadcastHashJoin [cs_item_sk,i_item_sk]
-                        Project [cs_ship_addr_sk,cs_item_sk,cs_ext_sales_price,d_year,d_qoy]
-                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                            Filter [cs_ship_addr_sk,cs_item_sk]
-                              ColumnarToRow
-                                InputAdapter
-                                  Scan parquet spark_catalog.default.catalog_sales [cs_ship_addr_sk,cs_item_sk,cs_ext_sales_price,cs_sold_date_sk]
-                            InputAdapter
-                              ReusedExchange [d_date_sk,d_year,d_qoy] #2
+                              Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk]
                         InputAdapter
-                          ReusedExchange [i_item_sk,i_category] #3
+                          BroadcastExchange #2
+                            WholeStageCodegen (1)
+                              Filter [d_date_sk]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
+                    InputAdapter
+                      BroadcastExchange #3
+                        WholeStageCodegen (2)
+                          Filter [i_item_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.item [i_item_sk,i_category]
+                Project [ws_ship_customer_sk,d_year,d_qoy,i_category,ws_ext_sales_price]
+                  BroadcastHashJoin [ws_item_sk,i_item_sk]
+                    InputAdapter
+                      BroadcastExchange #4
+                        WholeStageCodegen (4)
+                          Project [ws_item_sk,ws_ship_customer_sk,ws_ext_sales_price,d_year,d_qoy]
+                            BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                              InputAdapter
+                                BroadcastExchange #5
+                                  WholeStageCodegen (3)
+                                    Filter [ws_ship_customer_sk,ws_item_sk]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_ship_customer_sk,ws_ext_sales_price,ws_sold_date_sk]
+                              Filter [d_date_sk]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
+                    Filter [i_item_sk]
+                      ColumnarToRow
+                        InputAdapter
+                          Scan parquet spark_catalog.default.item [i_item_sk,i_category]
+                Project [cs_ship_addr_sk,d_year,d_qoy,i_category,cs_ext_sales_price]
+                  BroadcastHashJoin [cs_item_sk,i_item_sk]
+                    Project [cs_ship_addr_sk,cs_item_sk,cs_ext_sales_price,d_year,d_qoy]
+                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                        Filter [cs_ship_addr_sk,cs_item_sk]
+                          ColumnarToRow
+                            InputAdapter
+                              Scan parquet spark_catalog.default.catalog_sales [cs_ship_addr_sk,cs_item_sk,cs_ext_sales_price,cs_sold_date_sk]
+                        InputAdapter
+                          ReusedExchange [d_date_sk,d_year,d_qoy] #2
+                    InputAdapter
+                      ReusedExchange [i_item_sk,i_category] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76/explain.txt
@@ -3,7 +3,7 @@ TakeOrderedAndProject (38)
 +- * HashAggregate (37)
    +- Exchange (36)
       +- * HashAggregate (35)
-         +- Union (34)
+         +- * Union (34)
             :- * Project (15)
             :  +- * BroadcastHashJoin Inner BuildRight (14)
             :     :- * Project (9)
@@ -47,10 +47,10 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#4)]
 PushedFilters: [IsNull(ss_store_sk), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 3]
+(2) ColumnarToRow [codegen id : 7]
 Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_sold_date_sk#4]
 
-(3) Filter [codegen id : 3]
+(3) Filter [codegen id : 7]
 Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_sold_date_sk#4]
 Condition : (isnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1))
 
@@ -72,13 +72,13 @@ Condition : isnotnull(i_item_sk#5)
 Input [2]: [i_item_sk#5, i_category#6]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(8) BroadcastHashJoin [codegen id : 3]
+(8) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#5]
 Join type: Inner
 Join condition: None
 
-(9) Project [codegen id : 3]
+(9) Project [codegen id : 7]
 Output [4]: [ss_store_sk#2, ss_ext_sales_price#3, ss_sold_date_sk#4, i_category#6]
 Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_sold_date_sk#4, i_item_sk#5, i_category#6]
 
@@ -100,13 +100,13 @@ Condition : isnotnull(d_date_sk#7)
 Input [3]: [d_date_sk#7, d_year#8, d_qoy#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
-(14) BroadcastHashJoin [codegen id : 3]
+(14) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#7]
 Join type: Inner
 Join condition: None
 
-(15) Project [codegen id : 3]
+(15) Project [codegen id : 7]
 Output [6]: [store AS channel#10, ss_store_sk#2 AS col_name#11, d_year#8, d_qoy#9, i_category#6, ss_ext_sales_price#3 AS ext_sales_price#12]
 Input [7]: [ss_store_sk#2, ss_ext_sales_price#3, ss_sold_date_sk#4, i_category#6, d_date_sk#7, d_year#8, d_qoy#9]
 
@@ -118,36 +118,36 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#16)]
 PushedFilters: [IsNull(ws_ship_customer_sk), IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_ship_customer_sk:int,ws_ext_sales_price:decimal(7,2)>
 
-(17) ColumnarToRow [codegen id : 6]
+(17) ColumnarToRow
 Input [4]: [ws_item_sk#13, ws_ship_customer_sk#14, ws_ext_sales_price#15, ws_sold_date_sk#16]
 
-(18) Filter [codegen id : 6]
+(18) Filter
 Input [4]: [ws_item_sk#13, ws_ship_customer_sk#14, ws_ext_sales_price#15, ws_sold_date_sk#16]
 Condition : (isnull(ws_ship_customer_sk#14) AND isnotnull(ws_item_sk#13))
 
 (19) ReusedExchange [Reuses operator id: 7]
 Output [2]: [i_item_sk#17, i_category#18]
 
-(20) BroadcastHashJoin [codegen id : 6]
+(20) BroadcastHashJoin
 Left keys [1]: [ws_item_sk#13]
 Right keys [1]: [i_item_sk#17]
 Join type: Inner
 Join condition: None
 
-(21) Project [codegen id : 6]
+(21) Project
 Output [4]: [ws_ship_customer_sk#14, ws_ext_sales_price#15, ws_sold_date_sk#16, i_category#18]
 Input [6]: [ws_item_sk#13, ws_ship_customer_sk#14, ws_ext_sales_price#15, ws_sold_date_sk#16, i_item_sk#17, i_category#18]
 
 (22) ReusedExchange [Reuses operator id: 13]
 Output [3]: [d_date_sk#19, d_year#20, d_qoy#21]
 
-(23) BroadcastHashJoin [codegen id : 6]
+(23) BroadcastHashJoin
 Left keys [1]: [ws_sold_date_sk#16]
 Right keys [1]: [d_date_sk#19]
 Join type: Inner
 Join condition: None
 
-(24) Project [codegen id : 6]
+(24) Project
 Output [6]: [web AS channel#22, ws_ship_customer_sk#14 AS col_name#23, d_year#20, d_qoy#21, i_category#18, ws_ext_sales_price#15 AS ext_sales_price#24]
 Input [7]: [ws_ship_customer_sk#14, ws_ext_sales_price#15, ws_sold_date_sk#16, i_category#18, d_date_sk#19, d_year#20, d_qoy#21]
 
@@ -159,42 +159,42 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#28)]
 PushedFilters: [IsNull(cs_ship_addr_sk), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_ship_addr_sk:int,cs_item_sk:int,cs_ext_sales_price:decimal(7,2)>
 
-(26) ColumnarToRow [codegen id : 9]
+(26) ColumnarToRow
 Input [4]: [cs_ship_addr_sk#25, cs_item_sk#26, cs_ext_sales_price#27, cs_sold_date_sk#28]
 
-(27) Filter [codegen id : 9]
+(27) Filter
 Input [4]: [cs_ship_addr_sk#25, cs_item_sk#26, cs_ext_sales_price#27, cs_sold_date_sk#28]
 Condition : (isnull(cs_ship_addr_sk#25) AND isnotnull(cs_item_sk#26))
 
 (28) ReusedExchange [Reuses operator id: 7]
 Output [2]: [i_item_sk#29, i_category#30]
 
-(29) BroadcastHashJoin [codegen id : 9]
+(29) BroadcastHashJoin
 Left keys [1]: [cs_item_sk#26]
 Right keys [1]: [i_item_sk#29]
 Join type: Inner
 Join condition: None
 
-(30) Project [codegen id : 9]
+(30) Project
 Output [4]: [cs_ship_addr_sk#25, cs_ext_sales_price#27, cs_sold_date_sk#28, i_category#30]
 Input [6]: [cs_ship_addr_sk#25, cs_item_sk#26, cs_ext_sales_price#27, cs_sold_date_sk#28, i_item_sk#29, i_category#30]
 
 (31) ReusedExchange [Reuses operator id: 13]
 Output [3]: [d_date_sk#31, d_year#32, d_qoy#33]
 
-(32) BroadcastHashJoin [codegen id : 9]
+(32) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#28]
 Right keys [1]: [d_date_sk#31]
 Join type: Inner
 Join condition: None
 
-(33) Project [codegen id : 9]
+(33) Project
 Output [6]: [catalog AS channel#34, cs_ship_addr_sk#25 AS col_name#35, d_year#32, d_qoy#33, i_category#30, cs_ext_sales_price#27 AS ext_sales_price#36]
 Input [7]: [cs_ship_addr_sk#25, cs_ext_sales_price#27, cs_sold_date_sk#28, i_category#30, d_date_sk#31, d_year#32, d_qoy#33]
 
-(34) Union
+(34) Union [codegen id : 7]
 
-(35) HashAggregate [codegen id : 10]
+(35) HashAggregate [codegen id : 7]
 Input [6]: [channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6, ext_sales_price#12]
 Keys [5]: [channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6]
 Functions [2]: [partial_count(1), partial_sum(UnscaledValue(ext_sales_price#12))]
@@ -205,7 +205,7 @@ Results [7]: [channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6, count#39
 Input [7]: [channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6, count#39, sum#40]
 Arguments: hashpartitioning(channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(37) HashAggregate [codegen id : 11]
+(37) HashAggregate [codegen id : 8]
 Input [7]: [channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6, count#39, sum#40]
 Keys [5]: [channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6]
 Functions [2]: [count(1), sum(UnscaledValue(ext_sales_price#12))]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76/simplified.txt
@@ -1,58 +1,54 @@
 TakeOrderedAndProject [channel,col_name,d_year,d_qoy,i_category,sales_cnt,sales_amt]
-  WholeStageCodegen (11)
+  WholeStageCodegen (8)
     HashAggregate [channel,col_name,d_year,d_qoy,i_category,count,sum] [count(1),sum(UnscaledValue(ext_sales_price)),sales_cnt,sales_amt,count,sum]
       InputAdapter
         Exchange [channel,col_name,d_year,d_qoy,i_category] #1
-          WholeStageCodegen (10)
+          WholeStageCodegen (7)
             HashAggregate [channel,col_name,d_year,d_qoy,i_category,ext_sales_price] [count,sum,count,sum]
-              InputAdapter
-                Union
-                  WholeStageCodegen (3)
-                    Project [ss_store_sk,d_year,d_qoy,i_category,ss_ext_sales_price]
-                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                        Project [ss_store_sk,ss_ext_sales_price,ss_sold_date_sk,i_category]
-                          BroadcastHashJoin [ss_item_sk,i_item_sk]
-                            Filter [ss_store_sk,ss_item_sk]
-                              ColumnarToRow
-                                InputAdapter
-                                  Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk]
+              Union
+                Project [ss_store_sk,d_year,d_qoy,i_category,ss_ext_sales_price]
+                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                    Project [ss_store_sk,ss_ext_sales_price,ss_sold_date_sk,i_category]
+                      BroadcastHashJoin [ss_item_sk,i_item_sk]
+                        Filter [ss_store_sk,ss_item_sk]
+                          ColumnarToRow
                             InputAdapter
-                              BroadcastExchange #2
-                                WholeStageCodegen (1)
-                                  Filter [i_item_sk]
-                                    ColumnarToRow
-                                      InputAdapter
-                                        Scan parquet spark_catalog.default.item [i_item_sk,i_category]
+                              Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk]
                         InputAdapter
-                          BroadcastExchange #3
-                            WholeStageCodegen (2)
-                              Filter [d_date_sk]
+                          BroadcastExchange #2
+                            WholeStageCodegen (1)
+                              Filter [i_item_sk]
                                 ColumnarToRow
                                   InputAdapter
-                                    Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
-                  WholeStageCodegen (6)
-                    Project [ws_ship_customer_sk,d_year,d_qoy,i_category,ws_ext_sales_price]
-                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                        Project [ws_ship_customer_sk,ws_ext_sales_price,ws_sold_date_sk,i_category]
-                          BroadcastHashJoin [ws_item_sk,i_item_sk]
-                            Filter [ws_ship_customer_sk,ws_item_sk]
-                              ColumnarToRow
-                                InputAdapter
-                                  Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_ship_customer_sk,ws_ext_sales_price,ws_sold_date_sk]
+                                    Scan parquet spark_catalog.default.item [i_item_sk,i_category]
+                    InputAdapter
+                      BroadcastExchange #3
+                        WholeStageCodegen (2)
+                          Filter [d_date_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
+                Project [ws_ship_customer_sk,d_year,d_qoy,i_category,ws_ext_sales_price]
+                  BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                    Project [ws_ship_customer_sk,ws_ext_sales_price,ws_sold_date_sk,i_category]
+                      BroadcastHashJoin [ws_item_sk,i_item_sk]
+                        Filter [ws_ship_customer_sk,ws_item_sk]
+                          ColumnarToRow
                             InputAdapter
-                              ReusedExchange [i_item_sk,i_category] #2
+                              Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_ship_customer_sk,ws_ext_sales_price,ws_sold_date_sk]
                         InputAdapter
-                          ReusedExchange [d_date_sk,d_year,d_qoy] #3
-                  WholeStageCodegen (9)
-                    Project [cs_ship_addr_sk,d_year,d_qoy,i_category,cs_ext_sales_price]
-                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                        Project [cs_ship_addr_sk,cs_ext_sales_price,cs_sold_date_sk,i_category]
-                          BroadcastHashJoin [cs_item_sk,i_item_sk]
-                            Filter [cs_ship_addr_sk,cs_item_sk]
-                              ColumnarToRow
-                                InputAdapter
-                                  Scan parquet spark_catalog.default.catalog_sales [cs_ship_addr_sk,cs_item_sk,cs_ext_sales_price,cs_sold_date_sk]
+                          ReusedExchange [i_item_sk,i_category] #2
+                    InputAdapter
+                      ReusedExchange [d_date_sk,d_year,d_qoy] #3
+                Project [cs_ship_addr_sk,d_year,d_qoy,i_category,cs_ext_sales_price]
+                  BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                    Project [cs_ship_addr_sk,cs_ext_sales_price,cs_sold_date_sk,i_category]
+                      BroadcastHashJoin [cs_item_sk,i_item_sk]
+                        Filter [cs_ship_addr_sk,cs_item_sk]
+                          ColumnarToRow
                             InputAdapter
-                              ReusedExchange [i_item_sk,i_category] #2
+                              Scan parquet spark_catalog.default.catalog_sales [cs_ship_addr_sk,cs_item_sk,cs_ext_sales_price,cs_sold_date_sk]
                         InputAdapter
-                          ReusedExchange [d_date_sk,d_year,d_qoy] #3
+                          ReusedExchange [i_item_sk,i_category] #2
+                    InputAdapter
+                      ReusedExchange [d_date_sk,d_year,d_qoy] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77/explain.txt
@@ -4,7 +4,7 @@ TakeOrderedAndProject (85)
    +- Exchange (83)
       +- * HashAggregate (82)
          +- * Expand (81)
-            +- Union (80)
+            +- * Union (80)
                :- * Project (30)
                :  +- * BroadcastHashJoin LeftOuter BuildRight (29)
                :     :- * HashAggregate (15)
@@ -153,7 +153,7 @@ Results [3]: [s_store_sk#7, sum#10, sum#11]
 Input [3]: [s_store_sk#7, sum#10, sum#11]
 Arguments: hashpartitioning(s_store_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(15) HashAggregate [codegen id : 8]
+(15) HashAggregate [codegen id : 20]
 Input [3]: [s_store_sk#7, sum#10, sum#11]
 Keys [1]: [s_store_sk#7]
 Functions [2]: [sum(UnscaledValue(ss_ext_sales_price#2)), sum(UnscaledValue(ss_net_profit#3))]
@@ -223,13 +223,13 @@ Results [3]: [s_store_sk#21, MakeDecimal(sum(UnscaledValue(sr_return_amt#17))#26
 Input [3]: [s_store_sk#21, returns#28, profit_loss#29]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
-(29) BroadcastHashJoin [codegen id : 8]
+(29) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [s_store_sk#7]
 Right keys [1]: [s_store_sk#21]
 Join type: LeftOuter
 Join condition: None
 
-(30) Project [codegen id : 8]
+(30) Project [codegen id : 20]
 Output [5]: [sales#14, coalesce(returns#28, 0.00) AS returns#30, (profit#15 - coalesce(profit_loss#29, 0.00)) AS profit#31, store channel AS channel#32, s_store_sk#7 AS id#33]
 Input [6]: [s_store_sk#7, sales#14, profit#15, s_store_sk#21, returns#28, profit_loss#29]
 
@@ -240,23 +240,23 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#37), dynamicpruningexpression(cs_sold_date_sk#37 IN dynamicpruning#5)]
 ReadSchema: struct<cs_call_center_sk:int,cs_ext_sales_price:decimal(7,2),cs_net_profit:decimal(7,2)>
 
-(32) ColumnarToRow [codegen id : 10]
+(32) ColumnarToRow [codegen id : 9]
 Input [4]: [cs_call_center_sk#34, cs_ext_sales_price#35, cs_net_profit#36, cs_sold_date_sk#37]
 
 (33) ReusedExchange [Reuses operator id: 90]
 Output [1]: [d_date_sk#38]
 
-(34) BroadcastHashJoin [codegen id : 10]
+(34) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_sold_date_sk#37]
 Right keys [1]: [d_date_sk#38]
 Join type: Inner
 Join condition: None
 
-(35) Project [codegen id : 10]
+(35) Project [codegen id : 9]
 Output [3]: [cs_call_center_sk#34, cs_ext_sales_price#35, cs_net_profit#36]
 Input [5]: [cs_call_center_sk#34, cs_ext_sales_price#35, cs_net_profit#36, cs_sold_date_sk#37, d_date_sk#38]
 
-(36) HashAggregate [codegen id : 10]
+(36) HashAggregate [codegen id : 9]
 Input [3]: [cs_call_center_sk#34, cs_ext_sales_price#35, cs_net_profit#36]
 Keys [1]: [cs_call_center_sk#34]
 Functions [2]: [partial_sum(UnscaledValue(cs_ext_sales_price#35)), partial_sum(UnscaledValue(cs_net_profit#36))]
@@ -267,7 +267,7 @@ Results [3]: [cs_call_center_sk#34, sum#41, sum#42]
 Input [3]: [cs_call_center_sk#34, sum#41, sum#42]
 Arguments: hashpartitioning(cs_call_center_sk#34, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(38) HashAggregate [codegen id : 11]
+(38) HashAggregate [codegen id : 10]
 Input [3]: [cs_call_center_sk#34, sum#41, sum#42]
 Keys [1]: [cs_call_center_sk#34]
 Functions [2]: [sum(UnscaledValue(cs_ext_sales_price#35)), sum(UnscaledValue(cs_net_profit#36))]
@@ -285,23 +285,23 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cr_returned_date_sk#49), dynamicpruningexpression(cr_returned_date_sk#49 IN dynamicpruning#5)]
 ReadSchema: struct<cr_return_amount:decimal(7,2),cr_net_loss:decimal(7,2)>
 
-(41) ColumnarToRow [codegen id : 13]
+(41) ColumnarToRow [codegen id : 12]
 Input [3]: [cr_return_amount#47, cr_net_loss#48, cr_returned_date_sk#49]
 
 (42) ReusedExchange [Reuses operator id: 90]
 Output [1]: [d_date_sk#50]
 
-(43) BroadcastHashJoin [codegen id : 13]
+(43) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [cr_returned_date_sk#49]
 Right keys [1]: [d_date_sk#50]
 Join type: Inner
 Join condition: None
 
-(44) Project [codegen id : 13]
+(44) Project [codegen id : 12]
 Output [2]: [cr_return_amount#47, cr_net_loss#48]
 Input [4]: [cr_return_amount#47, cr_net_loss#48, cr_returned_date_sk#49, d_date_sk#50]
 
-(45) HashAggregate [codegen id : 13]
+(45) HashAggregate [codegen id : 12]
 Input [2]: [cr_return_amount#47, cr_net_loss#48]
 Keys: []
 Functions [2]: [partial_sum(UnscaledValue(cr_return_amount#47)), partial_sum(UnscaledValue(cr_net_loss#48))]
@@ -319,11 +319,11 @@ Functions [2]: [sum(UnscaledValue(cr_return_amount#47)), sum(UnscaledValue(cr_ne
 Aggregate Attributes [2]: [sum(UnscaledValue(cr_return_amount#47))#55, sum(UnscaledValue(cr_net_loss#48))#56]
 Results [2]: [MakeDecimal(sum(UnscaledValue(cr_return_amount#47))#55,17,2) AS returns#57, MakeDecimal(sum(UnscaledValue(cr_net_loss#48))#56,17,2) AS profit_loss#58]
 
-(48) BroadcastNestedLoopJoin [codegen id : 14]
+(48) BroadcastNestedLoopJoin
 Join type: Inner
 Join condition: None
 
-(49) Project [codegen id : 14]
+(49) Project
 Output [5]: [sales#45, returns#57, (profit#46 - profit_loss#58) AS profit#59, catalog channel AS channel#60, cs_call_center_sk#34 AS id#61]
 Input [5]: [cs_call_center_sk#34, sales#45, profit#46, returns#57, profit_loss#58]
 
@@ -335,23 +335,23 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#65), dynamicpruningexpression(ws_so
 PushedFilters: [IsNotNull(ws_web_page_sk)]
 ReadSchema: struct<ws_web_page_sk:int,ws_ext_sales_price:decimal(7,2),ws_net_profit:decimal(7,2)>
 
-(51) ColumnarToRow [codegen id : 17]
+(51) ColumnarToRow [codegen id : 15]
 Input [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65]
 
-(52) Filter [codegen id : 17]
+(52) Filter [codegen id : 15]
 Input [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65]
 Condition : isnotnull(ws_web_page_sk#62)
 
 (53) ReusedExchange [Reuses operator id: 90]
 Output [1]: [d_date_sk#66]
 
-(54) BroadcastHashJoin [codegen id : 17]
+(54) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ws_sold_date_sk#65]
 Right keys [1]: [d_date_sk#66]
 Join type: Inner
 Join condition: None
 
-(55) Project [codegen id : 17]
+(55) Project [codegen id : 15]
 Output [3]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64]
 Input [5]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65, d_date_sk#66]
 
@@ -362,10 +362,10 @@ Location [not included in comparison]/{warehouse_dir}/web_page]
 PushedFilters: [IsNotNull(wp_web_page_sk)]
 ReadSchema: struct<wp_web_page_sk:int>
 
-(57) ColumnarToRow [codegen id : 16]
+(57) ColumnarToRow [codegen id : 14]
 Input [1]: [wp_web_page_sk#67]
 
-(58) Filter [codegen id : 16]
+(58) Filter [codegen id : 14]
 Input [1]: [wp_web_page_sk#67]
 Condition : isnotnull(wp_web_page_sk#67)
 
@@ -373,17 +373,17 @@ Condition : isnotnull(wp_web_page_sk#67)
 Input [1]: [wp_web_page_sk#67]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
 
-(60) BroadcastHashJoin [codegen id : 17]
+(60) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ws_web_page_sk#62]
 Right keys [1]: [wp_web_page_sk#67]
 Join type: Inner
 Join condition: None
 
-(61) Project [codegen id : 17]
+(61) Project [codegen id : 15]
 Output [3]: [ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#67]
 Input [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#67]
 
-(62) HashAggregate [codegen id : 17]
+(62) HashAggregate [codegen id : 15]
 Input [3]: [ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#67]
 Keys [1]: [wp_web_page_sk#67]
 Functions [2]: [partial_sum(UnscaledValue(ws_ext_sales_price#63)), partial_sum(UnscaledValue(ws_net_profit#64))]
@@ -394,7 +394,7 @@ Results [3]: [wp_web_page_sk#67, sum#70, sum#71]
 Input [3]: [wp_web_page_sk#67, sum#70, sum#71]
 Arguments: hashpartitioning(wp_web_page_sk#67, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(64) HashAggregate [codegen id : 22]
+(64) HashAggregate
 Input [3]: [wp_web_page_sk#67, sum#70, sum#71]
 Keys [1]: [wp_web_page_sk#67]
 Functions [2]: [sum(UnscaledValue(ws_ext_sales_price#63)), sum(UnscaledValue(ws_net_profit#64))]
@@ -409,40 +409,40 @@ PartitionFilters: [isnotnull(wr_returned_date_sk#79), dynamicpruningexpression(w
 PushedFilters: [IsNotNull(wr_web_page_sk)]
 ReadSchema: struct<wr_web_page_sk:int,wr_return_amt:decimal(7,2),wr_net_loss:decimal(7,2)>
 
-(66) ColumnarToRow [codegen id : 20]
+(66) ColumnarToRow [codegen id : 18]
 Input [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79]
 
-(67) Filter [codegen id : 20]
+(67) Filter [codegen id : 18]
 Input [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79]
 Condition : isnotnull(wr_web_page_sk#76)
 
 (68) ReusedExchange [Reuses operator id: 90]
 Output [1]: [d_date_sk#80]
 
-(69) BroadcastHashJoin [codegen id : 20]
+(69) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [wr_returned_date_sk#79]
 Right keys [1]: [d_date_sk#80]
 Join type: Inner
 Join condition: None
 
-(70) Project [codegen id : 20]
+(70) Project [codegen id : 18]
 Output [3]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78]
 Input [5]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79, d_date_sk#80]
 
 (71) ReusedExchange [Reuses operator id: 59]
 Output [1]: [wp_web_page_sk#81]
 
-(72) BroadcastHashJoin [codegen id : 20]
+(72) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [wr_web_page_sk#76]
 Right keys [1]: [wp_web_page_sk#81]
 Join type: Inner
 Join condition: None
 
-(73) Project [codegen id : 20]
+(73) Project [codegen id : 18]
 Output [3]: [wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#81]
 Input [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#81]
 
-(74) HashAggregate [codegen id : 20]
+(74) HashAggregate [codegen id : 18]
 Input [3]: [wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#81]
 Keys [1]: [wp_web_page_sk#81]
 Functions [2]: [partial_sum(UnscaledValue(wr_return_amt#77)), partial_sum(UnscaledValue(wr_net_loss#78))]
@@ -453,7 +453,7 @@ Results [3]: [wp_web_page_sk#81, sum#84, sum#85]
 Input [3]: [wp_web_page_sk#81, sum#84, sum#85]
 Arguments: hashpartitioning(wp_web_page_sk#81, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(76) HashAggregate [codegen id : 21]
+(76) HashAggregate [codegen id : 19]
 Input [3]: [wp_web_page_sk#81, sum#84, sum#85]
 Keys [1]: [wp_web_page_sk#81]
 Functions [2]: [sum(UnscaledValue(wr_return_amt#77)), sum(UnscaledValue(wr_net_loss#78))]
@@ -464,23 +464,23 @@ Results [3]: [wp_web_page_sk#81, MakeDecimal(sum(UnscaledValue(wr_return_amt#77)
 Input [3]: [wp_web_page_sk#81, returns#88, profit_loss#89]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-(78) BroadcastHashJoin [codegen id : 22]
+(78) BroadcastHashJoin
 Left keys [1]: [wp_web_page_sk#67]
 Right keys [1]: [wp_web_page_sk#81]
 Join type: LeftOuter
 Join condition: None
 
-(79) Project [codegen id : 22]
+(79) Project
 Output [5]: [sales#74, coalesce(returns#88, 0.00) AS returns#90, (profit#75 - coalesce(profit_loss#89, 0.00)) AS profit#91, web channel AS channel#92, wp_web_page_sk#67 AS id#93]
 Input [6]: [wp_web_page_sk#67, sales#74, profit#75, wp_web_page_sk#81, returns#88, profit_loss#89]
 
-(80) Union
+(80) Union [codegen id : 20]
 
-(81) Expand [codegen id : 23]
+(81) Expand [codegen id : 20]
 Input [5]: [sales#14, returns#30, profit#31, channel#32, id#33]
 Arguments: [[sales#14, returns#30, profit#31, channel#32, id#33, 0], [sales#14, returns#30, profit#31, channel#32, null, 1], [sales#14, returns#30, profit#31, null, null, 3]], [sales#14, returns#30, profit#31, channel#94, id#95, spark_grouping_id#96]
 
-(82) HashAggregate [codegen id : 23]
+(82) HashAggregate [codegen id : 20]
 Input [6]: [sales#14, returns#30, profit#31, channel#94, id#95, spark_grouping_id#96]
 Keys [3]: [channel#94, id#95, spark_grouping_id#96]
 Functions [3]: [partial_sum(sales#14), partial_sum(returns#30), partial_sum(profit#31)]
@@ -491,7 +491,7 @@ Results [9]: [channel#94, id#95, spark_grouping_id#96, sum#103, isEmpty#104, sum
 Input [9]: [channel#94, id#95, spark_grouping_id#96, sum#103, isEmpty#104, sum#105, isEmpty#106, sum#107, isEmpty#108]
 Arguments: hashpartitioning(channel#94, id#95, spark_grouping_id#96, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(84) HashAggregate [codegen id : 24]
+(84) HashAggregate [codegen id : 21]
 Input [9]: [channel#94, id#95, spark_grouping_id#96, sum#103, isEmpty#104, sum#105, isEmpty#106, sum#107, isEmpty#108]
 Keys [3]: [channel#94, id#95, spark_grouping_id#96]
 Functions [3]: [sum(sales#14), sum(returns#30), sum(profit#31)]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77/simplified.txt
@@ -1,143 +1,139 @@
 TakeOrderedAndProject [channel,id,sales,returns,profit]
-  WholeStageCodegen (24)
+  WholeStageCodegen (21)
     HashAggregate [channel,id,spark_grouping_id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
       InputAdapter
         Exchange [channel,id,spark_grouping_id] #1
-          WholeStageCodegen (23)
+          WholeStageCodegen (20)
             HashAggregate [channel,id,spark_grouping_id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
               Expand [sales,returns,profit,channel,id]
-                InputAdapter
-                  Union
-                    WholeStageCodegen (8)
-                      Project [sales,returns,profit,profit_loss,s_store_sk]
-                        BroadcastHashJoin [s_store_sk,s_store_sk]
-                          HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(ss_ext_sales_price)),sum(UnscaledValue(ss_net_profit)),sales,profit,sum,sum]
-                            InputAdapter
-                              Exchange [s_store_sk] #2
-                                WholeStageCodegen (3)
-                                  HashAggregate [s_store_sk,ss_ext_sales_price,ss_net_profit] [sum,sum,sum,sum]
-                                    Project [ss_ext_sales_price,ss_net_profit,s_store_sk]
-                                      BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                        Project [ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                            Filter [ss_store_sk]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
-                                                    SubqueryBroadcast [d_date_sk] #1
-                                                      BroadcastExchange #3
-                                                        WholeStageCodegen (1)
-                                                          Project [d_date_sk]
-                                                            Filter [d_date,d_date_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                Union
+                  Project [sales,returns,profit,profit_loss,s_store_sk]
+                    BroadcastHashJoin [s_store_sk,s_store_sk]
+                      HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(ss_ext_sales_price)),sum(UnscaledValue(ss_net_profit)),sales,profit,sum,sum]
+                        InputAdapter
+                          Exchange [s_store_sk] #2
+                            WholeStageCodegen (3)
+                              HashAggregate [s_store_sk,ss_ext_sales_price,ss_net_profit] [sum,sum,sum,sum]
+                                Project [ss_ext_sales_price,ss_net_profit,s_store_sk]
+                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                    Project [ss_store_sk,ss_ext_sales_price,ss_net_profit]
+                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                        Filter [ss_store_sk]
+                                          ColumnarToRow
                                             InputAdapter
-                                              ReusedExchange [d_date_sk] #3
-                                        InputAdapter
-                                          BroadcastExchange #4
-                                            WholeStageCodegen (2)
-                                              Filter [s_store_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.store [s_store_sk]
-                          InputAdapter
-                            BroadcastExchange #5
-                              WholeStageCodegen (7)
-                                HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(sr_return_amt)),sum(UnscaledValue(sr_net_loss)),returns,profit_loss,sum,sum]
-                                  InputAdapter
-                                    Exchange [s_store_sk] #6
-                                      WholeStageCodegen (6)
-                                        HashAggregate [s_store_sk,sr_return_amt,sr_net_loss] [sum,sum,sum,sum]
-                                          Project [sr_return_amt,sr_net_loss,s_store_sk]
-                                            BroadcastHashJoin [sr_store_sk,s_store_sk]
-                                              Project [sr_store_sk,sr_return_amt,sr_net_loss]
-                                                BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
-                                                  Filter [sr_store_sk]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
-                                                          ReusedSubquery [d_date_sk] #1
-                                                  InputAdapter
-                                                    ReusedExchange [d_date_sk] #3
-                                              InputAdapter
-                                                ReusedExchange [s_store_sk] #4
-                    WholeStageCodegen (14)
-                      Project [sales,returns,profit,profit_loss,cs_call_center_sk]
-                        BroadcastNestedLoopJoin
-                          InputAdapter
-                            BroadcastExchange #7
-                              WholeStageCodegen (11)
-                                HashAggregate [cs_call_center_sk,sum,sum] [sum(UnscaledValue(cs_ext_sales_price)),sum(UnscaledValue(cs_net_profit)),sales,profit,sum,sum]
-                                  InputAdapter
-                                    Exchange [cs_call_center_sk] #8
-                                      WholeStageCodegen (10)
-                                        HashAggregate [cs_call_center_sk,cs_ext_sales_price,cs_net_profit] [sum,sum,sum,sum]
-                                          Project [cs_call_center_sk,cs_ext_sales_price,cs_net_profit]
-                                            BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet spark_catalog.default.catalog_sales [cs_call_center_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
-                                                    ReusedSubquery [d_date_sk] #1
-                                              InputAdapter
-                                                ReusedExchange [d_date_sk] #3
-                          HashAggregate [sum,sum] [sum(UnscaledValue(cr_return_amount)),sum(UnscaledValue(cr_net_loss)),returns,profit_loss,sum,sum]
-                            InputAdapter
-                              Exchange #9
-                                WholeStageCodegen (13)
-                                  HashAggregate [cr_return_amount,cr_net_loss] [sum,sum,sum,sum]
-                                    Project [cr_return_amount,cr_net_loss]
-                                      BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.catalog_returns [cr_return_amount,cr_net_loss,cr_returned_date_sk]
-                                              ReusedSubquery [d_date_sk] #1
+                                              Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
+                                                SubqueryBroadcast [d_date_sk] #1
+                                                  BroadcastExchange #3
+                                                    WholeStageCodegen (1)
+                                                      Project [d_date_sk]
+                                                        Filter [d_date,d_date_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
                                         InputAdapter
                                           ReusedExchange [d_date_sk] #3
-                    WholeStageCodegen (22)
-                      Project [sales,returns,profit,profit_loss,wp_web_page_sk]
-                        BroadcastHashJoin [wp_web_page_sk,wp_web_page_sk]
-                          HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(ws_ext_sales_price)),sum(UnscaledValue(ws_net_profit)),sales,profit,sum,sum]
-                            InputAdapter
-                              Exchange [wp_web_page_sk] #10
-                                WholeStageCodegen (17)
-                                  HashAggregate [wp_web_page_sk,ws_ext_sales_price,ws_net_profit] [sum,sum,sum,sum]
-                                    Project [ws_ext_sales_price,ws_net_profit,wp_web_page_sk]
-                                      BroadcastHashJoin [ws_web_page_sk,wp_web_page_sk]
-                                        Project [ws_web_page_sk,ws_ext_sales_price,ws_net_profit]
-                                          BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                            Filter [ws_web_page_sk]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet spark_catalog.default.web_sales [ws_web_page_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
-                                                    ReusedSubquery [d_date_sk] #1
-                                            InputAdapter
-                                              ReusedExchange [d_date_sk] #3
-                                        InputAdapter
-                                          BroadcastExchange #11
-                                            WholeStageCodegen (16)
-                                              Filter [wp_web_page_sk]
+                                    InputAdapter
+                                      BroadcastExchange #4
+                                        WholeStageCodegen (2)
+                                          Filter [s_store_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.store [s_store_sk]
+                      InputAdapter
+                        BroadcastExchange #5
+                          WholeStageCodegen (7)
+                            HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(sr_return_amt)),sum(UnscaledValue(sr_net_loss)),returns,profit_loss,sum,sum]
+                              InputAdapter
+                                Exchange [s_store_sk] #6
+                                  WholeStageCodegen (6)
+                                    HashAggregate [s_store_sk,sr_return_amt,sr_net_loss] [sum,sum,sum,sum]
+                                      Project [sr_return_amt,sr_net_loss,s_store_sk]
+                                        BroadcastHashJoin [sr_store_sk,s_store_sk]
+                                          Project [sr_store_sk,sr_return_amt,sr_net_loss]
+                                            BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
+                                              Filter [sr_store_sk]
                                                 ColumnarToRow
                                                   InputAdapter
-                                                    Scan parquet spark_catalog.default.web_page [wp_web_page_sk]
-                          InputAdapter
-                            BroadcastExchange #12
-                              WholeStageCodegen (21)
-                                HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(wr_return_amt)),sum(UnscaledValue(wr_net_loss)),returns,profit_loss,sum,sum]
-                                  InputAdapter
-                                    Exchange [wp_web_page_sk] #13
-                                      WholeStageCodegen (20)
-                                        HashAggregate [wp_web_page_sk,wr_return_amt,wr_net_loss] [sum,sum,sum,sum]
-                                          Project [wr_return_amt,wr_net_loss,wp_web_page_sk]
-                                            BroadcastHashJoin [wr_web_page_sk,wp_web_page_sk]
-                                              Project [wr_web_page_sk,wr_return_amt,wr_net_loss]
-                                                BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
-                                                  Filter [wr_web_page_sk]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.web_returns [wr_web_page_sk,wr_return_amt,wr_net_loss,wr_returned_date_sk]
-                                                          ReusedSubquery [d_date_sk] #1
-                                                  InputAdapter
-                                                    ReusedExchange [d_date_sk] #3
+                                                    Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
+                                                      ReusedSubquery [d_date_sk] #1
                                               InputAdapter
-                                                ReusedExchange [wp_web_page_sk] #11
+                                                ReusedExchange [d_date_sk] #3
+                                          InputAdapter
+                                            ReusedExchange [s_store_sk] #4
+                  Project [sales,returns,profit,profit_loss,cs_call_center_sk]
+                    BroadcastNestedLoopJoin
+                      InputAdapter
+                        BroadcastExchange #7
+                          WholeStageCodegen (10)
+                            HashAggregate [cs_call_center_sk,sum,sum] [sum(UnscaledValue(cs_ext_sales_price)),sum(UnscaledValue(cs_net_profit)),sales,profit,sum,sum]
+                              InputAdapter
+                                Exchange [cs_call_center_sk] #8
+                                  WholeStageCodegen (9)
+                                    HashAggregate [cs_call_center_sk,cs_ext_sales_price,cs_net_profit] [sum,sum,sum,sum]
+                                      Project [cs_call_center_sk,cs_ext_sales_price,cs_net_profit]
+                                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                          ColumnarToRow
+                                            InputAdapter
+                                              Scan parquet spark_catalog.default.catalog_sales [cs_call_center_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
+                                                ReusedSubquery [d_date_sk] #1
+                                          InputAdapter
+                                            ReusedExchange [d_date_sk] #3
+                      HashAggregate [sum,sum] [sum(UnscaledValue(cr_return_amount)),sum(UnscaledValue(cr_net_loss)),returns,profit_loss,sum,sum]
+                        InputAdapter
+                          Exchange #9
+                            WholeStageCodegen (12)
+                              HashAggregate [cr_return_amount,cr_net_loss] [sum,sum,sum,sum]
+                                Project [cr_return_amount,cr_net_loss]
+                                  BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet spark_catalog.default.catalog_returns [cr_return_amount,cr_net_loss,cr_returned_date_sk]
+                                          ReusedSubquery [d_date_sk] #1
+                                    InputAdapter
+                                      ReusedExchange [d_date_sk] #3
+                  Project [sales,returns,profit,profit_loss,wp_web_page_sk]
+                    BroadcastHashJoin [wp_web_page_sk,wp_web_page_sk]
+                      HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(ws_ext_sales_price)),sum(UnscaledValue(ws_net_profit)),sales,profit,sum,sum]
+                        InputAdapter
+                          Exchange [wp_web_page_sk] #10
+                            WholeStageCodegen (15)
+                              HashAggregate [wp_web_page_sk,ws_ext_sales_price,ws_net_profit] [sum,sum,sum,sum]
+                                Project [ws_ext_sales_price,ws_net_profit,wp_web_page_sk]
+                                  BroadcastHashJoin [ws_web_page_sk,wp_web_page_sk]
+                                    Project [ws_web_page_sk,ws_ext_sales_price,ws_net_profit]
+                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                        Filter [ws_web_page_sk]
+                                          ColumnarToRow
+                                            InputAdapter
+                                              Scan parquet spark_catalog.default.web_sales [ws_web_page_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
+                                                ReusedSubquery [d_date_sk] #1
+                                        InputAdapter
+                                          ReusedExchange [d_date_sk] #3
+                                    InputAdapter
+                                      BroadcastExchange #11
+                                        WholeStageCodegen (14)
+                                          Filter [wp_web_page_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.web_page [wp_web_page_sk]
+                      InputAdapter
+                        BroadcastExchange #12
+                          WholeStageCodegen (19)
+                            HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(wr_return_amt)),sum(UnscaledValue(wr_net_loss)),returns,profit_loss,sum,sum]
+                              InputAdapter
+                                Exchange [wp_web_page_sk] #13
+                                  WholeStageCodegen (18)
+                                    HashAggregate [wp_web_page_sk,wr_return_amt,wr_net_loss] [sum,sum,sum,sum]
+                                      Project [wr_return_amt,wr_net_loss,wp_web_page_sk]
+                                        BroadcastHashJoin [wr_web_page_sk,wp_web_page_sk]
+                                          Project [wr_web_page_sk,wr_return_amt,wr_net_loss]
+                                            BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
+                                              Filter [wr_web_page_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet spark_catalog.default.web_returns [wr_web_page_sk,wr_return_amt,wr_net_loss,wr_returned_date_sk]
+                                                      ReusedSubquery [d_date_sk] #1
+                                              InputAdapter
+                                                ReusedExchange [d_date_sk] #3
+                                          InputAdapter
+                                            ReusedExchange [wp_web_page_sk] #11

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/explain.txt
@@ -25,7 +25,7 @@ TakeOrderedAndProject (45)
                :        :     :              +- ReusedExchange (8)
                :        :     +- * Sort (26)
                :        :        +- Exchange (25)
-               :        :           +- Union (24)
+               :        :           +- * Union (24)
                :        :              :- * Project (18)
                :        :              :  +- * BroadcastHashJoin Inner BuildRight (17)
                :        :              :     :- * ColumnarToRow (15)
@@ -112,19 +112,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#10), dynamicpruningexpression(ws_sold_date_sk#10 IN dynamicpruning#7)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
-(15) ColumnarToRow [codegen id : 8]
+(15) ColumnarToRow [codegen id : 9]
 Input [2]: [ws_bill_customer_sk#9, ws_sold_date_sk#10]
 
 (16) ReusedExchange [Reuses operator id: 57]
 Output [1]: [d_date_sk#11]
 
-(17) BroadcastHashJoin [codegen id : 8]
+(17) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ws_sold_date_sk#10]
 Right keys [1]: [d_date_sk#11]
 Join type: Inner
 Join condition: None
 
-(18) Project [codegen id : 8]
+(18) Project [codegen id : 9]
 Output [1]: [ws_bill_customer_sk#9 AS customer_sk#12]
 Input [3]: [ws_bill_customer_sk#9, ws_sold_date_sk#10, d_date_sk#11]
 
@@ -135,39 +135,39 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#14), dynamicpruningexpression(cs_sold_date_sk#14 IN dynamicpruning#7)]
 ReadSchema: struct<cs_ship_customer_sk:int>
 
-(20) ColumnarToRow [codegen id : 10]
+(20) ColumnarToRow
 Input [2]: [cs_ship_customer_sk#13, cs_sold_date_sk#14]
 
 (21) ReusedExchange [Reuses operator id: 57]
 Output [1]: [d_date_sk#15]
 
-(22) BroadcastHashJoin [codegen id : 10]
+(22) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#14]
 Right keys [1]: [d_date_sk#15]
 Join type: Inner
 Join condition: None
 
-(23) Project [codegen id : 10]
+(23) Project
 Output [1]: [cs_ship_customer_sk#13 AS customer_sk#16]
 Input [3]: [cs_ship_customer_sk#13, cs_sold_date_sk#14, d_date_sk#15]
 
-(24) Union
+(24) Union [codegen id : 9]
 
 (25) Exchange
 Input [1]: [customer_sk#12]
 Arguments: hashpartitioning(customer_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(26) Sort [codegen id : 11]
+(26) Sort [codegen id : 10]
 Input [1]: [customer_sk#12]
 Arguments: [customer_sk#12 ASC NULLS FIRST], false, 0
 
-(27) SortMergeJoin [codegen id : 13]
+(27) SortMergeJoin [codegen id : 12]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customer_sk#12]
 Join type: LeftSemi
 Join condition: None
 
-(28) Project [codegen id : 13]
+(28) Project [codegen id : 12]
 Output [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
@@ -178,14 +178,14 @@ Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(30) ColumnarToRow [codegen id : 12]
+(30) ColumnarToRow [codegen id : 11]
 Input [2]: [ca_address_sk#17, ca_county#18]
 
-(31) Filter [codegen id : 12]
+(31) Filter [codegen id : 11]
 Input [2]: [ca_address_sk#17, ca_county#18]
 Condition : (ca_county#18 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#17))
 
-(32) Project [codegen id : 12]
+(32) Project [codegen id : 11]
 Output [1]: [ca_address_sk#17]
 Input [2]: [ca_address_sk#17, ca_county#18]
 
@@ -193,13 +193,13 @@ Input [2]: [ca_address_sk#17, ca_county#18]
 Input [1]: [ca_address_sk#17]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
-(34) BroadcastHashJoin [codegen id : 13]
+(34) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#17]
 Join type: Inner
 Join condition: None
 
-(35) Project [codegen id : 13]
+(35) Project [codegen id : 12]
 Output [1]: [c_current_cdemo_sk#2]
 Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#17]
 
@@ -221,17 +221,17 @@ Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_stat
 Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Condition : isnotnull(cd_demo_sk#19)
 
-(40) BroadcastHashJoin [codegen id : 14]
+(40) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#19]
 Join type: Inner
 Join condition: None
 
-(41) Project [codegen id : 14]
+(41) Project [codegen id : 13]
 Output [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Input [10]: [c_current_cdemo_sk#2, cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 
-(42) HashAggregate [codegen id : 14]
+(42) HashAggregate [codegen id : 13]
 Input [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Keys [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Functions [1]: [partial_count(1)]
@@ -242,7 +242,7 @@ Results [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_pur
 Input [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
 Arguments: hashpartitioning(cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(44) HashAggregate [codegen id : 15]
+(44) HashAggregate [codegen id : 14]
 Input [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
 Keys [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Functions [1]: [count(1)]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/simplified.txt
@@ -1,15 +1,15 @@
 TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,cnt1,cnt2,cnt3,cnt4,cnt5,cnt6]
-  WholeStageCodegen (15)
+  WholeStageCodegen (14)
     HashAggregate [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,count] [count(1),cnt1,cnt2,cnt3,cnt4,cnt5,cnt6,count]
       InputAdapter
         Exchange [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] #1
-          WholeStageCodegen (14)
+          WholeStageCodegen (13)
             HashAggregate [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] [count,count]
               Project [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
                 BroadcastHashJoin [c_current_cdemo_sk,cd_demo_sk]
                   InputAdapter
                     BroadcastExchange #2
-                      WholeStageCodegen (13)
+                      WholeStageCodegen (12)
                         Project [c_current_cdemo_sk]
                           BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
                             Project [c_current_cdemo_sk,c_current_addr_sk]
@@ -59,12 +59,12 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                       InputAdapter
                                                         ReusedExchange [d_date_sk] #6
                                 InputAdapter
-                                  WholeStageCodegen (11)
+                                  WholeStageCodegen (10)
                                     Sort [customer_sk]
                                       InputAdapter
                                         Exchange [customer_sk] #7
-                                          Union
-                                            WholeStageCodegen (8)
+                                          WholeStageCodegen (9)
+                                            Union
                                               Project [ws_bill_customer_sk]
                                                 BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                   ColumnarToRow
@@ -73,7 +73,6 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                         ReusedSubquery [d_date_sk] #2
                                                   InputAdapter
                                                     ReusedExchange [d_date_sk] #6
-                                            WholeStageCodegen (10)
                                               Project [cs_ship_customer_sk]
                                                 BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                   ColumnarToRow
@@ -84,7 +83,7 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                     ReusedExchange [d_date_sk] #6
                             InputAdapter
                               BroadcastExchange #8
-                                WholeStageCodegen (12)
+                                WholeStageCodegen (11)
                                   Project [ca_address_sk]
                                     Filter [ca_county,ca_address_sk]
                                       ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a/explain.txt
@@ -20,7 +20,7 @@ TakeOrderedAndProject (41)
                :     :     :           :  +- Scan parquet spark_catalog.default.store_sales (4)
                :     :     :           +- ReusedExchange (6)
                :     :     +- BroadcastExchange (22)
-               :     :        +- Union (21)
+               :     :        +- * Union (21)
                :     :           :- * Project (15)
                :     :           :  +- * BroadcastHashJoin Inner BuildRight (14)
                :     :           :     :- * ColumnarToRow (12)
@@ -49,10 +49,10 @@ Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_current_addr_sk), IsNotNull(c_current_cdemo_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int>
 
-(2) ColumnarToRow [codegen id : 9]
+(2) ColumnarToRow [codegen id : 8]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
-(3) Filter [codegen id : 9]
+(3) Filter [codegen id : 8]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 Condition : (isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2))
 
@@ -83,7 +83,7 @@ Input [3]: [ss_customer_sk#4, ss_sold_date_sk#5, d_date_sk#7]
 Input [1]: [ss_customer_sk#4]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(10) BroadcastHashJoin [codegen id : 9]
+(10) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#4]
 Join type: LeftSemi
@@ -96,19 +96,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#9), dynamicpruningexpression(ws_sold_date_sk#9 IN dynamicpruning#6)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
-(12) ColumnarToRow [codegen id : 4]
+(12) ColumnarToRow [codegen id : 5]
 Input [2]: [ws_bill_customer_sk#8, ws_sold_date_sk#9]
 
 (13) ReusedExchange [Reuses operator id: 46]
 Output [1]: [d_date_sk#10]
 
-(14) BroadcastHashJoin [codegen id : 4]
+(14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_sold_date_sk#9]
 Right keys [1]: [d_date_sk#10]
 Join type: Inner
 Join condition: None
 
-(15) Project [codegen id : 4]
+(15) Project [codegen id : 5]
 Output [1]: [ws_bill_customer_sk#8 AS customer_sk#11]
 Input [3]: [ws_bill_customer_sk#8, ws_sold_date_sk#9, d_date_sk#10]
 
@@ -119,35 +119,35 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#13), dynamicpruningexpression(cs_sold_date_sk#13 IN dynamicpruning#6)]
 ReadSchema: struct<cs_ship_customer_sk:int>
 
-(17) ColumnarToRow [codegen id : 6]
+(17) ColumnarToRow
 Input [2]: [cs_ship_customer_sk#12, cs_sold_date_sk#13]
 
 (18) ReusedExchange [Reuses operator id: 46]
 Output [1]: [d_date_sk#14]
 
-(19) BroadcastHashJoin [codegen id : 6]
+(19) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#13]
 Right keys [1]: [d_date_sk#14]
 Join type: Inner
 Join condition: None
 
-(20) Project [codegen id : 6]
+(20) Project
 Output [1]: [cs_ship_customer_sk#12 AS customer_sk#15]
 Input [3]: [cs_ship_customer_sk#12, cs_sold_date_sk#13, d_date_sk#14]
 
-(21) Union
+(21) Union [codegen id : 5]
 
 (22) BroadcastExchange
 Input [1]: [customer_sk#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
-(23) BroadcastHashJoin [codegen id : 9]
+(23) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customer_sk#11]
 Join type: LeftSemi
 Join condition: None
 
-(24) Project [codegen id : 9]
+(24) Project [codegen id : 8]
 Output [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
@@ -158,14 +158,14 @@ Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(26) ColumnarToRow [codegen id : 7]
+(26) ColumnarToRow [codegen id : 6]
 Input [2]: [ca_address_sk#16, ca_county#17]
 
-(27) Filter [codegen id : 7]
+(27) Filter [codegen id : 6]
 Input [2]: [ca_address_sk#16, ca_county#17]
 Condition : (ca_county#17 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#16))
 
-(28) Project [codegen id : 7]
+(28) Project [codegen id : 6]
 Output [1]: [ca_address_sk#16]
 Input [2]: [ca_address_sk#16, ca_county#17]
 
@@ -173,13 +173,13 @@ Input [2]: [ca_address_sk#16, ca_county#17]
 Input [1]: [ca_address_sk#16]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
 
-(30) BroadcastHashJoin [codegen id : 9]
+(30) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#16]
 Join type: Inner
 Join condition: None
 
-(31) Project [codegen id : 9]
+(31) Project [codegen id : 8]
 Output [1]: [c_current_cdemo_sk#2]
 Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#16]
 
@@ -190,10 +190,10 @@ Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
-(33) ColumnarToRow [codegen id : 8]
+(33) ColumnarToRow [codegen id : 7]
 Input [9]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, cd_dep_count#24, cd_dep_employed_count#25, cd_dep_college_count#26]
 
-(34) Filter [codegen id : 8]
+(34) Filter [codegen id : 7]
 Input [9]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, cd_dep_count#24, cd_dep_employed_count#25, cd_dep_college_count#26]
 Condition : isnotnull(cd_demo_sk#18)
 
@@ -201,17 +201,17 @@ Condition : isnotnull(cd_demo_sk#18)
 Input [9]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, cd_dep_count#24, cd_dep_employed_count#25, cd_dep_college_count#26]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
-(36) BroadcastHashJoin [codegen id : 9]
+(36) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#18]
 Join type: Inner
 Join condition: None
 
-(37) Project [codegen id : 9]
+(37) Project [codegen id : 8]
 Output [8]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, cd_dep_count#24, cd_dep_employed_count#25, cd_dep_college_count#26]
 Input [10]: [c_current_cdemo_sk#2, cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, cd_dep_count#24, cd_dep_employed_count#25, cd_dep_college_count#26]
 
-(38) HashAggregate [codegen id : 9]
+(38) HashAggregate [codegen id : 8]
 Input [8]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, cd_dep_count#24, cd_dep_employed_count#25, cd_dep_college_count#26]
 Keys [8]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, cd_dep_count#24, cd_dep_employed_count#25, cd_dep_college_count#26]
 Functions [1]: [partial_count(1)]
@@ -222,7 +222,7 @@ Results [9]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_pur
 Input [9]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, cd_dep_count#24, cd_dep_employed_count#25, cd_dep_college_count#26, count#28]
 Arguments: hashpartitioning(cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, cd_dep_count#24, cd_dep_employed_count#25, cd_dep_college_count#26, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(40) HashAggregate [codegen id : 10]
+(40) HashAggregate [codegen id : 9]
 Input [9]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, cd_dep_count#24, cd_dep_employed_count#25, cd_dep_college_count#26, count#28]
 Keys [8]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, cd_dep_count#24, cd_dep_employed_count#25, cd_dep_college_count#26]
 Functions [1]: [count(1)]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a/simplified.txt
@@ -1,9 +1,9 @@
 TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,cnt1,cnt2,cnt3,cnt4,cnt5,cnt6]
-  WholeStageCodegen (10)
+  WholeStageCodegen (9)
     HashAggregate [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,count] [count(1),cnt1,cnt2,cnt3,cnt4,cnt5,cnt6,count]
       InputAdapter
         Exchange [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] #1
-          WholeStageCodegen (9)
+          WholeStageCodegen (8)
             HashAggregate [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] [count,count]
               Project [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
                 BroadcastHashJoin [c_current_cdemo_sk,cd_demo_sk]
@@ -36,8 +36,8 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                         ReusedExchange [d_date_sk] #3
                           InputAdapter
                             BroadcastExchange #4
-                              Union
-                                WholeStageCodegen (4)
+                              WholeStageCodegen (5)
+                                Union
                                   Project [ws_bill_customer_sk]
                                     BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                       ColumnarToRow
@@ -46,7 +46,6 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                             ReusedSubquery [d_date_sk] #1
                                       InputAdapter
                                         ReusedExchange [d_date_sk] #3
-                                WholeStageCodegen (6)
                                   Project [cs_ship_customer_sk]
                                     BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                       ColumnarToRow
@@ -57,7 +56,7 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                         ReusedExchange [d_date_sk] #3
                       InputAdapter
                         BroadcastExchange #5
-                          WholeStageCodegen (7)
+                          WholeStageCodegen (6)
                             Project [ca_address_sk]
                               Filter [ca_county,ca_address_sk]
                                 ColumnarToRow
@@ -65,7 +64,7 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                     Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
                   InputAdapter
                     BroadcastExchange #6
-                      WholeStageCodegen (8)
+                      WholeStageCodegen (7)
                         Filter [cd_demo_sk]
                           ColumnarToRow
                             InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/explain.txt
@@ -523,7 +523,7 @@ Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquer
 * HashAggregate (109)
 +- Exchange (108)
    +- * HashAggregate (107)
-      +- Union (106)
+      +- * Union (106)
          :- * Project (95)
          :  +- * BroadcastHashJoin Inner BuildRight (94)
          :     :- * ColumnarToRow (92)
@@ -548,19 +548,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ss_sold_date_sk#77), dynamicpruningexpression(ss_sold_date_sk#77 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(92) ColumnarToRow [codegen id : 2]
+(92) ColumnarToRow [codegen id : 4]
 Input [3]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77]
 
 (93) ReusedExchange [Reuses operator id: 123]
 Output [1]: [d_date_sk#78]
 
-(94) BroadcastHashJoin [codegen id : 2]
+(94) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#77]
 Right keys [1]: [d_date_sk#78]
 Join type: Inner
 Join condition: None
 
-(95) Project [codegen id : 2]
+(95) Project [codegen id : 4]
 Output [2]: [ss_quantity#75 AS quantity#79, ss_list_price#76 AS list_price#80]
 Input [4]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77, d_date_sk#78]
 
@@ -571,19 +571,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#83), dynamicpruningexpression(cs_sold_date_sk#83 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(97) ColumnarToRow [codegen id : 4]
+(97) ColumnarToRow
 Input [3]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83]
 
 (98) ReusedExchange [Reuses operator id: 123]
 Output [1]: [d_date_sk#84]
 
-(99) BroadcastHashJoin [codegen id : 4]
+(99) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#83]
 Right keys [1]: [d_date_sk#84]
 Join type: Inner
 Join condition: None
 
-(100) Project [codegen id : 4]
+(100) Project
 Output [2]: [cs_quantity#81 AS quantity#85, cs_list_price#82 AS list_price#86]
 Input [4]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83, d_date_sk#84]
 
@@ -594,25 +594,25 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#89), dynamicpruningexpression(ws_sold_date_sk#89 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(102) ColumnarToRow [codegen id : 6]
+(102) ColumnarToRow
 Input [3]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89]
 
 (103) ReusedExchange [Reuses operator id: 123]
 Output [1]: [d_date_sk#90]
 
-(104) BroadcastHashJoin [codegen id : 6]
+(104) BroadcastHashJoin
 Left keys [1]: [ws_sold_date_sk#89]
 Right keys [1]: [d_date_sk#90]
 Join type: Inner
 Join condition: None
 
-(105) Project [codegen id : 6]
+(105) Project
 Output [2]: [ws_quantity#87 AS quantity#91, ws_list_price#88 AS list_price#92]
 Input [4]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89, d_date_sk#90]
 
-(106) Union
+(106) Union [codegen id : 4]
 
-(107) HashAggregate [codegen id : 7]
+(107) HashAggregate [codegen id : 4]
 Input [2]: [quantity#79, list_price#80]
 Keys: []
 Functions [1]: [partial_avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]
@@ -623,7 +623,7 @@ Results [2]: [sum#95, count#96]
 Input [2]: [sum#95, count#96]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
 
-(109) HashAggregate [codegen id : 8]
+(109) HashAggregate [codegen id : 5]
 Input [2]: [sum#95, count#96]
 Keys: []
 Functions [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/simplified.txt
@@ -3,41 +3,37 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
     BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
       Filter [sales]
         Subquery #4
-          WholeStageCodegen (8)
+          WholeStageCodegen (5)
             HashAggregate [sum,count] [avg((cast(quantity as decimal(10,0)) * list_price)),average_sales,sum,count]
               InputAdapter
                 Exchange #14
-                  WholeStageCodegen (7)
+                  WholeStageCodegen (4)
                     HashAggregate [quantity,list_price] [sum,count,sum,count]
-                      InputAdapter
-                        Union
-                          WholeStageCodegen (2)
-                            Project [ss_quantity,ss_list_price]
-                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
-                                      ReusedSubquery [d_date_sk] #3
-                                InputAdapter
-                                  ReusedExchange [d_date_sk] #7
-                          WholeStageCodegen (4)
-                            Project [cs_quantity,cs_list_price]
-                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
-                                      ReusedSubquery [d_date_sk] #3
-                                InputAdapter
-                                  ReusedExchange [d_date_sk] #7
-                          WholeStageCodegen (6)
-                            Project [ws_quantity,ws_list_price]
-                              BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
-                                      ReusedSubquery [d_date_sk] #3
-                                InputAdapter
-                                  ReusedExchange [d_date_sk] #7
+                      Union
+                        Project [ss_quantity,ss_list_price]
+                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
+                                  ReusedSubquery [d_date_sk] #3
+                            InputAdapter
+                              ReusedExchange [d_date_sk] #7
+                        Project [cs_quantity,cs_list_price]
+                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
+                                  ReusedSubquery [d_date_sk] #3
+                            InputAdapter
+                              ReusedExchange [d_date_sk] #7
+                        Project [ws_quantity,ws_list_price]
+                          BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
+                                  ReusedSubquery [d_date_sk] #3
+                            InputAdapter
+                              ReusedExchange [d_date_sk] #7
         HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum((cast(ss_quantity as decimal(10,0)) * ss_list_price)),count(1),channel,sales,number_sales,sum,isEmpty,count]
           InputAdapter
             Exchange [i_brand_id,i_class_id,i_category_id] #1

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/explain.txt
@@ -493,7 +493,7 @@ Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquer
 * HashAggregate (103)
 +- Exchange (102)
    +- * HashAggregate (101)
-      +- Union (100)
+      +- * Union (100)
          :- * Project (89)
          :  +- * BroadcastHashJoin Inner BuildRight (88)
          :     :- * ColumnarToRow (86)
@@ -518,19 +518,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ss_sold_date_sk#77), dynamicpruningexpression(ss_sold_date_sk#77 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(86) ColumnarToRow [codegen id : 2]
+(86) ColumnarToRow [codegen id : 4]
 Input [3]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77]
 
 (87) ReusedExchange [Reuses operator id: 117]
 Output [1]: [d_date_sk#78]
 
-(88) BroadcastHashJoin [codegen id : 2]
+(88) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#77]
 Right keys [1]: [d_date_sk#78]
 Join type: Inner
 Join condition: None
 
-(89) Project [codegen id : 2]
+(89) Project [codegen id : 4]
 Output [2]: [ss_quantity#75 AS quantity#79, ss_list_price#76 AS list_price#80]
 Input [4]: [ss_quantity#75, ss_list_price#76, ss_sold_date_sk#77, d_date_sk#78]
 
@@ -541,19 +541,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#83), dynamicpruningexpression(cs_sold_date_sk#83 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(91) ColumnarToRow [codegen id : 4]
+(91) ColumnarToRow
 Input [3]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83]
 
 (92) ReusedExchange [Reuses operator id: 117]
 Output [1]: [d_date_sk#84]
 
-(93) BroadcastHashJoin [codegen id : 4]
+(93) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#83]
 Right keys [1]: [d_date_sk#84]
 Join type: Inner
 Join condition: None
 
-(94) Project [codegen id : 4]
+(94) Project
 Output [2]: [cs_quantity#81 AS quantity#85, cs_list_price#82 AS list_price#86]
 Input [4]: [cs_quantity#81, cs_list_price#82, cs_sold_date_sk#83, d_date_sk#84]
 
@@ -564,25 +564,25 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#89), dynamicpruningexpression(ws_sold_date_sk#89 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(96) ColumnarToRow [codegen id : 6]
+(96) ColumnarToRow
 Input [3]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89]
 
 (97) ReusedExchange [Reuses operator id: 117]
 Output [1]: [d_date_sk#90]
 
-(98) BroadcastHashJoin [codegen id : 6]
+(98) BroadcastHashJoin
 Left keys [1]: [ws_sold_date_sk#89]
 Right keys [1]: [d_date_sk#90]
 Join type: Inner
 Join condition: None
 
-(99) Project [codegen id : 6]
+(99) Project
 Output [2]: [ws_quantity#87 AS quantity#91, ws_list_price#88 AS list_price#92]
 Input [4]: [ws_quantity#87, ws_list_price#88, ws_sold_date_sk#89, d_date_sk#90]
 
-(100) Union
+(100) Union [codegen id : 4]
 
-(101) HashAggregate [codegen id : 7]
+(101) HashAggregate [codegen id : 4]
 Input [2]: [quantity#79, list_price#80]
 Keys: []
 Functions [1]: [partial_avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]
@@ -593,7 +593,7 @@ Results [2]: [sum#95, count#96]
 Input [2]: [sum#95, count#96]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
 
-(103) HashAggregate [codegen id : 8]
+(103) HashAggregate [codegen id : 5]
 Input [2]: [sum#95, count#96]
 Keys: []
 Functions [1]: [avg((cast(quantity#79 as decimal(10,0)) * list_price#80))]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/simplified.txt
@@ -3,41 +3,37 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
     BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
       Filter [sales]
         Subquery #4
-          WholeStageCodegen (8)
+          WholeStageCodegen (5)
             HashAggregate [sum,count] [avg((cast(quantity as decimal(10,0)) * list_price)),average_sales,sum,count]
               InputAdapter
                 Exchange #12
-                  WholeStageCodegen (7)
+                  WholeStageCodegen (4)
                     HashAggregate [quantity,list_price] [sum,count,sum,count]
-                      InputAdapter
-                        Union
-                          WholeStageCodegen (2)
-                            Project [ss_quantity,ss_list_price]
-                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
-                                      ReusedSubquery [d_date_sk] #3
-                                InputAdapter
-                                  ReusedExchange [d_date_sk] #6
-                          WholeStageCodegen (4)
-                            Project [cs_quantity,cs_list_price]
-                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
-                                      ReusedSubquery [d_date_sk] #3
-                                InputAdapter
-                                  ReusedExchange [d_date_sk] #6
-                          WholeStageCodegen (6)
-                            Project [ws_quantity,ws_list_price]
-                              BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
-                                      ReusedSubquery [d_date_sk] #3
-                                InputAdapter
-                                  ReusedExchange [d_date_sk] #6
+                      Union
+                        Project [ss_quantity,ss_list_price]
+                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
+                                  ReusedSubquery [d_date_sk] #3
+                            InputAdapter
+                              ReusedExchange [d_date_sk] #6
+                        Project [cs_quantity,cs_list_price]
+                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
+                                  ReusedSubquery [d_date_sk] #3
+                            InputAdapter
+                              ReusedExchange [d_date_sk] #6
+                        Project [ws_quantity,ws_list_price]
+                          BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
+                                  ReusedSubquery [d_date_sk] #3
+                            InputAdapter
+                              ReusedExchange [d_date_sk] #6
         HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum((cast(ss_quantity as decimal(10,0)) * ss_list_price)),count(1),channel,sales,number_sales,sum,isEmpty,count]
           InputAdapter
             Exchange [i_brand_id,i_class_id,i_category_id] #1

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
@@ -1005,7 +1005,7 @@ Subquery:1 Hosting operator id = 72 Hosting Expression = Subquery scalar-subquer
 * HashAggregate (189)
 +- Exchange (188)
    +- * HashAggregate (187)
-      +- Union (186)
+      +- * Union (186)
          :- * Project (175)
          :  +- * BroadcastHashJoin Inner BuildRight (174)
          :     :- * ColumnarToRow (172)
@@ -1030,19 +1030,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ss_sold_date_sk#309), dynamicpruningexpression(ss_sold_date_sk#309 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(172) ColumnarToRow [codegen id : 2]
+(172) ColumnarToRow [codegen id : 4]
 Input [3]: [ss_quantity#307, ss_list_price#308, ss_sold_date_sk#309]
 
 (173) ReusedExchange [Reuses operator id: 204]
 Output [1]: [d_date_sk#310]
 
-(174) BroadcastHashJoin [codegen id : 2]
+(174) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#309]
 Right keys [1]: [d_date_sk#310]
 Join type: Inner
 Join condition: None
 
-(175) Project [codegen id : 2]
+(175) Project [codegen id : 4]
 Output [2]: [ss_quantity#307 AS quantity#311, ss_list_price#308 AS list_price#312]
 Input [4]: [ss_quantity#307, ss_list_price#308, ss_sold_date_sk#309, d_date_sk#310]
 
@@ -1053,19 +1053,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#315), dynamicpruningexpression(cs_sold_date_sk#315 IN dynamicpruning#316)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(177) ColumnarToRow [codegen id : 4]
+(177) ColumnarToRow
 Input [3]: [cs_quantity#313, cs_list_price#314, cs_sold_date_sk#315]
 
 (178) ReusedExchange [Reuses operator id: 194]
 Output [1]: [d_date_sk#317]
 
-(179) BroadcastHashJoin [codegen id : 4]
+(179) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#315]
 Right keys [1]: [d_date_sk#317]
 Join type: Inner
 Join condition: None
 
-(180) Project [codegen id : 4]
+(180) Project
 Output [2]: [cs_quantity#313 AS quantity#318, cs_list_price#314 AS list_price#319]
 Input [4]: [cs_quantity#313, cs_list_price#314, cs_sold_date_sk#315, d_date_sk#317]
 
@@ -1076,25 +1076,25 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#322), dynamicpruningexpression(ws_sold_date_sk#322 IN dynamicpruning#316)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(182) ColumnarToRow [codegen id : 6]
+(182) ColumnarToRow
 Input [3]: [ws_quantity#320, ws_list_price#321, ws_sold_date_sk#322]
 
 (183) ReusedExchange [Reuses operator id: 194]
 Output [1]: [d_date_sk#323]
 
-(184) BroadcastHashJoin [codegen id : 6]
+(184) BroadcastHashJoin
 Left keys [1]: [ws_sold_date_sk#322]
 Right keys [1]: [d_date_sk#323]
 Join type: Inner
 Join condition: None
 
-(185) Project [codegen id : 6]
+(185) Project
 Output [2]: [ws_quantity#320 AS quantity#324, ws_list_price#321 AS list_price#325]
 Input [4]: [ws_quantity#320, ws_list_price#321, ws_sold_date_sk#322, d_date_sk#323]
 
-(186) Union
+(186) Union [codegen id : 4]
 
-(187) HashAggregate [codegen id : 7]
+(187) HashAggregate [codegen id : 4]
 Input [2]: [quantity#311, list_price#312]
 Keys: []
 Functions [1]: [partial_avg((cast(quantity#311 as decimal(10,0)) * list_price#312))]
@@ -1105,7 +1105,7 @@ Results [2]: [sum#328, count#329]
 Input [2]: [sum#328, count#329]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=20]
 
-(189) HashAggregate [codegen id : 8]
+(189) HashAggregate [codegen id : 5]
 Input [2]: [sum#328, count#329]
 Keys: []
 Functions [1]: [avg((cast(quantity#311 as decimal(10,0)) * list_price#312))]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/simplified.txt
@@ -15,48 +15,44 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,num
                             WholeStageCodegen (38)
                               Filter [sales]
                                 Subquery #3
-                                  WholeStageCodegen (8)
+                                  WholeStageCodegen (5)
                                     HashAggregate [sum,count] [avg((cast(quantity as decimal(10,0)) * list_price)),average_sales,sum,count]
                                       InputAdapter
                                         Exchange #15
-                                          WholeStageCodegen (7)
+                                          WholeStageCodegen (4)
                                             HashAggregate [quantity,list_price] [sum,count,sum,count]
-                                              InputAdapter
-                                                Union
-                                                  WholeStageCodegen (2)
-                                                    Project [ss_quantity,ss_list_price]
-                                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
-                                                              ReusedSubquery [d_date_sk] #2
-                                                        InputAdapter
-                                                          ReusedExchange [d_date_sk] #8
-                                                  WholeStageCodegen (4)
-                                                    Project [cs_quantity,cs_list_price]
-                                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
-                                                              SubqueryBroadcast [d_date_sk] #4
-                                                                BroadcastExchange #16
-                                                                  WholeStageCodegen (1)
-                                                                    Project [d_date_sk]
-                                                                      Filter [d_year,d_date_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
-                                                        InputAdapter
-                                                          ReusedExchange [d_date_sk] #16
-                                                  WholeStageCodegen (6)
-                                                    Project [ws_quantity,ws_list_price]
-                                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
-                                                              ReusedSubquery [d_date_sk] #4
-                                                        InputAdapter
-                                                          ReusedExchange [d_date_sk] #16
+                                              Union
+                                                Project [ss_quantity,ss_list_price]
+                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
+                                                          ReusedSubquery [d_date_sk] #2
+                                                    InputAdapter
+                                                      ReusedExchange [d_date_sk] #8
+                                                Project [cs_quantity,cs_list_price]
+                                                  BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
+                                                          SubqueryBroadcast [d_date_sk] #4
+                                                            BroadcastExchange #16
+                                                              WholeStageCodegen (1)
+                                                                Project [d_date_sk]
+                                                                  Filter [d_year,d_date_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
+                                                    InputAdapter
+                                                      ReusedExchange [d_date_sk] #16
+                                                Project [ws_quantity,ws_list_price]
+                                                  BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
+                                                          ReusedSubquery [d_date_sk] #4
+                                                    InputAdapter
+                                                      ReusedExchange [d_date_sk] #16
                                 HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum((cast(ss_quantity as decimal(10,0)) * ss_list_price)),count(1),channel,sales,number_sales,sum,isEmpty,count]
                                   InputAdapter
                                     Exchange [i_brand_id,i_class_id,i_category_id] #2

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/explain.txt
@@ -975,7 +975,7 @@ Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquer
 * HashAggregate (183)
 +- Exchange (182)
    +- * HashAggregate (181)
-      +- Union (180)
+      +- * Union (180)
          :- * Project (169)
          :  +- * BroadcastHashJoin Inner BuildRight (168)
          :     :- * ColumnarToRow (166)
@@ -1000,19 +1000,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ss_sold_date_sk#309), dynamicpruningexpression(ss_sold_date_sk#309 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(166) ColumnarToRow [codegen id : 2]
+(166) ColumnarToRow [codegen id : 4]
 Input [3]: [ss_quantity#307, ss_list_price#308, ss_sold_date_sk#309]
 
 (167) ReusedExchange [Reuses operator id: 198]
 Output [1]: [d_date_sk#310]
 
-(168) BroadcastHashJoin [codegen id : 2]
+(168) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#309]
 Right keys [1]: [d_date_sk#310]
 Join type: Inner
 Join condition: None
 
-(169) Project [codegen id : 2]
+(169) Project [codegen id : 4]
 Output [2]: [ss_quantity#307 AS quantity#311, ss_list_price#308 AS list_price#312]
 Input [4]: [ss_quantity#307, ss_list_price#308, ss_sold_date_sk#309, d_date_sk#310]
 
@@ -1023,19 +1023,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#315), dynamicpruningexpression(cs_sold_date_sk#315 IN dynamicpruning#316)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(171) ColumnarToRow [codegen id : 4]
+(171) ColumnarToRow
 Input [3]: [cs_quantity#313, cs_list_price#314, cs_sold_date_sk#315]
 
 (172) ReusedExchange [Reuses operator id: 188]
 Output [1]: [d_date_sk#317]
 
-(173) BroadcastHashJoin [codegen id : 4]
+(173) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#315]
 Right keys [1]: [d_date_sk#317]
 Join type: Inner
 Join condition: None
 
-(174) Project [codegen id : 4]
+(174) Project
 Output [2]: [cs_quantity#313 AS quantity#318, cs_list_price#314 AS list_price#319]
 Input [4]: [cs_quantity#313, cs_list_price#314, cs_sold_date_sk#315, d_date_sk#317]
 
@@ -1046,25 +1046,25 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#322), dynamicpruningexpression(ws_sold_date_sk#322 IN dynamicpruning#316)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(176) ColumnarToRow [codegen id : 6]
+(176) ColumnarToRow
 Input [3]: [ws_quantity#320, ws_list_price#321, ws_sold_date_sk#322]
 
 (177) ReusedExchange [Reuses operator id: 188]
 Output [1]: [d_date_sk#323]
 
-(178) BroadcastHashJoin [codegen id : 6]
+(178) BroadcastHashJoin
 Left keys [1]: [ws_sold_date_sk#322]
 Right keys [1]: [d_date_sk#323]
 Join type: Inner
 Join condition: None
 
-(179) Project [codegen id : 6]
+(179) Project
 Output [2]: [ws_quantity#320 AS quantity#324, ws_list_price#321 AS list_price#325]
 Input [4]: [ws_quantity#320, ws_list_price#321, ws_sold_date_sk#322, d_date_sk#323]
 
-(180) Union
+(180) Union [codegen id : 4]
 
-(181) HashAggregate [codegen id : 7]
+(181) HashAggregate [codegen id : 4]
 Input [2]: [quantity#311, list_price#312]
 Keys: []
 Functions [1]: [partial_avg((cast(quantity#311 as decimal(10,0)) * list_price#312))]
@@ -1075,7 +1075,7 @@ Results [2]: [sum#328, count#329]
 Input [2]: [sum#328, count#329]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
 
-(183) HashAggregate [codegen id : 8]
+(183) HashAggregate [codegen id : 5]
 Input [2]: [sum#328, count#329]
 Keys: []
 Functions [1]: [avg((cast(quantity#311 as decimal(10,0)) * list_price#312))]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/simplified.txt
@@ -15,48 +15,44 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,num
                             WholeStageCodegen (26)
                               Filter [sales]
                                 Subquery #3
-                                  WholeStageCodegen (8)
+                                  WholeStageCodegen (5)
                                     HashAggregate [sum,count] [avg((cast(quantity as decimal(10,0)) * list_price)),average_sales,sum,count]
                                       InputAdapter
                                         Exchange #13
-                                          WholeStageCodegen (7)
+                                          WholeStageCodegen (4)
                                             HashAggregate [quantity,list_price] [sum,count,sum,count]
-                                              InputAdapter
-                                                Union
-                                                  WholeStageCodegen (2)
-                                                    Project [ss_quantity,ss_list_price]
-                                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
-                                                              ReusedSubquery [d_date_sk] #2
-                                                        InputAdapter
-                                                          ReusedExchange [d_date_sk] #7
-                                                  WholeStageCodegen (4)
-                                                    Project [cs_quantity,cs_list_price]
-                                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
-                                                              SubqueryBroadcast [d_date_sk] #4
-                                                                BroadcastExchange #14
-                                                                  WholeStageCodegen (1)
-                                                                    Project [d_date_sk]
-                                                                      Filter [d_year,d_date_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
-                                                        InputAdapter
-                                                          ReusedExchange [d_date_sk] #14
-                                                  WholeStageCodegen (6)
-                                                    Project [ws_quantity,ws_list_price]
-                                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
-                                                              ReusedSubquery [d_date_sk] #4
-                                                        InputAdapter
-                                                          ReusedExchange [d_date_sk] #14
+                                              Union
+                                                Project [ss_quantity,ss_list_price]
+                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
+                                                          ReusedSubquery [d_date_sk] #2
+                                                    InputAdapter
+                                                      ReusedExchange [d_date_sk] #7
+                                                Project [cs_quantity,cs_list_price]
+                                                  BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
+                                                          SubqueryBroadcast [d_date_sk] #4
+                                                            BroadcastExchange #14
+                                                              WholeStageCodegen (1)
+                                                                Project [d_date_sk]
+                                                                  Filter [d_year,d_date_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
+                                                    InputAdapter
+                                                      ReusedExchange [d_date_sk] #14
+                                                Project [ws_quantity,ws_list_price]
+                                                  BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
+                                                          ReusedSubquery [d_date_sk] #4
+                                                    InputAdapter
+                                                      ReusedExchange [d_date_sk] #14
                                 HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum((cast(ss_quantity as decimal(10,0)) * ss_list_price)),count(1),channel,sales,number_sales,sum,isEmpty,count]
                                   InputAdapter
                                     Exchange [i_brand_id,i_class_id,i_category_id] #2

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a/explain.txt
@@ -1,6 +1,6 @@
 == Physical Plan ==
 TakeOrderedAndProject (153)
-+- Union (152)
++- * Union (152)
    :- * HashAggregate (41)
    :  +- Exchange (40)
    :     +- * HashAggregate (39)
@@ -341,7 +341,7 @@ Results [18]: [i_item_id#27, ca_country#24, ca_state#23, ca_county#22, sum#49, c
 Input [18]: [i_item_id#27, ca_country#24, ca_state#23, ca_county#22, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60, sum#61, count#62]
 Arguments: hashpartitioning(i_item_id#27, ca_country#24, ca_state#23, ca_county#22, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(41) HashAggregate [codegen id : 8]
+(41) HashAggregate [codegen id : 36]
 Input [18]: [i_item_id#27, ca_country#24, ca_state#23, ca_county#22, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60, sum#61, count#62]
 Keys [4]: [i_item_id#27, ca_country#24, ca_state#23, ca_county#22]
 Functions [7]: [avg(agg1#28), avg(agg2#29), avg(agg3#30), avg(agg4#31), avg(agg5#32), avg(agg6#33), avg(agg7#34)]
@@ -356,49 +356,49 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#85), dynamicpruningexpression(cs_so
 PushedFilters: [IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_bill_cdemo_sk:int,cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2),cs_sales_price:decimal(7,2),cs_coupon_amt:decimal(7,2),cs_net_profit:decimal(7,2)>
 
-(43) ColumnarToRow [codegen id : 15]
+(43) ColumnarToRow [codegen id : 14]
 Input [9]: [cs_bill_customer_sk#77, cs_bill_cdemo_sk#78, cs_item_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cs_sold_date_sk#85]
 
-(44) Filter [codegen id : 15]
+(44) Filter [codegen id : 14]
 Input [9]: [cs_bill_customer_sk#77, cs_bill_cdemo_sk#78, cs_item_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cs_sold_date_sk#85]
 Condition : ((isnotnull(cs_bill_cdemo_sk#78) AND isnotnull(cs_bill_customer_sk#77)) AND isnotnull(cs_item_sk#79))
 
 (45) ReusedExchange [Reuses operator id: 8]
 Output [2]: [cd_demo_sk#86, cd_dep_count#87]
 
-(46) BroadcastHashJoin [codegen id : 15]
+(46) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [cs_bill_cdemo_sk#78]
 Right keys [1]: [cd_demo_sk#86]
 Join type: Inner
 Join condition: None
 
-(47) Project [codegen id : 15]
+(47) Project [codegen id : 14]
 Output [9]: [cs_bill_customer_sk#77, cs_item_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cs_sold_date_sk#85, cd_dep_count#87]
 Input [11]: [cs_bill_customer_sk#77, cs_bill_cdemo_sk#78, cs_item_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cs_sold_date_sk#85, cd_demo_sk#86, cd_dep_count#87]
 
 (48) ReusedExchange [Reuses operator id: 15]
 Output [4]: [c_customer_sk#88, c_current_cdemo_sk#89, c_current_addr_sk#90, c_birth_year#91]
 
-(49) BroadcastHashJoin [codegen id : 15]
+(49) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [cs_bill_customer_sk#77]
 Right keys [1]: [c_customer_sk#88]
 Join type: Inner
 Join condition: None
 
-(50) Project [codegen id : 15]
+(50) Project [codegen id : 14]
 Output [11]: [cs_item_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cs_sold_date_sk#85, cd_dep_count#87, c_current_cdemo_sk#89, c_current_addr_sk#90, c_birth_year#91]
 Input [13]: [cs_bill_customer_sk#77, cs_item_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cs_sold_date_sk#85, cd_dep_count#87, c_customer_sk#88, c_current_cdemo_sk#89, c_current_addr_sk#90, c_birth_year#91]
 
 (51) ReusedExchange [Reuses operator id: 21]
 Output [1]: [cd_demo_sk#92]
 
-(52) BroadcastHashJoin [codegen id : 15]
+(52) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_current_cdemo_sk#89]
 Right keys [1]: [cd_demo_sk#92]
 Join type: Inner
 Join condition: None
 
-(53) Project [codegen id : 15]
+(53) Project [codegen id : 14]
 Output [10]: [cs_item_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cs_sold_date_sk#85, cd_dep_count#87, c_current_addr_sk#90, c_birth_year#91]
 Input [12]: [cs_item_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cs_sold_date_sk#85, cd_dep_count#87, c_current_cdemo_sk#89, c_current_addr_sk#90, c_birth_year#91, cd_demo_sk#92]
 
@@ -409,10 +409,10 @@ Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [AL,MS,NC,ND,OK,TN,WI]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
 
-(55) ColumnarToRow [codegen id : 12]
+(55) ColumnarToRow [codegen id : 11]
 Input [3]: [ca_address_sk#93, ca_state#94, ca_country#95]
 
-(56) Filter [codegen id : 12]
+(56) Filter [codegen id : 11]
 Input [3]: [ca_address_sk#93, ca_state#94, ca_country#95]
 Condition : (ca_state#94 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#93))
 
@@ -420,43 +420,43 @@ Condition : (ca_state#94 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#9
 Input [3]: [ca_address_sk#93, ca_state#94, ca_country#95]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(58) BroadcastHashJoin [codegen id : 15]
+(58) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_current_addr_sk#90]
 Right keys [1]: [ca_address_sk#93]
 Join type: Inner
 Join condition: None
 
-(59) Project [codegen id : 15]
+(59) Project [codegen id : 14]
 Output [11]: [cs_item_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cs_sold_date_sk#85, cd_dep_count#87, c_birth_year#91, ca_state#94, ca_country#95]
 Input [13]: [cs_item_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cs_sold_date_sk#85, cd_dep_count#87, c_current_addr_sk#90, c_birth_year#91, ca_address_sk#93, ca_state#94, ca_country#95]
 
 (60) ReusedExchange [Reuses operator id: 158]
 Output [1]: [d_date_sk#96]
 
-(61) BroadcastHashJoin [codegen id : 15]
+(61) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [cs_sold_date_sk#85]
 Right keys [1]: [d_date_sk#96]
 Join type: Inner
 Join condition: None
 
-(62) Project [codegen id : 15]
+(62) Project [codegen id : 14]
 Output [10]: [cs_item_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cd_dep_count#87, c_birth_year#91, ca_state#94, ca_country#95]
 Input [12]: [cs_item_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cs_sold_date_sk#85, cd_dep_count#87, c_birth_year#91, ca_state#94, ca_country#95, d_date_sk#96]
 
 (63) ReusedExchange [Reuses operator id: 36]
 Output [2]: [i_item_sk#97, i_item_id#98]
 
-(64) BroadcastHashJoin [codegen id : 15]
+(64) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [cs_item_sk#79]
 Right keys [1]: [i_item_sk#97]
 Join type: Inner
 Join condition: None
 
-(65) Project [codegen id : 15]
+(65) Project [codegen id : 14]
 Output [10]: [i_item_id#98, ca_country#95, ca_state#94, cast(cs_quantity#80 as decimal(12,2)) AS agg1#99, cast(cs_list_price#81 as decimal(12,2)) AS agg2#100, cast(cs_coupon_amt#83 as decimal(12,2)) AS agg3#101, cast(cs_sales_price#82 as decimal(12,2)) AS agg4#102, cast(cs_net_profit#84 as decimal(12,2)) AS agg5#103, cast(c_birth_year#91 as decimal(12,2)) AS agg6#104, cast(cd_dep_count#87 as decimal(12,2)) AS agg7#105]
 Input [12]: [cs_item_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cd_dep_count#87, c_birth_year#91, ca_state#94, ca_country#95, i_item_sk#97, i_item_id#98]
 
-(66) HashAggregate [codegen id : 15]
+(66) HashAggregate [codegen id : 14]
 Input [10]: [i_item_id#98, ca_country#95, ca_state#94, agg1#99, agg2#100, agg3#101, agg4#102, agg5#103, agg6#104, agg7#105]
 Keys [3]: [i_item_id#98, ca_country#95, ca_state#94]
 Functions [7]: [partial_avg(agg1#99), partial_avg(agg2#100), partial_avg(agg3#101), partial_avg(agg4#102), partial_avg(agg5#103), partial_avg(agg6#104), partial_avg(agg7#105)]
@@ -467,7 +467,7 @@ Results [17]: [i_item_id#98, ca_country#95, ca_state#94, sum#120, count#121, sum
 Input [17]: [i_item_id#98, ca_country#95, ca_state#94, sum#120, count#121, sum#122, count#123, sum#124, count#125, sum#126, count#127, sum#128, count#129, sum#130, count#131, sum#132, count#133]
 Arguments: hashpartitioning(i_item_id#98, ca_country#95, ca_state#94, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(68) HashAggregate [codegen id : 16]
+(68) HashAggregate
 Input [17]: [i_item_id#98, ca_country#95, ca_state#94, sum#120, count#121, sum#122, count#123, sum#124, count#125, sum#126, count#127, sum#128, count#129, sum#130, count#131, sum#132, count#133]
 Keys [3]: [i_item_id#98, ca_country#95, ca_state#94]
 Functions [7]: [avg(agg1#99), avg(agg2#100), avg(agg3#101), avg(agg4#102), avg(agg5#103), avg(agg6#104), avg(agg7#105)]
@@ -482,49 +482,49 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#157), dynamicpruningexpression(cs_s
 PushedFilters: [IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_bill_cdemo_sk:int,cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2),cs_sales_price:decimal(7,2),cs_coupon_amt:decimal(7,2),cs_net_profit:decimal(7,2)>
 
-(70) ColumnarToRow [codegen id : 23]
+(70) ColumnarToRow [codegen id : 21]
 Input [9]: [cs_bill_customer_sk#149, cs_bill_cdemo_sk#150, cs_item_sk#151, cs_quantity#152, cs_list_price#153, cs_sales_price#154, cs_coupon_amt#155, cs_net_profit#156, cs_sold_date_sk#157]
 
-(71) Filter [codegen id : 23]
+(71) Filter [codegen id : 21]
 Input [9]: [cs_bill_customer_sk#149, cs_bill_cdemo_sk#150, cs_item_sk#151, cs_quantity#152, cs_list_price#153, cs_sales_price#154, cs_coupon_amt#155, cs_net_profit#156, cs_sold_date_sk#157]
 Condition : ((isnotnull(cs_bill_cdemo_sk#150) AND isnotnull(cs_bill_customer_sk#149)) AND isnotnull(cs_item_sk#151))
 
 (72) ReusedExchange [Reuses operator id: 8]
 Output [2]: [cd_demo_sk#158, cd_dep_count#159]
 
-(73) BroadcastHashJoin [codegen id : 23]
+(73) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [cs_bill_cdemo_sk#150]
 Right keys [1]: [cd_demo_sk#158]
 Join type: Inner
 Join condition: None
 
-(74) Project [codegen id : 23]
+(74) Project [codegen id : 21]
 Output [9]: [cs_bill_customer_sk#149, cs_item_sk#151, cs_quantity#152, cs_list_price#153, cs_sales_price#154, cs_coupon_amt#155, cs_net_profit#156, cs_sold_date_sk#157, cd_dep_count#159]
 Input [11]: [cs_bill_customer_sk#149, cs_bill_cdemo_sk#150, cs_item_sk#151, cs_quantity#152, cs_list_price#153, cs_sales_price#154, cs_coupon_amt#155, cs_net_profit#156, cs_sold_date_sk#157, cd_demo_sk#158, cd_dep_count#159]
 
 (75) ReusedExchange [Reuses operator id: 15]
 Output [4]: [c_customer_sk#160, c_current_cdemo_sk#161, c_current_addr_sk#162, c_birth_year#163]
 
-(76) BroadcastHashJoin [codegen id : 23]
+(76) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [cs_bill_customer_sk#149]
 Right keys [1]: [c_customer_sk#160]
 Join type: Inner
 Join condition: None
 
-(77) Project [codegen id : 23]
+(77) Project [codegen id : 21]
 Output [11]: [cs_item_sk#151, cs_quantity#152, cs_list_price#153, cs_sales_price#154, cs_coupon_amt#155, cs_net_profit#156, cs_sold_date_sk#157, cd_dep_count#159, c_current_cdemo_sk#161, c_current_addr_sk#162, c_birth_year#163]
 Input [13]: [cs_bill_customer_sk#149, cs_item_sk#151, cs_quantity#152, cs_list_price#153, cs_sales_price#154, cs_coupon_amt#155, cs_net_profit#156, cs_sold_date_sk#157, cd_dep_count#159, c_customer_sk#160, c_current_cdemo_sk#161, c_current_addr_sk#162, c_birth_year#163]
 
 (78) ReusedExchange [Reuses operator id: 21]
 Output [1]: [cd_demo_sk#164]
 
-(79) BroadcastHashJoin [codegen id : 23]
+(79) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [c_current_cdemo_sk#161]
 Right keys [1]: [cd_demo_sk#164]
 Join type: Inner
 Join condition: None
 
-(80) Project [codegen id : 23]
+(80) Project [codegen id : 21]
 Output [10]: [cs_item_sk#151, cs_quantity#152, cs_list_price#153, cs_sales_price#154, cs_coupon_amt#155, cs_net_profit#156, cs_sold_date_sk#157, cd_dep_count#159, c_current_addr_sk#162, c_birth_year#163]
 Input [12]: [cs_item_sk#151, cs_quantity#152, cs_list_price#153, cs_sales_price#154, cs_coupon_amt#155, cs_net_profit#156, cs_sold_date_sk#157, cd_dep_count#159, c_current_cdemo_sk#161, c_current_addr_sk#162, c_birth_year#163, cd_demo_sk#164]
 
@@ -535,14 +535,14 @@ Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [AL,MS,NC,ND,OK,TN,WI]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
 
-(82) ColumnarToRow [codegen id : 20]
+(82) ColumnarToRow [codegen id : 18]
 Input [3]: [ca_address_sk#165, ca_state#166, ca_country#167]
 
-(83) Filter [codegen id : 20]
+(83) Filter [codegen id : 18]
 Input [3]: [ca_address_sk#165, ca_state#166, ca_country#167]
 Condition : (ca_state#166 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#165))
 
-(84) Project [codegen id : 20]
+(84) Project [codegen id : 18]
 Output [2]: [ca_address_sk#165, ca_country#167]
 Input [3]: [ca_address_sk#165, ca_state#166, ca_country#167]
 
@@ -550,43 +550,43 @@ Input [3]: [ca_address_sk#165, ca_state#166, ca_country#167]
 Input [2]: [ca_address_sk#165, ca_country#167]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-(86) BroadcastHashJoin [codegen id : 23]
+(86) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [c_current_addr_sk#162]
 Right keys [1]: [ca_address_sk#165]
 Join type: Inner
 Join condition: None
 
-(87) Project [codegen id : 23]
+(87) Project [codegen id : 21]
 Output [10]: [cs_item_sk#151, cs_quantity#152, cs_list_price#153, cs_sales_price#154, cs_coupon_amt#155, cs_net_profit#156, cs_sold_date_sk#157, cd_dep_count#159, c_birth_year#163, ca_country#167]
 Input [12]: [cs_item_sk#151, cs_quantity#152, cs_list_price#153, cs_sales_price#154, cs_coupon_amt#155, cs_net_profit#156, cs_sold_date_sk#157, cd_dep_count#159, c_current_addr_sk#162, c_birth_year#163, ca_address_sk#165, ca_country#167]
 
 (88) ReusedExchange [Reuses operator id: 158]
 Output [1]: [d_date_sk#168]
 
-(89) BroadcastHashJoin [codegen id : 23]
+(89) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [cs_sold_date_sk#157]
 Right keys [1]: [d_date_sk#168]
 Join type: Inner
 Join condition: None
 
-(90) Project [codegen id : 23]
+(90) Project [codegen id : 21]
 Output [9]: [cs_item_sk#151, cs_quantity#152, cs_list_price#153, cs_sales_price#154, cs_coupon_amt#155, cs_net_profit#156, cd_dep_count#159, c_birth_year#163, ca_country#167]
 Input [11]: [cs_item_sk#151, cs_quantity#152, cs_list_price#153, cs_sales_price#154, cs_coupon_amt#155, cs_net_profit#156, cs_sold_date_sk#157, cd_dep_count#159, c_birth_year#163, ca_country#167, d_date_sk#168]
 
 (91) ReusedExchange [Reuses operator id: 36]
 Output [2]: [i_item_sk#169, i_item_id#170]
 
-(92) BroadcastHashJoin [codegen id : 23]
+(92) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [cs_item_sk#151]
 Right keys [1]: [i_item_sk#169]
 Join type: Inner
 Join condition: None
 
-(93) Project [codegen id : 23]
+(93) Project [codegen id : 21]
 Output [9]: [i_item_id#170, ca_country#167, cast(cs_quantity#152 as decimal(12,2)) AS agg1#171, cast(cs_list_price#153 as decimal(12,2)) AS agg2#172, cast(cs_coupon_amt#155 as decimal(12,2)) AS agg3#173, cast(cs_sales_price#154 as decimal(12,2)) AS agg4#174, cast(cs_net_profit#156 as decimal(12,2)) AS agg5#175, cast(c_birth_year#163 as decimal(12,2)) AS agg6#176, cast(cd_dep_count#159 as decimal(12,2)) AS agg7#177]
 Input [11]: [cs_item_sk#151, cs_quantity#152, cs_list_price#153, cs_sales_price#154, cs_coupon_amt#155, cs_net_profit#156, cd_dep_count#159, c_birth_year#163, ca_country#167, i_item_sk#169, i_item_id#170]
 
-(94) HashAggregate [codegen id : 23]
+(94) HashAggregate [codegen id : 21]
 Input [9]: [i_item_id#170, ca_country#167, agg1#171, agg2#172, agg3#173, agg4#174, agg5#175, agg6#176, agg7#177]
 Keys [2]: [i_item_id#170, ca_country#167]
 Functions [7]: [partial_avg(agg1#171), partial_avg(agg2#172), partial_avg(agg3#173), partial_avg(agg4#174), partial_avg(agg5#175), partial_avg(agg6#176), partial_avg(agg7#177)]
@@ -597,7 +597,7 @@ Results [16]: [i_item_id#170, ca_country#167, sum#192, count#193, sum#194, count
 Input [16]: [i_item_id#170, ca_country#167, sum#192, count#193, sum#194, count#195, sum#196, count#197, sum#198, count#199, sum#200, count#201, sum#202, count#203, sum#204, count#205]
 Arguments: hashpartitioning(i_item_id#170, ca_country#167, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(96) HashAggregate [codegen id : 24]
+(96) HashAggregate
 Input [16]: [i_item_id#170, ca_country#167, sum#192, count#193, sum#194, count#195, sum#196, count#197, sum#198, count#199, sum#200, count#201, sum#202, count#203, sum#204, count#205]
 Keys [2]: [i_item_id#170, ca_country#167]
 Functions [7]: [avg(agg1#171), avg(agg2#172), avg(agg3#173), avg(agg4#174), avg(agg5#175), avg(agg6#176), avg(agg7#177)]
@@ -612,49 +612,49 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#230), dynamicpruningexpression(cs_s
 PushedFilters: [IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_bill_cdemo_sk:int,cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2),cs_sales_price:decimal(7,2),cs_coupon_amt:decimal(7,2),cs_net_profit:decimal(7,2)>
 
-(98) ColumnarToRow [codegen id : 31]
+(98) ColumnarToRow [codegen id : 28]
 Input [9]: [cs_bill_customer_sk#222, cs_bill_cdemo_sk#223, cs_item_sk#224, cs_quantity#225, cs_list_price#226, cs_sales_price#227, cs_coupon_amt#228, cs_net_profit#229, cs_sold_date_sk#230]
 
-(99) Filter [codegen id : 31]
+(99) Filter [codegen id : 28]
 Input [9]: [cs_bill_customer_sk#222, cs_bill_cdemo_sk#223, cs_item_sk#224, cs_quantity#225, cs_list_price#226, cs_sales_price#227, cs_coupon_amt#228, cs_net_profit#229, cs_sold_date_sk#230]
 Condition : ((isnotnull(cs_bill_cdemo_sk#223) AND isnotnull(cs_bill_customer_sk#222)) AND isnotnull(cs_item_sk#224))
 
 (100) ReusedExchange [Reuses operator id: 8]
 Output [2]: [cd_demo_sk#231, cd_dep_count#232]
 
-(101) BroadcastHashJoin [codegen id : 31]
+(101) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [cs_bill_cdemo_sk#223]
 Right keys [1]: [cd_demo_sk#231]
 Join type: Inner
 Join condition: None
 
-(102) Project [codegen id : 31]
+(102) Project [codegen id : 28]
 Output [9]: [cs_bill_customer_sk#222, cs_item_sk#224, cs_quantity#225, cs_list_price#226, cs_sales_price#227, cs_coupon_amt#228, cs_net_profit#229, cs_sold_date_sk#230, cd_dep_count#232]
 Input [11]: [cs_bill_customer_sk#222, cs_bill_cdemo_sk#223, cs_item_sk#224, cs_quantity#225, cs_list_price#226, cs_sales_price#227, cs_coupon_amt#228, cs_net_profit#229, cs_sold_date_sk#230, cd_demo_sk#231, cd_dep_count#232]
 
 (103) ReusedExchange [Reuses operator id: 15]
 Output [4]: [c_customer_sk#233, c_current_cdemo_sk#234, c_current_addr_sk#235, c_birth_year#236]
 
-(104) BroadcastHashJoin [codegen id : 31]
+(104) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [cs_bill_customer_sk#222]
 Right keys [1]: [c_customer_sk#233]
 Join type: Inner
 Join condition: None
 
-(105) Project [codegen id : 31]
+(105) Project [codegen id : 28]
 Output [11]: [cs_item_sk#224, cs_quantity#225, cs_list_price#226, cs_sales_price#227, cs_coupon_amt#228, cs_net_profit#229, cs_sold_date_sk#230, cd_dep_count#232, c_current_cdemo_sk#234, c_current_addr_sk#235, c_birth_year#236]
 Input [13]: [cs_bill_customer_sk#222, cs_item_sk#224, cs_quantity#225, cs_list_price#226, cs_sales_price#227, cs_coupon_amt#228, cs_net_profit#229, cs_sold_date_sk#230, cd_dep_count#232, c_customer_sk#233, c_current_cdemo_sk#234, c_current_addr_sk#235, c_birth_year#236]
 
 (106) ReusedExchange [Reuses operator id: 21]
 Output [1]: [cd_demo_sk#237]
 
-(107) BroadcastHashJoin [codegen id : 31]
+(107) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [c_current_cdemo_sk#234]
 Right keys [1]: [cd_demo_sk#237]
 Join type: Inner
 Join condition: None
 
-(108) Project [codegen id : 31]
+(108) Project [codegen id : 28]
 Output [10]: [cs_item_sk#224, cs_quantity#225, cs_list_price#226, cs_sales_price#227, cs_coupon_amt#228, cs_net_profit#229, cs_sold_date_sk#230, cd_dep_count#232, c_current_addr_sk#235, c_birth_year#236]
 Input [12]: [cs_item_sk#224, cs_quantity#225, cs_list_price#226, cs_sales_price#227, cs_coupon_amt#228, cs_net_profit#229, cs_sold_date_sk#230, cd_dep_count#232, c_current_cdemo_sk#234, c_current_addr_sk#235, c_birth_year#236, cd_demo_sk#237]
 
@@ -665,14 +665,14 @@ Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [AL,MS,NC,ND,OK,TN,WI]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(110) ColumnarToRow [codegen id : 28]
+(110) ColumnarToRow [codegen id : 25]
 Input [2]: [ca_address_sk#238, ca_state#239]
 
-(111) Filter [codegen id : 28]
+(111) Filter [codegen id : 25]
 Input [2]: [ca_address_sk#238, ca_state#239]
 Condition : (ca_state#239 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#238))
 
-(112) Project [codegen id : 28]
+(112) Project [codegen id : 25]
 Output [1]: [ca_address_sk#238]
 Input [2]: [ca_address_sk#238, ca_state#239]
 
@@ -680,43 +680,43 @@ Input [2]: [ca_address_sk#238, ca_state#239]
 Input [1]: [ca_address_sk#238]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-(114) BroadcastHashJoin [codegen id : 31]
+(114) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [c_current_addr_sk#235]
 Right keys [1]: [ca_address_sk#238]
 Join type: Inner
 Join condition: None
 
-(115) Project [codegen id : 31]
+(115) Project [codegen id : 28]
 Output [9]: [cs_item_sk#224, cs_quantity#225, cs_list_price#226, cs_sales_price#227, cs_coupon_amt#228, cs_net_profit#229, cs_sold_date_sk#230, cd_dep_count#232, c_birth_year#236]
 Input [11]: [cs_item_sk#224, cs_quantity#225, cs_list_price#226, cs_sales_price#227, cs_coupon_amt#228, cs_net_profit#229, cs_sold_date_sk#230, cd_dep_count#232, c_current_addr_sk#235, c_birth_year#236, ca_address_sk#238]
 
 (116) ReusedExchange [Reuses operator id: 158]
 Output [1]: [d_date_sk#240]
 
-(117) BroadcastHashJoin [codegen id : 31]
+(117) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [cs_sold_date_sk#230]
 Right keys [1]: [d_date_sk#240]
 Join type: Inner
 Join condition: None
 
-(118) Project [codegen id : 31]
+(118) Project [codegen id : 28]
 Output [8]: [cs_item_sk#224, cs_quantity#225, cs_list_price#226, cs_sales_price#227, cs_coupon_amt#228, cs_net_profit#229, cd_dep_count#232, c_birth_year#236]
 Input [10]: [cs_item_sk#224, cs_quantity#225, cs_list_price#226, cs_sales_price#227, cs_coupon_amt#228, cs_net_profit#229, cs_sold_date_sk#230, cd_dep_count#232, c_birth_year#236, d_date_sk#240]
 
 (119) ReusedExchange [Reuses operator id: 36]
 Output [2]: [i_item_sk#241, i_item_id#242]
 
-(120) BroadcastHashJoin [codegen id : 31]
+(120) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [cs_item_sk#224]
 Right keys [1]: [i_item_sk#241]
 Join type: Inner
 Join condition: None
 
-(121) Project [codegen id : 31]
+(121) Project [codegen id : 28]
 Output [8]: [i_item_id#242, cast(cs_quantity#225 as decimal(12,2)) AS agg1#243, cast(cs_list_price#226 as decimal(12,2)) AS agg2#244, cast(cs_coupon_amt#228 as decimal(12,2)) AS agg3#245, cast(cs_sales_price#227 as decimal(12,2)) AS agg4#246, cast(cs_net_profit#229 as decimal(12,2)) AS agg5#247, cast(c_birth_year#236 as decimal(12,2)) AS agg6#248, cast(cd_dep_count#232 as decimal(12,2)) AS agg7#249]
 Input [10]: [cs_item_sk#224, cs_quantity#225, cs_list_price#226, cs_sales_price#227, cs_coupon_amt#228, cs_net_profit#229, cd_dep_count#232, c_birth_year#236, i_item_sk#241, i_item_id#242]
 
-(122) HashAggregate [codegen id : 31]
+(122) HashAggregate [codegen id : 28]
 Input [8]: [i_item_id#242, agg1#243, agg2#244, agg3#245, agg4#246, agg5#247, agg6#248, agg7#249]
 Keys [1]: [i_item_id#242]
 Functions [7]: [partial_avg(agg1#243), partial_avg(agg2#244), partial_avg(agg3#245), partial_avg(agg4#246), partial_avg(agg5#247), partial_avg(agg6#248), partial_avg(agg7#249)]
@@ -727,7 +727,7 @@ Results [15]: [i_item_id#242, sum#264, count#265, sum#266, count#267, sum#268, c
 Input [15]: [i_item_id#242, sum#264, count#265, sum#266, count#267, sum#268, count#269, sum#270, count#271, sum#272, count#273, sum#274, count#275, sum#276, count#277]
 Arguments: hashpartitioning(i_item_id#242, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(124) HashAggregate [codegen id : 32]
+(124) HashAggregate
 Input [15]: [i_item_id#242, sum#264, count#265, sum#266, count#267, sum#268, count#269, sum#270, count#271, sum#272, count#273, sum#274, count#275, sum#276, count#277]
 Keys [1]: [i_item_id#242]
 Functions [7]: [avg(agg1#243), avg(agg2#244), avg(agg3#245), avg(agg4#246), avg(agg5#247), avg(agg6#248), avg(agg7#249)]
@@ -742,75 +742,75 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#303), dynamicpruningexpression(cs_s
 PushedFilters: [IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_bill_cdemo_sk:int,cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2),cs_sales_price:decimal(7,2),cs_coupon_amt:decimal(7,2),cs_net_profit:decimal(7,2)>
 
-(126) ColumnarToRow [codegen id : 39]
+(126) ColumnarToRow [codegen id : 35]
 Input [9]: [cs_bill_customer_sk#295, cs_bill_cdemo_sk#296, cs_item_sk#297, cs_quantity#298, cs_list_price#299, cs_sales_price#300, cs_coupon_amt#301, cs_net_profit#302, cs_sold_date_sk#303]
 
-(127) Filter [codegen id : 39]
+(127) Filter [codegen id : 35]
 Input [9]: [cs_bill_customer_sk#295, cs_bill_cdemo_sk#296, cs_item_sk#297, cs_quantity#298, cs_list_price#299, cs_sales_price#300, cs_coupon_amt#301, cs_net_profit#302, cs_sold_date_sk#303]
 Condition : ((isnotnull(cs_bill_cdemo_sk#296) AND isnotnull(cs_bill_customer_sk#295)) AND isnotnull(cs_item_sk#297))
 
 (128) ReusedExchange [Reuses operator id: 8]
 Output [2]: [cd_demo_sk#304, cd_dep_count#305]
 
-(129) BroadcastHashJoin [codegen id : 39]
+(129) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [cs_bill_cdemo_sk#296]
 Right keys [1]: [cd_demo_sk#304]
 Join type: Inner
 Join condition: None
 
-(130) Project [codegen id : 39]
+(130) Project [codegen id : 35]
 Output [9]: [cs_bill_customer_sk#295, cs_item_sk#297, cs_quantity#298, cs_list_price#299, cs_sales_price#300, cs_coupon_amt#301, cs_net_profit#302, cs_sold_date_sk#303, cd_dep_count#305]
 Input [11]: [cs_bill_customer_sk#295, cs_bill_cdemo_sk#296, cs_item_sk#297, cs_quantity#298, cs_list_price#299, cs_sales_price#300, cs_coupon_amt#301, cs_net_profit#302, cs_sold_date_sk#303, cd_demo_sk#304, cd_dep_count#305]
 
 (131) ReusedExchange [Reuses operator id: 15]
 Output [4]: [c_customer_sk#306, c_current_cdemo_sk#307, c_current_addr_sk#308, c_birth_year#309]
 
-(132) BroadcastHashJoin [codegen id : 39]
+(132) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [cs_bill_customer_sk#295]
 Right keys [1]: [c_customer_sk#306]
 Join type: Inner
 Join condition: None
 
-(133) Project [codegen id : 39]
+(133) Project [codegen id : 35]
 Output [11]: [cs_item_sk#297, cs_quantity#298, cs_list_price#299, cs_sales_price#300, cs_coupon_amt#301, cs_net_profit#302, cs_sold_date_sk#303, cd_dep_count#305, c_current_cdemo_sk#307, c_current_addr_sk#308, c_birth_year#309]
 Input [13]: [cs_bill_customer_sk#295, cs_item_sk#297, cs_quantity#298, cs_list_price#299, cs_sales_price#300, cs_coupon_amt#301, cs_net_profit#302, cs_sold_date_sk#303, cd_dep_count#305, c_customer_sk#306, c_current_cdemo_sk#307, c_current_addr_sk#308, c_birth_year#309]
 
 (134) ReusedExchange [Reuses operator id: 21]
 Output [1]: [cd_demo_sk#310]
 
-(135) BroadcastHashJoin [codegen id : 39]
+(135) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [c_current_cdemo_sk#307]
 Right keys [1]: [cd_demo_sk#310]
 Join type: Inner
 Join condition: None
 
-(136) Project [codegen id : 39]
+(136) Project [codegen id : 35]
 Output [10]: [cs_item_sk#297, cs_quantity#298, cs_list_price#299, cs_sales_price#300, cs_coupon_amt#301, cs_net_profit#302, cs_sold_date_sk#303, cd_dep_count#305, c_current_addr_sk#308, c_birth_year#309]
 Input [12]: [cs_item_sk#297, cs_quantity#298, cs_list_price#299, cs_sales_price#300, cs_coupon_amt#301, cs_net_profit#302, cs_sold_date_sk#303, cd_dep_count#305, c_current_cdemo_sk#307, c_current_addr_sk#308, c_birth_year#309, cd_demo_sk#310]
 
 (137) ReusedExchange [Reuses operator id: 113]
 Output [1]: [ca_address_sk#311]
 
-(138) BroadcastHashJoin [codegen id : 39]
+(138) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [c_current_addr_sk#308]
 Right keys [1]: [ca_address_sk#311]
 Join type: Inner
 Join condition: None
 
-(139) Project [codegen id : 39]
+(139) Project [codegen id : 35]
 Output [9]: [cs_item_sk#297, cs_quantity#298, cs_list_price#299, cs_sales_price#300, cs_coupon_amt#301, cs_net_profit#302, cs_sold_date_sk#303, cd_dep_count#305, c_birth_year#309]
 Input [11]: [cs_item_sk#297, cs_quantity#298, cs_list_price#299, cs_sales_price#300, cs_coupon_amt#301, cs_net_profit#302, cs_sold_date_sk#303, cd_dep_count#305, c_current_addr_sk#308, c_birth_year#309, ca_address_sk#311]
 
 (140) ReusedExchange [Reuses operator id: 158]
 Output [1]: [d_date_sk#312]
 
-(141) BroadcastHashJoin [codegen id : 39]
+(141) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [cs_sold_date_sk#303]
 Right keys [1]: [d_date_sk#312]
 Join type: Inner
 Join condition: None
 
-(142) Project [codegen id : 39]
+(142) Project [codegen id : 35]
 Output [8]: [cs_item_sk#297, cs_quantity#298, cs_list_price#299, cs_sales_price#300, cs_coupon_amt#301, cs_net_profit#302, cd_dep_count#305, c_birth_year#309]
 Input [10]: [cs_item_sk#297, cs_quantity#298, cs_list_price#299, cs_sales_price#300, cs_coupon_amt#301, cs_net_profit#302, cs_sold_date_sk#303, cd_dep_count#305, c_birth_year#309, d_date_sk#312]
 
@@ -821,10 +821,10 @@ Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int>
 
-(144) ColumnarToRow [codegen id : 38]
+(144) ColumnarToRow [codegen id : 34]
 Input [1]: [i_item_sk#313]
 
-(145) Filter [codegen id : 38]
+(145) Filter [codegen id : 34]
 Input [1]: [i_item_sk#313]
 Condition : isnotnull(i_item_sk#313)
 
@@ -832,17 +832,17 @@ Condition : isnotnull(i_item_sk#313)
 Input [1]: [i_item_sk#313]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=13]
 
-(147) BroadcastHashJoin [codegen id : 39]
+(147) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [cs_item_sk#297]
 Right keys [1]: [i_item_sk#313]
 Join type: Inner
 Join condition: None
 
-(148) Project [codegen id : 39]
+(148) Project [codegen id : 35]
 Output [7]: [cast(cs_quantity#298 as decimal(12,2)) AS agg1#314, cast(cs_list_price#299 as decimal(12,2)) AS agg2#315, cast(cs_coupon_amt#301 as decimal(12,2)) AS agg3#316, cast(cs_sales_price#300 as decimal(12,2)) AS agg4#317, cast(cs_net_profit#302 as decimal(12,2)) AS agg5#318, cast(c_birth_year#309 as decimal(12,2)) AS agg6#319, cast(cd_dep_count#305 as decimal(12,2)) AS agg7#320]
 Input [9]: [cs_item_sk#297, cs_quantity#298, cs_list_price#299, cs_sales_price#300, cs_coupon_amt#301, cs_net_profit#302, cd_dep_count#305, c_birth_year#309, i_item_sk#313]
 
-(149) HashAggregate [codegen id : 39]
+(149) HashAggregate [codegen id : 35]
 Input [7]: [agg1#314, agg2#315, agg3#316, agg4#317, agg5#318, agg6#319, agg7#320]
 Keys: []
 Functions [7]: [partial_avg(agg1#314), partial_avg(agg2#315), partial_avg(agg3#316), partial_avg(agg4#317), partial_avg(agg5#318), partial_avg(agg6#319), partial_avg(agg7#320)]
@@ -853,14 +853,14 @@ Results [14]: [sum#335, count#336, sum#337, count#338, sum#339, count#340, sum#3
 Input [14]: [sum#335, count#336, sum#337, count#338, sum#339, count#340, sum#341, count#342, sum#343, count#344, sum#345, count#346, sum#347, count#348]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
 
-(151) HashAggregate [codegen id : 40]
+(151) HashAggregate
 Input [14]: [sum#335, count#336, sum#337, count#338, sum#339, count#340, sum#341, count#342, sum#343, count#344, sum#345, count#346, sum#347, count#348]
 Keys: []
 Functions [7]: [avg(agg1#314), avg(agg2#315), avg(agg3#316), avg(agg4#317), avg(agg5#318), avg(agg6#319), avg(agg7#320)]
 Aggregate Attributes [7]: [avg(agg1#314)#349, avg(agg2#315)#350, avg(agg3#316)#351, avg(agg4#317)#352, avg(agg5#318)#353, avg(agg6#319)#354, avg(agg7#320)#355]
 Results [11]: [null AS i_item_id#356, null AS ca_country#357, null AS ca_state#358, null AS county#359, avg(agg1#314)#349 AS agg1#360, avg(agg2#315)#350 AS agg2#361, avg(agg3#316)#351 AS agg3#362, avg(agg4#317)#352 AS agg4#363, avg(agg5#318)#353 AS agg5#364, avg(agg6#319)#354 AS agg6#365, avg(agg7#320)#355 AS agg7#366]
 
-(152) Union
+(152) Union [codegen id : 36]
 
 (153) TakeOrderedAndProject
 Input [11]: [i_item_id#27, ca_country#24, ca_state#23, ca_county#22, agg1#70, agg2#71, agg3#72, agg4#73, agg5#74, agg6#75, agg7#76]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a/simplified.txt
@@ -1,6 +1,6 @@
 TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,agg4,agg5,agg6,agg7]
-  Union
-    WholeStageCodegen (8)
+  WholeStageCodegen (36)
+    Union
       HashAggregate [i_item_id,ca_country,ca_state,ca_county,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(agg2),avg(agg3),avg(agg4),avg(agg5),avg(agg6),avg(agg7),agg1,agg2,agg3,agg4,agg5,agg6,agg7,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange [i_item_id,ca_country,ca_state,ca_county] #1
@@ -69,11 +69,10 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                             ColumnarToRow
                               InputAdapter
                                 Scan parquet spark_catalog.default.item [i_item_sk,i_item_id]
-    WholeStageCodegen (16)
       HashAggregate [i_item_id,ca_country,ca_state,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(agg2),avg(agg3),avg(agg4),avg(agg5),avg(agg6),avg(agg7),county,agg1,agg2,agg3,agg4,agg5,agg6,agg7,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange [i_item_id,ca_country,ca_state] #8
-            WholeStageCodegen (15)
+            WholeStageCodegen (14)
               HashAggregate [i_item_id,ca_country,ca_state,agg1,agg2,agg3,agg4,agg5,agg6,agg7] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [i_item_id,ca_country,ca_state,cs_quantity,cs_list_price,cs_coupon_amt,cs_sales_price,cs_net_profit,c_birth_year,cd_dep_count]
                   BroadcastHashJoin [cs_item_sk,i_item_sk]
@@ -100,7 +99,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                   ReusedExchange [cd_demo_sk] #5
                             InputAdapter
                               BroadcastExchange #9
-                                WholeStageCodegen (12)
+                                WholeStageCodegen (11)
                                   Filter [ca_state,ca_address_sk]
                                     ColumnarToRow
                                       InputAdapter
@@ -109,11 +108,10 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                           ReusedExchange [d_date_sk] #2
                     InputAdapter
                       ReusedExchange [i_item_sk,i_item_id] #7
-    WholeStageCodegen (24)
       HashAggregate [i_item_id,ca_country,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(agg2),avg(agg3),avg(agg4),avg(agg5),avg(agg6),avg(agg7),ca_state,county,agg1,agg2,agg3,agg4,agg5,agg6,agg7,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange [i_item_id,ca_country] #10
-            WholeStageCodegen (23)
+            WholeStageCodegen (21)
               HashAggregate [i_item_id,ca_country,agg1,agg2,agg3,agg4,agg5,agg6,agg7] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [i_item_id,ca_country,cs_quantity,cs_list_price,cs_coupon_amt,cs_sales_price,cs_net_profit,c_birth_year,cd_dep_count]
                   BroadcastHashJoin [cs_item_sk,i_item_sk]
@@ -140,7 +138,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                   ReusedExchange [cd_demo_sk] #5
                             InputAdapter
                               BroadcastExchange #11
-                                WholeStageCodegen (20)
+                                WholeStageCodegen (18)
                                   Project [ca_address_sk,ca_country]
                                     Filter [ca_state,ca_address_sk]
                                       ColumnarToRow
@@ -150,11 +148,10 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                           ReusedExchange [d_date_sk] #2
                     InputAdapter
                       ReusedExchange [i_item_sk,i_item_id] #7
-    WholeStageCodegen (32)
       HashAggregate [i_item_id,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(agg2),avg(agg3),avg(agg4),avg(agg5),avg(agg6),avg(agg7),ca_country,ca_state,county,agg1,agg2,agg3,agg4,agg5,agg6,agg7,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange [i_item_id] #12
-            WholeStageCodegen (31)
+            WholeStageCodegen (28)
               HashAggregate [i_item_id,agg1,agg2,agg3,agg4,agg5,agg6,agg7] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [i_item_id,cs_quantity,cs_list_price,cs_coupon_amt,cs_sales_price,cs_net_profit,c_birth_year,cd_dep_count]
                   BroadcastHashJoin [cs_item_sk,i_item_sk]
@@ -181,7 +178,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                   ReusedExchange [cd_demo_sk] #5
                             InputAdapter
                               BroadcastExchange #13
-                                WholeStageCodegen (28)
+                                WholeStageCodegen (25)
                                   Project [ca_address_sk]
                                     Filter [ca_state,ca_address_sk]
                                       ColumnarToRow
@@ -191,11 +188,10 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                           ReusedExchange [d_date_sk] #2
                     InputAdapter
                       ReusedExchange [i_item_sk,i_item_id] #7
-    WholeStageCodegen (40)
       HashAggregate [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(agg2),avg(agg3),avg(agg4),avg(agg5),avg(agg6),avg(agg7),i_item_id,ca_country,ca_state,county,agg1,agg2,agg3,agg4,agg5,agg6,agg7,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange #14
-            WholeStageCodegen (39)
+            WholeStageCodegen (35)
               HashAggregate [agg1,agg2,agg3,agg4,agg5,agg6,agg7] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [cs_quantity,cs_list_price,cs_coupon_amt,cs_sales_price,cs_net_profit,c_birth_year,cd_dep_count]
                   BroadcastHashJoin [cs_item_sk,i_item_sk]
@@ -226,7 +222,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                           ReusedExchange [d_date_sk] #2
                     InputAdapter
                       BroadcastExchange #15
-                        WholeStageCodegen (38)
+                        WholeStageCodegen (34)
                           Filter [i_item_sk]
                             ColumnarToRow
                               InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22a/explain.txt
@@ -1,6 +1,6 @@
 == Physical Plan ==
 TakeOrderedAndProject (45)
-+- Union (44)
++- * Union (44)
    :- * HashAggregate (23)
    :  +- * HashAggregate (22)
    :     +- * HashAggregate (21)
@@ -141,21 +141,21 @@ Results [6]: [i_product_name#11, i_brand#8, i_class#9, i_category#10, sum#15, co
 Input [6]: [i_product_name#11, i_brand#8, i_class#9, i_category#10, sum#15, count#16]
 Arguments: hashpartitioning(i_product_name#11, i_brand#8, i_class#9, i_category#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(21) HashAggregate [codegen id : 5]
+(21) HashAggregate [codegen id : 25]
 Input [6]: [i_product_name#11, i_brand#8, i_class#9, i_category#10, sum#15, count#16]
 Keys [4]: [i_product_name#11, i_brand#8, i_class#9, i_category#10]
 Functions [1]: [avg(inv_quantity_on_hand#3)]
 Aggregate Attributes [1]: [avg(inv_quantity_on_hand#3)#17]
 Results [5]: [i_product_name#11, i_brand#8, i_class#9, i_category#10, avg(inv_quantity_on_hand#3)#17 AS qoh#18]
 
-(22) HashAggregate [codegen id : 5]
+(22) HashAggregate [codegen id : 25]
 Input [5]: [i_product_name#11, i_brand#8, i_class#9, i_category#10, qoh#18]
 Keys [4]: [i_product_name#11, i_brand#8, i_class#9, i_category#10]
 Functions [1]: [partial_avg(qoh#18)]
 Aggregate Attributes [2]: [sum#19, count#20]
 Results [6]: [i_product_name#11, i_brand#8, i_class#9, i_category#10, sum#21, count#22]
 
-(23) HashAggregate [codegen id : 5]
+(23) HashAggregate [codegen id : 25]
 Input [6]: [i_product_name#11, i_brand#8, i_class#9, i_category#10, sum#21, count#22]
 Keys [4]: [i_product_name#11, i_brand#8, i_class#9, i_category#10]
 Functions [1]: [avg(qoh#18)]
@@ -165,14 +165,14 @@ Results [5]: [i_product_name#11 AS i_product_name#24, i_brand#8 AS i_brand#25, i
 (24) ReusedExchange [Reuses operator id: 20]
 Output [6]: [i_product_name#29, i_brand#30, i_class#31, i_category#32, sum#33, count#34]
 
-(25) HashAggregate [codegen id : 10]
+(25) HashAggregate [codegen id : 9]
 Input [6]: [i_product_name#29, i_brand#30, i_class#31, i_category#32, sum#33, count#34]
 Keys [4]: [i_product_name#29, i_brand#30, i_class#31, i_category#32]
 Functions [1]: [avg(inv_quantity_on_hand#35)]
 Aggregate Attributes [1]: [avg(inv_quantity_on_hand#35)#17]
 Results [4]: [i_product_name#29, i_brand#30, i_class#31, avg(inv_quantity_on_hand#35)#17 AS qoh#36]
 
-(26) HashAggregate [codegen id : 10]
+(26) HashAggregate [codegen id : 9]
 Input [4]: [i_product_name#29, i_brand#30, i_class#31, qoh#36]
 Keys [3]: [i_product_name#29, i_brand#30, i_class#31]
 Functions [1]: [partial_avg(qoh#36)]
@@ -183,7 +183,7 @@ Results [5]: [i_product_name#29, i_brand#30, i_class#31, sum#39, count#40]
 Input [5]: [i_product_name#29, i_brand#30, i_class#31, sum#39, count#40]
 Arguments: hashpartitioning(i_product_name#29, i_brand#30, i_class#31, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(28) HashAggregate [codegen id : 11]
+(28) HashAggregate
 Input [5]: [i_product_name#29, i_brand#30, i_class#31, sum#39, count#40]
 Keys [3]: [i_product_name#29, i_brand#30, i_class#31]
 Functions [1]: [avg(qoh#36)]
@@ -193,14 +193,14 @@ Results [5]: [i_product_name#29, i_brand#30, i_class#31, null AS i_category#42, 
 (29) ReusedExchange [Reuses operator id: 20]
 Output [6]: [i_product_name#44, i_brand#45, i_class#46, i_category#47, sum#48, count#49]
 
-(30) HashAggregate [codegen id : 16]
+(30) HashAggregate [codegen id : 14]
 Input [6]: [i_product_name#44, i_brand#45, i_class#46, i_category#47, sum#48, count#49]
 Keys [4]: [i_product_name#44, i_brand#45, i_class#46, i_category#47]
 Functions [1]: [avg(inv_quantity_on_hand#50)]
 Aggregate Attributes [1]: [avg(inv_quantity_on_hand#50)#17]
 Results [3]: [i_product_name#44, i_brand#45, avg(inv_quantity_on_hand#50)#17 AS qoh#51]
 
-(31) HashAggregate [codegen id : 16]
+(31) HashAggregate [codegen id : 14]
 Input [3]: [i_product_name#44, i_brand#45, qoh#51]
 Keys [2]: [i_product_name#44, i_brand#45]
 Functions [1]: [partial_avg(qoh#51)]
@@ -211,7 +211,7 @@ Results [4]: [i_product_name#44, i_brand#45, sum#54, count#55]
 Input [4]: [i_product_name#44, i_brand#45, sum#54, count#55]
 Arguments: hashpartitioning(i_product_name#44, i_brand#45, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(33) HashAggregate [codegen id : 17]
+(33) HashAggregate
 Input [4]: [i_product_name#44, i_brand#45, sum#54, count#55]
 Keys [2]: [i_product_name#44, i_brand#45]
 Functions [1]: [avg(qoh#51)]
@@ -221,14 +221,14 @@ Results [5]: [i_product_name#44, i_brand#45, null AS i_class#57, null AS i_categ
 (34) ReusedExchange [Reuses operator id: 20]
 Output [6]: [i_product_name#60, i_brand#61, i_class#62, i_category#63, sum#64, count#65]
 
-(35) HashAggregate [codegen id : 22]
+(35) HashAggregate [codegen id : 19]
 Input [6]: [i_product_name#60, i_brand#61, i_class#62, i_category#63, sum#64, count#65]
 Keys [4]: [i_product_name#60, i_brand#61, i_class#62, i_category#63]
 Functions [1]: [avg(inv_quantity_on_hand#66)]
 Aggregate Attributes [1]: [avg(inv_quantity_on_hand#66)#17]
 Results [2]: [i_product_name#60, avg(inv_quantity_on_hand#66)#17 AS qoh#67]
 
-(36) HashAggregate [codegen id : 22]
+(36) HashAggregate [codegen id : 19]
 Input [2]: [i_product_name#60, qoh#67]
 Keys [1]: [i_product_name#60]
 Functions [1]: [partial_avg(qoh#67)]
@@ -239,7 +239,7 @@ Results [3]: [i_product_name#60, sum#70, count#71]
 Input [3]: [i_product_name#60, sum#70, count#71]
 Arguments: hashpartitioning(i_product_name#60, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(38) HashAggregate [codegen id : 23]
+(38) HashAggregate
 Input [3]: [i_product_name#60, sum#70, count#71]
 Keys [1]: [i_product_name#60]
 Functions [1]: [avg(qoh#67)]
@@ -249,14 +249,14 @@ Results [5]: [i_product_name#60, null AS i_brand#73, null AS i_class#74, null AS
 (39) ReusedExchange [Reuses operator id: 20]
 Output [6]: [i_product_name#77, i_brand#78, i_class#79, i_category#80, sum#81, count#82]
 
-(40) HashAggregate [codegen id : 28]
+(40) HashAggregate [codegen id : 24]
 Input [6]: [i_product_name#77, i_brand#78, i_class#79, i_category#80, sum#81, count#82]
 Keys [4]: [i_product_name#77, i_brand#78, i_class#79, i_category#80]
 Functions [1]: [avg(inv_quantity_on_hand#83)]
 Aggregate Attributes [1]: [avg(inv_quantity_on_hand#83)#17]
 Results [1]: [avg(inv_quantity_on_hand#83)#17 AS qoh#84]
 
-(41) HashAggregate [codegen id : 28]
+(41) HashAggregate [codegen id : 24]
 Input [1]: [qoh#84]
 Keys: []
 Functions [1]: [partial_avg(qoh#84)]
@@ -267,14 +267,14 @@ Results [2]: [sum#87, count#88]
 Input [2]: [sum#87, count#88]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
-(43) HashAggregate [codegen id : 29]
+(43) HashAggregate
 Input [2]: [sum#87, count#88]
 Keys: []
 Functions [1]: [avg(qoh#84)]
 Aggregate Attributes [1]: [avg(qoh#84)#89]
 Results [5]: [null AS i_product_name#90, null AS i_brand#91, null AS i_class#92, null AS i_category#93, avg(qoh#84)#89 AS qoh#94]
 
-(44) Union
+(44) Union [codegen id : 25]
 
 (45) TakeOrderedAndProject
 Input [5]: [i_product_name#24, i_brand#25, i_class#26, i_category#27, qoh#28]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22a/simplified.txt
@@ -1,6 +1,6 @@
 TakeOrderedAndProject [qoh,i_product_name,i_brand,i_class,i_category]
-  Union
-    WholeStageCodegen (5)
+  WholeStageCodegen (25)
+    Union
       HashAggregate [i_product_name,i_brand,i_class,i_category,sum,count] [avg(qoh),i_product_name,i_brand,i_class,i_category,qoh,sum,count]
         HashAggregate [i_product_name,i_brand,i_class,i_category,qoh] [sum,count,sum,count]
           HashAggregate [i_product_name,i_brand,i_class,i_category,sum,count] [avg(inv_quantity_on_hand),qoh,sum,count]
@@ -42,38 +42,34 @@ TakeOrderedAndProject [qoh,i_product_name,i_brand,i_class,i_category]
                                 ColumnarToRow
                                   InputAdapter
                                     Scan parquet spark_catalog.default.warehouse [w_warehouse_sk]
-    WholeStageCodegen (11)
       HashAggregate [i_product_name,i_brand,i_class,sum,count] [avg(qoh),i_category,qoh,sum,count]
         InputAdapter
           Exchange [i_product_name,i_brand,i_class] #5
-            WholeStageCodegen (10)
+            WholeStageCodegen (9)
               HashAggregate [i_product_name,i_brand,i_class,qoh] [sum,count,sum,count]
                 HashAggregate [i_product_name,i_brand,i_class,i_category,sum,count] [avg(inv_quantity_on_hand),qoh,sum,count]
                   InputAdapter
                     ReusedExchange [i_product_name,i_brand,i_class,i_category,sum,count] #1
-    WholeStageCodegen (17)
       HashAggregate [i_product_name,i_brand,sum,count] [avg(qoh),i_class,i_category,qoh,sum,count]
         InputAdapter
           Exchange [i_product_name,i_brand] #6
-            WholeStageCodegen (16)
+            WholeStageCodegen (14)
               HashAggregate [i_product_name,i_brand,qoh] [sum,count,sum,count]
                 HashAggregate [i_product_name,i_brand,i_class,i_category,sum,count] [avg(inv_quantity_on_hand),qoh,sum,count]
                   InputAdapter
                     ReusedExchange [i_product_name,i_brand,i_class,i_category,sum,count] #1
-    WholeStageCodegen (23)
       HashAggregate [i_product_name,sum,count] [avg(qoh),i_brand,i_class,i_category,qoh,sum,count]
         InputAdapter
           Exchange [i_product_name] #7
-            WholeStageCodegen (22)
+            WholeStageCodegen (19)
               HashAggregate [i_product_name,qoh] [sum,count,sum,count]
                 HashAggregate [i_product_name,i_brand,i_class,i_category,sum,count] [avg(inv_quantity_on_hand),qoh,sum,count]
                   InputAdapter
                     ReusedExchange [i_product_name,i_brand,i_class,i_category,sum,count] #1
-    WholeStageCodegen (29)
       HashAggregate [sum,count] [avg(qoh),i_product_name,i_brand,i_class,i_category,qoh,sum,count]
         InputAdapter
           Exchange #8
-            WholeStageCodegen (28)
+            WholeStageCodegen (24)
               HashAggregate [qoh] [sum,count,sum,count]
                 HashAggregate [i_product_name,i_brand,i_class,i_category,sum,count] [avg(inv_quantity_on_hand),qoh,sum,count]
                   InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a.sf100/explain.txt
@@ -1,6 +1,6 @@
 == Physical Plan ==
 TakeOrderedAndProject (73)
-+- Union (72)
++- * Union (72)
    :- * HashAggregate (28)
    :  +- Exchange (27)
    :     +- * HashAggregate (26)
@@ -201,7 +201,7 @@ Results [10]: [i_item_id#18, s_state#16, sum#31, count#32, sum#33, count#34, sum
 Input [10]: [i_item_id#18, s_state#16, sum#31, count#32, sum#33, count#34, sum#35, count#36, sum#37, count#38]
 Arguments: hashpartitioning(i_item_id#18, s_state#16, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(28) HashAggregate [codegen id : 6]
+(28) HashAggregate [codegen id : 16]
 Input [10]: [i_item_id#18, s_state#16, sum#31, count#32, sum#33, count#34, sum#35, count#36, sum#37, count#38]
 Keys [2]: [i_item_id#18, s_state#16]
 Functions [4]: [avg(agg1#19), avg(UnscaledValue(agg2#20)), avg(UnscaledValue(agg3#21)), avg(UnscaledValue(agg4#22))]
@@ -216,23 +216,23 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#55), dynamicpruningexpression(ss_so
 PushedFilters: [IsNotNull(ss_cdemo_sk), IsNotNull(ss_store_sk), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_cdemo_sk:int,ss_store_sk:int,ss_quantity:int,ss_list_price:decimal(7,2),ss_sales_price:decimal(7,2),ss_coupon_amt:decimal(7,2)>
 
-(30) ColumnarToRow [codegen id : 11]
+(30) ColumnarToRow [codegen id : 10]
 Input [8]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
 
-(31) Filter [codegen id : 11]
+(31) Filter [codegen id : 10]
 Input [8]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
 Condition : ((isnotnull(ss_cdemo_sk#49) AND isnotnull(ss_store_sk#50)) AND isnotnull(ss_item_sk#48))
 
 (32) ReusedExchange [Reuses operator id: 8]
 Output [1]: [cd_demo_sk#56]
 
-(33) BroadcastHashJoin [codegen id : 11]
+(33) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_cdemo_sk#49]
 Right keys [1]: [cd_demo_sk#56]
 Join type: Inner
 Join condition: None
 
-(34) Project [codegen id : 11]
+(34) Project [codegen id : 10]
 Output [7]: [ss_item_sk#48, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
 Input [9]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55, cd_demo_sk#56]
 
@@ -243,14 +243,14 @@ Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_state), EqualTo(s_state,TN), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_state:string>
 
-(36) ColumnarToRow [codegen id : 8]
+(36) ColumnarToRow [codegen id : 7]
 Input [2]: [s_store_sk#57, s_state#58]
 
-(37) Filter [codegen id : 8]
+(37) Filter [codegen id : 7]
 Input [2]: [s_store_sk#57, s_state#58]
 Condition : ((isnotnull(s_state#58) AND (s_state#58 = TN)) AND isnotnull(s_store_sk#57))
 
-(38) Project [codegen id : 8]
+(38) Project [codegen id : 7]
 Output [1]: [s_store_sk#57]
 Input [2]: [s_store_sk#57, s_state#58]
 
@@ -258,43 +258,43 @@ Input [2]: [s_store_sk#57, s_state#58]
 Input [1]: [s_store_sk#57]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
-(40) BroadcastHashJoin [codegen id : 11]
+(40) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#50]
 Right keys [1]: [s_store_sk#57]
 Join type: Inner
 Join condition: None
 
-(41) Project [codegen id : 11]
+(41) Project [codegen id : 10]
 Output [6]: [ss_item_sk#48, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
 Input [8]: [ss_item_sk#48, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55, s_store_sk#57]
 
 (42) ReusedExchange [Reuses operator id: 78]
 Output [1]: [d_date_sk#59]
 
-(43) BroadcastHashJoin [codegen id : 11]
+(43) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#55]
 Right keys [1]: [d_date_sk#59]
 Join type: Inner
 Join condition: None
 
-(44) Project [codegen id : 11]
+(44) Project [codegen id : 10]
 Output [5]: [ss_item_sk#48, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54]
 Input [7]: [ss_item_sk#48, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55, d_date_sk#59]
 
 (45) ReusedExchange [Reuses operator id: 23]
 Output [2]: [i_item_sk#60, i_item_id#61]
 
-(46) BroadcastHashJoin [codegen id : 11]
+(46) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_item_sk#48]
 Right keys [1]: [i_item_sk#60]
 Join type: Inner
 Join condition: None
 
-(47) Project [codegen id : 11]
+(47) Project [codegen id : 10]
 Output [5]: [i_item_id#61, ss_quantity#51 AS agg1#62, ss_list_price#52 AS agg2#63, ss_coupon_amt#54 AS agg3#64, ss_sales_price#53 AS agg4#65]
 Input [7]: [ss_item_sk#48, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, i_item_sk#60, i_item_id#61]
 
-(48) HashAggregate [codegen id : 11]
+(48) HashAggregate [codegen id : 10]
 Input [5]: [i_item_id#61, agg1#62, agg2#63, agg3#64, agg4#65]
 Keys [1]: [i_item_id#61]
 Functions [4]: [partial_avg(agg1#62), partial_avg(UnscaledValue(agg2#63)), partial_avg(UnscaledValue(agg3#64)), partial_avg(UnscaledValue(agg4#65))]
@@ -305,7 +305,7 @@ Results [9]: [i_item_id#61, sum#74, count#75, sum#76, count#77, sum#78, count#79
 Input [9]: [i_item_id#61, sum#74, count#75, sum#76, count#77, sum#78, count#79, sum#80, count#81]
 Arguments: hashpartitioning(i_item_id#61, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(50) HashAggregate [codegen id : 12]
+(50) HashAggregate
 Input [9]: [i_item_id#61, sum#74, count#75, sum#76, count#77, sum#78, count#79, sum#80, count#81]
 Keys [1]: [i_item_id#61]
 Functions [4]: [avg(agg1#62), avg(UnscaledValue(agg2#63)), avg(UnscaledValue(agg3#64)), avg(UnscaledValue(agg4#65))]
@@ -320,49 +320,49 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#99), dynamicpruningexpression(ss_so
 PushedFilters: [IsNotNull(ss_cdemo_sk), IsNotNull(ss_store_sk), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_cdemo_sk:int,ss_store_sk:int,ss_quantity:int,ss_list_price:decimal(7,2),ss_sales_price:decimal(7,2),ss_coupon_amt:decimal(7,2)>
 
-(52) ColumnarToRow [codegen id : 17]
+(52) ColumnarToRow [codegen id : 15]
 Input [8]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
 
-(53) Filter [codegen id : 17]
+(53) Filter [codegen id : 15]
 Input [8]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
 Condition : ((isnotnull(ss_cdemo_sk#93) AND isnotnull(ss_store_sk#94)) AND isnotnull(ss_item_sk#92))
 
 (54) ReusedExchange [Reuses operator id: 8]
 Output [1]: [cd_demo_sk#100]
 
-(55) BroadcastHashJoin [codegen id : 17]
+(55) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_cdemo_sk#93]
 Right keys [1]: [cd_demo_sk#100]
 Join type: Inner
 Join condition: None
 
-(56) Project [codegen id : 17]
+(56) Project [codegen id : 15]
 Output [7]: [ss_item_sk#92, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
 Input [9]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99, cd_demo_sk#100]
 
 (57) ReusedExchange [Reuses operator id: 39]
 Output [1]: [s_store_sk#101]
 
-(58) BroadcastHashJoin [codegen id : 17]
+(58) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_store_sk#94]
 Right keys [1]: [s_store_sk#101]
 Join type: Inner
 Join condition: None
 
-(59) Project [codegen id : 17]
+(59) Project [codegen id : 15]
 Output [6]: [ss_item_sk#92, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
 Input [8]: [ss_item_sk#92, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99, s_store_sk#101]
 
 (60) ReusedExchange [Reuses operator id: 78]
 Output [1]: [d_date_sk#102]
 
-(61) BroadcastHashJoin [codegen id : 17]
+(61) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_sold_date_sk#99]
 Right keys [1]: [d_date_sk#102]
 Join type: Inner
 Join condition: None
 
-(62) Project [codegen id : 17]
+(62) Project [codegen id : 15]
 Output [5]: [ss_item_sk#92, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98]
 Input [7]: [ss_item_sk#92, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99, d_date_sk#102]
 
@@ -373,10 +373,10 @@ Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int>
 
-(64) ColumnarToRow [codegen id : 16]
+(64) ColumnarToRow [codegen id : 14]
 Input [1]: [i_item_sk#103]
 
-(65) Filter [codegen id : 16]
+(65) Filter [codegen id : 14]
 Input [1]: [i_item_sk#103]
 Condition : isnotnull(i_item_sk#103)
 
@@ -384,17 +384,17 @@ Condition : isnotnull(i_item_sk#103)
 Input [1]: [i_item_sk#103]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(67) BroadcastHashJoin [codegen id : 17]
+(67) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_item_sk#92]
 Right keys [1]: [i_item_sk#103]
 Join type: Inner
 Join condition: None
 
-(68) Project [codegen id : 17]
+(68) Project [codegen id : 15]
 Output [4]: [ss_quantity#95 AS agg1#104, ss_list_price#96 AS agg2#105, ss_coupon_amt#98 AS agg3#106, ss_sales_price#97 AS agg4#107]
 Input [6]: [ss_item_sk#92, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, i_item_sk#103]
 
-(69) HashAggregate [codegen id : 17]
+(69) HashAggregate [codegen id : 15]
 Input [4]: [agg1#104, agg2#105, agg3#106, agg4#107]
 Keys: []
 Functions [4]: [partial_avg(agg1#104), partial_avg(UnscaledValue(agg2#105)), partial_avg(UnscaledValue(agg3#106)), partial_avg(UnscaledValue(agg4#107))]
@@ -405,14 +405,14 @@ Results [8]: [sum#116, count#117, sum#118, count#119, sum#120, count#121, sum#12
 Input [8]: [sum#116, count#117, sum#118, count#119, sum#120, count#121, sum#122, count#123]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(71) HashAggregate [codegen id : 18]
+(71) HashAggregate
 Input [8]: [sum#116, count#117, sum#118, count#119, sum#120, count#121, sum#122, count#123]
 Keys: []
 Functions [4]: [avg(agg1#104), avg(UnscaledValue(agg2#105)), avg(UnscaledValue(agg3#106)), avg(UnscaledValue(agg4#107))]
 Aggregate Attributes [4]: [avg(agg1#104)#124, avg(UnscaledValue(agg2#105))#125, avg(UnscaledValue(agg3#106))#126, avg(UnscaledValue(agg4#107))#127]
 Results [7]: [null AS i_item_id#128, null AS s_state#129, 1 AS g_state#130, avg(agg1#104)#124 AS agg1#131, cast((avg(UnscaledValue(agg2#105))#125 / 100.0) as decimal(11,6)) AS agg2#132, cast((avg(UnscaledValue(agg3#106))#126 / 100.0) as decimal(11,6)) AS agg3#133, cast((avg(UnscaledValue(agg4#107))#127 / 100.0) as decimal(11,6)) AS agg4#134]
 
-(72) Union
+(72) Union [codegen id : 16]
 
 (73) TakeOrderedAndProject
 Input [7]: [i_item_id#18, s_state#16, g_state#43, agg1#44, agg2#45, agg3#46, agg4#47]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a.sf100/simplified.txt
@@ -1,6 +1,6 @@
 TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
-  Union
-    WholeStageCodegen (6)
+  WholeStageCodegen (16)
+    Union
       HashAggregate [i_item_id,s_state,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(UnscaledValue(agg2)),avg(UnscaledValue(agg3)),avg(UnscaledValue(agg4)),g_state,agg1,agg2,agg3,agg4,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange [i_item_id,s_state] #1
@@ -50,11 +50,10 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                             ColumnarToRow
                               InputAdapter
                                 Scan parquet spark_catalog.default.item [i_item_sk,i_item_id]
-    WholeStageCodegen (12)
       HashAggregate [i_item_id,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(UnscaledValue(agg2)),avg(UnscaledValue(agg3)),avg(UnscaledValue(agg4)),s_state,g_state,agg1,agg2,agg3,agg4,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange [i_item_id] #6
-            WholeStageCodegen (11)
+            WholeStageCodegen (10)
               HashAggregate [i_item_id,agg1,agg2,agg3,agg4] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [i_item_id,ss_quantity,ss_list_price,ss_coupon_amt,ss_sales_price]
                   BroadcastHashJoin [ss_item_sk,i_item_sk]
@@ -73,7 +72,7 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                                   ReusedExchange [cd_demo_sk] #3
                             InputAdapter
                               BroadcastExchange #7
-                                WholeStageCodegen (8)
+                                WholeStageCodegen (7)
                                   Project [s_store_sk]
                                     Filter [s_state,s_store_sk]
                                       ColumnarToRow
@@ -83,11 +82,10 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                           ReusedExchange [d_date_sk] #2
                     InputAdapter
                       ReusedExchange [i_item_sk,i_item_id] #5
-    WholeStageCodegen (18)
       HashAggregate [sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(UnscaledValue(agg2)),avg(UnscaledValue(agg3)),avg(UnscaledValue(agg4)),i_item_id,s_state,g_state,agg1,agg2,agg3,agg4,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange #8
-            WholeStageCodegen (17)
+            WholeStageCodegen (15)
               HashAggregate [agg1,agg2,agg3,agg4] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [ss_quantity,ss_list_price,ss_coupon_amt,ss_sales_price]
                   BroadcastHashJoin [ss_item_sk,i_item_sk]
@@ -110,7 +108,7 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                           ReusedExchange [d_date_sk] #2
                     InputAdapter
                       BroadcastExchange #9
-                        WholeStageCodegen (16)
+                        WholeStageCodegen (14)
                           Filter [i_item_sk]
                             ColumnarToRow
                               InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a/explain.txt
@@ -1,6 +1,6 @@
 == Physical Plan ==
 TakeOrderedAndProject (73)
-+- Union (72)
++- * Union (72)
    :- * HashAggregate (28)
    :  +- Exchange (27)
    :     +- * HashAggregate (26)
@@ -201,7 +201,7 @@ Results [10]: [i_item_id#18, s_state#16, sum#31, count#32, sum#33, count#34, sum
 Input [10]: [i_item_id#18, s_state#16, sum#31, count#32, sum#33, count#34, sum#35, count#36, sum#37, count#38]
 Arguments: hashpartitioning(i_item_id#18, s_state#16, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(28) HashAggregate [codegen id : 6]
+(28) HashAggregate [codegen id : 16]
 Input [10]: [i_item_id#18, s_state#16, sum#31, count#32, sum#33, count#34, sum#35, count#36, sum#37, count#38]
 Keys [2]: [i_item_id#18, s_state#16]
 Functions [4]: [avg(agg1#19), avg(UnscaledValue(agg2#20)), avg(UnscaledValue(agg3#21)), avg(UnscaledValue(agg4#22))]
@@ -216,36 +216,36 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#55), dynamicpruningexpression(ss_so
 PushedFilters: [IsNotNull(ss_cdemo_sk), IsNotNull(ss_store_sk), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_cdemo_sk:int,ss_store_sk:int,ss_quantity:int,ss_list_price:decimal(7,2),ss_sales_price:decimal(7,2),ss_coupon_amt:decimal(7,2)>
 
-(30) ColumnarToRow [codegen id : 11]
+(30) ColumnarToRow [codegen id : 10]
 Input [8]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
 
-(31) Filter [codegen id : 11]
+(31) Filter [codegen id : 10]
 Input [8]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
 Condition : ((isnotnull(ss_cdemo_sk#49) AND isnotnull(ss_store_sk#50)) AND isnotnull(ss_item_sk#48))
 
 (32) ReusedExchange [Reuses operator id: 8]
 Output [1]: [cd_demo_sk#56]
 
-(33) BroadcastHashJoin [codegen id : 11]
+(33) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_cdemo_sk#49]
 Right keys [1]: [cd_demo_sk#56]
 Join type: Inner
 Join condition: None
 
-(34) Project [codegen id : 11]
+(34) Project [codegen id : 10]
 Output [7]: [ss_item_sk#48, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
 Input [9]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55, cd_demo_sk#56]
 
 (35) ReusedExchange [Reuses operator id: 78]
 Output [1]: [d_date_sk#57]
 
-(36) BroadcastHashJoin [codegen id : 11]
+(36) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#55]
 Right keys [1]: [d_date_sk#57]
 Join type: Inner
 Join condition: None
 
-(37) Project [codegen id : 11]
+(37) Project [codegen id : 10]
 Output [6]: [ss_item_sk#48, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54]
 Input [8]: [ss_item_sk#48, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55, d_date_sk#57]
 
@@ -256,14 +256,14 @@ Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_state), EqualTo(s_state,TN), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_state:string>
 
-(39) ColumnarToRow [codegen id : 9]
+(39) ColumnarToRow [codegen id : 8]
 Input [2]: [s_store_sk#58, s_state#59]
 
-(40) Filter [codegen id : 9]
+(40) Filter [codegen id : 8]
 Input [2]: [s_store_sk#58, s_state#59]
 Condition : ((isnotnull(s_state#59) AND (s_state#59 = TN)) AND isnotnull(s_store_sk#58))
 
-(41) Project [codegen id : 9]
+(41) Project [codegen id : 8]
 Output [1]: [s_store_sk#58]
 Input [2]: [s_store_sk#58, s_state#59]
 
@@ -271,30 +271,30 @@ Input [2]: [s_store_sk#58, s_state#59]
 Input [1]: [s_store_sk#58]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
-(43) BroadcastHashJoin [codegen id : 11]
+(43) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#50]
 Right keys [1]: [s_store_sk#58]
 Join type: Inner
 Join condition: None
 
-(44) Project [codegen id : 11]
+(44) Project [codegen id : 10]
 Output [5]: [ss_item_sk#48, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54]
 Input [7]: [ss_item_sk#48, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, s_store_sk#58]
 
 (45) ReusedExchange [Reuses operator id: 23]
 Output [2]: [i_item_sk#60, i_item_id#61]
 
-(46) BroadcastHashJoin [codegen id : 11]
+(46) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_item_sk#48]
 Right keys [1]: [i_item_sk#60]
 Join type: Inner
 Join condition: None
 
-(47) Project [codegen id : 11]
+(47) Project [codegen id : 10]
 Output [5]: [i_item_id#61, ss_quantity#51 AS agg1#62, ss_list_price#52 AS agg2#63, ss_coupon_amt#54 AS agg3#64, ss_sales_price#53 AS agg4#65]
 Input [7]: [ss_item_sk#48, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, i_item_sk#60, i_item_id#61]
 
-(48) HashAggregate [codegen id : 11]
+(48) HashAggregate [codegen id : 10]
 Input [5]: [i_item_id#61, agg1#62, agg2#63, agg3#64, agg4#65]
 Keys [1]: [i_item_id#61]
 Functions [4]: [partial_avg(agg1#62), partial_avg(UnscaledValue(agg2#63)), partial_avg(UnscaledValue(agg3#64)), partial_avg(UnscaledValue(agg4#65))]
@@ -305,7 +305,7 @@ Results [9]: [i_item_id#61, sum#74, count#75, sum#76, count#77, sum#78, count#79
 Input [9]: [i_item_id#61, sum#74, count#75, sum#76, count#77, sum#78, count#79, sum#80, count#81]
 Arguments: hashpartitioning(i_item_id#61, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(50) HashAggregate [codegen id : 12]
+(50) HashAggregate
 Input [9]: [i_item_id#61, sum#74, count#75, sum#76, count#77, sum#78, count#79, sum#80, count#81]
 Keys [1]: [i_item_id#61]
 Functions [4]: [avg(agg1#62), avg(UnscaledValue(agg2#63)), avg(UnscaledValue(agg3#64)), avg(UnscaledValue(agg4#65))]
@@ -320,49 +320,49 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#99), dynamicpruningexpression(ss_so
 PushedFilters: [IsNotNull(ss_cdemo_sk), IsNotNull(ss_store_sk), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_cdemo_sk:int,ss_store_sk:int,ss_quantity:int,ss_list_price:decimal(7,2),ss_sales_price:decimal(7,2),ss_coupon_amt:decimal(7,2)>
 
-(52) ColumnarToRow [codegen id : 17]
+(52) ColumnarToRow [codegen id : 15]
 Input [8]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
 
-(53) Filter [codegen id : 17]
+(53) Filter [codegen id : 15]
 Input [8]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
 Condition : ((isnotnull(ss_cdemo_sk#93) AND isnotnull(ss_store_sk#94)) AND isnotnull(ss_item_sk#92))
 
 (54) ReusedExchange [Reuses operator id: 8]
 Output [1]: [cd_demo_sk#100]
 
-(55) BroadcastHashJoin [codegen id : 17]
+(55) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_cdemo_sk#93]
 Right keys [1]: [cd_demo_sk#100]
 Join type: Inner
 Join condition: None
 
-(56) Project [codegen id : 17]
+(56) Project [codegen id : 15]
 Output [7]: [ss_item_sk#92, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
 Input [9]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99, cd_demo_sk#100]
 
 (57) ReusedExchange [Reuses operator id: 78]
 Output [1]: [d_date_sk#101]
 
-(58) BroadcastHashJoin [codegen id : 17]
+(58) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_sold_date_sk#99]
 Right keys [1]: [d_date_sk#101]
 Join type: Inner
 Join condition: None
 
-(59) Project [codegen id : 17]
+(59) Project [codegen id : 15]
 Output [6]: [ss_item_sk#92, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98]
 Input [8]: [ss_item_sk#92, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99, d_date_sk#101]
 
 (60) ReusedExchange [Reuses operator id: 42]
 Output [1]: [s_store_sk#102]
 
-(61) BroadcastHashJoin [codegen id : 17]
+(61) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_store_sk#94]
 Right keys [1]: [s_store_sk#102]
 Join type: Inner
 Join condition: None
 
-(62) Project [codegen id : 17]
+(62) Project [codegen id : 15]
 Output [5]: [ss_item_sk#92, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98]
 Input [7]: [ss_item_sk#92, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, s_store_sk#102]
 
@@ -373,10 +373,10 @@ Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int>
 
-(64) ColumnarToRow [codegen id : 16]
+(64) ColumnarToRow [codegen id : 14]
 Input [1]: [i_item_sk#103]
 
-(65) Filter [codegen id : 16]
+(65) Filter [codegen id : 14]
 Input [1]: [i_item_sk#103]
 Condition : isnotnull(i_item_sk#103)
 
@@ -384,17 +384,17 @@ Condition : isnotnull(i_item_sk#103)
 Input [1]: [i_item_sk#103]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(67) BroadcastHashJoin [codegen id : 17]
+(67) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_item_sk#92]
 Right keys [1]: [i_item_sk#103]
 Join type: Inner
 Join condition: None
 
-(68) Project [codegen id : 17]
+(68) Project [codegen id : 15]
 Output [4]: [ss_quantity#95 AS agg1#104, ss_list_price#96 AS agg2#105, ss_coupon_amt#98 AS agg3#106, ss_sales_price#97 AS agg4#107]
 Input [6]: [ss_item_sk#92, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, i_item_sk#103]
 
-(69) HashAggregate [codegen id : 17]
+(69) HashAggregate [codegen id : 15]
 Input [4]: [agg1#104, agg2#105, agg3#106, agg4#107]
 Keys: []
 Functions [4]: [partial_avg(agg1#104), partial_avg(UnscaledValue(agg2#105)), partial_avg(UnscaledValue(agg3#106)), partial_avg(UnscaledValue(agg4#107))]
@@ -405,14 +405,14 @@ Results [8]: [sum#116, count#117, sum#118, count#119, sum#120, count#121, sum#12
 Input [8]: [sum#116, count#117, sum#118, count#119, sum#120, count#121, sum#122, count#123]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(71) HashAggregate [codegen id : 18]
+(71) HashAggregate
 Input [8]: [sum#116, count#117, sum#118, count#119, sum#120, count#121, sum#122, count#123]
 Keys: []
 Functions [4]: [avg(agg1#104), avg(UnscaledValue(agg2#105)), avg(UnscaledValue(agg3#106)), avg(UnscaledValue(agg4#107))]
 Aggregate Attributes [4]: [avg(agg1#104)#124, avg(UnscaledValue(agg2#105))#125, avg(UnscaledValue(agg3#106))#126, avg(UnscaledValue(agg4#107))#127]
 Results [7]: [null AS i_item_id#128, null AS s_state#129, 1 AS g_state#130, avg(agg1#104)#124 AS agg1#131, cast((avg(UnscaledValue(agg2#105))#125 / 100.0) as decimal(11,6)) AS agg2#132, cast((avg(UnscaledValue(agg3#106))#126 / 100.0) as decimal(11,6)) AS agg3#133, cast((avg(UnscaledValue(agg4#107))#127 / 100.0) as decimal(11,6)) AS agg4#134]
 
-(72) Union
+(72) Union [codegen id : 16]
 
 (73) TakeOrderedAndProject
 Input [7]: [i_item_id#18, s_state#16, g_state#43, agg1#44, agg2#45, agg3#46, agg4#47]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a/simplified.txt
@@ -1,6 +1,6 @@
 TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
-  Union
-    WholeStageCodegen (6)
+  WholeStageCodegen (16)
+    Union
       HashAggregate [i_item_id,s_state,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(UnscaledValue(agg2)),avg(UnscaledValue(agg3)),avg(UnscaledValue(agg4)),g_state,agg1,agg2,agg3,agg4,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange [i_item_id,s_state] #1
@@ -50,11 +50,10 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                             ColumnarToRow
                               InputAdapter
                                 Scan parquet spark_catalog.default.item [i_item_sk,i_item_id]
-    WholeStageCodegen (12)
       HashAggregate [i_item_id,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(UnscaledValue(agg2)),avg(UnscaledValue(agg3)),avg(UnscaledValue(agg4)),s_state,g_state,agg1,agg2,agg3,agg4,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange [i_item_id] #6
-            WholeStageCodegen (11)
+            WholeStageCodegen (10)
               HashAggregate [i_item_id,agg1,agg2,agg3,agg4] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [i_item_id,ss_quantity,ss_list_price,ss_coupon_amt,ss_sales_price]
                   BroadcastHashJoin [ss_item_sk,i_item_sk]
@@ -75,7 +74,7 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                               ReusedExchange [d_date_sk] #2
                         InputAdapter
                           BroadcastExchange #7
-                            WholeStageCodegen (9)
+                            WholeStageCodegen (8)
                               Project [s_store_sk]
                                 Filter [s_state,s_store_sk]
                                   ColumnarToRow
@@ -83,11 +82,10 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                                       Scan parquet spark_catalog.default.store [s_store_sk,s_state]
                     InputAdapter
                       ReusedExchange [i_item_sk,i_item_id] #5
-    WholeStageCodegen (18)
       HashAggregate [sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(UnscaledValue(agg2)),avg(UnscaledValue(agg3)),avg(UnscaledValue(agg4)),i_item_id,s_state,g_state,agg1,agg2,agg3,agg4,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange #8
-            WholeStageCodegen (17)
+            WholeStageCodegen (15)
               HashAggregate [agg1,agg2,agg3,agg4] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [ss_quantity,ss_list_price,ss_coupon_amt,ss_sales_price]
                   BroadcastHashJoin [ss_item_sk,i_item_sk]
@@ -110,7 +108,7 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                           ReusedExchange [s_store_sk] #7
                     InputAdapter
                       BroadcastExchange #9
-                        WholeStageCodegen (16)
+                        WholeStageCodegen (14)
                           Filter [i_item_sk]
                             ColumnarToRow
                               InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a.sf100/explain.txt
@@ -28,7 +28,7 @@ TakeOrderedAndProject (50)
                :           :           :              +- ReusedExchange (8)
                :           :           +- * Sort (26)
                :           :              +- Exchange (25)
-               :           :                 +- Union (24)
+               :           :                 +- * Union (24)
                :           :                    :- * Project (18)
                :           :                    :  +- * BroadcastHashJoin Inner BuildRight (17)
                :           :                    :     :- * ColumnarToRow (15)
@@ -117,19 +117,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#9), dynamicpruningexpression(ws_sold_date_sk#9 IN dynamicpruning#6)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
-(15) ColumnarToRow [codegen id : 8]
+(15) ColumnarToRow [codegen id : 9]
 Input [2]: [ws_bill_customer_sk#8, ws_sold_date_sk#9]
 
 (16) ReusedExchange [Reuses operator id: 55]
 Output [1]: [d_date_sk#10]
 
-(17) BroadcastHashJoin [codegen id : 8]
+(17) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ws_sold_date_sk#9]
 Right keys [1]: [d_date_sk#10]
 Join type: Inner
 Join condition: None
 
-(18) Project [codegen id : 8]
+(18) Project [codegen id : 9]
 Output [1]: [ws_bill_customer_sk#8 AS customsk#11]
 Input [3]: [ws_bill_customer_sk#8, ws_sold_date_sk#9, d_date_sk#10]
 
@@ -140,39 +140,39 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#13), dynamicpruningexpression(cs_sold_date_sk#13 IN dynamicpruning#6)]
 ReadSchema: struct<cs_ship_customer_sk:int>
 
-(20) ColumnarToRow [codegen id : 10]
+(20) ColumnarToRow
 Input [2]: [cs_ship_customer_sk#12, cs_sold_date_sk#13]
 
 (21) ReusedExchange [Reuses operator id: 55]
 Output [1]: [d_date_sk#14]
 
-(22) BroadcastHashJoin [codegen id : 10]
+(22) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#13]
 Right keys [1]: [d_date_sk#14]
 Join type: Inner
 Join condition: None
 
-(23) Project [codegen id : 10]
+(23) Project
 Output [1]: [cs_ship_customer_sk#12 AS customsk#15]
 Input [3]: [cs_ship_customer_sk#12, cs_sold_date_sk#13, d_date_sk#14]
 
-(24) Union
+(24) Union [codegen id : 9]
 
 (25) Exchange
 Input [1]: [customsk#11]
 Arguments: hashpartitioning(customsk#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(26) Sort [codegen id : 11]
+(26) Sort [codegen id : 10]
 Input [1]: [customsk#11]
 Arguments: [customsk#11 ASC NULLS FIRST], false, 0
 
-(27) SortMergeJoin [codegen id : 12]
+(27) SortMergeJoin [codegen id : 11]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customsk#11]
 Join type: LeftSemi
 Join condition: None
 
-(28) Project [codegen id : 12]
+(28) Project [codegen id : 11]
 Output [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
@@ -180,7 +180,7 @@ Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Arguments: hashpartitioning(c_current_addr_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(30) Sort [codegen id : 13]
+(30) Sort [codegen id : 12]
 Input [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Arguments: [c_current_addr_sk#3 ASC NULLS FIRST], false, 0
 
@@ -191,10 +191,10 @@ Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(32) ColumnarToRow [codegen id : 14]
+(32) ColumnarToRow [codegen id : 13]
 Input [2]: [ca_address_sk#16, ca_state#17]
 
-(33) Filter [codegen id : 14]
+(33) Filter [codegen id : 13]
 Input [2]: [ca_address_sk#16, ca_state#17]
 Condition : isnotnull(ca_address_sk#16)
 
@@ -202,17 +202,17 @@ Condition : isnotnull(ca_address_sk#16)
 Input [2]: [ca_address_sk#16, ca_state#17]
 Arguments: hashpartitioning(ca_address_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(35) Sort [codegen id : 15]
+(35) Sort [codegen id : 14]
 Input [2]: [ca_address_sk#16, ca_state#17]
 Arguments: [ca_address_sk#16 ASC NULLS FIRST], false, 0
 
-(36) SortMergeJoin [codegen id : 16]
+(36) SortMergeJoin [codegen id : 15]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#16]
 Join type: Inner
 Join condition: None
 
-(37) Project [codegen id : 16]
+(37) Project [codegen id : 15]
 Output [2]: [c_current_cdemo_sk#2, ca_state#17]
 Input [4]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#16, ca_state#17]
 
@@ -220,7 +220,7 @@ Input [4]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#16, ca_stat
 Input [2]: [c_current_cdemo_sk#2, ca_state#17]
 Arguments: hashpartitioning(c_current_cdemo_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(39) Sort [codegen id : 17]
+(39) Sort [codegen id : 16]
 Input [2]: [c_current_cdemo_sk#2, ca_state#17]
 Arguments: [c_current_cdemo_sk#2 ASC NULLS FIRST], false, 0
 
@@ -231,10 +231,10 @@ Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
-(41) ColumnarToRow [codegen id : 18]
+(41) ColumnarToRow [codegen id : 17]
 Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 
-(42) Filter [codegen id : 18]
+(42) Filter [codegen id : 17]
 Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 Condition : isnotnull(cd_demo_sk#18)
 
@@ -242,21 +242,21 @@ Condition : isnotnull(cd_demo_sk#18)
 Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 Arguments: hashpartitioning(cd_demo_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(44) Sort [codegen id : 19]
+(44) Sort [codegen id : 18]
 Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 Arguments: [cd_demo_sk#18 ASC NULLS FIRST], false, 0
 
-(45) SortMergeJoin [codegen id : 20]
+(45) SortMergeJoin [codegen id : 19]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#18]
 Join type: Inner
 Join condition: None
 
-(46) Project [codegen id : 20]
+(46) Project [codegen id : 19]
 Output [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 Input [8]: [c_current_cdemo_sk#2, ca_state#17, cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 
-(47) HashAggregate [codegen id : 20]
+(47) HashAggregate [codegen id : 19]
 Input [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 Keys [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 Functions [10]: [partial_count(1), partial_avg(cd_dep_count#21), partial_max(cd_dep_count#21), partial_sum(cd_dep_count#21), partial_avg(cd_dep_employed_count#22), partial_max(cd_dep_employed_count#22), partial_sum(cd_dep_employed_count#22), partial_avg(cd_dep_college_count#23), partial_max(cd_dep_college_count#23), partial_sum(cd_dep_college_count#23)]
@@ -267,7 +267,7 @@ Results [19]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21,
 Input [19]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, count#37, sum#38, count#39, max#40, sum#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49]
 Arguments: hashpartitioning(ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(49) HashAggregate [codegen id : 21]
+(49) HashAggregate [codegen id : 20]
 Input [19]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, count#37, sum#38, count#39, max#40, sum#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49]
 Keys [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 Functions [10]: [count(1), avg(cd_dep_count#21), max(cd_dep_count#21), sum(cd_dep_count#21), avg(cd_dep_employed_count#22), max(cd_dep_employed_count#22), sum(cd_dep_employed_count#22), avg(cd_dep_college_count#23), max(cd_dep_college_count#23), sum(cd_dep_college_count#23)]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a.sf100/simplified.txt
@@ -1,26 +1,26 @@
 TakeOrderedAndProject [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,cnt1,avg(cd_dep_count),max(cd_dep_count),sum(cd_dep_count),cnt2,avg(cd_dep_employed_count),max(cd_dep_employed_count),sum(cd_dep_employed_count),cnt3,avg(cd_dep_college_count),max(cd_dep_college_count),sum(cd_dep_college_count)]
-  WholeStageCodegen (21)
+  WholeStageCodegen (20)
     HashAggregate [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,count,sum,count,max,sum,sum,count,max,sum,sum,count,max,sum] [count(1),avg(cd_dep_count),max(cd_dep_count),sum(cd_dep_count),avg(cd_dep_employed_count),max(cd_dep_employed_count),sum(cd_dep_employed_count),avg(cd_dep_college_count),max(cd_dep_college_count),sum(cd_dep_college_count),cnt1,avg(cd_dep_count),max(cd_dep_count),sum(cd_dep_count),cnt2,avg(cd_dep_employed_count),max(cd_dep_employed_count),sum(cd_dep_employed_count),cnt3,avg(cd_dep_college_count),max(cd_dep_college_count),sum(cd_dep_college_count),count,sum,count,max,sum,sum,count,max,sum,sum,count,max,sum]
       InputAdapter
         Exchange [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] #1
-          WholeStageCodegen (20)
+          WholeStageCodegen (19)
             HashAggregate [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] [count,sum,count,max,sum,sum,count,max,sum,sum,count,max,sum,count,sum,count,max,sum,sum,count,max,sum,sum,count,max,sum]
               Project [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
                 SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
                   InputAdapter
-                    WholeStageCodegen (17)
+                    WholeStageCodegen (16)
                       Sort [c_current_cdemo_sk]
                         InputAdapter
                           Exchange [c_current_cdemo_sk] #2
-                            WholeStageCodegen (16)
+                            WholeStageCodegen (15)
                               Project [c_current_cdemo_sk,ca_state]
                                 SortMergeJoin [c_current_addr_sk,ca_address_sk]
                                   InputAdapter
-                                    WholeStageCodegen (13)
+                                    WholeStageCodegen (12)
                                       Sort [c_current_addr_sk]
                                         InputAdapter
                                           Exchange [c_current_addr_sk] #3
-                                            WholeStageCodegen (12)
+                                            WholeStageCodegen (11)
                                               Project [c_current_cdemo_sk,c_current_addr_sk]
                                                 SortMergeJoin [c_customer_sk,customsk]
                                                   InputAdapter
@@ -58,12 +58,12 @@ TakeOrderedAndProject [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_
                                                                         InputAdapter
                                                                           ReusedExchange [d_date_sk] #6
                                                   InputAdapter
-                                                    WholeStageCodegen (11)
+                                                    WholeStageCodegen (10)
                                                       Sort [customsk]
                                                         InputAdapter
                                                           Exchange [customsk] #7
-                                                            Union
-                                                              WholeStageCodegen (8)
+                                                            WholeStageCodegen (9)
+                                                              Union
                                                                 Project [ws_bill_customer_sk]
                                                                   BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                                     ColumnarToRow
@@ -72,7 +72,6 @@ TakeOrderedAndProject [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_
                                                                           ReusedSubquery [d_date_sk] #1
                                                                     InputAdapter
                                                                       ReusedExchange [d_date_sk] #6
-                                                              WholeStageCodegen (10)
                                                                 Project [cs_ship_customer_sk]
                                                                   BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                     ColumnarToRow
@@ -82,21 +81,21 @@ TakeOrderedAndProject [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_
                                                                     InputAdapter
                                                                       ReusedExchange [d_date_sk] #6
                                   InputAdapter
-                                    WholeStageCodegen (15)
+                                    WholeStageCodegen (14)
                                       Sort [ca_address_sk]
                                         InputAdapter
                                           Exchange [ca_address_sk] #8
-                                            WholeStageCodegen (14)
+                                            WholeStageCodegen (13)
                                               Filter [ca_address_sk]
                                                 ColumnarToRow
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
                   InputAdapter
-                    WholeStageCodegen (19)
+                    WholeStageCodegen (18)
                       Sort [cd_demo_sk]
                         InputAdapter
                           Exchange [cd_demo_sk] #9
-                            WholeStageCodegen (18)
+                            WholeStageCodegen (17)
                               Filter [cd_demo_sk]
                                 ColumnarToRow
                                   InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a/explain.txt
@@ -20,7 +20,7 @@ TakeOrderedAndProject (40)
                :     :     :           :  +- Scan parquet spark_catalog.default.store_sales (4)
                :     :     :           +- ReusedExchange (6)
                :     :     +- BroadcastExchange (22)
-               :     :        +- Union (21)
+               :     :        +- * Union (21)
                :     :           :- * Project (15)
                :     :           :  +- * BroadcastHashJoin Inner BuildRight (14)
                :     :           :     :- * ColumnarToRow (12)
@@ -48,10 +48,10 @@ Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_current_addr_sk), IsNotNull(c_current_cdemo_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int>
 
-(2) ColumnarToRow [codegen id : 9]
+(2) ColumnarToRow [codegen id : 8]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
-(3) Filter [codegen id : 9]
+(3) Filter [codegen id : 8]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 Condition : (isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2))
 
@@ -82,7 +82,7 @@ Input [3]: [ss_customer_sk#4, ss_sold_date_sk#5, d_date_sk#7]
 Input [1]: [ss_customer_sk#4]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(10) BroadcastHashJoin [codegen id : 9]
+(10) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#4]
 Join type: LeftSemi
@@ -95,19 +95,19 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#9), dynamicpruningexpression(ws_sold_date_sk#9 IN dynamicpruning#6)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
-(12) ColumnarToRow [codegen id : 4]
+(12) ColumnarToRow [codegen id : 5]
 Input [2]: [ws_bill_customer_sk#8, ws_sold_date_sk#9]
 
 (13) ReusedExchange [Reuses operator id: 45]
 Output [1]: [d_date_sk#10]
 
-(14) BroadcastHashJoin [codegen id : 4]
+(14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_sold_date_sk#9]
 Right keys [1]: [d_date_sk#10]
 Join type: Inner
 Join condition: None
 
-(15) Project [codegen id : 4]
+(15) Project [codegen id : 5]
 Output [1]: [ws_bill_customer_sk#8 AS customsk#11]
 Input [3]: [ws_bill_customer_sk#8, ws_sold_date_sk#9, d_date_sk#10]
 
@@ -118,35 +118,35 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#13), dynamicpruningexpression(cs_sold_date_sk#13 IN dynamicpruning#6)]
 ReadSchema: struct<cs_ship_customer_sk:int>
 
-(17) ColumnarToRow [codegen id : 6]
+(17) ColumnarToRow
 Input [2]: [cs_ship_customer_sk#12, cs_sold_date_sk#13]
 
 (18) ReusedExchange [Reuses operator id: 45]
 Output [1]: [d_date_sk#14]
 
-(19) BroadcastHashJoin [codegen id : 6]
+(19) BroadcastHashJoin
 Left keys [1]: [cs_sold_date_sk#13]
 Right keys [1]: [d_date_sk#14]
 Join type: Inner
 Join condition: None
 
-(20) Project [codegen id : 6]
+(20) Project
 Output [1]: [cs_ship_customer_sk#12 AS customsk#15]
 Input [3]: [cs_ship_customer_sk#12, cs_sold_date_sk#13, d_date_sk#14]
 
-(21) Union
+(21) Union [codegen id : 5]
 
 (22) BroadcastExchange
 Input [1]: [customsk#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
-(23) BroadcastHashJoin [codegen id : 9]
+(23) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customsk#11]
 Join type: LeftSemi
 Join condition: None
 
-(24) Project [codegen id : 9]
+(24) Project [codegen id : 8]
 Output [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
@@ -157,10 +157,10 @@ Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(26) ColumnarToRow [codegen id : 7]
+(26) ColumnarToRow [codegen id : 6]
 Input [2]: [ca_address_sk#16, ca_state#17]
 
-(27) Filter [codegen id : 7]
+(27) Filter [codegen id : 6]
 Input [2]: [ca_address_sk#16, ca_state#17]
 Condition : isnotnull(ca_address_sk#16)
 
@@ -168,13 +168,13 @@ Condition : isnotnull(ca_address_sk#16)
 Input [2]: [ca_address_sk#16, ca_state#17]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
-(29) BroadcastHashJoin [codegen id : 9]
+(29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#16]
 Join type: Inner
 Join condition: None
 
-(30) Project [codegen id : 9]
+(30) Project [codegen id : 8]
 Output [2]: [c_current_cdemo_sk#2, ca_state#17]
 Input [4]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#16, ca_state#17]
 
@@ -185,10 +185,10 @@ Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
-(32) ColumnarToRow [codegen id : 8]
+(32) ColumnarToRow [codegen id : 7]
 Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 
-(33) Filter [codegen id : 8]
+(33) Filter [codegen id : 7]
 Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 Condition : isnotnull(cd_demo_sk#18)
 
@@ -196,17 +196,17 @@ Condition : isnotnull(cd_demo_sk#18)
 Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
-(35) BroadcastHashJoin [codegen id : 9]
+(35) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#18]
 Join type: Inner
 Join condition: None
 
-(36) Project [codegen id : 9]
+(36) Project [codegen id : 8]
 Output [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 Input [8]: [c_current_cdemo_sk#2, ca_state#17, cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 
-(37) HashAggregate [codegen id : 9]
+(37) HashAggregate [codegen id : 8]
 Input [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 Keys [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 Functions [10]: [partial_count(1), partial_avg(cd_dep_count#21), partial_max(cd_dep_count#21), partial_sum(cd_dep_count#21), partial_avg(cd_dep_employed_count#22), partial_max(cd_dep_employed_count#22), partial_sum(cd_dep_employed_count#22), partial_avg(cd_dep_college_count#23), partial_max(cd_dep_college_count#23), partial_sum(cd_dep_college_count#23)]
@@ -217,7 +217,7 @@ Results [19]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21,
 Input [19]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, count#37, sum#38, count#39, max#40, sum#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49]
 Arguments: hashpartitioning(ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(39) HashAggregate [codegen id : 10]
+(39) HashAggregate [codegen id : 9]
 Input [19]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, count#37, sum#38, count#39, max#40, sum#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49]
 Keys [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
 Functions [10]: [count(1), avg(cd_dep_count#21), max(cd_dep_count#21), sum(cd_dep_count#21), avg(cd_dep_employed_count#22), max(cd_dep_employed_count#22), sum(cd_dep_employed_count#22), avg(cd_dep_college_count#23), max(cd_dep_college_count#23), sum(cd_dep_college_count#23)]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a/simplified.txt
@@ -1,9 +1,9 @@
 TakeOrderedAndProject [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,cnt1,avg(cd_dep_count),max(cd_dep_count),sum(cd_dep_count),cnt2,avg(cd_dep_employed_count),max(cd_dep_employed_count),sum(cd_dep_employed_count),cnt3,avg(cd_dep_college_count),max(cd_dep_college_count),sum(cd_dep_college_count)]
-  WholeStageCodegen (10)
+  WholeStageCodegen (9)
     HashAggregate [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,count,sum,count,max,sum,sum,count,max,sum,sum,count,max,sum] [count(1),avg(cd_dep_count),max(cd_dep_count),sum(cd_dep_count),avg(cd_dep_employed_count),max(cd_dep_employed_count),sum(cd_dep_employed_count),avg(cd_dep_college_count),max(cd_dep_college_count),sum(cd_dep_college_count),cnt1,avg(cd_dep_count),max(cd_dep_count),sum(cd_dep_count),cnt2,avg(cd_dep_employed_count),max(cd_dep_employed_count),sum(cd_dep_employed_count),cnt3,avg(cd_dep_college_count),max(cd_dep_college_count),sum(cd_dep_college_count),count,sum,count,max,sum,sum,count,max,sum,sum,count,max,sum]
       InputAdapter
         Exchange [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] #1
-          WholeStageCodegen (9)
+          WholeStageCodegen (8)
             HashAggregate [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] [count,sum,count,max,sum,sum,count,max,sum,sum,count,max,sum,count,sum,count,max,sum,sum,count,max,sum,sum,count,max,sum]
               Project [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
                 BroadcastHashJoin [c_current_cdemo_sk,cd_demo_sk]
@@ -36,8 +36,8 @@ TakeOrderedAndProject [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_
                                         ReusedExchange [d_date_sk] #3
                           InputAdapter
                             BroadcastExchange #4
-                              Union
-                                WholeStageCodegen (4)
+                              WholeStageCodegen (5)
+                                Union
                                   Project [ws_bill_customer_sk]
                                     BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                       ColumnarToRow
@@ -46,7 +46,6 @@ TakeOrderedAndProject [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_
                                             ReusedSubquery [d_date_sk] #1
                                       InputAdapter
                                         ReusedExchange [d_date_sk] #3
-                                WholeStageCodegen (6)
                                   Project [cs_ship_customer_sk]
                                     BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                       ColumnarToRow
@@ -57,14 +56,14 @@ TakeOrderedAndProject [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_
                                         ReusedExchange [d_date_sk] #3
                       InputAdapter
                         BroadcastExchange #5
-                          WholeStageCodegen (7)
+                          WholeStageCodegen (6)
                             Filter [ca_address_sk]
                               ColumnarToRow
                                 InputAdapter
                                   Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
                   InputAdapter
                     BroadcastExchange #6
-                      WholeStageCodegen (8)
+                      WholeStageCodegen (7)
                         Filter [cd_demo_sk]
                           ColumnarToRow
                             InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/explain.txt
@@ -7,7 +7,7 @@ TakeOrderedAndProject (41)
             +- * HashAggregate (36)
                +- Exchange (35)
                   +- * HashAggregate (34)
-                     +- Union (33)
+                     +- * Union (33)
                         :- * HashAggregate (22)
                         :  +- Exchange (21)
                         :     +- * HashAggregate (20)
@@ -141,7 +141,7 @@ Results [4]: [i_category#12, i_class#11, sum#15, sum#16]
 Input [4]: [i_category#12, i_class#11, sum#15, sum#16]
 Arguments: hashpartitioning(i_category#12, i_class#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(22) HashAggregate [codegen id : 5]
+(22) HashAggregate [codegen id : 15]
 Input [4]: [i_category#12, i_class#11, sum#15, sum#16]
 Keys [2]: [i_category#12, i_class#11]
 Functions [2]: [sum(UnscaledValue(ss_net_profit#4)), sum(UnscaledValue(ss_ext_sales_price#3))]
@@ -151,14 +151,14 @@ Results [6]: [cast((MakeDecimal(sum(UnscaledValue(ss_net_profit#4))#17,17,2) / M
 (23) ReusedExchange [Reuses operator id: 21]
 Output [4]: [i_category#23, i_class#24, sum#25, sum#26]
 
-(24) HashAggregate [codegen id : 10]
+(24) HashAggregate [codegen id : 9]
 Input [4]: [i_category#23, i_class#24, sum#25, sum#26]
 Keys [2]: [i_category#23, i_class#24]
 Functions [2]: [sum(UnscaledValue(ss_net_profit#27)), sum(UnscaledValue(ss_ext_sales_price#28))]
 Aggregate Attributes [2]: [sum(UnscaledValue(ss_net_profit#27))#29, sum(UnscaledValue(ss_ext_sales_price#28))#30]
 Results [3]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#27))#29,17,2) AS ss_net_profit#31, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#28))#30,17,2) AS ss_ext_sales_price#32, i_category#23]
 
-(25) HashAggregate [codegen id : 10]
+(25) HashAggregate [codegen id : 9]
 Input [3]: [ss_net_profit#31, ss_ext_sales_price#32, i_category#23]
 Keys [1]: [i_category#23]
 Functions [2]: [partial_sum(ss_net_profit#31), partial_sum(ss_ext_sales_price#32)]
@@ -169,7 +169,7 @@ Results [5]: [i_category#23, sum#37, isEmpty#38, sum#39, isEmpty#40]
 Input [5]: [i_category#23, sum#37, isEmpty#38, sum#39, isEmpty#40]
 Arguments: hashpartitioning(i_category#23, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(27) HashAggregate [codegen id : 11]
+(27) HashAggregate
 Input [5]: [i_category#23, sum#37, isEmpty#38, sum#39, isEmpty#40]
 Keys [1]: [i_category#23]
 Functions [2]: [sum(ss_net_profit#31), sum(ss_ext_sales_price#32)]
@@ -179,14 +179,14 @@ Results [6]: [(sum(ss_net_profit#31)#41 / sum(ss_ext_sales_price#32)#42) AS gros
 (28) ReusedExchange [Reuses operator id: 21]
 Output [4]: [i_category#48, i_class#49, sum#50, sum#51]
 
-(29) HashAggregate [codegen id : 16]
+(29) HashAggregate [codegen id : 14]
 Input [4]: [i_category#48, i_class#49, sum#50, sum#51]
 Keys [2]: [i_category#48, i_class#49]
 Functions [2]: [sum(UnscaledValue(ss_net_profit#52)), sum(UnscaledValue(ss_ext_sales_price#53))]
 Aggregate Attributes [2]: [sum(UnscaledValue(ss_net_profit#52))#29, sum(UnscaledValue(ss_ext_sales_price#53))#30]
 Results [2]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#52))#29,17,2) AS ss_net_profit#54, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#53))#30,17,2) AS ss_ext_sales_price#55]
 
-(30) HashAggregate [codegen id : 16]
+(30) HashAggregate [codegen id : 14]
 Input [2]: [ss_net_profit#54, ss_ext_sales_price#55]
 Keys: []
 Functions [2]: [partial_sum(ss_net_profit#54), partial_sum(ss_ext_sales_price#55)]
@@ -197,16 +197,16 @@ Results [4]: [sum#60, isEmpty#61, sum#62, isEmpty#63]
 Input [4]: [sum#60, isEmpty#61, sum#62, isEmpty#63]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
 
-(32) HashAggregate [codegen id : 17]
+(32) HashAggregate
 Input [4]: [sum#60, isEmpty#61, sum#62, isEmpty#63]
 Keys: []
 Functions [2]: [sum(ss_net_profit#54), sum(ss_ext_sales_price#55)]
 Aggregate Attributes [2]: [sum(ss_net_profit#54)#64, sum(ss_ext_sales_price#55)#65]
 Results [6]: [(sum(ss_net_profit#54)#64 / sum(ss_ext_sales_price#55)#65) AS gross_margin#66, null AS i_category#67, null AS i_class#68, 1 AS t_category#69, 1 AS t_class#70, 2 AS lochierarchy#71]
 
-(33) Union
+(33) Union [codegen id : 15]
 
-(34) HashAggregate [codegen id : 18]
+(34) HashAggregate [codegen id : 15]
 Input [6]: [gross_margin#19, i_category#12, i_class#11, t_category#20, t_class#21, lochierarchy#22]
 Keys [6]: [gross_margin#19, i_category#12, i_class#11, t_category#20, t_class#21, lochierarchy#22]
 Functions: []
@@ -217,7 +217,7 @@ Results [6]: [gross_margin#19, i_category#12, i_class#11, t_category#20, t_class
 Input [6]: [gross_margin#19, i_category#12, i_class#11, t_category#20, t_class#21, lochierarchy#22]
 Arguments: hashpartitioning(gross_margin#19, i_category#12, i_class#11, t_category#20, t_class#21, lochierarchy#22, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(36) HashAggregate [codegen id : 19]
+(36) HashAggregate [codegen id : 16]
 Input [6]: [gross_margin#19, i_category#12, i_class#11, t_category#20, t_class#21, lochierarchy#22]
 Keys [6]: [gross_margin#19, i_category#12, i_class#11, t_category#20, t_class#21, lochierarchy#22]
 Functions: []
@@ -228,7 +228,7 @@ Results [5]: [gross_margin#19, i_category#12, i_class#11, lochierarchy#22, CASE 
 Input [5]: [gross_margin#19, i_category#12, i_class#11, lochierarchy#22, _w0#72]
 Arguments: hashpartitioning(lochierarchy#22, _w0#72, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(38) Sort [codegen id : 20]
+(38) Sort [codegen id : 17]
 Input [5]: [gross_margin#19, i_category#12, i_class#11, lochierarchy#22, _w0#72]
 Arguments: [lochierarchy#22 ASC NULLS FIRST, _w0#72 ASC NULLS FIRST, gross_margin#19 ASC NULLS FIRST], false, 0
 
@@ -236,7 +236,7 @@ Arguments: [lochierarchy#22 ASC NULLS FIRST, _w0#72 ASC NULLS FIRST, gross_margi
 Input [5]: [gross_margin#19, i_category#12, i_class#11, lochierarchy#22, _w0#72]
 Arguments: [rank(gross_margin#19) windowspecdefinition(lochierarchy#22, _w0#72, gross_margin#19 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#73], [lochierarchy#22, _w0#72], [gross_margin#19 ASC NULLS FIRST]
 
-(40) Project [codegen id : 21]
+(40) Project [codegen id : 18]
 Output [5]: [gross_margin#19, i_category#12, i_class#11, lochierarchy#22, rank_within_parent#73]
 Input [6]: [gross_margin#19, i_category#12, i_class#11, lochierarchy#22, _w0#72, rank_within_parent#73]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/simplified.txt
@@ -1,76 +1,72 @@
 TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,gross_margin,i_class]
-  WholeStageCodegen (21)
+  WholeStageCodegen (18)
     Project [gross_margin,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter
         Window [gross_margin,lochierarchy,_w0]
-          WholeStageCodegen (20)
+          WholeStageCodegen (17)
             Sort [lochierarchy,_w0,gross_margin]
               InputAdapter
                 Exchange [lochierarchy,_w0] #1
-                  WholeStageCodegen (19)
+                  WholeStageCodegen (16)
                     HashAggregate [gross_margin,i_category,i_class,t_category,t_class,lochierarchy] [_w0]
                       InputAdapter
                         Exchange [gross_margin,i_category,i_class,t_category,t_class,lochierarchy] #2
-                          WholeStageCodegen (18)
+                          WholeStageCodegen (15)
                             HashAggregate [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
-                              InputAdapter
-                                Union
-                                  WholeStageCodegen (5)
-                                    HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),gross_margin,t_category,t_class,lochierarchy,sum,sum]
-                                      InputAdapter
-                                        Exchange [i_category,i_class] #3
-                                          WholeStageCodegen (4)
-                                            HashAggregate [i_category,i_class,ss_net_profit,ss_ext_sales_price] [sum,sum,sum,sum]
-                                              Project [ss_ext_sales_price,ss_net_profit,i_class,i_category]
-                                                BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                  Project [ss_item_sk,ss_ext_sales_price,ss_net_profit]
-                                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                      Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                          Filter [ss_item_sk,ss_store_sk]
+                              Union
+                                HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),gross_margin,t_category,t_class,lochierarchy,sum,sum]
+                                  InputAdapter
+                                    Exchange [i_category,i_class] #3
+                                      WholeStageCodegen (4)
+                                        HashAggregate [i_category,i_class,ss_net_profit,ss_ext_sales_price] [sum,sum,sum,sum]
+                                          Project [ss_ext_sales_price,ss_net_profit,i_class,i_category]
+                                            BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                              Project [ss_item_sk,ss_ext_sales_price,ss_net_profit]
+                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                  Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
+                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                      Filter [ss_item_sk,ss_store_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
+                                                              SubqueryBroadcast [d_date_sk] #1
+                                                                BroadcastExchange #4
+                                                                  WholeStageCodegen (1)
+                                                                    Project [d_date_sk]
+                                                                      Filter [d_year,d_date_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
+                                                      InputAdapter
+                                                        ReusedExchange [d_date_sk] #4
+                                                  InputAdapter
+                                                    BroadcastExchange #5
+                                                      WholeStageCodegen (2)
+                                                        Project [s_store_sk]
+                                                          Filter [s_state,s_store_sk]
                                                             ColumnarToRow
                                                               InputAdapter
-                                                                Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
-                                                                  SubqueryBroadcast [d_date_sk] #1
-                                                                    BroadcastExchange #4
-                                                                      WholeStageCodegen (1)
-                                                                        Project [d_date_sk]
-                                                                          Filter [d_year,d_date_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
-                                                          InputAdapter
-                                                            ReusedExchange [d_date_sk] #4
-                                                      InputAdapter
-                                                        BroadcastExchange #5
-                                                          WholeStageCodegen (2)
-                                                            Project [s_store_sk]
-                                                              Filter [s_state,s_store_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.store [s_store_sk,s_state]
-                                                  InputAdapter
-                                                    BroadcastExchange #6
-                                                      WholeStageCodegen (3)
-                                                        Filter [i_item_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.item [i_item_sk,i_class,i_category]
-                                  WholeStageCodegen (11)
-                                    HashAggregate [i_category,sum,isEmpty,sum,isEmpty] [sum(ss_net_profit),sum(ss_ext_sales_price),gross_margin,i_class,t_category,t_class,lochierarchy,sum,isEmpty,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange [i_category] #7
-                                          WholeStageCodegen (10)
-                                            HashAggregate [i_category,ss_net_profit,ss_ext_sales_price] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),ss_net_profit,ss_ext_sales_price,sum,sum]
-                                                InputAdapter
-                                                  ReusedExchange [i_category,i_class,sum,sum] #3
-                                  WholeStageCodegen (17)
-                                    HashAggregate [sum,isEmpty,sum,isEmpty] [sum(ss_net_profit),sum(ss_ext_sales_price),gross_margin,i_category,i_class,t_category,t_class,lochierarchy,sum,isEmpty,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange #8
-                                          WholeStageCodegen (16)
-                                            HashAggregate [ss_net_profit,ss_ext_sales_price] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),ss_net_profit,ss_ext_sales_price,sum,sum]
-                                                InputAdapter
-                                                  ReusedExchange [i_category,i_class,sum,sum] #3
+                                                                Scan parquet spark_catalog.default.store [s_store_sk,s_state]
+                                              InputAdapter
+                                                BroadcastExchange #6
+                                                  WholeStageCodegen (3)
+                                                    Filter [i_item_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_class,i_category]
+                                HashAggregate [i_category,sum,isEmpty,sum,isEmpty] [sum(ss_net_profit),sum(ss_ext_sales_price),gross_margin,i_class,t_category,t_class,lochierarchy,sum,isEmpty,sum,isEmpty]
+                                  InputAdapter
+                                    Exchange [i_category] #7
+                                      WholeStageCodegen (9)
+                                        HashAggregate [i_category,ss_net_profit,ss_ext_sales_price] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                          HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),ss_net_profit,ss_ext_sales_price,sum,sum]
+                                            InputAdapter
+                                              ReusedExchange [i_category,i_class,sum,sum] #3
+                                HashAggregate [sum,isEmpty,sum,isEmpty] [sum(ss_net_profit),sum(ss_ext_sales_price),gross_margin,i_category,i_class,t_category,t_class,lochierarchy,sum,isEmpty,sum,isEmpty]
+                                  InputAdapter
+                                    Exchange #8
+                                      WholeStageCodegen (14)
+                                        HashAggregate [ss_net_profit,ss_ext_sales_price] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                          HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),ss_net_profit,ss_ext_sales_price,sum,sum]
+                                            InputAdapter
+                                              ReusedExchange [i_category,i_class,sum,sum] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/explain.txt
@@ -7,7 +7,7 @@ TakeOrderedAndProject (41)
             +- * HashAggregate (36)
                +- Exchange (35)
                   +- * HashAggregate (34)
-                     +- Union (33)
+                     +- * Union (33)
                         :- * HashAggregate (22)
                         :  +- Exchange (21)
                         :     +- * HashAggregate (20)
@@ -141,7 +141,7 @@ Results [4]: [i_category#10, i_class#9, sum#15, sum#16]
 Input [4]: [i_category#10, i_class#9, sum#15, sum#16]
 Arguments: hashpartitioning(i_category#10, i_class#9, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(22) HashAggregate [codegen id : 5]
+(22) HashAggregate [codegen id : 15]
 Input [4]: [i_category#10, i_class#9, sum#15, sum#16]
 Keys [2]: [i_category#10, i_class#9]
 Functions [2]: [sum(UnscaledValue(ss_net_profit#4)), sum(UnscaledValue(ss_ext_sales_price#3))]
@@ -151,14 +151,14 @@ Results [6]: [cast((MakeDecimal(sum(UnscaledValue(ss_net_profit#4))#17,17,2) / M
 (23) ReusedExchange [Reuses operator id: 21]
 Output [4]: [i_category#23, i_class#24, sum#25, sum#26]
 
-(24) HashAggregate [codegen id : 10]
+(24) HashAggregate [codegen id : 9]
 Input [4]: [i_category#23, i_class#24, sum#25, sum#26]
 Keys [2]: [i_category#23, i_class#24]
 Functions [2]: [sum(UnscaledValue(ss_net_profit#27)), sum(UnscaledValue(ss_ext_sales_price#28))]
 Aggregate Attributes [2]: [sum(UnscaledValue(ss_net_profit#27))#29, sum(UnscaledValue(ss_ext_sales_price#28))#30]
 Results [3]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#27))#29,17,2) AS ss_net_profit#31, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#28))#30,17,2) AS ss_ext_sales_price#32, i_category#23]
 
-(25) HashAggregate [codegen id : 10]
+(25) HashAggregate [codegen id : 9]
 Input [3]: [ss_net_profit#31, ss_ext_sales_price#32, i_category#23]
 Keys [1]: [i_category#23]
 Functions [2]: [partial_sum(ss_net_profit#31), partial_sum(ss_ext_sales_price#32)]
@@ -169,7 +169,7 @@ Results [5]: [i_category#23, sum#37, isEmpty#38, sum#39, isEmpty#40]
 Input [5]: [i_category#23, sum#37, isEmpty#38, sum#39, isEmpty#40]
 Arguments: hashpartitioning(i_category#23, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(27) HashAggregate [codegen id : 11]
+(27) HashAggregate
 Input [5]: [i_category#23, sum#37, isEmpty#38, sum#39, isEmpty#40]
 Keys [1]: [i_category#23]
 Functions [2]: [sum(ss_net_profit#31), sum(ss_ext_sales_price#32)]
@@ -179,14 +179,14 @@ Results [6]: [(sum(ss_net_profit#31)#41 / sum(ss_ext_sales_price#32)#42) AS gros
 (28) ReusedExchange [Reuses operator id: 21]
 Output [4]: [i_category#48, i_class#49, sum#50, sum#51]
 
-(29) HashAggregate [codegen id : 16]
+(29) HashAggregate [codegen id : 14]
 Input [4]: [i_category#48, i_class#49, sum#50, sum#51]
 Keys [2]: [i_category#48, i_class#49]
 Functions [2]: [sum(UnscaledValue(ss_net_profit#52)), sum(UnscaledValue(ss_ext_sales_price#53))]
 Aggregate Attributes [2]: [sum(UnscaledValue(ss_net_profit#52))#29, sum(UnscaledValue(ss_ext_sales_price#53))#30]
 Results [2]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#52))#29,17,2) AS ss_net_profit#54, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#53))#30,17,2) AS ss_ext_sales_price#55]
 
-(30) HashAggregate [codegen id : 16]
+(30) HashAggregate [codegen id : 14]
 Input [2]: [ss_net_profit#54, ss_ext_sales_price#55]
 Keys: []
 Functions [2]: [partial_sum(ss_net_profit#54), partial_sum(ss_ext_sales_price#55)]
@@ -197,16 +197,16 @@ Results [4]: [sum#60, isEmpty#61, sum#62, isEmpty#63]
 Input [4]: [sum#60, isEmpty#61, sum#62, isEmpty#63]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
 
-(32) HashAggregate [codegen id : 17]
+(32) HashAggregate
 Input [4]: [sum#60, isEmpty#61, sum#62, isEmpty#63]
 Keys: []
 Functions [2]: [sum(ss_net_profit#54), sum(ss_ext_sales_price#55)]
 Aggregate Attributes [2]: [sum(ss_net_profit#54)#64, sum(ss_ext_sales_price#55)#65]
 Results [6]: [(sum(ss_net_profit#54)#64 / sum(ss_ext_sales_price#55)#65) AS gross_margin#66, null AS i_category#67, null AS i_class#68, 1 AS t_category#69, 1 AS t_class#70, 2 AS lochierarchy#71]
 
-(33) Union
+(33) Union [codegen id : 15]
 
-(34) HashAggregate [codegen id : 18]
+(34) HashAggregate [codegen id : 15]
 Input [6]: [gross_margin#19, i_category#10, i_class#9, t_category#20, t_class#21, lochierarchy#22]
 Keys [6]: [gross_margin#19, i_category#10, i_class#9, t_category#20, t_class#21, lochierarchy#22]
 Functions: []
@@ -217,7 +217,7 @@ Results [6]: [gross_margin#19, i_category#10, i_class#9, t_category#20, t_class#
 Input [6]: [gross_margin#19, i_category#10, i_class#9, t_category#20, t_class#21, lochierarchy#22]
 Arguments: hashpartitioning(gross_margin#19, i_category#10, i_class#9, t_category#20, t_class#21, lochierarchy#22, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(36) HashAggregate [codegen id : 19]
+(36) HashAggregate [codegen id : 16]
 Input [6]: [gross_margin#19, i_category#10, i_class#9, t_category#20, t_class#21, lochierarchy#22]
 Keys [6]: [gross_margin#19, i_category#10, i_class#9, t_category#20, t_class#21, lochierarchy#22]
 Functions: []
@@ -228,7 +228,7 @@ Results [5]: [gross_margin#19, i_category#10, i_class#9, lochierarchy#22, CASE W
 Input [5]: [gross_margin#19, i_category#10, i_class#9, lochierarchy#22, _w0#72]
 Arguments: hashpartitioning(lochierarchy#22, _w0#72, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(38) Sort [codegen id : 20]
+(38) Sort [codegen id : 17]
 Input [5]: [gross_margin#19, i_category#10, i_class#9, lochierarchy#22, _w0#72]
 Arguments: [lochierarchy#22 ASC NULLS FIRST, _w0#72 ASC NULLS FIRST, gross_margin#19 ASC NULLS FIRST], false, 0
 
@@ -236,7 +236,7 @@ Arguments: [lochierarchy#22 ASC NULLS FIRST, _w0#72 ASC NULLS FIRST, gross_margi
 Input [5]: [gross_margin#19, i_category#10, i_class#9, lochierarchy#22, _w0#72]
 Arguments: [rank(gross_margin#19) windowspecdefinition(lochierarchy#22, _w0#72, gross_margin#19 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#73], [lochierarchy#22, _w0#72], [gross_margin#19 ASC NULLS FIRST]
 
-(40) Project [codegen id : 21]
+(40) Project [codegen id : 18]
 Output [5]: [gross_margin#19, i_category#10, i_class#9, lochierarchy#22, rank_within_parent#73]
 Input [6]: [gross_margin#19, i_category#10, i_class#9, lochierarchy#22, _w0#72, rank_within_parent#73]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/simplified.txt
@@ -1,76 +1,72 @@
 TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,gross_margin,i_class]
-  WholeStageCodegen (21)
+  WholeStageCodegen (18)
     Project [gross_margin,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter
         Window [gross_margin,lochierarchy,_w0]
-          WholeStageCodegen (20)
+          WholeStageCodegen (17)
             Sort [lochierarchy,_w0,gross_margin]
               InputAdapter
                 Exchange [lochierarchy,_w0] #1
-                  WholeStageCodegen (19)
+                  WholeStageCodegen (16)
                     HashAggregate [gross_margin,i_category,i_class,t_category,t_class,lochierarchy] [_w0]
                       InputAdapter
                         Exchange [gross_margin,i_category,i_class,t_category,t_class,lochierarchy] #2
-                          WholeStageCodegen (18)
+                          WholeStageCodegen (15)
                             HashAggregate [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
-                              InputAdapter
-                                Union
-                                  WholeStageCodegen (5)
-                                    HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),gross_margin,t_category,t_class,lochierarchy,sum,sum]
-                                      InputAdapter
-                                        Exchange [i_category,i_class] #3
-                                          WholeStageCodegen (4)
-                                            HashAggregate [i_category,i_class,ss_net_profit,ss_ext_sales_price] [sum,sum,sum,sum]
-                                              Project [ss_ext_sales_price,ss_net_profit,i_class,i_category]
-                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                  Project [ss_store_sk,ss_ext_sales_price,ss_net_profit,i_class,i_category]
-                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                      Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                          Filter [ss_item_sk,ss_store_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
-                                                                  SubqueryBroadcast [d_date_sk] #1
-                                                                    BroadcastExchange #4
-                                                                      WholeStageCodegen (1)
-                                                                        Project [d_date_sk]
-                                                                          Filter [d_year,d_date_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
+                              Union
+                                HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),gross_margin,t_category,t_class,lochierarchy,sum,sum]
+                                  InputAdapter
+                                    Exchange [i_category,i_class] #3
+                                      WholeStageCodegen (4)
+                                        HashAggregate [i_category,i_class,ss_net_profit,ss_ext_sales_price] [sum,sum,sum,sum]
+                                          Project [ss_ext_sales_price,ss_net_profit,i_class,i_category]
+                                            BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                              Project [ss_store_sk,ss_ext_sales_price,ss_net_profit,i_class,i_category]
+                                                BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                  Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
+                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                      Filter [ss_item_sk,ss_store_sk]
+                                                        ColumnarToRow
                                                           InputAdapter
-                                                            ReusedExchange [d_date_sk] #4
+                                                            Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
+                                                              SubqueryBroadcast [d_date_sk] #1
+                                                                BroadcastExchange #4
+                                                                  WholeStageCodegen (1)
+                                                                    Project [d_date_sk]
+                                                                      Filter [d_year,d_date_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                       InputAdapter
-                                                        BroadcastExchange #5
-                                                          WholeStageCodegen (2)
-                                                            Filter [i_item_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_class,i_category]
+                                                        ReusedExchange [d_date_sk] #4
                                                   InputAdapter
-                                                    BroadcastExchange #6
-                                                      WholeStageCodegen (3)
-                                                        Project [s_store_sk]
-                                                          Filter [s_state,s_store_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.store [s_store_sk,s_state]
-                                  WholeStageCodegen (11)
-                                    HashAggregate [i_category,sum,isEmpty,sum,isEmpty] [sum(ss_net_profit),sum(ss_ext_sales_price),gross_margin,i_class,t_category,t_class,lochierarchy,sum,isEmpty,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange [i_category] #7
-                                          WholeStageCodegen (10)
-                                            HashAggregate [i_category,ss_net_profit,ss_ext_sales_price] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),ss_net_profit,ss_ext_sales_price,sum,sum]
-                                                InputAdapter
-                                                  ReusedExchange [i_category,i_class,sum,sum] #3
-                                  WholeStageCodegen (17)
-                                    HashAggregate [sum,isEmpty,sum,isEmpty] [sum(ss_net_profit),sum(ss_ext_sales_price),gross_margin,i_category,i_class,t_category,t_class,lochierarchy,sum,isEmpty,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange #8
-                                          WholeStageCodegen (16)
-                                            HashAggregate [ss_net_profit,ss_ext_sales_price] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),ss_net_profit,ss_ext_sales_price,sum,sum]
-                                                InputAdapter
-                                                  ReusedExchange [i_category,i_class,sum,sum] #3
+                                                    BroadcastExchange #5
+                                                      WholeStageCodegen (2)
+                                                        Filter [i_item_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.item [i_item_sk,i_class,i_category]
+                                              InputAdapter
+                                                BroadcastExchange #6
+                                                  WholeStageCodegen (3)
+                                                    Project [s_store_sk]
+                                                      Filter [s_state,s_store_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet spark_catalog.default.store [s_store_sk,s_state]
+                                HashAggregate [i_category,sum,isEmpty,sum,isEmpty] [sum(ss_net_profit),sum(ss_ext_sales_price),gross_margin,i_class,t_category,t_class,lochierarchy,sum,isEmpty,sum,isEmpty]
+                                  InputAdapter
+                                    Exchange [i_category] #7
+                                      WholeStageCodegen (9)
+                                        HashAggregate [i_category,ss_net_profit,ss_ext_sales_price] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                          HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),ss_net_profit,ss_ext_sales_price,sum,sum]
+                                            InputAdapter
+                                              ReusedExchange [i_category,i_class,sum,sum] #3
+                                HashAggregate [sum,isEmpty,sum,isEmpty] [sum(ss_net_profit),sum(ss_ext_sales_price),gross_margin,i_category,i_class,t_category,t_class,lochierarchy,sum,isEmpty,sum,isEmpty]
+                                  InputAdapter
+                                    Exchange #8
+                                      WholeStageCodegen (14)
+                                        HashAggregate [ss_net_profit,ss_ext_sales_price] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
+                                          HashAggregate [i_category,i_class,sum,sum] [sum(UnscaledValue(ss_net_profit)),sum(UnscaledValue(ss_ext_sales_price)),ss_net_profit,ss_ext_sales_price,sum,sum]
+                                            InputAdapter
+                                              ReusedExchange [i_category,i_class,sum,sum] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/explain.txt
@@ -15,7 +15,7 @@ TakeOrderedAndProject (90)
             :           :           +- * BroadcastHashJoin Inner BuildRight (17)
             :           :              :- * Project (12)
             :           :              :  +- * BroadcastHashJoin Inner BuildRight (11)
-            :           :              :     :- Union (9)
+            :           :              :     :- * Union (9)
             :           :              :     :  :- * Project (4)
             :           :              :     :  :  +- * Filter (3)
             :           :              :     :  :     +- * ColumnarToRow (2)
@@ -36,7 +36,7 @@ TakeOrderedAndProject (90)
             :           :           +- * BroadcastHashJoin Inner BuildRight (38)
             :           :              :- * Project (33)
             :           :              :  +- * BroadcastHashJoin Inner BuildRight (32)
-            :           :              :     :- Union (30)
+            :           :              :     :- * Union (30)
             :           :              :     :  :- * Project (25)
             :           :              :     :  :  +- * Filter (24)
             :           :              :     :  :     +- * ColumnarToRow (23)
@@ -99,14 +99,14 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#4), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_store_sk:int,ss_ext_sales_price:decimal(7,2),ss_net_profit:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 1]
+(2) ColumnarToRow [codegen id : 3]
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 
-(3) Filter [codegen id : 1]
+(3) Filter [codegen id : 3]
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 Condition : isnotnull(ss_store_sk#1)
 
-(4) Project [codegen id : 1]
+(4) Project [codegen id : 3]
 Output [6]: [ss_store_sk#1 AS store_sk#6, ss_sold_date_sk#4 AS date_sk#7, ss_ext_sales_price#2 AS sales_price#8, ss_net_profit#3 AS profit#9, 0.00 AS return_amt#10, 0.00 AS net_loss#11]
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 
@@ -118,29 +118,29 @@ PartitionFilters: [isnotnull(sr_returned_date_sk#15), dynamicpruningexpression(s
 PushedFilters: [IsNotNull(sr_store_sk)]
 ReadSchema: struct<sr_store_sk:int,sr_return_amt:decimal(7,2),sr_net_loss:decimal(7,2)>
 
-(6) ColumnarToRow [codegen id : 2]
+(6) ColumnarToRow
 Input [4]: [sr_store_sk#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 
-(7) Filter [codegen id : 2]
+(7) Filter
 Input [4]: [sr_store_sk#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 Condition : isnotnull(sr_store_sk#12)
 
-(8) Project [codegen id : 2]
+(8) Project
 Output [6]: [sr_store_sk#12 AS store_sk#16, sr_returned_date_sk#15 AS date_sk#17, 0.00 AS sales_price#18, 0.00 AS profit#19, sr_return_amt#13 AS return_amt#20, sr_net_loss#14 AS net_loss#21]
 Input [4]: [sr_store_sk#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 
-(9) Union
+(9) Union [codegen id : 3]
 
 (10) ReusedExchange [Reuses operator id: 95]
 Output [1]: [d_date_sk#22]
 
-(11) BroadcastHashJoin [codegen id : 5]
+(11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [date_sk#7]
 Right keys [1]: [d_date_sk#22]
 Join type: Inner
 Join condition: None
 
-(12) Project [codegen id : 5]
+(12) Project [codegen id : 3]
 Output [5]: [store_sk#6, sales_price#8, profit#9, return_amt#10, net_loss#11]
 Input [7]: [store_sk#6, date_sk#7, sales_price#8, profit#9, return_amt#10, net_loss#11, d_date_sk#22]
 
@@ -151,10 +151,10 @@ Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
-(14) ColumnarToRow [codegen id : 4]
+(14) ColumnarToRow [codegen id : 2]
 Input [2]: [s_store_sk#23, s_store_id#24]
 
-(15) Filter [codegen id : 4]
+(15) Filter [codegen id : 2]
 Input [2]: [s_store_sk#23, s_store_id#24]
 Condition : isnotnull(s_store_sk#23)
 
@@ -162,17 +162,17 @@ Condition : isnotnull(s_store_sk#23)
 Input [2]: [s_store_sk#23, s_store_id#24]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(17) BroadcastHashJoin [codegen id : 5]
+(17) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [store_sk#6]
 Right keys [1]: [s_store_sk#23]
 Join type: Inner
 Join condition: None
 
-(18) Project [codegen id : 5]
+(18) Project [codegen id : 3]
 Output [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#24]
 Input [7]: [store_sk#6, sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_sk#23, s_store_id#24]
 
-(19) HashAggregate [codegen id : 5]
+(19) HashAggregate [codegen id : 3]
 Input [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#24]
 Keys [1]: [s_store_id#24]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#8)), partial_sum(UnscaledValue(return_amt#10)), partial_sum(UnscaledValue(profit#9)), partial_sum(UnscaledValue(net_loss#11))]
@@ -183,7 +183,7 @@ Results [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
 Input [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
 Arguments: hashpartitioning(s_store_id#24, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(21) HashAggregate [codegen id : 6]
+(21) HashAggregate [codegen id : 4]
 Input [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
 Keys [1]: [s_store_id#24]
 Functions [4]: [sum(UnscaledValue(sales_price#8)), sum(UnscaledValue(return_amt#10)), sum(UnscaledValue(profit#9)), sum(UnscaledValue(net_loss#11))]
@@ -217,29 +217,29 @@ PartitionFilters: [isnotnull(cr_returned_date_sk#55), dynamicpruningexpression(c
 PushedFilters: [IsNotNull(cr_catalog_page_sk)]
 ReadSchema: struct<cr_catalog_page_sk:int,cr_return_amount:decimal(7,2),cr_net_loss:decimal(7,2)>
 
-(27) ColumnarToRow [codegen id : 8]
+(27) ColumnarToRow
 Input [4]: [cr_catalog_page_sk#52, cr_return_amount#53, cr_net_loss#54, cr_returned_date_sk#55]
 
-(28) Filter [codegen id : 8]
+(28) Filter
 Input [4]: [cr_catalog_page_sk#52, cr_return_amount#53, cr_net_loss#54, cr_returned_date_sk#55]
 Condition : isnotnull(cr_catalog_page_sk#52)
 
-(29) Project [codegen id : 8]
+(29) Project
 Output [6]: [cr_catalog_page_sk#52 AS page_sk#56, cr_returned_date_sk#55 AS date_sk#57, 0.00 AS sales_price#58, 0.00 AS profit#59, cr_return_amount#53 AS return_amt#60, cr_net_loss#54 AS net_loss#61]
 Input [4]: [cr_catalog_page_sk#52, cr_return_amount#53, cr_net_loss#54, cr_returned_date_sk#55]
 
-(30) Union
+(30) Union [codegen id : 7]
 
 (31) ReusedExchange [Reuses operator id: 95]
 Output [1]: [d_date_sk#62]
 
-(32) BroadcastHashJoin [codegen id : 11]
+(32) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [date_sk#47]
 Right keys [1]: [d_date_sk#62]
 Join type: Inner
 Join condition: None
 
-(33) Project [codegen id : 11]
+(33) Project [codegen id : 7]
 Output [5]: [page_sk#46, sales_price#48, profit#49, return_amt#50, net_loss#51]
 Input [7]: [page_sk#46, date_sk#47, sales_price#48, profit#49, return_amt#50, net_loss#51, d_date_sk#62]
 
@@ -250,10 +250,10 @@ Location [not included in comparison]/{warehouse_dir}/catalog_page]
 PushedFilters: [IsNotNull(cp_catalog_page_sk)]
 ReadSchema: struct<cp_catalog_page_sk:int,cp_catalog_page_id:string>
 
-(35) ColumnarToRow [codegen id : 10]
+(35) ColumnarToRow [codegen id : 6]
 Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 
-(36) Filter [codegen id : 10]
+(36) Filter [codegen id : 6]
 Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 Condition : isnotnull(cp_catalog_page_sk#63)
 
@@ -261,17 +261,17 @@ Condition : isnotnull(cp_catalog_page_sk#63)
 Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
-(38) BroadcastHashJoin [codegen id : 11]
+(38) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [page_sk#46]
 Right keys [1]: [cp_catalog_page_sk#63]
 Join type: Inner
 Join condition: None
 
-(39) Project [codegen id : 11]
+(39) Project [codegen id : 7]
 Output [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#64]
 Input [7]: [page_sk#46, sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_sk#63, cp_catalog_page_id#64]
 
-(40) HashAggregate [codegen id : 11]
+(40) HashAggregate [codegen id : 7]
 Input [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#64]
 Keys [1]: [cp_catalog_page_id#64]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#48)), partial_sum(UnscaledValue(return_amt#50)), partial_sum(UnscaledValue(profit#49)), partial_sum(UnscaledValue(net_loss#51))]
@@ -282,7 +282,7 @@ Results [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
 Input [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
 Arguments: hashpartitioning(cp_catalog_page_id#64, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(42) HashAggregate [codegen id : 12]
+(42) HashAggregate [codegen id : 8]
 Input [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
 Keys [1]: [cp_catalog_page_id#64]
 Functions [4]: [sum(UnscaledValue(sales_price#48)), sum(UnscaledValue(return_amt#50)), sum(UnscaledValue(profit#49)), sum(UnscaledValue(net_loss#51))]
@@ -297,14 +297,14 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#85), dynamicpruningexpression(ws_so
 PushedFilters: [IsNotNull(ws_web_site_sk)]
 ReadSchema: struct<ws_web_site_sk:int,ws_ext_sales_price:decimal(7,2),ws_net_profit:decimal(7,2)>
 
-(44) ColumnarToRow [codegen id : 13]
+(44) ColumnarToRow [codegen id : 9]
 Input [4]: [ws_web_site_sk#82, ws_ext_sales_price#83, ws_net_profit#84, ws_sold_date_sk#85]
 
-(45) Filter [codegen id : 13]
+(45) Filter [codegen id : 9]
 Input [4]: [ws_web_site_sk#82, ws_ext_sales_price#83, ws_net_profit#84, ws_sold_date_sk#85]
 Condition : isnotnull(ws_web_site_sk#82)
 
-(46) Project [codegen id : 13]
+(46) Project [codegen id : 9]
 Output [6]: [ws_web_site_sk#82 AS wsr_web_site_sk#86, ws_sold_date_sk#85 AS date_sk#87, ws_ext_sales_price#83 AS sales_price#88, ws_net_profit#84 AS profit#89, 0.00 AS return_amt#90, 0.00 AS net_loss#91]
 Input [4]: [ws_web_site_sk#82, ws_ext_sales_price#83, ws_net_profit#84, ws_sold_date_sk#85]
 
@@ -315,14 +315,14 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(wr_returned_date_sk#96), dynamicpruningexpression(wr_returned_date_sk#96 IN dynamicpruning#5)]
 ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_amt:decimal(7,2),wr_net_loss:decimal(7,2)>
 
-(48) ColumnarToRow [codegen id : 14]
+(48) ColumnarToRow [codegen id : 10]
 Input [5]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95, wr_returned_date_sk#96]
 
 (49) Exchange
 Input [5]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95, wr_returned_date_sk#96]
 Arguments: hashpartitioning(wr_item_sk#92, wr_order_number#93, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(50) Sort [codegen id : 15]
+(50) Sort [codegen id : 11]
 Input [5]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95, wr_returned_date_sk#96]
 Arguments: [wr_item_sk#92 ASC NULLS FIRST, wr_order_number#93 ASC NULLS FIRST], false, 0
 
@@ -333,14 +333,14 @@ Location [not included in comparison]/{warehouse_dir}/web_sales]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_order_number), IsNotNull(ws_web_site_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_web_site_sk:int,ws_order_number:int>
 
-(52) ColumnarToRow [codegen id : 16]
+(52) ColumnarToRow [codegen id : 12]
 Input [4]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99, ws_sold_date_sk#100]
 
-(53) Filter [codegen id : 16]
+(53) Filter [codegen id : 12]
 Input [4]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99, ws_sold_date_sk#100]
 Condition : ((isnotnull(ws_item_sk#97) AND isnotnull(ws_order_number#99)) AND isnotnull(ws_web_site_sk#98))
 
-(54) Project [codegen id : 16]
+(54) Project [codegen id : 12]
 Output [3]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99]
 Input [4]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99, ws_sold_date_sk#100]
 
@@ -348,17 +348,17 @@ Input [4]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99, ws_sold_date_s
 Input [3]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99]
 Arguments: hashpartitioning(ws_item_sk#97, ws_order_number#99, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(56) Sort [codegen id : 17]
+(56) Sort [codegen id : 13]
 Input [3]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99]
 Arguments: [ws_item_sk#97 ASC NULLS FIRST, ws_order_number#99 ASC NULLS FIRST], false, 0
 
-(57) SortMergeJoin [codegen id : 18]
+(57) SortMergeJoin [codegen id : 14]
 Left keys [2]: [wr_item_sk#92, wr_order_number#93]
 Right keys [2]: [ws_item_sk#97, ws_order_number#99]
 Join type: Inner
 Join condition: None
 
-(58) Project [codegen id : 18]
+(58) Project [codegen id : 14]
 Output [6]: [ws_web_site_sk#98 AS wsr_web_site_sk#101, wr_returned_date_sk#96 AS date_sk#102, 0.00 AS sales_price#103, 0.00 AS profit#104, wr_return_amt#94 AS return_amt#105, wr_net_loss#95 AS net_loss#106]
 Input [8]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95, wr_returned_date_sk#96, ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99]
 
@@ -367,13 +367,13 @@ Input [8]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95,
 (60) ReusedExchange [Reuses operator id: 95]
 Output [1]: [d_date_sk#107]
 
-(61) BroadcastHashJoin [codegen id : 21]
+(61) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [date_sk#87]
 Right keys [1]: [d_date_sk#107]
 Join type: Inner
 Join condition: None
 
-(62) Project [codegen id : 21]
+(62) Project [codegen id : 17]
 Output [5]: [wsr_web_site_sk#86, sales_price#88, profit#89, return_amt#90, net_loss#91]
 Input [7]: [wsr_web_site_sk#86, date_sk#87, sales_price#88, profit#89, return_amt#90, net_loss#91, d_date_sk#107]
 
@@ -384,10 +384,10 @@ Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_site_id:string>
 
-(64) ColumnarToRow [codegen id : 20]
+(64) ColumnarToRow [codegen id : 16]
 Input [2]: [web_site_sk#108, web_site_id#109]
 
-(65) Filter [codegen id : 20]
+(65) Filter [codegen id : 16]
 Input [2]: [web_site_sk#108, web_site_id#109]
 Condition : isnotnull(web_site_sk#108)
 
@@ -395,17 +395,17 @@ Condition : isnotnull(web_site_sk#108)
 Input [2]: [web_site_sk#108, web_site_id#109]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(67) BroadcastHashJoin [codegen id : 21]
+(67) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [wsr_web_site_sk#86]
 Right keys [1]: [web_site_sk#108]
 Join type: Inner
 Join condition: None
 
-(68) Project [codegen id : 21]
+(68) Project [codegen id : 17]
 Output [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#109]
 Input [7]: [wsr_web_site_sk#86, sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_sk#108, web_site_id#109]
 
-(69) HashAggregate [codegen id : 21]
+(69) HashAggregate [codegen id : 17]
 Input [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#109]
 Keys [1]: [web_site_id#109]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#88)), partial_sum(UnscaledValue(return_amt#90)), partial_sum(UnscaledValue(profit#89)), partial_sum(UnscaledValue(net_loss#91))]
@@ -416,7 +416,7 @@ Results [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
 Input [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
 Arguments: hashpartitioning(web_site_id#109, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(71) HashAggregate [codegen id : 22]
+(71) HashAggregate [codegen id : 18]
 Input [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
 Keys [1]: [web_site_id#109]
 Functions [4]: [sum(UnscaledValue(sales_price#88)), sum(UnscaledValue(return_amt#90)), sum(UnscaledValue(profit#89)), sum(UnscaledValue(net_loss#91))]
@@ -425,7 +425,7 @@ Results [5]: [web channel AS channel#122, concat(web_site, web_site_id#109) AS i
 
 (72) Union
 
-(73) HashAggregate [codegen id : 23]
+(73) HashAggregate [codegen id : 19]
 Input [5]: [channel#37, id#38, sales#39, returns#40, profit#41]
 Keys [2]: [channel#37, id#38]
 Functions [3]: [partial_sum(sales#39), partial_sum(returns#40), partial_sum(profit#41)]
@@ -436,7 +436,7 @@ Results [8]: [channel#37, id#38, sum#133, isEmpty#134, sum#135, isEmpty#136, sum
 Input [8]: [channel#37, id#38, sum#133, isEmpty#134, sum#135, isEmpty#136, sum#137, isEmpty#138]
 Arguments: hashpartitioning(channel#37, id#38, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(75) HashAggregate [codegen id : 24]
+(75) HashAggregate [codegen id : 20]
 Input [8]: [channel#37, id#38, sum#133, isEmpty#134, sum#135, isEmpty#136, sum#137, isEmpty#138]
 Keys [2]: [channel#37, id#38]
 Functions [3]: [sum(sales#39), sum(returns#40), sum(profit#41)]
@@ -446,14 +446,14 @@ Results [5]: [channel#37, id#38, cast(sum(sales#39)#139 as decimal(37,2)) AS sal
 (76) ReusedExchange [Reuses operator id: 74]
 Output [8]: [channel#145, id#146, sum#147, isEmpty#148, sum#149, isEmpty#150, sum#151, isEmpty#152]
 
-(77) HashAggregate [codegen id : 48]
+(77) HashAggregate [codegen id : 40]
 Input [8]: [channel#145, id#146, sum#147, isEmpty#148, sum#149, isEmpty#150, sum#151, isEmpty#152]
 Keys [2]: [channel#145, id#146]
 Functions [3]: [sum(sales#153), sum(returns#154), sum(profit#155)]
 Aggregate Attributes [3]: [sum(sales#153)#139, sum(returns#154)#140, sum(profit#155)#141]
 Results [4]: [channel#145, sum(sales#153)#139 AS sales#156, sum(returns#154)#140 AS returns#157, sum(profit#155)#141 AS profit#158]
 
-(78) HashAggregate [codegen id : 48]
+(78) HashAggregate [codegen id : 40]
 Input [4]: [channel#145, sales#156, returns#157, profit#158]
 Keys [1]: [channel#145]
 Functions [3]: [partial_sum(sales#156), partial_sum(returns#157), partial_sum(profit#158)]
@@ -464,7 +464,7 @@ Results [7]: [channel#145, sum#165, isEmpty#166, sum#167, isEmpty#168, sum#169, 
 Input [7]: [channel#145, sum#165, isEmpty#166, sum#167, isEmpty#168, sum#169, isEmpty#170]
 Arguments: hashpartitioning(channel#145, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(80) HashAggregate [codegen id : 49]
+(80) HashAggregate [codegen id : 41]
 Input [7]: [channel#145, sum#165, isEmpty#166, sum#167, isEmpty#168, sum#169, isEmpty#170]
 Keys [1]: [channel#145]
 Functions [3]: [sum(sales#156), sum(returns#157), sum(profit#158)]
@@ -474,14 +474,14 @@ Results [5]: [channel#145, null AS id#174, sum(sales#156)#171 AS sum(sales)#175,
 (81) ReusedExchange [Reuses operator id: 74]
 Output [8]: [channel#178, id#179, sum#180, isEmpty#181, sum#182, isEmpty#183, sum#184, isEmpty#185]
 
-(82) HashAggregate [codegen id : 73]
+(82) HashAggregate [codegen id : 61]
 Input [8]: [channel#178, id#179, sum#180, isEmpty#181, sum#182, isEmpty#183, sum#184, isEmpty#185]
 Keys [2]: [channel#178, id#179]
 Functions [3]: [sum(sales#186), sum(returns#187), sum(profit#188)]
 Aggregate Attributes [3]: [sum(sales#186)#139, sum(returns#187)#140, sum(profit#188)#141]
 Results [3]: [sum(sales#186)#139 AS sales#189, sum(returns#187)#140 AS returns#190, sum(profit#188)#141 AS profit#191]
 
-(83) HashAggregate [codegen id : 73]
+(83) HashAggregate [codegen id : 61]
 Input [3]: [sales#189, returns#190, profit#191]
 Keys: []
 Functions [3]: [partial_sum(sales#189), partial_sum(returns#190), partial_sum(profit#191)]
@@ -492,7 +492,7 @@ Results [6]: [sum#198, isEmpty#199, sum#200, isEmpty#201, sum#202, isEmpty#203]
 Input [6]: [sum#198, isEmpty#199, sum#200, isEmpty#201, sum#202, isEmpty#203]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
 
-(85) HashAggregate [codegen id : 74]
+(85) HashAggregate [codegen id : 62]
 Input [6]: [sum#198, isEmpty#199, sum#200, isEmpty#201, sum#202, isEmpty#203]
 Keys: []
 Functions [3]: [sum(sales#189), sum(returns#190), sum(profit#191)]
@@ -501,7 +501,7 @@ Results [5]: [null AS channel#207, null AS id#208, sum(sales#189)#204 AS sum(sal
 
 (86) Union
 
-(87) HashAggregate [codegen id : 75]
+(87) HashAggregate [codegen id : 63]
 Input [5]: [channel#37, id#38, sales#142, returns#143, profit#144]
 Keys [5]: [channel#37, id#38, sales#142, returns#143, profit#144]
 Functions: []
@@ -512,7 +512,7 @@ Results [5]: [channel#37, id#38, sales#142, returns#143, profit#144]
 Input [5]: [channel#37, id#38, sales#142, returns#143, profit#144]
 Arguments: hashpartitioning(channel#37, id#38, sales#142, returns#143, profit#144, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(89) HashAggregate [codegen id : 76]
+(89) HashAggregate [codegen id : 64]
 Input [5]: [channel#37, id#38, sales#142, returns#143, profit#144]
 Keys [5]: [channel#37, id#38, sales#142, returns#143, profit#144]
 Functions: []

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/simplified.txt
@@ -1,102 +1,96 @@
 TakeOrderedAndProject [channel,id,sales,returns,profit]
-  WholeStageCodegen (76)
+  WholeStageCodegen (64)
     HashAggregate [channel,id,sales,returns,profit]
       InputAdapter
         Exchange [channel,id,sales,returns,profit] #1
-          WholeStageCodegen (75)
+          WholeStageCodegen (63)
             HashAggregate [channel,id,sales,returns,profit]
               InputAdapter
                 Union
-                  WholeStageCodegen (24)
+                  WholeStageCodegen (20)
                     HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
                         Exchange [channel,id] #2
-                          WholeStageCodegen (23)
+                          WholeStageCodegen (19)
                             HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (6)
+                                  WholeStageCodegen (4)
                                     HashAggregate [s_store_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
                                       InputAdapter
                                         Exchange [s_store_id] #3
-                                          WholeStageCodegen (5)
+                                          WholeStageCodegen (3)
                                             HashAggregate [s_store_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                               Project [sales_price,profit,return_amt,net_loss,s_store_id]
                                                 BroadcastHashJoin [store_sk,s_store_sk]
                                                   Project [store_sk,sales_price,profit,return_amt,net_loss]
                                                     BroadcastHashJoin [date_sk,d_date_sk]
-                                                      InputAdapter
-                                                        Union
-                                                          WholeStageCodegen (1)
-                                                            Project [ss_store_sk,ss_sold_date_sk,ss_ext_sales_price,ss_net_profit]
-                                                              Filter [ss_store_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
-                                                                      SubqueryBroadcast [d_date_sk] #1
-                                                                        BroadcastExchange #4
-                                                                          WholeStageCodegen (1)
-                                                                            Project [d_date_sk]
-                                                                              Filter [d_date,d_date_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
-                                                          WholeStageCodegen (2)
-                                                            Project [sr_store_sk,sr_returned_date_sk,sr_return_amt,sr_net_loss]
-                                                              Filter [sr_store_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
-                                                                      ReusedSubquery [d_date_sk] #1
+                                                      Union
+                                                        Project [ss_store_sk,ss_sold_date_sk,ss_ext_sales_price,ss_net_profit]
+                                                          Filter [ss_store_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
+                                                                  SubqueryBroadcast [d_date_sk] #1
+                                                                    BroadcastExchange #4
+                                                                      WholeStageCodegen (1)
+                                                                        Project [d_date_sk]
+                                                                          Filter [d_date,d_date_sk]
+                                                                            ColumnarToRow
+                                                                              InputAdapter
+                                                                                Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                                                        Project [sr_store_sk,sr_returned_date_sk,sr_return_amt,sr_net_loss]
+                                                          Filter [sr_store_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
+                                                                  ReusedSubquery [d_date_sk] #1
                                                       InputAdapter
                                                         ReusedExchange [d_date_sk] #4
                                                   InputAdapter
                                                     BroadcastExchange #5
-                                                      WholeStageCodegen (4)
+                                                      WholeStageCodegen (2)
                                                         Filter [s_store_sk]
                                                           ColumnarToRow
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
-                                  WholeStageCodegen (12)
+                                  WholeStageCodegen (8)
                                     HashAggregate [cp_catalog_page_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
                                       InputAdapter
                                         Exchange [cp_catalog_page_id] #6
-                                          WholeStageCodegen (11)
+                                          WholeStageCodegen (7)
                                             HashAggregate [cp_catalog_page_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                               Project [sales_price,profit,return_amt,net_loss,cp_catalog_page_id]
                                                 BroadcastHashJoin [page_sk,cp_catalog_page_sk]
                                                   Project [page_sk,sales_price,profit,return_amt,net_loss]
                                                     BroadcastHashJoin [date_sk,d_date_sk]
-                                                      InputAdapter
-                                                        Union
-                                                          WholeStageCodegen (7)
-                                                            Project [cs_catalog_page_sk,cs_sold_date_sk,cs_ext_sales_price,cs_net_profit]
-                                                              Filter [cs_catalog_page_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.catalog_sales [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
-                                                                      ReusedSubquery [d_date_sk] #1
-                                                          WholeStageCodegen (8)
-                                                            Project [cr_catalog_page_sk,cr_returned_date_sk,cr_return_amount,cr_net_loss]
-                                                              Filter [cr_catalog_page_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.catalog_returns [cr_catalog_page_sk,cr_return_amount,cr_net_loss,cr_returned_date_sk]
-                                                                      ReusedSubquery [d_date_sk] #1
+                                                      Union
+                                                        Project [cs_catalog_page_sk,cs_sold_date_sk,cs_ext_sales_price,cs_net_profit]
+                                                          Filter [cs_catalog_page_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.catalog_sales [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
+                                                                  ReusedSubquery [d_date_sk] #1
+                                                        Project [cr_catalog_page_sk,cr_returned_date_sk,cr_return_amount,cr_net_loss]
+                                                          Filter [cr_catalog_page_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.catalog_returns [cr_catalog_page_sk,cr_return_amount,cr_net_loss,cr_returned_date_sk]
+                                                                  ReusedSubquery [d_date_sk] #1
                                                       InputAdapter
                                                         ReusedExchange [d_date_sk] #4
                                                   InputAdapter
                                                     BroadcastExchange #7
-                                                      WholeStageCodegen (10)
+                                                      WholeStageCodegen (6)
                                                         Filter [cp_catalog_page_sk]
                                                           ColumnarToRow
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
-                                  WholeStageCodegen (22)
+                                  WholeStageCodegen (18)
                                     HashAggregate [web_site_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
                                       InputAdapter
                                         Exchange [web_site_id] #8
-                                          WholeStageCodegen (21)
+                                          WholeStageCodegen (17)
                                             HashAggregate [web_site_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                               Project [sales_price,profit,return_amt,net_loss,web_site_id]
                                                 BroadcastHashJoin [wsr_web_site_sk,web_site_sk]
@@ -104,32 +98,32 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                     BroadcastHashJoin [date_sk,d_date_sk]
                                                       InputAdapter
                                                         Union
-                                                          WholeStageCodegen (13)
+                                                          WholeStageCodegen (9)
                                                             Project [ws_web_site_sk,ws_sold_date_sk,ws_ext_sales_price,ws_net_profit]
                                                               Filter [ws_web_site_sk]
                                                                 ColumnarToRow
                                                                   InputAdapter
                                                                     Scan parquet spark_catalog.default.web_sales [ws_web_site_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
                                                                       ReusedSubquery [d_date_sk] #1
-                                                          WholeStageCodegen (18)
+                                                          WholeStageCodegen (14)
                                                             Project [ws_web_site_sk,wr_returned_date_sk,wr_return_amt,wr_net_loss]
                                                               SortMergeJoin [wr_item_sk,wr_order_number,ws_item_sk,ws_order_number]
                                                                 InputAdapter
-                                                                  WholeStageCodegen (15)
+                                                                  WholeStageCodegen (11)
                                                                     Sort [wr_item_sk,wr_order_number]
                                                                       InputAdapter
                                                                         Exchange [wr_item_sk,wr_order_number] #9
-                                                                          WholeStageCodegen (14)
+                                                                          WholeStageCodegen (10)
                                                                             ColumnarToRow
                                                                               InputAdapter
                                                                                 Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss,wr_returned_date_sk]
                                                                                   ReusedSubquery [d_date_sk] #1
                                                                 InputAdapter
-                                                                  WholeStageCodegen (17)
+                                                                  WholeStageCodegen (13)
                                                                     Sort [ws_item_sk,ws_order_number]
                                                                       InputAdapter
                                                                         Exchange [ws_item_sk,ws_order_number] #10
-                                                                          WholeStageCodegen (16)
+                                                                          WholeStageCodegen (12)
                                                                             Project [ws_item_sk,ws_web_site_sk,ws_order_number]
                                                                               Filter [ws_item_sk,ws_order_number,ws_web_site_sk]
                                                                                 ColumnarToRow
@@ -139,25 +133,25 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                         ReusedExchange [d_date_sk] #4
                                                   InputAdapter
                                                     BroadcastExchange #11
-                                                      WholeStageCodegen (20)
+                                                      WholeStageCodegen (16)
                                                         Filter [web_site_sk]
                                                           ColumnarToRow
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.web_site [web_site_sk,web_site_id]
-                  WholeStageCodegen (49)
+                  WholeStageCodegen (41)
                     HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sum(sales),sum(returns),sum(profit),sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
                         Exchange [channel] #12
-                          WholeStageCodegen (48)
+                          WholeStageCodegen (40)
                             HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 InputAdapter
                                   ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2
-                  WholeStageCodegen (74)
+                  WholeStageCodegen (62)
                     HashAggregate [sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),channel,id,sum(sales),sum(returns),sum(profit),sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
                         Exchange #13
-                          WholeStageCodegen (73)
+                          WholeStageCodegen (61)
                             HashAggregate [sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a/explain.txt
@@ -15,7 +15,7 @@ TakeOrderedAndProject (87)
             :           :           +- * BroadcastHashJoin Inner BuildRight (17)
             :           :              :- * Project (12)
             :           :              :  +- * BroadcastHashJoin Inner BuildRight (11)
-            :           :              :     :- Union (9)
+            :           :              :     :- * Union (9)
             :           :              :     :  :- * Project (4)
             :           :              :     :  :  +- * Filter (3)
             :           :              :     :  :     +- * ColumnarToRow (2)
@@ -36,7 +36,7 @@ TakeOrderedAndProject (87)
             :           :           +- * BroadcastHashJoin Inner BuildRight (38)
             :           :              :- * Project (33)
             :           :              :  +- * BroadcastHashJoin Inner BuildRight (32)
-            :           :              :     :- Union (30)
+            :           :              :     :- * Union (30)
             :           :              :     :  :- * Project (25)
             :           :              :     :  :  +- * Filter (24)
             :           :              :     :  :     +- * ColumnarToRow (23)
@@ -57,7 +57,7 @@ TakeOrderedAndProject (87)
             :                       +- * BroadcastHashJoin Inner BuildRight (64)
             :                          :- * Project (59)
             :                          :  +- * BroadcastHashJoin Inner BuildRight (58)
-            :                          :     :- Union (56)
+            :                          :     :- * Union (56)
             :                          :     :  :- * Project (46)
             :                          :     :  :  +- * Filter (45)
             :                          :     :  :     +- * ColumnarToRow (44)
@@ -96,14 +96,14 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#4), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_store_sk:int,ss_ext_sales_price:decimal(7,2),ss_net_profit:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 1]
+(2) ColumnarToRow [codegen id : 3]
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 
-(3) Filter [codegen id : 1]
+(3) Filter [codegen id : 3]
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 Condition : isnotnull(ss_store_sk#1)
 
-(4) Project [codegen id : 1]
+(4) Project [codegen id : 3]
 Output [6]: [ss_store_sk#1 AS store_sk#6, ss_sold_date_sk#4 AS date_sk#7, ss_ext_sales_price#2 AS sales_price#8, ss_net_profit#3 AS profit#9, 0.00 AS return_amt#10, 0.00 AS net_loss#11]
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 
@@ -115,29 +115,29 @@ PartitionFilters: [isnotnull(sr_returned_date_sk#15), dynamicpruningexpression(s
 PushedFilters: [IsNotNull(sr_store_sk)]
 ReadSchema: struct<sr_store_sk:int,sr_return_amt:decimal(7,2),sr_net_loss:decimal(7,2)>
 
-(6) ColumnarToRow [codegen id : 2]
+(6) ColumnarToRow
 Input [4]: [sr_store_sk#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 
-(7) Filter [codegen id : 2]
+(7) Filter
 Input [4]: [sr_store_sk#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 Condition : isnotnull(sr_store_sk#12)
 
-(8) Project [codegen id : 2]
+(8) Project
 Output [6]: [sr_store_sk#12 AS store_sk#16, sr_returned_date_sk#15 AS date_sk#17, 0.00 AS sales_price#18, 0.00 AS profit#19, sr_return_amt#13 AS return_amt#20, sr_net_loss#14 AS net_loss#21]
 Input [4]: [sr_store_sk#12, sr_return_amt#13, sr_net_loss#14, sr_returned_date_sk#15]
 
-(9) Union
+(9) Union [codegen id : 3]
 
 (10) ReusedExchange [Reuses operator id: 92]
 Output [1]: [d_date_sk#22]
 
-(11) BroadcastHashJoin [codegen id : 5]
+(11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [date_sk#7]
 Right keys [1]: [d_date_sk#22]
 Join type: Inner
 Join condition: None
 
-(12) Project [codegen id : 5]
+(12) Project [codegen id : 3]
 Output [5]: [store_sk#6, sales_price#8, profit#9, return_amt#10, net_loss#11]
 Input [7]: [store_sk#6, date_sk#7, sales_price#8, profit#9, return_amt#10, net_loss#11, d_date_sk#22]
 
@@ -148,10 +148,10 @@ Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
-(14) ColumnarToRow [codegen id : 4]
+(14) ColumnarToRow [codegen id : 2]
 Input [2]: [s_store_sk#23, s_store_id#24]
 
-(15) Filter [codegen id : 4]
+(15) Filter [codegen id : 2]
 Input [2]: [s_store_sk#23, s_store_id#24]
 Condition : isnotnull(s_store_sk#23)
 
@@ -159,17 +159,17 @@ Condition : isnotnull(s_store_sk#23)
 Input [2]: [s_store_sk#23, s_store_id#24]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(17) BroadcastHashJoin [codegen id : 5]
+(17) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [store_sk#6]
 Right keys [1]: [s_store_sk#23]
 Join type: Inner
 Join condition: None
 
-(18) Project [codegen id : 5]
+(18) Project [codegen id : 3]
 Output [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#24]
 Input [7]: [store_sk#6, sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_sk#23, s_store_id#24]
 
-(19) HashAggregate [codegen id : 5]
+(19) HashAggregate [codegen id : 3]
 Input [5]: [sales_price#8, profit#9, return_amt#10, net_loss#11, s_store_id#24]
 Keys [1]: [s_store_id#24]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#8)), partial_sum(UnscaledValue(return_amt#10)), partial_sum(UnscaledValue(profit#9)), partial_sum(UnscaledValue(net_loss#11))]
@@ -180,7 +180,7 @@ Results [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
 Input [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
 Arguments: hashpartitioning(s_store_id#24, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(21) HashAggregate [codegen id : 6]
+(21) HashAggregate [codegen id : 4]
 Input [5]: [s_store_id#24, sum#29, sum#30, sum#31, sum#32]
 Keys [1]: [s_store_id#24]
 Functions [4]: [sum(UnscaledValue(sales_price#8)), sum(UnscaledValue(return_amt#10)), sum(UnscaledValue(profit#9)), sum(UnscaledValue(net_loss#11))]
@@ -214,29 +214,29 @@ PartitionFilters: [isnotnull(cr_returned_date_sk#55), dynamicpruningexpression(c
 PushedFilters: [IsNotNull(cr_catalog_page_sk)]
 ReadSchema: struct<cr_catalog_page_sk:int,cr_return_amount:decimal(7,2),cr_net_loss:decimal(7,2)>
 
-(27) ColumnarToRow [codegen id : 8]
+(27) ColumnarToRow
 Input [4]: [cr_catalog_page_sk#52, cr_return_amount#53, cr_net_loss#54, cr_returned_date_sk#55]
 
-(28) Filter [codegen id : 8]
+(28) Filter
 Input [4]: [cr_catalog_page_sk#52, cr_return_amount#53, cr_net_loss#54, cr_returned_date_sk#55]
 Condition : isnotnull(cr_catalog_page_sk#52)
 
-(29) Project [codegen id : 8]
+(29) Project
 Output [6]: [cr_catalog_page_sk#52 AS page_sk#56, cr_returned_date_sk#55 AS date_sk#57, 0.00 AS sales_price#58, 0.00 AS profit#59, cr_return_amount#53 AS return_amt#60, cr_net_loss#54 AS net_loss#61]
 Input [4]: [cr_catalog_page_sk#52, cr_return_amount#53, cr_net_loss#54, cr_returned_date_sk#55]
 
-(30) Union
+(30) Union [codegen id : 7]
 
 (31) ReusedExchange [Reuses operator id: 92]
 Output [1]: [d_date_sk#62]
 
-(32) BroadcastHashJoin [codegen id : 11]
+(32) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [date_sk#47]
 Right keys [1]: [d_date_sk#62]
 Join type: Inner
 Join condition: None
 
-(33) Project [codegen id : 11]
+(33) Project [codegen id : 7]
 Output [5]: [page_sk#46, sales_price#48, profit#49, return_amt#50, net_loss#51]
 Input [7]: [page_sk#46, date_sk#47, sales_price#48, profit#49, return_amt#50, net_loss#51, d_date_sk#62]
 
@@ -247,10 +247,10 @@ Location [not included in comparison]/{warehouse_dir}/catalog_page]
 PushedFilters: [IsNotNull(cp_catalog_page_sk)]
 ReadSchema: struct<cp_catalog_page_sk:int,cp_catalog_page_id:string>
 
-(35) ColumnarToRow [codegen id : 10]
+(35) ColumnarToRow [codegen id : 6]
 Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 
-(36) Filter [codegen id : 10]
+(36) Filter [codegen id : 6]
 Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 Condition : isnotnull(cp_catalog_page_sk#63)
 
@@ -258,17 +258,17 @@ Condition : isnotnull(cp_catalog_page_sk#63)
 Input [2]: [cp_catalog_page_sk#63, cp_catalog_page_id#64]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
-(38) BroadcastHashJoin [codegen id : 11]
+(38) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [page_sk#46]
 Right keys [1]: [cp_catalog_page_sk#63]
 Join type: Inner
 Join condition: None
 
-(39) Project [codegen id : 11]
+(39) Project [codegen id : 7]
 Output [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#64]
 Input [7]: [page_sk#46, sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_sk#63, cp_catalog_page_id#64]
 
-(40) HashAggregate [codegen id : 11]
+(40) HashAggregate [codegen id : 7]
 Input [5]: [sales_price#48, profit#49, return_amt#50, net_loss#51, cp_catalog_page_id#64]
 Keys [1]: [cp_catalog_page_id#64]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#48)), partial_sum(UnscaledValue(return_amt#50)), partial_sum(UnscaledValue(profit#49)), partial_sum(UnscaledValue(net_loss#51))]
@@ -279,7 +279,7 @@ Results [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
 Input [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
 Arguments: hashpartitioning(cp_catalog_page_id#64, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(42) HashAggregate [codegen id : 12]
+(42) HashAggregate [codegen id : 8]
 Input [5]: [cp_catalog_page_id#64, sum#69, sum#70, sum#71, sum#72]
 Keys [1]: [cp_catalog_page_id#64]
 Functions [4]: [sum(UnscaledValue(sales_price#48)), sum(UnscaledValue(return_amt#50)), sum(UnscaledValue(profit#49)), sum(UnscaledValue(net_loss#51))]
@@ -294,14 +294,14 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#85), dynamicpruningexpression(ws_so
 PushedFilters: [IsNotNull(ws_web_site_sk)]
 ReadSchema: struct<ws_web_site_sk:int,ws_ext_sales_price:decimal(7,2),ws_net_profit:decimal(7,2)>
 
-(44) ColumnarToRow [codegen id : 13]
+(44) ColumnarToRow [codegen id : 12]
 Input [4]: [ws_web_site_sk#82, ws_ext_sales_price#83, ws_net_profit#84, ws_sold_date_sk#85]
 
-(45) Filter [codegen id : 13]
+(45) Filter [codegen id : 12]
 Input [4]: [ws_web_site_sk#82, ws_ext_sales_price#83, ws_net_profit#84, ws_sold_date_sk#85]
 Condition : isnotnull(ws_web_site_sk#82)
 
-(46) Project [codegen id : 13]
+(46) Project [codegen id : 12]
 Output [6]: [ws_web_site_sk#82 AS wsr_web_site_sk#86, ws_sold_date_sk#85 AS date_sk#87, ws_ext_sales_price#83 AS sales_price#88, ws_net_profit#84 AS profit#89, 0.00 AS return_amt#90, 0.00 AS net_loss#91]
 Input [4]: [ws_web_site_sk#82, ws_ext_sales_price#83, ws_net_profit#84, ws_sold_date_sk#85]
 
@@ -312,7 +312,7 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(wr_returned_date_sk#96), dynamicpruningexpression(wr_returned_date_sk#96 IN dynamicpruning#5)]
 ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_amt:decimal(7,2),wr_net_loss:decimal(7,2)>
 
-(48) ColumnarToRow [codegen id : 14]
+(48) ColumnarToRow [codegen id : 9]
 Input [5]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95, wr_returned_date_sk#96]
 
 (49) BroadcastExchange
@@ -337,28 +337,28 @@ Condition : ((isnotnull(ws_item_sk#97) AND isnotnull(ws_order_number#99)) AND is
 Output [3]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99]
 Input [4]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99, ws_sold_date_sk#100]
 
-(54) BroadcastHashJoin [codegen id : 15]
+(54) BroadcastHashJoin
 Left keys [2]: [wr_item_sk#92, wr_order_number#93]
 Right keys [2]: [ws_item_sk#97, ws_order_number#99]
 Join type: Inner
 Join condition: None
 
-(55) Project [codegen id : 15]
+(55) Project
 Output [6]: [ws_web_site_sk#98 AS wsr_web_site_sk#101, wr_returned_date_sk#96 AS date_sk#102, 0.00 AS sales_price#103, 0.00 AS profit#104, wr_return_amt#94 AS return_amt#105, wr_net_loss#95 AS net_loss#106]
 Input [8]: [wr_item_sk#92, wr_order_number#93, wr_return_amt#94, wr_net_loss#95, wr_returned_date_sk#96, ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99]
 
-(56) Union
+(56) Union [codegen id : 12]
 
 (57) ReusedExchange [Reuses operator id: 92]
 Output [1]: [d_date_sk#107]
 
-(58) BroadcastHashJoin [codegen id : 18]
+(58) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [date_sk#87]
 Right keys [1]: [d_date_sk#107]
 Join type: Inner
 Join condition: None
 
-(59) Project [codegen id : 18]
+(59) Project [codegen id : 12]
 Output [5]: [wsr_web_site_sk#86, sales_price#88, profit#89, return_amt#90, net_loss#91]
 Input [7]: [wsr_web_site_sk#86, date_sk#87, sales_price#88, profit#89, return_amt#90, net_loss#91, d_date_sk#107]
 
@@ -369,10 +369,10 @@ Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_site_id:string>
 
-(61) ColumnarToRow [codegen id : 17]
+(61) ColumnarToRow [codegen id : 11]
 Input [2]: [web_site_sk#108, web_site_id#109]
 
-(62) Filter [codegen id : 17]
+(62) Filter [codegen id : 11]
 Input [2]: [web_site_sk#108, web_site_id#109]
 Condition : isnotnull(web_site_sk#108)
 
@@ -380,17 +380,17 @@ Condition : isnotnull(web_site_sk#108)
 Input [2]: [web_site_sk#108, web_site_id#109]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=6]
 
-(64) BroadcastHashJoin [codegen id : 18]
+(64) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [wsr_web_site_sk#86]
 Right keys [1]: [web_site_sk#108]
 Join type: Inner
 Join condition: None
 
-(65) Project [codegen id : 18]
+(65) Project [codegen id : 12]
 Output [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#109]
 Input [7]: [wsr_web_site_sk#86, sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_sk#108, web_site_id#109]
 
-(66) HashAggregate [codegen id : 18]
+(66) HashAggregate [codegen id : 12]
 Input [5]: [sales_price#88, profit#89, return_amt#90, net_loss#91, web_site_id#109]
 Keys [1]: [web_site_id#109]
 Functions [4]: [partial_sum(UnscaledValue(sales_price#88)), partial_sum(UnscaledValue(return_amt#90)), partial_sum(UnscaledValue(profit#89)), partial_sum(UnscaledValue(net_loss#91))]
@@ -401,7 +401,7 @@ Results [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
 Input [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
 Arguments: hashpartitioning(web_site_id#109, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(68) HashAggregate [codegen id : 19]
+(68) HashAggregate [codegen id : 13]
 Input [5]: [web_site_id#109, sum#114, sum#115, sum#116, sum#117]
 Keys [1]: [web_site_id#109]
 Functions [4]: [sum(UnscaledValue(sales_price#88)), sum(UnscaledValue(return_amt#90)), sum(UnscaledValue(profit#89)), sum(UnscaledValue(net_loss#91))]
@@ -410,7 +410,7 @@ Results [5]: [web channel AS channel#122, concat(web_site, web_site_id#109) AS i
 
 (69) Union
 
-(70) HashAggregate [codegen id : 20]
+(70) HashAggregate [codegen id : 14]
 Input [5]: [channel#37, id#38, sales#39, returns#40, profit#41]
 Keys [2]: [channel#37, id#38]
 Functions [3]: [partial_sum(sales#39), partial_sum(returns#40), partial_sum(profit#41)]
@@ -421,7 +421,7 @@ Results [8]: [channel#37, id#38, sum#133, isEmpty#134, sum#135, isEmpty#136, sum
 Input [8]: [channel#37, id#38, sum#133, isEmpty#134, sum#135, isEmpty#136, sum#137, isEmpty#138]
 Arguments: hashpartitioning(channel#37, id#38, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(72) HashAggregate [codegen id : 21]
+(72) HashAggregate [codegen id : 15]
 Input [8]: [channel#37, id#38, sum#133, isEmpty#134, sum#135, isEmpty#136, sum#137, isEmpty#138]
 Keys [2]: [channel#37, id#38]
 Functions [3]: [sum(sales#39), sum(returns#40), sum(profit#41)]
@@ -431,14 +431,14 @@ Results [5]: [channel#37, id#38, cast(sum(sales#39)#139 as decimal(37,2)) AS sal
 (73) ReusedExchange [Reuses operator id: 71]
 Output [8]: [channel#145, id#146, sum#147, isEmpty#148, sum#149, isEmpty#150, sum#151, isEmpty#152]
 
-(74) HashAggregate [codegen id : 42]
+(74) HashAggregate [codegen id : 30]
 Input [8]: [channel#145, id#146, sum#147, isEmpty#148, sum#149, isEmpty#150, sum#151, isEmpty#152]
 Keys [2]: [channel#145, id#146]
 Functions [3]: [sum(sales#153), sum(returns#154), sum(profit#155)]
 Aggregate Attributes [3]: [sum(sales#153)#139, sum(returns#154)#140, sum(profit#155)#141]
 Results [4]: [channel#145, sum(sales#153)#139 AS sales#156, sum(returns#154)#140 AS returns#157, sum(profit#155)#141 AS profit#158]
 
-(75) HashAggregate [codegen id : 42]
+(75) HashAggregate [codegen id : 30]
 Input [4]: [channel#145, sales#156, returns#157, profit#158]
 Keys [1]: [channel#145]
 Functions [3]: [partial_sum(sales#156), partial_sum(returns#157), partial_sum(profit#158)]
@@ -449,7 +449,7 @@ Results [7]: [channel#145, sum#165, isEmpty#166, sum#167, isEmpty#168, sum#169, 
 Input [7]: [channel#145, sum#165, isEmpty#166, sum#167, isEmpty#168, sum#169, isEmpty#170]
 Arguments: hashpartitioning(channel#145, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(77) HashAggregate [codegen id : 43]
+(77) HashAggregate [codegen id : 31]
 Input [7]: [channel#145, sum#165, isEmpty#166, sum#167, isEmpty#168, sum#169, isEmpty#170]
 Keys [1]: [channel#145]
 Functions [3]: [sum(sales#156), sum(returns#157), sum(profit#158)]
@@ -459,14 +459,14 @@ Results [5]: [channel#145, null AS id#174, sum(sales#156)#171 AS sum(sales)#175,
 (78) ReusedExchange [Reuses operator id: 71]
 Output [8]: [channel#178, id#179, sum#180, isEmpty#181, sum#182, isEmpty#183, sum#184, isEmpty#185]
 
-(79) HashAggregate [codegen id : 64]
+(79) HashAggregate [codegen id : 46]
 Input [8]: [channel#178, id#179, sum#180, isEmpty#181, sum#182, isEmpty#183, sum#184, isEmpty#185]
 Keys [2]: [channel#178, id#179]
 Functions [3]: [sum(sales#186), sum(returns#187), sum(profit#188)]
 Aggregate Attributes [3]: [sum(sales#186)#139, sum(returns#187)#140, sum(profit#188)#141]
 Results [3]: [sum(sales#186)#139 AS sales#189, sum(returns#187)#140 AS returns#190, sum(profit#188)#141 AS profit#191]
 
-(80) HashAggregate [codegen id : 64]
+(80) HashAggregate [codegen id : 46]
 Input [3]: [sales#189, returns#190, profit#191]
 Keys: []
 Functions [3]: [partial_sum(sales#189), partial_sum(returns#190), partial_sum(profit#191)]
@@ -477,7 +477,7 @@ Results [6]: [sum#198, isEmpty#199, sum#200, isEmpty#201, sum#202, isEmpty#203]
 Input [6]: [sum#198, isEmpty#199, sum#200, isEmpty#201, sum#202, isEmpty#203]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
-(82) HashAggregate [codegen id : 65]
+(82) HashAggregate [codegen id : 47]
 Input [6]: [sum#198, isEmpty#199, sum#200, isEmpty#201, sum#202, isEmpty#203]
 Keys: []
 Functions [3]: [sum(sales#189), sum(returns#190), sum(profit#191)]
@@ -486,7 +486,7 @@ Results [5]: [null AS channel#207, null AS id#208, sum(sales#189)#204 AS sum(sal
 
 (83) Union
 
-(84) HashAggregate [codegen id : 66]
+(84) HashAggregate [codegen id : 48]
 Input [5]: [channel#37, id#38, sales#142, returns#143, profit#144]
 Keys [5]: [channel#37, id#38, sales#142, returns#143, profit#144]
 Functions: []
@@ -497,7 +497,7 @@ Results [5]: [channel#37, id#38, sales#142, returns#143, profit#144]
 Input [5]: [channel#37, id#38, sales#142, returns#143, profit#144]
 Arguments: hashpartitioning(channel#37, id#38, sales#142, returns#143, profit#144, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(86) HashAggregate [codegen id : 67]
+(86) HashAggregate [codegen id : 49]
 Input [5]: [channel#37, id#38, sales#142, returns#143, profit#144]
 Keys [5]: [channel#37, id#38, sales#142, returns#143, profit#144]
 Functions: []

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a/simplified.txt
@@ -1,154 +1,145 @@
 TakeOrderedAndProject [channel,id,sales,returns,profit]
-  WholeStageCodegen (67)
+  WholeStageCodegen (49)
     HashAggregate [channel,id,sales,returns,profit]
       InputAdapter
         Exchange [channel,id,sales,returns,profit] #1
-          WholeStageCodegen (66)
+          WholeStageCodegen (48)
             HashAggregate [channel,id,sales,returns,profit]
               InputAdapter
                 Union
-                  WholeStageCodegen (21)
+                  WholeStageCodegen (15)
                     HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
                         Exchange [channel,id] #2
-                          WholeStageCodegen (20)
+                          WholeStageCodegen (14)
                             HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (6)
+                                  WholeStageCodegen (4)
                                     HashAggregate [s_store_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
                                       InputAdapter
                                         Exchange [s_store_id] #3
-                                          WholeStageCodegen (5)
+                                          WholeStageCodegen (3)
                                             HashAggregate [s_store_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                               Project [sales_price,profit,return_amt,net_loss,s_store_id]
                                                 BroadcastHashJoin [store_sk,s_store_sk]
                                                   Project [store_sk,sales_price,profit,return_amt,net_loss]
                                                     BroadcastHashJoin [date_sk,d_date_sk]
-                                                      InputAdapter
-                                                        Union
-                                                          WholeStageCodegen (1)
-                                                            Project [ss_store_sk,ss_sold_date_sk,ss_ext_sales_price,ss_net_profit]
-                                                              Filter [ss_store_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
-                                                                      SubqueryBroadcast [d_date_sk] #1
-                                                                        BroadcastExchange #4
-                                                                          WholeStageCodegen (1)
-                                                                            Project [d_date_sk]
-                                                                              Filter [d_date,d_date_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
-                                                          WholeStageCodegen (2)
-                                                            Project [sr_store_sk,sr_returned_date_sk,sr_return_amt,sr_net_loss]
-                                                              Filter [sr_store_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
-                                                                      ReusedSubquery [d_date_sk] #1
+                                                      Union
+                                                        Project [ss_store_sk,ss_sold_date_sk,ss_ext_sales_price,ss_net_profit]
+                                                          Filter [ss_store_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
+                                                                  SubqueryBroadcast [d_date_sk] #1
+                                                                    BroadcastExchange #4
+                                                                      WholeStageCodegen (1)
+                                                                        Project [d_date_sk]
+                                                                          Filter [d_date,d_date_sk]
+                                                                            ColumnarToRow
+                                                                              InputAdapter
+                                                                                Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                                                        Project [sr_store_sk,sr_returned_date_sk,sr_return_amt,sr_net_loss]
+                                                          Filter [sr_store_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
+                                                                  ReusedSubquery [d_date_sk] #1
                                                       InputAdapter
                                                         ReusedExchange [d_date_sk] #4
                                                   InputAdapter
                                                     BroadcastExchange #5
-                                                      WholeStageCodegen (4)
+                                                      WholeStageCodegen (2)
                                                         Filter [s_store_sk]
                                                           ColumnarToRow
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
-                                  WholeStageCodegen (12)
+                                  WholeStageCodegen (8)
                                     HashAggregate [cp_catalog_page_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
                                       InputAdapter
                                         Exchange [cp_catalog_page_id] #6
-                                          WholeStageCodegen (11)
+                                          WholeStageCodegen (7)
                                             HashAggregate [cp_catalog_page_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                               Project [sales_price,profit,return_amt,net_loss,cp_catalog_page_id]
                                                 BroadcastHashJoin [page_sk,cp_catalog_page_sk]
                                                   Project [page_sk,sales_price,profit,return_amt,net_loss]
                                                     BroadcastHashJoin [date_sk,d_date_sk]
-                                                      InputAdapter
-                                                        Union
-                                                          WholeStageCodegen (7)
-                                                            Project [cs_catalog_page_sk,cs_sold_date_sk,cs_ext_sales_price,cs_net_profit]
-                                                              Filter [cs_catalog_page_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.catalog_sales [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
-                                                                      ReusedSubquery [d_date_sk] #1
-                                                          WholeStageCodegen (8)
-                                                            Project [cr_catalog_page_sk,cr_returned_date_sk,cr_return_amount,cr_net_loss]
-                                                              Filter [cr_catalog_page_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.catalog_returns [cr_catalog_page_sk,cr_return_amount,cr_net_loss,cr_returned_date_sk]
-                                                                      ReusedSubquery [d_date_sk] #1
+                                                      Union
+                                                        Project [cs_catalog_page_sk,cs_sold_date_sk,cs_ext_sales_price,cs_net_profit]
+                                                          Filter [cs_catalog_page_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.catalog_sales [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
+                                                                  ReusedSubquery [d_date_sk] #1
+                                                        Project [cr_catalog_page_sk,cr_returned_date_sk,cr_return_amount,cr_net_loss]
+                                                          Filter [cr_catalog_page_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.catalog_returns [cr_catalog_page_sk,cr_return_amount,cr_net_loss,cr_returned_date_sk]
+                                                                  ReusedSubquery [d_date_sk] #1
                                                       InputAdapter
                                                         ReusedExchange [d_date_sk] #4
                                                   InputAdapter
                                                     BroadcastExchange #7
-                                                      WholeStageCodegen (10)
+                                                      WholeStageCodegen (6)
                                                         Filter [cp_catalog_page_sk]
                                                           ColumnarToRow
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
-                                  WholeStageCodegen (19)
+                                  WholeStageCodegen (13)
                                     HashAggregate [web_site_id,sum,sum,sum,sum] [sum(UnscaledValue(sales_price)),sum(UnscaledValue(return_amt)),sum(UnscaledValue(profit)),sum(UnscaledValue(net_loss)),channel,id,sales,returns,profit,sum,sum,sum,sum]
                                       InputAdapter
                                         Exchange [web_site_id] #8
-                                          WholeStageCodegen (18)
+                                          WholeStageCodegen (12)
                                             HashAggregate [web_site_id,sales_price,return_amt,profit,net_loss] [sum,sum,sum,sum,sum,sum,sum,sum]
                                               Project [sales_price,profit,return_amt,net_loss,web_site_id]
                                                 BroadcastHashJoin [wsr_web_site_sk,web_site_sk]
                                                   Project [wsr_web_site_sk,sales_price,profit,return_amt,net_loss]
                                                     BroadcastHashJoin [date_sk,d_date_sk]
-                                                      InputAdapter
-                                                        Union
-                                                          WholeStageCodegen (13)
-                                                            Project [ws_web_site_sk,ws_sold_date_sk,ws_ext_sales_price,ws_net_profit]
-                                                              Filter [ws_web_site_sk]
+                                                      Union
+                                                        Project [ws_web_site_sk,ws_sold_date_sk,ws_ext_sales_price,ws_net_profit]
+                                                          Filter [ws_web_site_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.web_sales [ws_web_site_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
+                                                                  ReusedSubquery [d_date_sk] #1
+                                                        Project [ws_web_site_sk,wr_returned_date_sk,wr_return_amt,wr_net_loss]
+                                                          BroadcastHashJoin [wr_item_sk,wr_order_number,ws_item_sk,ws_order_number]
+                                                            InputAdapter
+                                                              BroadcastExchange #9
+                                                                WholeStageCodegen (9)
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss,wr_returned_date_sk]
+                                                                        ReusedSubquery [d_date_sk] #1
+                                                            Project [ws_item_sk,ws_web_site_sk,ws_order_number]
+                                                              Filter [ws_item_sk,ws_order_number,ws_web_site_sk]
                                                                 ColumnarToRow
                                                                   InputAdapter
-                                                                    Scan parquet spark_catalog.default.web_sales [ws_web_site_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
-                                                                      ReusedSubquery [d_date_sk] #1
-                                                          WholeStageCodegen (15)
-                                                            Project [ws_web_site_sk,wr_returned_date_sk,wr_return_amt,wr_net_loss]
-                                                              BroadcastHashJoin [wr_item_sk,wr_order_number,ws_item_sk,ws_order_number]
-                                                                InputAdapter
-                                                                  BroadcastExchange #9
-                                                                    WholeStageCodegen (14)
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss,wr_returned_date_sk]
-                                                                            ReusedSubquery [d_date_sk] #1
-                                                                Project [ws_item_sk,ws_web_site_sk,ws_order_number]
-                                                                  Filter [ws_item_sk,ws_order_number,ws_web_site_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_web_site_sk,ws_order_number,ws_sold_date_sk]
+                                                                    Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_web_site_sk,ws_order_number,ws_sold_date_sk]
                                                       InputAdapter
                                                         ReusedExchange [d_date_sk] #4
                                                   InputAdapter
                                                     BroadcastExchange #10
-                                                      WholeStageCodegen (17)
+                                                      WholeStageCodegen (11)
                                                         Filter [web_site_sk]
                                                           ColumnarToRow
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.web_site [web_site_sk,web_site_id]
-                  WholeStageCodegen (43)
+                  WholeStageCodegen (31)
                     HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sum(sales),sum(returns),sum(profit),sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
                         Exchange [channel] #11
-                          WholeStageCodegen (42)
+                          WholeStageCodegen (30)
                             HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 InputAdapter
                                   ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2
-                  WholeStageCodegen (65)
+                  WholeStageCodegen (47)
                     HashAggregate [sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),channel,id,sum(sales),sum(returns),sum(profit),sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
                         Exchange #12
-                          WholeStageCodegen (64)
+                          WholeStageCodegen (46)
                             HashAggregate [sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a/explain.txt
@@ -7,7 +7,7 @@ TakeOrderedAndProject (70)
             +- Exchange (65)
                +- WindowGroupLimit (64)
                   +- * Sort (63)
-                     +- Union (62)
+                     +- * Union (62)
                         :- * HashAggregate (21)
                         :  +- Exchange (20)
                         :     +- * HashAggregate (19)
@@ -166,7 +166,7 @@ Results [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#
 Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#20, isEmpty#21]
 Arguments: hashpartitioning(i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(21) HashAggregate [codegen id : 5]
+(21) HashAggregate [codegen id : 45]
 Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#20, isEmpty#21]
 Keys [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
 Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
@@ -176,14 +176,14 @@ Results [9]: [i_category#16 AS i_category#23, i_class#15 AS i_class#24, i_brand#
 (22) ReusedExchange [Reuses operator id: 20]
 Output [10]: [i_category#32, i_class#33, i_brand#34, i_product_name#35, d_year#36, d_qoy#37, d_moy#38, s_store_id#39, sum#40, isEmpty#41]
 
-(23) HashAggregate [codegen id : 10]
+(23) HashAggregate [codegen id : 9]
 Input [10]: [i_category#32, i_class#33, i_brand#34, i_product_name#35, d_year#36, d_qoy#37, d_moy#38, s_store_id#39, sum#40, isEmpty#41]
 Keys [8]: [i_category#32, i_class#33, i_brand#34, i_product_name#35, d_year#36, d_qoy#37, d_moy#38, s_store_id#39]
 Functions [1]: [sum(coalesce((ss_sales_price#42 * cast(ss_quantity#43 as decimal(10,0))), 0.00))]
 Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#42 * cast(ss_quantity#43 as decimal(10,0))), 0.00))#22]
 Results [8]: [i_category#32, i_class#33, i_brand#34, i_product_name#35, d_year#36, d_qoy#37, d_moy#38, sum(coalesce((ss_sales_price#42 * cast(ss_quantity#43 as decimal(10,0))), 0.00))#22 AS sumsales#44]
 
-(24) HashAggregate [codegen id : 10]
+(24) HashAggregate [codegen id : 9]
 Input [8]: [i_category#32, i_class#33, i_brand#34, i_product_name#35, d_year#36, d_qoy#37, d_moy#38, sumsales#44]
 Keys [7]: [i_category#32, i_class#33, i_brand#34, i_product_name#35, d_year#36, d_qoy#37, d_moy#38]
 Functions [1]: [partial_sum(sumsales#44)]
@@ -194,7 +194,7 @@ Results [9]: [i_category#32, i_class#33, i_brand#34, i_product_name#35, d_year#3
 Input [9]: [i_category#32, i_class#33, i_brand#34, i_product_name#35, d_year#36, d_qoy#37, d_moy#38, sum#47, isEmpty#48]
 Arguments: hashpartitioning(i_category#32, i_class#33, i_brand#34, i_product_name#35, d_year#36, d_qoy#37, d_moy#38, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(26) HashAggregate [codegen id : 11]
+(26) HashAggregate
 Input [9]: [i_category#32, i_class#33, i_brand#34, i_product_name#35, d_year#36, d_qoy#37, d_moy#38, sum#47, isEmpty#48]
 Keys [7]: [i_category#32, i_class#33, i_brand#34, i_product_name#35, d_year#36, d_qoy#37, d_moy#38]
 Functions [1]: [sum(sumsales#44)]
@@ -204,14 +204,14 @@ Results [9]: [i_category#32, i_class#33, i_brand#34, i_product_name#35, d_year#3
 (27) ReusedExchange [Reuses operator id: 20]
 Output [10]: [i_category#52, i_class#53, i_brand#54, i_product_name#55, d_year#56, d_qoy#57, d_moy#58, s_store_id#59, sum#60, isEmpty#61]
 
-(28) HashAggregate [codegen id : 16]
+(28) HashAggregate [codegen id : 14]
 Input [10]: [i_category#52, i_class#53, i_brand#54, i_product_name#55, d_year#56, d_qoy#57, d_moy#58, s_store_id#59, sum#60, isEmpty#61]
 Keys [8]: [i_category#52, i_class#53, i_brand#54, i_product_name#55, d_year#56, d_qoy#57, d_moy#58, s_store_id#59]
 Functions [1]: [sum(coalesce((ss_sales_price#62 * cast(ss_quantity#63 as decimal(10,0))), 0.00))]
 Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#62 * cast(ss_quantity#63 as decimal(10,0))), 0.00))#22]
 Results [7]: [i_category#52, i_class#53, i_brand#54, i_product_name#55, d_year#56, d_qoy#57, sum(coalesce((ss_sales_price#62 * cast(ss_quantity#63 as decimal(10,0))), 0.00))#22 AS sumsales#64]
 
-(29) HashAggregate [codegen id : 16]
+(29) HashAggregate [codegen id : 14]
 Input [7]: [i_category#52, i_class#53, i_brand#54, i_product_name#55, d_year#56, d_qoy#57, sumsales#64]
 Keys [6]: [i_category#52, i_class#53, i_brand#54, i_product_name#55, d_year#56, d_qoy#57]
 Functions [1]: [partial_sum(sumsales#64)]
@@ -222,7 +222,7 @@ Results [8]: [i_category#52, i_class#53, i_brand#54, i_product_name#55, d_year#5
 Input [8]: [i_category#52, i_class#53, i_brand#54, i_product_name#55, d_year#56, d_qoy#57, sum#67, isEmpty#68]
 Arguments: hashpartitioning(i_category#52, i_class#53, i_brand#54, i_product_name#55, d_year#56, d_qoy#57, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(31) HashAggregate [codegen id : 17]
+(31) HashAggregate
 Input [8]: [i_category#52, i_class#53, i_brand#54, i_product_name#55, d_year#56, d_qoy#57, sum#67, isEmpty#68]
 Keys [6]: [i_category#52, i_class#53, i_brand#54, i_product_name#55, d_year#56, d_qoy#57]
 Functions [1]: [sum(sumsales#64)]
@@ -232,14 +232,14 @@ Results [9]: [i_category#52, i_class#53, i_brand#54, i_product_name#55, d_year#5
 (32) ReusedExchange [Reuses operator id: 20]
 Output [10]: [i_category#73, i_class#74, i_brand#75, i_product_name#76, d_year#77, d_qoy#78, d_moy#79, s_store_id#80, sum#81, isEmpty#82]
 
-(33) HashAggregate [codegen id : 22]
+(33) HashAggregate [codegen id : 19]
 Input [10]: [i_category#73, i_class#74, i_brand#75, i_product_name#76, d_year#77, d_qoy#78, d_moy#79, s_store_id#80, sum#81, isEmpty#82]
 Keys [8]: [i_category#73, i_class#74, i_brand#75, i_product_name#76, d_year#77, d_qoy#78, d_moy#79, s_store_id#80]
 Functions [1]: [sum(coalesce((ss_sales_price#83 * cast(ss_quantity#84 as decimal(10,0))), 0.00))]
 Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#83 * cast(ss_quantity#84 as decimal(10,0))), 0.00))#22]
 Results [6]: [i_category#73, i_class#74, i_brand#75, i_product_name#76, d_year#77, sum(coalesce((ss_sales_price#83 * cast(ss_quantity#84 as decimal(10,0))), 0.00))#22 AS sumsales#85]
 
-(34) HashAggregate [codegen id : 22]
+(34) HashAggregate [codegen id : 19]
 Input [6]: [i_category#73, i_class#74, i_brand#75, i_product_name#76, d_year#77, sumsales#85]
 Keys [5]: [i_category#73, i_class#74, i_brand#75, i_product_name#76, d_year#77]
 Functions [1]: [partial_sum(sumsales#85)]
@@ -250,7 +250,7 @@ Results [7]: [i_category#73, i_class#74, i_brand#75, i_product_name#76, d_year#7
 Input [7]: [i_category#73, i_class#74, i_brand#75, i_product_name#76, d_year#77, sum#88, isEmpty#89]
 Arguments: hashpartitioning(i_category#73, i_class#74, i_brand#75, i_product_name#76, d_year#77, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(36) HashAggregate [codegen id : 23]
+(36) HashAggregate
 Input [7]: [i_category#73, i_class#74, i_brand#75, i_product_name#76, d_year#77, sum#88, isEmpty#89]
 Keys [5]: [i_category#73, i_class#74, i_brand#75, i_product_name#76, d_year#77]
 Functions [1]: [sum(sumsales#85)]
@@ -260,14 +260,14 @@ Results [9]: [i_category#73, i_class#74, i_brand#75, i_product_name#76, d_year#7
 (37) ReusedExchange [Reuses operator id: 20]
 Output [10]: [i_category#95, i_class#96, i_brand#97, i_product_name#98, d_year#99, d_qoy#100, d_moy#101, s_store_id#102, sum#103, isEmpty#104]
 
-(38) HashAggregate [codegen id : 28]
+(38) HashAggregate [codegen id : 24]
 Input [10]: [i_category#95, i_class#96, i_brand#97, i_product_name#98, d_year#99, d_qoy#100, d_moy#101, s_store_id#102, sum#103, isEmpty#104]
 Keys [8]: [i_category#95, i_class#96, i_brand#97, i_product_name#98, d_year#99, d_qoy#100, d_moy#101, s_store_id#102]
 Functions [1]: [sum(coalesce((ss_sales_price#105 * cast(ss_quantity#106 as decimal(10,0))), 0.00))]
 Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#105 * cast(ss_quantity#106 as decimal(10,0))), 0.00))#22]
 Results [5]: [i_category#95, i_class#96, i_brand#97, i_product_name#98, sum(coalesce((ss_sales_price#105 * cast(ss_quantity#106 as decimal(10,0))), 0.00))#22 AS sumsales#107]
 
-(39) HashAggregate [codegen id : 28]
+(39) HashAggregate [codegen id : 24]
 Input [5]: [i_category#95, i_class#96, i_brand#97, i_product_name#98, sumsales#107]
 Keys [4]: [i_category#95, i_class#96, i_brand#97, i_product_name#98]
 Functions [1]: [partial_sum(sumsales#107)]
@@ -278,7 +278,7 @@ Results [6]: [i_category#95, i_class#96, i_brand#97, i_product_name#98, sum#110,
 Input [6]: [i_category#95, i_class#96, i_brand#97, i_product_name#98, sum#110, isEmpty#111]
 Arguments: hashpartitioning(i_category#95, i_class#96, i_brand#97, i_product_name#98, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(41) HashAggregate [codegen id : 29]
+(41) HashAggregate
 Input [6]: [i_category#95, i_class#96, i_brand#97, i_product_name#98, sum#110, isEmpty#111]
 Keys [4]: [i_category#95, i_class#96, i_brand#97, i_product_name#98]
 Functions [1]: [sum(sumsales#107)]
@@ -288,14 +288,14 @@ Results [9]: [i_category#95, i_class#96, i_brand#97, i_product_name#98, null AS 
 (42) ReusedExchange [Reuses operator id: 20]
 Output [10]: [i_category#118, i_class#119, i_brand#120, i_product_name#121, d_year#122, d_qoy#123, d_moy#124, s_store_id#125, sum#126, isEmpty#127]
 
-(43) HashAggregate [codegen id : 34]
+(43) HashAggregate [codegen id : 29]
 Input [10]: [i_category#118, i_class#119, i_brand#120, i_product_name#121, d_year#122, d_qoy#123, d_moy#124, s_store_id#125, sum#126, isEmpty#127]
 Keys [8]: [i_category#118, i_class#119, i_brand#120, i_product_name#121, d_year#122, d_qoy#123, d_moy#124, s_store_id#125]
 Functions [1]: [sum(coalesce((ss_sales_price#128 * cast(ss_quantity#129 as decimal(10,0))), 0.00))]
 Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#128 * cast(ss_quantity#129 as decimal(10,0))), 0.00))#22]
 Results [4]: [i_category#118, i_class#119, i_brand#120, sum(coalesce((ss_sales_price#128 * cast(ss_quantity#129 as decimal(10,0))), 0.00))#22 AS sumsales#130]
 
-(44) HashAggregate [codegen id : 34]
+(44) HashAggregate [codegen id : 29]
 Input [4]: [i_category#118, i_class#119, i_brand#120, sumsales#130]
 Keys [3]: [i_category#118, i_class#119, i_brand#120]
 Functions [1]: [partial_sum(sumsales#130)]
@@ -306,7 +306,7 @@ Results [5]: [i_category#118, i_class#119, i_brand#120, sum#133, isEmpty#134]
 Input [5]: [i_category#118, i_class#119, i_brand#120, sum#133, isEmpty#134]
 Arguments: hashpartitioning(i_category#118, i_class#119, i_brand#120, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(46) HashAggregate [codegen id : 35]
+(46) HashAggregate
 Input [5]: [i_category#118, i_class#119, i_brand#120, sum#133, isEmpty#134]
 Keys [3]: [i_category#118, i_class#119, i_brand#120]
 Functions [1]: [sum(sumsales#130)]
@@ -316,14 +316,14 @@ Results [9]: [i_category#118, i_class#119, i_brand#120, null AS i_product_name#1
 (47) ReusedExchange [Reuses operator id: 20]
 Output [10]: [i_category#142, i_class#143, i_brand#144, i_product_name#145, d_year#146, d_qoy#147, d_moy#148, s_store_id#149, sum#150, isEmpty#151]
 
-(48) HashAggregate [codegen id : 40]
+(48) HashAggregate [codegen id : 34]
 Input [10]: [i_category#142, i_class#143, i_brand#144, i_product_name#145, d_year#146, d_qoy#147, d_moy#148, s_store_id#149, sum#150, isEmpty#151]
 Keys [8]: [i_category#142, i_class#143, i_brand#144, i_product_name#145, d_year#146, d_qoy#147, d_moy#148, s_store_id#149]
 Functions [1]: [sum(coalesce((ss_sales_price#152 * cast(ss_quantity#153 as decimal(10,0))), 0.00))]
 Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#152 * cast(ss_quantity#153 as decimal(10,0))), 0.00))#22]
 Results [3]: [i_category#142, i_class#143, sum(coalesce((ss_sales_price#152 * cast(ss_quantity#153 as decimal(10,0))), 0.00))#22 AS sumsales#154]
 
-(49) HashAggregate [codegen id : 40]
+(49) HashAggregate [codegen id : 34]
 Input [3]: [i_category#142, i_class#143, sumsales#154]
 Keys [2]: [i_category#142, i_class#143]
 Functions [1]: [partial_sum(sumsales#154)]
@@ -334,7 +334,7 @@ Results [4]: [i_category#142, i_class#143, sum#157, isEmpty#158]
 Input [4]: [i_category#142, i_class#143, sum#157, isEmpty#158]
 Arguments: hashpartitioning(i_category#142, i_class#143, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(51) HashAggregate [codegen id : 41]
+(51) HashAggregate
 Input [4]: [i_category#142, i_class#143, sum#157, isEmpty#158]
 Keys [2]: [i_category#142, i_class#143]
 Functions [1]: [sum(sumsales#154)]
@@ -344,14 +344,14 @@ Results [9]: [i_category#142, i_class#143, null AS i_brand#160, null AS i_produc
 (52) ReusedExchange [Reuses operator id: 20]
 Output [10]: [i_category#167, i_class#168, i_brand#169, i_product_name#170, d_year#171, d_qoy#172, d_moy#173, s_store_id#174, sum#175, isEmpty#176]
 
-(53) HashAggregate [codegen id : 46]
+(53) HashAggregate [codegen id : 39]
 Input [10]: [i_category#167, i_class#168, i_brand#169, i_product_name#170, d_year#171, d_qoy#172, d_moy#173, s_store_id#174, sum#175, isEmpty#176]
 Keys [8]: [i_category#167, i_class#168, i_brand#169, i_product_name#170, d_year#171, d_qoy#172, d_moy#173, s_store_id#174]
 Functions [1]: [sum(coalesce((ss_sales_price#177 * cast(ss_quantity#178 as decimal(10,0))), 0.00))]
 Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#177 * cast(ss_quantity#178 as decimal(10,0))), 0.00))#22]
 Results [2]: [i_category#167, sum(coalesce((ss_sales_price#177 * cast(ss_quantity#178 as decimal(10,0))), 0.00))#22 AS sumsales#179]
 
-(54) HashAggregate [codegen id : 46]
+(54) HashAggregate [codegen id : 39]
 Input [2]: [i_category#167, sumsales#179]
 Keys [1]: [i_category#167]
 Functions [1]: [partial_sum(sumsales#179)]
@@ -362,7 +362,7 @@ Results [3]: [i_category#167, sum#182, isEmpty#183]
 Input [3]: [i_category#167, sum#182, isEmpty#183]
 Arguments: hashpartitioning(i_category#167, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(56) HashAggregate [codegen id : 47]
+(56) HashAggregate
 Input [3]: [i_category#167, sum#182, isEmpty#183]
 Keys [1]: [i_category#167]
 Functions [1]: [sum(sumsales#179)]
@@ -372,14 +372,14 @@ Results [9]: [i_category#167, null AS i_class#185, null AS i_brand#186, null AS 
 (57) ReusedExchange [Reuses operator id: 20]
 Output [10]: [i_category#193, i_class#194, i_brand#195, i_product_name#196, d_year#197, d_qoy#198, d_moy#199, s_store_id#200, sum#201, isEmpty#202]
 
-(58) HashAggregate [codegen id : 52]
+(58) HashAggregate [codegen id : 44]
 Input [10]: [i_category#193, i_class#194, i_brand#195, i_product_name#196, d_year#197, d_qoy#198, d_moy#199, s_store_id#200, sum#201, isEmpty#202]
 Keys [8]: [i_category#193, i_class#194, i_brand#195, i_product_name#196, d_year#197, d_qoy#198, d_moy#199, s_store_id#200]
 Functions [1]: [sum(coalesce((ss_sales_price#203 * cast(ss_quantity#204 as decimal(10,0))), 0.00))]
 Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#203 * cast(ss_quantity#204 as decimal(10,0))), 0.00))#22]
 Results [1]: [sum(coalesce((ss_sales_price#203 * cast(ss_quantity#204 as decimal(10,0))), 0.00))#22 AS sumsales#205]
 
-(59) HashAggregate [codegen id : 52]
+(59) HashAggregate [codegen id : 44]
 Input [1]: [sumsales#205]
 Keys: []
 Functions [1]: [partial_sum(sumsales#205)]
@@ -390,16 +390,16 @@ Results [2]: [sum#208, isEmpty#209]
 Input [2]: [sum#208, isEmpty#209]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
 
-(61) HashAggregate [codegen id : 53]
+(61) HashAggregate
 Input [2]: [sum#208, isEmpty#209]
 Keys: []
 Functions [1]: [sum(sumsales#205)]
 Aggregate Attributes [1]: [sum(sumsales#205)#210]
 Results [9]: [null AS i_category#211, null AS i_class#212, null AS i_brand#213, null AS i_product_name#214, null AS d_year#215, null AS d_qoy#216, null AS d_moy#217, null AS s_store_id#218, sum(sumsales#205)#210 AS sumsales#219]
 
-(62) Union
+(62) Union [codegen id : 45]
 
-(63) Sort [codegen id : 54]
+(63) Sort [codegen id : 45]
 Input [9]: [i_category#23, i_class#24, i_brand#25, i_product_name#26, d_year#27, d_qoy#28, d_moy#29, s_store_id#30, sumsales#31]
 Arguments: [i_category#23 ASC NULLS FIRST, sumsales#31 DESC NULLS LAST], false, 0
 
@@ -411,7 +411,7 @@ Arguments: [i_category#23], [sumsales#31 DESC NULLS LAST], rank(sumsales#31), 10
 Input [9]: [i_category#23, i_class#24, i_brand#25, i_product_name#26, d_year#27, d_qoy#28, d_moy#29, s_store_id#30, sumsales#31]
 Arguments: hashpartitioning(i_category#23, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(66) Sort [codegen id : 55]
+(66) Sort [codegen id : 46]
 Input [9]: [i_category#23, i_class#24, i_brand#25, i_product_name#26, d_year#27, d_qoy#28, d_moy#29, s_store_id#30, sumsales#31]
 Arguments: [i_category#23 ASC NULLS FIRST, sumsales#31 DESC NULLS LAST], false, 0
 
@@ -423,7 +423,7 @@ Arguments: [i_category#23], [sumsales#31 DESC NULLS LAST], rank(sumsales#31), 10
 Input [9]: [i_category#23, i_class#24, i_brand#25, i_product_name#26, d_year#27, d_qoy#28, d_moy#29, s_store_id#30, sumsales#31]
 Arguments: [rank(sumsales#31) windowspecdefinition(i_category#23, sumsales#31 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#220], [i_category#23], [sumsales#31 DESC NULLS LAST]
 
-(69) Filter [codegen id : 56]
+(69) Filter [codegen id : 47]
 Input [10]: [i_category#23, i_class#24, i_brand#25, i_product_name#26, d_year#27, d_qoy#28, d_moy#29, s_store_id#30, sumsales#31, rk#220]
 Condition : (rk#220 <= 100)
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a/simplified.txt
@@ -1,127 +1,117 @@
 TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sumsales,rk]
-  WholeStageCodegen (56)
+  WholeStageCodegen (47)
     Filter [rk]
       InputAdapter
         Window [sumsales,i_category]
           WindowGroupLimit [i_category,sumsales]
-            WholeStageCodegen (55)
+            WholeStageCodegen (46)
               Sort [i_category,sumsales]
                 InputAdapter
                   Exchange [i_category] #1
                     WindowGroupLimit [i_category,sumsales]
-                      WholeStageCodegen (54)
+                      WholeStageCodegen (45)
                         Sort [i_category,sumsales]
-                          InputAdapter
-                            Union
-                              WholeStageCodegen (5)
-                                HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
-                                  InputAdapter
-                                    Exchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id] #2
-                                      WholeStageCodegen (4)
-                                        HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,ss_sales_price,ss_quantity] [sum,isEmpty,sum,isEmpty]
-                                          Project [ss_quantity,ss_sales_price,d_year,d_moy,d_qoy,s_store_id,i_brand,i_class,i_category,i_product_name]
-                                            BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                              Project [ss_item_sk,ss_quantity,ss_sales_price,d_year,d_moy,d_qoy,s_store_id]
-                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                  Project [ss_item_sk,ss_store_sk,ss_quantity,ss_sales_price,d_year,d_moy,d_qoy]
-                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                      Filter [ss_store_sk,ss_item_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_quantity,ss_sales_price,ss_sold_date_sk]
-                                                              SubqueryBroadcast [d_date_sk] #1
-                                                                BroadcastExchange #3
-                                                                  WholeStageCodegen (1)
-                                                                    Project [d_date_sk,d_year,d_moy,d_qoy]
-                                                                      Filter [d_month_seq,d_date_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq,d_year,d_moy,d_qoy]
+                          Union
+                            HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
+                              InputAdapter
+                                Exchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id] #2
+                                  WholeStageCodegen (4)
+                                    HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,ss_sales_price,ss_quantity] [sum,isEmpty,sum,isEmpty]
+                                      Project [ss_quantity,ss_sales_price,d_year,d_moy,d_qoy,s_store_id,i_brand,i_class,i_category,i_product_name]
+                                        BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                          Project [ss_item_sk,ss_quantity,ss_sales_price,d_year,d_moy,d_qoy,s_store_id]
+                                            BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                              Project [ss_item_sk,ss_store_sk,ss_quantity,ss_sales_price,d_year,d_moy,d_qoy]
+                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                  Filter [ss_store_sk,ss_item_sk]
+                                                    ColumnarToRow
                                                       InputAdapter
-                                                        ReusedExchange [d_date_sk,d_year,d_moy,d_qoy] #3
+                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_quantity,ss_sales_price,ss_sold_date_sk]
+                                                          SubqueryBroadcast [d_date_sk] #1
+                                                            BroadcastExchange #3
+                                                              WholeStageCodegen (1)
+                                                                Project [d_date_sk,d_year,d_moy,d_qoy]
+                                                                  Filter [d_month_seq,d_date_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq,d_year,d_moy,d_qoy]
                                                   InputAdapter
-                                                    BroadcastExchange #4
-                                                      WholeStageCodegen (2)
-                                                        Filter [s_store_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
+                                                    ReusedExchange [d_date_sk,d_year,d_moy,d_qoy] #3
                                               InputAdapter
-                                                BroadcastExchange #5
-                                                  WholeStageCodegen (3)
-                                                    Filter [i_item_sk]
+                                                BroadcastExchange #4
+                                                  WholeStageCodegen (2)
+                                                    Filter [s_store_sk]
                                                       ColumnarToRow
                                                         InputAdapter
-                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_product_name]
-                              WholeStageCodegen (11)
-                                HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,sum,isEmpty] [sum(sumsales),s_store_id,sumsales,sum,isEmpty]
-                                  InputAdapter
-                                    Exchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy] #6
-                                      WholeStageCodegen (10)
-                                        HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,sumsales] [sum,isEmpty,sum,isEmpty]
-                                          HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
-                                            InputAdapter
-                                              ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2
-                              WholeStageCodegen (17)
-                                HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,sum,isEmpty] [sum(sumsales),d_moy,s_store_id,sumsales,sum,isEmpty]
-                                  InputAdapter
-                                    Exchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy] #7
-                                      WholeStageCodegen (16)
-                                        HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,sumsales] [sum,isEmpty,sum,isEmpty]
-                                          HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
-                                            InputAdapter
-                                              ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2
-                              WholeStageCodegen (23)
-                                HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,sum,isEmpty] [sum(sumsales),d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
-                                  InputAdapter
-                                    Exchange [i_category,i_class,i_brand,i_product_name,d_year] #8
-                                      WholeStageCodegen (22)
-                                        HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,sumsales] [sum,isEmpty,sum,isEmpty]
-                                          HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
-                                            InputAdapter
-                                              ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2
-                              WholeStageCodegen (29)
-                                HashAggregate [i_category,i_class,i_brand,i_product_name,sum,isEmpty] [sum(sumsales),d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
-                                  InputAdapter
-                                    Exchange [i_category,i_class,i_brand,i_product_name] #9
-                                      WholeStageCodegen (28)
-                                        HashAggregate [i_category,i_class,i_brand,i_product_name,sumsales] [sum,isEmpty,sum,isEmpty]
-                                          HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
-                                            InputAdapter
-                                              ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2
-                              WholeStageCodegen (35)
-                                HashAggregate [i_category,i_class,i_brand,sum,isEmpty] [sum(sumsales),i_product_name,d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
-                                  InputAdapter
-                                    Exchange [i_category,i_class,i_brand] #10
-                                      WholeStageCodegen (34)
-                                        HashAggregate [i_category,i_class,i_brand,sumsales] [sum,isEmpty,sum,isEmpty]
-                                          HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
-                                            InputAdapter
-                                              ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2
-                              WholeStageCodegen (41)
-                                HashAggregate [i_category,i_class,sum,isEmpty] [sum(sumsales),i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
-                                  InputAdapter
-                                    Exchange [i_category,i_class] #11
-                                      WholeStageCodegen (40)
-                                        HashAggregate [i_category,i_class,sumsales] [sum,isEmpty,sum,isEmpty]
-                                          HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
-                                            InputAdapter
-                                              ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2
-                              WholeStageCodegen (47)
-                                HashAggregate [i_category,sum,isEmpty] [sum(sumsales),i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
-                                  InputAdapter
-                                    Exchange [i_category] #12
-                                      WholeStageCodegen (46)
-                                        HashAggregate [i_category,sumsales] [sum,isEmpty,sum,isEmpty]
-                                          HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
-                                            InputAdapter
-                                              ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2
-                              WholeStageCodegen (53)
-                                HashAggregate [sum,isEmpty] [sum(sumsales),i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
-                                  InputAdapter
-                                    Exchange #13
-                                      WholeStageCodegen (52)
-                                        HashAggregate [sumsales] [sum,isEmpty,sum,isEmpty]
-                                          HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
-                                            InputAdapter
-                                              ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2
+                                                          Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
+                                          InputAdapter
+                                            BroadcastExchange #5
+                                              WholeStageCodegen (3)
+                                                Filter [i_item_sk]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_product_name]
+                            HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,sum,isEmpty] [sum(sumsales),s_store_id,sumsales,sum,isEmpty]
+                              InputAdapter
+                                Exchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy] #6
+                                  WholeStageCodegen (9)
+                                    HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,sumsales] [sum,isEmpty,sum,isEmpty]
+                                      HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
+                                        InputAdapter
+                                          ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2
+                            HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,sum,isEmpty] [sum(sumsales),d_moy,s_store_id,sumsales,sum,isEmpty]
+                              InputAdapter
+                                Exchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy] #7
+                                  WholeStageCodegen (14)
+                                    HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,sumsales] [sum,isEmpty,sum,isEmpty]
+                                      HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
+                                        InputAdapter
+                                          ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2
+                            HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,sum,isEmpty] [sum(sumsales),d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
+                              InputAdapter
+                                Exchange [i_category,i_class,i_brand,i_product_name,d_year] #8
+                                  WholeStageCodegen (19)
+                                    HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,sumsales] [sum,isEmpty,sum,isEmpty]
+                                      HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
+                                        InputAdapter
+                                          ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2
+                            HashAggregate [i_category,i_class,i_brand,i_product_name,sum,isEmpty] [sum(sumsales),d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
+                              InputAdapter
+                                Exchange [i_category,i_class,i_brand,i_product_name] #9
+                                  WholeStageCodegen (24)
+                                    HashAggregate [i_category,i_class,i_brand,i_product_name,sumsales] [sum,isEmpty,sum,isEmpty]
+                                      HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
+                                        InputAdapter
+                                          ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2
+                            HashAggregate [i_category,i_class,i_brand,sum,isEmpty] [sum(sumsales),i_product_name,d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
+                              InputAdapter
+                                Exchange [i_category,i_class,i_brand] #10
+                                  WholeStageCodegen (29)
+                                    HashAggregate [i_category,i_class,i_brand,sumsales] [sum,isEmpty,sum,isEmpty]
+                                      HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
+                                        InputAdapter
+                                          ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2
+                            HashAggregate [i_category,i_class,sum,isEmpty] [sum(sumsales),i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
+                              InputAdapter
+                                Exchange [i_category,i_class] #11
+                                  WholeStageCodegen (34)
+                                    HashAggregate [i_category,i_class,sumsales] [sum,isEmpty,sum,isEmpty]
+                                      HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
+                                        InputAdapter
+                                          ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2
+                            HashAggregate [i_category,sum,isEmpty] [sum(sumsales),i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
+                              InputAdapter
+                                Exchange [i_category] #12
+                                  WholeStageCodegen (39)
+                                    HashAggregate [i_category,sumsales] [sum,isEmpty,sum,isEmpty]
+                                      HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
+                                        InputAdapter
+                                          ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2
+                            HashAggregate [sum,isEmpty] [sum(sumsales),i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
+                              InputAdapter
+                                Exchange #13
+                                  WholeStageCodegen (44)
+                                    HashAggregate [sumsales] [sum,isEmpty,sum,isEmpty]
+                                      HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
+                                        InputAdapter
+                                          ReusedExchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] #2

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/explain.txt
@@ -7,7 +7,7 @@ TakeOrderedAndProject (56)
             +- * HashAggregate (51)
                +- Exchange (50)
                   +- * HashAggregate (49)
-                     +- Union (48)
+                     +- * Union (48)
                         :- * HashAggregate (37)
                         :  +- Exchange (36)
                         :     +- * HashAggregate (35)
@@ -228,7 +228,7 @@ Results [3]: [s_state#8, s_county#7, sum#21]
 Input [3]: [s_state#8, s_county#7, sum#21]
 Arguments: hashpartitioning(s_state#8, s_county#7, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(37) HashAggregate [codegen id : 9]
+(37) HashAggregate [codegen id : 27]
 Input [3]: [s_state#8, s_county#7, sum#21]
 Keys [2]: [s_state#8, s_county#7]
 Functions [1]: [sum(UnscaledValue(ss_net_profit#2))]
@@ -238,14 +238,14 @@ Results [6]: [cast(MakeDecimal(sum(UnscaledValue(ss_net_profit#2))#22,17,2) as d
 (38) ReusedExchange [Reuses operator id: 36]
 Output [3]: [s_state#27, s_county#28, sum#29]
 
-(39) HashAggregate [codegen id : 18]
+(39) HashAggregate [codegen id : 17]
 Input [3]: [s_state#27, s_county#28, sum#29]
 Keys [2]: [s_state#27, s_county#28]
 Functions [1]: [sum(UnscaledValue(ss_net_profit#30))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_profit#30))#22]
 Results [2]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#30))#22,17,2) AS total_sum#31, s_state#27]
 
-(40) HashAggregate [codegen id : 18]
+(40) HashAggregate [codegen id : 17]
 Input [2]: [total_sum#31, s_state#27]
 Keys [1]: [s_state#27]
 Functions [1]: [partial_sum(total_sum#31)]
@@ -256,7 +256,7 @@ Results [3]: [s_state#27, sum#34, isEmpty#35]
 Input [3]: [s_state#27, sum#34, isEmpty#35]
 Arguments: hashpartitioning(s_state#27, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(42) HashAggregate [codegen id : 19]
+(42) HashAggregate
 Input [3]: [s_state#27, sum#34, isEmpty#35]
 Keys [1]: [s_state#27]
 Functions [1]: [sum(total_sum#31)]
@@ -266,14 +266,14 @@ Results [6]: [sum(total_sum#31)#36 AS total_sum#37, s_state#27, null AS s_county
 (43) ReusedExchange [Reuses operator id: 36]
 Output [3]: [s_state#42, s_county#43, sum#44]
 
-(44) HashAggregate [codegen id : 28]
+(44) HashAggregate [codegen id : 26]
 Input [3]: [s_state#42, s_county#43, sum#44]
 Keys [2]: [s_state#42, s_county#43]
 Functions [1]: [sum(UnscaledValue(ss_net_profit#45))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_profit#45))#22]
 Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#45))#22,17,2) AS total_sum#46]
 
-(45) HashAggregate [codegen id : 28]
+(45) HashAggregate [codegen id : 26]
 Input [1]: [total_sum#46]
 Keys: []
 Functions [1]: [partial_sum(total_sum#46)]
@@ -284,16 +284,16 @@ Results [2]: [sum#49, isEmpty#50]
 Input [2]: [sum#49, isEmpty#50]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
-(47) HashAggregate [codegen id : 29]
+(47) HashAggregate
 Input [2]: [sum#49, isEmpty#50]
 Keys: []
 Functions [1]: [sum(total_sum#46)]
 Aggregate Attributes [1]: [sum(total_sum#46)#51]
 Results [6]: [sum(total_sum#46)#51 AS total_sum#52, null AS s_state#53, null AS s_county#54, 1 AS g_state#55, 1 AS g_county#56, 2 AS lochierarchy#57]
 
-(48) Union
+(48) Union [codegen id : 27]
 
-(49) HashAggregate [codegen id : 30]
+(49) HashAggregate [codegen id : 27]
 Input [6]: [total_sum#23, s_state#8, s_county#7, g_state#24, g_county#25, lochierarchy#26]
 Keys [6]: [total_sum#23, s_state#8, s_county#7, g_state#24, g_county#25, lochierarchy#26]
 Functions: []
@@ -304,7 +304,7 @@ Results [6]: [total_sum#23, s_state#8, s_county#7, g_state#24, g_county#25, loch
 Input [6]: [total_sum#23, s_state#8, s_county#7, g_state#24, g_county#25, lochierarchy#26]
 Arguments: hashpartitioning(total_sum#23, s_state#8, s_county#7, g_state#24, g_county#25, lochierarchy#26, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(51) HashAggregate [codegen id : 31]
+(51) HashAggregate [codegen id : 28]
 Input [6]: [total_sum#23, s_state#8, s_county#7, g_state#24, g_county#25, lochierarchy#26]
 Keys [6]: [total_sum#23, s_state#8, s_county#7, g_state#24, g_county#25, lochierarchy#26]
 Functions: []
@@ -315,7 +315,7 @@ Results [5]: [total_sum#23, s_state#8, s_county#7, lochierarchy#26, CASE WHEN (g
 Input [5]: [total_sum#23, s_state#8, s_county#7, lochierarchy#26, _w0#58]
 Arguments: hashpartitioning(lochierarchy#26, _w0#58, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(53) Sort [codegen id : 32]
+(53) Sort [codegen id : 29]
 Input [5]: [total_sum#23, s_state#8, s_county#7, lochierarchy#26, _w0#58]
 Arguments: [lochierarchy#26 ASC NULLS FIRST, _w0#58 ASC NULLS FIRST, total_sum#23 DESC NULLS LAST], false, 0
 
@@ -323,7 +323,7 @@ Arguments: [lochierarchy#26 ASC NULLS FIRST, _w0#58 ASC NULLS FIRST, total_sum#2
 Input [5]: [total_sum#23, s_state#8, s_county#7, lochierarchy#26, _w0#58]
 Arguments: [rank(total_sum#23) windowspecdefinition(lochierarchy#26, _w0#58, total_sum#23 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#59], [lochierarchy#26, _w0#58], [total_sum#23 DESC NULLS LAST]
 
-(55) Project [codegen id : 33]
+(55) Project [codegen id : 30]
 Output [5]: [total_sum#23, s_state#8, s_county#7, lochierarchy#26, rank_within_parent#59]
 Input [6]: [total_sum#23, s_state#8, s_county#7, lochierarchy#26, _w0#58, rank_within_parent#59]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/simplified.txt
@@ -1,100 +1,96 @@
 TakeOrderedAndProject [lochierarchy,s_state,rank_within_parent,total_sum,s_county]
-  WholeStageCodegen (33)
+  WholeStageCodegen (30)
     Project [total_sum,s_state,s_county,lochierarchy,rank_within_parent]
       InputAdapter
         Window [total_sum,lochierarchy,_w0]
-          WholeStageCodegen (32)
+          WholeStageCodegen (29)
             Sort [lochierarchy,_w0,total_sum]
               InputAdapter
                 Exchange [lochierarchy,_w0] #1
-                  WholeStageCodegen (31)
+                  WholeStageCodegen (28)
                     HashAggregate [total_sum,s_state,s_county,g_state,g_county,lochierarchy] [_w0]
                       InputAdapter
                         Exchange [total_sum,s_state,s_county,g_state,g_county,lochierarchy] #2
-                          WholeStageCodegen (30)
+                          WholeStageCodegen (27)
                             HashAggregate [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
-                              InputAdapter
-                                Union
-                                  WholeStageCodegen (9)
-                                    HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,g_state,g_county,lochierarchy,sum]
-                                      InputAdapter
-                                        Exchange [s_state,s_county] #3
-                                          WholeStageCodegen (8)
-                                            HashAggregate [s_state,s_county,ss_net_profit] [sum,sum]
-                                              Project [ss_net_profit,s_county,s_state]
-                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                  Project [ss_store_sk,ss_net_profit]
-                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                      Filter [ss_store_sk]
+                              Union
+                                HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,g_state,g_county,lochierarchy,sum]
+                                  InputAdapter
+                                    Exchange [s_state,s_county] #3
+                                      WholeStageCodegen (8)
+                                        HashAggregate [s_state,s_county,ss_net_profit] [sum,sum]
+                                          Project [ss_net_profit,s_county,s_state]
+                                            BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                              Project [ss_store_sk,ss_net_profit]
+                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                  Filter [ss_store_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_net_profit,ss_sold_date_sk]
+                                                          SubqueryBroadcast [d_date_sk] #1
+                                                            BroadcastExchange #4
+                                                              WholeStageCodegen (1)
+                                                                Project [d_date_sk]
+                                                                  Filter [d_month_seq,d_date_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq]
+                                                  InputAdapter
+                                                    ReusedExchange [d_date_sk] #4
+                                              InputAdapter
+                                                BroadcastExchange #5
+                                                  WholeStageCodegen (7)
+                                                    BroadcastHashJoin [s_state,s_state]
+                                                      Filter [s_store_sk]
                                                         ColumnarToRow
                                                           InputAdapter
-                                                            Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_net_profit,ss_sold_date_sk]
-                                                              SubqueryBroadcast [d_date_sk] #1
-                                                                BroadcastExchange #4
-                                                                  WholeStageCodegen (1)
-                                                                    Project [d_date_sk]
-                                                                      Filter [d_month_seq,d_date_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq]
+                                                            Scan parquet spark_catalog.default.store [s_store_sk,s_county,s_state]
                                                       InputAdapter
-                                                        ReusedExchange [d_date_sk] #4
-                                                  InputAdapter
-                                                    BroadcastExchange #5
-                                                      WholeStageCodegen (7)
-                                                        BroadcastHashJoin [s_state,s_state]
-                                                          Filter [s_store_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.store [s_store_sk,s_county,s_state]
-                                                          InputAdapter
-                                                            BroadcastExchange #6
-                                                              WholeStageCodegen (6)
-                                                                Project [s_state]
-                                                                  Filter [ranking]
-                                                                    InputAdapter
-                                                                      Window [_w0,s_state]
-                                                                        WindowGroupLimit [s_state,_w0]
-                                                                          WholeStageCodegen (5)
-                                                                            Sort [s_state,_w0]
-                                                                              HashAggregate [s_state,sum] [sum(UnscaledValue(ss_net_profit)),_w0,sum]
-                                                                                InputAdapter
-                                                                                  Exchange [s_state] #7
-                                                                                    WholeStageCodegen (4)
-                                                                                      HashAggregate [s_state,ss_net_profit] [sum,sum]
-                                                                                        Project [ss_net_profit,s_state]
-                                                                                          BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                                            Project [ss_store_sk,ss_net_profit]
-                                                                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                                Filter [ss_store_sk]
-                                                                                                  ColumnarToRow
-                                                                                                    InputAdapter
-                                                                                                      Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_net_profit,ss_sold_date_sk]
-                                                                                                        ReusedSubquery [d_date_sk] #1
+                                                        BroadcastExchange #6
+                                                          WholeStageCodegen (6)
+                                                            Project [s_state]
+                                                              Filter [ranking]
+                                                                InputAdapter
+                                                                  Window [_w0,s_state]
+                                                                    WindowGroupLimit [s_state,_w0]
+                                                                      WholeStageCodegen (5)
+                                                                        Sort [s_state,_w0]
+                                                                          HashAggregate [s_state,sum] [sum(UnscaledValue(ss_net_profit)),_w0,sum]
+                                                                            InputAdapter
+                                                                              Exchange [s_state] #7
+                                                                                WholeStageCodegen (4)
+                                                                                  HashAggregate [s_state,ss_net_profit] [sum,sum]
+                                                                                    Project [ss_net_profit,s_state]
+                                                                                      BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                                                        Project [ss_store_sk,ss_net_profit]
+                                                                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                                            Filter [ss_store_sk]
+                                                                                              ColumnarToRow
                                                                                                 InputAdapter
-                                                                                                  ReusedExchange [d_date_sk] #4
+                                                                                                  Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_net_profit,ss_sold_date_sk]
+                                                                                                    ReusedSubquery [d_date_sk] #1
                                                                                             InputAdapter
-                                                                                              BroadcastExchange #8
-                                                                                                WholeStageCodegen (3)
-                                                                                                  Filter [s_store_sk]
-                                                                                                    ColumnarToRow
-                                                                                                      InputAdapter
-                                                                                                        Scan parquet spark_catalog.default.store [s_store_sk,s_state]
-                                  WholeStageCodegen (19)
-                                    HashAggregate [s_state,sum,isEmpty] [sum(total_sum),total_sum,s_county,g_state,g_county,lochierarchy,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange [s_state] #9
-                                          WholeStageCodegen (18)
-                                            HashAggregate [s_state,total_sum] [sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,sum]
-                                                InputAdapter
-                                                  ReusedExchange [s_state,s_county,sum] #3
-                                  WholeStageCodegen (29)
-                                    HashAggregate [sum,isEmpty] [sum(total_sum),total_sum,s_state,s_county,g_state,g_county,lochierarchy,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange #10
-                                          WholeStageCodegen (28)
-                                            HashAggregate [total_sum] [sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,sum]
-                                                InputAdapter
-                                                  ReusedExchange [s_state,s_county,sum] #3
+                                                                                              ReusedExchange [d_date_sk] #4
+                                                                                        InputAdapter
+                                                                                          BroadcastExchange #8
+                                                                                            WholeStageCodegen (3)
+                                                                                              Filter [s_store_sk]
+                                                                                                ColumnarToRow
+                                                                                                  InputAdapter
+                                                                                                    Scan parquet spark_catalog.default.store [s_store_sk,s_state]
+                                HashAggregate [s_state,sum,isEmpty] [sum(total_sum),total_sum,s_county,g_state,g_county,lochierarchy,sum,isEmpty]
+                                  InputAdapter
+                                    Exchange [s_state] #9
+                                      WholeStageCodegen (17)
+                                        HashAggregate [s_state,total_sum] [sum,isEmpty,sum,isEmpty]
+                                          HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,sum]
+                                            InputAdapter
+                                              ReusedExchange [s_state,s_county,sum] #3
+                                HashAggregate [sum,isEmpty] [sum(total_sum),total_sum,s_state,s_county,g_state,g_county,lochierarchy,sum,isEmpty]
+                                  InputAdapter
+                                    Exchange #10
+                                      WholeStageCodegen (26)
+                                        HashAggregate [total_sum] [sum,isEmpty,sum,isEmpty]
+                                          HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,sum]
+                                            InputAdapter
+                                              ReusedExchange [s_state,s_county,sum] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/explain.txt
@@ -7,7 +7,7 @@ TakeOrderedAndProject (56)
             +- * HashAggregate (51)
                +- Exchange (50)
                   +- * HashAggregate (49)
-                     +- Union (48)
+                     +- * Union (48)
                         :- * HashAggregate (37)
                         :  +- Exchange (36)
                         :     +- * HashAggregate (35)
@@ -228,7 +228,7 @@ Results [3]: [s_state#8, s_county#7, sum#21]
 Input [3]: [s_state#8, s_county#7, sum#21]
 Arguments: hashpartitioning(s_state#8, s_county#7, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(37) HashAggregate [codegen id : 9]
+(37) HashAggregate [codegen id : 27]
 Input [3]: [s_state#8, s_county#7, sum#21]
 Keys [2]: [s_state#8, s_county#7]
 Functions [1]: [sum(UnscaledValue(ss_net_profit#2))]
@@ -238,14 +238,14 @@ Results [6]: [cast(MakeDecimal(sum(UnscaledValue(ss_net_profit#2))#22,17,2) as d
 (38) ReusedExchange [Reuses operator id: 36]
 Output [3]: [s_state#27, s_county#28, sum#29]
 
-(39) HashAggregate [codegen id : 18]
+(39) HashAggregate [codegen id : 17]
 Input [3]: [s_state#27, s_county#28, sum#29]
 Keys [2]: [s_state#27, s_county#28]
 Functions [1]: [sum(UnscaledValue(ss_net_profit#30))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_profit#30))#22]
 Results [2]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#30))#22,17,2) AS total_sum#31, s_state#27]
 
-(40) HashAggregate [codegen id : 18]
+(40) HashAggregate [codegen id : 17]
 Input [2]: [total_sum#31, s_state#27]
 Keys [1]: [s_state#27]
 Functions [1]: [partial_sum(total_sum#31)]
@@ -256,7 +256,7 @@ Results [3]: [s_state#27, sum#34, isEmpty#35]
 Input [3]: [s_state#27, sum#34, isEmpty#35]
 Arguments: hashpartitioning(s_state#27, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(42) HashAggregate [codegen id : 19]
+(42) HashAggregate
 Input [3]: [s_state#27, sum#34, isEmpty#35]
 Keys [1]: [s_state#27]
 Functions [1]: [sum(total_sum#31)]
@@ -266,14 +266,14 @@ Results [6]: [sum(total_sum#31)#36 AS total_sum#37, s_state#27, null AS s_county
 (43) ReusedExchange [Reuses operator id: 36]
 Output [3]: [s_state#42, s_county#43, sum#44]
 
-(44) HashAggregate [codegen id : 28]
+(44) HashAggregate [codegen id : 26]
 Input [3]: [s_state#42, s_county#43, sum#44]
 Keys [2]: [s_state#42, s_county#43]
 Functions [1]: [sum(UnscaledValue(ss_net_profit#45))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_profit#45))#22]
 Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_profit#45))#22,17,2) AS total_sum#46]
 
-(45) HashAggregate [codegen id : 28]
+(45) HashAggregate [codegen id : 26]
 Input [1]: [total_sum#46]
 Keys: []
 Functions [1]: [partial_sum(total_sum#46)]
@@ -284,16 +284,16 @@ Results [2]: [sum#49, isEmpty#50]
 Input [2]: [sum#49, isEmpty#50]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
-(47) HashAggregate [codegen id : 29]
+(47) HashAggregate
 Input [2]: [sum#49, isEmpty#50]
 Keys: []
 Functions [1]: [sum(total_sum#46)]
 Aggregate Attributes [1]: [sum(total_sum#46)#51]
 Results [6]: [sum(total_sum#46)#51 AS total_sum#52, null AS s_state#53, null AS s_county#54, 1 AS g_state#55, 1 AS g_county#56, 2 AS lochierarchy#57]
 
-(48) Union
+(48) Union [codegen id : 27]
 
-(49) HashAggregate [codegen id : 30]
+(49) HashAggregate [codegen id : 27]
 Input [6]: [total_sum#23, s_state#8, s_county#7, g_state#24, g_county#25, lochierarchy#26]
 Keys [6]: [total_sum#23, s_state#8, s_county#7, g_state#24, g_county#25, lochierarchy#26]
 Functions: []
@@ -304,7 +304,7 @@ Results [6]: [total_sum#23, s_state#8, s_county#7, g_state#24, g_county#25, loch
 Input [6]: [total_sum#23, s_state#8, s_county#7, g_state#24, g_county#25, lochierarchy#26]
 Arguments: hashpartitioning(total_sum#23, s_state#8, s_county#7, g_state#24, g_county#25, lochierarchy#26, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(51) HashAggregate [codegen id : 31]
+(51) HashAggregate [codegen id : 28]
 Input [6]: [total_sum#23, s_state#8, s_county#7, g_state#24, g_county#25, lochierarchy#26]
 Keys [6]: [total_sum#23, s_state#8, s_county#7, g_state#24, g_county#25, lochierarchy#26]
 Functions: []
@@ -315,7 +315,7 @@ Results [5]: [total_sum#23, s_state#8, s_county#7, lochierarchy#26, CASE WHEN (g
 Input [5]: [total_sum#23, s_state#8, s_county#7, lochierarchy#26, _w0#58]
 Arguments: hashpartitioning(lochierarchy#26, _w0#58, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(53) Sort [codegen id : 32]
+(53) Sort [codegen id : 29]
 Input [5]: [total_sum#23, s_state#8, s_county#7, lochierarchy#26, _w0#58]
 Arguments: [lochierarchy#26 ASC NULLS FIRST, _w0#58 ASC NULLS FIRST, total_sum#23 DESC NULLS LAST], false, 0
 
@@ -323,7 +323,7 @@ Arguments: [lochierarchy#26 ASC NULLS FIRST, _w0#58 ASC NULLS FIRST, total_sum#2
 Input [5]: [total_sum#23, s_state#8, s_county#7, lochierarchy#26, _w0#58]
 Arguments: [rank(total_sum#23) windowspecdefinition(lochierarchy#26, _w0#58, total_sum#23 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#59], [lochierarchy#26, _w0#58], [total_sum#23 DESC NULLS LAST]
 
-(55) Project [codegen id : 33]
+(55) Project [codegen id : 30]
 Output [5]: [total_sum#23, s_state#8, s_county#7, lochierarchy#26, rank_within_parent#59]
 Input [6]: [total_sum#23, s_state#8, s_county#7, lochierarchy#26, _w0#58, rank_within_parent#59]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/simplified.txt
@@ -1,100 +1,96 @@
 TakeOrderedAndProject [lochierarchy,s_state,rank_within_parent,total_sum,s_county]
-  WholeStageCodegen (33)
+  WholeStageCodegen (30)
     Project [total_sum,s_state,s_county,lochierarchy,rank_within_parent]
       InputAdapter
         Window [total_sum,lochierarchy,_w0]
-          WholeStageCodegen (32)
+          WholeStageCodegen (29)
             Sort [lochierarchy,_w0,total_sum]
               InputAdapter
                 Exchange [lochierarchy,_w0] #1
-                  WholeStageCodegen (31)
+                  WholeStageCodegen (28)
                     HashAggregate [total_sum,s_state,s_county,g_state,g_county,lochierarchy] [_w0]
                       InputAdapter
                         Exchange [total_sum,s_state,s_county,g_state,g_county,lochierarchy] #2
-                          WholeStageCodegen (30)
+                          WholeStageCodegen (27)
                             HashAggregate [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
-                              InputAdapter
-                                Union
-                                  WholeStageCodegen (9)
-                                    HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,g_state,g_county,lochierarchy,sum]
-                                      InputAdapter
-                                        Exchange [s_state,s_county] #3
-                                          WholeStageCodegen (8)
-                                            HashAggregate [s_state,s_county,ss_net_profit] [sum,sum]
-                                              Project [ss_net_profit,s_county,s_state]
-                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                  Project [ss_store_sk,ss_net_profit]
-                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                      Filter [ss_store_sk]
+                              Union
+                                HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,g_state,g_county,lochierarchy,sum]
+                                  InputAdapter
+                                    Exchange [s_state,s_county] #3
+                                      WholeStageCodegen (8)
+                                        HashAggregate [s_state,s_county,ss_net_profit] [sum,sum]
+                                          Project [ss_net_profit,s_county,s_state]
+                                            BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                              Project [ss_store_sk,ss_net_profit]
+                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                  Filter [ss_store_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_net_profit,ss_sold_date_sk]
+                                                          SubqueryBroadcast [d_date_sk] #1
+                                                            BroadcastExchange #4
+                                                              WholeStageCodegen (1)
+                                                                Project [d_date_sk]
+                                                                  Filter [d_month_seq,d_date_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq]
+                                                  InputAdapter
+                                                    ReusedExchange [d_date_sk] #4
+                                              InputAdapter
+                                                BroadcastExchange #5
+                                                  WholeStageCodegen (7)
+                                                    BroadcastHashJoin [s_state,s_state]
+                                                      Filter [s_store_sk]
                                                         ColumnarToRow
                                                           InputAdapter
-                                                            Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_net_profit,ss_sold_date_sk]
-                                                              SubqueryBroadcast [d_date_sk] #1
-                                                                BroadcastExchange #4
-                                                                  WholeStageCodegen (1)
-                                                                    Project [d_date_sk]
-                                                                      Filter [d_month_seq,d_date_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq]
+                                                            Scan parquet spark_catalog.default.store [s_store_sk,s_county,s_state]
                                                       InputAdapter
-                                                        ReusedExchange [d_date_sk] #4
-                                                  InputAdapter
-                                                    BroadcastExchange #5
-                                                      WholeStageCodegen (7)
-                                                        BroadcastHashJoin [s_state,s_state]
-                                                          Filter [s_store_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.store [s_store_sk,s_county,s_state]
-                                                          InputAdapter
-                                                            BroadcastExchange #6
-                                                              WholeStageCodegen (6)
-                                                                Project [s_state]
-                                                                  Filter [ranking]
-                                                                    InputAdapter
-                                                                      Window [_w0,s_state]
-                                                                        WindowGroupLimit [s_state,_w0]
-                                                                          WholeStageCodegen (5)
-                                                                            Sort [s_state,_w0]
-                                                                              HashAggregate [s_state,sum] [sum(UnscaledValue(ss_net_profit)),_w0,sum]
-                                                                                InputAdapter
-                                                                                  Exchange [s_state] #7
-                                                                                    WholeStageCodegen (4)
-                                                                                      HashAggregate [s_state,ss_net_profit] [sum,sum]
-                                                                                        Project [ss_net_profit,s_state]
-                                                                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                            Project [ss_net_profit,ss_sold_date_sk,s_state]
-                                                                                              BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                                                Filter [ss_store_sk]
-                                                                                                  ColumnarToRow
-                                                                                                    InputAdapter
-                                                                                                      Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_net_profit,ss_sold_date_sk]
-                                                                                                        ReusedSubquery [d_date_sk] #1
+                                                        BroadcastExchange #6
+                                                          WholeStageCodegen (6)
+                                                            Project [s_state]
+                                                              Filter [ranking]
+                                                                InputAdapter
+                                                                  Window [_w0,s_state]
+                                                                    WindowGroupLimit [s_state,_w0]
+                                                                      WholeStageCodegen (5)
+                                                                        Sort [s_state,_w0]
+                                                                          HashAggregate [s_state,sum] [sum(UnscaledValue(ss_net_profit)),_w0,sum]
+                                                                            InputAdapter
+                                                                              Exchange [s_state] #7
+                                                                                WholeStageCodegen (4)
+                                                                                  HashAggregate [s_state,ss_net_profit] [sum,sum]
+                                                                                    Project [ss_net_profit,s_state]
+                                                                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                                        Project [ss_net_profit,ss_sold_date_sk,s_state]
+                                                                                          BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                                                            Filter [ss_store_sk]
+                                                                                              ColumnarToRow
                                                                                                 InputAdapter
-                                                                                                  BroadcastExchange #8
-                                                                                                    WholeStageCodegen (2)
-                                                                                                      Filter [s_store_sk]
-                                                                                                        ColumnarToRow
-                                                                                                          InputAdapter
-                                                                                                            Scan parquet spark_catalog.default.store [s_store_sk,s_state]
+                                                                                                  Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_net_profit,ss_sold_date_sk]
+                                                                                                    ReusedSubquery [d_date_sk] #1
                                                                                             InputAdapter
-                                                                                              ReusedExchange [d_date_sk] #4
-                                  WholeStageCodegen (19)
-                                    HashAggregate [s_state,sum,isEmpty] [sum(total_sum),total_sum,s_county,g_state,g_county,lochierarchy,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange [s_state] #9
-                                          WholeStageCodegen (18)
-                                            HashAggregate [s_state,total_sum] [sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,sum]
-                                                InputAdapter
-                                                  ReusedExchange [s_state,s_county,sum] #3
-                                  WholeStageCodegen (29)
-                                    HashAggregate [sum,isEmpty] [sum(total_sum),total_sum,s_state,s_county,g_state,g_county,lochierarchy,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange #10
-                                          WholeStageCodegen (28)
-                                            HashAggregate [total_sum] [sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,sum]
-                                                InputAdapter
-                                                  ReusedExchange [s_state,s_county,sum] #3
+                                                                                              BroadcastExchange #8
+                                                                                                WholeStageCodegen (2)
+                                                                                                  Filter [s_store_sk]
+                                                                                                    ColumnarToRow
+                                                                                                      InputAdapter
+                                                                                                        Scan parquet spark_catalog.default.store [s_store_sk,s_state]
+                                                                                        InputAdapter
+                                                                                          ReusedExchange [d_date_sk] #4
+                                HashAggregate [s_state,sum,isEmpty] [sum(total_sum),total_sum,s_county,g_state,g_county,lochierarchy,sum,isEmpty]
+                                  InputAdapter
+                                    Exchange [s_state] #9
+                                      WholeStageCodegen (17)
+                                        HashAggregate [s_state,total_sum] [sum,isEmpty,sum,isEmpty]
+                                          HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,sum]
+                                            InputAdapter
+                                              ReusedExchange [s_state,s_county,sum] #3
+                                HashAggregate [sum,isEmpty] [sum(total_sum),total_sum,s_state,s_county,g_state,g_county,lochierarchy,sum,isEmpty]
+                                  InputAdapter
+                                    Exchange #10
+                                      WholeStageCodegen (26)
+                                        HashAggregate [total_sum] [sum,isEmpty,sum,isEmpty]
+                                          HashAggregate [s_state,s_county,sum] [sum(UnscaledValue(ss_net_profit)),total_sum,sum]
+                                            InputAdapter
+                                              ReusedExchange [s_state,s_county,sum] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/explain.txt
@@ -7,7 +7,7 @@ TakeOrderedAndProject (92)
             :- * HashAggregate (77)
             :  +- Exchange (76)
             :     +- * HashAggregate (75)
-            :        +- Union (74)
+            :        +- * Union (74)
             :           :- * Project (30)
             :           :  +- * BroadcastHashJoin LeftOuter BuildRight (29)
             :           :     :- * HashAggregate (15)
@@ -160,7 +160,7 @@ Results [3]: [s_store_sk#7, sum#10, sum#11]
 Input [3]: [s_store_sk#7, sum#10, sum#11]
 Arguments: hashpartitioning(s_store_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(15) HashAggregate [codegen id : 8]
+(15) HashAggregate [codegen id : 18]
 Input [3]: [s_store_sk#7, sum#10, sum#11]
 Keys [1]: [s_store_sk#7]
 Functions [2]: [sum(UnscaledValue(ss_ext_sales_price#2)), sum(UnscaledValue(ss_net_profit#3))]
@@ -230,13 +230,13 @@ Results [3]: [s_store_sk#21, MakeDecimal(sum(UnscaledValue(sr_return_amt#17))#26
 Input [3]: [s_store_sk#21, returns#28, profit_loss#29]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
-(29) BroadcastHashJoin [codegen id : 8]
+(29) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [s_store_sk#7]
 Right keys [1]: [s_store_sk#21]
 Join type: LeftOuter
 Join condition: None
 
-(30) Project [codegen id : 8]
+(30) Project [codegen id : 18]
 Output [5]: [store channel AS channel#30, s_store_sk#7 AS id#31, sales#14, coalesce(returns#28, 0.00) AS returns#32, (profit#15 - coalesce(profit_loss#29, 0.00)) AS profit#33]
 Input [6]: [s_store_sk#7, sales#14, profit#15, s_store_sk#21, returns#28, profit_loss#29]
 
@@ -247,23 +247,23 @@ Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#37), dynamicpruningexpression(cs_sold_date_sk#37 IN dynamicpruning#5)]
 ReadSchema: struct<cs_call_center_sk:int,cs_ext_sales_price:decimal(7,2),cs_net_profit:decimal(7,2)>
 
-(32) ColumnarToRow [codegen id : 10]
+(32) ColumnarToRow [codegen id : 9]
 Input [4]: [cs_call_center_sk#34, cs_ext_sales_price#35, cs_net_profit#36, cs_sold_date_sk#37]
 
 (33) ReusedExchange [Reuses operator id: 97]
 Output [1]: [d_date_sk#38]
 
-(34) BroadcastHashJoin [codegen id : 10]
+(34) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_sold_date_sk#37]
 Right keys [1]: [d_date_sk#38]
 Join type: Inner
 Join condition: None
 
-(35) Project [codegen id : 10]
+(35) Project [codegen id : 9]
 Output [3]: [cs_call_center_sk#34, cs_ext_sales_price#35, cs_net_profit#36]
 Input [5]: [cs_call_center_sk#34, cs_ext_sales_price#35, cs_net_profit#36, cs_sold_date_sk#37, d_date_sk#38]
 
-(36) HashAggregate [codegen id : 10]
+(36) HashAggregate [codegen id : 9]
 Input [3]: [cs_call_center_sk#34, cs_ext_sales_price#35, cs_net_profit#36]
 Keys [1]: [cs_call_center_sk#34]
 Functions [2]: [partial_sum(UnscaledValue(cs_ext_sales_price#35)), partial_sum(UnscaledValue(cs_net_profit#36))]
@@ -274,7 +274,7 @@ Results [3]: [cs_call_center_sk#34, sum#41, sum#42]
 Input [3]: [cs_call_center_sk#34, sum#41, sum#42]
 Arguments: hashpartitioning(cs_call_center_sk#34, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(38) HashAggregate [codegen id : 11]
+(38) HashAggregate [codegen id : 10]
 Input [3]: [cs_call_center_sk#34, sum#41, sum#42]
 Keys [1]: [cs_call_center_sk#34]
 Functions [2]: [sum(UnscaledValue(cs_ext_sales_price#35)), sum(UnscaledValue(cs_net_profit#36))]
@@ -292,11 +292,11 @@ Output: []
 Output [2]: [Subquery scalar-subquery#47, [id=#7].returns AS returns#48, ReusedSubquery Subquery scalar-subquery#47, [id=#7].profit_loss AS profit_loss#49]
 Input: []
 
-(42) BroadcastNestedLoopJoin [codegen id : 12]
+(42) BroadcastNestedLoopJoin
 Join type: Inner
 Join condition: None
 
-(43) Project [codegen id : 12]
+(43) Project
 Output [5]: [catalog channel AS channel#50, cs_call_center_sk#34 AS id#51, sales#45, returns#48, (profit#46 - profit_loss#49) AS profit#52]
 Input [5]: [cs_call_center_sk#34, sales#45, profit#46, returns#48, profit_loss#49]
 
@@ -308,23 +308,23 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#56), dynamicpruningexpression(ws_so
 PushedFilters: [IsNotNull(ws_web_page_sk)]
 ReadSchema: struct<ws_web_page_sk:int,ws_ext_sales_price:decimal(7,2),ws_net_profit:decimal(7,2)>
 
-(45) ColumnarToRow [codegen id : 15]
+(45) ColumnarToRow [codegen id : 13]
 Input [4]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55, ws_sold_date_sk#56]
 
-(46) Filter [codegen id : 15]
+(46) Filter [codegen id : 13]
 Input [4]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55, ws_sold_date_sk#56]
 Condition : isnotnull(ws_web_page_sk#53)
 
 (47) ReusedExchange [Reuses operator id: 97]
 Output [1]: [d_date_sk#57]
 
-(48) BroadcastHashJoin [codegen id : 15]
+(48) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ws_sold_date_sk#56]
 Right keys [1]: [d_date_sk#57]
 Join type: Inner
 Join condition: None
 
-(49) Project [codegen id : 15]
+(49) Project [codegen id : 13]
 Output [3]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55]
 Input [5]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55, ws_sold_date_sk#56, d_date_sk#57]
 
@@ -335,10 +335,10 @@ Location [not included in comparison]/{warehouse_dir}/web_page]
 PushedFilters: [IsNotNull(wp_web_page_sk)]
 ReadSchema: struct<wp_web_page_sk:int>
 
-(51) ColumnarToRow [codegen id : 14]
+(51) ColumnarToRow [codegen id : 12]
 Input [1]: [wp_web_page_sk#58]
 
-(52) Filter [codegen id : 14]
+(52) Filter [codegen id : 12]
 Input [1]: [wp_web_page_sk#58]
 Condition : isnotnull(wp_web_page_sk#58)
 
@@ -346,17 +346,17 @@ Condition : isnotnull(wp_web_page_sk#58)
 Input [1]: [wp_web_page_sk#58]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
 
-(54) BroadcastHashJoin [codegen id : 15]
+(54) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ws_web_page_sk#53]
 Right keys [1]: [wp_web_page_sk#58]
 Join type: Inner
 Join condition: None
 
-(55) Project [codegen id : 15]
+(55) Project [codegen id : 13]
 Output [3]: [ws_ext_sales_price#54, ws_net_profit#55, wp_web_page_sk#58]
 Input [4]: [ws_web_page_sk#53, ws_ext_sales_price#54, ws_net_profit#55, wp_web_page_sk#58]
 
-(56) HashAggregate [codegen id : 15]
+(56) HashAggregate [codegen id : 13]
 Input [3]: [ws_ext_sales_price#54, ws_net_profit#55, wp_web_page_sk#58]
 Keys [1]: [wp_web_page_sk#58]
 Functions [2]: [partial_sum(UnscaledValue(ws_ext_sales_price#54)), partial_sum(UnscaledValue(ws_net_profit#55))]
@@ -367,7 +367,7 @@ Results [3]: [wp_web_page_sk#58, sum#61, sum#62]
 Input [3]: [wp_web_page_sk#58, sum#61, sum#62]
 Arguments: hashpartitioning(wp_web_page_sk#58, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(58) HashAggregate [codegen id : 20]
+(58) HashAggregate
 Input [3]: [wp_web_page_sk#58, sum#61, sum#62]
 Keys [1]: [wp_web_page_sk#58]
 Functions [2]: [sum(UnscaledValue(ws_ext_sales_price#54)), sum(UnscaledValue(ws_net_profit#55))]
@@ -382,40 +382,40 @@ PartitionFilters: [isnotnull(wr_returned_date_sk#70), dynamicpruningexpression(w
 PushedFilters: [IsNotNull(wr_web_page_sk)]
 ReadSchema: struct<wr_web_page_sk:int,wr_return_amt:decimal(7,2),wr_net_loss:decimal(7,2)>
 
-(60) ColumnarToRow [codegen id : 18]
+(60) ColumnarToRow [codegen id : 16]
 Input [4]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69, wr_returned_date_sk#70]
 
-(61) Filter [codegen id : 18]
+(61) Filter [codegen id : 16]
 Input [4]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69, wr_returned_date_sk#70]
 Condition : isnotnull(wr_web_page_sk#67)
 
 (62) ReusedExchange [Reuses operator id: 97]
 Output [1]: [d_date_sk#71]
 
-(63) BroadcastHashJoin [codegen id : 18]
+(63) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [wr_returned_date_sk#70]
 Right keys [1]: [d_date_sk#71]
 Join type: Inner
 Join condition: None
 
-(64) Project [codegen id : 18]
+(64) Project [codegen id : 16]
 Output [3]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69]
 Input [5]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69, wr_returned_date_sk#70, d_date_sk#71]
 
 (65) ReusedExchange [Reuses operator id: 53]
 Output [1]: [wp_web_page_sk#72]
 
-(66) BroadcastHashJoin [codegen id : 18]
+(66) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [wr_web_page_sk#67]
 Right keys [1]: [wp_web_page_sk#72]
 Join type: Inner
 Join condition: None
 
-(67) Project [codegen id : 18]
+(67) Project [codegen id : 16]
 Output [3]: [wr_return_amt#68, wr_net_loss#69, wp_web_page_sk#72]
 Input [4]: [wr_web_page_sk#67, wr_return_amt#68, wr_net_loss#69, wp_web_page_sk#72]
 
-(68) HashAggregate [codegen id : 18]
+(68) HashAggregate [codegen id : 16]
 Input [3]: [wr_return_amt#68, wr_net_loss#69, wp_web_page_sk#72]
 Keys [1]: [wp_web_page_sk#72]
 Functions [2]: [partial_sum(UnscaledValue(wr_return_amt#68)), partial_sum(UnscaledValue(wr_net_loss#69))]
@@ -426,7 +426,7 @@ Results [3]: [wp_web_page_sk#72, sum#75, sum#76]
 Input [3]: [wp_web_page_sk#72, sum#75, sum#76]
 Arguments: hashpartitioning(wp_web_page_sk#72, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(70) HashAggregate [codegen id : 19]
+(70) HashAggregate [codegen id : 17]
 Input [3]: [wp_web_page_sk#72, sum#75, sum#76]
 Keys [1]: [wp_web_page_sk#72]
 Functions [2]: [sum(UnscaledValue(wr_return_amt#68)), sum(UnscaledValue(wr_net_loss#69))]
@@ -437,19 +437,19 @@ Results [3]: [wp_web_page_sk#72, MakeDecimal(sum(UnscaledValue(wr_return_amt#68)
 Input [3]: [wp_web_page_sk#72, returns#79, profit_loss#80]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-(72) BroadcastHashJoin [codegen id : 20]
+(72) BroadcastHashJoin
 Left keys [1]: [wp_web_page_sk#58]
 Right keys [1]: [wp_web_page_sk#72]
 Join type: LeftOuter
 Join condition: None
 
-(73) Project [codegen id : 20]
+(73) Project
 Output [5]: [web channel AS channel#81, wp_web_page_sk#58 AS id#82, sales#65, coalesce(returns#79, 0.00) AS returns#83, (profit#66 - coalesce(profit_loss#80, 0.00)) AS profit#84]
 Input [6]: [wp_web_page_sk#58, sales#65, profit#66, wp_web_page_sk#72, returns#79, profit_loss#80]
 
-(74) Union
+(74) Union [codegen id : 18]
 
-(75) HashAggregate [codegen id : 21]
+(75) HashAggregate [codegen id : 18]
 Input [5]: [channel#30, id#31, sales#14, returns#32, profit#33]
 Keys [2]: [channel#30, id#31]
 Functions [3]: [partial_sum(sales#14), partial_sum(returns#32), partial_sum(profit#33)]
@@ -460,7 +460,7 @@ Results [8]: [channel#30, id#31, sum#91, isEmpty#92, sum#93, isEmpty#94, sum#95,
 Input [8]: [channel#30, id#31, sum#91, isEmpty#92, sum#93, isEmpty#94, sum#95, isEmpty#96]
 Arguments: hashpartitioning(channel#30, id#31, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(77) HashAggregate [codegen id : 22]
+(77) HashAggregate [codegen id : 19]
 Input [8]: [channel#30, id#31, sum#91, isEmpty#92, sum#93, isEmpty#94, sum#95, isEmpty#96]
 Keys [2]: [channel#30, id#31]
 Functions [3]: [sum(sales#14), sum(returns#32), sum(profit#33)]
@@ -470,14 +470,14 @@ Results [5]: [channel#30, id#31, cast(sum(sales#14)#97 as decimal(37,2)) AS sale
 (78) ReusedExchange [Reuses operator id: 76]
 Output [8]: [channel#103, id#104, sum#105, isEmpty#106, sum#107, isEmpty#108, sum#109, isEmpty#110]
 
-(79) HashAggregate [codegen id : 44]
+(79) HashAggregate [codegen id : 38]
 Input [8]: [channel#103, id#104, sum#105, isEmpty#106, sum#107, isEmpty#108, sum#109, isEmpty#110]
 Keys [2]: [channel#103, id#104]
 Functions [3]: [sum(sales#111), sum(returns#112), sum(profit#113)]
 Aggregate Attributes [3]: [sum(sales#111)#97, sum(returns#112)#98, sum(profit#113)#99]
 Results [4]: [channel#103, sum(sales#111)#97 AS sales#114, sum(returns#112)#98 AS returns#115, sum(profit#113)#99 AS profit#116]
 
-(80) HashAggregate [codegen id : 44]
+(80) HashAggregate [codegen id : 38]
 Input [4]: [channel#103, sales#114, returns#115, profit#116]
 Keys [1]: [channel#103]
 Functions [3]: [partial_sum(sales#114), partial_sum(returns#115), partial_sum(profit#116)]
@@ -488,7 +488,7 @@ Results [7]: [channel#103, sum#123, isEmpty#124, sum#125, isEmpty#126, sum#127, 
 Input [7]: [channel#103, sum#123, isEmpty#124, sum#125, isEmpty#126, sum#127, isEmpty#128]
 Arguments: hashpartitioning(channel#103, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(82) HashAggregate [codegen id : 45]
+(82) HashAggregate [codegen id : 39]
 Input [7]: [channel#103, sum#123, isEmpty#124, sum#125, isEmpty#126, sum#127, isEmpty#128]
 Keys [1]: [channel#103]
 Functions [3]: [sum(sales#114), sum(returns#115), sum(profit#116)]
@@ -498,14 +498,14 @@ Results [5]: [channel#103, null AS id#132, sum(sales#114)#129 AS sales#133, sum(
 (83) ReusedExchange [Reuses operator id: 76]
 Output [8]: [channel#136, id#137, sum#138, isEmpty#139, sum#140, isEmpty#141, sum#142, isEmpty#143]
 
-(84) HashAggregate [codegen id : 67]
+(84) HashAggregate [codegen id : 58]
 Input [8]: [channel#136, id#137, sum#138, isEmpty#139, sum#140, isEmpty#141, sum#142, isEmpty#143]
 Keys [2]: [channel#136, id#137]
 Functions [3]: [sum(sales#144), sum(returns#145), sum(profit#146)]
 Aggregate Attributes [3]: [sum(sales#144)#97, sum(returns#145)#98, sum(profit#146)#99]
 Results [3]: [sum(sales#144)#97 AS sales#147, sum(returns#145)#98 AS returns#148, sum(profit#146)#99 AS profit#149]
 
-(85) HashAggregate [codegen id : 67]
+(85) HashAggregate [codegen id : 58]
 Input [3]: [sales#147, returns#148, profit#149]
 Keys: []
 Functions [3]: [partial_sum(sales#147), partial_sum(returns#148), partial_sum(profit#149)]
@@ -516,7 +516,7 @@ Results [6]: [sum#156, isEmpty#157, sum#158, isEmpty#159, sum#160, isEmpty#161]
 Input [6]: [sum#156, isEmpty#157, sum#158, isEmpty#159, sum#160, isEmpty#161]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
 
-(87) HashAggregate [codegen id : 68]
+(87) HashAggregate [codegen id : 59]
 Input [6]: [sum#156, isEmpty#157, sum#158, isEmpty#159, sum#160, isEmpty#161]
 Keys: []
 Functions [3]: [sum(sales#147), sum(returns#148), sum(profit#149)]
@@ -525,7 +525,7 @@ Results [5]: [null AS channel#165, null AS id#166, sum(sales#147)#162 AS sales#1
 
 (88) Union
 
-(89) HashAggregate [codegen id : 69]
+(89) HashAggregate [codegen id : 60]
 Input [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
 Keys [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
 Functions: []
@@ -536,7 +536,7 @@ Results [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
 Input [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
 Arguments: hashpartitioning(channel#30, id#31, sales#100, returns#101, profit#102, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(91) HashAggregate [codegen id : 70]
+(91) HashAggregate [codegen id : 61]
 Input [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
 Keys [5]: [channel#30, id#31, sales#100, returns#101, profit#102]
 Functions: []

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/simplified.txt
@@ -1,173 +1,169 @@
 TakeOrderedAndProject [channel,id,sales,returns,profit]
-  WholeStageCodegen (70)
+  WholeStageCodegen (61)
     HashAggregate [channel,id,sales,returns,profit]
       InputAdapter
         Exchange [channel,id,sales,returns,profit] #1
-          WholeStageCodegen (69)
+          WholeStageCodegen (60)
             HashAggregate [channel,id,sales,returns,profit]
               InputAdapter
                 Union
-                  WholeStageCodegen (22)
+                  WholeStageCodegen (19)
                     HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
                         Exchange [channel,id] #2
-                          WholeStageCodegen (21)
+                          WholeStageCodegen (18)
                             HashAggregate [channel,id,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
-                              InputAdapter
-                                Union
-                                  WholeStageCodegen (8)
-                                    Project [s_store_sk,sales,returns,profit,profit_loss]
-                                      BroadcastHashJoin [s_store_sk,s_store_sk]
-                                        HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(ss_ext_sales_price)),sum(UnscaledValue(ss_net_profit)),sales,profit,sum,sum]
-                                          InputAdapter
-                                            Exchange [s_store_sk] #3
-                                              WholeStageCodegen (3)
-                                                HashAggregate [s_store_sk,ss_ext_sales_price,ss_net_profit] [sum,sum,sum,sum]
-                                                  Project [ss_ext_sales_price,ss_net_profit,s_store_sk]
-                                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                      Project [ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                          Filter [ss_store_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
-                                                                  SubqueryBroadcast [d_date_sk] #1
-                                                                    BroadcastExchange #4
-                                                                      WholeStageCodegen (1)
-                                                                        Project [d_date_sk]
-                                                                          Filter [d_date,d_date_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                              Union
+                                Project [s_store_sk,sales,returns,profit,profit_loss]
+                                  BroadcastHashJoin [s_store_sk,s_store_sk]
+                                    HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(ss_ext_sales_price)),sum(UnscaledValue(ss_net_profit)),sales,profit,sum,sum]
+                                      InputAdapter
+                                        Exchange [s_store_sk] #3
+                                          WholeStageCodegen (3)
+                                            HashAggregate [s_store_sk,ss_ext_sales_price,ss_net_profit] [sum,sum,sum,sum]
+                                              Project [ss_ext_sales_price,ss_net_profit,s_store_sk]
+                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                  Project [ss_store_sk,ss_ext_sales_price,ss_net_profit]
+                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                      Filter [ss_store_sk]
+                                                        ColumnarToRow
                                                           InputAdapter
-                                                            ReusedExchange [d_date_sk] #4
+                                                            Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
+                                                              SubqueryBroadcast [d_date_sk] #1
+                                                                BroadcastExchange #4
+                                                                  WholeStageCodegen (1)
+                                                                    Project [d_date_sk]
+                                                                      Filter [d_date,d_date_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
                                                       InputAdapter
-                                                        BroadcastExchange #5
-                                                          WholeStageCodegen (2)
-                                                            Filter [s_store_sk]
+                                                        ReusedExchange [d_date_sk] #4
+                                                  InputAdapter
+                                                    BroadcastExchange #5
+                                                      WholeStageCodegen (2)
+                                                        Filter [s_store_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.store [s_store_sk]
+                                    InputAdapter
+                                      BroadcastExchange #6
+                                        WholeStageCodegen (7)
+                                          HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(sr_return_amt)),sum(UnscaledValue(sr_net_loss)),returns,profit_loss,sum,sum]
+                                            InputAdapter
+                                              Exchange [s_store_sk] #7
+                                                WholeStageCodegen (6)
+                                                  HashAggregate [s_store_sk,sr_return_amt,sr_net_loss] [sum,sum,sum,sum]
+                                                    Project [sr_return_amt,sr_net_loss,s_store_sk]
+                                                      BroadcastHashJoin [sr_store_sk,s_store_sk]
+                                                        Project [sr_store_sk,sr_return_amt,sr_net_loss]
+                                                          BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
+                                                            Filter [sr_store_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
-                                                                  Scan parquet spark_catalog.default.store [s_store_sk]
-                                        InputAdapter
-                                          BroadcastExchange #6
-                                            WholeStageCodegen (7)
-                                              HashAggregate [s_store_sk,sum,sum] [sum(UnscaledValue(sr_return_amt)),sum(UnscaledValue(sr_net_loss)),returns,profit_loss,sum,sum]
-                                                InputAdapter
-                                                  Exchange [s_store_sk] #7
-                                                    WholeStageCodegen (6)
-                                                      HashAggregate [s_store_sk,sr_return_amt,sr_net_loss] [sum,sum,sum,sum]
-                                                        Project [sr_return_amt,sr_net_loss,s_store_sk]
-                                                          BroadcastHashJoin [sr_store_sk,s_store_sk]
-                                                            Project [sr_store_sk,sr_return_amt,sr_net_loss]
-                                                              BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
-                                                                Filter [sr_store_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
-                                                                        ReusedSubquery [d_date_sk] #1
-                                                                InputAdapter
-                                                                  ReusedExchange [d_date_sk] #4
-                                                            InputAdapter
-                                                              ReusedExchange [s_store_sk] #5
-                                  WholeStageCodegen (12)
-                                    Project [cs_call_center_sk,sales,returns,profit,profit_loss]
-                                      BroadcastNestedLoopJoin
-                                        InputAdapter
-                                          BroadcastExchange #8
-                                            WholeStageCodegen (11)
-                                              HashAggregate [cs_call_center_sk,sum,sum] [sum(UnscaledValue(cs_ext_sales_price)),sum(UnscaledValue(cs_net_profit)),sales,profit,sum,sum]
-                                                InputAdapter
-                                                  Exchange [cs_call_center_sk] #9
-                                                    WholeStageCodegen (10)
-                                                      HashAggregate [cs_call_center_sk,cs_ext_sales_price,cs_net_profit] [sum,sum,sum,sum]
-                                                        Project [cs_call_center_sk,cs_ext_sales_price,cs_net_profit]
-                                                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.catalog_sales [cs_call_center_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
-                                                                  ReusedSubquery [d_date_sk] #1
+                                                                  Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
+                                                                    ReusedSubquery [d_date_sk] #1
                                                             InputAdapter
                                                               ReusedExchange [d_date_sk] #4
-                                        Project
-                                          Subquery #2
-                                            WholeStageCodegen (3)
-                                              Project [returns,profit_loss]
-                                                HashAggregate [sum,sum] [sum(UnscaledValue(cr_return_amount)),sum(UnscaledValue(cr_net_loss)),returns,profit_loss,sum,sum]
-                                                  InputAdapter
-                                                    Exchange #10
-                                                      WholeStageCodegen (2)
-                                                        HashAggregate [cr_return_amount,cr_net_loss] [sum,sum,sum,sum]
-                                                          Project [cr_return_amount,cr_net_loss]
-                                                            BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.catalog_returns [cr_return_amount,cr_net_loss,cr_returned_date_sk]
-                                                                    ReusedSubquery [d_date_sk] #1
-                                                              InputAdapter
-                                                                ReusedExchange [d_date_sk] #4
-                                          ReusedSubquery [mergedValue] #2
-                                          Scan OneRowRelation
-                                  WholeStageCodegen (20)
-                                    Project [wp_web_page_sk,sales,returns,profit,profit_loss]
-                                      BroadcastHashJoin [wp_web_page_sk,wp_web_page_sk]
-                                        HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(ws_ext_sales_price)),sum(UnscaledValue(ws_net_profit)),sales,profit,sum,sum]
-                                          InputAdapter
-                                            Exchange [wp_web_page_sk] #11
-                                              WholeStageCodegen (15)
-                                                HashAggregate [wp_web_page_sk,ws_ext_sales_price,ws_net_profit] [sum,sum,sum,sum]
-                                                  Project [ws_ext_sales_price,ws_net_profit,wp_web_page_sk]
-                                                    BroadcastHashJoin [ws_web_page_sk,wp_web_page_sk]
-                                                      Project [ws_web_page_sk,ws_ext_sales_price,ws_net_profit]
-                                                        BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                          Filter [ws_web_page_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.web_sales [ws_web_page_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
-                                                                  ReusedSubquery [d_date_sk] #1
+                                                        InputAdapter
+                                                          ReusedExchange [s_store_sk] #5
+                                Project [cs_call_center_sk,sales,returns,profit,profit_loss]
+                                  BroadcastNestedLoopJoin
+                                    InputAdapter
+                                      BroadcastExchange #8
+                                        WholeStageCodegen (10)
+                                          HashAggregate [cs_call_center_sk,sum,sum] [sum(UnscaledValue(cs_ext_sales_price)),sum(UnscaledValue(cs_net_profit)),sales,profit,sum,sum]
+                                            InputAdapter
+                                              Exchange [cs_call_center_sk] #9
+                                                WholeStageCodegen (9)
+                                                  HashAggregate [cs_call_center_sk,cs_ext_sales_price,cs_net_profit] [sum,sum,sum,sum]
+                                                    Project [cs_call_center_sk,cs_ext_sales_price,cs_net_profit]
+                                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet spark_catalog.default.catalog_sales [cs_call_center_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
+                                                              ReusedSubquery [d_date_sk] #1
+                                                        InputAdapter
+                                                          ReusedExchange [d_date_sk] #4
+                                    Project
+                                      Subquery #2
+                                        WholeStageCodegen (3)
+                                          Project [returns,profit_loss]
+                                            HashAggregate [sum,sum] [sum(UnscaledValue(cr_return_amount)),sum(UnscaledValue(cr_net_loss)),returns,profit_loss,sum,sum]
+                                              InputAdapter
+                                                Exchange #10
+                                                  WholeStageCodegen (2)
+                                                    HashAggregate [cr_return_amount,cr_net_loss] [sum,sum,sum,sum]
+                                                      Project [cr_return_amount,cr_net_loss]
+                                                        BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.catalog_returns [cr_return_amount,cr_net_loss,cr_returned_date_sk]
+                                                                ReusedSubquery [d_date_sk] #1
                                                           InputAdapter
                                                             ReusedExchange [d_date_sk] #4
+                                      ReusedSubquery [mergedValue] #2
+                                      Scan OneRowRelation
+                                Project [wp_web_page_sk,sales,returns,profit,profit_loss]
+                                  BroadcastHashJoin [wp_web_page_sk,wp_web_page_sk]
+                                    HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(ws_ext_sales_price)),sum(UnscaledValue(ws_net_profit)),sales,profit,sum,sum]
+                                      InputAdapter
+                                        Exchange [wp_web_page_sk] #11
+                                          WholeStageCodegen (13)
+                                            HashAggregate [wp_web_page_sk,ws_ext_sales_price,ws_net_profit] [sum,sum,sum,sum]
+                                              Project [ws_ext_sales_price,ws_net_profit,wp_web_page_sk]
+                                                BroadcastHashJoin [ws_web_page_sk,wp_web_page_sk]
+                                                  Project [ws_web_page_sk,ws_ext_sales_price,ws_net_profit]
+                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                      Filter [ws_web_page_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet spark_catalog.default.web_sales [ws_web_page_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
+                                                              ReusedSubquery [d_date_sk] #1
                                                       InputAdapter
-                                                        BroadcastExchange #12
-                                                          WholeStageCodegen (14)
-                                                            Filter [wp_web_page_sk]
+                                                        ReusedExchange [d_date_sk] #4
+                                                  InputAdapter
+                                                    BroadcastExchange #12
+                                                      WholeStageCodegen (12)
+                                                        Filter [wp_web_page_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.web_page [wp_web_page_sk]
+                                    InputAdapter
+                                      BroadcastExchange #13
+                                        WholeStageCodegen (17)
+                                          HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(wr_return_amt)),sum(UnscaledValue(wr_net_loss)),returns,profit_loss,sum,sum]
+                                            InputAdapter
+                                              Exchange [wp_web_page_sk] #14
+                                                WholeStageCodegen (16)
+                                                  HashAggregate [wp_web_page_sk,wr_return_amt,wr_net_loss] [sum,sum,sum,sum]
+                                                    Project [wr_return_amt,wr_net_loss,wp_web_page_sk]
+                                                      BroadcastHashJoin [wr_web_page_sk,wp_web_page_sk]
+                                                        Project [wr_web_page_sk,wr_return_amt,wr_net_loss]
+                                                          BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
+                                                            Filter [wr_web_page_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
-                                                                  Scan parquet spark_catalog.default.web_page [wp_web_page_sk]
-                                        InputAdapter
-                                          BroadcastExchange #13
-                                            WholeStageCodegen (19)
-                                              HashAggregate [wp_web_page_sk,sum,sum] [sum(UnscaledValue(wr_return_amt)),sum(UnscaledValue(wr_net_loss)),returns,profit_loss,sum,sum]
-                                                InputAdapter
-                                                  Exchange [wp_web_page_sk] #14
-                                                    WholeStageCodegen (18)
-                                                      HashAggregate [wp_web_page_sk,wr_return_amt,wr_net_loss] [sum,sum,sum,sum]
-                                                        Project [wr_return_amt,wr_net_loss,wp_web_page_sk]
-                                                          BroadcastHashJoin [wr_web_page_sk,wp_web_page_sk]
-                                                            Project [wr_web_page_sk,wr_return_amt,wr_net_loss]
-                                                              BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
-                                                                Filter [wr_web_page_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.web_returns [wr_web_page_sk,wr_return_amt,wr_net_loss,wr_returned_date_sk]
-                                                                        ReusedSubquery [d_date_sk] #1
-                                                                InputAdapter
-                                                                  ReusedExchange [d_date_sk] #4
+                                                                  Scan parquet spark_catalog.default.web_returns [wr_web_page_sk,wr_return_amt,wr_net_loss,wr_returned_date_sk]
+                                                                    ReusedSubquery [d_date_sk] #1
                                                             InputAdapter
-                                                              ReusedExchange [wp_web_page_sk] #12
-                  WholeStageCodegen (45)
+                                                              ReusedExchange [d_date_sk] #4
+                                                        InputAdapter
+                                                          ReusedExchange [wp_web_page_sk] #12
+                  WholeStageCodegen (39)
                     HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
                         Exchange [channel] #15
-                          WholeStageCodegen (44)
+                          WholeStageCodegen (38)
                             HashAggregate [channel,sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 InputAdapter
                                   ReusedExchange [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] #2
-                  WholeStageCodegen (68)
+                  WholeStageCodegen (59)
                     HashAggregate [sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),channel,id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
                         Exchange #16
-                          WholeStageCodegen (67)
+                          WholeStageCodegen (58)
                             HashAggregate [sales,returns,profit] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                               HashAggregate [channel,id,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                                 InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/explain.txt
@@ -7,7 +7,7 @@ TakeOrderedAndProject (34)
             +- * HashAggregate (29)
                +- Exchange (28)
                   +- * HashAggregate (27)
-                     +- Union (26)
+                     +- * Union (26)
                         :- * HashAggregate (15)
                         :  +- Exchange (14)
                         :     +- * HashAggregate (13)
@@ -102,7 +102,7 @@ Results [3]: [i_category#8, i_class#7, sum#10]
 Input [3]: [i_category#8, i_class#7, sum#10]
 Arguments: hashpartitioning(i_category#8, i_class#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(15) HashAggregate [codegen id : 4]
+(15) HashAggregate [codegen id : 12]
 Input [3]: [i_category#8, i_class#7, sum#10]
 Keys [2]: [i_category#8, i_class#7]
 Functions [1]: [sum(UnscaledValue(ws_net_paid#2))]
@@ -112,14 +112,14 @@ Results [6]: [cast(MakeDecimal(sum(UnscaledValue(ws_net_paid#2))#11,17,2) as dec
 (16) ReusedExchange [Reuses operator id: 14]
 Output [3]: [i_category#16, i_class#17, sum#18]
 
-(17) HashAggregate [codegen id : 8]
+(17) HashAggregate [codegen id : 7]
 Input [3]: [i_category#16, i_class#17, sum#18]
 Keys [2]: [i_category#16, i_class#17]
 Functions [1]: [sum(UnscaledValue(ws_net_paid#19))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#19))#11]
 Results [2]: [MakeDecimal(sum(UnscaledValue(ws_net_paid#19))#11,17,2) AS total_sum#20, i_category#16]
 
-(18) HashAggregate [codegen id : 8]
+(18) HashAggregate [codegen id : 7]
 Input [2]: [total_sum#20, i_category#16]
 Keys [1]: [i_category#16]
 Functions [1]: [partial_sum(total_sum#20)]
@@ -130,7 +130,7 @@ Results [3]: [i_category#16, sum#23, isEmpty#24]
 Input [3]: [i_category#16, sum#23, isEmpty#24]
 Arguments: hashpartitioning(i_category#16, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(20) HashAggregate [codegen id : 9]
+(20) HashAggregate
 Input [3]: [i_category#16, sum#23, isEmpty#24]
 Keys [1]: [i_category#16]
 Functions [1]: [sum(total_sum#20)]
@@ -140,14 +140,14 @@ Results [6]: [sum(total_sum#20)#25 AS total_sum#26, i_category#16, null AS i_cla
 (21) ReusedExchange [Reuses operator id: 14]
 Output [3]: [i_category#31, i_class#32, sum#33]
 
-(22) HashAggregate [codegen id : 13]
+(22) HashAggregate [codegen id : 11]
 Input [3]: [i_category#31, i_class#32, sum#33]
 Keys [2]: [i_category#31, i_class#32]
 Functions [1]: [sum(UnscaledValue(ws_net_paid#34))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#34))#11]
 Results [1]: [MakeDecimal(sum(UnscaledValue(ws_net_paid#34))#11,17,2) AS total_sum#35]
 
-(23) HashAggregate [codegen id : 13]
+(23) HashAggregate [codegen id : 11]
 Input [1]: [total_sum#35]
 Keys: []
 Functions [1]: [partial_sum(total_sum#35)]
@@ -158,16 +158,16 @@ Results [2]: [sum#38, isEmpty#39]
 Input [2]: [sum#38, isEmpty#39]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=4]
 
-(25) HashAggregate [codegen id : 14]
+(25) HashAggregate
 Input [2]: [sum#38, isEmpty#39]
 Keys: []
 Functions [1]: [sum(total_sum#35)]
 Aggregate Attributes [1]: [sum(total_sum#35)#40]
 Results [6]: [sum(total_sum#35)#40 AS total_sum#41, null AS i_category#42, null AS i_class#43, 1 AS g_category#44, 1 AS g_class#45, 2 AS lochierarchy#46]
 
-(26) Union
+(26) Union [codegen id : 12]
 
-(27) HashAggregate [codegen id : 15]
+(27) HashAggregate [codegen id : 12]
 Input [6]: [total_sum#12, i_category#8, i_class#7, g_category#13, g_class#14, lochierarchy#15]
 Keys [6]: [total_sum#12, i_category#8, i_class#7, g_category#13, g_class#14, lochierarchy#15]
 Functions: []
@@ -178,7 +178,7 @@ Results [6]: [total_sum#12, i_category#8, i_class#7, g_category#13, g_class#14, 
 Input [6]: [total_sum#12, i_category#8, i_class#7, g_category#13, g_class#14, lochierarchy#15]
 Arguments: hashpartitioning(total_sum#12, i_category#8, i_class#7, g_category#13, g_class#14, lochierarchy#15, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(29) HashAggregate [codegen id : 16]
+(29) HashAggregate [codegen id : 13]
 Input [6]: [total_sum#12, i_category#8, i_class#7, g_category#13, g_class#14, lochierarchy#15]
 Keys [6]: [total_sum#12, i_category#8, i_class#7, g_category#13, g_class#14, lochierarchy#15]
 Functions: []
@@ -189,7 +189,7 @@ Results [5]: [total_sum#12, i_category#8, i_class#7, lochierarchy#15, CASE WHEN 
 Input [5]: [total_sum#12, i_category#8, i_class#7, lochierarchy#15, _w0#47]
 Arguments: hashpartitioning(lochierarchy#15, _w0#47, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(31) Sort [codegen id : 17]
+(31) Sort [codegen id : 14]
 Input [5]: [total_sum#12, i_category#8, i_class#7, lochierarchy#15, _w0#47]
 Arguments: [lochierarchy#15 ASC NULLS FIRST, _w0#47 ASC NULLS FIRST, total_sum#12 DESC NULLS LAST], false, 0
 
@@ -197,7 +197,7 @@ Arguments: [lochierarchy#15 ASC NULLS FIRST, _w0#47 ASC NULLS FIRST, total_sum#1
 Input [5]: [total_sum#12, i_category#8, i_class#7, lochierarchy#15, _w0#47]
 Arguments: [rank(total_sum#12) windowspecdefinition(lochierarchy#15, _w0#47, total_sum#12 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#48], [lochierarchy#15, _w0#47], [total_sum#12 DESC NULLS LAST]
 
-(33) Project [codegen id : 18]
+(33) Project [codegen id : 15]
 Output [5]: [total_sum#12, i_category#8, i_class#7, lochierarchy#15, rank_within_parent#48]
 Input [6]: [total_sum#12, i_category#8, i_class#7, lochierarchy#15, _w0#47, rank_within_parent#48]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/simplified.txt
@@ -1,66 +1,62 @@
 TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,total_sum,i_class]
-  WholeStageCodegen (18)
+  WholeStageCodegen (15)
     Project [total_sum,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter
         Window [total_sum,lochierarchy,_w0]
-          WholeStageCodegen (17)
+          WholeStageCodegen (14)
             Sort [lochierarchy,_w0,total_sum]
               InputAdapter
                 Exchange [lochierarchy,_w0] #1
-                  WholeStageCodegen (16)
+                  WholeStageCodegen (13)
                     HashAggregate [total_sum,i_category,i_class,g_category,g_class,lochierarchy] [_w0]
                       InputAdapter
                         Exchange [total_sum,i_category,i_class,g_category,g_class,lochierarchy] #2
-                          WholeStageCodegen (15)
+                          WholeStageCodegen (12)
                             HashAggregate [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
-                              InputAdapter
-                                Union
-                                  WholeStageCodegen (4)
-                                    HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,g_category,g_class,lochierarchy,sum]
-                                      InputAdapter
-                                        Exchange [i_category,i_class] #3
-                                          WholeStageCodegen (3)
-                                            HashAggregate [i_category,i_class,ws_net_paid] [sum,sum]
-                                              Project [ws_net_paid,i_class,i_category]
-                                                BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                  Project [ws_item_sk,ws_net_paid]
-                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                      Filter [ws_item_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_net_paid,ws_sold_date_sk]
-                                                              SubqueryBroadcast [d_date_sk] #1
-                                                                BroadcastExchange #4
-                                                                  WholeStageCodegen (1)
-                                                                    Project [d_date_sk]
-                                                                      Filter [d_month_seq,d_date_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq]
+                              Union
+                                HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,g_category,g_class,lochierarchy,sum]
+                                  InputAdapter
+                                    Exchange [i_category,i_class] #3
+                                      WholeStageCodegen (3)
+                                        HashAggregate [i_category,i_class,ws_net_paid] [sum,sum]
+                                          Project [ws_net_paid,i_class,i_category]
+                                            BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                              Project [ws_item_sk,ws_net_paid]
+                                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                  Filter [ws_item_sk]
+                                                    ColumnarToRow
                                                       InputAdapter
-                                                        ReusedExchange [d_date_sk] #4
+                                                        Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_net_paid,ws_sold_date_sk]
+                                                          SubqueryBroadcast [d_date_sk] #1
+                                                            BroadcastExchange #4
+                                                              WholeStageCodegen (1)
+                                                                Project [d_date_sk]
+                                                                  Filter [d_month_seq,d_date_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq]
                                                   InputAdapter
-                                                    BroadcastExchange #5
-                                                      WholeStageCodegen (2)
-                                                        Filter [i_item_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.item [i_item_sk,i_class,i_category]
-                                  WholeStageCodegen (9)
-                                    HashAggregate [i_category,sum,isEmpty] [sum(total_sum),total_sum,i_class,g_category,g_class,lochierarchy,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange [i_category] #6
-                                          WholeStageCodegen (8)
-                                            HashAggregate [i_category,total_sum] [sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,sum]
-                                                InputAdapter
-                                                  ReusedExchange [i_category,i_class,sum] #3
-                                  WholeStageCodegen (14)
-                                    HashAggregate [sum,isEmpty] [sum(total_sum),total_sum,i_category,i_class,g_category,g_class,lochierarchy,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange #7
-                                          WholeStageCodegen (13)
-                                            HashAggregate [total_sum] [sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,sum]
-                                                InputAdapter
-                                                  ReusedExchange [i_category,i_class,sum] #3
+                                                    ReusedExchange [d_date_sk] #4
+                                              InputAdapter
+                                                BroadcastExchange #5
+                                                  WholeStageCodegen (2)
+                                                    Filter [i_item_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_class,i_category]
+                                HashAggregate [i_category,sum,isEmpty] [sum(total_sum),total_sum,i_class,g_category,g_class,lochierarchy,sum,isEmpty]
+                                  InputAdapter
+                                    Exchange [i_category] #6
+                                      WholeStageCodegen (7)
+                                        HashAggregate [i_category,total_sum] [sum,isEmpty,sum,isEmpty]
+                                          HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,sum]
+                                            InputAdapter
+                                              ReusedExchange [i_category,i_class,sum] #3
+                                HashAggregate [sum,isEmpty] [sum(total_sum),total_sum,i_category,i_class,g_category,g_class,lochierarchy,sum,isEmpty]
+                                  InputAdapter
+                                    Exchange #7
+                                      WholeStageCodegen (11)
+                                        HashAggregate [total_sum] [sum,isEmpty,sum,isEmpty]
+                                          HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,sum]
+                                            InputAdapter
+                                              ReusedExchange [i_category,i_class,sum] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/explain.txt
@@ -7,7 +7,7 @@ TakeOrderedAndProject (34)
             +- * HashAggregate (29)
                +- Exchange (28)
                   +- * HashAggregate (27)
-                     +- Union (26)
+                     +- * Union (26)
                         :- * HashAggregate (15)
                         :  +- Exchange (14)
                         :     +- * HashAggregate (13)
@@ -102,7 +102,7 @@ Results [3]: [i_category#8, i_class#7, sum#10]
 Input [3]: [i_category#8, i_class#7, sum#10]
 Arguments: hashpartitioning(i_category#8, i_class#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(15) HashAggregate [codegen id : 4]
+(15) HashAggregate [codegen id : 12]
 Input [3]: [i_category#8, i_class#7, sum#10]
 Keys [2]: [i_category#8, i_class#7]
 Functions [1]: [sum(UnscaledValue(ws_net_paid#2))]
@@ -112,14 +112,14 @@ Results [6]: [cast(MakeDecimal(sum(UnscaledValue(ws_net_paid#2))#11,17,2) as dec
 (16) ReusedExchange [Reuses operator id: 14]
 Output [3]: [i_category#16, i_class#17, sum#18]
 
-(17) HashAggregate [codegen id : 8]
+(17) HashAggregate [codegen id : 7]
 Input [3]: [i_category#16, i_class#17, sum#18]
 Keys [2]: [i_category#16, i_class#17]
 Functions [1]: [sum(UnscaledValue(ws_net_paid#19))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#19))#11]
 Results [2]: [MakeDecimal(sum(UnscaledValue(ws_net_paid#19))#11,17,2) AS total_sum#20, i_category#16]
 
-(18) HashAggregate [codegen id : 8]
+(18) HashAggregate [codegen id : 7]
 Input [2]: [total_sum#20, i_category#16]
 Keys [1]: [i_category#16]
 Functions [1]: [partial_sum(total_sum#20)]
@@ -130,7 +130,7 @@ Results [3]: [i_category#16, sum#23, isEmpty#24]
 Input [3]: [i_category#16, sum#23, isEmpty#24]
 Arguments: hashpartitioning(i_category#16, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(20) HashAggregate [codegen id : 9]
+(20) HashAggregate
 Input [3]: [i_category#16, sum#23, isEmpty#24]
 Keys [1]: [i_category#16]
 Functions [1]: [sum(total_sum#20)]
@@ -140,14 +140,14 @@ Results [6]: [sum(total_sum#20)#25 AS total_sum#26, i_category#16, null AS i_cla
 (21) ReusedExchange [Reuses operator id: 14]
 Output [3]: [i_category#31, i_class#32, sum#33]
 
-(22) HashAggregate [codegen id : 13]
+(22) HashAggregate [codegen id : 11]
 Input [3]: [i_category#31, i_class#32, sum#33]
 Keys [2]: [i_category#31, i_class#32]
 Functions [1]: [sum(UnscaledValue(ws_net_paid#34))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#34))#11]
 Results [1]: [MakeDecimal(sum(UnscaledValue(ws_net_paid#34))#11,17,2) AS total_sum#35]
 
-(23) HashAggregate [codegen id : 13]
+(23) HashAggregate [codegen id : 11]
 Input [1]: [total_sum#35]
 Keys: []
 Functions [1]: [partial_sum(total_sum#35)]
@@ -158,16 +158,16 @@ Results [2]: [sum#38, isEmpty#39]
 Input [2]: [sum#38, isEmpty#39]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=4]
 
-(25) HashAggregate [codegen id : 14]
+(25) HashAggregate
 Input [2]: [sum#38, isEmpty#39]
 Keys: []
 Functions [1]: [sum(total_sum#35)]
 Aggregate Attributes [1]: [sum(total_sum#35)#40]
 Results [6]: [sum(total_sum#35)#40 AS total_sum#41, null AS i_category#42, null AS i_class#43, 1 AS g_category#44, 1 AS g_class#45, 2 AS lochierarchy#46]
 
-(26) Union
+(26) Union [codegen id : 12]
 
-(27) HashAggregate [codegen id : 15]
+(27) HashAggregate [codegen id : 12]
 Input [6]: [total_sum#12, i_category#8, i_class#7, g_category#13, g_class#14, lochierarchy#15]
 Keys [6]: [total_sum#12, i_category#8, i_class#7, g_category#13, g_class#14, lochierarchy#15]
 Functions: []
@@ -178,7 +178,7 @@ Results [6]: [total_sum#12, i_category#8, i_class#7, g_category#13, g_class#14, 
 Input [6]: [total_sum#12, i_category#8, i_class#7, g_category#13, g_class#14, lochierarchy#15]
 Arguments: hashpartitioning(total_sum#12, i_category#8, i_class#7, g_category#13, g_class#14, lochierarchy#15, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(29) HashAggregate [codegen id : 16]
+(29) HashAggregate [codegen id : 13]
 Input [6]: [total_sum#12, i_category#8, i_class#7, g_category#13, g_class#14, lochierarchy#15]
 Keys [6]: [total_sum#12, i_category#8, i_class#7, g_category#13, g_class#14, lochierarchy#15]
 Functions: []
@@ -189,7 +189,7 @@ Results [5]: [total_sum#12, i_category#8, i_class#7, lochierarchy#15, CASE WHEN 
 Input [5]: [total_sum#12, i_category#8, i_class#7, lochierarchy#15, _w0#47]
 Arguments: hashpartitioning(lochierarchy#15, _w0#47, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(31) Sort [codegen id : 17]
+(31) Sort [codegen id : 14]
 Input [5]: [total_sum#12, i_category#8, i_class#7, lochierarchy#15, _w0#47]
 Arguments: [lochierarchy#15 ASC NULLS FIRST, _w0#47 ASC NULLS FIRST, total_sum#12 DESC NULLS LAST], false, 0
 
@@ -197,7 +197,7 @@ Arguments: [lochierarchy#15 ASC NULLS FIRST, _w0#47 ASC NULLS FIRST, total_sum#1
 Input [5]: [total_sum#12, i_category#8, i_class#7, lochierarchy#15, _w0#47]
 Arguments: [rank(total_sum#12) windowspecdefinition(lochierarchy#15, _w0#47, total_sum#12 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank_within_parent#48], [lochierarchy#15, _w0#47], [total_sum#12 DESC NULLS LAST]
 
-(33) Project [codegen id : 18]
+(33) Project [codegen id : 15]
 Output [5]: [total_sum#12, i_category#8, i_class#7, lochierarchy#15, rank_within_parent#48]
 Input [6]: [total_sum#12, i_category#8, i_class#7, lochierarchy#15, _w0#47, rank_within_parent#48]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/simplified.txt
@@ -1,66 +1,62 @@
 TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,total_sum,i_class]
-  WholeStageCodegen (18)
+  WholeStageCodegen (15)
     Project [total_sum,i_category,i_class,lochierarchy,rank_within_parent]
       InputAdapter
         Window [total_sum,lochierarchy,_w0]
-          WholeStageCodegen (17)
+          WholeStageCodegen (14)
             Sort [lochierarchy,_w0,total_sum]
               InputAdapter
                 Exchange [lochierarchy,_w0] #1
-                  WholeStageCodegen (16)
+                  WholeStageCodegen (13)
                     HashAggregate [total_sum,i_category,i_class,g_category,g_class,lochierarchy] [_w0]
                       InputAdapter
                         Exchange [total_sum,i_category,i_class,g_category,g_class,lochierarchy] #2
-                          WholeStageCodegen (15)
+                          WholeStageCodegen (12)
                             HashAggregate [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
-                              InputAdapter
-                                Union
-                                  WholeStageCodegen (4)
-                                    HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,g_category,g_class,lochierarchy,sum]
-                                      InputAdapter
-                                        Exchange [i_category,i_class] #3
-                                          WholeStageCodegen (3)
-                                            HashAggregate [i_category,i_class,ws_net_paid] [sum,sum]
-                                              Project [ws_net_paid,i_class,i_category]
-                                                BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                  Project [ws_item_sk,ws_net_paid]
-                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                      Filter [ws_item_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_net_paid,ws_sold_date_sk]
-                                                              SubqueryBroadcast [d_date_sk] #1
-                                                                BroadcastExchange #4
-                                                                  WholeStageCodegen (1)
-                                                                    Project [d_date_sk]
-                                                                      Filter [d_month_seq,d_date_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq]
+                              Union
+                                HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,g_category,g_class,lochierarchy,sum]
+                                  InputAdapter
+                                    Exchange [i_category,i_class] #3
+                                      WholeStageCodegen (3)
+                                        HashAggregate [i_category,i_class,ws_net_paid] [sum,sum]
+                                          Project [ws_net_paid,i_class,i_category]
+                                            BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                              Project [ws_item_sk,ws_net_paid]
+                                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                  Filter [ws_item_sk]
+                                                    ColumnarToRow
                                                       InputAdapter
-                                                        ReusedExchange [d_date_sk] #4
+                                                        Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_net_paid,ws_sold_date_sk]
+                                                          SubqueryBroadcast [d_date_sk] #1
+                                                            BroadcastExchange #4
+                                                              WholeStageCodegen (1)
+                                                                Project [d_date_sk]
+                                                                  Filter [d_month_seq,d_date_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq]
                                                   InputAdapter
-                                                    BroadcastExchange #5
-                                                      WholeStageCodegen (2)
-                                                        Filter [i_item_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.item [i_item_sk,i_class,i_category]
-                                  WholeStageCodegen (9)
-                                    HashAggregate [i_category,sum,isEmpty] [sum(total_sum),total_sum,i_class,g_category,g_class,lochierarchy,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange [i_category] #6
-                                          WholeStageCodegen (8)
-                                            HashAggregate [i_category,total_sum] [sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,sum]
-                                                InputAdapter
-                                                  ReusedExchange [i_category,i_class,sum] #3
-                                  WholeStageCodegen (14)
-                                    HashAggregate [sum,isEmpty] [sum(total_sum),total_sum,i_category,i_class,g_category,g_class,lochierarchy,sum,isEmpty]
-                                      InputAdapter
-                                        Exchange #7
-                                          WholeStageCodegen (13)
-                                            HashAggregate [total_sum] [sum,isEmpty,sum,isEmpty]
-                                              HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,sum]
-                                                InputAdapter
-                                                  ReusedExchange [i_category,i_class,sum] #3
+                                                    ReusedExchange [d_date_sk] #4
+                                              InputAdapter
+                                                BroadcastExchange #5
+                                                  WholeStageCodegen (2)
+                                                    Filter [i_item_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_class,i_category]
+                                HashAggregate [i_category,sum,isEmpty] [sum(total_sum),total_sum,i_class,g_category,g_class,lochierarchy,sum,isEmpty]
+                                  InputAdapter
+                                    Exchange [i_category] #6
+                                      WholeStageCodegen (7)
+                                        HashAggregate [i_category,total_sum] [sum,isEmpty,sum,isEmpty]
+                                          HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,sum]
+                                            InputAdapter
+                                              ReusedExchange [i_category,i_class,sum] #3
+                                HashAggregate [sum,isEmpty] [sum(total_sum),total_sum,i_category,i_class,g_category,g_class,lochierarchy,sum,isEmpty]
+                                  InputAdapter
+                                    Exchange #7
+                                      WholeStageCodegen (11)
+                                        HashAggregate [total_sum] [sum,isEmpty,sum,isEmpty]
+                                          HashAggregate [i_category,i_class,sum] [sum(UnscaledValue(ws_net_paid)),total_sum,sum]
+                                            InputAdapter
+                                              ReusedExchange [i_category,i_class,sum] #3

--- a/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
@@ -268,7 +268,8 @@ trait PlanStabilitySuite extends DisableAdaptiveExecutionSuite {
       // Disable char/varchar read-side handling for better performance.
       SQLConf.READ_SIDE_CHAR_PADDING.key -> "false",
       SQLConf.LEGACY_NO_CHAR_PADDING_IN_PREDICATE.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
+      SQLConf.WHOLESTAGE_UNION_CODEGEN_ENABLED.key -> "false") {
       val qe = sql(queryString).queryExecution
       val plan = qe.executedPlan
       val explain = normalizeLocation(normalizeIds(qe.explainString(FormattedMode)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
@@ -268,8 +268,7 @@ trait PlanStabilitySuite extends DisableAdaptiveExecutionSuite {
       // Disable char/varchar read-side handling for better performance.
       SQLConf.READ_SIDE_CHAR_PADDING.key -> "false",
       SQLConf.LEGACY_NO_CHAR_PADDING_IN_PREDICATE.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB",
-      SQLConf.WHOLESTAGE_UNION_CODEGEN_ENABLED.key -> "false") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
       val qe = sql(queryString).queryExecution
       val plan = qe.executedPlan
       val explain = normalizeLocation(normalizeIds(qe.explainString(FormattedMode)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -178,7 +178,6 @@ class SQLQueryTestSuite extends SharedSparkSession
     // regex magic.
     .set("spark.test.noSerdeInExplain", "true")
     .set(SQLConf.SCHEMA_LEVEL_COLLATIONS_ENABLED, true)
-    .set(SQLConf.WHOLESTAGE_UNION_CODEGEN_ENABLED, false)
 
   // SPARK-32106 Since we add SQL test 'transform.sql' will use `cat` command,
   // here we need to ignore it.

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -178,6 +178,7 @@ class SQLQueryTestSuite extends SharedSparkSession
     // regex magic.
     .set("spark.test.noSerdeInExplain", "true")
     .set(SQLConf.SCHEMA_LEVEL_COLLATIONS_ENABLED, true)
+    .set(SQLConf.WHOLESTAGE_UNION_CODEGEN_ENABLED, false)
 
   // SPARK-32106 Since we add SQL test 'transform.sql' will use `cat` command,
   // here we need to ignore it.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -726,16 +726,18 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
   }
 
   test("SPARK-25278: output metrics are wrong for plans repeated in the query") {
-    val name = "demo_view"
-    withView(name) {
-      sql(s"CREATE OR REPLACE VIEW $name AS VALUES 1,2")
-      val view = spark.table(name)
-      val union = view.union(view)
-      testSparkPlanMetrics(union, 1, Map(
-        0L -> ("Union" -> Map()),
-        1L -> ("Project" -> Map()),
-        2L -> ("LocalTableScan" -> Map("number of output rows" -> 2L)),
-        3L -> ("LocalTableScan" -> Map("number of output rows" -> 2L))))
+    withSQLConf(SQLConf.WHOLESTAGE_UNION_CODEGEN_ENABLED.key -> "false") {
+      val name = "demo_view"
+      withView(name) {
+        sql(s"CREATE OR REPLACE VIEW $name AS VALUES 1,2")
+        val view = spark.table(name)
+        val union = view.union(view)
+        testSparkPlanMetrics(union, 1, Map(
+          0L -> ("Union" -> Map()),
+          1L -> ("Project" -> Map()),
+          2L -> ("LocalTableScan" -> Map("number of output rows" -> 2L)),
+          3L -> ("LocalTableScan" -> Map("number of output rows" -> 2L))))
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Flip the default value of `spark.sql.codegen.wholeStage.union.enabled` (introduced by SPARK-56482) from `false` to `true`, and update the golden files / metric assertions that were pinned on the "Union is not fused" assumption.

Concrete changes:

- `SQLConf.WHOLESTAGE_UNION_CODEGEN_ENABLED` default `false` → `true`.
- Regenerate the affected approved plans under `PlanStabilitySuite` (TPCDS V1.4 / V2.7 / Modified, TPCH) where Union fusion changes the `WholeStageCodegen` boundary.
- Regenerate the `explain.sql.out` golden file under `SQLQueryTestSuite` (the `explain-aqe.sql.out` formatted plan does not carry codegen ids and is unchanged).
- Wrap the `SQLMetricsSuite` test "SPARK-25278: output metrics are wrong for plans repeated in the query" with `withSQLConf(WHOLESTAGE_UNION_CODEGEN_ENABLED -> "false")`. Its expected metric map assumes the non-fused 4-node physical layout (`Union -> Project -> 2 x LocalTableScan`); this is an assertion about plan shape rather than a golden file, so the explicit pin is retained.

### Why are the changes needed?

The UnionExec whole-stage codegen path introduced by SPARK-56482 is currently disabled by default, so only a handful of cases that explicitly enable the conf exercise it on master CI, and follow-up changes can easily regress without being noticed. Flipping the default to `true` makes every Scala unit test, every golden-file / metric-driven suite (`PlanStabilitySuite`, `SQLQueryTestSuite`, `SQLMetricsSuite`, ...), the `tpcds-1g` end-to-end TPC-DS steps, and local development runs all exercise this path by default, providing steady, continuous regression coverage for UnionExec whole-stage codegen.

### Does this PR introduce _any_ user-facing change?

Yes. The default value of `spark.sql.codegen.wholeStage.union.enabled` flips from `false` to `true`. Query semantics via the public API are unchanged (results, row ordering, and error behavior are all the same), but:

- `UnionExec`'s non-partitioning-aware path now merges with its parent/child operators into the same `WholeStageCodegenExec` stage, so `EXPLAIN` output's stage boundaries and codegen ids change.
- User code that asserts on the exact number of physical plan nodes or on the `WholeStageCodegen` boundary split (e.g., some tests or performance monitoring scripts) may need updates.
- Users who want the previous behavior can explicitly `SET spark.sql.codegen.wholeStage.union.enabled = false`.

### How was this patch tested?

CI, plus locally regenerating the `PlanStabilitySuite` and `SQLQueryTestSuite` golden files via `SPARK_GENERATE_GOLDEN_FILES=1` and manually reviewing the diffs.

### Was this patch authored or co-authored using generative AI tooling?

No.
