### PR TITLE
[SPARK-56795][SQL] Reject column types unsupported by the data source on CREATE TABLE / ALTER TABLE

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -1108,44 +1108,45 @@ object DDLUtils extends Logging {
 
   // Checks correctness of table's column names and types.
   private[sql] def checkTableColumns(table: CatalogTable, schema: StructType): Unit = {
-    table.provider.foreach {
-      _.toLowerCase(Locale.ROOT) match {
-        case HIVE_PROVIDER =>
-          val serde = table.storage.serde
-          if (schema.exists(_.dataType.isInstanceOf[AnsiIntervalType])) {
-            throw hiveTableWithAnsiIntervalsError(table.identifier)
-          } else if (serde == HiveSerDe.sourceToSerDe("orc").get.serde) {
-            checkDataColNames("orc", schema)
-          } else if (serde == HiveSerDe.sourceToSerDe("parquet").get.serde ||
-            serde == Some("parquet.hive.serde.ParquetHiveSerDe") ||
-            serde == Some("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe")) {
-            checkDataColNames("parquet", schema)
-          } else if (serde == HiveSerDe.sourceToSerDe("avro").get.serde) {
-            checkDataColNames("avro", schema)
-          }
-        case "parquet" => checkDataColNames("parquet", schema)
-        case "orc" => checkDataColNames("orc", schema)
-        case "avro" => checkDataColNames("avro", schema)
-        case _ =>
-      }
+    val format = table.provider.flatMap { _.toLowerCase(Locale.ROOT) match {
+      case HIVE_PROVIDER =>
+        val serde = table.storage.serde
+        if (schema.exists(_.dataType.isInstanceOf[AnsiIntervalType])) {
+          throw hiveTableWithAnsiIntervalsError(table.identifier)
+        } else if (serde == HiveSerDe.sourceToSerDe("orc").get.serde) {
+          lookupFileFormat("orc")
+        } else if (serde == HiveSerDe.sourceToSerDe("parquet").get.serde ||
+          serde == Some("parquet.hive.serde.ParquetHiveSerDe") ||
+          serde == Some("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe")) {
+          lookupFileFormat("parquet")
+        } else if (serde == HiveSerDe.sourceToSerDe("avro").get.serde) {
+          lookupFileFormat("avro")
+        } else {
+          None
+        }
+      case provider => lookupFileFormat(provider)
+    }}
+
+    format.foreach { f =>
+      DataSourceUtils.checkFieldNames(f, schema)
+      DataSourceUtils.verifySchema(f, schema)
     }
   }
 
-  def checkDataColNames(provider: String, schema: StructType): Unit = {
+  def lookupFileFormat(provider: String): Option[FileFormat] = {
     val source = try {
       DataSource.lookupDataSource(provider, SQLConf.get).getConstructor().newInstance()
     } catch {
       case e: Throwable =>
         logError(log"Failed to find data source: ${MDC(LogKeys.DATA_SOURCE, provider)} " +
-          log"when check data column names.", e)
-        return
+          log"when checking table columns.", e)
+        return None
     }
     source match {
-      case f: FileFormat => DataSourceUtils.checkFieldNames(f, schema)
+      case f: FileFormat => Some(f)
       case f: FileDataSourceV2 =>
-        DataSourceUtils.checkFieldNames(
-          f.fallbackFileFormat.getDeclaredConstructor().newInstance(), schema)
-      case _ =>
+        Some(f.fallbackFileFormat.getDeclaredConstructor().newInstance())
+      case _ => None
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -68,7 +68,7 @@ import org.apache.spark.unsafe.types.UTF8String
  * Replaces generic operations with specific variants that are designed to work with Spark
  * SQL Data Sources.
  *
- * Note that, this rule must be run after `PreprocessTableCreation` and
+ * Note that, this rule must be run after `PreprocessTableDDL` and
  * `PreprocessTableInsertion`.
  */
 object DataSourceAnalysis extends Rule[LogicalPlan] {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.TypeUtils._
 import org.apache.spark.sql.classic.SparkSession
+import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.connector.expressions.{FieldReference, RewritableTransform}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.command.DDLUtils
@@ -133,9 +134,9 @@ class ResolveSQLOnFile(sparkSession: SparkSession) extends Rule[LogicalPlan] {
 }
 
 /**
- * Preprocess [[CreateTable]], to do some normalization and checking.
+ * Preprocess table DDL commands, to do some normalization and checking.
  */
-case class PreprocessTableCreation(catalog: SessionCatalog) extends Rule[LogicalPlan] {
+case class PreprocessTableDDL(catalog: SessionCatalog) extends Rule[LogicalPlan] {
 
   def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
     // When we CREATE TABLE without specifying the table schema, we should fail the query if
@@ -322,6 +323,15 @@ case class PreprocessTableCreation(catalog: SessionCatalog) extends Rule[Logical
       SchemaUtils.checkTransformDuplication(
         partitioning, "in the partitioning", isCaseSensitive)
 
+      val provider = create match {
+        case c: CreateTable => c.tableSpec.provider
+        case c: CreateTableAsSelect => c.tableSpec.provider
+        case c: ReplaceTable => c.tableSpec.provider
+        case c: ReplaceTableAsSelect => c.tableSpec.provider
+        case _ => None
+      }
+      checkColumns(provider, schema)
+
       if (schema.isEmpty) {
         if (partitioning.nonEmpty) {
           throw QueryCompilationErrors.specifyPartitionNotAllowedWhenTableSchemaNotDefinedError()
@@ -345,6 +355,26 @@ case class PreprocessTableCreation(catalog: SessionCatalog) extends Rule[Logical
 
         create.withPartitioning(normalizedPartitions)
       }
+
+    case a @ AddColumns(ResolvedTable(_, _, t, _), cols) if a.resolved =>
+      checkColumns(
+        Option(t.properties().get(TableCatalog.PROP_PROVIDER)),
+        StructType(cols.map(c => StructField(c.colName, c.dataType, c.nullable))))
+      a
+
+    case r @ ReplaceColumns(ResolvedTable(_, _, t, _), cols) if r.resolved =>
+      checkColumns(
+        Option(t.properties().get(TableCatalog.PROP_PROVIDER)),
+        StructType(cols.map(c => StructField(c.colName, c.dataType, c.nullable))))
+      r
+  }
+
+  /** Checks the schema is supported by the destination [[FileFormat]]. */
+  private def checkColumns(provider: Option[String], schema: StructType): Unit = {
+    provider.flatMap(DDLUtils.lookupFileFormat).foreach { format =>
+      DataSourceUtils.checkFieldNames(format, schema)
+      DataSourceUtils.verifySchema(format, schema)
+    }
   }
 
   private def fallBackV2ToV1(cls: Class[_]): Class[_] =

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -246,7 +246,7 @@ abstract class BaseSessionStateBuilder(
     override val postHocResolutionRules: Seq[Rule[LogicalPlan]] =
       DetectAmbiguousSelfJoin +:
         QualifyLocationWithWarehouse(catalog) +:
-        PreprocessTableCreation(catalog) +:
+        PreprocessTableDDL(catalog) +:
         PreprocessTableInsertion +:
         DataSourceAnalysis +:
         ApplyCharTypePadding +:

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLInsertTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLInsertTestSuite.scala
@@ -387,7 +387,8 @@ trait SQLInsertTestSuite extends QueryTest with AdaptiveSparkPlanHelper {
       val e = intercept[AnalysisException] {
         sql("CREATE TABLE t2(name STRING, part INTERVAL) USING PARQUET PARTITIONED BY (part)")
       }.getMessage
-      assert(e.contains("Cannot use \"INTERVAL\""))
+      assert(e.contains("Cannot use \"INTERVAL\"") ||
+        e.contains("UNSUPPORTED_DATA_TYPE_FOR_DATASOURCE"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -175,6 +175,27 @@ class DataSourceV2SQLSuiteV1Filter
       "catalogName" -> s"`${catalogName}`",
       "config" -> s""""spark.sql.catalog.${catalogName}""""))
 
+  test("CreateTable: rejects column types unsupported by the data source") {
+    val formats = Seq("CSV", "JSON", "ORC")
+    val types = Seq("GEOGRAPHY(4326)", "GEOMETRY(0)")
+    formats.foreach { format =>
+      types.foreach { typeName =>
+        val t = "testcat.tbl"
+        withTable(t) {
+          checkError(
+            exception = intercept[AnalysisException] {
+              sql(s"CREATE TABLE $t (g $typeName) USING $format")
+            },
+            condition = "UNSUPPORTED_DATA_TYPE_FOR_DATASOURCE",
+            parameters = Map(
+              "columnName" -> "`g`",
+              "columnType" -> s""""$typeName"""",
+              "format" -> format))
+        }
+      }
+    }
+  }
+
   test("CreateTable: use v2 plan because catalog is set") {
     spark.sql("CREATE TABLE testcat.table_name (id bigint NOT NULL, data string) USING foo")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/V2CommandsCaseSensitivitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/V2CommandsCaseSensitivitySuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.catalog.TableChange.ColumnPosition
 import org.apache.spark.sql.connector.expressions.Expressions
 import org.apache.spark.sql.errors.QueryErrorsBase
-import org.apache.spark.sql.execution.datasources.PreprocessTableCreation
+import org.apache.spark.sql.execution.datasources.PreprocessTableDDL
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{LongType, StringType}
@@ -45,7 +45,7 @@ class V2CommandsCaseSensitivitySuite
     toAttributes(schema))
 
   override protected def extendedAnalysisRules: Seq[Rule[LogicalPlan]] = {
-    Seq(PreprocessTableCreation(spark.sessionState.catalog))
+    Seq(PreprocessTableDDL(spark.sessionState.catalog))
   }
 
   test("CreateTableAsSelect: using top level field for partitioning") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableAddColumnsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableAddColumnsSuiteBase.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.command
 
 import java.time.{Duration, Period}
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 
 /**
  * This base suite contains unified tests for the `ALTER TABLE .. ADD COLUMNS` command that
@@ -48,6 +48,27 @@ trait AlterTableAddColumnsSuiteBase extends QueryTest with DDLCommandTestUtils {
       checkAnswer(
         sql(s"SELECT id, ym, dt data FROM $t"),
         Seq(Row(0, Period.ofYears(100), Duration.ofHours(10))))
+    }
+  }
+
+  test("rejects column types unsupported by the data source") {
+    val formats = Seq("CSV", "JSON", "ORC")
+    val types = Seq("GEOGRAPHY(4326)", "GEOMETRY(0)")
+    formats.foreach { format =>
+      types.foreach { typeName =>
+        withNamespaceAndTable("ns", "tbl") { t =>
+          sql(s"CREATE TABLE $t (c1 INT) USING $format")
+          checkError(
+            exception = intercept[AnalysisException] {
+              sql(s"ALTER TABLE $t ADD COLUMNS (g $typeName)")
+            },
+            condition = "UNSUPPORTED_DATA_TYPE_FOR_DATASOURCE",
+            parameters = Map(
+              "columnName" -> "`g`",
+              "columnType" -> s""""$typeName"""",
+              "format" -> format))
+        }
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableReplaceColumnsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableReplaceColumnsSuiteBase.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.command
 
 import java.time.{Duration, Period}
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 
 /**
  * This base suite contains unified tests for the `ALTER TABLE .. REPLACE COLUMNS` command that
@@ -49,6 +49,27 @@ trait AlterTableReplaceColumnsSuiteBase extends QueryTest with DDLCommandTestUti
         sql(s"SELECT new_ym, new_dt, new_data FROM $t"),
         Seq(
           Row(Period.ofYears(3), Duration.ofMinutes(4), 5)))
+    }
+  }
+
+  test("rejects column types unsupported by the data source") {
+    val formats = Seq("CSV", "JSON", "ORC")
+    val types = Seq("GEOGRAPHY(4326)", "GEOMETRY(0)")
+    formats.foreach { format =>
+      types.foreach { typeName =>
+        withNamespaceAndTable("ns", "tbl") { t =>
+          sql(s"CREATE TABLE $t (c1 INT) USING $format")
+          checkError(
+            exception = intercept[AnalysisException] {
+              sql(s"ALTER TABLE $t REPLACE COLUMNS (g $typeName)")
+            },
+            condition = "UNSUPPORTED_DATA_TYPE_FOR_DATASOURCE",
+            parameters = Map(
+              "columnName" -> "`g`",
+              "columnType" -> s""""$typeName"""",
+              "format" -> format))
+        }
+      }
     }
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -143,7 +143,7 @@ class HiveSessionStateBuilder(
       DetectAmbiguousSelfJoin +:
         RelationConversions(catalog) +:
         QualifyLocationWithWarehouse(catalog) +:
-        PreprocessTableCreation(catalog) +:
+        PreprocessTableDDL(catalog) +:
         PreprocessTableInsertion +:
         DataSourceAnalysis +:
         ApplyCharTypePadding +:

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -162,7 +162,7 @@ class DetermineTableStats(session: SparkSession) extends Rule[LogicalPlan] {
 /**
  * Replaces generic operations with specific variants that are designed to work with Hive.
  *
- * Note that, this rule must be run after `PreprocessTableCreation` and
+ * Note that, this rule must be run after `PreprocessTableDDL` and
  * `PreprocessTableInsertion`.
  */
 object HiveAnalysis extends Rule[LogicalPlan] {
@@ -207,7 +207,7 @@ object HiveAnalysis extends Rule[LogicalPlan] {
  * - When scanning Hive-serde Parquet/ORC tables
  *
  * This rule must be run before all other DDL post-hoc resolution rules, i.e.
- * `PreprocessTableCreation`, `PreprocessTableInsertion`, `DataSourceAnalysis` and `HiveAnalysis`.
+ * `PreprocessTableDDL`, `PreprocessTableInsertion`, `DataSourceAnalysis` and `HiveAnalysis`.
  */
 case class RelationConversions(
     sessionCatalog: HiveSessionCatalog) extends Rule[LogicalPlan] {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Run `DataSourceUtils.verifySchema` against the destination `FileFormat` at analysis
time, so unsupported column types are rejected on `CREATE TABLE` and `ALTER TABLE
ADD/REPLACE COLUMNS` regardless of whether the table is on a V1 or V2 path.

- V1: `DDLUtils.checkTableColumns` now also calls `verifySchema` on the resolved
  `FileFormat`, via a new `lookupFileFormat` helper.
- V2: `PreprocessTableCreation` is renamed to `PreprocessTableDDL` and additionally
  matches `AddColumns` / `ReplaceColumns`, running the same name + type check that
  it already runs for `V2CreateTablePlan`.

### Why are the changes needed?

Without this, schemas like `STRUCT … USING csv`, `GEOGRAPHY … USING json | csv |
avro | orc`, non-`STRING` columns `USING text`, or `VARIANT … USING avro | csv`
are accepted at catalog time and only fail later — for V1 ALTER and most V2
paths, the table can persist in a broken state until the next read or write.

### Does this PR introduce _any_ user-facing change?

The same schemas are rejected as before — just earlier (analysis time instead of
first read/write).

### How was this patch tested?

- `AlterTableAddColumnsSuiteBase` (V1 in-memory, V1 Hive, V2 in-memory)
- `AlterTableReplaceColumnsSuiteBase` (V2 only — V1 throws unsupported)
- `DataSourceV2SQLSuite` (V2 CREATE TABLE)

All cover `GEOGRAPHY(4326)` / `GEOMETRY(0)` columns against `csv` / `json` / `orc`.

### Was this patch authored or co-authored using generative AI tooling?

No.