### PR TITLE
[SPARK-56796][UI] Fix sticky tooltips for Stage page additional metrics

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -26,9 +26,12 @@ import {
 
 export {setTaskThreadDumpEnabled};
 
-function setTooltip(selector, text) {
-  $(selector).attr("data-bs-toggle", "tooltip")
+function setTooltip(selector, text, trigger) {
+  var tooltip = $(selector).attr("data-bs-toggle", "tooltip")
     .attr("title", text);
+  if (trigger) {
+    tooltip.attr("data-bs-trigger", trigger);
+  }
 }
 
 var shouldBlockUI = true;
@@ -362,18 +365,18 @@ $(document).ready(function () {
     "</div>");
 
   setTooltip('#scheduler_delay', "Scheduler delay includes time to ship the task from the scheduler to the executor, and time to send " +
-    "the task result from the executor to the scheduler. If scheduler delay is large, consider decreasing the size of tasks or decreasing the size of task results.");
-  setTooltip('#task_deserialization_time', "Time spent deserializing the task closure on the executor, including the time to read the broadcasted task.");
-  setTooltip('#shuffle_read_fetch_wait_time', "Time that the task spent blocked waiting for shuffle data to be read from remote machines.");
-  setTooltip('#shuffle_remote_reads', "Total shuffle bytes read from remote executors. This is a subset of the shuffle read bytes; the remaining shuffle data is read locally. ");
-  setTooltip('#shuffle_write_time', "Time that the task spent writing shuffle data.");
-  setTooltip('#result_serialization_time', "Time spent serializing the task result on the executor before sending it back to the driver.");
-  setTooltip('#getting_result_time', "Time that the driver spends fetching task results from workers. If this is large, consider decreasing the amount of data returned from each task.");
+    "the task result from the executor to the scheduler. If scheduler delay is large, consider decreasing the size of tasks or decreasing the size of task results.", "hover");
+  setTooltip('#task_deserialization_time', "Time spent deserializing the task closure on the executor, including the time to read the broadcasted task.", "hover");
+  setTooltip('#shuffle_read_fetch_wait_time', "Time that the task spent blocked waiting for shuffle data to be read from remote machines.", "hover");
+  setTooltip('#shuffle_remote_reads', "Total shuffle bytes read from remote executors. This is a subset of the shuffle read bytes; the remaining shuffle data is read locally. ", "hover");
+  setTooltip('#shuffle_write_time', "Time that the task spent writing shuffle data.", "hover");
+  setTooltip('#result_serialization_time', "Time spent serializing the task result on the executor before sending it back to the driver.", "hover");
+  setTooltip('#getting_result_time', "Time that the driver spends fetching task results from workers. If this is large, consider decreasing the amount of data returned from each task.", "hover");
   setTooltip('#peak_execution_memory', "Execution memory refers to the memory used by internal data structures created during " +
     "shuffles, aggregations and joins when Tungsten is enabled. The value of this accumulator " +
     "should be approximately the sum of the peak sizes across all such data structures created " +
     "in this task. For SQL jobs, this only tracks all unsafe operators, broadcast joins, and " +
-    "external sort.");
+    "external sort.", "hover");
   var tasksSummary = $("#parent-container");
   getStandAloneAppId(function (appId) {
     // rendering the UI page


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR updates the Stage page additional metrics tooltips to use `data-bs-trigger="hover"` ([SPARK-56796](https://issues.apache.org/jira/browse/SPARK-56796)).
The change is limited to the additional metrics checkbox options under `Show Additional Metrics`, such as `Scheduler Delay`, `Task Deserialization Time`, `Getting Result Time`, and `Peak Execution Memory`.



### Why are the changes needed?
Currently, after selecting one of the Stage page additional metrics checkboxes, the tooltip can remain visible even after the mouse leaves the option.
This happens because Bootstrap tooltips use the default `hover focus` trigger. When a checkbox inside the tooltip target is clicked, focus can keep the tooltip active after mouseleave.

For these checkbox options, the tooltip should only be shown while hovering.



### Does this PR introduce _any_ user-facing change?
Yes.

In the Stage page, tooltips for `Show Additional Metrics` checkbox options now disappear when the mouse leaves the option after selecting it.



### How was this patch tested?

Manually tested in the Spark UI Stage page:

1. Opened a stage detail page.
2. Expanded `Show Additional Metrics`.
3. Hovered over an additional metric option to show the tooltip.
4. Selected the checkbox.
5. Moved the mouse away from the option.
6. Verified that the tooltip no longer remains visible after mouseleave.


### Was this patch authored or co-authored using generative AI tooling?
Yes. Generated-by: OpenAI GPT-5.5 Codex

### Before the fix

https://github.com/user-attachments/assets/c2ece423-5150-4478-b4e5-0931de396085

### After the fix

https://github.com/user-attachments/assets/9dde5476-412b-461b-a35b-bc40cea943a3


