### PR TITLE
[SPARK-56798][SQL][DOCS] Clarify streaming CDC emission timing and netChanges scope

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
@@ -71,10 +71,21 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * </ul>
  * <p>
  * Streaming reads support carry-over removal, update detection, and net change
- * computation. Net change collapses are kept in the state store keyed by row identity;
- * row identities only touched in the latest observed commit are held back until either a
- * later commit (with strictly greater `_commit_timestamp`) advances the global watermark
- * past them, or the source terminates.
+ * computation. Two streaming-specific behaviors to be aware of:
+ * <ul>
+ *   <li><b>Output is delayed by one commit.</b> When a micro-batch ingests a
+ *       commit, that commit's output rows are buffered and not emitted in the
+ *       same batch. They are emitted by the next micro-batch -- the one that
+ *       ingests the following commit. The last commit's output is emitted
+ *       when the source terminates.</li>
+ *   <li><b>netChanges only merges changes that are buffered together.</b> For
+ *       a typical CDC source that produces at most one change per row per
+ *       commit, only one commit's changes are buffered at a time per row, so
+ *       the streaming output is the same as {@code computeUpdates}. Multiple
+ *       commits' changes are merged only when those commits touch the same
+ *       row before the older one's output has been emitted. For full-range
+ *       collapse, use a batch read.</li>
+ * </ul>
  * <p>
  * <b>Pushdown contract.</b> When any post-processing pass applies (carry-over
  * removal, update detection, or netChanges), Spark only pushes predicates

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Changelog.java
@@ -73,18 +73,18 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * Streaming reads support carry-over removal, update detection, and net change
  * computation. Two streaming-specific behaviors to be aware of:
  * <ul>
- *   <li><b>Output is delayed by one commit.</b> When a micro-batch ingests a
- *       commit, that commit's output rows are buffered and not emitted in the
- *       same batch. They are emitted by the next micro-batch -- the one that
- *       ingests the following commit. The last commit's output is emitted
- *       when the source terminates.</li>
- *   <li><b>netChanges only merges changes that are buffered together.</b> For
- *       a typical CDC source that produces at most one change per row per
- *       commit, only one commit's changes are buffered at a time per row, so
- *       the streaming output is the same as {@code computeUpdates}. Multiple
- *       commits' changes are merged only when those commits touch the same
- *       row before the older one's output has been emitted. For full-range
- *       collapse, use a batch read.</li>
+ *   <li><b>Output is buffered until the watermark advances past the commit.</b>
+ *       When a micro-batch ingests a commit, that commit's output rows are
+ *       buffered in state and not emitted in the same batch. They are emitted
+ *       by a later micro-batch -- whichever one advances the watermark past
+ *       the commit's {@code _commit_timestamp}. The last commit's output is
+ *       emitted when the source terminates.</li>
+ *   <li><b>netChanges only merges changes that are buffered together.</b>
+ *       When each row identity appears in at most one commit within any
+ *       buffered window, the streaming output is the same as
+ *       {@code computeUpdates}. Cross-commit merging only happens when
+ *       several commits touch the same row before the earliest one's output
+ *       has been released. For full-range collapse, use a batch read.</li>
  * </ul>
  * <p>
  * <b>Pushdown contract.</b> When any post-processing pass applies (carry-over


### PR DESCRIPTION
### What changes were proposed in this pull request?

Address two follow-up review threads on PR #55637 (streaming CDC netChanges) by clarifying the streaming behavior in the `Changelog` Javadoc.

The previous paragraph read as if the emission lag were a netChanges-specific property; in fact carry-over removal and update detection use append-mode `Aggregate` keyed on `_commit_timestamp` and have the same lag as the netChanges `transformWithState` timer. The paragraph also did not set expectations for what streaming netChanges actually collapses in practice.

Replaced the existing single paragraph with a bulleted list:

- **Output is buffered until the watermark advances past the commit.** When a micro-batch ingests a commit, that commit's output rows are buffered in state and not emitted in the same batch. They are emitted by a later micro-batch -- whichever one advances the watermark past the commit's `_commit_timestamp`. The last commit's output is emitted when the source terminates.
- **netChanges only merges changes that are buffered together.** When each row identity appears in at most one commit within any buffered window, the streaming output is the same as `computeUpdates`. Cross-commit merging only happens when several commits touch the same row before the earliest one's output has been released. For full-range collapse, use a batch read.

This is a sub-task of SPARK-55668.

### Why are the changes needed?

Spelling out the emission timing and the practical netChanges scope prevents adopters from forming wrong expectations about what streaming netChanges does for typical CDC workloads. Anchoring the lag on watermark progression (not commit count) and the netChanges merge condition on row-identity occurrences within the buffered window (not on changes within a single commit) keeps the doc consistent with what `CdcNetChangesStatefulProcessor` actually implements -- including the cases where multiple distinct commits share a micro-batch or the same row identity is touched in multiple commits before the older one's output has been released.

### Does this PR introduce _any_ user-facing change?

Documentation only. No behavior change.

### How was this patch tested?

Doc-only change. `Xdoclint:html,syntax,accessibility` is clean on `Changelog.java` (errors limited to expected "cannot find symbol" without classpath). No code changed; existing CDC test suites unaffected.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude opus-4-7