### PR TITLE
[SPARK-56806][BUILD] Fix `jetty-proxy` artifact ID in `core/pom.xml`'s `includeArtifactIds`

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -561,7 +561,7 @@
               <overWriteIfNewer>true</overWriteIfNewer>
               <useSubDirectoryPerType>true</useSubDirectoryPerType>
               <includeArtifactIds>
-                guava,protobuf-java,jetty-io,jetty-ee10-servlet,jetty-ee10-servlets,jetty-http,jetty-ee10-plus,jetty-util,jetty-server,jetty-security,jetty-proxy,jetty-client,jetty-session,jetty-compression-server,jetty-compression-common,jetty-compression-gzip
+                guava,protobuf-java,jetty-io,jetty-ee10-servlet,jetty-ee10-servlets,jetty-http,jetty-ee10-plus,jetty-util,jetty-server,jetty-security,jetty-ee10-proxy,jetty-client,jetty-session,jetty-compression-server,jetty-compression-common,jetty-compression-gzip
               </includeArtifactIds>
               <silent>true</silent>
             </configuration>


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `core/pom.xml`, the `<includeArtifactIds>` list under the `maven-dependency-plugin`'s `copy-dependencies` execution still references the old artifact ID `jetty-proxy`, while the actual `<dependency>` declared in the same file (and the corresponding `<include>` in the `maven-shade-plugin`) both use the renamed `jetty-ee10-proxy`. This PR renames `jetty-proxy` → `jetty-ee10-proxy` in the `<includeArtifactIds>` list to keep all three locations consistent.

### Why are the changes needed?

Because there is no longer any artifact with id `jetty-proxy` on the classpath, the `copy-dependencies` execution silently skips the proxy JAR. With `SPARK_PREPEND_CLASSES`, Spark relies on the unshaded original JARs being copied to `target/`, so the proxy JAR is missing in that mode. Renaming the entry restores the intended behavior.

### Does this PR introduce _any_ user-facing change?

No. Build-only fix.

### How was this patch tested?

Existing build. Verified that the dependency block (`org.eclipse.jetty.ee10:jetty-ee10-proxy`) and the `maven-shade-plugin` `<include>` already use the same renamed artifact ID.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)