### PR TITLE
[SPARK-56463][PYTHON][FOLLOWUP][3.5] Fix wrong kwargs

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1205,8 +1205,8 @@ class UserDefinedType(DataType):
         m = __import__(pyModule, globals(), locals(), [pyClass])
         if not hasattr(m, pyClass):
             raise PySparkValueError(
-                errorClass="UNSUPPORTED_OPERATION",
-                messageParameters={"operation": "unpickling user defined types"},
+                error_class="UNSUPPORTED_OPERATION",
+                message_parameters={"operation": "unpickling user defined types"},
             )
         else:
             UDT = getattr(m, pyClass)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes wrong kwargs `errorClass` and `messageParameters` for `PySparkValueError` in `types.py`, which are introduced by #55330. They should be `error_class` and `message_parameters`.

### Why are the changes needed?
Bug fix.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manual review because `dev/lint-python` doesn't work for now (Will fix in a separate PR).

### Was this patch authored or co-authored using generative AI tooling?
No.