### PR TITLE
[SPARK-56638][SQL] Replace legacy parser error for ParserUtils validation failures

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4742,19 +4742,9 @@
           "Syntax error: call to table-valued function is invalid because parentheses are missing around the provided TABLE argument <argumentName>; please surround this with parentheses and try again."
         ]
       },
-      "INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_ORDER_BY_WITHOUT_PARTITIONING" : {
-        "message" : [
-          "ORDER BY cannot be specified unless either PARTITION BY or WITH SINGLE PARTITION is also present."
-        ]
-      },
       "INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_PARTITIONING" : {
         "message" : [
           "The table function call includes a table argument with an invalid partitioning/ordering specification: the <clause> clause included multiple expressions without parentheses surrounding them; please add parentheses around these expressions and then retry the query again."
-        ]
-      },
-      "INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_WITH_SINGLE_PARTITION" : {
-        "message" : [
-          "WITH SINGLE PARTITION cannot be specified if PARTITION BY is also present."
         ]
       },
       "INVALID_TABLE_VALUED_FUNC_NAME" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4712,6 +4712,16 @@
           "Partition key <partKey> must set value."
         ]
       },
+      "EMPTY_QUANTIFIED_PATTERN" : {
+        "message" : [
+          "Expected something between '(' and ')'."
+        ]
+      },
+      "EMPTY_REFRESH_RESOURCE_PATH" : {
+        "message" : [
+          "Resource paths cannot be empty in REFRESH statements. Use / to match everything."
+        ]
+      },
       "FUNCTION_WITH_UNSUPPORTED_SYNTAX" : {
         "message" : [
           "The function <prettyName> does not support <syntax>."
@@ -4722,14 +4732,39 @@
           "Expected a column reference for transform <transform>: <expr>."
         ]
       },
+      "INVALID_REFRESH_RESOURCE_PATH" : {
+        "message" : [
+          "REFRESH statements cannot contain ' ', '\\n', '\\r', '\\t' inside unquoted resource paths."
+        ]
+      },
       "INVALID_TABLE_FUNCTION_IDENTIFIER_ARGUMENT_MISSING_PARENTHESES" : {
         "message" : [
           "Syntax error: call to table-valued function is invalid because parentheses are missing around the provided TABLE argument <argumentName>; please surround this with parentheses and try again."
         ]
       },
+      "INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_ORDER_BY_WITHOUT_PARTITIONING" : {
+        "message" : [
+          "ORDER BY cannot be specified unless either PARTITION BY or WITH SINGLE PARTITION is also present."
+        ]
+      },
+      "INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_PARTITIONING" : {
+        "message" : [
+          "The table function call includes a table argument with an invalid partitioning/ordering specification: the <clause> clause included multiple expressions without parentheses surrounding them; please add parentheses around these expressions and then retry the query again."
+        ]
+      },
+      "INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_WITH_SINGLE_PARTITION" : {
+        "message" : [
+          "WITH SINGLE PARTITION cannot be specified if PARTITION BY is also present."
+        ]
+      },
       "INVALID_TABLE_VALUED_FUNC_NAME" : {
         "message" : [
           "Table valued function cannot specify database name: <funcName>."
+        ]
+      },
+      "INVALID_WINDOW_FRAME_BOUND" : {
+        "message" : [
+          "Frame bound value must be a literal."
         ]
       },
       "INVALID_WINDOW_REFERENCE" : {
@@ -4780,6 +4815,11 @@
       "UNSUPPORTED_FUNC_NAME" : {
         "message" : [
           "Unsupported function name <funcName>."
+        ]
+      },
+      "UNSUPPORTED_ROW_FORMAT_LINES_TERMINATED_BY" : {
+        "message" : [
+          "LINES TERMINATED BY only supports newline '\\n' right now: <value>."
         ]
       },
       "UNSUPPORTED_SQL_STATEMENT" : {
@@ -9054,11 +9094,6 @@
     ]
   },
   "_LEGACY_ERROR_TEMP_0063" : {
-    "message" : [
-      "<msg>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_0064" : {
     "message" : [
       "<msg>."
     ]

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4832,6 +4832,12 @@
     },
     "sqlState" : "42823"
   },
+  "INVALID_TABLESAMPLE_FRACTION" : {
+    "message" : [
+      "Sampling fraction (<fraction>) must be on interval [0, 1]."
+    ],
+    "sqlState" : "22023"
+  },
   "INVALID_TEMP_OBJ_QUALIFIER" : {
     "message" : [
       "Temporary <objectType> <objectName> cannot be qualified with <qualifier>. Temporary objects can only be qualified with SESSION or SYSTEM.SESSION."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4649,19 +4649,9 @@
           "Syntax error: call to table-valued function is invalid because parentheses are missing around the provided TABLE argument <argumentName>; please surround this with parentheses and try again."
         ]
       },
-      "INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_ORDER_BY_WITHOUT_PARTITIONING" : {
-        "message" : [
-          "ORDER BY cannot be specified unless either PARTITION BY or WITH SINGLE PARTITION is also present."
-        ]
-      },
       "INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_PARTITIONING" : {
         "message" : [
           "The table function call includes a table argument with an invalid partitioning/ordering specification: the <clause> clause included multiple expressions without parentheses surrounding them; please add parentheses around these expressions and then retry the query again."
-        ]
-      },
-      "INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_WITH_SINGLE_PARTITION" : {
-        "message" : [
-          "WITH SINGLE PARTITION cannot be specified if PARTITION BY is also present."
         ]
       },
       "INVALID_TABLE_VALUED_FUNC_NAME" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4619,6 +4619,16 @@
           "Partition key <partKey> must set value."
         ]
       },
+      "EMPTY_QUANTIFIED_PATTERN" : {
+        "message" : [
+          "Expected something between '(' and ')'."
+        ]
+      },
+      "EMPTY_REFRESH_RESOURCE_PATH" : {
+        "message" : [
+          "Resource paths cannot be empty in REFRESH statements. Use / to match everything."
+        ]
+      },
       "FUNCTION_WITH_UNSUPPORTED_SYNTAX" : {
         "message" : [
           "The function <prettyName> does not support <syntax>."
@@ -4629,14 +4639,39 @@
           "Expected a column reference for transform <transform>: <expr>."
         ]
       },
+      "INVALID_REFRESH_RESOURCE_PATH" : {
+        "message" : [
+          "REFRESH statements cannot contain ' ', '\\n', '\\r', '\\t' inside unquoted resource paths."
+        ]
+      },
       "INVALID_TABLE_FUNCTION_IDENTIFIER_ARGUMENT_MISSING_PARENTHESES" : {
         "message" : [
           "Syntax error: call to table-valued function is invalid because parentheses are missing around the provided TABLE argument <argumentName>; please surround this with parentheses and try again."
         ]
       },
+      "INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_ORDER_BY_WITHOUT_PARTITIONING" : {
+        "message" : [
+          "ORDER BY cannot be specified unless either PARTITION BY or WITH SINGLE PARTITION is also present."
+        ]
+      },
+      "INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_PARTITIONING" : {
+        "message" : [
+          "The table function call includes a table argument with an invalid partitioning/ordering specification: the <clause> clause included multiple expressions without parentheses surrounding them; please add parentheses around these expressions and then retry the query again."
+        ]
+      },
+      "INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_WITH_SINGLE_PARTITION" : {
+        "message" : [
+          "WITH SINGLE PARTITION cannot be specified if PARTITION BY is also present."
+        ]
+      },
       "INVALID_TABLE_VALUED_FUNC_NAME" : {
         "message" : [
           "Table valued function cannot specify database name: <funcName>."
+        ]
+      },
+      "INVALID_WINDOW_FRAME_BOUND" : {
+        "message" : [
+          "Frame bound value must be a literal."
         ]
       },
       "INVALID_WINDOW_REFERENCE" : {
@@ -4687,6 +4722,11 @@
       "UNSUPPORTED_FUNC_NAME" : {
         "message" : [
           "Unsupported function name <funcName>."
+        ]
+      },
+      "UNSUPPORTED_ROW_FORMAT_LINES_TERMINATED_BY" : {
+        "message" : [
+          "LINES TERMINATED BY only supports newline '\\n' right now: <value>."
         ]
       },
       "UNSUPPORTED_SQL_STATEMENT" : {
@@ -8945,11 +8985,6 @@
     ]
   },
   "_LEGACY_ERROR_TEMP_0063" : {
-    "message" : [
-      "<msg>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_0064" : {
     "message" : [
       "<msg>."
     ]

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4739,6 +4739,12 @@
     },
     "sqlState" : "42823"
   },
+  "INVALID_TABLESAMPLE_FRACTION" : {
+    "message" : [
+      "Sampling fraction (<fraction>) must be on interval [0, 1]."
+    ],
+    "sqlState" : "22023"
+  },
   "INVALID_TEMP_OBJ_QUALIFIER" : {
     "message" : [
       "Temporary <objectType> <objectName> cannot be qualified with <qualifier>. Temporary objects can only be qualified with SESSION or SYSTEM.SESSION."

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -288,6 +288,13 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
       ctx)
   }
 
+  def invalidTableSampleFractionError(fraction: Double, ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      errorClass = "INVALID_TABLESAMPLE_FRACTION",
+      messageParameters = Map("fraction" -> fraction.toString),
+      ctx)
+  }
+
   def invalidEscapeStringError(invalidEscape: String, ctx: PredicateContext): Throwable = {
     new ParseException(
       errorClass = "INVALID_ESC",

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -295,6 +295,56 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
       ctx)
   }
 
+  def unsupportedRowFormatLinesTerminatedByError(
+      value: String,
+      ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      errorClass = "INVALID_SQL_SYNTAX.UNSUPPORTED_ROW_FORMAT_LINES_TERMINATED_BY",
+      messageParameters = Map("value" -> value),
+      ctx)
+  }
+
+  def invalidTableFunctionTableArgumentPartitioningError(
+      clause: String,
+      ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      errorClass = "INVALID_SQL_SYNTAX.INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_PARTITIONING",
+      messageParameters = Map("clause" -> clause),
+      ctx)
+  }
+
+  def invalidTableFunctionTableArgumentWithSinglePartitionError(
+      ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      errorClass =
+        "INVALID_SQL_SYNTAX.INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_WITH_SINGLE_PARTITION",
+      ctx)
+  }
+
+  def invalidTableFunctionTableArgumentOrderByWithoutPartitioningError(
+      ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      errorClass =
+        "INVALID_SQL_SYNTAX.INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_ORDER_BY_WITHOUT_PARTITIONING",
+      ctx)
+  }
+
+  def emptyQuantifiedPatternError(ctx: ParserRuleContext): Throwable = {
+    new ParseException(errorClass = "INVALID_SQL_SYNTAX.EMPTY_QUANTIFIED_PATTERN", ctx)
+  }
+
+  def invalidWindowFrameBoundError(ctx: ParserRuleContext): Throwable = {
+    new ParseException(errorClass = "INVALID_SQL_SYNTAX.INVALID_WINDOW_FRAME_BOUND", ctx)
+  }
+
+  def emptyRefreshResourcePathError(ctx: ParserRuleContext): Throwable = {
+    new ParseException(errorClass = "INVALID_SQL_SYNTAX.EMPTY_REFRESH_RESOURCE_PATH", ctx)
+  }
+
+  def invalidRefreshResourcePathError(ctx: ParserRuleContext): Throwable = {
+    new ParseException(errorClass = "INVALID_SQL_SYNTAX.INVALID_REFRESH_RESOURCE_PATH", ctx)
+  }
+
   def invalidEscapeStringError(invalidEscape: String, ctx: PredicateContext): Throwable = {
     new ParseException(
       errorClass = "INVALID_ESC",

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -313,22 +313,6 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
       ctx)
   }
 
-  def invalidTableFunctionTableArgumentWithSinglePartitionError(
-      ctx: ParserRuleContext): Throwable = {
-    new ParseException(
-      errorClass =
-        "INVALID_SQL_SYNTAX.INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_WITH_SINGLE_PARTITION",
-      ctx)
-  }
-
-  def invalidTableFunctionTableArgumentOrderByWithoutPartitioningError(
-      ctx: ParserRuleContext): Throwable = {
-    new ParseException(
-      errorClass =
-        "INVALID_SQL_SYNTAX.INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_ORDER_BY_WITHOUT_PARTITIONING",
-      ctx)
-  }
-
   def emptyQuantifiedPatternError(ctx: ParserRuleContext): Throwable = {
     new ParseException(errorClass = "INVALID_SQL_SYNTAX.EMPTY_QUANTIFIED_PATTERN", ctx)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1883,10 +1883,9 @@ class AstBuilder extends DataTypeAstBuilder
       entry("TOK_TABLEROWFORMATNULL", ctx.nullDefinedAs) ++
       Option(ctx.linesSeparatedBy).toSeq.map { stringLitCtx =>
         val value = string(visitStringLit(stringLitCtx))
-        validate(
-          value == "\n",
-          s"LINES TERMINATED BY only supports newline '\\n' right now: $value",
-          ctx)
+        if (value != "\n") {
+          throw QueryParsingErrors.unsupportedRowFormatLinesTerminatedByError(value, ctx)
+        }
         "TOK_TABLEROWFORMATLINES" -> value
       }
 
@@ -2799,30 +2798,25 @@ class AstBuilder extends DataTypeAstBuilder
       }
       partitionByExpressions = p.partition.asScala.map(expression).toSeq
       orderByExpressions = p.sortItem.asScala.map(visitSortItem).toSeq
-      def invalidPartitionOrOrderingExpression(clause: String): String = {
-        "The table function call includes a table argument with an invalid " +
-          s"partitioning/ordering specification: the $clause clause included multiple " +
-          "expressions without parentheses surrounding them; please add parentheses around " +
-          "these expressions and then retry the query again"
+      Option(p.invalidMultiPartitionExpression).foreach { invalidCtx =>
+        throw QueryParsingErrors.invalidTableFunctionTableArgumentPartitioningError(
+          "PARTITION BY",
+          invalidCtx)
       }
-      validate(
-        Option(p.invalidMultiPartitionExpression).isEmpty,
-        message = invalidPartitionOrOrderingExpression("PARTITION BY"),
-        ctx = p.invalidMultiPartitionExpression)
-      validate(
-        Option(p.invalidMultiSortItem).isEmpty,
-        message = invalidPartitionOrOrderingExpression("ORDER BY"),
-        ctx = p.invalidMultiSortItem)
+      Option(p.invalidMultiSortItem).foreach { invalidCtx =>
+        throw QueryParsingErrors.invalidTableFunctionTableArgumentPartitioningError(
+          "ORDER BY",
+          invalidCtx)
+      }
     }
-    validate(
-      !(withSinglePartition && partitionByExpressions.nonEmpty),
-      message = "WITH SINGLE PARTITION cannot be specified if PARTITION BY is also present",
-      ctx = ctx.tableArgumentPartitioning)
-    validate(
-      !(orderByExpressions.nonEmpty && partitionByExpressions.isEmpty && !withSinglePartition),
-      message = "ORDER BY cannot be specified unless either " +
-        "PARTITION BY or WITH SINGLE PARTITION is also present",
-      ctx = ctx.tableArgumentPartitioning)
+    if (withSinglePartition && partitionByExpressions.nonEmpty) {
+      throw QueryParsingErrors.invalidTableFunctionTableArgumentWithSinglePartitionError(
+        ctx.tableArgumentPartitioning)
+    }
+    if (orderByExpressions.nonEmpty && partitionByExpressions.isEmpty && !withSinglePartition) {
+      throw QueryParsingErrors.invalidTableFunctionTableArgumentOrderByWithoutPartitioningError(
+        ctx.tableArgumentPartitioning)
+    }
     FunctionTableSubqueryArgumentExpression(
       plan = p,
       partitionByExpressions = partitionByExpressions,
@@ -3423,7 +3417,9 @@ class AstBuilder extends DataTypeAstBuilder
       case SqlBaseParser.LIKE | SqlBaseParser.ILIKE =>
         Option(ctx.quantifier).map(_.getType) match {
           case Some(SqlBaseParser.ANY) | Some(SqlBaseParser.SOME) =>
-            validate(!ctx.expression.isEmpty, "Expected something between '(' and ')'.", ctx)
+            if (ctx.expression.isEmpty) {
+              throw QueryParsingErrors.emptyQuantifiedPatternError(ctx)
+            }
             val expressions = expressionList(ctx.expression)
             if (expressions.forall(_.foldable) && expressions.forall(_.dataType == StringType)) {
               // If there are many pattern expressions, will throw StackOverflowError.
@@ -3439,7 +3435,9 @@ class AstBuilder extends DataTypeAstBuilder
                 .map(p => invertIfNotDefined(getLike(e, p))).toSeq.reduceLeft(Or)
             }
           case Some(SqlBaseParser.ALL) =>
-            validate(!ctx.expression.isEmpty, "Expected something between '(' and ')'.", ctx)
+            if (ctx.expression.isEmpty) {
+              throw QueryParsingErrors.emptyQuantifiedPatternError(ctx)
+            }
             val expressions = expressionList(ctx.expression)
             if (expressions.forall(_.foldable) && expressions.forall(_.dataType == StringType)) {
               // If there are many pattern expressions, will throw StackOverflowError.
@@ -3862,9 +3860,9 @@ class AstBuilder extends DataTypeAstBuilder
   override def visitFrameBound(ctx: FrameBoundContext): Expression = withOrigin(ctx) {
     def value: Expression = {
       val e = expression(ctx.expression)
-      validate(
-        e.resolved && e.foldable || e.isInstanceOf[Parameter],
-        "Frame bound value must be a literal.", ctx)
+      if (!(e.resolved && e.foldable || e.isInstanceOf[Parameter])) {
+        throw QueryParsingErrors.invalidWindowFrameBoundError(ctx)
+      }
       e
     }
 
@@ -5458,10 +5456,9 @@ class AstBuilder extends DataTypeAstBuilder
           entry("mapkey.delim", ctx.keysTerminatedBy) ++
           Option(ctx.linesSeparatedBy).toSeq.map { token =>
             val value = string(visitStringLit(token))
-            validate(
-              value == "\n",
-              s"LINES TERMINATED BY only supports newline '\\n' right now: $value",
-              ctx)
+            if (value != "\n") {
+              throw QueryParsingErrors.unsupportedRowFormatLinesTerminatedByError(value, ctx)
+            }
             "line.delim" -> value
           }
     SerdeInfo(serdeProperties = entries.toMap)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2513,9 +2513,9 @@ class AstBuilder extends DataTypeAstBuilder
       // function takes X PERCENT as the input and the range of X is [0, 100], we need to
       // adjust the fraction.
       val eps = RandomSampler.roundingEpsilon
-      validate(fraction >= 0.0 - eps && fraction <= 1.0 + eps,
-        s"Sampling fraction ($fraction) must be on interval [0, 1]",
-        ctx)
+      if (fraction < 0.0 - eps || fraction > 1.0 + eps) {
+        throw QueryParsingErrors.invalidTableSampleFractionError(fraction, ctx)
+      }
       val method = if (isSystem) SampleMethod.System else SampleMethod.Bernoulli
       Sample(0.0, fraction, withReplacement = false, seed, query, method)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2809,14 +2809,6 @@ class AstBuilder extends DataTypeAstBuilder
           invalidCtx)
       }
     }
-    if (withSinglePartition && partitionByExpressions.nonEmpty) {
-      throw QueryParsingErrors.invalidTableFunctionTableArgumentWithSinglePartitionError(
-        ctx.tableArgumentPartitioning)
-    }
-    if (orderByExpressions.nonEmpty && partitionByExpressions.isEmpty && !withSinglePartition) {
-      throw QueryParsingErrors.invalidTableFunctionTableArgumentOrderByWithoutPartitioningError(
-        ctx.tableArgumentPartitioning)
-    }
     FunctionTableSubqueryArgumentExpression(
       plan = p,
       partitionByExpressions = partitionByExpressions,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2802,14 +2802,6 @@ class AstBuilder extends DataTypeAstBuilder
           invalidCtx)
       }
     }
-    if (withSinglePartition && partitionByExpressions.nonEmpty) {
-      throw QueryParsingErrors.invalidTableFunctionTableArgumentWithSinglePartitionError(
-        ctx.tableArgumentPartitioning)
-    }
-    if (orderByExpressions.nonEmpty && partitionByExpressions.isEmpty && !withSinglePartition) {
-      throw QueryParsingErrors.invalidTableFunctionTableArgumentOrderByWithoutPartitioningError(
-        ctx.tableArgumentPartitioning)
-    }
     FunctionTableSubqueryArgumentExpression(
       plan = p,
       partitionByExpressions = partitionByExpressions,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2505,9 +2505,9 @@ class AstBuilder extends DataTypeAstBuilder
       // function takes X PERCENT as the input and the range of X is [0, 100], we need to
       // adjust the fraction.
       val eps = RandomSampler.roundingEpsilon
-      validate(fraction >= 0.0 - eps && fraction <= 1.0 + eps,
-        s"Sampling fraction ($fraction) must be on interval [0, 1]",
-        ctx)
+      if (fraction < 0.0 - eps || fraction > 1.0 + eps) {
+        throw QueryParsingErrors.invalidTableSampleFractionError(fraction, ctx)
+      }
       val method = if (isSystem) SampleMethod.System else SampleMethod.Bernoulli
       Sample(0.0, fraction, withReplacement = false, seed, query, method)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1875,10 +1875,9 @@ class AstBuilder extends DataTypeAstBuilder
       entry("TOK_TABLEROWFORMATNULL", ctx.nullDefinedAs) ++
       Option(ctx.linesSeparatedBy).toSeq.map { stringLitCtx =>
         val value = string(visitStringLit(stringLitCtx))
-        validate(
-          value == "\n",
-          s"LINES TERMINATED BY only supports newline '\\n' right now: $value",
-          ctx)
+        if (value != "\n") {
+          throw QueryParsingErrors.unsupportedRowFormatLinesTerminatedByError(value, ctx)
+        }
         "TOK_TABLEROWFORMATLINES" -> value
       }
 
@@ -2792,30 +2791,25 @@ class AstBuilder extends DataTypeAstBuilder
       }
       partitionByExpressions = p.partition.asScala.map(expression).toSeq
       orderByExpressions = p.sortItem.asScala.map(visitSortItem).toSeq
-      def invalidPartitionOrOrderingExpression(clause: String): String = {
-        "The table function call includes a table argument with an invalid " +
-          s"partitioning/ordering specification: the $clause clause included multiple " +
-          "expressions without parentheses surrounding them; please add parentheses around " +
-          "these expressions and then retry the query again"
+      Option(p.invalidMultiPartitionExpression).foreach { invalidCtx =>
+        throw QueryParsingErrors.invalidTableFunctionTableArgumentPartitioningError(
+          "PARTITION BY",
+          invalidCtx)
       }
-      validate(
-        Option(p.invalidMultiPartitionExpression).isEmpty,
-        message = invalidPartitionOrOrderingExpression("PARTITION BY"),
-        ctx = p.invalidMultiPartitionExpression)
-      validate(
-        Option(p.invalidMultiSortItem).isEmpty,
-        message = invalidPartitionOrOrderingExpression("ORDER BY"),
-        ctx = p.invalidMultiSortItem)
+      Option(p.invalidMultiSortItem).foreach { invalidCtx =>
+        throw QueryParsingErrors.invalidTableFunctionTableArgumentPartitioningError(
+          "ORDER BY",
+          invalidCtx)
+      }
     }
-    validate(
-      !(withSinglePartition && partitionByExpressions.nonEmpty),
-      message = "WITH SINGLE PARTITION cannot be specified if PARTITION BY is also present",
-      ctx = ctx.tableArgumentPartitioning)
-    validate(
-      !(orderByExpressions.nonEmpty && partitionByExpressions.isEmpty && !withSinglePartition),
-      message = "ORDER BY cannot be specified unless either " +
-        "PARTITION BY or WITH SINGLE PARTITION is also present",
-      ctx = ctx.tableArgumentPartitioning)
+    if (withSinglePartition && partitionByExpressions.nonEmpty) {
+      throw QueryParsingErrors.invalidTableFunctionTableArgumentWithSinglePartitionError(
+        ctx.tableArgumentPartitioning)
+    }
+    if (orderByExpressions.nonEmpty && partitionByExpressions.isEmpty && !withSinglePartition) {
+      throw QueryParsingErrors.invalidTableFunctionTableArgumentOrderByWithoutPartitioningError(
+        ctx.tableArgumentPartitioning)
+    }
     FunctionTableSubqueryArgumentExpression(
       plan = p,
       partitionByExpressions = partitionByExpressions,
@@ -3416,7 +3410,9 @@ class AstBuilder extends DataTypeAstBuilder
       case SqlBaseParser.LIKE | SqlBaseParser.ILIKE =>
         Option(ctx.quantifier).map(_.getType) match {
           case Some(SqlBaseParser.ANY) | Some(SqlBaseParser.SOME) =>
-            validate(!ctx.expression.isEmpty, "Expected something between '(' and ')'.", ctx)
+            if (ctx.expression.isEmpty) {
+              throw QueryParsingErrors.emptyQuantifiedPatternError(ctx)
+            }
             val expressions = expressionList(ctx.expression)
             if (expressions.forall(_.foldable) && expressions.forall(_.dataType == StringType)) {
               // If there are many pattern expressions, will throw StackOverflowError.
@@ -3432,7 +3428,9 @@ class AstBuilder extends DataTypeAstBuilder
                 .map(p => invertIfNotDefined(getLike(e, p))).toSeq.reduceLeft(Or)
             }
           case Some(SqlBaseParser.ALL) =>
-            validate(!ctx.expression.isEmpty, "Expected something between '(' and ')'.", ctx)
+            if (ctx.expression.isEmpty) {
+              throw QueryParsingErrors.emptyQuantifiedPatternError(ctx)
+            }
             val expressions = expressionList(ctx.expression)
             if (expressions.forall(_.foldable) && expressions.forall(_.dataType == StringType)) {
               // If there are many pattern expressions, will throw StackOverflowError.
@@ -3855,9 +3853,9 @@ class AstBuilder extends DataTypeAstBuilder
   override def visitFrameBound(ctx: FrameBoundContext): Expression = withOrigin(ctx) {
     def value: Expression = {
       val e = expression(ctx.expression)
-      validate(
-        e.resolved && e.foldable || e.isInstanceOf[Parameter],
-        "Frame bound value must be a literal.", ctx)
+      if (!(e.resolved && e.foldable || e.isInstanceOf[Parameter])) {
+        throw QueryParsingErrors.invalidWindowFrameBoundError(ctx)
+      }
       e
     }
 
@@ -5451,10 +5449,9 @@ class AstBuilder extends DataTypeAstBuilder
           entry("mapkey.delim", ctx.keysTerminatedBy) ++
           Option(ctx.linesSeparatedBy).toSeq.map { token =>
             val value = string(visitStringLit(token))
-            validate(
-              value == "\n",
-              s"LINES TERMINATED BY only supports newline '\\n' right now: $value",
-              ctx)
+            if (value != "\n") {
+              throw QueryParsingErrors.unsupportedRowFormatLinesTerminatedByError(value, ctx)
+            }
             "line.delim" -> value
           }
     SerdeInfo(serdeProperties = entries.toMap)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -105,16 +105,6 @@ object ParserUtils extends SparkParserUtils {
     Option(value).toSeq.map(x => key -> string(x))
   }
 
-  /** Validate the condition. If it doesn't throw a parse exception. */
-  def validate(f: => Boolean, message: String, ctx: ParserRuleContext): Unit = {
-    if (!f) {
-      throw new ParseException(
-        errorClass = "_LEGACY_ERROR_TEMP_0064",
-        messageParameters = Map("msg" -> message),
-        ctx)
-    }
-  }
-
   /** the column name pattern in quoted regex without qualifier */
   val escapedIdentifier = "`((?s).+)`".r
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -261,8 +261,8 @@ class ExpressionParserSuite extends AnalysisTest {
     Seq("any", "some", "all").foreach { quantifier =>
       checkError(
         exception = parseException(s"a like $quantifier()"),
-        condition = "_LEGACY_ERROR_TEMP_0064",
-        parameters = Map("msg" -> "Expected something between '(' and ')'."),
+        condition = "INVALID_SQL_SYNTAX.EMPTY_QUANTIFIED_PATTERN",
+        parameters = Map.empty,
         context = ExpectedContext(
           fragment = s"like $quantifier()",
           start = 2,
@@ -461,8 +461,8 @@ class ExpressionParserSuite extends AnalysisTest {
     // We cannot use an arbitrary expression.
     checkError(
       exception = parseException("foo(*) over (partition by a order by b rows exp(b) preceding)"),
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> "Frame bound value must be a literal."),
+      condition = "INVALID_SQL_SYNTAX.INVALID_WINDOW_FRAME_BOUND",
+      parameters = Map.empty,
       context = ExpectedContext(
         fragment = "exp(b) preceding",
         start = 44,
@@ -1232,8 +1232,8 @@ class ExpressionParserSuite extends AnalysisTest {
     Seq("any", "some", "all").foreach { quantifier =>
       checkError(
         exception = parseException(s"a ilike $quantifier()"),
-        condition = "_LEGACY_ERROR_TEMP_0064",
-        parameters = Map("msg" -> "Expected something between '(' and ')'."),
+        condition = "INVALID_SQL_SYNTAX.EMPTY_QUANTIFIED_PATTERN",
+        parameters = Map.empty,
         context = ExpectedContext(
           fragment = s"ilike $quantifier()",
           start = 2,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParserUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParserUtilsSuite.scala
@@ -232,21 +232,6 @@ class ParserUtilsSuite extends SparkFunSuite {
     assert(position(emptyContext.stop) == Origin(None, None))
   }
 
-  test("validate") {
-    val f1 = { ctx: ParserRuleContext =>
-      ctx.children != null && !ctx.children.isEmpty
-    }
-    val message = "ParserRuleContext should not be empty."
-    validate(f1(showFuncContext), message, showFuncContext)
-
-    checkError(
-      exception = intercept[ParseException] {
-        validate(f1(emptyContext), message, emptyContext)
-      },
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> message))
-  }
-
   test("withOrigin") {
     val ctx = createDbContext.locationSpec.asScala.head
     val current = CurrentOrigin.get

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -994,8 +994,8 @@ class PlanParserSuite extends AnalysisTest {
     val fragment2 = "tablesample(bucket 11 out of 10)"
     checkError(
       exception = parseException(sql2),
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> "Sampling fraction (1.1) must be on interval [0, 1]"),
+      condition = "INVALID_TABLESAMPLE_FRACTION",
+      parameters = Map("fraction" -> "1.1"),
       context = ExpectedContext(
         fragment = fragment2,
         start = 16,
@@ -1157,8 +1157,8 @@ class PlanParserSuite extends AnalysisTest {
     // > 100 PERCENT
     checkError(
       exception = parseException(s"$sql tablesample system (150 percent) as x"),
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> "Sampling fraction (1.5) must be on interval [0, 1]"),
+      condition = "INVALID_TABLESAMPLE_FRACTION",
+      parameters = Map("fraction" -> "1.5"),
       context = ExpectedContext(
         fragment = "tablesample system (150 percent)",
         start = 16,
@@ -1166,8 +1166,8 @@ class PlanParserSuite extends AnalysisTest {
     // Negative PERCENT
     checkError(
       exception = parseException(s"$sql tablesample system (-10 percent) as x"),
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> "Sampling fraction (-0.1) must be on interval [0, 1]"),
+      condition = "INVALID_TABLESAMPLE_FRACTION",
+      parameters = Map("fraction" -> "-0.1"),
       context = ExpectedContext(
         fragment = "tablesample system (-10 percent)",
         start = 16,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -2004,6 +2004,18 @@ class PlanParserSuite extends AnalysisTest {
             start = 29,
             stop = 110 + partition.length)
         )
+        val sql9tableArg = "table(select col1, col2, col3 from v2)"
+        val sql9partition = s"$partition by col1 $order by col2 asc, col3 desc"
+        val sql9 = s"select * from my_tvf(arg1 => $sql9tableArg $sql9partition)"
+        checkError(
+          exception = parseException(sql9),
+          condition = "INVALID_SQL_SYNTAX.INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_PARTITIONING",
+          parameters = Map("clause" -> "ORDER BY"),
+          context = ExpectedContext(
+            fragment = s"$sql9tableArg $sql9partition",
+            start = 29,
+            stop = 99 + partition.length + order.length)
+        )
       }
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -1997,13 +1997,8 @@ class PlanParserSuite extends AnalysisTest {
         val sql8 = s"select * from my_tvf(arg1 => $sql8tableArg $sql8partition)"
         checkError(
           exception = parseException(sql8),
-          condition = "_LEGACY_ERROR_TEMP_0064",
-          parameters = Map(
-            "msg" ->
-              ("The table function call includes a table argument with an invalid " +
-              "partitioning/ordering specification: the PARTITION BY clause included multiple " +
-              "expressions without parentheses surrounding them; please add parentheses around " +
-              "these expressions and then retry the query again")),
+          condition = "INVALID_SQL_SYNTAX.INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_PARTITIONING",
+          parameters = Map("clause" -> "PARTITION BY"),
           context = ExpectedContext(
             fragment = s"$sql8tableArg $sql8partition",
             start = 29,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -432,15 +432,13 @@ class SparkSqlAstBuilder extends AstBuilder {
 
   private def extractUnquotedResourcePath(ctx: RefreshResourceContext): String = withOrigin(ctx) {
     val unquotedPath = remainder(ctx.REFRESH.getSymbol).trim
-    validate(
-      unquotedPath != null && !unquotedPath.isEmpty,
-      "Resource paths cannot be empty in REFRESH statements. Use / to match everything",
-      ctx)
+    if (unquotedPath == null || unquotedPath.isEmpty) {
+      throw QueryParsingErrors.emptyRefreshResourcePathError(ctx)
+    }
     val forbiddenSymbols = Seq(" ", "\n", "\r", "\t")
-    validate(
-      !forbiddenSymbols.exists(unquotedPath.contains(_)),
-      "REFRESH statements cannot contain ' ', '\\n', '\\r', '\\t' inside unquoted resource paths",
-      ctx)
+    if (forbiddenSymbols.exists(unquotedPath.contains(_))) {
+      throw QueryParsingErrors.invalidRefreshResourcePathError(ctx)
+    }
     unquotedPath
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -431,15 +431,13 @@ class SparkSqlAstBuilder extends AstBuilder {
 
   private def extractUnquotedResourcePath(ctx: RefreshResourceContext): String = withOrigin(ctx) {
     val unquotedPath = remainder(ctx.REFRESH.getSymbol).trim
-    validate(
-      unquotedPath != null && !unquotedPath.isEmpty,
-      "Resource paths cannot be empty in REFRESH statements. Use / to match everything",
-      ctx)
+    if (unquotedPath == null || unquotedPath.isEmpty) {
+      throw QueryParsingErrors.emptyRefreshResourcePathError(ctx)
+    }
     val forbiddenSymbols = Seq(" ", "\n", "\r", "\t")
-    validate(
-      !forbiddenSymbols.exists(unquotedPath.contains(_)),
-      "REFRESH statements cannot contain ' ', '\\n', '\\r', '\\t' inside unquoted resource paths",
-      ctx)
+    if (forbiddenSymbols.exists(unquotedPath.contains(_))) {
+      throw QueryParsingErrors.invalidRefreshResourcePathError(ctx)
+    }
     unquotedPath
   }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/ilike-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/ilike-all.sql.out
@@ -199,10 +199,8 @@ SELECT company FROM ilike_any_table WHERE company ILIKE ALL ()
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
-  "messageParameters" : {
-    "msg" : "Expected something between '(' and ')'."
-  },
+  "errorClass" : "INVALID_SQL_SYNTAX.EMPTY_QUANTIFIED_PATTERN",
+  "sqlState" : "42000",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/ilike-any.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/ilike-any.sql.out
@@ -199,10 +199,8 @@ SELECT company FROM ilike_any_table WHERE company ILIKE ANY ()
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
-  "messageParameters" : {
-    "msg" : "Expected something between '(' and ')'."
-  },
+  "errorClass" : "INVALID_SQL_SYNTAX.EMPTY_QUANTIFIED_PATTERN",
+  "sqlState" : "42000",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/like-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/like-all.sql.out
@@ -199,10 +199,8 @@ SELECT company FROM like_all_table WHERE company LIKE ALL ()
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
-  "messageParameters" : {
-    "msg" : "Expected something between '(' and ')'."
-  },
+  "errorClass" : "INVALID_SQL_SYNTAX.EMPTY_QUANTIFIED_PATTERN",
+  "sqlState" : "42000",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/like-any.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/like-any.sql.out
@@ -199,10 +199,8 @@ SELECT company FROM like_any_table WHERE company LIKE ANY ()
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
-  "messageParameters" : {
-    "msg" : "Expected something between '(' and ')'."
-  },
+  "errorClass" : "INVALID_SQL_SYNTAX.EMPTY_QUANTIFIED_PATTERN",
+  "sqlState" : "42000",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -2040,9 +2040,10 @@ table t
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
+  "errorClass" : "INVALID_TABLESAMPLE_FRACTION",
+  "sqlState" : "22023",
   "messageParameters" : {
-    "msg" : "Sampling fraction (-1.0) must be on interval [0, 1]"
+    "fraction" : "-1.0"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2105,9 +2106,10 @@ table t
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
+  "errorClass" : "INVALID_TABLESAMPLE_FRACTION",
+  "sqlState" : "22023",
   "messageParameters" : {
-    "msg" : "Sampling fraction (2.0) must be on interval [0, 1]"
+    "fraction" : "2.0"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/tablesample-negative.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/tablesample-negative.sql.out
@@ -26,9 +26,10 @@ SELECT mydb1.t1 FROM t1 TABLESAMPLE (-1 PERCENT)
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
+  "errorClass" : "INVALID_TABLESAMPLE_FRACTION",
+  "sqlState" : "22023",
   "messageParameters" : {
-    "msg" : "Sampling fraction (-0.01) must be on interval [0, 1]"
+    "fraction" : "-0.01"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -45,9 +46,10 @@ SELECT mydb1.t1 FROM t1 TABLESAMPLE (101 PERCENT)
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
+  "errorClass" : "INVALID_TABLESAMPLE_FRACTION",
+  "sqlState" : "22023",
   "messageParameters" : {
-    "msg" : "Sampling fraction (1.01) must be on interval [0, 1]"
+    "fraction" : "1.01"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/transform.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/transform.sql.out
@@ -495,9 +495,10 @@ SELECT a, b, decode(c, 'UTF-8'), d, e, f, g, h, i, j, k, l FROM (
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
+  "errorClass" : "INVALID_SQL_SYNTAX.UNSUPPORTED_ROW_FORMAT_LINES_TERMINATED_BY",
+  "sqlState" : "42000",
   "messageParameters" : {
-    "msg" : "LINES TERMINATED BY only supports newline '\\n' right now: @"
+    "value" : "@"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udf/udf-window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udf/udf-window.sql.out
@@ -332,10 +332,8 @@ RANGE BETWEEN CURRENT ROW AND current_date PRECEDING) FROM testData ORDER BY cat
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
-  "messageParameters" : {
-    "msg" : "Frame bound value must be a literal."
-  },
+  "errorClass" : "INVALID_SQL_SYNTAX.INVALID_WINDOW_FRAME_BOUND",
+  "sqlState" : "42000",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/window.sql.out
@@ -529,10 +529,8 @@ RANGE BETWEEN CURRENT ROW AND current_date PRECEDING) FROM testData ORDER BY cat
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
-  "messageParameters" : {
-    "msg" : "Frame bound value must be a literal."
-  },
+  "errorClass" : "INVALID_SQL_SYNTAX.INVALID_WINDOW_FRAME_BOUND",
+  "sqlState" : "42000",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/ilike-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ilike-all.sql.out
@@ -130,10 +130,8 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
-  "messageParameters" : {
-    "msg" : "Expected something between '(' and ')'."
-  },
+  "errorClass" : "INVALID_SQL_SYNTAX.EMPTY_QUANTIFIED_PATTERN",
+  "sqlState" : "42000",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/ilike-any.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ilike-any.sql.out
@@ -136,10 +136,8 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
-  "messageParameters" : {
-    "msg" : "Expected something between '(' and ')'."
-  },
+  "errorClass" : "INVALID_SQL_SYNTAX.EMPTY_QUANTIFIED_PATTERN",
+  "sqlState" : "42000",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/like-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/like-all.sql.out
@@ -130,10 +130,8 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
-  "messageParameters" : {
-    "msg" : "Expected something between '(' and ')'."
-  },
+  "errorClass" : "INVALID_SQL_SYNTAX.EMPTY_QUANTIFIED_PATTERN",
+  "sqlState" : "42000",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/like-any.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/like-any.sql.out
@@ -136,10 +136,8 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
-  "messageParameters" : {
-    "msg" : "Expected something between '(' and ')'."
-  },
+  "errorClass" : "INVALID_SQL_SYNTAX.EMPTY_QUANTIFIED_PATTERN",
+  "sqlState" : "42000",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
@@ -1951,9 +1951,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
+  "errorClass" : "INVALID_TABLESAMPLE_FRACTION",
+  "sqlState" : "22023",
   "messageParameters" : {
-    "msg" : "Sampling fraction (-1.0) must be on interval [0, 1]"
+    "fraction" : "-1.0"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2022,9 +2023,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
+  "errorClass" : "INVALID_TABLESAMPLE_FRACTION",
+  "sqlState" : "22023",
   "messageParameters" : {
-    "msg" : "Sampling fraction (2.0) must be on interval [0, 1]"
+    "fraction" : "2.0"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/tablesample-negative.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/tablesample-negative.sql.out
@@ -30,9 +30,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
+  "errorClass" : "INVALID_TABLESAMPLE_FRACTION",
+  "sqlState" : "22023",
   "messageParameters" : {
-    "msg" : "Sampling fraction (-0.01) must be on interval [0, 1]"
+    "fraction" : "-0.01"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -51,9 +52,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
+  "errorClass" : "INVALID_TABLESAMPLE_FRACTION",
+  "sqlState" : "22023",
   "messageParameters" : {
-    "msg" : "Sampling fraction (1.01) must be on interval [0, 1]"
+    "fraction" : "1.01"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/transform.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/transform.sql.out
@@ -401,9 +401,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
+  "errorClass" : "INVALID_SQL_SYNTAX.UNSUPPORTED_ROW_FORMAT_LINES_TERMINATED_BY",
+  "sqlState" : "42000",
   "messageParameters" : {
-    "msg" : "LINES TERMINATED BY only supports newline '\\n' right now: @"
+    "value" : "@"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-window.sql.out
@@ -326,10 +326,8 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
-  "messageParameters" : {
-    "msg" : "Frame bound value must be a literal."
-  },
+  "errorClass" : "INVALID_SQL_SYNTAX.INVALID_WINDOW_FRAME_BOUND",
+  "sqlState" : "42000",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/window.sql.out
@@ -504,10 +504,8 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0064",
-  "messageParameters" : {
-    "msg" : "Frame bound value must be a literal."
-  },
+  "errorClass" : "INVALID_SQL_SYNTAX.INVALID_WINDOW_FRAME_BOUND",
+  "sqlState" : "42000",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/scala/org/apache/spark/sql/LateralColumnAliasSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/LateralColumnAliasSuite.scala
@@ -1022,8 +1022,8 @@ class LateralColumnAliasSuite extends LateralColumnAliasSuiteBase {
           "(partition by dept order by salary rows between n preceding and current row) as rank " +
           s"from $testTable where dept in (1, 6)")
       },
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> "Frame bound value must be a literal."),
+      condition = "INVALID_SQL_SYNTAX.INVALID_WINDOW_FRAME_BOUND",
+      parameters = Map.empty,
       context = ExpectedContext(fragment = "n preceding", start = 87, stop = 97)
     )
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -421,13 +421,11 @@ class SparkSqlParserSuite extends AnalysisTest with SharedSparkSession {
     assertEqual("REFRESH \'path with space\'", RefreshResource("path with space"))
     assertEqual("REFRESH \"path with space 2\"", RefreshResource("path with space 2"))
 
-    val errMsg1 =
-      "REFRESH statements cannot contain ' ', '\\n', '\\r', '\\t' inside unquoted resource paths"
     val sql1 = "REFRESH a b"
     checkError(
       exception = parseException(sql1),
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> errMsg1),
+      condition = "INVALID_SQL_SYNTAX.INVALID_REFRESH_RESOURCE_PATH",
+      parameters = Map.empty,
       context = ExpectedContext(
         fragment = sql1,
         start = 0,
@@ -436,8 +434,8 @@ class SparkSqlParserSuite extends AnalysisTest with SharedSparkSession {
     val sql2 = "REFRESH a\tb"
     checkError(
       exception = parseException(sql2),
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> errMsg1),
+      condition = "INVALID_SQL_SYNTAX.INVALID_REFRESH_RESOURCE_PATH",
+      parameters = Map.empty,
       context = ExpectedContext(
         fragment = sql2,
         start = 0,
@@ -446,8 +444,8 @@ class SparkSqlParserSuite extends AnalysisTest with SharedSparkSession {
     val sql3 = "REFRESH a\nb"
     checkError(
       exception = parseException(sql3),
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> errMsg1),
+      condition = "INVALID_SQL_SYNTAX.INVALID_REFRESH_RESOURCE_PATH",
+      parameters = Map.empty,
       context = ExpectedContext(
         fragment = sql3,
         start = 0,
@@ -456,8 +454,8 @@ class SparkSqlParserSuite extends AnalysisTest with SharedSparkSession {
     val sql4 = "REFRESH a\rb"
     checkError(
       exception = parseException(sql4),
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> errMsg1),
+      condition = "INVALID_SQL_SYNTAX.INVALID_REFRESH_RESOURCE_PATH",
+      parameters = Map.empty,
       context = ExpectedContext(
         fragment = sql4,
         start = 0,
@@ -466,8 +464,8 @@ class SparkSqlParserSuite extends AnalysisTest with SharedSparkSession {
     val sql5 = "REFRESH a\r\nb"
     checkError(
       exception = parseException(sql5),
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> errMsg1),
+      condition = "INVALID_SQL_SYNTAX.INVALID_REFRESH_RESOURCE_PATH",
+      parameters = Map.empty,
       context = ExpectedContext(
         fragment = sql5,
         start = 0,
@@ -476,19 +474,18 @@ class SparkSqlParserSuite extends AnalysisTest with SharedSparkSession {
     val sql6 = "REFRESH @ $a$"
     checkError(
       exception = parseException(sql6),
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> errMsg1),
+      condition = "INVALID_SQL_SYNTAX.INVALID_REFRESH_RESOURCE_PATH",
+      parameters = Map.empty,
       context = ExpectedContext(
         fragment = sql6,
         start = 0,
         stop = 12))
 
-    val errMsg2 = "Resource paths cannot be empty in REFRESH statements. Use / to match everything"
     val sql7 = "REFRESH  "
     checkError(
       exception = parseException(sql7),
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> errMsg2),
+      condition = "INVALID_SQL_SYNTAX.EMPTY_REFRESH_RESOURCE_PATH",
+      parameters = Map.empty,
       context = ExpectedContext(
         fragment = "REFRESH",
         start = 0,
@@ -497,8 +494,8 @@ class SparkSqlParserSuite extends AnalysisTest with SharedSparkSession {
     val sql8 = "REFRESH"
     checkError(
       exception = parseException(sql8),
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> errMsg2),
+      condition = "INVALID_SQL_SYNTAX.EMPTY_REFRESH_RESOURCE_PATH",
+      parameters = Map.empty,
       context = ExpectedContext(
         fragment = sql8,
         start = 0,
@@ -745,7 +742,6 @@ class SparkSqlParserSuite extends AnalysisTest with SharedSparkSession {
   test("SPARK-32607: Script Transformation ROW FORMAT DELIMITED" +
     " `TOK_TABLEROWFORMATLINES` only support '\\n'") {
 
-    val errMsg = "LINES TERMINATED BY only supports newline '\\n' right now: @"
     // test input format TOK_TABLEROWFORMATLINES
     val sql1 =
       s"""SELECT TRANSFORM(a, b, c, d, e)
@@ -761,8 +757,8 @@ class SparkSqlParserSuite extends AnalysisTest with SharedSparkSession {
          |FROM v""".stripMargin
     checkError(
       exception = parseException(sql1),
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> errMsg),
+      condition = "INVALID_SQL_SYNTAX.UNSUPPORTED_ROW_FORMAT_LINES_TERMINATED_BY",
+      parameters = Map("value" -> "@"),
       context = ExpectedContext(
         fragment = sql1,
         start = 0,
@@ -783,8 +779,8 @@ class SparkSqlParserSuite extends AnalysisTest with SharedSparkSession {
          |FROM v""".stripMargin
     checkError(
       exception = parseException(sql2),
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" -> errMsg),
+      condition = "INVALID_SQL_SYNTAX.UNSUPPORTED_ROW_FORMAT_LINES_TERMINATED_BY",
+      parameters = Map("value" -> "@"),
       context = ExpectedContext(
         fragment = sql2,
         start = 0,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
@@ -410,12 +410,8 @@ class PythonUDTFSuite extends SharedSparkSession {
           |  WITH SINGLE PARTITION
           |  ORDER BY device_id, data_ds)
           |""".stripMargin)),
-      condition = "_LEGACY_ERROR_TEMP_0064",
-      parameters = Map("msg" ->
-        ("The table function call includes a table argument with an invalid " +
-          "partitioning/ordering specification: the ORDER BY clause included multiple " +
-          "expressions without parentheses surrounding them; please add parentheses around these " +
-          "expressions and then retry the query again")),
+      condition = "INVALID_SQL_SYNTAX.INVALID_TABLE_FUNCTION_TABLE_ARGUMENT_PARTITIONING",
+      parameters = Map("clause" -> "ORDER BY"),
       context = ExpectedContext(
         fragment = "TABLE(SELECT 1 AS device_id, 2 AS data_ds)\n  " +
           "WITH SINGLE PARTITION\n  " +


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This PR removes the remaining use of `_LEGACY_ERROR_TEMP_0064` from parser validation paths that depended on `ParserUtils.validate(...)` ([SPARK-56638](https://issues.apache.org/jira/browse/SPARK-56638)).

Specifically, this PR:
- Adds named parser error conditions for the affected validation failures
- Adds corresponding `QueryParsingErrors` helpers
- Replaces `ParserUtils.validate(...)` call sites with specific parser errors
- Removes `ParserUtils.validate(...)`
- Updates parser tests and SQL golden files to assert the new error classes

This includes the `TABLESAMPLE` fraction validation path, covering both existing `TABLESAMPLE` syntax and `TABLESAMPLE SYSTEM` from [#54972](https://github.com/apache/spark/pull/54972).

### Why are the changes needed?

`ParserUtils.validate(...)` always threw `_LEGACY_ERROR_TEMP_0064`, which made different parser validation failures share the same generic legacy error class.

Using named error classes makes each parser failure explicit and removes this legacy temporary error from the affected parser paths.

`INVALID_TABLESAMPLE_FRACTION` uses SQLSTATE `22023` because the statement is syntactically valid, but the supplied sampling fraction is invalid/out of range. The other parser syntax validation errors are added under `INVALID_SQL_SYNTAX`, which uses SQLSTATE `42000`.

### Does this PR introduce _any_ user-facing change?

Yes. The error class changes from `_LEGACY_ERROR_TEMP_0064` to named error classes for the affected parser validation failures.

For invalid `TABLESAMPLE` fractions, the new error class is `INVALID_TABLESAMPLE_FRACTION`.

### How was this patch tested?

```bash
build/sbt 'catalyst / Test / testOnly org.apache.spark.sql.catalyst.parser.PlanParserSuite -- -z "sampled relations"'
build/sbt 'catalyst / Test / testOnly org.apache.spark.sql.catalyst.parser.PlanParserSuite -- -z "TABLESAMPLE SYSTEM - fraction out of range"'

SPARK_GENERATE_GOLDEN_FILES=1 build/sbt 'sql / Test / testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z "tablesample-negative.sql"'
SPARK_GENERATE_GOLDEN_FILES=1 build/sbt 'sql / Test / testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z "pipe-operators.sql"'
build/sbt 'sql / Test / testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z "tablesample-negative.sql"' 'sql / Test / testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z "pipe-operators.sql"'
```

### Was this patch authored or co-authored using generative AI tooling?
Yes. Generated-by: OpenAI GPT-5.5 Codex