### PR TITLE
[SPARK-55294][PYTHON] Add support for PyArrow-backed dtypes in pandas API

### DIFF
--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -55,7 +55,10 @@ from pyspark.pandas.internal import (
     SPARK_DEFAULT_INDEX_NAME,
 )
 from pyspark.pandas.spark.accessors import SparkIndexOpsMethods
-from pyspark.pandas.typedef.typehints import handle_dtype_as_extension_dtype
+from pyspark.pandas.typedef.typehints import (
+    handle_dtype_as_extension_dtype,
+    is_pyarrow_backed_dtype,
+)
 from pyspark.pandas.utils import (
     ansi_mode_context,
     combine_frames,
@@ -247,6 +250,7 @@ def column_op(f: Callable[..., Column]) -> Callable[..., SeriesOrIndex]:
                 use_extension_dtypes=any(
                     handle_dtype_as_extension_dtype(col.dtype) for col in [self] + cols
                 ),
+                use_arrow_dtypes=any(is_pyarrow_backed_dtype(col.dtype) for col in [self] + cols),
             )
 
             if not field.is_extension_dtype:

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -47,22 +47,15 @@ from pyspark.sql.types import (
 )
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.typedef.typehints import (
-    extension_dtypes_available,
-    extension_float_dtypes_available,
     extension_object_dtypes_available,
     handle_dtype_as_extension_dtype,
+    is_pyarrow_backed_dtype,
     is_str_dtype,
     spark_type_to_pandas_dtype,
 )
 
-if extension_dtypes_available:
-    from pandas import Int8Dtype, Int16Dtype, Int32Dtype, Int64Dtype
-
-if extension_float_dtypes_available:
-    from pandas import Float32Dtype, Float64Dtype
-
 if extension_object_dtypes_available:
-    from pandas import BooleanDtype, StringDtype
+    from pandas import StringDtype
 
 
 def is_valid_operand_for_numeric_arithmetic(operand: Any, *, allow_bool: bool = True) -> bool:
@@ -98,7 +91,9 @@ def transform_boolean_operand_to_numeric(
         assert spark_type, "spark_type must be provided if the operand is a boolean IndexOpsMixin"
         assert isinstance(spark_type, NumericType), "spark_type must be NumericType"
         dtype = spark_type_to_pandas_dtype(
-            spark_type, use_extension_dtypes=operand._internal.data_fields[0].is_extension_dtype
+            spark_type,
+            use_extension_dtypes=operand._internal.data_fields[0].is_extension_dtype,
+            use_arrow_dtypes=is_pyarrow_backed_dtype(operand.dtype),
         )
         return operand._with_new_scol(
             operand.spark.column.cast(spark_type),
@@ -284,17 +279,12 @@ class DataTypeOps(object, metaclass=ABCMeta):
         elif isinstance(spark_type, DecimalType):
             return object.__new__(DecimalOps)
         elif isinstance(spark_type, FractionalType):
-            if extension_float_dtypes_available and type(dtype) in [Float32Dtype, Float64Dtype]:
+            if handle_dtype_as_extension_dtype(dtype):
                 return object.__new__(FractionalExtensionOps)
             else:
                 return object.__new__(FractionalOps)
         elif isinstance(spark_type, IntegralType):
-            if extension_dtypes_available and type(dtype) in [
-                Int8Dtype,
-                Int16Dtype,
-                Int32Dtype,
-                Int64Dtype,
-            ]:
+            if handle_dtype_as_extension_dtype(dtype):
                 return object.__new__(IntegralExtensionOps)
             else:
                 return object.__new__(IntegralOps)
@@ -307,7 +297,7 @@ class DataTypeOps(object, metaclass=ABCMeta):
             else:
                 return object.__new__(StringOps)
         elif isinstance(spark_type, BooleanType):
-            if extension_object_dtypes_available and isinstance(dtype, BooleanDtype):
+            if handle_dtype_as_extension_dtype(dtype):
                 return object.__new__(BooleanExtensionOps)
             else:
                 return object.__new__(BooleanOps)
@@ -427,7 +417,22 @@ class DataTypeOps(object, metaclass=ABCMeta):
         from pyspark.pandas.base import IndexOpsMixin
 
         if _should_return_all_false(left, right):
-            left_scol = left._with_new_scol(F.lit(False))
+            use_extension_dtypes = handle_dtype_as_extension_dtype(left.dtype) or (
+                isinstance(right, IndexOpsMixin) and handle_dtype_as_extension_dtype(right.dtype)
+            )
+            use_arrow_dtypes = is_pyarrow_backed_dtype(left.dtype) or (
+                isinstance(right, IndexOpsMixin) and is_pyarrow_backed_dtype(right.dtype)
+            )
+            field = left._internal.data_fields[0].copy(
+                dtype=spark_type_to_pandas_dtype(
+                    BooleanType(),
+                    use_extension_dtypes=use_extension_dtypes,
+                    use_arrow_dtypes=use_arrow_dtypes,
+                ),
+                spark_type=BooleanType(),
+                nullable=False,
+            )
+            left_scol = left._with_new_scol(F.lit(False), field=field)
             if isinstance(right, IndexOpsMixin):
                 return left_scol.rename(None)  # type: ignore[attr-defined]
             else:
@@ -510,12 +515,20 @@ class DataTypeOps(object, metaclass=ABCMeta):
                 index_spark_columns=index_spark_columns,
                 data_spark_columns=data_spark_columns,
                 index_fields=[
-                    InternalField.from_struct_field(index_field)
-                    for index_field in sdf_new.select(index_spark_columns).schema.fields
+                    InternalField.from_struct_field(
+                        index_field,
+                        use_extension_dtypes=field.is_extension_dtype,
+                        use_arrow_dtypes=is_pyarrow_backed_dtype(field.dtype),
+                    )
+                    for index_field, field in zip(
+                        sdf_new.select(index_spark_columns).schema.fields,
+                        left._internal.index_fields,
+                    )
                 ],
                 data_fields=[
                     InternalField.from_struct_field(
-                        sdf_new.select(data_spark_columns).schema.fields[0]
+                        sdf_new.select(data_spark_columns).schema.fields[0],
+                        use_arrow_dtypes=is_pyarrow_backed_dtype(left.dtype),
                     )
                 ],
             )
@@ -531,7 +544,22 @@ class DataTypeOps(object, metaclass=ABCMeta):
         _sanitize_list_like(right)
 
         if _should_return_all_false(left, right):
-            left_scol = left._with_new_scol(F.lit(True))
+            use_extension_dtypes = handle_dtype_as_extension_dtype(left.dtype) or (
+                isinstance(right, IndexOpsMixin) and handle_dtype_as_extension_dtype(right.dtype)
+            )
+            use_arrow_dtypes = is_pyarrow_backed_dtype(left.dtype) or (
+                isinstance(right, IndexOpsMixin) and is_pyarrow_backed_dtype(right.dtype)
+            )
+            field = left._internal.data_fields[0].copy(
+                dtype=spark_type_to_pandas_dtype(
+                    BooleanType(),
+                    use_extension_dtypes=use_extension_dtypes,
+                    use_arrow_dtypes=use_arrow_dtypes,
+                ),
+                spark_type=BooleanType(),
+                nullable=False,
+            )
+            left_scol = left._with_new_scol(F.lit(True), field=field)
             if isinstance(right, IndexOpsMixin):
                 return left_scol.rename(None)  # type: ignore[attr-defined]
             else:

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -43,6 +43,7 @@ from pyspark.pandas.internal import (
     SPARK_DEFAULT_SERIES_NAME,
 )
 from pyspark.pandas.exceptions import SparkPandasIndexingError, SparkPandasNotImplementedError
+from pyspark.pandas.typedef.typehints import is_pyarrow_backed_dtype
 from pyspark.pandas.utils import (
     is_name_like_tuple,
     is_name_like_value,
@@ -802,6 +803,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
                         new_field = InternalField.from_struct_field(
                             self._internal.spark_frame.select(new_scol).schema[0],
                             use_extension_dtypes=new_field.is_extension_dtype,
+                            use_arrow_dtypes=is_pyarrow_backed_dtype(new_field.dtype),
                         )
                         break
                 new_data_spark_columns.append(new_scol)

--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -101,7 +101,10 @@ class InternalField:
 
     @staticmethod
     def from_struct_field(
-        struct_field: StructField, *, use_extension_dtypes: bool = False
+        struct_field: StructField,
+        *,
+        use_extension_dtypes: bool = False,
+        use_arrow_dtypes: bool = False,
     ) -> "InternalField":
         """
         Returns a new InternalField object created from the given StructField.
@@ -114,6 +117,8 @@ class InternalField:
             The StructField used to create a new InternalField object.
         use_extension_dtypes : bool
             If True, try to use the extension dtypes.
+        use_arrow_dtypes : bool
+            If True, try to use the pyarrow-backed dtypes.
 
         Returns
         -------
@@ -121,7 +126,9 @@ class InternalField:
         """
         return InternalField(
             dtype=spark_type_to_pandas_dtype(
-                struct_field.dataType, use_extension_dtypes=use_extension_dtypes
+                struct_field.dataType,
+                use_extension_dtypes=use_extension_dtypes,
+                use_arrow_dtypes=use_arrow_dtypes,
             ),
             struct_field=struct_field,
         )

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -22,10 +22,14 @@ import pandas as pd
 from pandas.api.types import CategoricalDtype
 
 from pyspark import pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.pandas.config import option_context
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
-from pyspark.pandas.typedef.typehints import extension_object_dtypes_available
+from pyspark.pandas.typedef.typehints import (
+    extension_arrow_dtypes_available,
+    extension_object_dtypes_available,
+)
 
 if extension_object_dtypes_available:
     from pandas import StringDtype
@@ -348,6 +352,29 @@ class StringExtensionOpsTestsMixin:
                 self.pser >= self.other_pser, (self.psser >= self.other_psser).sort_index()
             )
             self.check_extension(self.pser >= self.pser, (self.psser >= self.psser).sort_index())
+
+    @unittest.skipIf(
+        not extension_arrow_dtypes_available
+        or LooseVersion(pd.__version__) < LooseVersion("3.0.0"),
+        "PyArrow-backed string dtype support requires pandas 3 and pyarrow",
+    )
+    def test_pyarrow_backed_string_comparisons(self):
+        import pyarrow as pa
+
+        pser = pd.Series(["x", "y", "z", None], dtype="string")
+        other_pser = pd.Series([None, "z", "y", "x"], dtype="string")
+        psser = ps.from_pandas(pser)
+        other_psser = ps.from_pandas(other_pser)
+
+        with option_context("compute.ops_on_diff_frames", True):
+            expected = (pser == other_pser) | (pser == pser)
+            actual = ((psser == other_psser) | (psser == psser)).sort_index().to_pandas()
+
+        self.assertIsInstance(expected.dtype, pd.ArrowDtype)
+        self.assertEqual(expected.dtype.pyarrow_dtype, pa.bool_())
+        self.assertIsInstance(actual.dtype, pd.ArrowDtype)
+        self.assertEqual(actual.dtype.pyarrow_dtype, pa.bool_())
+        self.assert_eq(expected, actual)
 
 
 class StringExtensionOpsTests(

--- a/python/pyspark/pandas/tests/test_typedef.py
+++ b/python/pyspark/pandas/tests/test_typedef.py
@@ -50,8 +50,11 @@ from pyspark.pandas.typedef import (
     extension_float_dtypes_available,
     extension_object_dtypes_available,
     infer_return_type,
+    is_pyarrow_backed_dtype,
     pandas_on_spark_type,
+    spark_type_to_pandas_dtype,
 )
+from pyspark.pandas.typedef.typehints import extension_arrow_dtypes_available
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 
@@ -475,6 +478,112 @@ class TypeHintTestsMixin:
         for extension_dtype, spark_type in type_mapper.items():
             self.assertEqual(as_spark_type(extension_dtype), spark_type)
             self.assertEqual(pandas_on_spark_type(extension_dtype), (extension_dtype, spark_type))
+
+    @unittest.skipIf(
+        not extension_arrow_dtypes_available, "PyArrow-backed dtypes are not available"
+    )
+    def test_as_spark_type_pyarrow_dtypes(self):
+        from pandas import ArrowDtype
+        import pyarrow as pa
+
+        type_mapper = {
+            ArrowDtype(pa.string()): StringType(),
+            ArrowDtype(pa.large_string()): StringType(),
+            ArrowDtype(pa.bool_()): BooleanType(),
+            ArrowDtype(pa.int8()): ByteType(),
+            ArrowDtype(pa.int16()): ShortType(),
+            ArrowDtype(pa.int32()): IntegerType(),
+            ArrowDtype(pa.int64()): LongType(),
+            ArrowDtype(pa.float32()): FloatType(),
+            ArrowDtype(pa.float64()): DoubleType(),
+        }
+
+        for arrow_dtype, spark_type in type_mapper.items():
+            self.assertEqual(as_spark_type(arrow_dtype), spark_type)
+            self.assertEqual(pandas_on_spark_type(arrow_dtype), (arrow_dtype, spark_type))
+
+    @unittest.skipIf(
+        not extension_arrow_dtypes_available, "PyArrow-backed dtypes are not available"
+    )
+    def test_spark_type_to_pandas_dtype_with_arrow_flag(self):
+        from pandas import ArrowDtype
+        import pyarrow as pa
+
+        type_mapper = {
+            BooleanType(): pa.bool_(),
+            ByteType(): pa.int8(),
+            ShortType(): pa.int16(),
+            IntegerType(): pa.int32(),
+            LongType(): pa.int64(),
+            FloatType(): pa.float32(),
+            DoubleType(): pa.float64(),
+        }
+
+        for spark_type, pyarrow_type in type_mapper.items():
+            result = spark_type_to_pandas_dtype(spark_type, use_arrow_dtypes=True)
+            self.assertEqual(result, ArrowDtype(pyarrow_type))
+
+    @unittest.skipIf(
+        not extension_object_dtypes_available, "The pandas extension object types are not available"
+    )
+    def test_spark_type_to_pandas_dtype_string(self):
+        result = spark_type_to_pandas_dtype(StringType(), use_extension_dtypes=True)
+        self.assertEqual(result, pd.StringDtype())
+
+        if LooseVersion(pd.__version__) >= LooseVersion("3.0.0"):
+            result = spark_type_to_pandas_dtype(StringType())
+            self.assertEqual(result, pd.StringDtype(na_value=np.nan))
+
+            if extension_arrow_dtypes_available:
+                result = spark_type_to_pandas_dtype(
+                    StringType(), use_extension_dtypes=True, use_arrow_dtypes=True
+                )
+                self.assertEqual(result, pd.StringDtype())
+
+    @unittest.skipIf(
+        not extension_arrow_dtypes_available, "PyArrow-backed dtypes are not available"
+    )
+    def test_is_str_dtype_with_pyarrow(self):
+        from pandas import ArrowDtype
+        import pyarrow as pa
+        from pyspark.pandas.typedef import is_str_dtype
+
+        if LooseVersion(pd.__version__) < LooseVersion("3.0.0"):
+            self.skipTest("PyArrow-backed string dtype support requires pandas 3")
+
+        arrow_string_dtype = ArrowDtype(pa.string())
+        self.assertTrue(is_str_dtype(arrow_string_dtype))
+
+        arrow_large_string_dtype = ArrowDtype(pa.large_string())
+        self.assertTrue(is_str_dtype(arrow_large_string_dtype))
+
+        arrow_int_dtype = ArrowDtype(pa.int64())
+        self.assertFalse(is_str_dtype(arrow_int_dtype))
+
+        arrow_bool_dtype = ArrowDtype(pa.bool_())
+        self.assertFalse(is_str_dtype(arrow_bool_dtype))
+
+    @unittest.skipIf(
+        not extension_arrow_dtypes_available, "PyArrow-backed dtypes are not available"
+    )
+    def test_is_pyarrow_backed_dtype(self):
+        from pandas import ArrowDtype
+        import pyarrow as pa
+
+        if LooseVersion(pd.__version__) < LooseVersion("3.0.0"):
+            self.skipTest("PyArrow-backed string dtype support requires pandas 3")
+
+        self.assertTrue(is_pyarrow_backed_dtype(ArrowDtype(pa.bool_())))
+        self.assertTrue(is_pyarrow_backed_dtype(ArrowDtype(pa.int64())))
+
+        pyarrow_string_dtype = pd.StringDtype()
+        self.assertTrue(is_pyarrow_backed_dtype(pyarrow_string_dtype))
+
+        pyarrow_str_dtype = pd.StringDtype(storage="pyarrow", na_value=np.nan)
+        self.assertFalse(is_pyarrow_backed_dtype(pyarrow_str_dtype))
+
+        python_string_dtype = pd.StringDtype(storage="python", na_value=np.nan)
+        self.assertFalse(is_pyarrow_backed_dtype(python_string_dtype))
 
 
 class TypeHintTests(TypeHintTestsMixin, PandasOnSparkTestCase):

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -57,10 +57,18 @@ try:
     except ImportError:
         extension_float_dtypes_available = False
 
+    try:
+        from pandas import ArrowDtype
+
+        extension_arrow_dtypes_available = True
+    except ImportError:
+        extension_arrow_dtypes_available = False
+
 except ImportError:
     extension_dtypes_available = False
     extension_object_dtypes_available = False
     extension_float_dtypes_available = False
+    extension_arrow_dtypes_available = False
     extension_dtypes = ()
 
 import pyarrow as pa
@@ -246,6 +254,24 @@ def as_spark_type(
                 return types.FloatType()
             elif isinstance(tpe, Float64Dtype) or (isinstance(tpe, str) and tpe == "Float64"):
                 return types.DoubleType()
+        if extension_arrow_dtypes_available and isinstance(tpe, ArrowDtype):
+            pyarrow_type = tpe.pyarrow_dtype
+            if pa.types.is_string(pyarrow_type) or pa.types.is_large_string(pyarrow_type):
+                return types.StringType()
+            elif pa.types.is_boolean(pyarrow_type):
+                return types.BooleanType()
+            elif pa.types.is_int8(pyarrow_type):
+                return types.ByteType()
+            elif pa.types.is_int16(pyarrow_type):
+                return types.ShortType()
+            elif pa.types.is_int32(pyarrow_type):
+                return types.IntegerType()
+            elif pa.types.is_int64(pyarrow_type):
+                return types.LongType()
+            elif pa.types.is_float32(pyarrow_type):
+                return types.FloatType()
+            elif pa.types.is_float64(pyarrow_type):
+                return types.DoubleType()
 
     if raise_error:
         raise TypeError("Type %s was not understood." % tpe)
@@ -254,9 +280,28 @@ def as_spark_type(
 
 
 def spark_type_to_pandas_dtype(
-    spark_type: types.DataType, *, use_extension_dtypes: bool = False
+    spark_type: types.DataType,
+    *,
+    use_extension_dtypes: bool = False,
+    use_arrow_dtypes: bool = False,
 ) -> Dtype:
     """Return the given Spark DataType to pandas dtype."""
+
+    if use_arrow_dtypes and extension_arrow_dtypes_available:
+        if isinstance(spark_type, types.BooleanType):
+            return ArrowDtype(pa.bool_())
+        elif isinstance(spark_type, types.ByteType):
+            return ArrowDtype(pa.int8())
+        elif isinstance(spark_type, types.ShortType):
+            return ArrowDtype(pa.int16())
+        elif isinstance(spark_type, types.IntegerType):
+            return ArrowDtype(pa.int32())
+        elif isinstance(spark_type, types.LongType):
+            return ArrowDtype(pa.int64())
+        elif isinstance(spark_type, types.FloatType):
+            return ArrowDtype(pa.float32())
+        elif isinstance(spark_type, types.DoubleType):
+            return ArrowDtype(pa.float64())
 
     if use_extension_dtypes and extension_dtypes_available:
         # IntegralType
@@ -329,14 +374,31 @@ def spark_type_to_pandas_dtype(
 def is_str_dtype(tpe: Dtype) -> bool:
     if LooseVersion(pd.__version__) < "3.0.0":
         return False
+    if extension_arrow_dtypes_available and isinstance(tpe, ArrowDtype):
+        pyarrow_type = tpe.pyarrow_dtype
+        if pa.types.is_string(pyarrow_type) or pa.types.is_large_string(pyarrow_type):
+            return True
     if extension_object_dtypes_available:
         return isinstance(tpe, StringDtype) and tpe.na_value is np.nan
+    return False
+
+
+def is_pyarrow_backed_dtype(tpe: Dtype) -> bool:
+    if extension_arrow_dtypes_available and isinstance(tpe, ArrowDtype):
+        return True
+
+    if extension_object_dtypes_available and isinstance(tpe, StringDtype):
+        storage = getattr(tpe, "storage", None)
+        return isinstance(storage, str) and storage.startswith("pyarrow") and tpe.na_value is pd.NA
+
     return False
 
 
 def handle_dtype_as_extension_dtype(tpe: Dtype) -> bool:
     if is_str_dtype(tpe):
         return False
+    if extension_arrow_dtypes_available and isinstance(tpe, ArrowDtype):
+        return True
     else:
         return isinstance(tpe, extension_dtypes)
 

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -54,7 +54,7 @@ from pyspark.pandas._typing import (
     Name,
     DataFrameOrSeries,
 )
-from pyspark.pandas.typedef.typehints import as_spark_type
+from pyspark.pandas.typedef.typehints import as_spark_type, is_pyarrow_backed_dtype
 
 if TYPE_CHECKING:
     from pyspark.pandas.indexes.base import Index
@@ -218,6 +218,7 @@ def combine_frames(
         # If the same named index is found, that's used.
         index_column_names = []
         index_use_extension_dtypes = []
+        index_use_arrow_dtypes = []
         for (
             i,
             ((this_column, this_name, this_field), (that_column, that_name, that_field)),
@@ -234,6 +235,9 @@ def combine_frames(
                 index_column_names.append(column_name)
                 index_use_extension_dtypes.append(
                     any(field.is_extension_dtype for field in [this_field, that_field])
+                )
+                index_use_arrow_dtypes.append(
+                    any(is_pyarrow_backed_dtype(field.dtype) for field in [this_field, that_field])
                 )
                 merged_index_scols.append(
                     F.when(this_scol.isNotNull(), this_scol).otherwise(that_scol).alias(column_name)
@@ -275,14 +279,22 @@ def combine_frames(
         schema = joined_df.select(*index_spark_columns, *new_data_columns).schema
 
         index_fields = [
-            InternalField.from_struct_field(struct_field, use_extension_dtypes=use_extension_dtypes)
-            for struct_field, use_extension_dtypes in zip(
-                schema.fields[: len(index_spark_columns)], index_use_extension_dtypes
+            InternalField.from_struct_field(
+                struct_field,
+                use_extension_dtypes=use_extension_dtypes,
+                use_arrow_dtypes=use_arrow_dtypes,
+            )
+            for struct_field, use_extension_dtypes, use_arrow_dtypes in zip(
+                schema.fields[: len(index_spark_columns)],
+                index_use_extension_dtypes,
+                index_use_arrow_dtypes,
             )
         ]
         data_fields = [
             InternalField.from_struct_field(
-                struct_field, use_extension_dtypes=field.is_extension_dtype
+                struct_field,
+                use_extension_dtypes=field.is_extension_dtype,
+                use_arrow_dtypes=is_pyarrow_backed_dtype(field.dtype),
             )
             for struct_field, field in zip(
                 schema.fields[len(index_spark_columns) :],


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?


This PR adds support for PyArrow-backed dtypes (e.g., bool[pyarrow]) in PySpark's pandas API. The changes include:
- Type detection and conversion: Added is_pyarrow_backed_dtype() function to detect PyArrow-backed dtypes and enhanced as_spark_type() to convert them to appropriate Spark types.
- Dtype preservation: Enhanced spark_type_to_pandas_dtype() with a use_arrow_dtypes parameter to preserve PyArrow dtypes when converting from Spark types back to pandas dtypes.
- Propagation through operations: Updated comparison operators in data_type_ops/base.py to preserve PyArrow dtypes in results, and propagated the use_arrow_dtypes parameter through InternalField.from_struct_field() and related code paths.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?

Starting with pandas 3.0, when PyArrow is installed, pandas automatically uses PyArrow-backed dtypes for string columns. Without this PR, PySpark's pandas API loses dtype information when working with PyArrow-backed dtypes

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?

Yes. Users working with PyArrow-backed dtypes will now see their dtypes preserved through PySpark operations
Before the PR:
```
>>> 26/05/09 19:25:26 WARN GarbageCollectionMetrics: To enable non-built-in garbage collector(s) List(scavenge), users should configure it(them) to spark.eventLog.gcMetrics.youngGenerationGarbageCollectors or spark.eventLog.gcMetrics.oldGenerationGarbageCollectors
26/05/09 19:25:26 WARN GarbageCollectionMetrics: To enable non-built-in garbage collector(s) List(global, scavenge), users should configure it(them) to spark.eventLog.gcMetrics.youngGenerationGarbageCollectors or spark.eventLog.gcMetrics.oldGenerationGarbageCollectors
import warnings
>>> warnings.filterwarnings('ignore')
>>> 
>>> import pandas as pd
>>> print(f"pandas: {pd.__version__}")
pandas: 3.0.2
>>> 
>>> import pyspark.pandas as ps
>>> s1 = ps.Series(['a', 'b', 'c'], dtype='string')
>>> s2 = ps.Series(['a', 'x', 'c'], dtype='string')
>>> result = s1 == s2
>>> print(f"result dtype: {result.dtype}")
result dtype: boolean
>>> print(result)
0     True                                                                      
1    False
2     True
dtype: boolean
>>> 
```
After the PR:
```
>>> 26/05/09 19:19:05 WARN GarbageCollectionMetrics: To enable non-built-in garbage collector(s) List(scavenge), users should configure it(them) to spark.eventLog.gcMetrics.youngGenerationGarbageCollectors or spark.eventLog.gcMetrics.oldGenerationGarbageCollectors
26/05/09 19:19:05 WARN GarbageCollectionMetrics: To enable non-built-in garbage collector(s) List(global, scavenge), users should configure it(them) to spark.eventLog.gcMetrics.youngGenerationGarbageCollectors or spark.eventLog.gcMetrics.oldGenerationGarbageCollectors

>>> import warnings
>>> warnings.filterwarnings('ignore')
>>> 
>>> import pandas as pd
>>> print(f"pandas: {pd.__version__}")
pandas: 3.0.2
>>> 
>>> import pyspark.pandas as ps
>>> s1 = ps.Series(['a', 'b', 'c'], dtype='string')
s2 = ps.Series(['a', 'x', 'c'], dtype='string')
result = s1 == s2
print(f"result dtype: {result.dtype}")
print(result)

>>> s2 = ps.Series(['a', 'x', 'c'], dtype='string')
>>> result = s1 == s2
>>> print(f"result dtype: {result.dtype}")
result dtype: bool[pyarrow]
>>> print(result)
0     True
1    False
2     True
dtype: bool[pyarrow]
>>> 
```
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?

New tests in python/pyspark/pandas/tests/test_typedef.py:
- test_as_spark_type_pyarrow_dtypes() - Tests conversion to Spark types
- test_spark_type_to_pandas_dtype_with_arrow_flag() - Tests conversion back to pandas dtypes
- test_is_str_dtype_with_pyarrow() - Tests string dtype detection
- test_is_pyarrow_backed_dtype() - Tests PyArrow dtype detection

Integration test in python/pyspark/pandas/tests/data_type_ops/test_string_ops.py:
- test_pyarrow_backed_string_comparisons() - Tests dtype preservation in comparison operations

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes. Generated-by: GPT 5.5