### PR TITLE
[SPARK-56807][INFRA] Downgrade black to 23.12.1 for older branches in Python CodeGen check

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -930,7 +930,7 @@ jobs:
     - name: Install dependencies for Python CodeGen check (branch-3.5, branch-4.0, branch-4.1)
       if: inputs.branch == 'branch-3.5' || inputs.branch == 'branch-4.0' || inputs.branch == 'branch-4.1'
       run: |
-        python3.12 -m pip install 'black==26.3.1' 'protobuf==6.33.5' 'mypy==1.8.0' 'mypy-protobuf==3.3.0'
+        python3.12 -m pip install 'black==23.12.1' 'protobuf==6.33.5' 'mypy==1.8.0' 'mypy-protobuf==3.3.0'
         python3.12 -m pip list
     - name: Install dependencies for Python CodeGen check
       if: ${{ inputs.branch != 'branch-3.5' && inputs.branch != 'branch-4.0' && inputs.branch != 'branch-4.1' }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aim to downgrade black version from 26.3.1 to 23.12.1 for older branches in Python CodeGen check

### Why are the changes needed?
To restore `Protobuf breaking change detection and Python CodeGen check` task in branch-4.1/branch-4.0 daily tests:
- 4.1: https://github.com/apache/spark/actions/runs/25593465226/job/75135261188
- 4.0: https://github.com/apache/spark/actions/runs/25593523634/job/75135418966

```
Oh no! 💥 💔 💥 The required version `23.12.1` does not match the running version `26.3.1`!
Traceback (most recent call last):
Start checking the generated codes in pyspark-connect.
  File "/home/runner/work/spark/spark/./dev/check-protos.py", line 84, in <module>
    check_protos(
  File "/home/runner/work/spark/spark/./dev/check-protos.py", line 49, in check_protos
RUN: /home/runner/work/spark/spark/dev/gen-protos.sh connect /tmp/check_connect__protosjcoo70pe
    run_cmd(f"{SPARK_HOME}/dev/gen-protos.sh {module_name} {tmp}")
  File "/home/runner/work/spark/spark/./dev/check-protos.py", line 43, in run_cmd
    return subprocess.check_output(cmd.split(" ")).decode("utf-8")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/runner/work/spark/spark/dev/gen-protos.sh', 'connect', '/tmp/check_connect__protosjcoo70pe']' returned non-zero exit status 1.
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Monitor the daily test results for branch-4.1/branch-4.0 after merging.



### Was this patch authored or co-authored using generative AI tooling?
No
