### PR TITLE
[SPARK-56808][INFRA][3.5] Fix branch-3.5 base image build against Ubuntu focal archive rotation

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update
 RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget openjdk-8-jdk libpython3-dev python3-pip python3-setuptools python3.8 python3.9
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
+RUN curl -sS https://bootstrap.pypa.io/pip/3.9/get-pip.py | python3.9
 
 RUN add-apt-repository ppa:pypy/ppa
 RUN apt update
@@ -47,7 +47,7 @@ RUN mkdir -p /usr/local/pypy/pypy3.8 && \
     ln -sf /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
     ln -sf /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3
 
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
+RUN curl -sS https://bootstrap.pypa.io/pip/3.8/get-pip.py | pypy3
 
 RUN $APT_INSTALL gnupg ca-certificates pandoc
 RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/' >> /etc/apt/sources.list

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -34,9 +34,10 @@ RUN echo 'deb https://mirrors.edge.kernel.org/ubuntu jammy main restricted unive
 
 RUN apt-get clean
 RUN apt-get update
-RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget openjdk-8-jdk libpython3-dev python3-pip python3-setuptools
+RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget openjdk-8-jdk libpython3-dev python3-pip python3-setuptools gnupg ca-certificates dirmngr
 # branch-3.5 tests use python3.8 and python3.9 explicitly; Jammy ships python3.10 by default,
 # so pull 3.8/3.9 from the deadsnakes PPA (same approach used by master for python3.9).
+# gnupg/ca-certificates/dirmngr must be installed first so add-apt-repository can import the PPA key.
 RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update
 RUN $APT_INSTALL python3.8 python3.8-distutils python3.9 python3.9-distutils
@@ -59,7 +60,7 @@ RUN mkdir -p /usr/local/pypy/pypy3.10 && \
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
 
-RUN $APT_INSTALL gnupg ca-certificates pandoc
+RUN $APT_INSTALL pandoc
 RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/' >> /etc/apt/sources.list
 RUN gpg --keyserver hkps://keyserver.ubuntu.com --recv-key E298A3A825C0D65DFD57CBB651716619E084DAB9
 RUN gpg -a --export E084DAB9 | apt-key add -

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -15,9 +15,11 @@
 # limitations under the License.
 #
 
-# Image for building and testing Spark branches. Based on Ubuntu 20.04.
+# Image for building and testing Spark branches. Based on Ubuntu 22.04.
+# Focal (20.04) reached end-of-standard-support and its archives/PPAs have
+# become unreliable, so this base image was moved to Jammy. See SPARK-56808.
 # See also in https://hub.docker.com/_/ubuntu
-FROM ubuntu:focal-20221019
+FROM ubuntu:jammy-20240911.1
 
 ENV FULL_REFRESH_DATE 20260510
 
@@ -26,58 +28,60 @@ ENV DEBCONF_NONINTERACTIVE_SEEN true
 
 ARG APT_INSTALL="apt-get install --no-install-recommends -y"
 
-RUN echo 'deb http://mirrors.edge.kernel.org/ubuntu focal main restricted universe multiverse' > /etc/apt/sources.list.d/mirror.list && \
-    echo 'deb http://mirrors.edge.kernel.org/ubuntu focal-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/mirror.list && \
-    echo 'deb http://mirrors.edge.kernel.org/ubuntu focal-security main restricted universe multiverse' >> /etc/apt/sources.list.d/mirror.list
+RUN echo 'deb https://mirrors.edge.kernel.org/ubuntu jammy main restricted universe multiverse' > /etc/apt/sources.list.d/mirror.list && \
+    echo 'deb https://mirrors.edge.kernel.org/ubuntu jammy-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/mirror.list && \
+    echo 'deb https://mirrors.edge.kernel.org/ubuntu jammy-security main restricted universe multiverse' >> /etc/apt/sources.list.d/mirror.list
 
 RUN apt-get clean
 RUN apt-get update
-RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget openjdk-8-jdk libpython3-dev python3-pip python3-setuptools python3.8 python3.9
+RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget openjdk-8-jdk libpython3-dev python3-pip python3-setuptools
+# branch-3.5 tests use python3.8 and python3.9 explicitly; Jammy ships python3.10 by default,
+# so pull 3.8/3.9 from the deadsnakes PPA (same approach used by master for python3.9).
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update
+RUN $APT_INSTALL python3.8 python3.8-distutils python3.9 python3.9-distutils
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
+# The generic get-pip.py requires Python 3.10+, so use the version-specific bootstrap URL.
 RUN curl -sS https://bootstrap.pypa.io/pip/3.9/get-pip.py | python3.9
+RUN curl -sS https://bootstrap.pypa.io/pip/3.8/get-pip.py | python3.8
 
-RUN add-apt-repository ppa:pypy/ppa
-RUN apt update
 RUN $APT_INSTALL gfortran libopenblas-dev liblapack-dev
 RUN $APT_INSTALL build-essential
 
-RUN mkdir -p /usr/local/pypy/pypy3.8 && \
-    curl -sqL https://downloads.python.org/pypy/pypy3.8-v7.3.11-linux64.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.8 --strip-components=1 && \
-    ln -sf /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3.8 && \
-    ln -sf /usr/local/pypy/pypy3.8/bin/pypy /usr/local/bin/pypy3
+# Upgrade pypy from 3.8 to 3.10 to gain Python 3.10 AST nodes (MatchStar, MatchAs).
+# Without them, the scipy build chain (pythran → beniget) fails with
+# `AttributeError: module 'gast' has no attribute 'MatchStar'` even with pinned gast.
+RUN mkdir -p /usr/local/pypy/pypy3.10 && \
+    curl -sqL https://downloads.python.org/pypy/pypy3.10-v7.3.17-linux64.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.10 --strip-components=1 && \
+    ln -sf /usr/local/pypy/pypy3.10/bin/pypy /usr/local/bin/pypy3.10 && \
+    ln -sf /usr/local/pypy/pypy3.10/bin/pypy /usr/local/bin/pypy3
 
-RUN curl -sS https://bootstrap.pypa.io/pip/3.8/get-pip.py | pypy3
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
 
 RUN $APT_INSTALL gnupg ca-certificates pandoc
-RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/' >> /etc/apt/sources.list
+RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/' >> /etc/apt/sources.list
 RUN gpg --keyserver hkps://keyserver.ubuntu.com --recv-key E298A3A825C0D65DFD57CBB651716619E084DAB9
 RUN gpg -a --export E084DAB9 | apt-key add -
-RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/'
+RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/'
 RUN apt update
 RUN $APT_INSTALL r-base libcurl4-openssl-dev qpdf libssl-dev zlib1g-dev
 RUN Rscript -e "install.packages(c('remotes', 'knitr', 'markdown', 'rmarkdown', 'testthat', 'e1071', 'survival', 'arrow', 'roxygen2', 'xml2'), repos='https://cloud.r-project.org/')"
 
 # See more in SPARK-39959, roxygen2 < 7.2.1
+# libuv1-dev is required by the R `fs` package (transitive dep of testthat/rmarkdown/etc.).
 RUN apt-get update && apt-get install -y libcurl4-openssl-dev libgit2-dev libssl-dev libxml2-dev \
           libfontconfig1-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev \
-          libtiff5-dev libjpeg-dev
+          libtiff5-dev libjpeg-dev libuv1-dev
 RUN Rscript -e "install.packages(c('remotes'), repos='https://cloud.r-project.org/')"
 RUN Rscript -e "remotes::install_version('roxygen2', version='7.2.0', repos='https://cloud.r-project.org')"
 
 # See more in SPARK-39735
 ENV R_LIBS_SITE "/usr/local/lib/R/site-library:${R_LIBS_SITE}:/usr/lib/R/library"
 
-# pypy3.8 lacks `ast.MatchStar` (a Python 3.10+ pattern-matching AST node),
-# so `beniget` fails with `AttributeError: module 'gast' has no attribute
-# 'MatchStar'` when pip builds scipy from source if a pre-0.5.3 `gast` is
-# resolved into the build-isolation overlay. Force gast>=0.5.3 (which defines
-# MatchStar as its own node class) via PIP_CONSTRAINT so the overlay pip picks
-# it up too.
-RUN echo 'gast>=0.5.3' > /tmp/pypy3-pip-constraints.txt && \
-    PIP_CONSTRAINT=/tmp/pypy3-pip-constraints.txt \
-        pypy3 -m pip install numpy 'pandas<=2.0.3' scipy coverage matplotlib && \
-    rm -f /tmp/pypy3-pip-constraints.txt
+# pypy3.10's ast module defines MatchStar/MatchAs, so gast/beniget/pythran/scipy
+# build out of the box without the gast>=0.5.3 PIP_CONSTRAINT workaround needed for pypy3.8.
+RUN pypy3 -m pip install numpy 'pandas<=2.0.3' scipy coverage matplotlib
 RUN python3.9 -m pip install 'numpy==1.25.1' 'pyarrow==12.0.1' 'pandas<=2.0.3' scipy unittest-xml-reporting plotly>=4.8 'mlflow>=2.3.1' coverage 'matplotlib==3.7.2' openpyxl 'memory-profiler==0.60.0' 'scikit-learn==1.1.*'
 
 # Add Python deps for Spark Connect.

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -68,7 +68,16 @@ RUN Rscript -e "remotes::install_version('roxygen2', version='7.2.0', repos='htt
 # See more in SPARK-39735
 ENV R_LIBS_SITE "/usr/local/lib/R/site-library:${R_LIBS_SITE}:/usr/lib/R/library"
 
-RUN pypy3 -m pip install numpy 'pandas<=2.0.3' scipy coverage matplotlib
+# pypy3.8 lacks `ast.MatchStar` (a Python 3.10+ pattern-matching AST node),
+# so `beniget` fails with `AttributeError: module 'gast' has no attribute
+# 'MatchStar'` when pip builds scipy from source if a pre-0.5.3 `gast` is
+# resolved into the build-isolation overlay. Force gast>=0.5.3 (which defines
+# MatchStar as its own node class) via PIP_CONSTRAINT so the overlay pip picks
+# it up too.
+RUN echo 'gast>=0.5.3' > /tmp/pypy3-pip-constraints.txt && \
+    PIP_CONSTRAINT=/tmp/pypy3-pip-constraints.txt \
+        pypy3 -m pip install numpy 'pandas<=2.0.3' scipy coverage matplotlib && \
+    rm -f /tmp/pypy3-pip-constraints.txt
 RUN python3.9 -m pip install 'numpy==1.25.1' 'pyarrow==12.0.1' 'pandas<=2.0.3' scipy unittest-xml-reporting plotly>=4.8 'mlflow>=2.3.1' coverage 'matplotlib==3.7.2' openpyxl 'memory-profiler==0.60.0' 'scikit-learn==1.1.*'
 
 # Add Python deps for Spark Connect.

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -26,9 +26,9 @@ ENV DEBCONF_NONINTERACTIVE_SEEN true
 
 ARG APT_INSTALL="apt-get install --no-install-recommends -y"
 
-RUN echo 'deb https://mirrors.edge.kernel.org/ubuntu focal main restricted universe multiverse' > /etc/apt/sources.list.d/mirror.list && \
-    echo 'deb https://mirrors.edge.kernel.org/ubuntu focal-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/mirror.list && \
-    echo 'deb https://mirrors.edge.kernel.org/ubuntu focal-security main restricted universe multiverse' >> /etc/apt/sources.list.d/mirror.list
+RUN echo 'deb http://mirrors.edge.kernel.org/ubuntu focal main restricted universe multiverse' > /etc/apt/sources.list.d/mirror.list && \
+    echo 'deb http://mirrors.edge.kernel.org/ubuntu focal-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/mirror.list && \
+    echo 'deb http://mirrors.edge.kernel.org/ubuntu focal-security main restricted universe multiverse' >> /etc/apt/sources.list.d/mirror.list
 
 RUN apt-get clean
 RUN apt-get update

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -19,12 +19,16 @@
 # See also in https://hub.docker.com/_/ubuntu
 FROM ubuntu:focal-20221019
 
-ENV FULL_REFRESH_DATE 20221118
+ENV FULL_REFRESH_DATE 20260510
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 
 ARG APT_INSTALL="apt-get install --no-install-recommends -y"
+
+RUN echo 'deb https://mirrors.edge.kernel.org/ubuntu focal main restricted universe multiverse' > /etc/apt/sources.list.d/mirror.list && \
+    echo 'deb https://mirrors.edge.kernel.org/ubuntu focal-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/mirror.list && \
+    echo 'deb https://mirrors.edge.kernel.org/ubuntu focal-security main restricted universe multiverse' >> /etc/apt/sources.list.d/mirror.list
 
 RUN apt-get clean
 RUN apt-get update
@@ -55,7 +59,7 @@ RUN $APT_INSTALL r-base libcurl4-openssl-dev qpdf libssl-dev zlib1g-dev
 RUN Rscript -e "install.packages(c('remotes', 'knitr', 'markdown', 'rmarkdown', 'testthat', 'e1071', 'survival', 'arrow', 'roxygen2', 'xml2'), repos='https://cloud.r-project.org/')"
 
 # See more in SPARK-39959, roxygen2 < 7.2.1
-RUN apt-get install -y libcurl4-openssl-dev libgit2-dev libssl-dev libxml2-dev \
+RUN apt-get update && apt-get install -y libcurl4-openssl-dev libgit2-dev libssl-dev libxml2-dev \
           libfontconfig1-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev \
           libtiff5-dev libjpeg-dev
 RUN Rscript -e "install.packages(c('remotes'), repos='https://cloud.r-project.org/')"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Three small changes in `dev/infra/Dockerfile` to make the scheduled `Base image build` job on `branch-3.5` green again:

1. Add `https://mirrors.edge.kernel.org/ubuntu` as an additional APT source (`focal`, `focal-updates`, `focal-security`). This mirrors the pattern the `master` branch already uses and provides a stable fallback when `archive.ubuntu.com` / `security.ubuntu.com` rotate point-release packages out of the canonical archive.
2. Merge `apt-get update` into the `SPARK-39959` install step so its APT index is aligned with the archive at install time, instead of relying on an index cached many Docker layers earlier.
3. Bump `FULL_REFRESH_DATE` from `20221118` to `20260510` so the GH Actions base-image cache is invalidated and this fix actually takes effect on the next run.

The base image itself (`ubuntu:focal-20221019`) is unchanged — `branch-3.5` is in maintenance and not a good place to upgrade to `jammy`.

### Why are the changes needed?

The scheduled `Build (branch-3.5, Scala 2.13, Hadoop 3, JDK 8)` workflow on 2026-05-09 failed during `Base image build` with multiple `404 Not Found` errors while installing `-dev` packages (`libtiff5-dev`, `libharfbuzz-dev`, `libglib2.0-dev`, `libfreetype6-dev`, `libblkid-dev`, `libmount-dev`, ...). See:

https://github.com/apache/spark/actions/runs/25599925191/job/75152057946

Root cause: Ubuntu 20.04 (focal) entered ESM in April 2025. Security point releases rotate out of `archive.ubuntu.com` / `security.ubuntu.com` faster than before. When the Dockerfile's cached APT index (fetched many layers earlier) references a point-release version that has since been rotated, `apt-get install` hits 404.

The fix avoids the race by (a) adding a reliably-synced additional mirror and (b) refreshing the APT index right before the failing install step.

### Does this PR introduce _any_ user-facing change?

No. Infra-only change to the CI base image on `branch-3.5`.

### How was this patch tested?
- Pass Github Actions

