### PR TITLE
[SPARK-56812][INFRA] Fix URL of get-pip.py in dev/infra/Dockerfile for Python 3.9

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -108,7 +108,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update && apt-get install -y \
     python3.9 python3.9-distutils \
     && rm -rf /var/lib/apt/lists/*
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
+RUN curl -sS https://bootstrap.pypa.io/pip/3.9/get-pip.py | python3.9
 RUN python3.9 -m pip install --ignore-installed 'blinker>=1.6.2' # mlflow needs this
 RUN python3.9 -m pip install --force $BASIC_PIP_PKGS unittest-xml-reporting $CONNECT_PIP_PKGS && \
     python3.9 -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu && \


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes a URL of `get-pip.py` in `dev/infra/Dockerfile` for Python 3.9.

### Why are the changes needed?
Currently `docker build dev/infra` fails with following error.
```
 => ERROR [15/32] RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9                                      0.6s
------
 > [15/32] RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9:
0.588 ERROR: This script does not work on Python 3.9. The minimum supported Python version is 3.10. Please use https://bootstrap.pypa.io/pip/3.9/get-pip.py instead.
------
Dockerfile:111
--------------------
 109 |         python3.9 python3.9-distutils \
 110 |         && rm -rf /var/lib/apt/lists/*
 111 | >>> RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
 112 |     RUN python3.9 -m pip install --ignore-installed 'blinker>=1.6.2' # mlflow needs this
 113 |     RUN python3.9 -m pip install --force $BASIC_PIP_PKGS unittest-xml-reporting $CONNECT_PIP_PKGS && \
--------------------
```

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Confirmed `docker build dev/infra` works.

### Was this patch authored or co-authored using generative AI tooling?
No.
