### PR TITLE
[SPARK-56591][SQL][TESTS][FOLLOW-UP] Drop redundant QueryTest mixin from SharedSparkSession-based test suites

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2ExtSessionColumnIdSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2ExtSessionColumnIdSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row, SparkSession}
+import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
 import org.apache.spark.sql.connector.catalog.SharedInMemoryTableCatalog
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -38,7 +38,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  * a static [[ConcurrentHashMap]] that all catalog instances share,
  * regardless of which session created them.
  */
-class DataSourceV2ExtSessionColumnIdSuite extends QueryTest with SharedSparkSession {
+class DataSourceV2ExtSessionColumnIdSuite extends SharedSparkSession {
 
   override protected def sparkConf: SparkConf = super.sparkConf
     .set(SQLConf.ANSI_ENABLED, true)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2MetadataTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2MetadataTableSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.connector.catalog.{Identifier, MetadataTable, Table, TableCatalog, TableChange, TableInfo, TableSummary}
 import org.apache.spark.sql.connector.expressions.LogicalExpressions
@@ -31,7 +31,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
  * metadata-only tables and Spark reads / writes them via the V1 data-source path.
  * View-related paths live in [[DataSourceV2MetadataViewSuite]].
  */
-class DataSourceV2MetadataTableSuite extends QueryTest with SharedSparkSession {
+class DataSourceV2MetadataTableSuite extends SharedSparkSession {
   import testImplicits._
 
   override def sparkConf: SparkConf = super.sparkConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2MetadataViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2MetadataViewSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, NoSuchViewException, TableAlreadyExistsException, ViewAlreadyExistsException}
 import org.apache.spark.sql.connector.catalog.{Identifier, MetadataTable, Table, TableCatalog, TableChange, TableInfo, TableSummary, TableViewCatalog, V1Table, ViewCatalog, ViewInfo}
 import org.apache.spark.sql.internal.SQLConf
@@ -39,7 +39,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
  * [[org.apache.spark.sql.execution.PersistedViewTestSuite]] body against the v2 path for full
  * parity with the v1 persisted-view coverage.
  */
-class DataSourceV2MetadataViewSuite extends QueryTest with SharedSparkSession {
+class DataSourceV2MetadataViewSuite extends SharedSparkSession {
   import testImplicits._
 
   override def sparkConf: SparkConf = super.sparkConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableNetChangesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableNetChangesSuite.scala
@@ -21,7 +21,7 @@ import java.util.Collections
 
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.catalog.{
   ChangelogProperties, Column, Identifier, InMemoryChangelogCatalog}
@@ -55,8 +55,7 @@ import org.apache.spark.unsafe.types.UTF8String
  * the same `_change_type` labels at the netChanges input.
  */
 trait ResolveChangelogTableNetChangesTestsBase
-    extends QueryTest
-    with SharedSparkSession
+    extends SharedSparkSession
     with BeforeAndAfterEach {
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTablePostProcessingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTablePostProcessingSuite.scala
@@ -22,7 +22,7 @@ import java.util.Collections
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkRuntimeException
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.connector.catalog.{
@@ -48,8 +48,7 @@ import org.apache.spark.unsafe.types.UTF8String
  * correctly transforms the plan and produces the expected output.
  */
 class ResolveChangelogTablePostProcessingSuite
-    extends QueryTest
-    with SharedSparkSession
+    extends SharedSparkSession
     with BeforeAndAfterEach {
 
   private val catalogName = "cdc_test_catalog"

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala
@@ -21,7 +21,7 @@ import java.util.Collections
 
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.expressions.Inline
 import org.apache.spark.sql.catalyst.plans.logical.{
   Aggregate, EventTimeWatermark, Filter, Generate, LogicalPlan, Project, TransformWithState}
@@ -47,8 +47,7 @@ import org.apache.spark.sql.types.LongType
  *     -> Project (drop helper columns)
  */
 class ResolveChangelogTableStreamingPostProcessingSuite
-    extends QueryTest
-    with SharedSparkSession
+    extends SharedSparkSession
     with BeforeAndAfterEach {
 
   private val catalogName = "cdc_streaming_pp"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.{NoSuchViewException, ViewAlreadyExistsException}
 import org.apache.spark.sql.connector.catalog.{Identifier, InMemoryTableCatalog, MetadataTable, Table, TableCatalog, TableDependency, TableSummary, TableViewCatalog, ViewInfo}
 import org.apache.spark.sql.metricview.serde.{AssetSource, Column, Constants, DimensionExpression, MeasureExpression, MetricView, MetricViewFactory, SQLSource}
@@ -36,7 +36,7 @@ import org.apache.spark.sql.types.Metadata
  * minimal [[TableViewCatalog]] so the same instance can also host the source table referenced by
  * the metric view's YAML.
  */
-class MetricViewV2CatalogSuite extends QueryTest with SharedSparkSession {
+class MetricViewV2CatalogSuite extends SharedSparkSession {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/UnionCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/UnionCodegenSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -28,7 +28,7 @@ import org.apache.spark.sql.types._
  * Tests for `UnionExec` whole-stage codegen fusion: plan-shape assertions,
  * correctness, type widening, metrics, and fallbacks.
  */
-class UnionCodegenSuite extends QueryTest with SharedSparkSession {
+class UnionCodegenSuite extends SharedSparkSession {
 
   // Union codegen fusion is off by default; turn it on for this suite.
   override protected def sparkConf: SparkConf =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/window/SegmentTreeWindowFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/window/SegmentTreeWindowFunctionSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.util.SparkErrorUtils
  * numeric/string/date-timestamp types, RANGE, Decimal/Binary merge, UDAF
  * fallback, and frame lifecycle.
  */
-class SegmentTreeWindowFunctionSuite extends QueryTest with SharedSparkSession {
+class SegmentTreeWindowFunctionSuite extends SharedSparkSession {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/window/SegmentTreeWindowMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/window/SegmentTreeWindowMetricsSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.window
 
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.metric.SQLMetricsTestUtils
 import org.apache.spark.sql.execution.ui.SparkPlanGraph
@@ -32,7 +31,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  * `numSegmentTreeFallbackFrames`; feature-flag off leaves both at 0.
  */
 class SegmentTreeWindowMetricsSuite
-    extends QueryTest with SharedSparkSession with SQLMetricsTestUtils {
+    extends SharedSparkSession with SQLMetricsTestUtils {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/window/WindowSegmentTreeAllowlistSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/window/WindowSegmentTreeAllowlistSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.window
 
-import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.metric.SQLMetricsTestUtils
 import org.apache.spark.sql.execution.ui.SparkPlanGraph
@@ -36,7 +36,7 @@ import org.apache.spark.sql.test.SharedSparkSession
  * [[SegmentTreeWindowFunctionSuite]].
  */
 class WindowSegmentTreeAllowlistSuite
-    extends QueryTest with SharedSparkSession with SQLMetricsTestUtils {
+    extends SharedSparkSession with SQLMetricsTestUtils {
 
   import testImplicits._
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Drop the redundant `QueryTest` term from `extends QueryTest with SharedSparkSession` (and its multi-line variants) across 11 test suites in `sql/core`. Where `QueryTest` was only imported to satisfy the extends clause, the import is also removed.

Affected files:
- `sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2ExtSessionColumnIdSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2MetadataTableSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2MetadataViewSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableNetChangesSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTablePostProcessingSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/connector/ResolveChangelogTableStreamingPostProcessingSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewV2CatalogSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/execution/UnionCodegenSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/execution/window/SegmentTreeWindowFunctionSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/execution/window/SegmentTreeWindowMetricsSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/execution/window/WindowSegmentTreeAllowlistSuite.scala`

Suites that reference `QueryTest.<member>` in the body (only `SegmentTreeWindowFunctionSuite` via `QueryTest.sameRows`) keep the import.

### Why are the changes needed?

`SharedSparkSession` already extends `QueryTest`:

```scala
trait SharedSparkSession extends QueryTest with SharedSparkSessionBase
```

so an explicit `extends QueryTest with SharedSparkSession` on each suite is redundant and slightly misleading about the trait hierarchy. Dropping it reduces noise and lowers the chance of the pattern being copied into new suites.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests; `build/sbt sql/Test/compile` passes cleanly on the affected sources.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code