### PR TITLE
[MINOR][INFRA][4.2] Fix `branch` input default in build_and_test.yml

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,8 +30,7 @@ on:
         description: Branch to run the build against
         required: false
         type: string
-        # Change 'master' to 'branch-4.0' in branch-4.0 branch after cutting it.
-        default: master
+        default: branch-4.2
       hadoop:
         description: Hadoop version to run with. HADOOP_PROFILE environment variable should accept it.
         required: false


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update the default value of the `branch` workflow input in `.github/workflows/build_and_test.yml` from `master` to `branch-4.2`, and drop the stale `# Change 'master' to 'branch-4.0' in branch-4.0 branch after cutting it.` comment.

### Why are the changes needed?

When `branch-4.2` was cut from master, the comment in `build_and_test.yml` flagged that the default should be updated, but it wasn't. As a result, the `Build` workflow on pushes to `branch-4.2` invokes the reusable `build_and_test.yml` without an explicit `branch` input, which falls back to the default `master`. The `precondition` job then runs `actions/checkout` with `ref: master` against `apache/spark`, so the CI tests `master` rather than `branch-4.2`.

For example, [this `branch-4.2` push CI run](https://github.com/apache/spark/actions/runs/25591666487/job/75130390722) tested `master` instead of `branch-4.2`.

The same fix was already applied on `branch-4.0` and `branch-4.1`.

### Does this PR introduce _any_ user-facing change?

No. CI-only.

### How was this patch tested?

GitHub Actions on this PR. The default takes effect on subsequent pushes to `branch-4.2`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code