### PR TITLE
[SPARK-56827][INFRA] Clean stale genjavadoc output before JavaUnidoc

### DIFF
--- a/docs/_plugins/build_api_docs.rb
+++ b/docs/_plugins/build_api_docs.rb
@@ -129,7 +129,9 @@ def build_spark_scala_and_java_docs_if_necessary
     return
   end
 
-  command = "build/sbt -Pkinesis-asl unidoc"
+  # Drop stale genjavadoc trees (target/java) before unifying Javadoc; leftover stubs
+  # (e.g. from a partial or Test/doc run) can make JavaUnidoc fail (SPARK-56827).
+  command = "build/sbt -Pkinesis-asl cleanGenjavadocOutput unidoc"
   puts "Running '#{command}'..."
 
   # Two filter passes on the unidoc output:

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1605,6 +1605,55 @@ object Unidoc {
   import sbtunidoc.JavaUnidocPlugin.autoImport._
   import sbtunidoc.ScalaUnidocPlugin.autoImport._
 
+  val cleanGenjavadocOutput = taskKey[Unit](
+    "Delete each module's target/java tree (genjavadoc stubs) before unified API docs " +
+      "so JavaUnidoc cannot pick up stale files (SPARK-56827)."
+  )
+
+  /**
+   * Collect `target/java` directories under the given root. Skips large or irrelevant
+   * trees (VCS, venvs, generated test data) to keep the walk cheap.
+   */
+  private def genjavadocJavaOutputDirs(root: File): Seq[File] = {
+    val skipNames = Set(
+      ".bloop",
+      ".git",
+      ".github",
+      ".idea",
+      ".metals",
+      ".venv",
+      ".vscode",
+      "bin",
+      "build",
+      "dist",
+      "docs",
+      "metastore_db",
+      "node_modules",
+      "out",
+      "python",
+      "R",
+      "target",
+      "work"
+    )
+
+    def walk(dir: File): Seq[File] = {
+      val name = dir.getName
+      if (skipNames.contains(name) || name.startsWith("tpcds-")) {
+        Nil
+      } else {
+        val mine = {
+          val tj = dir / "target" / "java"
+          if (tj.isDirectory) Seq(tj) else Nil
+        }
+        val children = Option(dir.listFiles()).map(_.toIndexedSeq).getOrElse(Nil)
+        val subDirs = children.filter(_.isDirectory).flatMap(walk)
+        mine ++ subDirs
+      }
+    }
+
+    walk(root)
+  }
+
   protected def ignoreUndocumentedPackages(packages: Seq[Seq[File]]): Seq[Seq[File]] = {
     packages
       .map(_.filterNot(_.getName.contains("$")))
@@ -1729,6 +1778,11 @@ object Unidoc {
       inAnyProject -- inProjects(OldDeps.project, repl, examples, tools, kubernetes,
         yarn, tags, streamingKafka010, sqlKafka010, connectCommon, connect, connectJdbc,
         connectClient, connectShims, protobuf, profiler, udfWorkerProto, udfWorkerCore),
+
+    cleanGenjavadocOutput := {
+      IO.delete(genjavadocJavaOutputDirs((ThisBuild / baseDirectory).value))
+      ()
+    }
   )
 }
 

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1610,50 +1610,6 @@ object Unidoc {
       "so JavaUnidoc cannot pick up stale files (SPARK-56827)."
   )
 
-  /**
-   * Collect `target/java` directories under the given root. Skips large or irrelevant
-   * trees (VCS, venvs, generated test data) to keep the walk cheap.
-   */
-  private def genjavadocJavaOutputDirs(root: File): Seq[File] = {
-    val skipNames = Set(
-      ".bloop",
-      ".git",
-      ".github",
-      ".idea",
-      ".metals",
-      ".venv",
-      ".vscode",
-      "bin",
-      "build",
-      "dist",
-      "docs",
-      "metastore_db",
-      "node_modules",
-      "out",
-      "python",
-      "R",
-      "target",
-      "work"
-    )
-
-    def walk(dir: File): Seq[File] = {
-      val name = dir.getName
-      if (skipNames.contains(name) || name.startsWith("tpcds-")) {
-        Nil
-      } else {
-        val mine = {
-          val tj = dir / "target" / "java"
-          if (tj.isDirectory) Seq(tj) else Nil
-        }
-        val children = Option(dir.listFiles()).map(_.toIndexedSeq).getOrElse(Nil)
-        val subDirs = children.filter(_.isDirectory).flatMap(walk)
-        mine ++ subDirs
-      }
-    }
-
-    walk(root)
-  }
-
   protected def ignoreUndocumentedPackages(packages: Seq[Seq[File]]): Seq[Seq[File]] = {
     packages
       .map(_.filterNot(_.getName.contains("$")))
@@ -1780,8 +1736,10 @@ object Unidoc {
         connectClient, connectShims, protobuf, profiler, udfWorkerProto, udfWorkerCore),
 
     cleanGenjavadocOutput := {
-      IO.delete(genjavadocJavaOutputDirs((ThisBuild / baseDirectory).value))
-      ()
+      val dirs = target.all(ScopeFilter(inAnyProject)).value
+        .map(_ / "java")
+        .filter(_.isDirectory)
+      IO.delete(dirs)
     }
   )
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds an SBT task `cleanGenjavadocOutput` (on the `spark` project, under existing Unidoc settings) that deletes every module tree `**/target/java` produced by genjavadoc. Those directories are then cleared automatically before the unified API doc step used by the docs build.

The Jekyll plugin `docs/_plugins/build_api_docs.rb` is updated so the command it runs becomes:

`build/sbt -Pkinesis-asl cleanGenjavadocOutput unidoc`

instead of only `unidoc`, in a single SBT session.

The directory walk skips obvious non-module trees (for example `.git`, `python`, `docs`, `node_modules`, `target` when recursing inside a module) so the cleanup stays cheap.

### Why are the changes needed?

JavaUnidoc aggregates genjavadoc stubs from `target/java` across modules. If those trees are **stale** (for example left over from a partial compile, an interrupted doc run, or paths that do not match the current sources), Javadoc can report many `error: reference not found` failures and exit with `JavadocGenerationFailed`, which breaks the **Documentation generation** CI job even when the Scala side of unidoc succeeds.

That failure mode is environmental (stale output on disk), not a regression in product APIs. Cleaning `target/java` before unidoc makes the docs job deterministic and avoids unrelated PRs being blocked by leftover stubs.

JIRA: https://issues.apache.org/jira/browse/SPARK-56827

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Manually: `build/sbt cleanGenjavadocOutput` from the repo root removes `**/target/java` (verified by creating a dummy file under `sql/catalyst/target/java`, running the task, and confirming removal).
- Manually: `build/sbt cleanGenjavadocOutput unidoc` completes successfully after injecting stale `target/java` content (same scenario as above, then full unidoc).
- `build/sbt compile` (loads the build definition after `SparkBuild.scala` changes).

No new automated tests were added: the change is build/docs orchestration only.

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated-by: Cursor (Claude)
