### PR TITLE
[SPARK-54993][PYTHON] Add type hints to NameTypeHolder and IndexNameTypeHolder classes

### DIFF
--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -25,7 +25,7 @@ import sys
 import typing
 from collections.abc import Iterable
 from inspect import isclass
-from typing import Any, Callable, Generic, List, Tuple, Union, Type, get_type_hints
+from typing import Any, Callable, Generic, List, Optional, Tuple, Union, Type, get_type_hints
 
 import numpy as np
 import pandas as pd
@@ -127,15 +127,15 @@ class UnknownType:
 
 
 class IndexNameTypeHolder:
-    name = None
-    tpe = None
-    short_name = "IndexNameType"
+    name: Optional[str] = None
+    tpe: Optional[Union[type, Dtype]] = None
+    short_name: str = "IndexNameType"
 
 
 class NameTypeHolder:
-    name = None
-    tpe = None
-    short_name = "NameType"
+    name: Optional[str] = None
+    tpe: Optional[Union[type, Dtype]] = None
+    short_name: str = "NameType"
 
 
 def as_spark_type(
@@ -726,7 +726,7 @@ def create_type_for_series_type(param: Any) -> Type[SeriesType]:
     new_class: Type[NameTypeHolder]
     if isinstance(param, ExtensionDtype):
         new_class = type(NameTypeHolder.short_name, (NameTypeHolder,), {})
-        new_class.tpe = param  # type: ignore[assignment]
+        new_class.tpe = param
     else:
         if LooseVersion(pd.__version__) < "3.0.0":
             new_class = param.type if isinstance(param, np.dtype) else param
@@ -893,13 +893,11 @@ def _new_type_holders(
             new_param.name = param.start
             if LooseVersion(pd.__version__) < "3.0.0":
                 if isinstance(param.stop, ExtensionDtype):
-                    new_param.tpe = param.stop  # type: ignore[assignment]
+                    new_param.tpe = param.stop
                 else:
                     # When the given argument is a numpy's dtype instance.
                     new_param.tpe = (
-                        param.stop.type  # type: ignore[assignment]
-                        if isinstance(param.stop, np.dtype)
-                        else param.stop
+                        param.stop.type if isinstance(param.stop, np.dtype) else param.stop
                     )
             else:
                 new_param.tpe = param.stop
@@ -914,13 +912,9 @@ def _new_type_holders(
             )
             if LooseVersion(pd.__version__) < "3.0.0":
                 if isinstance(param, ExtensionDtype):
-                    new_type.tpe = param  # type: ignore[assignment]
+                    new_type.tpe = param
                 else:
-                    new_type.tpe = (
-                        param.type  # type: ignore[assignment]
-                        if isinstance(param, np.dtype)
-                        else param
-                    )
+                    new_type.tpe = param.type if isinstance(param, np.dtype) else param
             else:
                 new_type.tpe = param
             new_types.append(new_type)


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR adds proper type annotations to the NameTypeHolder and IndexNameTypeHolder classes in python/pyspark/pandas/typedef/typehints.py
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
This is a subtask of [ SPARK-54993](https://issues.apache.org/jira/browse/SPARK-54953) (upgrading mypy to latest version). Changes improve type checking.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No. 
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Errors on typehints.py before Changes (delete `# type: ignore[assignment]`):
```
starting mypy annotations test...
annotations failed mypy checks:
python/pyspark/pandas/typedef/typehints.py:729: error: Incompatible types in assignment (expression has type "ExtensionDtype", variable has type "None")  [assignment]
python/pyspark/pandas/typedef/typehints.py:896: error: Incompatible types in assignment (expression has type "ExtensionDtype", variable has type "None")  [assignment]
python/pyspark/pandas/typedef/typehints.py:900: error: Incompatible types in assignment (expression has type "type[Any] | Any", variable has type "None")  [assignment]
python/pyspark/pandas/typedef/typehints.py:917: error: Incompatible types in assignment (expression has type "ExtensionDtype", variable has type "None")  [assignment]
python/pyspark/pandas/typedef/typehints.py:920: error: Incompatible types in assignment (expression has type "type[Any] | Any", variable has type "None")  [assignment]
```
After changes:
Verified with mypy that typehints.py has no type errors


<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Github Copilot GPT 5.2-Codex
