### PR TITLE
[SPARK-56829][SQL][TESTS] Drop redundant SparkFunSuite mixin from SharedSparkSession-based test suites

### DIFF
--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
@@ -24,7 +24,7 @@ import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericData, GenericRecordBuilder}
 import org.apache.avro.message.{BinaryMessageDecoder, BinaryMessageEncoder}
 
-import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.SparkException
 import org.apache.spark.sql.{RandomDataGenerator, Row}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, NoopFilters, OrderedFilters, StructFilters}
 import org.apache.spark.sql.catalyst.expressions.{ExpressionEvalHelper, GenericInternalRow, Literal}
@@ -37,8 +37,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.ArrayImplicits._
 
-class AvroCatalystDataConversionSuite extends SparkFunSuite
-  with SharedSparkSession
+class AvroCatalystDataConversionSuite extends SharedSparkSession
   with ExpressionEvalHelper {
 
   private def roundTripTest(data: Literal): Unit = {

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufCatalystDataConversionSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufCatalystDataConversionSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.protobuf
 
 import com.google.protobuf.{ByteString, DynamicMessage, Message}
 
-import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.{RandomDataGenerator, Row}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, NoopFilters, OrderedFilters, StructFilters}
 import org.apache.spark.sql.catalyst.expressions.{ExpressionEvalHelper, GenericInternalRow, Literal}
@@ -34,8 +33,7 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.ArrayImplicits._
 
 class ProtobufCatalystDataConversionSuite
-    extends SparkFunSuite
-    with SharedSparkSession
+    extends SharedSparkSession
     with ExpressionEvalHelper
     with ProtobufTestBase {
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
@@ -70,9 +70,7 @@ import org.apache.spark.util.Utils
  * compatibility.
  */
 // scalastyle:on
-class ProtoToParsedPlanTestSuite
-    extends SharedSparkSession
-    with ResourceHelper {
+class ProtoToParsedPlanTestSuite extends SharedSparkSession with ResourceHelper {
 
   private val cleanOrphanedGoldenFiles: Boolean =
     System.getenv("SPARK_CLEAN_ORPHANED_GOLDEN_FILES") == "1"

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
@@ -24,7 +24,7 @@ import java.util
 
 import scala.util.{Failure, Success, Try}
 
-import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.SparkConf
 import org.apache.spark.connect.proto
 import org.apache.spark.internal.LogKeys.PATH
 import org.apache.spark.sql.catalyst.{catalog, QueryPlanningTracker}
@@ -71,8 +71,7 @@ import org.apache.spark.util.Utils
  */
 // scalastyle:on
 class ProtoToParsedPlanTestSuite
-    extends SparkFunSuite
-    with SharedSparkSession
+    extends SharedSparkSession
     with ResourceHelper {
 
   private val cleanOrphanedGoldenFiles: Boolean =

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/RequestDecompressionInterceptorSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/RequestDecompressionInterceptorSuite.scala
@@ -25,11 +25,10 @@ import com.github.luben.zstd.Zstd
 import com.google.protobuf.ByteString
 import io.grpc.{Metadata, ServerCall, ServerCallHandler, Status}
 
-import org.apache.spark.SparkFunSuite
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.test.SharedSparkSession
 
-class RequestDecompressionInterceptorSuite extends SparkFunSuite with SharedSparkSession {
+class RequestDecompressionInterceptorSuite extends SharedSparkSession {
   private val testUserId = "testUserId"
   private val testSessionId = UUID.randomUUID().toString
   private val testUserCtx = proto.UserContext

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListenerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListenerSuite.scala
@@ -37,9 +37,7 @@ import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryListener}
 import org.apache.spark.sql.streaming.Trigger.ProcessingTime
 import org.apache.spark.sql.test.SharedSparkSession
 
-class SparkConnectListenerBusListenerSuite
-    extends SharedSparkSession
-    with MockitoSugar {
+class SparkConnectListenerBusListenerSuite extends SharedSparkSession with MockitoSugar {
 
   override def afterEach(): Unit = {
     try {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListenerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListenerSuite.scala
@@ -29,7 +29,6 @@ import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.scalatestplus.mockito.MockitoSugar
 
-import org.apache.spark.SparkFunSuite
 import org.apache.spark.connect.proto.{Command, ExecutePlanResponse}
 import org.apache.spark.sql.connect.SparkConnectTestUtils
 import org.apache.spark.sql.connect.execution.ExecuteResponseObserver
@@ -39,8 +38,7 @@ import org.apache.spark.sql.streaming.Trigger.ProcessingTime
 import org.apache.spark.sql.test.SharedSparkSession
 
 class SparkConnectListenerBusListenerSuite
-    extends SparkFunSuite
-    with SharedSparkSession
+    extends SharedSparkSession
     with MockitoSugar {
 
   override def afterEach(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CacheManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CacheManagerSuite.scala
@@ -19,10 +19,9 @@ package org.apache.spark.sql
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.test.SharedSparkSession
 
-class CacheManagerSuite extends SparkFunSuite with SharedSparkSession {
+class CacheManagerSuite extends SharedSparkSession {
 
   test("SPARK-44199: isSubDirectory tests") {
     val cacheManager = spark.sharedState.cacheManager

--- a/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
@@ -17,13 +17,13 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.{SparkFunSuite, SparkRuntimeException, SparkUnsupportedOperationException}
+import org.apache.spark.{SparkRuntimeException, SparkUnsupportedOperationException}
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, SpecificInternalRow}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
-class RowSuite extends SparkFunSuite with SharedSparkSession {
+class RowSuite extends SharedSparkSession {
   import testImplicits._
 
   test("create row") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ScalaReflectionRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ScalaReflectionRelationSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 
 import java.sql.{Date, Timestamp}
 
-import org.apache.spark.{SparkFunSuite, SparkUnsupportedOperationException}
+import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql.test.SharedSparkSession
 
 case class ReflectData(
@@ -76,7 +76,7 @@ case class ComplexReflectData(
 
 case class InvalidInJava(`abstract`: Int)
 
-class ScalaReflectionRelationSuite extends SparkFunSuite with SharedSparkSession {
+class ScalaReflectionRelationSuite extends SharedSparkSession {
   import testImplicits._
 
   // To avoid syntax error thrown by genjavadoc, make this case class non-top level and private.

--- a/sql/core/src/test/scala/org/apache/spark/sql/SerializationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SerializationSuite.scala
@@ -17,11 +17,11 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.SparkConf
 import org.apache.spark.serializer.JavaSerializer
 import org.apache.spark.sql.test.SharedSparkSession
 
-class SerializationSuite extends SparkFunSuite with SharedSparkSession {
+class SerializationSuite extends SharedSparkSession {
 
   test("[SPARK-5235] SQLContext should be serializable") {
     val spark = SparkSession.builder().getOrCreate()

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationExpressionWalkerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationExpressionWalkerSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.collation
 
 import java.sql.Timestamp
 
-import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.analysis.ExpressionBuilder
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.variant.ParseJson
@@ -34,7 +33,7 @@ import org.apache.spark.util.Utils
  *  This suite is introduced in order to test a bulk of expressions and functionalities related to
  *  collations
  */
-class CollationExpressionWalkerSuite extends SparkFunSuite with SharedSparkSession {
+class CollationExpressionWalkerSuite extends SharedSparkSession {
   import testImplicits._
 
   // Trait to distinguish different cases for generation

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/AggregatingAccumulatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/AggregatingAccumulatorSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.execution
 
 import java.util.Properties
 
-import org.apache.spark.{SparkFunSuite, TaskContext, TaskContextImpl}
+import org.apache.spark.{TaskContext, TaskContextImpl}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.{ExpressionEvalHelper, If, SortArray, SparkPartitionID, SpecificInternalRow}
@@ -32,8 +32,7 @@ import org.apache.spark.unsafe.types.UTF8String
  * Test suite for [[AggregatingAccumulator]].
  */
 class AggregatingAccumulatorSuite
-  extends SparkFunSuite
-  with SharedSparkSession
+  extends SharedSparkSession
   with ExpressionEvalHelper {
   private val a = $"a".long
   private val b = $"b".string

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/UnsafeKVExternalSorterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/UnsafeKVExternalSorterSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.unsafe.map.BytesToBytesMap
 /**
  * Test suite for [[UnsafeKVExternalSorter]], with randomly generated test data.
  */
-class UnsafeKVExternalSorterSuite extends SparkFunSuite with SharedSparkSession {
+class UnsafeKVExternalSorterSuite extends SharedSparkSession {
   private val keyTypes = Seq(IntegerType, FloatType, DoubleType, StringType)
   private val valueTypes = Seq(IntegerType, FloatType, DoubleType, StringType)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcTaskInterruptSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcTaskInterruptSuite.scala
@@ -26,7 +26,7 @@ import scala.util.control.NonFatal
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 
-import org.apache.spark.{SparkFunSuite, TaskContext}
+import org.apache.spark.TaskContext
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects}
@@ -40,7 +40,7 @@ import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructT
  * to `Thread.interrupt()`; closing the JDBC connection from the `TaskInterruptListener`
  * unblocks the thread by causing the socket to throw.
  */
-class JdbcTaskInterruptSuite extends SparkFunSuite with SharedSparkSession {
+class JdbcTaskInterruptSuite extends SharedSparkSession {
 
   private val testJdbcUrl = "jdbc:taskinterrupt:test"
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLogSuite.scala
@@ -27,13 +27,12 @@ import scala.util.Random
 
 import org.apache.hadoop.fs.{FileSystem, FSDataInputStream, Path, RawLocalFileSystem}
 
-import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.execution.streaming.sinks.{FileStreamSinkLog, SinkFileStatus}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.ArrayImplicits._
 
-class FileStreamSinkLogSuite extends SparkFunSuite with SharedSparkSession {
+class FileStreamSinkLogSuite extends SharedSparkSession {
 
   import org.apache.spark.sql.execution.streaming.runtime.CompactibleFileStreamLog._
   import FileStreamSinkLog._

--- a/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.expressions
 
-import org.apache.spark.{SparkFunSuite, SparkIllegalArgumentException}
+import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, InternalRow}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.HiveResult.hiveResultString
@@ -27,7 +27,7 @@ import org.apache.spark.tags.SlowSQLTest
 import org.apache.spark.util.{ThreadUtils, Utils}
 
 @SlowSQLTest
-class ExpressionInfoSuite extends SparkFunSuite with SharedSparkSession {
+class ExpressionInfoSuite extends SharedSparkSession {
 
   test("Replace _FUNC_ in ExpressionInfo") {
     val info = spark.sessionState.catalog.lookupFunctionInfo(FunctionIdentifier("upper"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.scripting
 
-import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.{CreateVariable, LeafNode, OneRowRelation, Project, SetVariable}
@@ -31,7 +30,7 @@ import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
  * Execution nodes are constructed manually and iterated through.
  * It is then checked if the leaf statements have been iterated in the expected order.
  */
-class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSession {
+class SqlScriptingExecutionNodeSuite extends SharedSparkSession {
   // Helpers
   case class TestCompoundBody(
       override val statements: Seq[CompoundStatementExec],

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/CommitLogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/CommitLogSuite.scala
@@ -20,12 +20,11 @@ package org.apache.spark.sql.streaming
 import java.io.{ByteArrayInputStream, FileInputStream, FileOutputStream}
 import java.nio.file.Path
 
-import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.execution.streaming.checkpointing.{CommitLog, CommitMetadata}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
-class CommitLogSuite extends SparkFunSuite with SharedSparkSession {
+class CommitLogSuite extends SharedSparkSession {
 
   private def testCommitLogV2FilePath: Path = {
     getWorkspaceFilePath(

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperationSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperationSuite.scala
@@ -29,13 +29,12 @@ import org.apache.hive.service.rpc.thrift.{TProtocolVersion, TTypeId}
 import org.mockito.Mockito.{doReturn, mock, spy, when, RETURNS_DEEP_STUBS}
 import org.mockito.invocation.InvocationOnMock
 
-import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.classic.{DataFrame, SparkSession}
 import org.apache.spark.sql.hive.thriftserver.ui.HiveThriftServer2EventManager
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{GeographyType, GeometryType, IntegerType, NullType, StringType, StructField, StructType}
 
-class SparkExecuteStatementOperationSuite extends SparkFunSuite with SharedSparkSession {
+class SparkExecuteStatementOperationSuite extends SharedSparkSession {
 
   test("SPARK-17112 `select null` via JDBC triggers IllegalArgumentException in ThriftServer") {
     val field1 = StructField("NULL", NullType)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Drop the redundant `SparkFunSuite` term from `extends SparkFunSuite with SharedSparkSession` (and its multi-line variants) across 18 test suites, and remove the now-unused `SparkFunSuite` imports.

Affected files:
- `connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala`
- `connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufCatalystDataConversionSuite.scala`
- `sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala`
- `sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/RequestDecompressionInterceptorSuite.scala`
- `sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListenerSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/CacheManagerSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/ScalaReflectionRelationSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/SerializationSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/collation/CollationExpressionWalkerSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/execution/AggregatingAccumulatorSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/execution/UnsafeKVExternalSorterSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcTaskInterruptSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLogSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/expressions/ExpressionInfoSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala`
- `sql/core/src/test/scala/org/apache/spark/sql/streaming/CommitLogSuite.scala`
- `sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperationSuite.scala`

`UnsafeKVExternalSorterSuite` uses `import org.apache.spark._` (wildcard), so only its extends clause changes; its imports are untouched.

### Why are the changes needed?

`SharedSparkSession` transitively extends `SparkFunSuite`:

```scala
trait SharedSparkSession extends QueryTest with SharedSparkSessionBase
// and:
abstract class QueryTest extends SparkFunSuite with QueryTestBase
```

so an explicit `extends SparkFunSuite with SharedSparkSession` on each suite is redundant. Dropping it reduces noise and lowers the chance of the pattern being copied into new suites.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests; the following SBT test compiles pass cleanly on the affected sources:

- `build/sbt sql/Test/compile`
- `build/sbt connect/Test/compile`
- `build/sbt protobuf/Test/compile`
- `build/sbt avro/Test/compile`
- `build/sbt -Phive-thriftserver hive-thriftserver/Test/compile`

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code