### PR TITLE
[SPARK-54434][PYTHON] Use return instead of exit in bin/find-spark-home short-circuit

### DIFF
--- a/bin/find-spark-home
+++ b/bin/find-spark-home
@@ -23,7 +23,7 @@ FIND_SPARK_HOME_PYTHON_SCRIPT="$(cd "$(dirname "$0")"; pwd)/find_spark_home.py"
 
 # Short circuit if the user already has this set.
 if [ ! -z "${SPARK_HOME}" ]; then
-   exit 0
+   return 0 2>/dev/null || exit 0
 elif [ ! -f "$FIND_SPARK_HOME_PYTHON_SCRIPT" ]; then
   # If we are not in the same directory as find_spark_home.py we are not pip installed so we don't
   # need to search the different Python directories for a Spark installation.

--- a/python/pyspark/tests/test_util.py
+++ b/python/pyspark/tests/test_util.py
@@ -16,6 +16,8 @@
 #
 import gc
 import os
+import subprocess
+import sys
 import time
 import unittest
 from unittest.mock import patch
@@ -88,6 +90,28 @@ class UtilTests(PySparkTestCase):
             self.assertEqual(origin, _find_spark_home())
         finally:
             os.environ["SPARK_HOME"] = origin
+
+    @unittest.skipIf(sys.platform == "win32", "find-spark-home is a bash script")
+    def test_find_spark_home_script_sourceable(self):
+        # SPARK-54434: bin/find-spark-home is documented to be sourced.
+        # When `SPARK_HOME` is already set, the script short-circuits.
+        # The short-circuit must use `return 0` rather than `exit 0`, otherwise
+        # sourcing the script terminates the caller's shell session.
+        script_path = os.path.join(os.environ["SPARK_HOME"], "bin", "find-spark-home")
+        # Source the script twice and print a marker afterwards. If the script
+        # calls `exit 0` while sourced, the outer shell terminates and the
+        # marker is never emitted.
+        cmd = (
+            f"export SPARK_HOME=/some/value && "
+            f"source {script_path} && "
+            f"source {script_path} && "
+            f"echo SOURCED_OK"
+        )
+        completed = subprocess.run(
+            ["bash", "-c", cmd], capture_output=True, text=True, check=False
+        )
+        self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+        self.assertIn("SOURCED_OK", completed.stdout)
 
     def test_timeout_decorator(self):
         @timeout(1)

--- a/python/pyspark/tests/test_util.py
+++ b/python/pyspark/tests/test_util.py
@@ -107,9 +107,7 @@ class UtilTests(PySparkTestCase):
             f"source {script_path} && "
             f"echo SOURCED_OK"
         )
-        completed = subprocess.run(
-            ["bash", "-c", cmd], capture_output=True, text=True, check=False
-        )
+        completed = subprocess.run(["bash", "-c", cmd], capture_output=True, text=True, check=False)
         self.assertEqual(completed.returncode, 0, msg=completed.stderr)
         self.assertIn("SOURCED_OK", completed.stdout)
 

--- a/python/pyspark/tests/test_util.py
+++ b/python/pyspark/tests/test_util.py
@@ -16,6 +16,7 @@
 #
 import gc
 import os
+import shlex
 import subprocess
 import sys
 import time
@@ -101,13 +102,19 @@ class UtilTests(PySparkTestCase):
         # Source the script twice and print a marker afterwards. If the script
         # calls `exit 0` while sourced, the outer shell terminates and the
         # marker is never emitted.
+        quoted_script_path = shlex.quote(script_path)
         cmd = (
             f"export SPARK_HOME=/some/value && "
-            f"source {script_path} && "
-            f"source {script_path} && "
+            f"source {quoted_script_path} && "
+            f"source {quoted_script_path} && "
             f"echo SOURCED_OK"
         )
         completed = subprocess.run(["bash", "-c", cmd], capture_output=True, text=True, check=False)
+        # The SOURCED_OK marker is the load-bearing assertion. On master the sourced
+        # `exit 0` terminates the `bash -c` shell itself with status 0, so the return
+        # code stays 0 whether or not the bug is present; only the absent marker exposes
+        # it. The returncode check is a secondary guard that surfaces stderr if the
+        # script errors out (e.g. a syntax error).
         self.assertEqual(completed.returncode, 0, msg=completed.stderr)
         self.assertIn("SOURCED_OK", completed.stdout)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`bin/find-spark-home` is documented as `# Should be included using "source" directive`, but its `SPARK_HOME`-already-set short-circuit calls `exit 0`. When the script is sourced, that terminates the caller's shell. This PR replaces `exit 0` with `return 0 2>/dev/null || exit 0` so the script behaves correctly when sourced (the documented path) and still works if executed directly.

A pyspark unit test (`test_find_spark_home_script_sourceable`) sources the script twice from a subshell and asserts a marker prints after. The test fails on master and passes with this change.

### Why are the changes needed?

`bin/find-spark-home` is sourced by `bin/load-spark-env.sh` and by user shell setup. As reported on SPARK-54434, if a user accidentally sources `bin/find-spark-home` twice in the same shell, the second invocation hits the short-circuit and `exit 0` closes the interactive shell session.

Reproducer:

```bash
export SPARK_HOME=/some/value
source $SPARK_HOME/bin/find-spark-home  # ok
source $SPARK_HOME/bin/find-spark-home  # shell terminates
```

### Does this PR introduce _any_ user-facing change?

No. Users who source `bin/find-spark-home` no longer lose their shell on the short-circuit path; users who execute it directly see no behavior change.

### How was this patch tested?

Added `pyspark.tests.test_util.UtilTests.test_find_spark_home_script_sourceable`, which sources the script twice from a bash subprocess and asserts a marker prints after the second source. The test fails on `master` because the marker is never emitted, and passes with this change.
