### PR TITLE
[SPARK-56818][DOCS] Fix Binder build by pinning Debian Bookworm base …

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM python:3.10-slim
+FROM python:3.10-slim-bookworm
 # install the notebook package
 RUN  pip install --no-cache notebook jupyterlab
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR pins the base image in `binder/Dockerfile` to `python:3.10-slim-bookworm`.

### Why are the changes needed?
The floating tag `python:3.10-slim` recently migrated from Debian 12 (Bookworm) to Debian 13 (Trixie). The `openjdk-17-jre` package is no longer available in the Trixie repositories, causing the Binder build for interactive documentation (Quickstart notebooks) to fail with `E: Package 'openjdk-17-jre' has no installation candidate`. 

Pinning the image to `bookworm` restores the build stability. 

Resolves Jira issue: [SPARK-56818](https://issues.apache.org/jira/browse/SPARK-56818)

### Does this PR introduce _any_ user-facing change?
No. This only affects the Binder documentation build infrastructure.

### How was this patch tested?
Verified locally by building the Docker image successfully with the `bookworm` tag. The `apt-get install` step now completes without errors.

### Was this patch authored or co-authored using generative AI tooling?
No.