### PR TITLE
[SPARK-56826][SQL] Skip PushVariantIntoScan for VariantGet with null-evaluating path

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PushVariantIntoScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PushVariantIntoScan.scala
@@ -214,7 +214,8 @@ class VariantInRelation {
   // fields, which also changes the struct type containing it, and it is difficult to reconstruct
   // the original struct value. This is not a big loss, because we need the full variant anyway.
   def collectRequestedFields(expr: Expression): Unit = expr match {
-    case v@VariantGet(StructPathToVariant(fields), path, _, _, _) if path.foldable =>
+    case v@VariantGet(StructPathToVariant(fields), path, _, _, _)
+        if path.foldable && path.eval() != null =>
       addField(fields, RequestedVariantField(v))
     case c@Cast(StructPathToVariant(fields), _, _, _) => addField(fields, RequestedVariantField(c))
     case IsNotNull(StructPath(_, _)) | IsNull(StructPath(_, _)) =>
@@ -245,7 +246,8 @@ class VariantInRelation {
 
     // Rewrite patterns should be consistent with visit patterns in `collectRequestedFields`.
     expr.transformDown {
-      case g@VariantGet(v@StructPathToVariant(fields), path, _, _, _) if path.foldable =>
+      case g@VariantGet(v@StructPathToVariant(fields), path, _, _, _)
+          if path.foldable && path.eval() != null =>
         // Rewrite the attribute in advance, rather than depending on the last branch to rewrite it.
         // Ww need to avoid the `v@StructPathToVariant(fields)` branch to rewrite the child again.
         GetStructField(rewriteAttribute(v), fields(RequestedVariantField(g)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PushVariantIntoScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PushVariantIntoScanSuite.scala
@@ -219,6 +219,42 @@ abstract class PushVariantIntoScanV1SuiteBase extends PushVariantIntoScanSuiteBa
       }
     }
   }
+
+  test(s"SPARK-56826: no pushdown for VariantGet with null-evaluating path " +
+      s"when NullPropagation is excluded ($readerName)") {
+    val nullPropagation = "org.apache.spark.sql.catalyst.optimizer.NullPropagation"
+    withSQLConf(SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> nullPropagation) {
+      withTable("T") {
+        sql("create table T (v variant) using PARQUET")
+        sql("select variant_get(v, cast(null as string), 'int') as a from T")
+          .queryExecution.optimizedPlan match {
+          case Project(_, l: LogicalRelation) =>
+            val v = l.output(0)
+            assert(v.dataType == StructType(Array(field(0, VariantType, "$",
+              timeZone = "UTC"))))
+          case other => fail(s"Expected LogicalRelation, got ${other.getClass.getName}")
+        }
+      }
+    }
+  }
+
+  test(s"SPARK-56826: pushdown still works for VariantGet with literal path " +
+      s"when NullPropagation is excluded ($readerName)") {
+    val nullPropagation = "org.apache.spark.sql.catalyst.optimizer.NullPropagation"
+    withSQLConf(SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> nullPropagation) {
+      withTable("T") {
+        sql("create table T (v variant) using PARQUET")
+        sql("select variant_get(v, '$.a', 'int') as a from T")
+          .queryExecution.optimizedPlan match {
+          case Project(projectList, l: LogicalRelation) =>
+            val v = l.output(0)
+            checkAlias(projectList(0), "a", GetStructField(v, 0))
+            assert(v.dataType == StructType(Array(field(0, IntegerType, "$.a"))))
+          case other => fail(s"Expected LogicalRelation, got ${other.getClass.getName}")
+        }
+      }
+    }
+  }
 }
 
 // V1 DataSource tests - Row-based reader


### PR DESCRIPTION


### What changes were proposed in this pull request?

Add && path.eval() != null to the VariantGet case-arm guard in both collectRequestedFields and rewriteExpr in PushVariantIntoScan.

### Why are the changes needed?

A VariantGet whose foldable path evaluates to null (e.g., variant_get(v, cast(null as string), 'int')) reaches PushVariantIntoScan when NullPropagation is excluded via spark.sql.optimizer.excludedRules.

### Does this PR introduce _any_ user-facing change?
No. With the default optimizer pipeline (NullPropagation enabled), VariantGet(_, Literal(null), ...) is eliminated upstream — this code path was unreachable in practice.

### How was this patch tested?
New unit tests in PushVariantIntoScanV1SuiteBase

### Was this patch authored or co-authored using generative AI tooling?
Yes