### PR TITLE
[SPARK-56815][DOCS][FOLLOWUP] Add Java 25 to `building-spark.md`

### DIFF
--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -27,7 +27,7 @@ license: |
 ## Apache Maven
 
 The Maven-based build is the build of reference for Apache Spark.
-Building Spark using Maven requires Maven 3.9.15 and Java 17/21.
+Building Spark using Maven requires Maven 3.9.15 and Java 17/21/25.
 Spark requires Scala 2.13; support for Scala 2.12 was removed in Spark 4.0.0.
 
 ### Setting up Maven's Memory Usage


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update `docs/building-spark.md` from `Java 17/21` to `Java 17/21/25`.

This is a follow-up of
- apache/spark#55798

### Why are the changes needed?

`docs/index.md` already states "Spark runs on Java 17/21/25", but `docs/building-spark.md` was missed and still says `Java 17/21`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A. Documentation-only change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)