### PR TITLE
[SPARK-56834][K8S] Use Java `25-jre` instead of `21-jre` image in K8s Dockerfile

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 ARG java_image_name=azul/zulu-openjdk
-ARG java_image_tag=21-jre
+ARG java_image_tag=25-jre
 
 FROM ${java_image_name}:${java_image_tag}
 LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java 25 image in the Spark K8s Dockerfile.

### Why are the changes needed?

As a part of [SPARK-51167 Build and Run Spark on Java 25](https://issues.apache.org/jira/browse/SPARK-51167), this PR uses the latest LTS Java release as the default JVM docker base image in Apache Spark 4.2.0.
- apache/spark#55798
- apache/spark#55827

### Does this PR introduce _any_ user-facing change?

- Yes because the default Java version is changed.
- However, a user still change this back via `-b java_image_tag=17` and the Apache Spark 4.2.0 provides the same capability for Java 17/21/25.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)