### PR TITLE
[SPARK-56838][SDP] Introduce AutoCDC parameters dataclass

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3374,6 +3374,19 @@
     ],
     "sqlState" : "42000"
   },
+  "AUTOCDC_INVALID_COLUMN_SELECTION" : {
+    "message" : [
+      "Invalid column selection."
+    ],
+    "subClass" : {
+      "COLUMNS_NOT_FOUND" : {
+        "message" : [
+          "The following columns are not present in the schema: <missingColumns>. Available columns: <availableColumns>."
+        ]
+      }
+    },
+    "sqlState" : "42703"
+  },
   "INVALID_CONF_VALUE" : {
     "message" : [
       "The value '<confValue>' in the config \"<confName>\" is invalid."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -193,7 +193,7 @@
   },
   "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA" : {
     "message" : [
-      "The following columns are not present in the schema: <missingColumns>. Available columns: <availableColumns>. Matching was <matching>."
+      "Using <caseSensitivity> column name comparison, the following columns are not present in the <schemaName> schema: <missingColumns>. Available columns: <availableColumns>."
     ],
     "sqlState" : "42703"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -82,6 +82,19 @@
     ],
     "sqlState" : "XX000"
   },
+  "AUTOCDC_INVALID_COLUMN_SELECTION" : {
+    "message" : [
+      "Invalid column selection."
+    ],
+    "subClass" : {
+      "COLUMNS_NOT_FOUND" : {
+        "message" : [
+          "The following columns are not present in the schema: <missingColumns>. Available columns: <availableColumns>."
+        ]
+      }
+    },
+    "sqlState" : "42703"
+  },
   "APPEND_ONCE_FROM_BATCH_QUERY" : {
     "message" : [
       "Creating a streaming table from a batch query prevents incremental loading of new data from source. Offending table: '<table>'.",
@@ -3373,19 +3386,6 @@
       "Column or field <name> is of type <type> while it's required to be <expectedType>."
     ],
     "sqlState" : "42000"
-  },
-  "AUTOCDC_INVALID_COLUMN_SELECTION" : {
-    "message" : [
-      "Invalid column selection."
-    ],
-    "subClass" : {
-      "COLUMNS_NOT_FOUND" : {
-        "message" : [
-          "The following columns are not present in the schema: <missingColumns>. Available columns: <availableColumns>."
-        ]
-      }
-    },
-    "sqlState" : "42703"
   },
   "INVALID_CONF_VALUE" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -191,22 +191,16 @@
     ],
     "sqlState" : "0A000"
   },
-  "AUTOCDC_INVALID_COLUMN_SELECTION" : {
+  "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA" : {
     "message" : [
-      "Invalid column selection."
+      "The following columns are not present in the schema: <missingColumns>. Available columns: <availableColumns>. Matching was <matching>."
     ],
-    "subClass" : {
-      "COLUMNS_NOT_FOUND" : {
-        "message" : [
-          "The following columns are not present in the schema: <missingColumns>. Available columns: <availableColumns>."
-        ]
-      },
-      "MULTIPART_COLUMN_IDENTIFIER" : {
-        "message" : [
-          "Column selection entries must be a single column identifier; got the multi-part identifier <columnName> (parts: <nameParts>)."
-        ]
-      }
-    },
+    "sqlState" : "42703"
+  },
+  "AUTOCDC_MULTIPART_COLUMN_IDENTIFIER" : {
+    "message" : [
+      "Expected a single column identifier; got the multi-part identifier <columnName> (parts: <nameParts>)."
+    ],
     "sqlState" : "42703"
   },
   "AVRO_CANNOT_WRITE_NULL_FIELD" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -200,6 +200,11 @@
         "message" : [
           "The following columns are not present in the schema: <missingColumns>. Available columns: <availableColumns>."
         ]
+      },
+      "MULTIPART_COLUMN_IDENTIFIER" : {
+        "message" : [
+          "Column selection entries must be a single column identifier; got the multi-part identifier <columnName> (parts: <nameParts>)."
+        ]
       }
     },
     "sqlState" : "42703"

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -82,19 +82,6 @@
     ],
     "sqlState" : "XX000"
   },
-  "AUTOCDC_INVALID_COLUMN_SELECTION" : {
-    "message" : [
-      "Invalid column selection."
-    ],
-    "subClass" : {
-      "COLUMNS_NOT_FOUND" : {
-        "message" : [
-          "The following columns are not present in the schema: <missingColumns>. Available columns: <availableColumns>."
-        ]
-      }
-    },
-    "sqlState" : "42703"
-  },
   "APPEND_ONCE_FROM_BATCH_QUERY" : {
     "message" : [
       "Creating a streaming table from a batch query prevents incremental loading of new data from source. Offending table: '<table>'.",
@@ -203,6 +190,19 @@
       "Operations that trigger DataFrame analysis or execution are not allowed in pipeline query functions. Move code outside of the pipeline query function."
     ],
     "sqlState" : "0A000"
+  },
+  "AUTOCDC_INVALID_COLUMN_SELECTION" : {
+    "message" : [
+      "Invalid column selection."
+    ],
+    "subClass" : {
+      "COLUMNS_NOT_FOUND" : {
+        "message" : [
+          "The following columns are not present in the schema: <missingColumns>. Available columns: <availableColumns>."
+        ]
+      }
+    },
+    "sqlState" : "42703"
   },
   "AVRO_CANNOT_WRITE_NULL_FIELD" : {
     "message" : [

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
@@ -18,11 +18,43 @@
 package org.apache.spark.sql.pipelines.autocdc
 
 import org.apache.spark.sql.{AnalysisException, Column}
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.types.StructType
+
+/** A column reference that must be a single, unqualified identifier (no nested
+  * field path and no table/alias qualifier). The constructor parses
+  * [[columnName]] with the Spark SQL parser and throws an [[AnalysisException]]
+  * if it does not resolve to exactly one name part.
+  */
+case class UnqualifiedColumnName(name: String) {
+  UnqualifiedColumnName.validate(name)
+}
+
+object UnqualifiedColumnName {
+  private def validate(columnName: String): Unit = {
+    val nameParts = CatalystSqlParser.parseMultipartIdentifier(columnName)
+    if (nameParts.length != 1) {
+      throw multipartColumnIdentifierError(columnName, nameParts)
+    }
+  }
+
+  private def multipartColumnIdentifierError(
+      columnName: String,
+      nameParts: Seq[String]
+  ): AnalysisException =
+    new AnalysisException(
+      errorClass = "AUTOCDC_INVALID_COLUMN_SELECTION.MULTIPART_COLUMN_IDENTIFIER",
+      messageParameters = Map(
+        "columnName" -> columnName,
+        "nameParts" -> nameParts.mkString(", ")
+      )
+    )
+}
 
 sealed trait ColumnSelection
 object ColumnSelection {
-  type ColumnList = Seq[String]
+  type ColumnList = Seq[UnqualifiedColumnName]
+
   case class IncludeColumns(columns: ColumnList) extends ColumnSelection
   case class ExcludeColumns(columns: ColumnList) extends ColumnSelection
 
@@ -36,20 +68,20 @@ object ColumnSelection {
         // A none column selection is interpreted as a no-op.
         schema
       case Some(IncludeColumns(includeColumns)) =>
-        validateColumnsExistInSchema(columns = includeColumns, schema = schema)
+        validateColumnsExistInSchema(includeColumns, schema)
 
-        val includeColumnSet = includeColumns.toSet
+        val includeColumnSet = includeColumns.map(_.name).toSet
         StructType(schema.fields.filter(f => includeColumnSet.contains(f.name)))
       case Some(ExcludeColumns(excludeColumns)) =>
-        validateColumnsExistInSchema(columns = excludeColumns, schema = schema)
+        validateColumnsExistInSchema(excludeColumns, schema)
 
-        val excludeColumnSet = excludeColumns.toSet
+        val excludeColumnSet = excludeColumns.map(_.name).toSet
         StructType(schema.fields.filterNot(f => excludeColumnSet.contains(f.name)))
     }
 
   private def validateColumnsExistInSchema(columns: ColumnList, schema: StructType): Unit = {
     val schemaColumns = schema.fieldNames.toSet
-    val missingColumns = columns.filterNot(schemaColumns.contains).distinct
+    val missingColumns = columns.map(_.name).filterNot(schemaColumns.contains).distinct
     if (missingColumns.nonEmpty) {
       throw new AnalysisException(
         errorClass = "AUTOCDC_INVALID_COLUMN_SELECTION.COLUMNS_NOT_FOUND",
@@ -65,7 +97,9 @@ object ColumnSelection {
 sealed trait ScdType
 
 object ScdType {
+  /** Representation for the standard SCD1 strategy. */
   case object Type1 extends ScdType
+  /** Representation for the standard SCD2 strategy. */
   case object Type2 extends ScdType
 }
 
@@ -78,13 +112,13 @@ object ScdType {
  * @param deleteCondition Expression that marks a source row as a DELETE. When None, all
  *                        rows are treated as upserts.
  * @param storedAsScdType The SCD strategy these args should be applied to.
- * @param columnSelection Which source columns to include in the target table. None means
+ * @param columnSelection Which source columns to select in the target table. None means
  *                        all columns.
  */
 case class ChangeArgs(
     keys: Seq[String],
     sequencing: Column,
-    deleteCondition: Option[Column] = None,
     storedAsScdType: ScdType,
+    deleteCondition: Option[Column] = None,
     columnSelection: Option[ColumnSelection] = None
 )

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
@@ -28,20 +28,9 @@ import org.apache.spark.sql.types.StructType
  * A single, unqualified column identifier (no nested path or table/alias qualifier). Backticks
  * are consumed: "`a.b`" is stored as "a.b" in [[name]]. Use [[name]] for direct schema-fieldName
  * comparison and [[quoted]] for APIs that re-parse identifier strings.
- *
- * Declared `final class` so the smart constructor is the only path to construction (no synthesized
- * `copy` can bypass it).
  */
-final class UnqualifiedColumnName private (val name: String) extends Serializable {
-
+case class UnqualifiedColumnName private (name: String) {
   def quoted: String = QuotingUtils.quoteIdentifier(name)
-
-  override def equals(other: Any): Boolean = other match {
-    case that: UnqualifiedColumnName => name == that.name
-    case _ => false
-  }
-
-  override def hashCode(): Int = name.hashCode
 }
 
 object UnqualifiedColumnName {
@@ -78,6 +67,7 @@ object ColumnSelection {
    * order follows the original schema; filtering happens in place.
    */
   def applyToSchema(
+      schemaName: String,
       schema: StructType,
       columnSelection: Option[ColumnSelection],
       ignoreCase: Boolean): StructType = columnSelection match {
@@ -86,7 +76,7 @@ object ColumnSelection {
       schema
     case Some(IncludeColumns(cols)) =>
       val includeColumnNames = cols.map(_.name)
-      validateColumnsExistInSchema(includeColumnNames, schema, ignoreCase)
+      validateColumnsExistInSchema(schemaName, schema, includeColumnNames, ignoreCase)
 
       val caseNormalizedIncludeColumnNames =
         includeColumnNames.map(normalizeCase(_, ignoreCase)).toSet
@@ -98,7 +88,7 @@ object ColumnSelection {
       )
     case Some(ExcludeColumns(cols)) =>
       val excludeColumnNames = cols.map(_.name)
-      validateColumnsExistInSchema(excludeColumnNames, schema, ignoreCase)
+      validateColumnsExistInSchema(schemaName, schema, excludeColumnNames, ignoreCase)
 
       val caseNormalizedExcludeColumnNames =
         excludeColumnNames.map(normalizeCase(_, ignoreCase)).toSet
@@ -111,8 +101,9 @@ object ColumnSelection {
   }
 
   private def validateColumnsExistInSchema(
-      columnNames: Seq[String],
+      schemaName: String,
       schema: StructType,
+      columnNames: Seq[String],
       ignoreCase: Boolean): Unit = {
     val caseNormalizedSchemaColumns =
       schema.fieldNames.map(normalizeCase(_, ignoreCase)).toSet
@@ -129,9 +120,10 @@ object ColumnSelection {
       throw new AnalysisException(
         errorClass = "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA",
         messageParameters = Map(
+          "caseSensitivity" -> CaseSensitivityLabels.of(ignoreCase),
+          "schemaName" -> schemaName,
           "missingColumns" -> columnsMissingInSchema.mkString(", "),
-          "availableColumns" -> schema.fieldNames.mkString(", "),
-          "matching" -> (if (ignoreCase) "case-insensitive" else "case-sensitive")
+          "availableColumns" -> schema.fieldNames.mkString(", ")
         ))
     }
   }
@@ -146,6 +138,15 @@ object ColumnSelection {
       name
     }
   }
+}
+
+/** User-facing case-sensitivity labels surfaced in AutoCDC error messages. */
+private[autocdc] object CaseSensitivityLabels {
+  val CaseSensitive: String = "case-sensitive"
+  val CaseInsensitive: String = "case-insensitive"
+
+  def of(ignoreCase: Boolean): String =
+    if (ignoreCase) CaseInsensitive else CaseSensitive
 }
 
 /** The SCD (Slowly Changing Dimension) strategy for a CDC flow. */

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.pipelines.autocdc
+
+import org.apache.spark.sql.{AnalysisException, Column}
+import org.apache.spark.sql.types.StructType
+
+sealed trait ColumnSelection
+object ColumnSelection {
+  type ColumnList = Seq[String]
+  case class IncludeColumns(columns: ColumnList) extends ColumnSelection
+  case class ExcludeColumns(columns: ColumnList) extends ColumnSelection
+
+  /**
+   * Applies [[ColumnSelection]] to a [[StructType]] and returns the filtered schema.
+   * Field names are matched exactly. Field order follows the original schema (filtered in place).
+   */
+  def applyToSchema(schema: StructType, columnSelection: Option[ColumnSelection]): StructType =
+    columnSelection match {
+      case None =>
+        // A none column selection is interpreted as a no-op (select all columns existing in the schema).
+        schema
+      case Some(IncludeColumns(includeColumns)) =>
+        validateColumnsExistInSchema(columns = includeColumns, schema = schema)
+        
+        val includeColumnSet = includeColumns.toSet
+        StructType(schema.fields.filter(f => includeColumnSet.contains(f.name)))
+      case Some(ExcludeColumns(excludeColumns)) =>
+        validateColumnsExistInSchema(columns = excludeColumns, schema = schema)
+        
+        val excludeColumnSet = excludeColumns.toSet
+        StructType(schema.fields.filterNot(f => excludeColumnSet.contains(f.name)))
+    }
+
+  private def validateColumnsExistInSchema(columns: ColumnList, schema: StructType): Unit = {
+    val schemaColumns = schema.fieldNames.toSet
+    val missingColumns = columns.filterNot(schemaColumns.contains).distinct
+    if (missingColumns.nonEmpty) {
+      throw new AnalysisException(
+        errorClass = "AUTOCDC_INVALID_COLUMN_SELECTION.COLUMNS_NOT_FOUND",
+        messageParameters = Map(
+          "missingColumns" -> missingColumns.mkString(", "),
+          "availableColumns" -> schema.fieldNames.mkString(", ")
+        ))
+    }
+  }
+}
+
+/** The SCD (Slowly Changing Dimension) strategy for a CDC flow. */
+sealed trait ScdType
+
+object ScdType {
+  case object Type1 extends ScdType
+  case object Type2 extends ScdType
+}
+
+/**
+ * Configuration for an AutoCDC flow.
+ *
+ * @param keys            The column(s) that uniquely identify a row in the source data.
+ * @param sequencing      Expression ordering CDC events to correctly resolve out-of-order
+ *                        arrivals. Must be a sortable type.
+ * @param deleteCondition Expression that marks a source row as a DELETE. When None, all
+ *                        rows are treated as upserts.
+ * @param storedAsScdType The SCD strategy these args should be applied to.
+ * @param columnSelection Which source columns to include in the target table. None means
+ *                        all columns.
+ */
+case class ChangeArgs(
+    keys: Seq[String],
+    sequencing: Column,
+    deleteCondition: Option[Column] = None,
+    storedAsScdType: ScdType,
+    columnSelection: Option[ColumnSelection] = None
+)

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
@@ -61,24 +61,34 @@ object ColumnSelection {
       extends ColumnSelection
 
   /**
-   * Applies [[ColumnSelection]] to a [[StructType]] and returns the filtered schema. Field
-   * order follows the original schema; filtering happens in place.
+   * Applies [[ColumnSelection]] to a [[StructType]] and returns the filtered schema. Field order
+   * follows the original schema; only matching fields are retained in the returned schema.
+   *
+   * @param schemaName      Logical name of the schema being filtered, surfaced in error messages
+   *                        when columns are not found (e.g. "microbatch", "target").
+   * @param schema          The schema to filter.
+   * @param columnSelection The user-provided selection. `None` is a no-op and returns `schema`
+   *                        unchanged.
+   * @param caseSensitive   Whether to match column names case-sensitively against the schema.
+   *                        Callers should derive this from the session, e.g.
+   *                        `session.sessionState.conf.caseSensitiveAnalysis`, so column matching
+   *                        stays consistent with `spark.sql.caseSensitive`.
    */
   def applyToSchema(
       schemaName: String,
       schema: StructType,
       columnSelection: Option[ColumnSelection],
-      ignoreCase: Boolean): StructType = columnSelection match {
+      caseSensitive: Boolean): StructType = columnSelection match {
     case None =>
       // A None column selection is interpreted as a no-op.
       schema
     case Some(IncludeColumns(cols)) =>
-      val keepIndices = lookupFieldIndices(schemaName, schema, cols, ignoreCase)
+      val keepIndices = lookupFieldIndices(schemaName, schema, cols, caseSensitive)
       StructType(schema.fields.zipWithIndex.collect {
         case (field, idx) if keepIndices.contains(idx) => field
       })
     case Some(ExcludeColumns(cols)) =>
-      val dropIndices = lookupFieldIndices(schemaName, schema, cols, ignoreCase)
+      val dropIndices = lookupFieldIndices(schemaName, schema, cols, caseSensitive)
       StructType(schema.fields.zipWithIndex.collect {
         case (field, idx) if !dropIndices.contains(idx) => field
       })
@@ -88,9 +98,9 @@ object ColumnSelection {
       schemaName: String,
       schema: StructType,
       fields: Seq[UnqualifiedColumnName],
-      ignoreCase: Boolean): Set[Int] = {
+      caseSensitive: Boolean): Set[Int] = {
     val caseAwareGetFieldIndex: String => Option[Int] =
-      if (ignoreCase) schema.getFieldIndexCaseInsensitive else schema.getFieldIndex
+      if (caseSensitive) schema.getFieldIndex else schema.getFieldIndexCaseInsensitive
 
     val fieldIndexResolutions = fields.map(f => f -> caseAwareGetFieldIndex(f.name))
     val missingFieldNames = fieldIndexResolutions.collect { case (f, None) => f.name }.distinct
@@ -98,7 +108,7 @@ object ColumnSelection {
       throw new AnalysisException(
         errorClass = "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA",
         messageParameters = Map(
-          "caseSensitivity" -> CaseSensitivityLabels.of(ignoreCase),
+          "caseSensitivity" -> CaseSensitivityLabels.of(caseSensitive),
           "schemaName" -> schemaName,
           "missingColumns" -> missingFieldNames.mkString(", "),
           "availableColumns" -> schema.fieldNames.mkString(", ")
@@ -114,8 +124,8 @@ private[autocdc] object CaseSensitivityLabels {
   val CaseSensitive: String = "case-sensitive"
   val CaseInsensitive: String = "case-insensitive"
 
-  def of(ignoreCase: Boolean): String =
-    if (ignoreCase) CaseInsensitive else CaseSensitive
+  def of(caseSensitive: Boolean): String =
+    if (caseSensitive) CaseSensitive else CaseInsensitive
 }
 
 /** The SCD (Slowly Changing Dimension) strategy for a CDC flow. */

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.pipelines.autocdc
 
-import java.util.Locale
-
 import org.apache.spark.sql.{AnalysisException, Column}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.util.QuotingUtils
@@ -72,71 +70,42 @@ object ColumnSelection {
       columnSelection: Option[ColumnSelection],
       ignoreCase: Boolean): StructType = columnSelection match {
     case None =>
-      // A none column selection is interpreted as a no-op.
+      // A None column selection is interpreted as a no-op.
       schema
     case Some(IncludeColumns(cols)) =>
-      val includeColumnNames = cols.map(_.name)
-      validateColumnsExistInSchema(schemaName, schema, includeColumnNames, ignoreCase)
-
-      val caseNormalizedIncludeColumnNames =
-        includeColumnNames.map(normalizeCase(_, ignoreCase)).toSet
-
-      StructType(
-        schema.fields.filter(schemaField =>
-          caseNormalizedIncludeColumnNames.contains(normalizeCase(schemaField.name, ignoreCase))
-        )
-      )
+      val keepIndices = lookupFieldIndices(schemaName, schema, cols, ignoreCase)
+      StructType(schema.fields.zipWithIndex.collect {
+        case (field, idx) if keepIndices.contains(idx) => field
+      })
     case Some(ExcludeColumns(cols)) =>
-      val excludeColumnNames = cols.map(_.name)
-      validateColumnsExistInSchema(schemaName, schema, excludeColumnNames, ignoreCase)
-
-      val caseNormalizedExcludeColumnNames =
-        excludeColumnNames.map(normalizeCase(_, ignoreCase)).toSet
-
-      StructType(
-        schema.fields.filterNot(schemaField =>
-          caseNormalizedExcludeColumnNames.contains(normalizeCase(schemaField.name, ignoreCase))
-        )
-      )
+      val dropIndices = lookupFieldIndices(schemaName, schema, cols, ignoreCase)
+      StructType(schema.fields.zipWithIndex.collect {
+        case (field, idx) if !dropIndices.contains(idx) => field
+      })
   }
 
-  private def validateColumnsExistInSchema(
+  private def lookupFieldIndices(
       schemaName: String,
       schema: StructType,
-      columnNames: Seq[String],
-      ignoreCase: Boolean): Unit = {
-    val caseNormalizedSchemaColumns =
-      schema.fieldNames.map(normalizeCase(_, ignoreCase)).toSet
+      fields: Seq[UnqualifiedColumnName],
+      ignoreCase: Boolean): Set[Int] = {
+    val caseAwareGetFieldIndex: String => Option[Int] =
+      if (ignoreCase) schema.getFieldIndexCaseInsensitive else schema.getFieldIndex
 
-    // Compare folded forms but report the missing and available columns using their original
-    // casing so error messages reflect what the user actually wrote and what the schema holds.
-    val columnsMissingInSchema = columnNames
-      .filterNot(columnName =>
-        caseNormalizedSchemaColumns.contains(normalizeCase(columnName, ignoreCase))
-      )
-      .distinct
-
-    if (columnsMissingInSchema.nonEmpty) {
+    val fieldIndexResolutions = fields.map(f => f -> caseAwareGetFieldIndex(f.name))
+    val missingFieldNames = fieldIndexResolutions.collect { case (f, None) => f.name }.distinct
+    if (missingFieldNames.nonEmpty) {
       throw new AnalysisException(
         errorClass = "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA",
         messageParameters = Map(
           "caseSensitivity" -> CaseSensitivityLabels.of(ignoreCase),
           "schemaName" -> schemaName,
-          "missingColumns" -> columnsMissingInSchema.mkString(", "),
+          "missingColumns" -> missingFieldNames.mkString(", "),
           "availableColumns" -> schema.fieldNames.mkString(", ")
-        ))
+        )
+      )
     }
-  }
-
-  /**
-   * If ignoreCase, normalize all strings to lowercase for stable comparison.
-   */
-  private def normalizeCase(name: String, ignoreCase: Boolean): String = {
-    if (ignoreCase) {
-      name.toLowerCase(Locale.ROOT)
-    } else {
-      name
-    }
+    fieldIndexResolutions.flatMap { case (_, idx) => idx }.toSet
   }
 }
 

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
@@ -21,11 +21,11 @@ import org.apache.spark.sql.{AnalysisException, Column}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.types.StructType
 
-/** A column reference that must be a single, unqualified identifier (no nested
-  * field path and no table/alias qualifier). The constructor parses
-  * [[columnName]] with the Spark SQL parser and throws an [[AnalysisException]]
-  * if it does not resolve to exactly one name part.
-  */
+/**
+ * A column reference that must be a single, unqualified identifier (no nested field path and
+ * no table/alias qualifier). The constructor parses [[name]] with the Spark SQL parser and
+ * throws an [[AnalysisException]] if it does not resolve to exactly one name part.
+ */
 case class UnqualifiedColumnName(name: String) {
   UnqualifiedColumnName.validate(name)
 }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
@@ -33,16 +33,16 @@ object ColumnSelection {
   def applyToSchema(schema: StructType, columnSelection: Option[ColumnSelection]): StructType =
     columnSelection match {
       case None =>
-        // A none column selection is interpreted as a no-op (select all columns existing in the schema).
+        // A none column selection is interpreted as a no-op.
         schema
       case Some(IncludeColumns(includeColumns)) =>
         validateColumnsExistInSchema(columns = includeColumns, schema = schema)
-        
+
         val includeColumnSet = includeColumns.toSet
         StructType(schema.fields.filter(f => includeColumnSet.contains(f.name)))
       case Some(ExcludeColumns(excludeColumns)) =>
         validateColumnsExistInSchema(columns = excludeColumns, schema = schema)
-        
+
         val excludeColumnSet = excludeColumns.toSet
         StructType(schema.fields.filterNot(f => excludeColumnSet.contains(f.name)))
     }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgs.scala
@@ -17,25 +17,40 @@
 
 package org.apache.spark.sql.pipelines.autocdc
 
+import java.util.Locale
+
 import org.apache.spark.sql.{AnalysisException, Column}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.catalyst.util.QuotingUtils
 import org.apache.spark.sql.types.StructType
 
 /**
- * A column reference that must be a single, unqualified identifier (no nested field path and
- * no table/alias qualifier). The constructor parses [[name]] with the Spark SQL parser and
- * throws an [[AnalysisException]] if it does not resolve to exactly one name part.
+ * A single, unqualified column identifier (no nested path or table/alias qualifier). Backticks
+ * are consumed: "`a.b`" is stored as "a.b" in [[name]]. Use [[name]] for direct schema-fieldName
+ * comparison and [[quoted]] for APIs that re-parse identifier strings.
+ *
+ * Declared `final class` so the smart constructor is the only path to construction (no synthesized
+ * `copy` can bypass it).
  */
-case class UnqualifiedColumnName(name: String) {
-  UnqualifiedColumnName.validate(name)
+final class UnqualifiedColumnName private (val name: String) extends Serializable {
+
+  def quoted: String = QuotingUtils.quoteIdentifier(name)
+
+  override def equals(other: Any): Boolean = other match {
+    case that: UnqualifiedColumnName => name == that.name
+    case _ => false
+  }
+
+  override def hashCode(): Int = name.hashCode
 }
 
 object UnqualifiedColumnName {
-  private def validate(columnName: String): Unit = {
-    val nameParts = CatalystSqlParser.parseMultipartIdentifier(columnName)
+  def apply(input: String): UnqualifiedColumnName = {
+    val nameParts = CatalystSqlParser.parseMultipartIdentifier(input)
     if (nameParts.length != 1) {
-      throw multipartColumnIdentifierError(columnName, nameParts)
+      throw multipartColumnIdentifierError(input, nameParts)
     }
+    new UnqualifiedColumnName(nameParts.head)
   }
 
   private def multipartColumnIdentifierError(
@@ -43,7 +58,7 @@ object UnqualifiedColumnName {
       nameParts: Seq[String]
   ): AnalysisException =
     new AnalysisException(
-      errorClass = "AUTOCDC_INVALID_COLUMN_SELECTION.MULTIPART_COLUMN_IDENTIFIER",
+      errorClass = "AUTOCDC_MULTIPART_COLUMN_IDENTIFIER",
       messageParameters = Map(
         "columnName" -> columnName,
         "nameParts" -> nameParts.mkString(", ")
@@ -53,42 +68,82 @@ object UnqualifiedColumnName {
 
 sealed trait ColumnSelection
 object ColumnSelection {
-  type ColumnList = Seq[UnqualifiedColumnName]
 
-  case class IncludeColumns(columns: ColumnList) extends ColumnSelection
-  case class ExcludeColumns(columns: ColumnList) extends ColumnSelection
+  case class IncludeColumns(columns: Seq[UnqualifiedColumnName]) extends ColumnSelection
+  case class ExcludeColumns(columns: Seq[UnqualifiedColumnName])
+      extends ColumnSelection
 
   /**
-   * Applies [[ColumnSelection]] to a [[StructType]] and returns the filtered schema.
-   * Field names are matched exactly. Field order follows the original schema (filtered in place).
+   * Applies [[ColumnSelection]] to a [[StructType]] and returns the filtered schema. Field
+   * order follows the original schema; filtering happens in place.
    */
-  def applyToSchema(schema: StructType, columnSelection: Option[ColumnSelection]): StructType =
-    columnSelection match {
-      case None =>
-        // A none column selection is interpreted as a no-op.
-        schema
-      case Some(IncludeColumns(includeColumns)) =>
-        validateColumnsExistInSchema(includeColumns, schema)
+  def applyToSchema(
+      schema: StructType,
+      columnSelection: Option[ColumnSelection],
+      ignoreCase: Boolean): StructType = columnSelection match {
+    case None =>
+      // A none column selection is interpreted as a no-op.
+      schema
+    case Some(IncludeColumns(cols)) =>
+      val includeColumnNames = cols.map(_.name)
+      validateColumnsExistInSchema(includeColumnNames, schema, ignoreCase)
 
-        val includeColumnSet = includeColumns.map(_.name).toSet
-        StructType(schema.fields.filter(f => includeColumnSet.contains(f.name)))
-      case Some(ExcludeColumns(excludeColumns)) =>
-        validateColumnsExistInSchema(excludeColumns, schema)
+      val caseNormalizedIncludeColumnNames =
+        includeColumnNames.map(normalizeCase(_, ignoreCase)).toSet
 
-        val excludeColumnSet = excludeColumns.map(_.name).toSet
-        StructType(schema.fields.filterNot(f => excludeColumnSet.contains(f.name)))
-    }
+      StructType(
+        schema.fields.filter(schemaField =>
+          caseNormalizedIncludeColumnNames.contains(normalizeCase(schemaField.name, ignoreCase))
+        )
+      )
+    case Some(ExcludeColumns(cols)) =>
+      val excludeColumnNames = cols.map(_.name)
+      validateColumnsExistInSchema(excludeColumnNames, schema, ignoreCase)
 
-  private def validateColumnsExistInSchema(columns: ColumnList, schema: StructType): Unit = {
-    val schemaColumns = schema.fieldNames.toSet
-    val missingColumns = columns.map(_.name).filterNot(schemaColumns.contains).distinct
-    if (missingColumns.nonEmpty) {
+      val caseNormalizedExcludeColumnNames =
+        excludeColumnNames.map(normalizeCase(_, ignoreCase)).toSet
+
+      StructType(
+        schema.fields.filterNot(schemaField =>
+          caseNormalizedExcludeColumnNames.contains(normalizeCase(schemaField.name, ignoreCase))
+        )
+      )
+  }
+
+  private def validateColumnsExistInSchema(
+      columnNames: Seq[String],
+      schema: StructType,
+      ignoreCase: Boolean): Unit = {
+    val caseNormalizedSchemaColumns =
+      schema.fieldNames.map(normalizeCase(_, ignoreCase)).toSet
+
+    // Compare folded forms but report the missing and available columns using their original
+    // casing so error messages reflect what the user actually wrote and what the schema holds.
+    val columnsMissingInSchema = columnNames
+      .filterNot(columnName =>
+        caseNormalizedSchemaColumns.contains(normalizeCase(columnName, ignoreCase))
+      )
+      .distinct
+
+    if (columnsMissingInSchema.nonEmpty) {
       throw new AnalysisException(
-        errorClass = "AUTOCDC_INVALID_COLUMN_SELECTION.COLUMNS_NOT_FOUND",
+        errorClass = "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA",
         messageParameters = Map(
-          "missingColumns" -> missingColumns.mkString(", "),
-          "availableColumns" -> schema.fieldNames.mkString(", ")
+          "missingColumns" -> columnsMissingInSchema.mkString(", "),
+          "availableColumns" -> schema.fieldNames.mkString(", "),
+          "matching" -> (if (ignoreCase) "case-insensitive" else "case-sensitive")
         ))
+    }
+  }
+
+  /**
+   * If ignoreCase, normalize all strings to lowercase for stable comparison.
+   */
+  private def normalizeCase(name: String, ignoreCase: Boolean): String = {
+    if (ignoreCase) {
+      name.toLowerCase(Locale.ROOT)
+    } else {
+      name
     }
   }
 }
@@ -116,7 +171,7 @@ object ScdType {
  *                        all columns.
  */
 case class ChangeArgs(
-    keys: Seq[String],
+    keys: Seq[UnqualifiedColumnName],
     sequencing: Column,
     storedAsScdType: ScdType,
     deleteCondition: Option[Column] = None,

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
@@ -40,6 +40,30 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
       ) == sourceSchema)
   }
 
+  test("ColumnSelection IncludeColumns(Seq()) returns an empty schema") {
+    // An explicit empty include-list is semantically distinct from None: it means "select
+    // no columns" and produces an empty StructType, not the original schema.
+    assert(
+      ColumnSelection.applyToSchema(
+        schemaName = "test",
+        schema = sourceSchema,
+        columnSelection = Some(ColumnSelection.IncludeColumns(Seq.empty)),
+        ignoreCase = false
+      ) == new StructType())
+  }
+
+  test("ColumnSelection ExcludeColumns(Seq()) leaves schema unchanged") {
+    // An empty exclude-list is a no-op: nothing to remove, so the original schema is
+    // returned unchanged (same observable behavior as None for this case).
+    assert(
+      ColumnSelection.applyToSchema(
+        schemaName = "test",
+        schema = sourceSchema,
+        columnSelection = Some(ColumnSelection.ExcludeColumns(Seq.empty)),
+        ignoreCase = false
+      ) == sourceSchema)
+  }
+
   test("ColumnSelection IncludeColumns filters by exact name in schema order") {
     val filteredSchema = ColumnSelection.applyToSchema(
       schemaName = "test",

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.pipelines.autocdc
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
+
+class ChangeArgsSuite extends SparkFunSuite {
+
+  private val sourceSchema = new StructType()
+    .add("id", IntegerType, nullable = false)
+    .add("Name", StringType)
+    .add("age", IntegerType)
+
+  test("ColumnSelection None leaves schema unchanged") {
+    assert(ColumnSelection.applyToSchema(sourceSchema, None) == sourceSchema)
+  }
+
+  test("ColumnSelection IncludeColumns filters by exact name in schema order") {
+    val filteredSchema = ColumnSelection.applyToSchema(
+      sourceSchema,
+      Some(ColumnSelection.IncludeColumns(Seq("age", "Name"))))
+
+    assert(filteredSchema == new StructType()
+      .add("Name", StringType)
+      .add("age", IntegerType))
+  }
+
+  test("ColumnSelection ExcludeColumns filters by exact name") {
+    val filteredSchema = ColumnSelection.applyToSchema(
+      sourceSchema,
+      Some(ColumnSelection.ExcludeColumns(Seq("id"))))
+
+    assert(filteredSchema == new StructType()
+      .add("Name", StringType)
+      .add("age", IntegerType))
+  }
+
+  test("ColumnSelection IncludeColumns fails for columns not present in schema") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        ColumnSelection.applyToSchema(
+          sourceSchema,
+          // Column inclusion is case-sensitive; "name" will not match against "Name".
+          Some(ColumnSelection.IncludeColumns(Seq("name", "missing")))
+        )
+      },
+      condition = "AUTOCDC_INVALID_COLUMN_SELECTION.COLUMNS_NOT_FOUND",
+      sqlState = "42703",
+      parameters = Map(
+        "missingColumns" -> "name, missing",
+        "availableColumns" -> "id, Name, age"
+      )
+    )
+  }
+
+  test("ColumnSelection ExcludeColumns fails for columns not present in schema") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        ColumnSelection.applyToSchema(
+          sourceSchema,
+          // Column exclusion is case-sensitive; "NAME" will not match against "Name".
+          Some(ColumnSelection.ExcludeColumns(Seq("NAME", "missing")))
+        )
+      },
+      condition = "AUTOCDC_INVALID_COLUMN_SELECTION.COLUMNS_NOT_FOUND",
+      sqlState = "42703",
+      parameters = Map(
+        "missingColumns" -> "NAME, missing",
+        "availableColumns" -> "id, Name, age"
+      )
+    )
+  }
+}

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
@@ -207,18 +207,24 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
 
   test("UnqualifiedColumnName accepts a simple single-part identifier") {
     assert(UnqualifiedColumnName("col").name == "col")
+    // .quoted always wraps in back-ticks, even when the input had none.
+    assert(UnqualifiedColumnName("col").quoted == "`col`")
   }
 
   test("UnqualifiedColumnName accepts a backtick-quoted name containing a literal dot") {
     // Backticks make the dot part of a single name part, so this passes validation. The
     // stored name is the parsed (unquoted) form so it matches the actual schema field name.
     assert(UnqualifiedColumnName("`a.b`").name == "a.b")
+    // .quoted re-wraps the parsed name in back-ticks, round-tripping back to the input form.
+    assert(UnqualifiedColumnName("`a.b`").quoted == "`a.b`")
   }
 
   test("UnqualifiedColumnName accepts redundant backticks around a single-part name") {
     // Backticks around an already-single-part identifier are decorative; the parser strips them
     // so the stored name has no surrounding back-ticks.
     assert(UnqualifiedColumnName("`col`").name == "col")
+    // .quoted re-wraps the parsed name in back-ticks, round-tripping back to the input form.
+    assert(UnqualifiedColumnName("`col`").quoted == "`col`")
   }
 
   test("UnqualifiedColumnName.quoted is safe to pass to functions.col for literal-dot names") {

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
@@ -18,11 +18,12 @@
 package org.apache.spark.sql.pipelines.autocdc
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.{functions => F, AnalysisException, Row}
 import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
-class ChangeArgsSuite extends SparkFunSuite {
+class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
 
   private val sourceSchema = new StructType()
     .add("id", IntegerType, nullable = false)
@@ -30,14 +31,24 @@ class ChangeArgsSuite extends SparkFunSuite {
     .add("age", IntegerType)
 
   test("ColumnSelection None leaves schema unchanged") {
-    assert(ColumnSelection.applyToSchema(sourceSchema, None) == sourceSchema)
+    assert(
+      ColumnSelection.applyToSchema(
+        schema = sourceSchema,
+        columnSelection = None,
+        ignoreCase = false
+      ) == sourceSchema)
   }
 
   test("ColumnSelection IncludeColumns filters by exact name in schema order") {
     val filteredSchema = ColumnSelection.applyToSchema(
-      sourceSchema,
-      Some(ColumnSelection.IncludeColumns(
-        Seq(UnqualifiedColumnName("age"), UnqualifiedColumnName("Name")))))
+      schema = sourceSchema,
+      columnSelection = Some(
+        ColumnSelection.IncludeColumns(
+          Seq(UnqualifiedColumnName("age"), UnqualifiedColumnName("Name"))
+        )
+      ),
+      ignoreCase = false
+    )
 
     assert(filteredSchema == new StructType()
       .add("Name", StringType)
@@ -46,8 +57,12 @@ class ChangeArgsSuite extends SparkFunSuite {
 
   test("ColumnSelection ExcludeColumns filters by exact name") {
     val filteredSchema = ColumnSelection.applyToSchema(
-      sourceSchema,
-      Some(ColumnSelection.ExcludeColumns(Seq(UnqualifiedColumnName("id")))))
+      schema = sourceSchema,
+      columnSelection = Some(
+        ColumnSelection.ExcludeColumns(Seq(UnqualifiedColumnName("id")))
+      ),
+      ignoreCase = false
+    )
 
     assert(filteredSchema == new StructType()
       .add("Name", StringType)
@@ -58,17 +73,22 @@ class ChangeArgsSuite extends SparkFunSuite {
     checkError(
       exception = intercept[AnalysisException] {
         ColumnSelection.applyToSchema(
-          sourceSchema,
-          // Column inclusion is case-sensitive; "name" will not match against "Name".
-          Some(ColumnSelection.IncludeColumns(
-            Seq(UnqualifiedColumnName("name"), UnqualifiedColumnName("missing"))))
+          schema = sourceSchema,
+          // Under ignoreCase = false, "name" will not match the schema field "Name".
+          columnSelection = Some(
+            ColumnSelection.IncludeColumns(
+              Seq(UnqualifiedColumnName("name"), UnqualifiedColumnName("missing"))
+            )
+          ),
+          ignoreCase = false
         )
       },
-      condition = "AUTOCDC_INVALID_COLUMN_SELECTION.COLUMNS_NOT_FOUND",
+      condition = "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA",
       sqlState = "42703",
       parameters = Map(
         "missingColumns" -> "name, missing",
-        "availableColumns" -> "id, Name, age"
+        "availableColumns" -> "id, Name, age",
+        "matching" -> "case-sensitive"
       )
     )
   }
@@ -77,17 +97,98 @@ class ChangeArgsSuite extends SparkFunSuite {
     checkError(
       exception = intercept[AnalysisException] {
         ColumnSelection.applyToSchema(
-          sourceSchema,
-          // Column exclusion is case-sensitive; "NAME" will not match against "Name".
-          Some(ColumnSelection.ExcludeColumns(
-            Seq(UnqualifiedColumnName("NAME"), UnqualifiedColumnName("missing"))))
+          schema = sourceSchema,
+          // Under ignoreCase = false, "NAME" will not match the schema field "Name".
+          columnSelection = Some(
+            ColumnSelection.ExcludeColumns(
+              Seq(UnqualifiedColumnName("NAME"), UnqualifiedColumnName("missing"))
+            )
+          ),
+          ignoreCase = false
         )
       },
-      condition = "AUTOCDC_INVALID_COLUMN_SELECTION.COLUMNS_NOT_FOUND",
+      condition = "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA",
       sqlState = "42703",
       parameters = Map(
         "missingColumns" -> "NAME, missing",
-        "availableColumns" -> "id, Name, age"
+        "availableColumns" -> "id, Name, age",
+        "matching" -> "case-sensitive"
+      )
+    )
+  }
+
+  test("ColumnSelection IncludeColumns matches case-insensitively under ignoreCase=true") {
+    // "NAME" and "AGE" do not exactly match the schema fields "Name" and "age", but
+    // ignoreCase = true folds both sides to lowercase before comparing.
+    val filteredSchema = ColumnSelection.applyToSchema(
+      schema = sourceSchema,
+      columnSelection = Some(
+        ColumnSelection.IncludeColumns(
+          Seq(UnqualifiedColumnName("AGE"), UnqualifiedColumnName("NAME"))
+        )
+      ),
+      ignoreCase = true
+    )
+
+    // The retained fields keep their original casing from the schema, not the user's input.
+    assert(filteredSchema == new StructType()
+      .add("Name", StringType)
+      .add("age", IntegerType))
+  }
+
+  test("ColumnSelection deduplicates user-provided columns that normalize to the same name") {
+    // Under ignoreCase = true, "name" and "NAME" both fold to "name" and refer to the same
+    // schema field. The returned schema must include "Name" once, not twice. Output ordering
+    // and casing follow the schema, not the user's input.
+    val filteredSchema = ColumnSelection.applyToSchema(
+      schema = sourceSchema,
+      columnSelection = Some(
+        ColumnSelection.IncludeColumns(
+          Seq(UnqualifiedColumnName("name"), UnqualifiedColumnName("NAME"))
+        )
+      ),
+      ignoreCase = true
+    )
+
+    assert(filteredSchema == new StructType().add("Name", StringType))
+  }
+
+  test("ColumnSelection ExcludeColumns matches case-insensitively under ignoreCase=true") {
+    val filteredSchema = ColumnSelection.applyToSchema(
+      schema = sourceSchema,
+      columnSelection = Some(
+        ColumnSelection.ExcludeColumns(Seq(UnqualifiedColumnName("name")))
+      ),
+      ignoreCase = true
+    )
+
+    assert(filteredSchema == new StructType()
+      .add("id", IntegerType, nullable = false)
+      .add("age", IntegerType))
+  }
+
+  test("ColumnSelection missing-column error under ignoreCase=true preserves user casing") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        ColumnSelection.applyToSchema(
+          schema = sourceSchema,
+          // "NAME" matches "Name" under ignoreCase=true, but "Missing" has no schema match.
+          // The error message reports the user's original casing for the missing column and
+          // the schema's original casing for the available columns.
+          columnSelection = Some(
+            ColumnSelection.IncludeColumns(
+              Seq(UnqualifiedColumnName("NAME"), UnqualifiedColumnName("Missing"))
+            )
+          ),
+          ignoreCase = true
+        )
+      },
+      condition = "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA",
+      sqlState = "42703",
+      parameters = Map(
+        "missingColumns" -> "Missing",
+        "availableColumns" -> "id, Name, age",
+        "matching" -> "case-insensitive"
       )
     )
   }
@@ -97,8 +198,64 @@ class ChangeArgsSuite extends SparkFunSuite {
   }
 
   test("UnqualifiedColumnName accepts a backtick-quoted name containing a literal dot") {
-    // Backticks make the dot part of a single name part, so this passes validation.
-    assert(UnqualifiedColumnName("`a.b`").name == "`a.b`")
+    // Backticks make the dot part of a single name part, so this passes validation. The
+    // stored name is the parsed (unquoted) form so it matches the actual schema field name.
+    assert(UnqualifiedColumnName("`a.b`").name == "a.b")
+  }
+
+  test("UnqualifiedColumnName.quoted is safe to pass to functions.col for literal-dot names") {
+    val schema = new StructType()
+      .add("a.b", IntegerType)
+      .add("c", IntegerType)
+
+    val df = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row(1, 2), Row(3, 4))),
+      schema
+    )
+
+    val key = UnqualifiedColumnName("`a.b`")
+
+    // Sanity-check: the unquoted `name` is not safe to pass to `functions.col`. The string is
+    // re-parsed and the literal dot is interpreted as a nested-field path separator, so the
+    // analyzer fails to resolve `a`.`b` against the available top-level columns.
+    checkError(
+      exception = intercept[AnalysisException] {
+        df.select(F.col(key.name)).collect()
+      },
+      condition = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
+      sqlState = "42703",
+      parameters = Map(
+        "objectName" -> "`a`.`b`",
+        "proposal" -> "`a.b`, `c`"
+      ),
+      context = ExpectedContext(
+        fragment = "col",
+        callSitePattern = ""
+      )
+    )
+
+    // The `quoted` form wraps the name in back-ticks so the re-parser treats the whole thing
+    // as a single identifier, resolving to the top-level "a.b" column.
+    assert(df.select(F.col(key.quoted)).collect().toSeq == Seq(Row(1), Row(3)))
+  }
+
+  test("IncludeColumns correctly matches a backtick-quoted literal-dot column") {
+    val schema = new StructType()
+      .add("a.b", IntegerType)
+      .add("c", StringType)
+
+    // The user writes `a.b` to refer to the literal-dot column "a.b" in the schema. After
+    // construction, the [[UnqualifiedColumnName]] holds "a.b", which matches the field name
+    // exactly and the column is included in the filtered schema.
+    val filteredSchema = ColumnSelection.applyToSchema(
+      schema = schema,
+      columnSelection = Some(
+        ColumnSelection.IncludeColumns(Seq(UnqualifiedColumnName("`a.b`")))
+      ),
+      ignoreCase = false
+    )
+
+    assert(filteredSchema == new StructType().add("a.b", IntegerType))
   }
 
   test("UnqualifiedColumnName rejects a dotted (multi-part) identifier") {
@@ -106,7 +263,7 @@ class ChangeArgsSuite extends SparkFunSuite {
       exception = intercept[AnalysisException] {
         UnqualifiedColumnName("a.b")
       },
-      condition = "AUTOCDC_INVALID_COLUMN_SELECTION.MULTIPART_COLUMN_IDENTIFIER",
+      condition = "AUTOCDC_MULTIPART_COLUMN_IDENTIFIER",
       sqlState = "42703",
       parameters = Map(
         "columnName" -> "a.b",
@@ -120,7 +277,7 @@ class ChangeArgsSuite extends SparkFunSuite {
       exception = intercept[AnalysisException] {
         UnqualifiedColumnName("src.x")
       },
-      condition = "AUTOCDC_INVALID_COLUMN_SELECTION.MULTIPART_COLUMN_IDENTIFIER",
+      condition = "AUTOCDC_MULTIPART_COLUMN_IDENTIFIER",
       sqlState = "42703",
       parameters = Map(
         "columnName" -> "src.x",
@@ -134,7 +291,7 @@ class ChangeArgsSuite extends SparkFunSuite {
       exception = intercept[AnalysisException] {
         UnqualifiedColumnName("a.b.c")
       },
-      condition = "AUTOCDC_INVALID_COLUMN_SELECTION.MULTIPART_COLUMN_IDENTIFIER",
+      condition = "AUTOCDC_MULTIPART_COLUMN_IDENTIFIER",
       sqlState = "42703",
       parameters = Map(
         "columnName" -> "a.b.c",

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
@@ -33,6 +33,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
   test("ColumnSelection None leaves schema unchanged") {
     assert(
       ColumnSelection.applyToSchema(
+        schemaName = "test",
         schema = sourceSchema,
         columnSelection = None,
         ignoreCase = false
@@ -41,6 +42,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
 
   test("ColumnSelection IncludeColumns filters by exact name in schema order") {
     val filteredSchema = ColumnSelection.applyToSchema(
+      schemaName = "test",
       schema = sourceSchema,
       columnSelection = Some(
         ColumnSelection.IncludeColumns(
@@ -57,6 +59,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
 
   test("ColumnSelection ExcludeColumns filters by exact name") {
     val filteredSchema = ColumnSelection.applyToSchema(
+      schemaName = "test",
       schema = sourceSchema,
       columnSelection = Some(
         ColumnSelection.ExcludeColumns(Seq(UnqualifiedColumnName("id")))
@@ -73,6 +76,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
     checkError(
       exception = intercept[AnalysisException] {
         ColumnSelection.applyToSchema(
+          schemaName = "test",
           schema = sourceSchema,
           // Under ignoreCase = false, "name" will not match the schema field "Name".
           columnSelection = Some(
@@ -86,9 +90,10 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
       condition = "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA",
       sqlState = "42703",
       parameters = Map(
+        "caseSensitivity" -> CaseSensitivityLabels.CaseSensitive,
+        "schemaName" -> "test",
         "missingColumns" -> "name, missing",
-        "availableColumns" -> "id, Name, age",
-        "matching" -> "case-sensitive"
+        "availableColumns" -> "id, Name, age"
       )
     )
   }
@@ -97,6 +102,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
     checkError(
       exception = intercept[AnalysisException] {
         ColumnSelection.applyToSchema(
+          schemaName = "test",
           schema = sourceSchema,
           // Under ignoreCase = false, "NAME" will not match the schema field "Name".
           columnSelection = Some(
@@ -110,9 +116,10 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
       condition = "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA",
       sqlState = "42703",
       parameters = Map(
+        "caseSensitivity" -> CaseSensitivityLabels.CaseSensitive,
+        "schemaName" -> "test",
         "missingColumns" -> "NAME, missing",
-        "availableColumns" -> "id, Name, age",
-        "matching" -> "case-sensitive"
+        "availableColumns" -> "id, Name, age"
       )
     )
   }
@@ -121,6 +128,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
     // "NAME" and "AGE" do not exactly match the schema fields "Name" and "age", but
     // ignoreCase = true folds both sides to lowercase before comparing.
     val filteredSchema = ColumnSelection.applyToSchema(
+      schemaName = "test",
       schema = sourceSchema,
       columnSelection = Some(
         ColumnSelection.IncludeColumns(
@@ -141,6 +149,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
     // schema field. The returned schema must include "Name" once, not twice. Output ordering
     // and casing follow the schema, not the user's input.
     val filteredSchema = ColumnSelection.applyToSchema(
+      schemaName = "test",
       schema = sourceSchema,
       columnSelection = Some(
         ColumnSelection.IncludeColumns(
@@ -155,6 +164,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
 
   test("ColumnSelection ExcludeColumns matches case-insensitively under ignoreCase=true") {
     val filteredSchema = ColumnSelection.applyToSchema(
+      schemaName = "test",
       schema = sourceSchema,
       columnSelection = Some(
         ColumnSelection.ExcludeColumns(Seq(UnqualifiedColumnName("name")))
@@ -171,6 +181,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
     checkError(
       exception = intercept[AnalysisException] {
         ColumnSelection.applyToSchema(
+          schemaName = "test",
           schema = sourceSchema,
           // "NAME" matches "Name" under ignoreCase=true, but "Missing" has no schema match.
           // The error message reports the user's original casing for the missing column and
@@ -186,9 +197,10 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
       condition = "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA",
       sqlState = "42703",
       parameters = Map(
+        "caseSensitivity" -> CaseSensitivityLabels.CaseInsensitive,
+        "schemaName" -> "test",
         "missingColumns" -> "Missing",
-        "availableColumns" -> "id, Name, age",
-        "matching" -> "case-insensitive"
+        "availableColumns" -> "id, Name, age"
       )
     )
   }
@@ -248,6 +260,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
     // construction, the [[UnqualifiedColumnName]] holds "a.b", which matches the field name
     // exactly and the column is included in the filtered schema.
     val filteredSchema = ColumnSelection.applyToSchema(
+      schemaName = "test",
       schema = schema,
       columnSelection = Some(
         ColumnSelection.IncludeColumns(Seq(UnqualifiedColumnName("`a.b`")))

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.pipelines.autocdc
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
 class ChangeArgsSuite extends SparkFunSuite {
@@ -35,7 +36,8 @@ class ChangeArgsSuite extends SparkFunSuite {
   test("ColumnSelection IncludeColumns filters by exact name in schema order") {
     val filteredSchema = ColumnSelection.applyToSchema(
       sourceSchema,
-      Some(ColumnSelection.IncludeColumns(Seq("age", "Name"))))
+      Some(ColumnSelection.IncludeColumns(
+        Seq(UnqualifiedColumnName("age"), UnqualifiedColumnName("Name")))))
 
     assert(filteredSchema == new StructType()
       .add("Name", StringType)
@@ -45,7 +47,7 @@ class ChangeArgsSuite extends SparkFunSuite {
   test("ColumnSelection ExcludeColumns filters by exact name") {
     val filteredSchema = ColumnSelection.applyToSchema(
       sourceSchema,
-      Some(ColumnSelection.ExcludeColumns(Seq("id"))))
+      Some(ColumnSelection.ExcludeColumns(Seq(UnqualifiedColumnName("id")))))
 
     assert(filteredSchema == new StructType()
       .add("Name", StringType)
@@ -58,7 +60,8 @@ class ChangeArgsSuite extends SparkFunSuite {
         ColumnSelection.applyToSchema(
           sourceSchema,
           // Column inclusion is case-sensitive; "name" will not match against "Name".
-          Some(ColumnSelection.IncludeColumns(Seq("name", "missing")))
+          Some(ColumnSelection.IncludeColumns(
+            Seq(UnqualifiedColumnName("name"), UnqualifiedColumnName("missing"))))
         )
       },
       condition = "AUTOCDC_INVALID_COLUMN_SELECTION.COLUMNS_NOT_FOUND",
@@ -76,7 +79,8 @@ class ChangeArgsSuite extends SparkFunSuite {
         ColumnSelection.applyToSchema(
           sourceSchema,
           // Column exclusion is case-sensitive; "NAME" will not match against "Name".
-          Some(ColumnSelection.ExcludeColumns(Seq("NAME", "missing")))
+          Some(ColumnSelection.ExcludeColumns(
+            Seq(UnqualifiedColumnName("NAME"), UnqualifiedColumnName("missing"))))
         )
       },
       condition = "AUTOCDC_INVALID_COLUMN_SELECTION.COLUMNS_NOT_FOUND",
@@ -85,6 +89,67 @@ class ChangeArgsSuite extends SparkFunSuite {
         "missingColumns" -> "NAME, missing",
         "availableColumns" -> "id, Name, age"
       )
+    )
+  }
+
+  test("UnqualifiedColumnName accepts a simple single-part identifier") {
+    assert(UnqualifiedColumnName("col").name == "col")
+  }
+
+  test("UnqualifiedColumnName accepts a backtick-quoted name containing a literal dot") {
+    // Backticks make the dot part of a single name part, so this passes validation.
+    assert(UnqualifiedColumnName("`a.b`").name == "`a.b`")
+  }
+
+  test("UnqualifiedColumnName rejects a dotted (multi-part) identifier") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        UnqualifiedColumnName("a.b")
+      },
+      condition = "AUTOCDC_INVALID_COLUMN_SELECTION.MULTIPART_COLUMN_IDENTIFIER",
+      sqlState = "42703",
+      parameters = Map(
+        "columnName" -> "a.b",
+        "nameParts" -> "a, b"
+      )
+    )
+  }
+
+  test("UnqualifiedColumnName rejects a qualified column reference") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        UnqualifiedColumnName("src.x")
+      },
+      condition = "AUTOCDC_INVALID_COLUMN_SELECTION.MULTIPART_COLUMN_IDENTIFIER",
+      sqlState = "42703",
+      parameters = Map(
+        "columnName" -> "src.x",
+        "nameParts" -> "src, x"
+      )
+    )
+  }
+
+  test("UnqualifiedColumnName rejects an identifier with three or more parts") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        UnqualifiedColumnName("a.b.c")
+      },
+      condition = "AUTOCDC_INVALID_COLUMN_SELECTION.MULTIPART_COLUMN_IDENTIFIER",
+      sqlState = "42703",
+      parameters = Map(
+        "columnName" -> "a.b.c",
+        "nameParts" -> "a, b, c"
+      )
+    )
+  }
+
+  test("UnqualifiedColumnName lets a ParseException from the SQL parser propagate") {
+    checkError(
+      exception = intercept[ParseException] {
+        UnqualifiedColumnName("")
+      },
+      condition = "PARSE_EMPTY_STATEMENT",
+      sqlState = Some("42617")
     )
   }
 }

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
@@ -36,7 +36,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
         schemaName = "test",
         schema = sourceSchema,
         columnSelection = None,
-        ignoreCase = false
+        caseSensitive = true
       ) == sourceSchema)
   }
 
@@ -48,7 +48,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
         schemaName = "test",
         schema = sourceSchema,
         columnSelection = Some(ColumnSelection.IncludeColumns(Seq.empty)),
-        ignoreCase = false
+        caseSensitive = true
       ) == new StructType())
   }
 
@@ -60,7 +60,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
         schemaName = "test",
         schema = sourceSchema,
         columnSelection = Some(ColumnSelection.ExcludeColumns(Seq.empty)),
-        ignoreCase = false
+        caseSensitive = true
       ) == sourceSchema)
   }
 
@@ -73,7 +73,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
           Seq(UnqualifiedColumnName("age"), UnqualifiedColumnName("Name"))
         )
       ),
-      ignoreCase = false
+      caseSensitive = true
     )
 
     assert(filteredSchema == new StructType()
@@ -88,7 +88,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
       columnSelection = Some(
         ColumnSelection.ExcludeColumns(Seq(UnqualifiedColumnName("id")))
       ),
-      ignoreCase = false
+      caseSensitive = true
     )
 
     assert(filteredSchema == new StructType()
@@ -102,13 +102,13 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
         ColumnSelection.applyToSchema(
           schemaName = "test",
           schema = sourceSchema,
-          // Under ignoreCase = false, "name" will not match the schema field "Name".
+          // Under caseSensitive = true, "name" will not match the schema field "Name".
           columnSelection = Some(
             ColumnSelection.IncludeColumns(
               Seq(UnqualifiedColumnName("name"), UnqualifiedColumnName("missing"))
             )
           ),
-          ignoreCase = false
+          caseSensitive = true
         )
       },
       condition = "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA",
@@ -128,13 +128,13 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
         ColumnSelection.applyToSchema(
           schemaName = "test",
           schema = sourceSchema,
-          // Under ignoreCase = false, "NAME" will not match the schema field "Name".
+          // Under caseSensitive = true, "NAME" will not match the schema field "Name".
           columnSelection = Some(
             ColumnSelection.ExcludeColumns(
               Seq(UnqualifiedColumnName("NAME"), UnqualifiedColumnName("missing"))
             )
           ),
-          ignoreCase = false
+          caseSensitive = true
         )
       },
       condition = "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA",
@@ -148,9 +148,9 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
     )
   }
 
-  test("ColumnSelection IncludeColumns matches case-insensitively under ignoreCase=true") {
+  test("ColumnSelection IncludeColumns matches case-insensitively under caseSensitive=false") {
     // "NAME" and "AGE" do not exactly match the schema fields "Name" and "age", but
-    // ignoreCase = true folds both sides to lowercase before comparing.
+    // caseSensitive = false folds both sides to lowercase before comparing.
     val filteredSchema = ColumnSelection.applyToSchema(
       schemaName = "test",
       schema = sourceSchema,
@@ -159,7 +159,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
           Seq(UnqualifiedColumnName("AGE"), UnqualifiedColumnName("NAME"))
         )
       ),
-      ignoreCase = true
+      caseSensitive = false
     )
 
     // The retained fields keep their original casing from the schema, not the user's input.
@@ -169,7 +169,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
   }
 
   test("ColumnSelection deduplicates user-provided columns that normalize to the same name") {
-    // Under ignoreCase = true, "name" and "NAME" both fold to "name" and refer to the same
+    // Under caseSensitive = false, "name" and "NAME" both fold to "name" and refer to the same
     // schema field. The returned schema must include "Name" once, not twice. Output ordering
     // and casing follow the schema, not the user's input.
     val filteredSchema = ColumnSelection.applyToSchema(
@@ -180,20 +180,20 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
           Seq(UnqualifiedColumnName("name"), UnqualifiedColumnName("NAME"))
         )
       ),
-      ignoreCase = true
+      caseSensitive = false
     )
 
     assert(filteredSchema == new StructType().add("Name", StringType))
   }
 
-  test("ColumnSelection ExcludeColumns matches case-insensitively under ignoreCase=true") {
+  test("ColumnSelection ExcludeColumns matches case-insensitively under caseSensitive=false") {
     val filteredSchema = ColumnSelection.applyToSchema(
       schemaName = "test",
       schema = sourceSchema,
       columnSelection = Some(
         ColumnSelection.ExcludeColumns(Seq(UnqualifiedColumnName("name")))
       ),
-      ignoreCase = true
+      caseSensitive = false
     )
 
     assert(filteredSchema == new StructType()
@@ -201,13 +201,13 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
       .add("age", IntegerType))
   }
 
-  test("ColumnSelection missing-column error under ignoreCase=true preserves user casing") {
+  test("ColumnSelection missing-column error under caseSensitive=false preserves user casing") {
     checkError(
       exception = intercept[AnalysisException] {
         ColumnSelection.applyToSchema(
           schemaName = "test",
           schema = sourceSchema,
-          // "NAME" matches "Name" under ignoreCase=true, but "Missing" has no schema match.
+          // "NAME" matches "Name" under caseSensitive=false, but "Missing" has no schema match.
           // The error message reports the user's original casing for the missing column and
           // the schema's original casing for the available columns.
           columnSelection = Some(
@@ -215,7 +215,7 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
               Seq(UnqualifiedColumnName("NAME"), UnqualifiedColumnName("Missing"))
             )
           ),
-          ignoreCase = true
+          caseSensitive = false
         )
       },
       condition = "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA",
@@ -301,10 +301,23 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
       columnSelection = Some(
         ColumnSelection.IncludeColumns(Seq(UnqualifiedColumnName("`a.b`")))
       ),
-      ignoreCase = false
+      caseSensitive = true
     )
 
     assert(filteredSchema == new StructType().add("a.b", IntegerType))
+  }
+
+  test("IncludeColumns correctly matches a backtick-quoted mixed-case column") {
+    val filteredSchema = ColumnSelection.applyToSchema(
+      schemaName = "test",
+      schema = sourceSchema,
+      columnSelection = Some(
+        ColumnSelection.IncludeColumns(Seq(UnqualifiedColumnName("`Name`")))
+      ),
+      caseSensitive = true
+    )
+
+    assert(filteredSchema == new StructType().add("Name", StringType))
   }
 
   test("UnqualifiedColumnName rejects a dotted (multi-part) identifier") {

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/ChangeArgsSuite.scala
@@ -215,6 +215,12 @@ class ChangeArgsSuite extends SparkFunSuite with SharedSparkSession {
     assert(UnqualifiedColumnName("`a.b`").name == "a.b")
   }
 
+  test("UnqualifiedColumnName accepts redundant backticks around a single-part name") {
+    // Backticks around an already-single-part identifier are decorative; the parser strips them
+    // so the stored name has no surrounding back-ticks.
+    assert(UnqualifiedColumnName("`col`").name == "col")
+  }
+
   test("UnqualifiedColumnName.quoted is safe to pass to functions.col for literal-dot names") {
     val schema = new StructType()
       .add("a.b", IntegerType)


### PR DESCRIPTION
Approved AutoCDC SPIP: https://lists.apache.org/thread/j6sj9wo9odgdpgzlxtvhoy7szs0jplf7

--------

Introduce `ChangeArgs` as the dataclass that represents AutoCDC API parameters. In future PRs:
1. `ChangeArgs` will be constructed, populated, and propagated by SDP SQL/Python flow registration API.
2. `ChangeArgs` will be referenced by SCD1/SCD2 algorithm implementations, to respect user specified configurations.
3. Advanced AutoCDC parameters (as per the SPIP) such as `ignoreNull` or `trackHistoryColumns` will be added and supported.

Additionally introduce `ColumnSelection` helper class, to encode the notion of user selecting a list of columns for inclusion/exclusion directly into a data type, rather than relying on implicit understanding of a raw string list.