### PR TITLE
[SPARK-56843][BUILD] Update `checkJavaVersion` to ban 25.0.[0-2] properly

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -125,6 +125,11 @@ object SparkBuild extends PomBuild {
           "The Java version used to build the project is outdated. " +
             s"Please use Java $minimumVersion or later.")
       }
+      if (currentVersionFeature == 25 && currentVersionUpdate < 3) {
+        throw new MessageOnlyException(
+          s"Java 25 requires update 3 or later due to JDK-8377811. " +
+            s"Current version: $currentVersion. Please use Java 25.0.3 or later.")
+      }
     },
     (Compile / compile) := ((Compile / compile) dependsOn checkJavaVersion).value,
     (Test / compile) := ((Test / compile) dependsOn checkJavaVersion).value


### PR DESCRIPTION
### What changes were proposed in this pull request?

Require Java 25.0.3 or later in `checkJavaVersion` function when building on Java 25 in order to avoid JDK-8377811

- https://bugs.openjdk.org/browse/JDK-8377811 (G1GC: Optional Evacuations may evacuate pinned objects)

This is consistent with our documentation too.
- https://github.com/apache/spark/pull/55798

https://github.com/apache/spark/blob/42422741167664dc0d2ad535279b2a4c67906539/docs/index.md?plain=1#L38

### Why are the changes needed?

The current check only enforces `java.minimum.version=17.0.11` and treats any JDK with a higher feature version as compatible, so early Java 25 updates (25.0.0/0.1/0.2) silently pass. Pinning Java 25 builds to 25.0.3+ avoids those updates without affecting Java 17/21 users.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual build with `build/sbt core/compile` on Java 17.0.11 and 21.x (pass), and confirmed the new error message is thrown when `currentVersionFeature == 25 && currentVersionUpdate < 3`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7