### PR TITLE
[SPARK-56846][DOCS][CONNECT] Document DataFrame column resolution behavior in spark-connect-gotchas

### DIFF
--- a/docs/spark-connect-gotchas.md
+++ b/docs/spark-connect-gotchas.md
@@ -434,11 +434,11 @@ df.withColumn("c", sf.col("c").cast("string")).select(df["c"]).collect()
 `withColumn("c", ...)` does not mutate `df`; it returns a new DataFrame whose `c` is a new attribute that hides the original. The trailing `df["c"]` still refers to the *original* `c` attribute, which is no longer in the projection list.
 
 * **Spark Classic** has always rejected this query at analysis time with `MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_APPEAR_IN_OPERATION`, because the original attribute is not present in the operator's child output.
-* **Spark Connect** rejects it with `CANNOT_RESOLVE_DATAFRAME_COLUMN` by default. The plan-id-tagged reference does not match any attribute in the current plan, and strict resolution does not fall back to name-based resolution.
+* **Spark Connect** rejects it with `CANNOT_RESOLVE_DATAFRAME_COLUMN` by default. The plan-id-tagged reference does not match any attribute in the current plan, and strict resolution does not fall back to name-based resolution. The strict behavior is controlled by the SQL config `spark.sql.analyzer.strictDataFrameColumnResolution` (added in Spark 4.2.0, default `true`). Setting it to `false` opts into a name-based fallback that resolves the tagged reference by name when plan-id-based resolution does not find the tagged attribute.
 
 ### Mitigation
 
-Use `sf.col("c")` (an untagged name reference) when you intend to refer to the column produced by the most recent projection or `withColumn`, rather than `df["c"]` (a tagged reference to `df`'s original column):
+Prefer fixing the call site: use `sf.col("c")` (an untagged name reference) when you intend to refer to the column produced by the most recent projection or `withColumn`, rather than `df["c"]` (a tagged reference to `df`'s original column):
 
 ```python
 import pyspark.sql.functions as sf
@@ -456,7 +456,7 @@ val df = spark.sql("SELECT 'x' AS c")
 df.withColumn("c", col("c").cast("string")).select(col("c")).collect()
 ```
 
-If you cannot change the call sites and want Spark Connect to accept the shadowed pattern, set the internal config `spark.sql.analyzer.strictDataFrameColumnResolution=false` to opt into a name-based fallback: when plan-id-based resolution does not find the tagged attribute, the analyzer also tries to resolve the reference by name. The lenient fallback is intended as an escape hatch and is not the default — prefer fixing the call site.
+If you cannot change the call sites, set `spark.sql.analyzer.strictDataFrameColumnResolution=false` to opt into the lenient name-based fallback. This is intended as an escape hatch and is not the default.
 
 # Summary
 

--- a/docs/spark-connect-gotchas.md
+++ b/docs/spark-connect-gotchas.md
@@ -73,7 +73,7 @@ Unlike query execution, Spark Classic and Spark Connect differ in when schema an
 
 # Common Gotchas (with Mitigations)
 
-If you are not careful about the difference between lazy vs. eager analysis, there are four key gotchas to be aware of: 1) overwriting temporary view names, 2) capturing external variables in UDFs, 3) delayed error detection, and 4) excessive schema access on new DataFrames.
+If you are not careful about the difference between lazy vs. eager analysis, there are five key gotchas to be aware of: 1) overwriting temporary view names, 2) capturing external variables in UDFs, 3) delayed error detection, 4) excessive schema access on new DataFrames, and 5) DataFrame column references after a column is shadowed.
 
 ## 1. Reusing temporary view names
 
@@ -418,6 +418,46 @@ println(structColumnFields)
 
 This approach is significantly faster when dealing with a large number of columns because it avoids creating and analyzing numerous DataFrames.
 
+## 5. DataFrame column references after column shadowing
+
+In Spark Connect, a DataFrame column reference such as `df["col"]` is tagged with the plan id of `df`. At analysis time the server resolves the reference by looking for the tagged ancestor in the plan and pulling the matching attribute from it. Spark Classic does not use plan ids; it resolves column references against the immediate child's output by attribute id and name.
+
+The two resolution strategies diverge once a column has been shadowed by another operator that produces an attribute with the same name:
+
+```python
+import pyspark.sql.functions as F
+
+df = spark.sql("SELECT 'x' AS col")
+df.withColumn("col", F.col("col").cast("string")).select(df["col"]).collect()
+```
+
+`withColumn("col", ...)` does not mutate `df`; it returns a new DataFrame whose `col` is a new attribute that hides the original. The trailing `df["col"]` still refers to the *original* `col` attribute, which is no longer in the projection list.
+
+* **Spark Classic** has always rejected this query at analysis time with `MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_APPEAR_IN_OPERATION`, because the original attribute is not present in the operator's child output.
+* **Spark Connect** rejects it with `CANNOT_RESOLVE_DATAFRAME_COLUMN` by default. The plan-id-tagged reference does not match any attribute in the current plan, and strict resolution does not fall back to name-based resolution.
+
+### Mitigation
+
+Use `F.col("col")` (an untagged name reference) when you intend to refer to the column produced by the most recent projection or `withColumn`, rather than `df["col"]` (a tagged reference to `df`'s original column):
+
+```python
+import pyspark.sql.functions as F
+
+df = spark.sql("SELECT 'x' AS col")
+df.withColumn("col", F.col("col").cast("string")).select(F.col("col")).collect()
+```
+
+**Scala example:**
+
+```scala
+import org.apache.spark.sql.functions._
+
+val df = spark.sql("SELECT 'x' AS col")
+df.withColumn("col", col("col").cast("string")).select(col("col")).collect()
+```
+
+If you cannot change the call sites and want Spark Connect to accept the shadowed pattern, set the internal config `spark.sql.analyzer.strictDataFrameColumnResolution=false` to opt into a name-based fallback: when plan-id-based resolution does not find the tagged attribute, the analyzer also tries to resolve the reference by name. The lenient fallback is intended as an escape hatch and is not the default — prefer fixing the call site.
+
 # Summary
 
 | Aspect                | Spark Classic | Spark Connect                                       |
@@ -428,5 +468,6 @@ This approach is significantly faster when dealing with a large number of column
 | **Schema access**     | Local         | Triggers RPC, and caches the schema on first access |
 | **Temporary views**   | Plan embedded | Name lookup                                         |
 | **UDF serialization** | At creation   | At execution                                        |
+| **DataFrame column references** | Resolved against child attributes by id/name | Resolved against the tagged ancestor's plan id      |
 
 The key difference is that Spark Connect defers analysis and name resolution to execution time.

--- a/docs/spark-connect-gotchas.md
+++ b/docs/spark-connect-gotchas.md
@@ -73,7 +73,7 @@ Unlike query execution, Spark Classic and Spark Connect differ in when schema an
 
 # Common Gotchas (with Mitigations)
 
-If you are not careful about the difference between lazy vs. eager analysis, there are five key gotchas to be aware of: 1) overwriting temporary view names, 2) capturing external variables in UDFs, 3) delayed error detection, 4) excessive schema access on new DataFrames, and 5) DataFrame column references after a column is shadowed.
+If you are not careful about the difference between lazy vs. eager analysis, there are several key gotchas to be aware of.
 
 ## 1. Reusing temporary view names
 
@@ -438,7 +438,7 @@ df.withColumn("c", sf.col("c").cast("string")).select(df["c"]).collect()
 
 ### Recommended way
 
-If you hit any of the confusing failures mentioned above, it is recommended to switch to `sf.col` first. `sf.col("c")` is an untagged name reference that resolves against the most recent projection or `withColumn`, rather than `df["c"]` which is a tagged reference to `df`'s original column:
+If you hit any of the confusing failures mentioned above, it is recommended to switch to `col` from `pyspark.sql.functions` first. `col("c")` is an untagged name reference that resolves against the most recent projection or `withColumn`, rather than `df["c"]` which is a tagged reference to `df`'s original column:
 
 ```python
 import pyspark.sql.functions as sf

--- a/docs/spark-connect-gotchas.md
+++ b/docs/spark-connect-gotchas.md
@@ -434,7 +434,7 @@ df.withColumn("c", sf.col("c").cast("string")).select(df["c"]).collect()
 `withColumn("c", ...)` does not mutate `df`; it returns a new DataFrame whose `c` is a new attribute that hides the original. The trailing `df["c"]` still refers to the *original* `c` attribute, which is no longer in the projection list.
 
 * **Spark Classic** has always rejected this query at analysis time with `MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_APPEAR_IN_OPERATION`, because the original attribute is not present in the operator's child output.
-* **Spark Connect** rejects it with `CANNOT_RESOLVE_DATAFRAME_COLUMN` by default. The plan-id-tagged reference does not match any attribute in the current plan, and strict resolution does not fall back to name-based resolution. The strict behavior is controlled by the SQL config `spark.sql.analyzer.strictDataFrameColumnResolution` (added in Spark 4.2.0, default `true`). Setting it to `false` opts into a name-based fallback that resolves the tagged reference by name when plan-id-based resolution does not find the tagged attribute.
+* **Spark Connect** rejects it with `CANNOT_RESOLVE_DATAFRAME_COLUMN` by default. The plan-id-tagged reference does not match any attribute in the current plan. But when the SQL config `spark.sql.analyzer.strictDataFrameColumnResolution` (added in Spark 4.2.0, default `true`) is set to `false`, the analyzer falls back to name-based resolution: the tagged `df["c"]` is resolved by name against the projected `c` from `withColumn`, and the query succeeds.
 
 ### Mitigation
 

--- a/docs/spark-connect-gotchas.md
+++ b/docs/spark-connect-gotchas.md
@@ -436,9 +436,9 @@ df.withColumn("c", sf.col("c").cast("string")).select(df["c"]).collect()
 * **Spark Classic** has always rejected this query at analysis time with `MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_APPEAR_IN_OPERATION`, because the original attribute is not present in the operator's child output.
 * **Spark Connect** rejects it with `CANNOT_RESOLVE_DATAFRAME_COLUMN` by default. The plan-id-tagged reference does not match any attribute in the current plan. But when the SQL config `spark.sql.analyzer.strictDataFrameColumnResolution` (added in Spark 4.2.0, default `true`) is set to `false`, the analyzer still tries plan-id-based resolution first, and only when that fails does it fall back to name-based resolution: the tagged `df["c"]` is then resolved by name against the projected `c` from `withColumn`, and the query succeeds.
 
-### Mitigation
+### Recommended way
 
-Prefer fixing the call site: use `sf.col("c")` (an untagged name reference) when you intend to refer to the column produced by the most recent projection or `withColumn`, rather than `df["c"]` (a tagged reference to `df`'s original column):
+If you hit any of the confusing failures mentioned above, it is recommended to switch to `sf.col` first. `sf.col("c")` is an untagged name reference that resolves against the most recent projection or `withColumn`, rather than `df["c"]` which is a tagged reference to `df`'s original column:
 
 ```python
 import pyspark.sql.functions as sf

--- a/docs/spark-connect-gotchas.md
+++ b/docs/spark-connect-gotchas.md
@@ -427,7 +427,7 @@ The two resolution strategies diverge once a column has been shadowed by another
 ```python
 import pyspark.sql.functions as sf
 
-df = spark.sql("SELECT 'x' AS c")
+df = spark.sql("SELECT 1 AS c")
 df.withColumn("c", sf.col("c").cast("string")).select(df["c"]).collect()
 ```
 
@@ -443,7 +443,7 @@ Prefer fixing the call site: use `sf.col("c")` (an untagged name reference) when
 ```python
 import pyspark.sql.functions as sf
 
-df = spark.sql("SELECT 'x' AS c")
+df = spark.sql("SELECT 1 AS c")
 df.withColumn("c", sf.col("c").cast("string")).select(sf.col("c")).collect()
 ```
 
@@ -452,7 +452,7 @@ df.withColumn("c", sf.col("c").cast("string")).select(sf.col("c")).collect()
 ```scala
 import org.apache.spark.sql.functions._
 
-val df = spark.sql("SELECT 'x' AS c")
+val df = spark.sql("SELECT 1 AS c")
 df.withColumn("c", col("c").cast("string")).select(col("c")).collect()
 ```
 

--- a/docs/spark-connect-gotchas.md
+++ b/docs/spark-connect-gotchas.md
@@ -420,31 +420,31 @@ This approach is significantly faster when dealing with a large number of column
 
 ## 5. DataFrame column references after column shadowing
 
-In Spark Connect, a DataFrame column reference such as `df["col"]` is tagged with the plan id of `df`. At analysis time the server resolves the reference by looking for the tagged ancestor in the plan and pulling the matching attribute from it. Spark Classic does not use plan ids; it resolves column references against the immediate child's output by attribute id and name.
+In Spark Connect, a DataFrame column reference such as `df["c"]` is tagged with the plan id of `df`. At analysis time the server resolves the reference by looking for the tagged ancestor in the plan and pulling the matching attribute from it. Spark Classic does not use plan ids; it resolves column references against the immediate child's output by attribute id and name.
 
 The two resolution strategies diverge once a column has been shadowed by another operator that produces an attribute with the same name:
 
 ```python
 import pyspark.sql.functions as F
 
-df = spark.sql("SELECT 'x' AS col")
-df.withColumn("col", F.col("col").cast("string")).select(df["col"]).collect()
+df = spark.sql("SELECT 'x' AS c")
+df.withColumn("c", F.col("c").cast("string")).select(df["c"]).collect()
 ```
 
-`withColumn("col", ...)` does not mutate `df`; it returns a new DataFrame whose `col` is a new attribute that hides the original. The trailing `df["col"]` still refers to the *original* `col` attribute, which is no longer in the projection list.
+`withColumn("c", ...)` does not mutate `df`; it returns a new DataFrame whose `c` is a new attribute that hides the original. The trailing `df["c"]` still refers to the *original* `c` attribute, which is no longer in the projection list.
 
 * **Spark Classic** has always rejected this query at analysis time with `MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_APPEAR_IN_OPERATION`, because the original attribute is not present in the operator's child output.
 * **Spark Connect** rejects it with `CANNOT_RESOLVE_DATAFRAME_COLUMN` by default. The plan-id-tagged reference does not match any attribute in the current plan, and strict resolution does not fall back to name-based resolution.
 
 ### Mitigation
 
-Use `F.col("col")` (an untagged name reference) when you intend to refer to the column produced by the most recent projection or `withColumn`, rather than `df["col"]` (a tagged reference to `df`'s original column):
+Use `F.col("c")` (an untagged name reference) when you intend to refer to the column produced by the most recent projection or `withColumn`, rather than `df["c"]` (a tagged reference to `df`'s original column):
 
 ```python
 import pyspark.sql.functions as F
 
-df = spark.sql("SELECT 'x' AS col")
-df.withColumn("col", F.col("col").cast("string")).select(F.col("col")).collect()
+df = spark.sql("SELECT 'x' AS c")
+df.withColumn("c", F.col("c").cast("string")).select(F.col("c")).collect()
 ```
 
 **Scala example:**
@@ -452,8 +452,8 @@ df.withColumn("col", F.col("col").cast("string")).select(F.col("col")).collect()
 ```scala
 import org.apache.spark.sql.functions._
 
-val df = spark.sql("SELECT 'x' AS col")
-df.withColumn("col", col("col").cast("string")).select(col("col")).collect()
+val df = spark.sql("SELECT 'x' AS c")
+df.withColumn("c", col("c").cast("string")).select(col("c")).collect()
 ```
 
 If you cannot change the call sites and want Spark Connect to accept the shadowed pattern, set the internal config `spark.sql.analyzer.strictDataFrameColumnResolution=false` to opt into a name-based fallback: when plan-id-based resolution does not find the tagged attribute, the analyzer also tries to resolve the reference by name. The lenient fallback is intended as an escape hatch and is not the default — prefer fixing the call site.

--- a/docs/spark-connect-gotchas.md
+++ b/docs/spark-connect-gotchas.md
@@ -434,7 +434,7 @@ df.withColumn("c", sf.col("c").cast("string")).select(df["c"]).collect()
 `withColumn("c", ...)` does not mutate `df`; it returns a new DataFrame whose `c` is a new attribute that hides the original. The trailing `df["c"]` still refers to the *original* `c` attribute, which is no longer in the projection list.
 
 * **Spark Classic** has always rejected this query at analysis time with `MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_APPEAR_IN_OPERATION`, because the original attribute is not present in the operator's child output.
-* **Spark Connect** rejects it with `CANNOT_RESOLVE_DATAFRAME_COLUMN` by default. The plan-id-tagged reference does not match any attribute in the current plan. But when the SQL config `spark.sql.analyzer.strictDataFrameColumnResolution` (added in Spark 4.2.0, default `true`) is set to `false`, the analyzer falls back to name-based resolution: the tagged `df["c"]` is resolved by name against the projected `c` from `withColumn`, and the query succeeds.
+* **Spark Connect** rejects it with `CANNOT_RESOLVE_DATAFRAME_COLUMN` by default. The plan-id-tagged reference does not match any attribute in the current plan. But when the SQL config `spark.sql.analyzer.strictDataFrameColumnResolution` (added in Spark 4.2.0, default `true`) is set to `false`, the analyzer still tries plan-id-based resolution first, and only when that fails does it fall back to name-based resolution: the tagged `df["c"]` is then resolved by name against the projected `c` from `withColumn`, and the query succeeds.
 
 ### Mitigation
 

--- a/docs/spark-connect-gotchas.md
+++ b/docs/spark-connect-gotchas.md
@@ -425,10 +425,10 @@ In Spark Connect, a DataFrame column reference such as `df["c"]` is tagged with 
 The two resolution strategies diverge once a column has been shadowed by another operator that produces an attribute with the same name:
 
 ```python
-import pyspark.sql.functions as F
+import pyspark.sql.functions as sf
 
 df = spark.sql("SELECT 'x' AS c")
-df.withColumn("c", F.col("c").cast("string")).select(df["c"]).collect()
+df.withColumn("c", sf.col("c").cast("string")).select(df["c"]).collect()
 ```
 
 `withColumn("c", ...)` does not mutate `df`; it returns a new DataFrame whose `c` is a new attribute that hides the original. The trailing `df["c"]` still refers to the *original* `c` attribute, which is no longer in the projection list.
@@ -438,13 +438,13 @@ df.withColumn("c", F.col("c").cast("string")).select(df["c"]).collect()
 
 ### Mitigation
 
-Use `F.col("c")` (an untagged name reference) when you intend to refer to the column produced by the most recent projection or `withColumn`, rather than `df["c"]` (a tagged reference to `df`'s original column):
+Use `sf.col("c")` (an untagged name reference) when you intend to refer to the column produced by the most recent projection or `withColumn`, rather than `df["c"]` (a tagged reference to `df`'s original column):
 
 ```python
-import pyspark.sql.functions as F
+import pyspark.sql.functions as sf
 
 df = spark.sql("SELECT 'x' AS c")
-df.withColumn("c", F.col("c").cast("string")).select(F.col("c")).collect()
+df.withColumn("c", sf.col("c").cast("string")).select(sf.col("c")).collect()
 ```
 
 **Scala example:**

--- a/docs/spark-connect-gotchas.md
+++ b/docs/spark-connect-gotchas.md
@@ -468,6 +468,6 @@ If you cannot change the call sites, set `spark.sql.analyzer.strictDataFrameColu
 | **Schema access**     | Local         | Triggers RPC, and caches the schema on first access |
 | **Temporary views**   | Plan embedded | Name lookup                                         |
 | **UDF serialization** | At creation   | At execution                                        |
-| **DataFrame column references** | Resolved against child attributes by id/name | Resolved against the tagged ancestor's plan id      |
+| **DataFrame column references** | Eagerly resolved | Lazily resolved against plan id                     |
 
 The key difference is that Spark Connect defers analysis and name resolution to execution time.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a new gotcha section to `docs/spark-connect-gotchas.md` describing how Spark Connect resolves DataFrame column references (`df["c"]`) via plan-id tagging, and how this diverges from Spark Classic once a column has been shadowed by `withColumn` or `select`.

The new section covers:

- The motivating example: `df.withColumn("c", sf.col("c").cast("string")).select(df["c"])` fails on both Spark Classic (`MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_APPEAR_IN_OPERATION`) and Spark Connect (`CANNOT_RESOLVE_DATAFRAME_COLUMN`).
- How the SQL config `spark.sql.analyzer.strictDataFrameColumnResolution` (added in Spark 4.2.0 by apache/spark#55531, default `true`) controls Spark Connect's behavior: under strict resolution the query fails; with `strictDataFrameColumnResolution=false`, the analyzer still tries plan-id-based resolution first and only falls back to name-based resolution when that fails, causing the same query to succeed.
- A "Recommended way" subsection: switch to `sf.col("c")` (an untagged name reference) instead of `df["c"]` (a tagged reference to `df`'s original column) when the column has been shadowed. Includes both Python and Scala examples.
- The escape-hatch note: `spark.sql.analyzer.strictDataFrameColumnResolution=false` for users who cannot change the call sites.

Also adds a "DataFrame column references" row to the summary table at the end of the document (Eagerly resolved vs Lazily resolved against plan id), consistent with the eager/lazy framing used throughout the file.

### Why are the changes needed?

The plan-id-based column resolution path is a Spark Connect-specific contract that is not documented anywhere user-facing. Users migrating workloads to Spark Connect have encountered surprises when patterns that previously "worked" stop resolving, with an error class (`CANNOT_RESOLVE_DATAFRAME_COLUMN`) and a config (`strictDataFrameColumnResolution`) whose connection to their code is not obvious. This adds explicit guidance and a code-level mitigation alongside the other Connect-vs-Classic gotchas already documented in this file.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only change.

### How was this patch tested?

Documentation-only change; no automated tests. Verified the markdown renders correctly and is consistent with the existing four-gotcha layout in `docs/spark-connect-gotchas.md`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Anthropic), claude-opus-4-7