### PR TITLE
[SPARK-36458][ML] Allow approxSimilarityJoin and approxNearestNeighbors to work without inputCol

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/LSH.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/LSH.scala
@@ -169,8 +169,15 @@ private[spark] abstract class LSHModel[T <: LSHModel[T]]
     }
 
     // Get the top k nearest neighbor by their distance to the key
-    val keyDistUDF = udf((x: Vector) => keyDistance(x, key))
-    val modelSubsetWithDistCol = modelSubset.withColumn(distCol, keyDistUDF(col($(inputCol))))
+    val modelSubsetWithDistCol = if (modelSubset.columns.contains($(inputCol))) {
+      val keyDistUDF = udf((x: Vector) => keyDistance(x, key))
+      modelSubset.withColumn(distCol, keyDistUDF(col($(inputCol))))
+    } else {
+      logWarning(s"Input column '${$(inputCol)}' is missing. " +
+        s"Using hash-based approximate distance.")
+      val keyHashDistUDF = udf((x: Array[Vector]) => hashDistance(x, keyHash))
+      modelSubset.withColumn(distCol, keyHashDistUDF(col($(outputCol))))
+    }
     modelSubsetWithDistCol.sort(distCol).limit(numNearestNeighbors)
   }
 
@@ -263,38 +270,57 @@ private[spark] abstract class LSHModel[T <: LSHModel[T]]
    *         between each pair.
    */
   def approxSimilarityJoin(
-      datasetA: Dataset[_],
-      datasetB: Dataset[_],
-      threshold: Double,
-      distCol: String): Dataset[_] = {
+    datasetA: Dataset[_],
+    datasetB: Dataset[_],
+    threshold: Double,
+    distCol: String): Dataset[_] = {
 
-    val leftColName = "datasetA"
-    val rightColName = "datasetB"
-    val explodeCols = Seq("entry", "hashValue")
-    val explodedA = processDataset(datasetA, leftColName, explodeCols)
+  val leftColName = "datasetA"
+  val rightColName = "datasetB"
+  val explodeCols = Seq("entry", "hashValue")
+  val explodedA = processDataset(datasetA, leftColName, explodeCols)
 
-    // If this is a self join, we need to recreate the inputCol of datasetB to avoid ambiguity.
-    // TODO: Remove recreateCol logic once SPARK-17154 is resolved.
-    val explodedB = if (datasetA != datasetB) {
-      processDataset(datasetB, rightColName, explodeCols)
-    } else {
-      val recreatedB = recreateCol(datasetB, $(inputCol), Identifiable.randomUID(inputCol.name))
+  // Only recreate inputCol when it exists in the dataset
+  val explodedB = if (datasetA != datasetB) {
+    processDataset(datasetB, rightColName, explodeCols)
+  } else {
+    if (datasetB.columns.contains($(inputCol))) {
+      val recreatedB = recreateCol(datasetB, $(inputCol),
+        Identifiable.randomUID(inputCol.name))
       processDataset(recreatedB, rightColName, explodeCols)
+    } else {
+      // inputCol not present, no need to recreate
+      processDataset(datasetB, rightColName, explodeCols)
     }
-
-    // Do a hash join on where the exploded hash values are equal.
-    val joinedDataset = explodedA.join(explodedB, explodeCols)
-      .drop(explodeCols: _*).distinct()
-
-    // Add a new column to store the distance of the two rows.
-    val distUDF = udf((x: Vector, y: Vector) => keyDistance(x, y))
-    val joinedDatasetWithDist = joinedDataset.select(col("*"),
-      distUDF(col(s"$leftColName.${$(inputCol)}"), col(s"$rightColName.${$(inputCol)}")).as(distCol)
-    )
-
-    // Filter the joined datasets where the distance are smaller than the threshold.
-    joinedDatasetWithDist.filter(col(distCol) < threshold)
   }
+
+  // Do a hash join on where the exploded hash values are equal.
+  val joinedDataset = explodedA.join(explodedB, explodeCols)
+    .drop(explodeCols: _*).distinct()
+
+  // Choose distance computation based on inputCol availability
+  val inputAvailable = datasetA.columns.contains($(inputCol)) &&
+    datasetB.columns.contains($(inputCol))
+
+  val joinedDatasetWithDist = if (inputAvailable) {
+    // Original: exact distance using inputCol
+    val distUDF = udf((x: Vector, y: Vector) => keyDistance(x, y))
+    joinedDataset.select(col("*"),
+      distUDF(col(s"$leftColName.${$(inputCol)}"),
+        col(s"$rightColName.${$(inputCol)}")).as(distCol))
+  } else {
+    // Fallback: approximate distance using outputCol (hashes)
+    logWarning(s"Input column '${$(inputCol)}' is missing from the datasets. " +
+      s"Falling back to hash-based approximate distance.")
+    val hashDistUDF = udf((x: Array[Vector], y: Array[Vector]) => hashDistance(x, y))
+    joinedDataset.select(col("*"),
+      hashDistUDF(col(s"$leftColName.${$(outputCol)}"),
+        col(s"$rightColName.${$(outputCol)}")).as(distCol))
+  }
+
+  // Filter the joined datasets where the distance are smaller than the threshold.
+  joinedDatasetWithDist.filter(col(distCol) < threshold)
+}
 
   /**
    * Overloaded method for approxSimilarityJoin. Use "distCol" as default distCol.

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/MinHashLSHSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/MinHashLSHSuite.scala
@@ -190,4 +190,76 @@ class MinHashLSHSuite extends MLTest with DefaultReadWriteTest {
         }
     }
   }
+  test("SPARK-36458: approxSimilarityJoin should work without inputCol") {
+    val dfA = spark.createDataFrame(Seq(
+      (0, Vectors.sparse(6, Seq((0, 1.0), (1, 1.0), (2, 1.0)))),
+      (1, Vectors.sparse(6, Seq((2, 1.0), (3, 1.0), (4, 1.0)))),
+      (2, Vectors.sparse(6, Seq((0, 1.0), (2, 1.0), (4, 1.0))))
+    )).toDF("id", "features")
+
+    val dfB = spark.createDataFrame(Seq(
+      (3, Vectors.sparse(6, Seq((1, 1.0), (3, 1.0), (5, 1.0)))),
+      (4, Vectors.sparse(6, Seq((2, 1.0), (3, 1.0), (5, 1.0)))),
+      (5, Vectors.sparse(6, Seq((1, 1.0), (2, 1.0), (4, 1.0))))
+    )).toDF("id", "features")
+
+    val mh = new MinHashLSH()
+      .setInputCol("features")
+      .setOutputCol("hashes")
+      .setNumHashTables(5)
+    val model = mh.fit(dfA)
+
+    // Transform and drop inputCol, keeping only outputCol
+    val transformedA = model.transform(dfA).select("id", "hashes")
+    val transformedB = model.transform(dfB).select("id", "hashes")
+
+    // Should not throw an exception - uses hash-based distance
+    val result = model.approxSimilarityJoin(transformedA, transformedB, 0.6, "JaccardDistance")
+    assert(result.columns.contains("JaccardDistance"))
+    // Result should have valid rows (may be empty depending on hash collision)
+    assert(result.count() >= 0)
+  }
+
+  test("SPARK-36458: approxNearestNeighbors should work without inputCol") {
+    val df = spark.createDataFrame(Seq(
+      (0, Vectors.sparse(6, Seq((0, 1.0), (1, 1.0), (2, 1.0)))),
+      (1, Vectors.sparse(6, Seq((2, 1.0), (3, 1.0), (4, 1.0)))),
+      (2, Vectors.sparse(6, Seq((0, 1.0), (2, 1.0), (4, 1.0))))
+    )).toDF("id", "features")
+
+    val mh = new MinHashLSH()
+      .setInputCol("features")
+      .setOutputCol("hashes")
+      .setNumHashTables(5)
+    val model = mh.fit(df)
+
+    // Transform and drop inputCol
+    val transformed = model.transform(df).select("id", "hashes")
+    val key = Vectors.sparse(6, Seq((1, 1.0), (3, 1.0)))
+
+    // Should not throw an exception
+    val result = model.approxNearestNeighbors(transformed, key, 2, "distCol")
+    assert(result.columns.contains("distCol"))
+    assert(result.count() <= 2)
+  }
+
+  test("SPARK-36458: approxSimilarityJoin self-join without inputCol") {
+    val df = spark.createDataFrame(Seq(
+      (0, Vectors.sparse(6, Seq((0, 1.0), (1, 1.0), (2, 1.0)))),
+      (1, Vectors.sparse(6, Seq((2, 1.0), (3, 1.0), (4, 1.0)))),
+      (2, Vectors.sparse(6, Seq((0, 1.0), (2, 1.0), (4, 1.0))))
+    )).toDF("id", "features")
+
+    val mh = new MinHashLSH()
+      .setInputCol("features")
+      .setOutputCol("hashes")
+      .setNumHashTables(5)
+    val model = mh.fit(df)
+
+    val transformed = model.transform(df).select("id", "hashes")
+
+    // Self-join without inputCol should also work
+    val result = model.approxSimilarityJoin(transformed, transformed, 0.6, "JaccardDistance")
+    assert(result.columns.contains("JaccardDistance"))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Modified `LSHModel` to conditionally check for the existence of `inputCol` in `approxSimilarityJoin` and `approxNearestNeighbors`. When `inputCol` is missing (user already transformed and dropped it), the methods now fall back to hash-based approximate distance using `outputCol` instead of throwing an error.

### Why are the changes needed?

Users who pre-compute hashes and drop the original features column to save memory/storage cannot use `approxSimilarityJoin` or `approxNearestNeighbors`. The documentation implies this should work, but the current implementation always requires `inputCol`.

### Does this PR introduce any user-facing change?

Yes. `approxSimilarityJoin` and `approxNearestNeighbors` now accept datasets that contain only the `outputCol` (hashes) without `inputCol`. When `inputCol` is present, behavior is unchanged (exact distance). When `inputCol` is absent, hash-based approximate distance is used with a warning logged.

### How was this patch tested?

Added 3 unit tests in `MinHashLSHSuite`:
- `approxSimilarityJoin` without `inputCol`
- `approxNearestNeighbors` without `inputCol`
- `approxSimilarityJoin` self-join without `inputCol`

All 17 tests pass (14 existing + 3 new).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Anthropic Claude Opus 4.6)
