### PR TITLE
[SPARK-56804][SQL] Add bulk read+convert path for DATE to TimestampNTZ Parquet vector updater

### DIFF
--- a/sql/core/benchmarks/ParquetVectorUpdaterBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/ParquetVectorUpdaterBenchmark-jdk21-results.txt
@@ -2,83 +2,83 @@
 Identity Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
 Identity Updaters:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-BooleanUpdater                                        0              0           0      17004.4           0.1       1.0X
-ByteUpdater (INT32 -> Byte)                           0              0           0       3748.2           0.3       0.2X
-ShortUpdater (INT32 -> Short)                         1              1           0       1683.0           0.6       0.1X
-IntegerUpdater                                        0              0           0      10179.2           0.1       0.6X
-LongUpdater                                           0              0           0       5075.5           0.2       0.3X
-FloatUpdater                                          0              0           0      10201.9           0.1       0.6X
-DoubleUpdater                                         0              0           0       5140.6           0.2       0.3X
-BinaryUpdater                                        15             15           0         71.3          14.0       0.0X
+BooleanUpdater                                        0              0           0      16210.2           0.1       1.0X
+ByteUpdater (INT32 -> Byte)                           0              0           0       3658.0           0.3       0.2X
+ShortUpdater (INT32 -> Short)                         1              1           0       1505.7           0.7       0.1X
+IntegerUpdater                                        0              0           0       8370.9           0.1       0.5X
+LongUpdater                                           0              0           0       4171.6           0.2       0.3X
+FloatUpdater                                          0              0           0       8347.5           0.1       0.5X
+DoubleUpdater                                         0              0           0       4155.4           0.2       0.3X
+BinaryUpdater                                        17             18           0         60.4          16.6       0.0X
 
 
 ================================================================================================
 Type-converting Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
 Type-converting Updaters:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-IntegerToLongUpdater                                     0              0           0       6208.4           0.2       1.0X
-IntegerToDoubleUpdater                                   0              0           0       6155.9           0.2       1.0X
-FloatToDoubleUpdater                                     0              0           0       2526.5           0.4       0.4X
-DateToTimestampNTZUpdater                               27             28           1         38.6          25.9       0.0X
-DowncastLongUpdater (INT64 -> Decimal(9,2))              0              0           0       5828.5           0.2       0.9X
+IntegerToLongUpdater                                     0              0           0       5503.7           0.2       1.0X
+IntegerToDoubleUpdater                                   0              0           0       5594.9           0.2       1.0X
+FloatToDoubleUpdater                                     0              0           0       2389.2           0.4       0.4X
+DateToTimestampNTZUpdater                               27             27           0         38.7          25.8       0.0X
+DowncastLongUpdater (INT64 -> Decimal(9,2))              0              0           0       5457.2           0.2       1.0X
 
 
 ================================================================================================
 Rebase Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
 Rebase Updaters:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-IntegerWithRebaseUpdater (DATE legacy)                       0              0           0       3651.5           0.3       1.0X
-LongWithRebaseUpdater (TIMESTAMP_MICROS legacy)              0              0           0       2621.2           0.4       0.7X
-LongAsMicrosUpdater (TIMESTAMP_MILLIS)                       2              3           0        420.5           2.4       0.1X
+IntegerWithRebaseUpdater (DATE legacy)                       0              0           0       3134.6           0.3       1.0X
+LongWithRebaseUpdater (TIMESTAMP_MICROS legacy)              0              0           0       2226.3           0.4       0.7X
+LongAsMicrosUpdater (TIMESTAMP_MILLIS)                       3              3           0        378.6           2.6       0.1X
 
 
 ================================================================================================
 Unsigned Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
 Unsigned Updaters:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-UnsignedIntegerUpdater (UINT32 -> Long)                    0              0           0       5879.9           0.2       1.0X
-UnsignedLongUpdater (UINT64 -> Decimal(20,0))             16             17           0         63.8          15.7       0.0X
+UnsignedIntegerUpdater (UINT32 -> Long)                    0              0           0       5518.2           0.2       1.0X
+UnsignedLongUpdater (UINT64 -> Decimal(20,0))             18             18           0         59.3          16.9       0.0X
 
 
 ================================================================================================
 Decimal Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
 Decimal Updaters:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-IntegerToDecimalUpdater                               0              0           0      10144.6           0.1       1.0X
-LongToDecimalUpdater                                  0              0           0       5061.5           0.2       0.5X
-FixedLenByteArrayToDecimalUpdater                    20             21           1         51.3          19.5       0.0X
+IntegerToDecimalUpdater                               0              0           0       8352.1           0.1       1.0X
+LongToDecimalUpdater                                  0              0           0       4135.5           0.2       0.5X
+FixedLenByteArrayToDecimalUpdater                    23             23           0         45.2          22.1       0.0X
 
 
 ================================================================================================
 FixedLenByteArray Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
 FixedLenByteArray Updaters:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-FixedLenByteArrayUpdater (len=16 -> Binary)                         20             21           1         51.8          19.3       1.0X
-FixedLenByteArrayAsIntUpdater (len=4 -> Decimal(9,2))                7              7           0        160.2           6.2       3.1X
-FixedLenByteArrayAsLongUpdater (len=8 -> Decimal(18,4))              8              8           0        133.2           7.5       2.6X
+FixedLenByteArrayUpdater (len=16 -> Binary)                         22             23           0         46.9          21.3       1.0X
+FixedLenByteArrayAsIntUpdater (len=4 -> Decimal(9,2))                6              6           0        163.6           6.1       3.5X
+FixedLenByteArrayAsLongUpdater (len=8 -> Decimal(18,4))              8              8           0        130.2           7.7       2.8X
 
 

--- a/sql/core/benchmarks/ParquetVectorUpdaterBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/ParquetVectorUpdaterBenchmark-jdk25-results.txt
@@ -2,17 +2,17 @@
 Identity Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 7763 64-Core Processor
 Identity Updaters:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-BooleanUpdater                                        0              0           0      17160.2           0.1       1.0X
-ByteUpdater (INT32 -> Byte)                           0              0           0       3686.1           0.3       0.2X
-ShortUpdater (INT32 -> Short)                         1              1           0       1662.8           0.6       0.1X
-IntegerUpdater                                        0              0           0      10282.0           0.1       0.6X
-LongUpdater                                           0              0           0       5151.9           0.2       0.3X
-FloatUpdater                                          0              0           0      10306.3           0.1       0.6X
-DoubleUpdater                                         0              0           0       5149.1           0.2       0.3X
+BooleanUpdater                                        0              0           0      17157.7           0.1       1.0X
+ByteUpdater (INT32 -> Byte)                           0              0           0       3689.5           0.3       0.2X
+ShortUpdater (INT32 -> Short)                         1              1           0       1663.5           0.6       0.1X
+IntegerUpdater                                        0              0           0       7764.8           0.1       0.5X
+LongUpdater                                           0              0           0       3870.3           0.3       0.2X
+FloatUpdater                                          0              0           0       7753.3           0.1       0.5X
+DoubleUpdater                                         0              0           0       5126.2           0.2       0.3X
 BinaryUpdater                                        15             16           0         67.8          14.8       0.0X
 
 
@@ -20,27 +20,27 @@ BinaryUpdater                                        15             16          
 Type-converting Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 7763 64-Core Processor
 Type-converting Updaters:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-IntegerToLongUpdater                                     0              0           0       6390.8           0.2       1.0X
-IntegerToDoubleUpdater                                   0              0           0       6415.4           0.2       1.0X
-FloatToDoubleUpdater                                     0              0           0       3196.5           0.3       0.5X
-DateToTimestampNTZUpdater                               29             29           0         36.6          27.3       0.0X
-DowncastLongUpdater (INT64 -> Decimal(9,2))              0              0           0       6568.8           0.2       1.0X
+IntegerToLongUpdater                                     0              0           0       6549.1           0.2       1.0X
+IntegerToDoubleUpdater                                   0              0           0       6601.1           0.2       1.0X
+FloatToDoubleUpdater                                     0              0           0       3195.1           0.3       0.5X
+DateToTimestampNTZUpdater                               23             23           0         45.3          22.1       0.0X
+DowncastLongUpdater (INT64 -> Decimal(9,2))              0              0           0       6707.4           0.1       1.0X
 
 
 ================================================================================================
 Rebase Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 7763 64-Core Processor
 Rebase Updaters:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-IntegerWithRebaseUpdater (DATE legacy)                       0              0           0       3665.9           0.3       1.0X
-LongWithRebaseUpdater (TIMESTAMP_MICROS legacy)              0              0           0       2652.9           0.4       0.7X
+IntegerWithRebaseUpdater (DATE legacy)                       0              0           0       3288.3           0.3       1.0X
+LongWithRebaseUpdater (TIMESTAMP_MICROS legacy)              0              0           0       2674.3           0.4       0.8X
 LongAsMicrosUpdater (TIMESTAMP_MILLIS)                       3              3           0        371.3           2.7       0.1X
 
 
@@ -48,37 +48,37 @@ LongAsMicrosUpdater (TIMESTAMP_MILLIS)                       3              3   
 Unsigned Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 7763 64-Core Processor
 Unsigned Updaters:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-UnsignedIntegerUpdater (UINT32 -> Long)                    0              0           0       5111.6           0.2       1.0X
-UnsignedLongUpdater (UINT64 -> Decimal(20,0))             17             18           0         60.4          16.6       0.0X
+UnsignedIntegerUpdater (UINT32 -> Long)                    0              0           0       6190.8           0.2       1.0X
+UnsignedLongUpdater (UINT64 -> Decimal(20,0))             17             18           1         60.4          16.6       0.0X
 
 
 ================================================================================================
 Decimal Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 7763 64-Core Processor
 Decimal Updaters:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-IntegerToDecimalUpdater                               0              0           0      10205.8           0.1       1.0X
-LongToDecimalUpdater                                  0              0           0       5111.4           0.2       0.5X
-FixedLenByteArrayToDecimalUpdater                    21             21           2         50.9          19.6       0.0X
+IntegerToDecimalUpdater                               0              0           0      10236.9           0.1       1.0X
+LongToDecimalUpdater                                  0              0           0       5108.9           0.2       0.5X
+FixedLenByteArrayToDecimalUpdater                    21             21           0         50.7          19.7       0.0X
 
 
 ================================================================================================
 FixedLenByteArray Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1010-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 7763 64-Core Processor
 FixedLenByteArray Updaters:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-FixedLenByteArrayUpdater (len=16 -> Binary)                         21             22           1         50.4          19.8       1.0X
+FixedLenByteArrayUpdater (len=16 -> Binary)                         21             22           1         50.3          19.9       1.0X
 FixedLenByteArrayAsIntUpdater (len=4 -> Decimal(9,2))                7              7           0        152.6           6.6       3.0X
-FixedLenByteArrayAsLongUpdater (len=8 -> Decimal(18,4))              8              8           0        127.7           7.8       2.5X
+FixedLenByteArrayAsLongUpdater (len=8 -> Decimal(18,4))              8              8           0        127.6           7.8       2.5X
 
 

--- a/sql/core/benchmarks/ParquetVectorUpdaterBenchmark-results.txt
+++ b/sql/core/benchmarks/ParquetVectorUpdaterBenchmark-results.txt
@@ -2,83 +2,83 @@
 Identity Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
 Identity Updaters:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-BooleanUpdater                                        0              0           0      14617.4           0.1       1.0X
-ByteUpdater (INT32 -> Byte)                           0              0           0       3667.7           0.3       0.3X
-ShortUpdater (INT32 -> Short)                         1              1           0       2048.9           0.5       0.1X
-IntegerUpdater                                        0              0           0      10281.9           0.1       0.7X
-LongUpdater                                           0              0           0       5138.0           0.2       0.4X
-FloatUpdater                                          0              0           0       7742.9           0.1       0.5X
-DoubleUpdater                                         0              0           0       3863.4           0.3       0.3X
-BinaryUpdater                                        15             15           0         70.2          14.2       0.0X
+BooleanUpdater                                        0              0           0      14808.9           0.1       1.0X
+ByteUpdater (INT32 -> Byte)                           0              0           0       3592.8           0.3       0.2X
+ShortUpdater (INT32 -> Short)                         1              1           0       1824.9           0.5       0.1X
+IntegerUpdater                                        0              0           0       8692.4           0.1       0.6X
+LongUpdater                                           0              0           0       4161.5           0.2       0.3X
+FloatUpdater                                          0              0           0       8404.9           0.1       0.6X
+DoubleUpdater                                         0              0           0       4193.8           0.2       0.3X
+BinaryUpdater                                        18             18           0         59.5          16.8       0.0X
 
 
 ================================================================================================
 Type-converting Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
 Type-converting Updaters:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-IntegerToLongUpdater                                     1              1           0       1279.7           0.8       1.0X
-IntegerToDoubleUpdater                                   1              1           0       1544.8           0.6       1.2X
-FloatToDoubleUpdater                                     1              1           0       1417.9           0.7       1.1X
-DateToTimestampNTZUpdater                               36             36           1         29.5          33.9       0.0X
-DowncastLongUpdater (INT64 -> Decimal(9,2))              1              1           0       1287.3           0.8       1.0X
+IntegerToLongUpdater                                     1              1           0       1129.3           0.9       1.0X
+IntegerToDoubleUpdater                                   1              1           0       1343.3           0.7       1.2X
+FloatToDoubleUpdater                                     1              1           0       1282.3           0.8       1.1X
+DateToTimestampNTZUpdater                               32             33           0         32.3          31.0       0.0X
+DowncastLongUpdater (INT64 -> Decimal(9,2))              1              1           0       1137.9           0.9       1.0X
 
 
 ================================================================================================
 Rebase Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
 Rebase Updaters:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-IntegerWithRebaseUpdater (DATE legacy)                       0              0           0       2599.8           0.4       1.0X
-LongWithRebaseUpdater (TIMESTAMP_MICROS legacy)              1              1           0       2092.2           0.5       0.8X
-LongAsMicrosUpdater (TIMESTAMP_MILLIS)                       2              2           0        454.7           2.2       0.2X
+IntegerWithRebaseUpdater (DATE legacy)                       0              0           0       2188.4           0.5       1.0X
+LongWithRebaseUpdater (TIMESTAMP_MICROS legacy)              1              1           0       1753.2           0.6       0.8X
+LongAsMicrosUpdater (TIMESTAMP_MILLIS)                       2              3           0        421.0           2.4       0.2X
 
 
 ================================================================================================
 Unsigned Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
 Unsigned Updaters:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-UnsignedIntegerUpdater (UINT32 -> Long)                    1              1           0       1091.2           0.9       1.0X
-UnsignedLongUpdater (UINT64 -> Decimal(20,0))             18             18           0         59.1          16.9       0.1X
+UnsignedIntegerUpdater (UINT32 -> Long)                    1              1           0        960.5           1.0       1.0X
+UnsignedLongUpdater (UINT64 -> Decimal(20,0))             18             18           0         58.7          17.0       0.1X
 
 
 ================================================================================================
 Decimal Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
 Decimal Updaters:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-IntegerToDecimalUpdater                               0              0           0      10241.7           0.1       1.0X
-LongToDecimalUpdater                                  0              0           0       5118.1           0.2       0.5X
-FixedLenByteArrayToDecimalUpdater                    21             21           0         51.1          19.6       0.0X
+IntegerToDecimalUpdater                               0              0           0       8367.2           0.1       1.0X
+LongToDecimalUpdater                                  0              0           0       4201.2           0.2       0.5X
+FixedLenByteArrayToDecimalUpdater                    24             24           0         43.9          22.8       0.0X
 
 
 ================================================================================================
 FixedLenByteArray Updaters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1010-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
 FixedLenByteArray Updaters:                              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-FixedLenByteArrayUpdater (len=16 -> Binary)                         19             19           0         55.1          18.2       1.0X
-FixedLenByteArrayAsIntUpdater (len=4 -> Decimal(9,2))                7              7           0        160.2           6.2       2.9X
-FixedLenByteArrayAsLongUpdater (len=8 -> Decimal(18,4))              9              9           0        123.1           8.1       2.2X
+FixedLenByteArrayUpdater (len=16 -> Binary)                         22             23           0         47.0          21.3       1.0X
+FixedLenByteArrayAsIntUpdater (len=4 -> Decimal(9,2))                6              6           0        164.7           6.1       3.5X
+FixedLenByteArrayAsLongUpdater (len=8 -> Decimal(18,4))              8              8           0        125.5           8.0       2.7X
 
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
@@ -429,9 +429,7 @@ public class ParquetVectorUpdaterFactory {
         int offset,
         WritableColumnVector values,
         VectorizedValuesReader valuesReader) {
-      for (int i = 0; i < total; ++i) {
-        readValue(offset + i, values, valuesReader);
-      }
+      valuesReader.readIntegersAsTimestampMicros(total, values, offset);
     }
 
     @Override

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.datasources.parquet;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.time.ZoneOffset;
 
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.values.ValuesReader;
@@ -26,6 +27,7 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.ParquetDecodingException;
 
 import org.apache.spark.SparkUnsupportedOperationException;
+import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.catalyst.util.RebaseDateTime;
 import org.apache.spark.sql.execution.datasources.DataSourceUtils;
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
@@ -201,6 +203,19 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
     // in `readIntegersAsLongs`.
     for (int i = 0; i < total; i += 1) {
       c.putInt(rowId + i, (int) buffer.getLong());
+    }
+  }
+
+  @Override
+  public final void readIntegersAsTimestampMicros(
+      int total, WritableColumnVector c, int rowId) {
+    int requiredBytes = total * 4;
+    ByteBuffer buffer = getBuffer(requiredBytes);
+    // Per-element conversion calls into `DateTimeUtils.daysToMicros`, which is `days *
+    // MICROS_PER_DAY` for UTC plus an overflow check via `Math.multiplyExact`. No
+    // `hasArray` bulk-copy path because source and target have different widths.
+    for (int i = 0; i < total; i += 1) {
+      c.putLong(rowId + i, DateTimeUtils.daysToMicros(buffer.getInt(), ZoneOffset.UTC));
     }
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedValuesReader.java
@@ -18,7 +18,9 @@
 package org.apache.spark.sql.execution.datasources.parquet;
 
 import java.nio.ByteBuffer;
+import java.time.ZoneOffset;
 
+import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
 
 import org.apache.parquet.io.api.Binary;
@@ -133,6 +135,32 @@ public interface VectorizedValuesReader {
   default void readLongsAsInts(int total, WritableColumnVector c, int rowId) {
     for (int i = 0; i < total; i += 1) {
       c.putInt(rowId + i, (int) readLong());
+    }
+  }
+
+  /**
+   * Reads {@code total} INT32 date-day values (days since 1970-01-01, Proleptic Gregorian),
+   * converts each to TimestampNTZ micros at UTC via
+   * {@link DateTimeUtils#daysToMicros(int, java.time.ZoneId)}, and writes them into
+   * {@code c} starting at {@code c[rowId]}. Used by the type-converting updater that
+   * reads parquet INT32 DATE columns into Spark {@code TimestampNTZType} targets in
+   * {@code CORRECTED} datetime-rebase mode. The {@code LEGACY}/{@code EXCEPTION} rebase
+   * variants are out of scope for this method.
+   *
+   * <p>The default implementation is a per-row loop that calls
+   * {@code DateTimeUtils.daysToMicros} per element; it is algorithmically equivalent to
+   * the legacy per-row Updater path but the per-element conversion call dominates the
+   * loop, so the speedup from overriding this method is more modest than for the pure
+   * primitive-cast siblings ({@link #readIntegersAsLongs}, {@link #readIntegersAsDoubles}).
+   * Subclasses backed by contiguous bulk storage (e.g. PLAIN encoding via
+   * {@link VectorizedPlainValuesReader}) should override to read source bytes once and run
+   * a tight in-method conversion loop, avoiding {@code total} virtual dispatches on
+   * {@link #readInteger()}. Readers without an override preserve correctness but gain no
+   * speedup.
+   */
+  default void readIntegersAsTimestampMicros(int total, WritableColumnVector c, int rowId) {
+    for (int i = 0; i < total; i += 1) {
+      c.putLong(rowId + i, DateTimeUtils.daysToMicros(readInteger(), ZoneOffset.UTC));
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -2072,6 +2072,69 @@ class ParquetIOSuite extends ParquetTest with SharedSparkSession {
       }
     }
   }
+
+  test("DATE -> TimestampNTZ widening end-to-end via vectorized read path") {
+    // Round-trips a DATE Parquet file read back as TimestampNTZType, exercising
+    // DateToTimestampNTZUpdater on the vectorized path in CORRECTED rebase mode.
+    // Sample mixes epoch, recent dates, pre-epoch, far-past and far-future days; each
+    // day-count converts to UTC midnight via `DateTimeUtils.daysToMicros`. Both
+    // REQUIRED and OPTIONAL columns are covered so that `readValue` and `readValues`
+    // are both invoked.
+    withSQLConf(
+        SQLConf.PARQUET_REBASE_MODE_IN_READ.key -> "CORRECTED",
+        SQLConf.PARQUET_REBASE_MODE_IN_WRITE.key -> "CORRECTED") {
+      withTempPath { file =>
+        val n = 5000
+        def sampleAt(i: Int): java.sql.Date = i % 6 match {
+          case 0 => java.sql.Date.valueOf("1970-01-01")
+          case 1 => java.sql.Date.valueOf("1900-01-01")
+          case 2 => java.sql.Date.valueOf("2023-01-01")
+          case 3 => java.sql.Date.valueOf("0001-01-01")
+          case 4 => java.sql.Date.valueOf("4707-11-28")
+          case _ =>
+            // Cover every month (1..12) and a few years to exercise month-boundary
+            // behavior, not just months 1..9 the previous string-formatting allowed.
+            val year = 2020 + (i % 80)
+            val month = 1 + (i % 12)
+            java.sql.Date.valueOf(f"$year%04d-$month%02d-15")
+        }
+
+        val nonNullData = (0 until n).map(i => Row(sampleAt(i)))
+        // Every 7th row is null; mixes value runs and null runs at sub-batch lengths.
+        val nullableData = (0 until n).map { i =>
+          if (i % 7 == 0) Row(null) else Row(sampleAt(i))
+        }
+
+        val nonNullWriteSchema = new StructType().add("v", DateType, nullable = false)
+        val nonNullReadSchema = new StructType().add("v", TimestampNTZType, nullable = false)
+        val nullableWriteSchema = new StructType().add("v", DateType, nullable = true)
+        val nullableReadSchema = new StructType().add("v", TimestampNTZType, nullable = true)
+
+        val nonNullPath = new java.io.File(file, "nonnull").getCanonicalPath
+        val nullablePath = new java.io.File(file, "nullable").getCanonicalPath
+        spark.createDataFrame(spark.sparkContext.parallelize(nonNullData, 4), nonNullWriteSchema)
+          .write.parquet(nonNullPath)
+        spark.createDataFrame(
+          spark.sparkContext.parallelize(nullableData, 4), nullableWriteSchema)
+          .write.parquet(nullablePath)
+
+        def dateToNtz(d: java.sql.Date): java.time.LocalDateTime = {
+          val days = d.toLocalDate.toEpochDay.toInt
+          val micros = DateTimeUtils.daysToMicros(days, java.time.ZoneOffset.UTC)
+          DateTimeUtils.microsToLocalDateTime(micros)
+        }
+        val expectedNonNull = nonNullData.map(r => Row(dateToNtz(r.getDate(0))))
+        val expectedNullable = nullableData.map { r =>
+          if (r.isNullAt(0)) Row(null) else Row(dateToNtz(r.getDate(0)))
+        }
+
+        withAllParquetReaders {
+          checkAnswer(spark.read.schema(nonNullReadSchema).parquet(nonNullPath), expectedNonNull)
+          checkAnswer(spark.read.schema(nullableReadSchema).parquet(nullablePath), expectedNullable)
+        }
+      }
+    }
+  }
 }
 
 class JobCommitFailureParquetOutputCommitter(outputPath: Path, context: TaskAttemptContext)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterSuite.scala
@@ -27,6 +27,7 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 import org.apache.parquet.schema.Type.Repetition
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
 import org.apache.spark.sql.types._
 
@@ -37,6 +38,7 @@ import org.apache.spark.sql.types._
  *   - `IntegerToDoubleUpdater` (INT32 -> Double)
  *   - `FloatToDoubleUpdater` (FLOAT -> Double)
  *   - `DowncastLongUpdater` (INT64 DECIMAL -> 32-bit Decimal via narrowing cast)
+ *   - `DateToTimestampNTZUpdater` (INT32 DATE -> TimestampNTZ micros at UTC)
  *
  * Covers boundary batch lengths, sign-extension on negative INT32 values, the singular
  * `readValue` path, and the factory's long-decimal dispatch
@@ -407,5 +409,88 @@ class ParquetVectorUpdaterSuite extends SparkFunSuite {
     val input = Array(-999_999_999L, -1L, 0L, 1L, 999_999_999L)
     val actual = readViaDowncastLongUpdater(desc, targetType, input)
     assert(actual === Array[Int](-999_999_999, -1, 0, 1, 999_999_999))
+  }
+
+  // ---- DateToTimestampNTZUpdater: INT32 DATE -> TimestampNTZ micros at UTC ----
+
+  // INT32 column descriptor annotated as DATE; routes the factory through the
+  // `sparkType == TimestampNTZType && isDateTypeMatched(descriptor)` branch.
+  private val int32DateDescriptor: ColumnDescriptor = {
+    val pt = Types.primitive(PrimitiveTypeName.INT32, Repetition.OPTIONAL)
+      .as(LogicalTypeAnnotation.dateType())
+      .named("col")
+    new ColumnDescriptor(Array("col"), pt, 0, 1)
+  }
+
+  // Reads `values.length` INT32 day-counts through `DateToTimestampNTZUpdater.readValues`
+  // and returns the resulting micros column.
+  private def readViaDateToTimestampNTZUpdater(values: Array[Int]): Array[Long] = {
+    val fac = newFactory(int32DateDescriptor)
+    val updater = fac.getUpdater(int32DateDescriptor, DataTypes.TimestampNTZType)
+    val out = new OnHeapColumnVector(values.length.max(1), DataTypes.TimestampNTZType)
+    val reader = newPlainReader(plainIntBytes(values), values.length)
+    updater.readValues(values.length, 0, out, reader)
+    val result = new Array[Long](values.length)
+    var i = 0
+    while (i < values.length) { result(i) = out.getLong(i); i += 1 }
+    result
+  }
+
+  // Realistic day-count sample: epoch, recent dates, pre-epoch, far-past, far-future. All
+  // values are well within `Math.multiplyExact(days * 86400, 1_000_000)`'s safe range.
+  private def dateSampleValues(n: Int): Array[Int] = {
+    val out = new Array[Int](n)
+    var i = 0
+    while (i < n) {
+      out(i) = i % 6 match {
+        case 0 => 0          // 1970-01-01 (epoch)
+        case 1 => -25567     // ~1900-01-01
+        case 2 => 19366      // ~2023-01-01
+        case 3 => -719162    // ~0001-01-01
+        case 4 => 1000000    // ~4707-11-28 (far future, still safe)
+        case _ => i * 37 - 100
+      }
+      i += 1
+    }
+    out
+  }
+
+  private def expectedMicros(values: Array[Int]): Array[Long] =
+    values.map(d => DateTimeUtils.daysToMicros(d, ZoneOffset.UTC))
+
+  for (n <- Seq(0, 1, 7, 8, 9, 17, 1024, 4097)) {
+    test(s"DateToTimestampNTZUpdater produces correct UTC micros (total=$n)") {
+      val input = dateSampleValues(n)
+      assert(readViaDateToTimestampNTZUpdater(input) === expectedMicros(input))
+    }
+  }
+
+  test("DateToTimestampNTZUpdater: readValue converts a single date-day to UTC micros") {
+    // Same rationale as the IntegerToLongUpdater readValue test: the def-level-decoder's
+    // run-of-1 path calls `readInteger()` directly rather than the bulk method.
+    val input = Array(0, 1, -1, 19366, -25567)
+    val fac = newFactory(int32DateDescriptor)
+    val updater = fac.getUpdater(int32DateDescriptor, DataTypes.TimestampNTZType)
+    val out = new OnHeapColumnVector(input.length, DataTypes.TimestampNTZType)
+    val reader = newPlainReader(plainIntBytes(input), input.length)
+    var i = 0
+    while (i < input.length) {
+      updater.readValue(i, out, reader)
+      i += 1
+    }
+    val actual = (0 until input.length).map(out.getLong).toArray
+    assert(actual === input.map(d => DateTimeUtils.daysToMicros(d, ZoneOffset.UTC)))
+  }
+
+  test("DateToTimestampNTZUpdater: epoch and signed day-counts produce expected micros") {
+    // Pins reference micros for a handful of well-known dates so the conversion semantics
+    // are visible at unit-test level without relying on DateTimeUtils for the expected
+    // side.
+    val input = Array(0, 1, -1)
+    val expected = Array(
+      0L,                  // 1970-01-01 00:00:00 UTC
+      86_400_000_000L,     // 1970-01-02 00:00:00 UTC
+      -86_400_000_000L)    // 1969-12-31 00:00:00 UTC
+    assert(readViaDateToTimestampNTZUpdater(input) === expected)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Extend the bulk read+convert pattern introduced in SPARK-56791 to `DateToTimestampNTZUpdater` (parquet INT32 DATE read into a Spark `TimestampNTZType` at UTC, CORRECTED rebase mode).

A new `readIntegersAsTimestampMicros` default method on `VectorizedValuesReader` does the per-row fallback. `VectorizedPlainValuesReader` overrides it to fetch source bytes once via `getBuffer(total * 4)` and run a tight in-method conversion loop. `DateToTimestampNTZUpdater.readValues` becomes a one-line delegation. The per-element conversion is `DateTimeUtils.daysToMicros(days, ZoneOffset.UTC)`, matching the per-row Updater's exact semantics including the `Math.multiplyExact` overflow check. The `LEGACY` / `EXCEPTION` rebase variants (handled by `DateToTimestampNTZWithRebaseUpdater`) are out of scope.

Unlike the pure-primitive-cast siblings (SPARK-56791/56801/56802), the per-element conversion here is a function call rather than a JVM-native widen, so the expected speedup is smaller; the win still comes from collapsing N `getBuffer(4)` allocations into one.

### Why are the changes needed?

`DateToTimestampNTZUpdater.readValues` allocates a fresh `ByteBuffer` slice inside `getBuffer(4)` for every element on the legacy path. Collapsing N allocations into one is the same win SPARK-56791 delivered for the INT32 -> Long sibling.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

(To be updated after the GHA benchmark and test runs complete.)

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code