### PR TITLE
[SPARK-56729][SQL] ReplaceData and WriteDelta should implement SupportsNonDeterministicExpression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -367,7 +367,10 @@ case class ReplaceData(
     originalTable: NamedRelation,
     projections: ReplaceDataProjections,
     groupFilterCondition: Option[Expression] = None,
-    write: Option[Write] = None) extends RowLevelWrite {
+    write: Option[Write] = None)
+    extends RowLevelWrite with SupportsNonDeterministicExpression {
+
+  override def allowNonDeterministicExpression: Boolean = operation.command() == MERGE
 
   override val isByName: Boolean = false
   override val withSchemaEvolution: Boolean = false
@@ -455,7 +458,10 @@ case class WriteDelta(
     originalTable: NamedRelation,
     projections: WriteDeltaProjections,
     groupFilterCondition: Option[Expression] = None,
-    write: Option[DeltaWrite] = None) extends RowLevelWrite {
+    write: Option[DeltaWrite] = None)
+    extends RowLevelWrite with SupportsNonDeterministicExpression {
+
+  override def allowNonDeterministicExpression: Boolean = operation.command() == MERGE
 
   override val isByName: Boolean = false
   override val withSchemaEvolution: Boolean = false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -370,7 +370,7 @@ case class ReplaceData(
     write: Option[Write] = None)
     extends RowLevelWrite with SupportsNonDeterministicExpression {
 
-  override def allowNonDeterministicExpression: Boolean = operation.command() == MERGE
+  override def allowNonDeterministicExpression: Boolean = operation.command == MERGE
 
   override val isByName: Boolean = false
   override val withSchemaEvolution: Boolean = false
@@ -461,7 +461,7 @@ case class WriteDelta(
     write: Option[DeltaWrite] = None)
     extends RowLevelWrite with SupportsNonDeterministicExpression {
 
-  override def allowNonDeterministicExpression: Boolean = operation.command() == MERGE
+  override def allowNonDeterministicExpression: Boolean = operation.command == MERGE
 
   override val isByName: Boolean = false
   override val withSchemaEvolution: Boolean = false

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -1345,4 +1345,64 @@ class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {
       "INVALID_NON_DETERMINISTIC_EXPRESSIONS" :: Nil
     )
   }
+
+  test("SPARK-56729: ReplaceData and WriteDelta allow non-deterministic expressions") {
+    import org.apache.spark.sql.catalyst.ProjectingInternalRow
+    import org.apache.spark.sql.catalyst.util.{ReplaceDataProjections, WriteDeltaProjections}
+    import org.apache.spark.sql.connector.catalog.InMemoryRowLevelOperationTable
+    import org.apache.spark.sql.connector.write.{RowLevelOperationInfoImpl,
+      RowLevelOperationTable}
+    import org.apache.spark.sql.connector.write.RowLevelOperation.Command
+    import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+    import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+    val schema = StructType(Seq(StructField("id", IntegerType)))
+    val tableProps = new java.util.HashMap[String, String]()
+    val inMemoryTable = new InMemoryRowLevelOperationTable(
+      "t", schema, Array.empty, tableProps)
+    val deltaProps = new java.util.HashMap[String, String]()
+    deltaProps.put("supports-deltas", "true")
+    val deltaTable = new InMemoryRowLevelOperationTable(
+      "t", schema, Array.empty, deltaProps)
+
+    def buildRelation(table: InMemoryRowLevelOperationTable,
+        command: Command): DataSourceV2Relation = {
+      val info = RowLevelOperationInfoImpl(command, CaseInsensitiveStringMap.empty())
+      val operation = table.newRowLevelOperationBuilder(info).build()
+      val opTable = RowLevelOperationTable(table, operation)
+      DataSourceV2Relation(
+        opTable,
+        Seq(AttributeReference("id", IntegerType)()),
+        None, None, CaseInsensitiveStringMap.empty())
+    }
+
+    val rowProjection = ProjectingInternalRow(schema, IndexedSeq(0))
+    val replaceProjections = ReplaceDataProjections(rowProjection, None)
+    val deltaProjections = WriteDeltaProjections(None, rowProjection, None)
+    val dummyQuery = testRelation
+
+    // MERGE should allow non-deterministic expressions
+    val mergeRelation = buildRelation(inMemoryTable, Command.MERGE)
+    val replaceDataMerge = ReplaceData(
+      mergeRelation, Literal(true), dummyQuery, mergeRelation, replaceProjections)
+    assert(replaceDataMerge.allowNonDeterministicExpression,
+      "ReplaceData should allow non-deterministic expressions for MERGE")
+    val mergeDeltaRelation = buildRelation(deltaTable, Command.MERGE)
+    val writeDeltaMerge = WriteDelta(
+      mergeDeltaRelation, Literal(true), dummyQuery, mergeDeltaRelation, deltaProjections)
+    assert(writeDeltaMerge.allowNonDeterministicExpression,
+      "WriteDelta should allow non-deterministic expressions for MERGE")
+
+    // DELETE should NOT allow non-deterministic expressions
+    val deleteRelation = buildRelation(inMemoryTable, Command.DELETE)
+    val replaceDataDelete = ReplaceData(
+      deleteRelation, Literal(true), dummyQuery, deleteRelation, replaceProjections)
+    assert(!replaceDataDelete.allowNonDeterministicExpression,
+      "ReplaceData should not allow non-deterministic expressions for DELETE")
+    val deleteDeltaRelation = buildRelation(deltaTable, Command.DELETE)
+    val writeDeltaDelete = WriteDelta(
+      deleteDeltaRelation, Literal(true), dummyQuery, deleteDeltaRelation, deltaProjections)
+    assert(!writeDeltaDelete.allowNonDeterministicExpression,
+      "WriteDelta should not allow non-deterministic expressions for DELETE")
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -1404,5 +1404,17 @@ class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {
       deleteDeltaRelation, Literal(true), dummyQuery, deleteDeltaRelation, deltaProjections)
     assert(!writeDeltaDelete.allowNonDeterministicExpression,
       "WriteDelta should not allow non-deterministic expressions for DELETE")
+
+    // UPDATE should NOT allow non-deterministic expressions
+    val updateRelation = buildRelation(inMemoryTable, Command.UPDATE)
+    val replaceDataUpdate = ReplaceData(
+      updateRelation, Literal(true), dummyQuery, updateRelation, replaceProjections)
+    assert(!replaceDataUpdate.allowNonDeterministicExpression,
+      "ReplaceData should not allow non-deterministic expressions for UPDATE")
+    val updateDeltaRelation = buildRelation(deltaTable, Command.UPDATE)
+    val writeDeltaUpdate = WriteDelta(
+      updateDeltaRelation, Literal(true), dummyQuery, updateDeltaRelation, deltaProjections)
+    assert(!writeDeltaUpdate.allowNonDeterministicExpression,
+      "WriteDelta should not allow non-deterministic expressions for UPDATE")
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
@@ -64,6 +64,7 @@ class RowLevelOperationRuntimeGroupFiltering(optimizeSubqueries: Rule[LogicalPla
       scan: SupportsRuntimeV2Filtering): Boolean = {
     conf.runtimeRowLevelOperationGroupFilterEnabled &&
       cond != TrueLiteral &&
+      cond.deterministic &&
       scan.filterAttributes.nonEmpty
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeNondeterministicSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeNondeterministicSuite.scala
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.expressions.DynamicPruningExpression
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Delta-based (merge-on-read / WriteDelta) variant of the SPARK-56729 non-deterministic
+ * MERGE source tests. Mirrors GroupBasedMergeNondeterministicSuite but exercises the
+ * WriteDelta path via DeltaBasedMergeIntoTableSuiteBase.
+ */
+object DeltaBasedMergeNondeterministicSuite {
+  val evalCounter = new AtomicInteger(0)
+}
+
+class DeltaBasedMergeNondeterministicSuite extends DeltaBasedMergeIntoTableSuiteBase {
+
+  import DeltaBasedMergeNondeterministicSuite.evalCounter
+
+  override protected lazy val extraTableProps: java.util.Map[String, String] = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("supports-deltas", "true")
+    props
+  }
+
+  test("SPARK-56729: non-deterministic source skips group filter and updates correctly") {
+    withSQLConf(
+      SQLConf.RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED.key -> "true",
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false"
+    ) {
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |""".stripMargin)
+
+        evalCounter.set(0)
+
+        spark.udf.register("nondet_pass",
+          udf((pk: Int) => {
+            DeltaBasedMergeNondeterministicSuite.evalCounter.incrementAndGet()
+            true
+          }).asNondeterministic())
+
+        sql(
+          """CREATE OR REPLACE TEMP VIEW source AS
+            |SELECT pk FROM VALUES (1), (2) t(pk) WHERE nondet_pass(pk)
+            |""".stripMargin)
+
+        val executedPlan = executeAndKeepPlan {
+          sql(
+            s"""MERGE INTO $tableNameAsString t
+               |USING source s
+               |ON t.pk = s.pk
+               |WHEN MATCHED THEN
+               | UPDATE SET t.salary = t.salary + 1
+               |""".stripMargin)
+        }
+
+        // Both rows updated correctly (no lost update)
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+          Seq(Row(1, 101, "hr"), Row(2, 201, "software")))
+
+        // Group filter was NOT injected (guard skipped it)
+        val dynamicFilters = collect(executedPlan) {
+          case b: BatchScanExec if b.runtimeFilters.exists(
+            _.isInstanceOf[DynamicPruningExpression]) => b
+        }
+        assert(dynamicFilters.isEmpty,
+          "Group filter should NOT be injected for non-deterministic source")
+
+        // Source scanned only once (2 rows = 2 UDF calls)
+        assert(evalCounter.get() == 2,
+          s"Expected 2 UDF calls (single scan), got ${evalCounter.get()}")
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedMergeNondeterministicSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedMergeNondeterministicSuite.scala
@@ -97,10 +97,9 @@ class GroupBasedMergeNondeterministicSuite extends MergeIntoTableSuiteBase {
     }
   }
 
-  test("SPARK-56729: non-deterministic source MERGE passes analysis and produces correct results") {
-    // End-to-end: a MERGE with rand() in the source (non-deterministic) previously failed with
-    // INVALID_NON_DETERMINISTIC_EXPRESSIONS. Now it passes analysis AND produces correct results
-    // with runtime group filter enabled.
+  test("SPARK-56729: rand() source produces correct results and skips group filter") {
+    // A MERGE with rand() in the source (non-deterministic) passes analysis, produces correct
+    // results, and the determinism guard prevents the group filter from being injected.
     withSQLConf(
       SQLConf.RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED.key -> "true",
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false"
@@ -117,23 +116,31 @@ class GroupBasedMergeNondeterministicSuite extends MergeIntoTableSuiteBase {
             |WHERE rand() < 2.0
             |""".stripMargin)
 
-        sql(
-          s"""MERGE INTO $tableNameAsString t
-             |USING source s
-             |ON t.pk = s.pk
-             |WHEN MATCHED THEN
-             | UPDATE SET t.salary = s.salary
-             |""".stripMargin)
+        val executedPlan = executeAndKeepPlan {
+          sql(
+            s"""MERGE INTO $tableNameAsString t
+               |USING source s
+               |ON t.pk = s.pk
+               |WHEN MATCHED THEN
+               | UPDATE SET t.salary = s.salary
+               |""".stripMargin)
+        }
 
         checkAnswer(
           sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
           Seq(Row(1, 150, "hr"), Row(2, 250, "software")))
+
+        val dynamicFilters = collect(executedPlan) {
+          case b: BatchScanExec if b.runtimeFilters.exists(
+            _.isInstanceOf[DynamicPruningExpression]) => b
+        }
+        assert(dynamicFilters.isEmpty,
+          "Group filter should NOT be injected for non-deterministic source")
       }
     }
   }
 
   test("SPARK-56729: deterministic source MERGE still uses runtime group filter") {
-    // A deterministic source should still benefit from the group filter optimization.
     withSQLConf(
       SQLConf.RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED.key -> "true",
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false"
@@ -159,57 +166,16 @@ class GroupBasedMergeNondeterministicSuite extends MergeIntoTableSuiteBase {
                |""".stripMargin)
         }
 
-        // Results are correct
         checkAnswer(
           sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
           Seq(Row(1, 150, "hr"), Row(2, 200, "software")))
 
-        // Dynamic pruning was applied (group filter injected for deterministic source)
         val dynamicFilters = collect(executedPlan) {
           case b: BatchScanExec if b.runtimeFilters.exists(
             _.isInstanceOf[DynamicPruningExpression]) => b
         }
         assert(dynamicFilters.nonEmpty,
           "Group filter should be injected for deterministic source MERGE")
-      }
-    }
-  }
-
-  test("SPARK-56729: non-deterministic source does not inject runtime group filter") {
-    // Verify the plan-level assertion: group filter is skipped for non-deterministic source.
-    withSQLConf(
-      SQLConf.RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED.key -> "true",
-      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false"
-    ) {
-      withTempView("source") {
-        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
-          """{ "pk": 1, "salary": 100, "dep": "hr" }
-            |{ "pk": 2, "salary": 200, "dep": "software" }
-            |""".stripMargin)
-
-        sql(
-          """CREATE OR REPLACE TEMP VIEW source AS
-            |SELECT pk, salary FROM VALUES (1, 150), (2, 250) t(pk, salary)
-            |WHERE rand() < 2.0
-            |""".stripMargin)
-
-        val executedPlan = executeAndKeepPlan {
-          sql(
-            s"""MERGE INTO $tableNameAsString t
-               |USING source s
-               |ON t.pk = s.pk
-               |WHEN MATCHED THEN
-               | UPDATE SET t.salary = s.salary
-               |""".stripMargin)
-        }
-
-        // No dynamic pruning applied (group filter skipped for non-deterministic source)
-        val dynamicFilters = collect(executedPlan) {
-          case b: BatchScanExec if b.runtimeFilters.exists(
-            _.isInstanceOf[DynamicPruningExpression]) => b
-        }
-        assert(dynamicFilters.isEmpty,
-          "Group filter should NOT be injected for non-deterministic source MERGE")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedMergeNondeterministicSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedMergeNondeterministicSuite.scala
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.expressions.DynamicPruningExpression
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Tests for SPARK-56729: non-deterministic MERGE source with runtime group filtering.
+ *
+ * Verifies that the determinism guard in RowLevelOperationRuntimeGroupFiltering
+ * prevents lost updates when the source contains non-deterministic expressions.
+ */
+object GroupBasedMergeNondeterministicSuite {
+  val evalCounter = new AtomicInteger(0)
+}
+
+class GroupBasedMergeNondeterministicSuite extends MergeIntoTableSuiteBase {
+
+  import GroupBasedMergeNondeterministicSuite.evalCounter
+
+  test("SPARK-56729: non-deterministic source skips group filter and updates correctly") {
+    // A non-deterministic UDF that always passes marks the source as non-deterministic.
+    // The determinism guard skips the group filter, so the source is scanned only once
+    // and both rows are correctly updated. Without the guard, the group filter would
+    // create a second independent scan of the source, risking lost updates.
+    withSQLConf(
+      SQLConf.RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED.key -> "true",
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false"
+    ) {
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |""".stripMargin)
+
+        evalCounter.set(0)
+
+        spark.udf.register("nondet_pass",
+          udf((pk: Int) => {
+            GroupBasedMergeNondeterministicSuite.evalCounter.incrementAndGet()
+            true
+          }).asNondeterministic())
+
+        sql(
+          """CREATE OR REPLACE TEMP VIEW source AS
+            |SELECT pk FROM VALUES (1), (2) t(pk) WHERE nondet_pass(pk)
+            |""".stripMargin)
+
+        val executedPlan = executeAndKeepPlan {
+          sql(
+            s"""MERGE INTO $tableNameAsString t
+               |USING source s
+               |ON t.pk = s.pk
+               |WHEN MATCHED THEN
+               | UPDATE SET t.salary = t.salary + 1
+               |""".stripMargin)
+        }
+
+        // Both rows updated correctly (no lost update due to partition pruning)
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+          Seq(Row(1, 101, "hr"), Row(2, 201, "software")))
+
+        // Group filter was NOT injected (guard skipped it)
+        val dynamicFilters = collect(executedPlan) {
+          case b: BatchScanExec if b.runtimeFilters.exists(
+            _.isInstanceOf[DynamicPruningExpression]) => b
+        }
+        assert(dynamicFilters.isEmpty,
+          "Group filter should NOT be injected for non-deterministic source")
+
+        // Source scanned only once (2 rows = 2 UDF calls), not twice
+        assert(evalCounter.get() == 2,
+          s"Expected 2 UDF calls (single scan), got ${evalCounter.get()}")
+      }
+    }
+  }
+
+  test("SPARK-56729: non-deterministic source MERGE passes analysis and produces correct results") {
+    // End-to-end: a MERGE with rand() in the source (non-deterministic) previously failed with
+    // INVALID_NON_DETERMINISTIC_EXPRESSIONS. Now it passes analysis AND produces correct results
+    // with runtime group filter enabled.
+    withSQLConf(
+      SQLConf.RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED.key -> "true",
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false"
+    ) {
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |""".stripMargin)
+
+        sql(
+          """CREATE OR REPLACE TEMP VIEW source AS
+            |SELECT pk, salary FROM VALUES (1, 150), (2, 250) t(pk, salary)
+            |WHERE rand() < 2.0
+            |""".stripMargin)
+
+        sql(
+          s"""MERGE INTO $tableNameAsString t
+             |USING source s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | UPDATE SET t.salary = s.salary
+             |""".stripMargin)
+
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+          Seq(Row(1, 150, "hr"), Row(2, 250, "software")))
+      }
+    }
+  }
+
+  test("SPARK-56729: deterministic source MERGE still uses runtime group filter") {
+    // A deterministic source should still benefit from the group filter optimization.
+    withSQLConf(
+      SQLConf.RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED.key -> "true",
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false"
+    ) {
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |""".stripMargin)
+
+        sql(
+          """CREATE OR REPLACE TEMP VIEW source AS
+            |SELECT pk, salary FROM VALUES (1, 150) t(pk, salary)
+            |""".stripMargin)
+
+        val executedPlan = executeAndKeepPlan {
+          sql(
+            s"""MERGE INTO $tableNameAsString t
+               |USING source s
+               |ON t.pk = s.pk
+               |WHEN MATCHED THEN
+               | UPDATE SET t.salary = s.salary
+               |""".stripMargin)
+        }
+
+        // Results are correct
+        checkAnswer(
+          sql(s"SELECT * FROM $tableNameAsString ORDER BY pk"),
+          Seq(Row(1, 150, "hr"), Row(2, 200, "software")))
+
+        // Dynamic pruning was applied (group filter injected for deterministic source)
+        val dynamicFilters = collect(executedPlan) {
+          case b: BatchScanExec if b.runtimeFilters.exists(
+            _.isInstanceOf[DynamicPruningExpression]) => b
+        }
+        assert(dynamicFilters.nonEmpty,
+          "Group filter should be injected for deterministic source MERGE")
+      }
+    }
+  }
+
+  test("SPARK-56729: non-deterministic source does not inject runtime group filter") {
+    // Verify the plan-level assertion: group filter is skipped for non-deterministic source.
+    withSQLConf(
+      SQLConf.RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED.key -> "true",
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false"
+    ) {
+      withTempView("source") {
+        createAndInitTable("pk INT NOT NULL, salary INT, dep STRING",
+          """{ "pk": 1, "salary": 100, "dep": "hr" }
+            |{ "pk": 2, "salary": 200, "dep": "software" }
+            |""".stripMargin)
+
+        sql(
+          """CREATE OR REPLACE TEMP VIEW source AS
+            |SELECT pk, salary FROM VALUES (1, 150), (2, 250) t(pk, salary)
+            |WHERE rand() < 2.0
+            |""".stripMargin)
+
+        val executedPlan = executeAndKeepPlan {
+          sql(
+            s"""MERGE INTO $tableNameAsString t
+               |USING source s
+               |ON t.pk = s.pk
+               |WHEN MATCHED THEN
+               | UPDATE SET t.salary = s.salary
+               |""".stripMargin)
+        }
+
+        // No dynamic pruning applied (group filter skipped for non-deterministic source)
+        val dynamicFilters = collect(executedPlan) {
+          case b: BatchScanExec if b.runtimeFilters.exists(
+            _.isInstanceOf[DynamicPruningExpression]) => b
+        }
+        assert(dynamicFilters.isEmpty,
+          "Group filter should NOT be injected for non-deterministic source MERGE")
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR allows non-deterministic expressions in the source of MERGE INTO statements for row-level operation tables (DSv2). Previously, any non-deterministic expression in a MERGE source (e.g., `rand()`, `uuid()`, a non-deterministic UDF) was unconditionally rejected with `INVALID_NON_DETERMINISTIC_EXPRESSIONS`.

The fix gates the analysis check on `operation.command == MERGE` -- when the command is MERGE, non-deterministic expressions are allowed in the source relation because the V2 MERGE execution model materializes the source before writing.

Additionally, this PR adds a determinism guard in `RowLevelOperationRuntimeGroupFiltering`: the runtime group filter is only injected when `cond.deterministic` is true. This prevents the group filter from re-scanning a non-deterministic source independently, which would produce different rows on the second evaluation and silently lose updates. When the source is non-deterministic, the guard skips the filter injection entirely, ensuring correctness at the cost of the optimization.

Known follow-up (SPARK-57685): non-determinism in MERGE *action* assignments (e.g., `SET x = uuid()`) is still unsupported and tracked separately.

### Why are the changes needed?

Without this change, legitimate MERGE statements with non-deterministic sources (common in ETL pipelines using `rand()` for sampling or non-deterministic UDFs for enrichment) fail at analysis time. The runtime group filter guard is needed because without it, a non-deterministic source would be evaluated twice with different results, causing silent data loss.

### Does this PR introduce _any_ user-facing change?

Yes. MERGE INTO with non-deterministic source expressions against DSv2 tables now succeeds instead of failing with `INVALID_NON_DETERMINISTIC_EXPRESSIONS`.

### How was this patch tested?

- `GroupBasedMergeNondeterministicSuite` (copy-on-write / ReplaceData path):
  - UDF-counter reproduce-then-verify test: non-deterministic source correctly updates all rows, group filter is skipped, source scanned exactly once
  - `rand()` source test: verifies correct results AND absence of group filter injection
  - Deterministic source control: verifies group filter IS still injected for deterministic sources
- `DeltaBasedMergeNondeterministicSuite` (merge-on-read / WriteDelta path):
  - Same UDF-counter reproduce-then-verify test under `deltaMerge=true` with `supports-deltas` table property
- `AnalysisErrorSuite`: verifies UPDATE/DELETE with non-deterministic expressions still rejected
- Existing `MergeIntoTableSuiteBase` and `DeltaBasedMergeIntoTableSuite` tests continue to pass

### Was this patch authored or co-authored using generative AI tooling?

Yes.