### PR TITLE
[SPARK-56860][PYTHON] Remove unused CogroupArrowUDFSerializer

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -654,26 +654,6 @@ class ArrowStreamAggPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
         return "ArrowStreamAggPandasUDFSerializer"
 
 
-class CogroupArrowUDFSerializer(ArrowStreamGroupUDFSerializer):
-    """
-    Serializes pyarrow.RecordBatch data with Arrow streaming format.
-
-    Loads Arrow record batches as `[([pa.RecordBatch], [pa.RecordBatch])]` (one tuple per group)
-    and serializes `[([pa.RecordBatch], arrow_type)]`.
-
-    Parameters
-    ----------
-    assign_cols_by_name : bool
-        If True, then DataFrames will get columns by name
-    """
-
-    def load_stream(self, stream):
-        """
-        Deserialize Cogrouped ArrowRecordBatches and yield as two `pyarrow.RecordBatch`es.
-        """
-        yield from ArrowStreamCoGroupSerializer.load_stream(self, stream)
-
-
 class CogroupPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
     def load_stream(self, stream):
         """


### PR DESCRIPTION
### What changes were proposed in this pull request?

Delete `CogroupArrowUDFSerializer` from `python/pyspark/sql/pandas/serializers.py`.

### Why are the changes needed?

`CogroupArrowUDFSerializer` is no longer used after SPARK-56312 refactored `SQL_COGROUPED_MAP_ARROW_UDF` to use `ArrowStreamCoGroupSerializer` directly. This class can be safely deleted.

Part of SPARK-55384.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests: `pyspark.sql.tests.arrow.test_arrow_cogrouped_map`.

### Was this patch authored or co-authored using generative AI tooling?

No.