### PR TITLE
[SPARK-56764][SQL] Add spark.jars to SharedState.jarClassLoader for persistent UDF resolution

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -192,8 +192,20 @@ private[sql] class SharedState(
   /**
    * A classloader used to load all user-added jar.
    */
-  val jarClassLoader = new NonClosableMutableURLClassLoader(
-    org.apache.spark.util.Utils.getContextOrSparkClassLoader)
+  val jarClassLoader = {
+    val loader = new NonClosableMutableURLClassLoader(
+      org.apache.spark.util.Utils.getContextOrSparkClassLoader)
+    // SPARK-56764: Add spark.jars to jarClassLoader so persistent UDF classes
+    // are loadable after restart without relying on parent classloader delegation
+    sparkContext.jars.foreach { jarUri =>
+      try {
+        loader.addURL(new java.net.URI(jarUri).toURL)
+      } catch {
+        case _: Exception => // skip jars with invalid URLs
+      }
+    }
+    loader
+  }
 
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SharedStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SharedStateSuite.scala
@@ -22,9 +22,11 @@ import java.net.URL
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FsUrlStreamHandlerFactory
 
-import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.{SparkConf, SparkContext, SparkException}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.util.Utils
 
 /**
  * Tests for [[org.apache.spark.sql.internal.SharedState]].
@@ -67,5 +69,32 @@ class SharedStateSuite extends SharedSparkSession {
 
     SQLConf.get.setConfString("spark.sql.catalog.spark_catalog.defaultDatabase",
       SessionCatalog.DEFAULT_DATABASE)
+  }
+
+  test("SPARK-56764: jarClassLoader should contain spark.jars") {
+    val tempJar = Utils.createTempDir().toPath.resolve("fake.jar")
+    java.nio.file.Files.createFile(tempJar)
+    val jarPath = tempJar.toUri.toString
+
+    // Stop the existing session so we can create a new SparkContext with spark.jars
+    spark.stop()
+
+    val conf = new SparkConf()
+      .setMaster("local")
+      .setAppName("SPARK-56764-test")
+      .set("spark.jars", jarPath)
+      .set("spark.ui.enabled", "false")
+
+    val sc = new SparkContext(conf)
+    try {
+      val session = SparkSession.builder().sparkContext(sc).getOrCreate()
+      val urls = session.sharedState.jarClassLoader.getURLs.map(_.toString)
+      assert(urls.exists(_.contains("fake.jar")),
+        s"jarClassLoader should contain spark.jars, but URLs were: ${urls.mkString(", ")}")
+    } finally {
+      sc.stop()
+      SparkSession.clearActiveSession()
+      SparkSession.clearDefaultSession()
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `spark.jars` to `SharedState.jarClassLoader` at creation time, so persistent UDF classes are resolvable on the driver.

### Why are the changes needed?

When SparkSession is created programmatically (without SparkSubmit), `spark.jars` are never loaded into any driver-side classloader:
- `SparkContext.addJar()` only registers jars for executor distribution (the `addedJars` map), does NOT add to any driver classloader
- `SharedState.jarClassLoader` is created empty with the app classloader as parent
- Classes from `spark.jars` are not findable via `jarClassLoader`

Note: when launched via SparkSubmit (spark-shell, Thrift Server), this works correctly because SparkSubmit creates a `MutableURLClassLoader` with the jars and sets it as the context classloader, which becomes `jarClassLoader`'s parent. The fix makes behavior consistent regardless of launch method.

### Does this PR introduce _any_ user-facing change?

Yes, persistent UDFs referencing classes from `spark.jars` now resolve correctly when SparkSession is created programmatically.

### How was this patch tested?

Added test in `SharedStateSuite` that creates a SparkContext programmatically with `spark.jars` and verifies `jarClassLoader` contains those jars. Test fails without the fix (jar not in classloader), passes with it.

### Was this patch authored or co-authored using generative AI tooling?

Generated by : Claude Opus 4.7