### PR TITLE
[SPARK-56395][SQL][FOLLOWUP] Fix missing comma in MimaExcludes on branch-4.2

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -57,7 +57,7 @@ object MimaExcludes {
     // [SPARK-56330][CORE] Add TaskInterruptListener to TaskContext for interrupt notifications
     ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.TaskContext.addTaskInterruptListener"),
     // [SPARK-56700][SS] Make DataStreamReader.name public
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.streaming.DataStreamReader.name")
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.streaming.DataStreamReader.name"),
     // [SPARK-56395][SQL] Add NEAREST BY top-K ranking join
     ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.Dataset.nearestByJoin")
   )


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a missing trailing comma to the `DataStreamReader.name` MiMa exclude entry in `project/MimaExcludes.scala` on branch-4.2. The cherry-pick of SPARK-56395 (commit 2c356ac6c2d) added a new `Dataset.nearestByJoin` exclude entry to `v42excludes` but did not append the required comma to the preceding `DataStreamReader.name` entry.

### Why are the changes needed?

Without the comma, SBT project loading fails on branch-4.2:

```
[error] /home/runner/work/spark/spark/project/MimaExcludes.scala:62:19: ')' expected but '.' found.
[error]     ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.Dataset.nearestByJoin")
[error]                   ^
[error] /home/runner/work/spark/spark/project/MimaExcludes.scala:63:3: ';' expected but ')' found.
[error]   )
[error]   ^
[error] two errors found
[error] (Compile / compileIncremental) Compilation failed
```

This breaks all CI builds on branch-4.2. Reported by @LuciferYang in https://github.com/apache/spark/pull/55682#discussion_r3239241097. This change is branch-4.2 only; master is unaffected because the `nearestByJoin` entry has not been merged to master yet.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing CI. The fix restores compilability of the SBT project definition.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)