### PR TITLE
[SPARK-56863][PYTHON][PS][TESTS] Drop redundant `SQLTestUtils`

### DIFF
--- a/python/pyspark/pandas/tests/computation/test_any_all.py
+++ b/python/pyspark/pandas/tests/computation/test_any_all.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameAnyAllMixin:
@@ -263,7 +262,6 @@ class FrameAnyAllMixin:
 class FrameAnyAllTests(
     FrameAnyAllMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_apply_func.py
+++ b/python/pyspark/pandas/tests/computation/test_apply_func.py
@@ -24,7 +24,6 @@ from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.pandas.config import option_context
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 # This file contains test cases for 'Function application, GroupBy & Window'
@@ -571,7 +570,6 @@ class FrameApplyFunctionMixin:
 class FrameApplyFunctionTests(
     FrameApplyFunctionMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/computation/test_binary_ops.py
@@ -21,7 +21,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 # This file contains test cases for 'Binary operator functions'
@@ -319,7 +318,6 @@ class FrameBinaryOpsMixin:
 class FrameBinaryOpsTests(
     FrameBinaryOpsMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_combine.py
+++ b/python/pyspark/pandas/tests/computation/test_combine.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 # This file contains test cases for 'Combining / joining / merging'
@@ -769,7 +768,6 @@ class FrameCombineMixin:
 class FrameCombineTests(
     FrameCombineMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_compute.py
+++ b/python/pyspark/pandas/tests/computation/test_compute.py
@@ -21,7 +21,6 @@ import pandas as pd
 from pyspark.sql import functions as sf
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 # This file contains test cases for 'Computations / Descriptive Stats'
@@ -570,7 +569,6 @@ class FrameComputeMixin:
 class FrameComputeTests(
     FrameComputeMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_corr.py
+++ b/python/pyspark/pandas/tests/computation/test_corr.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, SPARK_CONF_ARROW_ENABLED
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameCorrMixin:
@@ -209,7 +208,6 @@ class FrameCorrMixin:
 class FrameCorrTests(
     FrameCorrMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_corrwith.py
+++ b/python/pyspark/pandas/tests/computation/test_corrwith.py
@@ -19,7 +19,6 @@ import numpy as np
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameCorrwithMixin:
@@ -66,7 +65,6 @@ class FrameCorrwithMixin:
 class FrameCorrwithTests(
     FrameCorrwithMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_cov.py
+++ b/python/pyspark/pandas/tests/computation/test_cov.py
@@ -21,7 +21,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameCovMixin:
@@ -102,7 +101,6 @@ class FrameCovMixin:
 class FrameCovTests(
     FrameCovMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_cumulative.py
+++ b/python/pyspark/pandas/tests/computation/test_cumulative.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameCumulativeMixin:
@@ -122,7 +121,6 @@ class FrameCumulativeMixin:
 class FrameCumulativeTests(
     FrameCumulativeMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_describe.py
+++ b/python/pyspark/pandas/tests/computation/test_describe.py
@@ -22,7 +22,6 @@ import pandas as pd
 from pyspark.loose_version import LooseVersion
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameDescribeMixin:
@@ -244,7 +243,6 @@ class FrameDescribeMixin:
 class FrameDescribeTests(
     FrameDescribeMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_eval.py
+++ b/python/pyspark/pandas/tests/computation/test_eval.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameEvalMixin:
@@ -62,7 +61,6 @@ class FrameEvalMixin:
 class FrameEvalTests(
     FrameEvalMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_idxmax_idxmin.py
+++ b/python/pyspark/pandas/tests/computation/test_idxmax_idxmin.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark.loose_version import LooseVersion
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameIdxMaxMinMixin:
@@ -280,7 +279,6 @@ class FrameIdxMaxMinMixin:
 class FrameIdxMaxMinTests(
     FrameIdxMaxMinMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_melt.py
+++ b/python/pyspark/pandas/tests/computation/test_melt.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.utils import name_like_string
 
 
@@ -168,7 +167,6 @@ class FrameMeltMixin:
 class FrameMeltTests(
     FrameMeltMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_missing_data.py
+++ b/python/pyspark/pandas/tests/computation/test_missing_data.py
@@ -22,7 +22,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 # This file contains test cases for 'Missing data handling'
@@ -490,7 +489,6 @@ class FrameMissingDataMixin:
 class FrameMissingDataTests(
     FrameMissingDataMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_pivot.py
+++ b/python/pyspark/pandas/tests/computation/test_pivot.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FramePivotMixin:
@@ -191,7 +190,6 @@ class FramePivotMixin:
 class FramePivotTests(
     FramePivotMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_pivot_table.py
+++ b/python/pyspark/pandas/tests/computation/test_pivot_table.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class PivotTableMixin:
@@ -75,7 +74,6 @@ class PivotTableMixin:
 class PivotTableTests(
     PivotTableMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_pivot_table_adv.py
+++ b/python/pyspark/pandas/tests/computation/test_pivot_table_adv.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class PivotTableAdvMixin:
@@ -75,7 +74,6 @@ class PivotTableAdvMixin:
 class PivotTableAdvTests(
     PivotTableAdvMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_pivot_table_multi_idx.py
+++ b/python/pyspark/pandas/tests/computation/test_pivot_table_multi_idx.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class PivotTableMultiIdxMixin:
@@ -73,7 +72,6 @@ class PivotTableMultiIdxMixin:
 class PivotTableMultiIdxTests(
     PivotTableMultiIdxMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_pivot_table_multi_idx_adv.py
+++ b/python/pyspark/pandas/tests/computation/test_pivot_table_multi_idx_adv.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class PivotTableMultiIdxAdvMixin:
@@ -75,7 +74,6 @@ class PivotTableMultiIdxAdvMixin:
 class PivotTableMultiIdxAdvTests(
     PivotTableMultiIdxAdvMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/computation/test_stats.py
+++ b/python/pyspark/pandas/tests/computation/test_stats.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class StatsTestsMixin:
@@ -313,7 +312,6 @@ class StatsTestsMixin:
 class StatsTests(
     StatsTestsMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_align.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_align.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class DiffFramesAlignMixin:
@@ -101,7 +100,7 @@ class DiffFramesAlignMixin:
         self.assertRaises(ValueError, lambda: psdf1.align(psdf3, axis=1))
 
 
-class DiffFramesAlignTests(DiffFramesAlignMixin, PandasOnSparkTestCase, SQLTestUtils):
+class DiffFramesAlignTests(DiffFramesAlignMixin, PandasOnSparkTestCase):
     pass
 
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_arithmetic.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_arithmetic.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.typedef.typehints import extension_float_dtypes_available
 
 
@@ -183,7 +182,6 @@ class ArithmeticMixin(ArithmeticTestingFuncMixin):
 class ArithmeticTests(
     ArithmeticMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_arithmetic_chain.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_arithmetic_chain.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.typedef.typehints import extension_float_dtypes_available
 
 
@@ -176,7 +175,6 @@ class ArithmeticChainMixin(ArithmeticChainTestingFuncMixin):
 class ArithmeticChainTests(
     ArithmeticChainMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_arithmetic_chain_ext.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_arithmetic_chain_ext.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.typedef.typehints import extension_dtypes_available
 from pyspark.pandas.tests.diff_frames_ops.test_arithmetic_chain import (
     ArithmeticChainTestingFuncMixin,
@@ -102,7 +101,6 @@ class ArithmeticChainExtMixin(ArithmeticChainTestingFuncMixin):
 class ArithmeticChainExtTests(
     ArithmeticChainExtMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_arithmetic_chain_ext_float.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_arithmetic_chain_ext_float.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.typedef.typehints import extension_float_dtypes_available
 from pyspark.pandas.tests.diff_frames_ops.test_arithmetic_chain import (
     ArithmeticChainTestingFuncMixin,
@@ -104,7 +103,6 @@ class ArithmeticChainExtFloatMixin(ArithmeticChainTestingFuncMixin):
 class ArithmeticChainExtFloatTests(
     ArithmeticChainExtFloatMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_arithmetic_ext.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_arithmetic_ext.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.typedef.typehints import extension_dtypes_available
 from pyspark.pandas.tests.diff_frames_ops.test_arithmetic import ArithmeticMixin
 
@@ -81,7 +80,6 @@ class ArithmeticExtMixin(ArithmeticMixin):
 class ArithmeticExtTests(
     ArithmeticExtMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_arithmetic_ext_float.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_arithmetic_ext_float.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.typedef.typehints import extension_float_dtypes_available
 from pyspark.pandas.tests.diff_frames_ops.test_arithmetic import ArithmeticMixin
 
@@ -81,7 +80,6 @@ class ArithmeticExtFloatMixin(ArithmeticMixin):
 class ArithmeticExtFloatTests(
     ArithmeticExtFloatMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_assign_frame.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_assign_frame.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class AssignFrameMixin:
@@ -225,7 +224,6 @@ class AssignFrameMixin:
 class AssignFrameTests(
     AssignFrameMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_assign_series.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_assign_series.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class AssignSeriesMixin:
@@ -223,7 +222,6 @@ class AssignSeriesMixin:
 class AssignSeriesTests(
     AssignSeriesMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_basic.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_basic.py
@@ -21,7 +21,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class BasicMixin:
@@ -221,7 +220,6 @@ class BasicMixin:
 class BasicTests(
     BasicMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_basic_slow.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_basic_slow.py
@@ -21,7 +21,6 @@ import numpy as np
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class DiffFramesBasicSlowMixin:
@@ -181,7 +180,7 @@ class DiffFramesBasicSlowMixin:
         )
 
 
-class DiffFramesBasicSlowTests(DiffFramesBasicSlowMixin, PandasOnSparkTestCase, SQLTestUtils):
+class DiffFramesBasicSlowTests(DiffFramesBasicSlowMixin, PandasOnSparkTestCase):
     pass
 
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_bitwise.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_bitwise.py
@@ -21,7 +21,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.typedef.typehints import extension_object_dtypes_available
 
 
@@ -92,7 +91,6 @@ class BitwiseMixin:
 class BitwiseTests(
     BitwiseMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_combine_first.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_combine_first.py
@@ -19,7 +19,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class CombineFirstMixin:
@@ -92,7 +91,6 @@ class CombineFirstMixin:
 class CombineFirstTests(
     CombineFirstMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_compare_series.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_compare_series.py
@@ -21,7 +21,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class CompareSeriesMixin:
@@ -137,7 +136,6 @@ class CompareSeriesMixin:
 class CompareSeriesTests(
     CompareSeriesMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_concat_inner.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_concat_inner.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class ConcatTestingFuncMixin:
@@ -105,7 +104,6 @@ class ConcatInnerMixin(ConcatTestingFuncMixin):
 class ConcatInnerTests(
     ConcatInnerMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_concat_outer.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_concat_outer.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.tests.diff_frames_ops.test_concat_inner import ConcatTestingFuncMixin
 
 
@@ -63,7 +62,6 @@ class ConcatOuterMixin(ConcatTestingFuncMixin):
 class ConcatOuterTests(
     ConcatOuterMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_corrwith.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_corrwith.py
@@ -21,7 +21,6 @@ import numpy as np
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class DiffFramesCorrWithMixin:
@@ -117,7 +116,6 @@ class DiffFramesCorrWithMixin:
 class DiffFramesCorrWithTests(
     DiffFramesCorrWithMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_cov.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_cov.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class DiffFramesCovMixin:
@@ -73,7 +72,6 @@ class DiffFramesCovMixin:
 class DiffFramesCovTests(
     DiffFramesCovMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_dot_frame.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_dot_frame.py
@@ -19,7 +19,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class DiffFramesDotFrameMixin:
@@ -85,7 +84,7 @@ class DiffFramesDotFrameMixin:
         self.assert_eq((psdf + 1).dot(psdf[0] * 10), (pdf + 1).dot(pdf[0] * 10))
 
 
-class DiffFramesDotFrameTests(DiffFramesDotFrameMixin, PandasOnSparkTestCase, SQLTestUtils):
+class DiffFramesDotFrameTests(DiffFramesDotFrameMixin, PandasOnSparkTestCase):
     pass
 
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_dot_series.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_dot_series.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class DiffFramesDotSeriesMixin:
@@ -126,7 +125,7 @@ class DiffFramesDotSeriesMixin:
             self.assert_eq(psser.dot(psser_other), 16381)
 
 
-class DiffFramesDotSeriesTests(DiffFramesDotSeriesMixin, PandasOnSparkTestCase, SQLTestUtils):
+class DiffFramesDotSeriesTests(DiffFramesDotSeriesMixin, PandasOnSparkTestCase):
     pass
 
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_error.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_error.py
@@ -22,7 +22,6 @@ import numpy as np
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class DiffFramesErrorMixin:
@@ -236,7 +235,6 @@ class DiffFramesErrorMixin:
 class DiffFramesErrorTests(
     DiffFramesErrorMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupByMixin:
@@ -109,7 +108,6 @@ class GroupByMixin:
 class GroupByTests(
     GroupByMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_aggregate.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_aggregate.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupByAggregateMixin:
@@ -121,7 +120,6 @@ class GroupByAggregateMixin:
 class GroupByAggregateTests(
     GroupByAggregateMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_apply.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_apply.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupByApplyMixin:
@@ -68,7 +67,6 @@ class GroupByApplyMixin:
 class GroupByApplyTests(
     GroupByApplyMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_cumulative.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_cumulative.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupByCumulativeMixin:
@@ -164,7 +163,6 @@ class GroupByCumulativeMixin:
 class GroupByCumulativeTests(
     GroupByCumulativeMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_diff.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_diff.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupByDiffMixin:
@@ -64,7 +63,6 @@ class GroupByDiffMixin:
 class GroupByDiffTests(
     GroupByDiffMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_diff_len.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_diff_len.py
@@ -21,7 +21,6 @@ from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupByDiffLenMixin:
@@ -87,7 +86,6 @@ class GroupByDiffLenMixin:
 class GroupByDiffLenTests(
     GroupByDiffLenMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_expanding.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_expanding.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupByExpandingTestingFuncMixin:
@@ -82,7 +81,6 @@ class GroupByExpandingMixin(GroupByExpandingTestingFuncMixin):
 class GroupByExpandingTests(
     GroupByExpandingMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_expanding_adv.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_expanding_adv.py
@@ -17,7 +17,6 @@
 
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.tests.diff_frames_ops.test_groupby_expanding import (
     GroupByExpandingTestingFuncMixin,
 )
@@ -44,7 +43,6 @@ class GroupByExpandingAdvMixin(GroupByExpandingTestingFuncMixin):
 class GroupByExpandingAdvTests(
     GroupByExpandingAdvMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_expanding_count.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_expanding_count.py
@@ -17,7 +17,6 @@
 
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.tests.diff_frames_ops.test_groupby_expanding import (
     GroupByExpandingTestingFuncMixin,
 )
@@ -41,7 +40,6 @@ class GroupByExpandingCountMixin(GroupByExpandingTestingFuncMixin):
 class GroupByExpandingCountTests(
     GroupByExpandingCountMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_fillna.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_fillna.py
@@ -21,7 +21,6 @@ from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupByFillNAMixin:
@@ -100,7 +99,6 @@ class GroupByFillNAMixin:
 class GroupByFillNATests(
     GroupByFillNAMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_filter.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_filter.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupByFilterMixin:
@@ -64,7 +63,6 @@ class GroupByFilterMixin:
 class GroupByFilterTests(
     GroupByFilterMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_rolling.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_rolling.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupByRollingTestingFuncMixin:
@@ -82,7 +81,6 @@ class GroupByRollingMixin(GroupByRollingTestingFuncMixin):
 class GroupByRollingTests(
     GroupByRollingMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_rolling_adv.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_rolling_adv.py
@@ -17,7 +17,6 @@
 
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.tests.diff_frames_ops.test_groupby_rolling import GroupByRollingTestingFuncMixin
 
 
@@ -42,7 +41,6 @@ class GroupByRollingAdvMixin(GroupByRollingTestingFuncMixin):
 class GroupByRollingAdvTests(
     GroupByRollingAdvMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_rolling_count.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_rolling_count.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupByRollingCountMixin:
@@ -68,7 +67,6 @@ class GroupByRollingCountMixin:
 class GroupByRollingCountTests(
     GroupByRollingCountMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_shift.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_shift.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupByShiftMixin:
@@ -67,7 +66,6 @@ class GroupByShiftMixin:
 class GroupByShiftTests(
     GroupByShiftMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_split_apply_combine.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_split_apply_combine.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupBySACMixin:
@@ -95,7 +94,6 @@ class GroupBySACMixin:
 class GroupBySACTests(
     GroupBySACMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_transform.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_transform.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupByTransformMixin:
@@ -64,7 +63,6 @@ class GroupByTransformMixin:
 class GroupByTransformTests(
     GroupByTransformMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_index.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_index.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class DiffFramesIndexMixin:
@@ -92,7 +91,7 @@ class DiffFramesIndexMixin:
             psdf[("1", "2", "3")] = ps.Series([100, 200, 300, 200])
 
 
-class DiffFramesIndexTests(DiffFramesIndexMixin, PandasOnSparkTestCase, SQLTestUtils):
+class DiffFramesIndexTests(DiffFramesIndexMixin, PandasOnSparkTestCase):
     pass
 
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_series.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_series.py
@@ -20,7 +20,6 @@ import numpy as np
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class DiffFramesSeriesMixin:
@@ -119,7 +118,7 @@ class DiffFramesSeriesMixin:
         self.assert_eq(pser == pandas_other, (psser == pandas_on_spark_other).sort_index())
 
 
-class DiffFramesSeriesTests(DiffFramesSeriesMixin, PandasOnSparkTestCase, SQLTestUtils):
+class DiffFramesSeriesTests(DiffFramesSeriesMixin, PandasOnSparkTestCase):
     pass
 
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_setitem_frame.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_setitem_frame.py
@@ -21,7 +21,6 @@ from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class DiffFramesSetItemFrameMixin:
@@ -116,7 +115,7 @@ class DiffFramesSetItemFrameMixin:
             psdf.iloc[[0], 1] = 10 * another_psdf.max_speed
 
 
-class DiffFramesSetItemFrameTests(DiffFramesSetItemFrameMixin, PandasOnSparkTestCase, SQLTestUtils):
+class DiffFramesSetItemFrameTests(DiffFramesSetItemFrameMixin, PandasOnSparkTestCase):
     pass
 
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_setitem_series.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_setitem_series.py
@@ -162,9 +162,7 @@ class DiffFramesSetItemSeriesMixin:
             psser1.iloc[[1, 2]] = -psser_another
 
 
-class DiffFramesSetItemSeriesTests(
-    DiffFramesSetItemSeriesMixin, PandasOnSparkTestCase
-):
+class DiffFramesSetItemSeriesTests(DiffFramesSetItemSeriesMixin, PandasOnSparkTestCase):
     pass
 
 

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_setitem_series.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_setitem_series.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class DiffFramesSetItemSeriesMixin:
@@ -164,7 +163,7 @@ class DiffFramesSetItemSeriesMixin:
 
 
 class DiffFramesSetItemSeriesTests(
-    DiffFramesSetItemSeriesMixin, PandasOnSparkTestCase, SQLTestUtils
+    DiffFramesSetItemSeriesMixin, PandasOnSparkTestCase
 ):
     pass
 

--- a/python/pyspark/pandas/tests/frame/test_attrs.py
+++ b/python/pyspark/pandas/tests/frame/test_attrs.py
@@ -21,7 +21,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 # This file contains test cases for 'Attributes and underlying data'
@@ -347,7 +346,6 @@ class FrameAttrsMixin:
 class FrameAttrsTests(
     FrameAttrsMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/frame/test_axis.py
+++ b/python/pyspark/pandas/tests/frame/test_axis.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameAxisMixin:
@@ -121,7 +120,6 @@ class FrameAxisMixin:
 class FrameAxisTests(
     FrameAxisMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/frame/test_constructor.py
+++ b/python/pyspark/pandas/tests/frame/test_constructor.py
@@ -29,7 +29,6 @@ from pyspark.pandas.typedef.typehints import (
 from pyspark.pandas.utils import is_testing
 
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 # This file contains test cases for 'Constructor'
@@ -576,7 +575,6 @@ class FrameConstructorMixin:
 class FrameConstructorTests(
     FrameConstructorMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/frame/test_conversion.py
+++ b/python/pyspark/pandas/tests/frame/test_conversion.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 # This file contains test cases for 'Conversion'
@@ -57,7 +56,6 @@ class FrameConversionMixin:
 class FrameConversionTests(
     FrameConversionMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/frame/test_reindexing.py
+++ b/python/pyspark/pandas/tests/frame/test_reindexing.py
@@ -26,7 +26,6 @@ from pyspark.errors import PySparkValueError
 from pyspark.loose_version import LooseVersion
 from pyspark.pandas.config import option_context
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 # This file contains test cases for 'Reindexing / Selection / Label manipulation'
@@ -960,7 +959,6 @@ class FrameReindexingMixin:
 class FrameReidexingTests(
     FrameReindexingMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/frame/test_reshaping.py
+++ b/python/pyspark/pandas/tests/frame/test_reshaping.py
@@ -22,7 +22,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 # This file contains test cases for 'Reshaping, sorting, transposing'
@@ -468,7 +467,6 @@ class FrameReshapingMixin:
 class FrameReshapingTests(
     FrameReshapingMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/frame/test_spark.py
+++ b/python/pyspark/pandas/tests/frame/test_spark.py
@@ -29,7 +29,6 @@ from pyspark.pandas.frame import CachedDataFrame
 from pyspark.pandas.exceptions import PandasNotImplementedError
 from pyspark.pandas.missing.frame import MissingPandasLikeDataFrame
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, SPARK_CONF_ARROW_ENABLED
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 # This file contains test cases for 'Spark-related'
@@ -306,7 +305,6 @@ class FrameSparkMixin:
 class FrameSparkTests(
     FrameSparkMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/frame/test_take.py
+++ b/python/pyspark/pandas/tests/frame/test_take.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameTakeMixin:
@@ -75,7 +74,6 @@ class FrameTakeMixin:
 class FrameTakeTests(
     FrameTakeMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/frame/test_take_adv.py
+++ b/python/pyspark/pandas/tests/frame/test_take_adv.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameTakeAdvMixin:
@@ -86,7 +85,6 @@ class FrameTakeAdvMixin:
 class FrameTakeAdvTests(
     FrameTakeAdvMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/frame/test_time_series.py
+++ b/python/pyspark/pandas/tests/frame/test_time_series.py
@@ -21,7 +21,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 # This file contains test cases for 'Time series-related'
@@ -122,7 +121,6 @@ class FrameTimeSeriesMixin:
 class FrameTimeSeriesTests(
     FrameTimeSeriesMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/frame/test_truncate.py
+++ b/python/pyspark/pandas/tests/frame/test_truncate.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameTruncateMixin:
@@ -116,7 +115,7 @@ class FrameTruncateMixin:
             psdf.truncate("C", "B", axis=1)
 
 
-class FrameTruncateTests(FrameTruncateMixin, PandasOnSparkTestCase, SQLTestUtils):
+class FrameTruncateTests(FrameTruncateMixin, PandasOnSparkTestCase):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_aggregate.py
+++ b/python/pyspark/pandas/tests/groupby/test_aggregate.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupbyAggregateMixin:
@@ -272,7 +271,6 @@ class GroupbyAggregateMixin:
 class GroupbyAggregateTests(
     GroupbyAggregateMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_apply_func.py
+++ b/python/pyspark/pandas/tests/groupby/test_apply_func.py
@@ -22,7 +22,6 @@ from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.pandas.config import option_context
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupbyApplyFuncMixin:
@@ -712,7 +711,6 @@ class GroupbyApplyFuncMixin:
 class GroupbyApplyFuncTests(
     GroupbyApplyFuncMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_corr.py
+++ b/python/pyspark/pandas/tests/groupby/test_corr.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class CorrMixin:
@@ -66,7 +65,6 @@ class CorrMixin:
 class CorrTests(
     CorrMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_cov.py
+++ b/python/pyspark/pandas/tests/groupby/test_cov.py
@@ -21,7 +21,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class CovMixin:
@@ -113,7 +112,6 @@ class CovMixin:
 class CovTests(
     CovMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_cumulative.py
+++ b/python/pyspark/pandas/tests/groupby/test_cumulative.py
@@ -21,7 +21,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.exceptions import DataError
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupbyCumulativeMixin:
@@ -390,7 +389,6 @@ class GroupbyCumulativeMixin:
 class GroupbyCumulativeTests(
     GroupbyCumulativeMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_describe.py
+++ b/python/pyspark/pandas/tests/groupby/test_describe.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupbyDescribeMixin:
@@ -186,7 +185,6 @@ class GroupbyDescribeMixin:
 class GroupbyDescribeTests(
     GroupbyDescribeMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_head_tail.py
+++ b/python/pyspark/pandas/tests/groupby/test_head_tail.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupbyHeadTailMixin:
@@ -204,7 +203,6 @@ class GroupbyHeadTailMixin:
 class GroupbyHeadTailTests(
     GroupbyHeadTailMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_index.py
+++ b/python/pyspark/pandas/tests/groupby/test_index.py
@@ -20,7 +20,6 @@ import pandas as pd
 from pyspark.loose_version import LooseVersion
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupbyIndexMixin:
@@ -282,7 +281,6 @@ class GroupbyIndexMixin:
 class GroupbyIndexTests(
     GroupbyIndexMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_missing_data.py
+++ b/python/pyspark/pandas/tests/groupby/test_missing_data.py
@@ -22,7 +22,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupbyMissingDataMixin:
@@ -322,7 +321,6 @@ class GroupbyMissingDataMixin:
 class GroupbyMissingDataTests(
     GroupbyMissingDataMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_split_apply.py
+++ b/python/pyspark/pandas/tests/groupby/test_split_apply.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class GroupbySplitApplyTestingFuncMixin:
@@ -169,7 +168,6 @@ class GroupbySplitApplyMixin(GroupbySplitApplyTestingFuncMixin):
 class GroupbySplitApplyTests(
     GroupbySplitApplyMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_split_apply_count.py
+++ b/python/pyspark/pandas/tests/groupby/test_split_apply_count.py
@@ -16,7 +16,6 @@
 #
 
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.tests.groupby.test_split_apply import GroupbySplitApplyTestingFuncMixin
 
 
@@ -31,7 +30,6 @@ class GroupbySplitApplyCountMixin(GroupbySplitApplyTestingFuncMixin):
 class GroupbySplitApplyCountTests(
     GroupbySplitApplyCountMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_split_apply_first.py
+++ b/python/pyspark/pandas/tests/groupby/test_split_apply_first.py
@@ -16,7 +16,6 @@
 #
 
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.tests.groupby.test_split_apply import GroupbySplitApplyTestingFuncMixin
 
 
@@ -31,7 +30,6 @@ class GroupbySplitApplyFirstMixin(GroupbySplitApplyTestingFuncMixin):
 class GroupbySplitApplyFirstTests(
     GroupbySplitApplyFirstMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_split_apply_last.py
+++ b/python/pyspark/pandas/tests/groupby/test_split_apply_last.py
@@ -16,7 +16,6 @@
 #
 
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.tests.groupby.test_split_apply import GroupbySplitApplyTestingFuncMixin
 
 
@@ -31,7 +30,6 @@ class GroupbySplitApplyLastMixin(GroupbySplitApplyTestingFuncMixin):
 class GroupbySplitApplyBasicTests(
     GroupbySplitApplyLastMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_split_apply_min_max.py
+++ b/python/pyspark/pandas/tests/groupby/test_split_apply_min_max.py
@@ -16,7 +16,6 @@
 #
 
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.tests.groupby.test_split_apply import GroupbySplitApplyTestingFuncMixin
 
 
@@ -31,7 +30,6 @@ class GroupbySplitApplyMMMixin(GroupbySplitApplyTestingFuncMixin):
 class GroupbySplitApplyMMTests(
     GroupbySplitApplyMMMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_split_apply_skew.py
+++ b/python/pyspark/pandas/tests/groupby/test_split_apply_skew.py
@@ -16,7 +16,6 @@
 #
 
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.tests.groupby.test_split_apply import GroupbySplitApplyTestingFuncMixin
 
 
@@ -31,7 +30,6 @@ class GroupbySplitApplySkewMixin(GroupbySplitApplyTestingFuncMixin):
 class GroupbySplitApplySkewTests(
     GroupbySplitApplySkewMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_split_apply_std.py
+++ b/python/pyspark/pandas/tests/groupby/test_split_apply_std.py
@@ -16,7 +16,6 @@
 #
 
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.tests.groupby.test_split_apply import GroupbySplitApplyTestingFuncMixin
 
 
@@ -31,7 +30,6 @@ class GroupbySplitApplyStdMixin(GroupbySplitApplyTestingFuncMixin):
 class GroupbySplitApplyStdTests(
     GroupbySplitApplyStdMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_split_apply_var.py
+++ b/python/pyspark/pandas/tests/groupby/test_split_apply_var.py
@@ -16,7 +16,6 @@
 #
 
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.tests.groupby.test_split_apply import GroupbySplitApplyTestingFuncMixin
 
 
@@ -31,7 +30,6 @@ class GroupbySplitApplyVarMixin(GroupbySplitApplyTestingFuncMixin):
 class GroupbySplitApplyVarTests(
     GroupbySplitApplyVarMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_stat.py
+++ b/python/pyspark/pandas/tests/groupby/test_stat.py
@@ -22,7 +22,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 using_pandas3 = LooseVersion(pd.__version__) >= "3.0.0"
 
@@ -160,7 +159,6 @@ class GroupbyStatMixin(GroupbyStatTestingFuncMixin):
 class GroupbyStatTests(
     GroupbyStatMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/groupby/test_stat_adv.py
+++ b/python/pyspark/pandas/tests/groupby/test_stat_adv.py
@@ -21,7 +21,6 @@ import pandas as pd
 from pyspark.loose_version import LooseVersion
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.tests.groupby.test_stat import GroupbyStatTestingFuncMixin, using_pandas3
 
 
@@ -177,7 +176,6 @@ class GroupbyStatAdvMixin(GroupbyStatTestingFuncMixin):
 class GroupbyStatAdvTests(
     GroupbyStatAdvMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_align.py
+++ b/python/pyspark/pandas/tests/indexes/test_align.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameAlignMixin:
@@ -72,7 +71,6 @@ class FrameAlignMixin:
 class FrameAlignTests(
     FrameAlignMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_append.py
+++ b/python/pyspark/pandas/tests/indexes/test_append.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class AppendMixin:
@@ -111,7 +110,6 @@ class AppendMixin:
 class AppendTests(
     AppendMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_conversion.py
+++ b/python/pyspark/pandas/tests/indexes/test_conversion.py
@@ -24,7 +24,6 @@ from pyspark.pandas.utils import (
     SPARK_CONF_ARROW_ENABLED,
     SPARK_CONF_PANDAS_STRUCT_MODE,
 )
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.testing.utils import is_ansi_mode_test
 
 
@@ -306,7 +305,6 @@ class ConversionMixin:
 class ConversionTests(
     ConversionMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_getattr.py
+++ b/python/pyspark/pandas/tests/indexes/test_getattr.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class IndexGetattrMixin:
@@ -61,7 +60,6 @@ class IndexGetattrMixin:
 class IndexGetattrTests(
     IndexGetattrMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_indexing.py
+++ b/python/pyspark/pandas/tests/indexes/test_indexing.py
@@ -21,7 +21,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 # This file contains test cases for 'Indexing, Iteration'
@@ -421,7 +420,6 @@ class FrameIndexingMixin:
 class FrameIndexingTests(
     FrameIndexingMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_indexing_adv.py
+++ b/python/pyspark/pandas/tests/indexes/test_indexing_adv.py
@@ -25,7 +25,6 @@ from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.pandas.exceptions import SparkPandasNotImplementedError
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class IndexingAdvMixin:
@@ -393,7 +392,6 @@ class IndexingAdvMixin:
 class IndexingAdvTests(
     IndexingAdvMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_indexing_iloc.py
+++ b/python/pyspark/pandas/tests/indexes/test_indexing_iloc.py
@@ -22,7 +22,6 @@ from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.pandas.exceptions import SparkPandasIndexingError, SparkPandasNotImplementedError
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class IndexingILocMixin:
@@ -287,7 +286,6 @@ class IndexingILocMixin:
 class IndexingILocTests(
     IndexingILocMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_indexing_loc.py
+++ b/python/pyspark/pandas/tests/indexes/test_indexing_loc.py
@@ -22,7 +22,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class IndexingLocMixin:
@@ -416,7 +415,6 @@ class IndexingLocMixin:
 class IndexingLocTests(
     IndexingLocMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_indexing_loc_2d.py
+++ b/python/pyspark/pandas/tests/indexes/test_indexing_loc_2d.py
@@ -22,7 +22,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.exceptions import SparkPandasIndexingError
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class IndexingLoc2DMixin:
@@ -231,7 +230,6 @@ class IndexingLoc2DMixin:
 class IndexingLoc2DTests(
     IndexingLoc2DMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_indexing_loc_multi_idx.py
+++ b/python/pyspark/pandas/tests/indexes/test_indexing_loc_multi_idx.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class IndexingLocMultiIdxMixin:
@@ -131,7 +130,6 @@ class IndexingLocMultiIdxMixin:
 class IndexingLocMultiIdxTests(
     IndexingLocMultiIdxMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_intersection.py
+++ b/python/pyspark/pandas/tests/indexes/test_intersection.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class IntersectionMixin:
@@ -149,7 +148,6 @@ class IntersectionMixin:
 class IntersectionTests(
     IntersectionMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_level.py
+++ b/python/pyspark/pandas/tests/indexes/test_level.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class LevelMixin:
@@ -156,7 +155,6 @@ class LevelMixin:
 class LevelTests(
     LevelMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_missing.py
+++ b/python/pyspark/pandas/tests/indexes/test_missing.py
@@ -21,7 +21,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.exceptions import PandasNotImplementedError
 from pyspark.pandas.missing.indexes import (
     MissingPandasLikeDatetimeIndex,
@@ -226,7 +225,6 @@ class MissingMixin:
 class MissingTests(
     MissingMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_monotonic.py
+++ b/python/pyspark/pandas/tests/indexes/test_monotonic.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class MonotonicMixin:
@@ -166,7 +165,6 @@ class MonotonicMixin:
 class MonotonicTests(
     MonotonicMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_name.py
+++ b/python/pyspark/pandas/tests/indexes/test_name.py
@@ -21,7 +21,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas.exceptions import PandasNotImplementedError
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class IndexNameMixin:
@@ -158,7 +157,6 @@ class IndexNameMixin:
 class IndexNameTests(
     IndexNameMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_reindex.py
+++ b/python/pyspark/pandas/tests/indexes/test_reindex.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameReindexMixin:
@@ -280,7 +279,6 @@ class FrameReindexMixin:
 class FrameReindexTests(
     FrameReindexMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_rename.py
+++ b/python/pyspark/pandas/tests/indexes/test_rename.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class FrameRenameMixin:
@@ -300,7 +299,6 @@ class FrameRenameMixin:
 class FrameRenameTests(
     FrameRenameMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_repeat.py
+++ b/python/pyspark/pandas/tests/indexes/test_repeat.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class RepeatMixin:
@@ -47,7 +46,6 @@ class RepeatMixin:
 class RepeatTests(
     RepeatMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_reset_index.py
+++ b/python/pyspark/pandas/tests/indexes/test_reset_index.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
 
 
@@ -147,7 +146,6 @@ class FrameResetIndexMixin:
 class FrameResetIndexTests(
     FrameResetIndexMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_stat.py
+++ b/python/pyspark/pandas/tests/indexes/test_stat.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class StatMixin:
@@ -163,7 +162,6 @@ class StatMixin:
 class StatTests(
     StatMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_union.py
+++ b/python/pyspark/pandas/tests/indexes/test_union.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class UnionMixin:
@@ -190,7 +189,6 @@ class UnionMixin:
 class UnionTests(
     UnionMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/indexes/test_unique.py
+++ b/python/pyspark/pandas/tests/indexes/test_unique.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class UniqueMixin:
@@ -146,7 +145,6 @@ class UniqueMixin:
 class UniqueTests(
     UniqueMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/io/test_dataframe_conversion.py
+++ b/python/pyspark/pandas/tests/io/test_dataframe_conversion.py
@@ -25,7 +25,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.testing.utils import (
     have_openpyxl,
     openpyxl_requirement_message,
@@ -262,7 +261,6 @@ class DataFrameConversionMixin:
 class DataFrameConversionTests(
     DataFrameConversionMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
     TestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/io/test_io.py
+++ b/python/pyspark/pandas/tests/io/test_io.py
@@ -23,7 +23,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.testing.utils import (
     have_jinja2,
     jinja2_requirement_message,
@@ -151,7 +150,6 @@ class FrameIOMixin:
 class FrameIOTests(
     FrameIOMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/io/test_series_conversion.py
+++ b/python/pyspark/pandas/tests/io/test_series_conversion.py
@@ -22,7 +22,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.testing.utils import have_jinja2, jinja2_requirement_message
 
 
@@ -68,7 +67,6 @@ class SeriesConversionTestsMixin:
 class SeriesConversionTests(
     SeriesConversionTestsMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/series/test_all_any.py
+++ b/python/pyspark/pandas/tests/series/test_all_any.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class SeriesAllAnyMixin:
@@ -83,7 +82,6 @@ class SeriesAllAnyMixin:
 class SeriesAllAnyTests(
     SeriesAllAnyMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/series/test_arg_ops.py
+++ b/python/pyspark/pandas/tests/series/test_arg_ops.py
@@ -21,7 +21,6 @@ import pandas as pd
 from pyspark.loose_version import LooseVersion
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class SeriesArgOpsMixin:
@@ -197,7 +196,6 @@ class SeriesArgOpsMixin:
 class SeriesArgOpsTests(
     SeriesArgOpsMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/series/test_as_of.py
+++ b/python/pyspark/pandas/tests/series/test_as_of.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class SeriesAsOfMixin:
@@ -115,7 +114,6 @@ class SeriesAsOfMixin:
 class SeriesAsOfTests(
     SeriesAsOfMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/series/test_as_type.py
+++ b/python/pyspark/pandas/tests/series/test_as_type.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.testing.utils import is_ansi_mode_test
 from pyspark.pandas.typedef.typehints import (
     extension_dtypes_available,
@@ -171,7 +170,6 @@ class SeriesAsTypeMixin:
 class SeriesAsTypeTests(
     SeriesAsTypeMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/series/test_compute.py
+++ b/python/pyspark/pandas/tests/series/test_compute.py
@@ -22,7 +22,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.errors import PySparkValueError
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class SeriesComputeMixin:
@@ -603,7 +602,6 @@ class SeriesComputeMixin:
 class SeriesComputeTests(
     SeriesComputeMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/series/test_conversion.py
+++ b/python/pyspark/pandas/tests/series/test_conversion.py
@@ -21,7 +21,6 @@ import pandas as pd
 from pyspark.loose_version import LooseVersion
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.testing.utils import have_tabulate, tabulate_requirement_message
 
 
@@ -78,7 +77,6 @@ class SeriesConversionMixin:
 class SeriesConversionTests(
     SeriesConversionMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/series/test_cumulative.py
+++ b/python/pyspark/pandas/tests/series/test_cumulative.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class SeriesCumulativeMixin:
@@ -120,7 +119,6 @@ class SeriesCumulativeMixin:
 class SeriesCumulativeTests(
     SeriesCumulativeMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/series/test_datetime.py
+++ b/python/pyspark/pandas/tests/series/test_datetime.py
@@ -24,7 +24,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class SeriesDateTimeTestsMixin:
@@ -293,7 +292,6 @@ class SeriesDateTimeTestsMixin:
 class SeriesDateTimeTests(
     SeriesDateTimeTestsMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/series/test_index.py
+++ b/python/pyspark/pandas/tests/series/test_index.py
@@ -21,7 +21,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class SeriesIndexMixin:
@@ -486,7 +485,6 @@ class SeriesIndexMixin:
 class SeriesIndexTests(
     SeriesIndexMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/series/test_missing_data.py
+++ b/python/pyspark/pandas/tests/series/test_missing_data.py
@@ -21,7 +21,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class SeriesMissingDataMixin:
@@ -255,7 +254,6 @@ class SeriesMissingDataMixin:
 class SeriesMissingDataTests(
     SeriesMissingDataMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/series/test_series.py
+++ b/python/pyspark/pandas/tests/series/test_series.py
@@ -30,7 +30,6 @@ from pyspark.testing.pandasutils import (
     PandasOnSparkTestCase,
     SPARK_CONF_ARROW_ENABLED,
 )
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.exceptions import PandasNotImplementedError
 from pyspark.pandas.missing.series import MissingPandasLikeSeries
 from pyspark.pandas.typedef.typehints import extension_object_dtypes_available
@@ -878,7 +877,6 @@ class SeriesTestsMixin:
 class SeriesTests(
     SeriesTestsMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/series/test_sort.py
+++ b/python/pyspark/pandas/tests/series/test_sort.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class SeriesSortMixin:
@@ -140,7 +139,6 @@ class SeriesSortMixin:
 class SeriesSortTests(
     SeriesSortMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/series/test_stat.py
+++ b/python/pyspark/pandas/tests/series/test_stat.py
@@ -21,7 +21,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class SeriesStatMixin:
@@ -728,7 +727,6 @@ class SeriesStatMixin:
 class SeriesStatTests(
     SeriesStatMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/series/test_string_ops_adv.py
+++ b/python/pyspark/pandas/tests/series/test_string_ops_adv.py
@@ -21,7 +21,6 @@ import re
 from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class SeriesStringOpsAdvMixin:
@@ -236,7 +235,6 @@ class SeriesStringOpsAdvMixin:
 class SeriesStringOpsAdvTests(
     SeriesStringOpsAdvMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/series/test_string_ops_basic.py
+++ b/python/pyspark/pandas/tests/series/test_string_ops_basic.py
@@ -21,7 +21,6 @@ import re
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class SeriesStringOpsMixin:
@@ -170,7 +169,6 @@ class SeriesStringOpsMixin:
 class SeriesStringOpsTests(
     SeriesStringOpsMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/test_frame_spark.py
+++ b/python/pyspark/pandas/tests/test_frame_spark.py
@@ -21,7 +21,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class SparkFrameMethodsTestsMixin:
@@ -144,7 +143,7 @@ class SparkFrameMethodsTestsMixin:
 
 
 class SparkFrameMethodsTests(
-    SparkFrameMethodsTestsMixin, PandasOnSparkTestCase, SQLTestUtils, TestUtils
+    SparkFrameMethodsTestsMixin, PandasOnSparkTestCase, TestUtils
 ):
     pass
 

--- a/python/pyspark/pandas/tests/test_frame_spark.py
+++ b/python/pyspark/pandas/tests/test_frame_spark.py
@@ -142,9 +142,7 @@ class SparkFrameMethodsTestsMixin:
         self.assert_eq(psdf, new_psdf)
 
 
-class SparkFrameMethodsTests(
-    SparkFrameMethodsTestsMixin, PandasOnSparkTestCase, TestUtils
-):
+class SparkFrameMethodsTests(SparkFrameMethodsTestsMixin, PandasOnSparkTestCase, TestUtils):
     pass
 
 

--- a/python/pyspark/pandas/tests/test_indexops_spark.py
+++ b/python/pyspark/pandas/tests/test_indexops_spark.py
@@ -62,9 +62,7 @@ class SparkIndexOpsMethodsTestsMixin:
             self.psser.spark.transform(lambda scol: F.col("non-existent"))
 
 
-class SparkIndexOpsMethodsTests(
-    SparkIndexOpsMethodsTestsMixin, PandasOnSparkTestCase
-):
+class SparkIndexOpsMethodsTests(SparkIndexOpsMethodsTestsMixin, PandasOnSparkTestCase):
     pass
 
 

--- a/python/pyspark/pandas/tests/test_indexops_spark.py
+++ b/python/pyspark/pandas/tests/test_indexops_spark.py
@@ -21,7 +21,6 @@ from pyspark.errors import AnalysisException
 from pyspark.sql import functions as F
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class SparkIndexOpsMethodsTestsMixin:
@@ -64,7 +63,7 @@ class SparkIndexOpsMethodsTestsMixin:
 
 
 class SparkIndexOpsMethodsTests(
-    SparkIndexOpsMethodsTestsMixin, PandasOnSparkTestCase, SQLTestUtils
+    SparkIndexOpsMethodsTestsMixin, PandasOnSparkTestCase
 ):
     pass
 

--- a/python/pyspark/pandas/tests/test_internal.py
+++ b/python/pyspark/pandas/tests/test_internal.py
@@ -25,7 +25,6 @@ from pyspark.pandas.internal import (
 )
 from pyspark.pandas.utils import spark_column_equals
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class InternalFrameTestsMixin:
@@ -134,7 +133,7 @@ class InternalFrameTestsMixin:
         )
 
 
-class InternalFrameTests(InternalFrameTestsMixin, PandasOnSparkTestCase, SQLTestUtils):
+class InternalFrameTests(InternalFrameTestsMixin, PandasOnSparkTestCase):
     pass
 
 

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -34,7 +34,6 @@ from pyspark.pandas.namespace import _get_index_map, read_delta
 from pyspark.pandas.utils import spark_column_equals
 from pyspark.pandas.missing.general_functions import MissingPandasLikeGeneralFunctions
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.testing import assert_frame_equal
 
 
@@ -734,7 +733,7 @@ class NamespaceTestsMixin:
                 getattr(ps, name)()
 
 
-class NamespaceTests(NamespaceTestsMixin, PandasOnSparkTestCase, SQLTestUtils):
+class NamespaceTests(NamespaceTestsMixin, PandasOnSparkTestCase):
     pass
 
 

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -21,7 +21,6 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.pandas import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 
 
 class NumPyCompatTestsMixin:
@@ -191,7 +190,6 @@ class NumPyCompatTestsMixin:
 class NumPyCompatTests(
     NumPyCompatTestsMixin,
     PandasOnSparkTestCase,
-    SQLTestUtils,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/test_sql.py
+++ b/python/pyspark/pandas/tests/test_sql.py
@@ -18,7 +18,6 @@
 from pyspark import pandas as ps
 from pyspark.errors import ParseException
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.testing.utils import assertDataFrameEqual
 
 
@@ -106,7 +105,7 @@ class SQLTestsMixin:
         assertDataFrameEqual(ps.sql("SELECT {tbl.A}, {tbl.B} FROM {tbl}", tbl=psdf), psdf)
 
 
-class SQLTests(SQLTestsMixin, PandasOnSparkTestCase, SQLTestUtils):
+class SQLTests(SQLTestsMixin, PandasOnSparkTestCase):
     pass
 
 

--- a/python/pyspark/pandas/tests/test_utils.py
+++ b/python/pyspark/pandas/tests/test_utils.py
@@ -30,7 +30,6 @@ from pyspark.testing.pandasutils import (
     _assert_pandas_equal,
     _assert_pandas_almost_equal,
 )
-from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.errors import PySparkAssertionError
 
 some_global_variable = 0
@@ -248,7 +247,7 @@ class TestClassForLazyProp:
         return self.some_variable
 
 
-class UtilsTests(UtilsTestsMixin, PandasOnSparkTestCase, SQLTestUtils):
+class UtilsTests(UtilsTestsMixin, PandasOnSparkTestCase):
     pass
 
 

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -226,7 +226,7 @@ class ReusedConnectTestCase(PySparkBaseTestCase, SQLTestUtils, PySparkErrorTestU
     not should_test_connect or is_remote_only(),
     connect_requirement_message or "Requires JVM access",
 )
-class ReusedMixedTestCase(ReusedConnectTestCase, SQLTestUtils):
+class ReusedMixedTestCase(ReusedConnectTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Drop the redundant `SQLTestUtils` mixin from Python test classes whose primary base already chains to `SQLTestUtils`. Two cleanups in this PR.

**1. `ReusedMixedTestCase` (`python/pyspark/testing/connectutils.py`)**

```diff
-class ReusedMixedTestCase(ReusedConnectTestCase, SQLTestUtils):
+class ReusedMixedTestCase(ReusedConnectTestCase):
```

Its parent `ReusedConnectTestCase` already mixes in `SQLTestUtils`:

```python
class ReusedConnectTestCase(PySparkBaseTestCase, SQLTestUtils, PySparkErrorTestUtils):
```

The `from pyspark.testing.sqlutils import SQLTestUtils` import is kept because `ReusedConnectTestCase` (still in the same file) uses it.

**2. 139 `PandasOnSparkTestCase`-based classes under `python/pyspark/pandas/tests/`**

`PandasOnSparkTestCase` already chains to `SQLTestUtils`:

```
PandasOnSparkTestCase -> ReusedSQLTestCase -> SQLTestUtils
```

so explicitly mixing `SQLTestUtils` in again on top of `PandasOnSparkTestCase` (and an `XxxMixin` body trait) is dead weight. This PR drops the redundant `SQLTestUtils` mixin -- and the now-unused `from pyspark.testing.sqlutils import SQLTestUtils` import -- from 139 test classes following the pattern:

```python
class FooTests(
    FooTestsMixin,
    PandasOnSparkTestCase,
    SQLTestUtils,   # <-- redundant
):
    pass
```

The MRO, inherited helper methods (`sql_conf`, `table`, `temp_view`, ...), and `unittest.TestCase` subclass relationship are all unchanged after the drop. Verified across a representative sample (`ReusedMixedTestCase`, `NamespaceTests`, `NumPyCompatTests`, `UnionTests`, `SparkFrameMethodsTests`):

| class | is `TestCase` | inherits `SQLTestUtils` | `sql_conf` resolves |
| --- | --- | --- | --- |
| ReusedMixedTestCase     | ✓ | ✓ | ✓ |
| NamespaceTests          | ✓ | ✓ | ✓ |
| NumPyCompatTests        | ✓ | ✓ | ✓ |
| UnionTests              | ✓ | ✓ | ✓ |
| SparkFrameMethodsTests  | ✓ | ✓ | ✓ |

Classes elsewhere that legitimately use `SQLTestUtils` as their main `TestCase`-adjacent base (e.g. `QueryExecutionListenerTests` in `python/pyspark/sql/tests/test_listener.py`, which mixes `unittest.TestCase` and `SQLTestUtils` directly) are not touched.

### Why are the changes needed?

Cleanup -- same spirit as the recently merged [SPARK-56841][SQL][TESTS] (`Drop redundant BeforeAndAfterEach and SharedSparkSession mixins`) but on the Python side.

### Does this PR introduce _any_ user-facing change?

No. Test-infra-only change.

### How was this patch tested?

Existing tests. MRO / `issubclass` / inherited-method checks (above) confirm the behavior of affected classes is unchanged. `py_compile` over a sample of the edited files succeeds.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude opus-4-7