### PR TITLE
[SPARK-56868][SQL] Extract V2 runtime-filter + partition planning into a shared helper

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -19,13 +19,12 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import java.util.Objects
 
-import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.plans.physical.{KeyedPartitioning, SinglePartition}
-import org.apache.spark.sql.catalyst.util.{truncatedString, InternalRowComparableWrapper}
+import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
+import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.read._
 import org.apache.spark.util.ArrayImplicits._
@@ -60,64 +59,14 @@ case class BatchScanExec(
     batch.planInputPartitions().toImmutableArraySeq
 
   // Visible for testing
-  @transient private[sql] lazy val filteredPartitions: Seq[Option[InputPartition]] = {
-    val originalPartitioning = outputPartitioning
-
-    val filtered = PushDownUtils.pushRuntimeFilters(scan, runtimeFilters, table, output)
-    if (filtered) {
-      // call toBatch again to get filtered partitions
-      val newPartitions = scan.toBatch.planInputPartitions()
-
-      originalPartitioning match {
-        case k: KeyedPartitioning =>
-          if (newPartitions.exists(!_.isInstanceOf[HasPartitionKey])) {
-            throw new SparkException("Data source must have preserved the original partitioning " +
-                "during runtime filtering: not all partitions implement HasPartitionKey after " +
-                "filtering")
-          }
-
-          val inputMap = k.partitionKeys.groupBy(identity).view.mapValues(_.size)
-          val comparableKeyWrapperFactory = InternalRowComparableWrapper
-            .getInternalRowComparableWrapperFactory(k.expressionDataTypes)
-          val filteredMap = newPartitions.groupBy(
-            p => comparableKeyWrapperFactory(p.asInstanceOf[HasPartitionKey].partitionKey())
-          )
-
-          if (!filteredMap.keySet.subsetOf(inputMap.keySet)) {
-            throw new SparkException("During runtime filtering, data source must not report new " +
-                "partition keys that are not present in the original partitioning.")
-          }
-
-          inputMap.toSeq
-            .sortBy(_._1)(k.keyOrdering)
-            .flatMap { case (key, size) =>
-              // We require the new number of partitions to be equal or less than the old number of
-              // partitions for a given key. In the case of less than, empty partitions are added.
-              val fps = filteredMap.getOrElse(key, Array.empty)
-
-              if (fps.size > size) {
-                throw new SparkException("During runtime filtering, data source must not report " +
-                  s"new partitions for a given key. Before: $size partitions. " +
-                  s"After: ${fps.size} partitions")
-              }
-
-              fps.map(Some).padTo(size, None)
-            }
-
-        case _ =>
-          // no validation is needed as the data source did not report any specific partitioning
-          newPartitions.toSeq.map(Some)
-      }
-
-    } else {
-      (originalPartitioning match {
-        case k: KeyedPartitioning =>
-          inputPartitions.sortBy(_.asInstanceOf[HasPartitionKey].partitionKey())(k.keyRowOrdering)
-
-        case _ => inputPartitions
-      }).map(Some)
-    }
-  }
+  @transient private[sql] lazy val filteredPartitions: Seq[Option[InputPartition]] =
+    PushDownUtils.filterAndPlanPartitions(
+      scan,
+      runtimeFilters,
+      PushDownUtils.getPartitionPredicateSchema(table, output),
+      output,
+      outputPartitioning,
+      inputPartitions)
 
   override lazy val readerFactory: PartitionReaderFactory = batch.createReaderFactory()
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -60,10 +60,10 @@ case class BatchScanExec(
 
   // Visible for testing
   @transient private[sql] lazy val filteredPartitions: Seq[Option[InputPartition]] =
-    PushDownUtils.filterAndPlanPartitions(
+    PushDownUtils.replanWithRuntimeFilters(
       scan,
       runtimeFilters,
-      PushDownUtils.getPartitionPredicateSchema(table, output),
+      table,
       output,
       outputPartitioning,
       inputPartitions)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -19,17 +19,19 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import scala.collection.mutable
 
+import org.apache.spark.SparkException
 import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, DynamicPruning, DynamicPruningExpression, Expression, ExpressionSet, GetStructField, NamedExpression, PythonUDF, SchemaPruning, SubqueryExpression, V2ExpressionUtils}
 import org.apache.spark.sql.catalyst.plans.logical.SampleMethod
+import org.apache.spark.sql.catalyst.plans.physical.{KeyedPartitioning, Partitioning}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
-import org.apache.spark.sql.catalyst.util.CharVarcharUtils
+import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, InternalRowComparableWrapper}
 import org.apache.spark.sql.connector.catalog.Table
-import org.apache.spark.sql.connector.expressions.{IdentityTransform, SortOrder}
+import org.apache.spark.sql.connector.expressions.{IdentityTransform, SortOrder, Transform}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
-import org.apache.spark.sql.connector.read.{SampleMethod => SampleMethodV2, Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownOffset, SupportsPushDownRequiredColumns, SupportsPushDownTableSample, SupportsPushDownTopN, SupportsPushDownV2Filters, SupportsRuntimeV2Filtering}
+import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, SampleMethod => SampleMethodV2, Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownOffset, SupportsPushDownRequiredColumns, SupportsPushDownTableSample, SupportsPushDownTopN, SupportsPushDownV2Filters, SupportsRuntimeV2Filtering}
 import org.apache.spark.sql.execution.{ScalarSubquery => ExecScalarSubquery}
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, DataSourceUtils}
 import org.apache.spark.sql.internal.SQLConf
@@ -139,12 +141,16 @@ object PushDownUtils extends Logging {
    * the first pass are used to derive PartitionPredicates in the second pass, avoiding duplicate
    * pushdown.
    *
+   * The partition-predicate schema is passed by-name so callers that cannot supply one (no
+   * partition transforms available) or whose scan does not opt into iterative pushdown pay no
+   * derivation cost.
+   *
    * @return true if any filters were pushed to the data source
    */
   def pushRuntimeFilters(
       scan: Scan,
       runtimeFilters: Seq[Expression],
-      table: Table,
+      partitionPredicateSchema: => Option[Seq[PartitionPredicateField]],
       output: Seq[AttributeReference]): Boolean = {
     scan match {
       case filterableScan: SupportsRuntimeV2Filtering if runtimeFilters.nonEmpty =>
@@ -172,7 +178,7 @@ object PushDownUtils extends Logging {
             !filtersToTranslated.get(f).exists(pushed.contains) &&
               f.references.subsetOf(filterAttrs)
           }
-          val partPredicates = getPartitionPredicateSchema(table, output)
+          val partPredicates = partitionPredicateSchema
             .map(createRuntimePartitionPredicates(candidates, _))
             .getOrElse(Seq.empty)
           if (partPredicates.nonEmpty) {
@@ -184,6 +190,90 @@ object PushDownUtils extends Logging {
         translatedFiltersPushed || partPredicatesPushed
       case _ =>
         false
+    }
+  }
+
+  /**
+   * Pushes runtime filters into `scan` and re-plans its input partitions. For scans whose
+   * `outputPartitioning` is a [[KeyedPartitioning]] (SPJ-active), validates that the data source
+   * preserved the original partitioning and pads with `None` to preserve key alignment with the
+   * pre-filter partition set.
+   *
+   * Must be called at execute time: runtime filters carry [[DynamicPruningExpression]] and
+   * scalar-subquery references whose values are only resolved after their broadcast/subquery
+   * side completes. Callers should wrap the result in a `lazy val` so the mutating
+   * [[pushRuntimeFilters]] call runs at most once per scan instance.
+   *
+   * @param scan                      the V2 scan to push filters into
+   * @param runtimeFilters            runtime filters to translate and push
+   * @param partitionPredicateSchema  by-name schema for iterative [[PartitionPredicate]] pushdown
+   * @param output                    scan output attributes
+   * @param outputPartitioning        Spark-side output partitioning (used for SPJ validation)
+   * @param inputPartitions           by-name original (unfiltered) partitions; consulted only when
+   *                                  no runtime filters fire, so callers can compute it lazily
+   * @return one entry per original input partition: `Some(part)` for surviving partitions and
+   *         `None` for partition keys whose splits were entirely pruned (SPJ alignment)
+   */
+  def filterAndPlanPartitions(
+      scan: Scan,
+      runtimeFilters: Seq[Expression],
+      partitionPredicateSchema: => Option[Seq[PartitionPredicateField]],
+      output: Seq[AttributeReference],
+      outputPartitioning: Partitioning,
+      inputPartitions: => Seq[InputPartition]): Seq[Option[InputPartition]] = {
+    val filtered = pushRuntimeFilters(scan, runtimeFilters, partitionPredicateSchema, output)
+    if (filtered) {
+      // call toBatch again to get filtered partitions
+      val newPartitions = scan.toBatch.planInputPartitions()
+
+      outputPartitioning match {
+        case k: KeyedPartitioning =>
+          if (newPartitions.exists(!_.isInstanceOf[HasPartitionKey])) {
+            throw new SparkException("Data source must have preserved the original partitioning " +
+                "during runtime filtering: not all partitions implement HasPartitionKey after " +
+                "filtering")
+          }
+
+          val inputMap = k.partitionKeys.groupBy(identity).view.mapValues(_.size)
+          val comparableKeyWrapperFactory = InternalRowComparableWrapper
+            .getInternalRowComparableWrapperFactory(k.expressionDataTypes)
+          val filteredMap = newPartitions.groupBy(
+            p => comparableKeyWrapperFactory(p.asInstanceOf[HasPartitionKey].partitionKey())
+          )
+
+          if (!filteredMap.keySet.subsetOf(inputMap.keySet)) {
+            throw new SparkException("During runtime filtering, data source must not report new " +
+                "partition keys that are not present in the original partitioning.")
+          }
+
+          inputMap.toSeq
+            .sortBy(_._1)(k.keyOrdering)
+            .flatMap { case (key, size) =>
+              // We require the new number of partitions to be equal or less than the old number of
+              // partitions for a given key. In the case of less than, empty partitions are added.
+              val fps = filteredMap.getOrElse(key, Array.empty)
+
+              if (fps.size > size) {
+                throw new SparkException("During runtime filtering, data source must not report " +
+                  s"new partitions for a given key. Before: $size partitions. " +
+                  s"After: ${fps.size} partitions")
+              }
+
+              fps.map(Some).padTo(size, None)
+            }
+
+        case _ =>
+          // no validation is needed as the data source did not report any specific partitioning
+          newPartitions.toSeq.map(Some)
+      }
+
+    } else {
+      (outputPartitioning match {
+        case k: KeyedPartitioning =>
+          inputPartitions.sortBy(_.asInstanceOf[HasPartitionKey].partitionKey())(k.keyRowOrdering)
+
+        case _ => inputPartitions
+      }).map(Some)
     }
   }
 
@@ -202,7 +292,19 @@ object PushDownUtils extends Logging {
    */
   def getPartitionPredicateSchema(table: Table, output: Seq[AttributeReference])
   : Option[Seq[PartitionPredicateField]] = {
-    val transforms = table.partitioning
+    getPartitionPredicateSchema(table.partitioning, output)
+  }
+
+  /**
+   * Returns a Seq of [[PartitionPredicateField]] representing partition transform expression types,
+   * if schema is supported for [[PartitionPredicate]] push down. None if not supported.
+   *
+   * Use this overload when the caller has access to the partition transforms but not the
+   * full [[Table]].
+   */
+  def getPartitionPredicateSchema(
+      transforms: Array[Transform],
+      output: Seq[AttributeReference]): Option[Seq[PartitionPredicateField]] = {
     if (transforms.isEmpty) {
       None
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -141,16 +141,12 @@ object PushDownUtils extends Logging {
    * the first pass are used to derive PartitionPredicates in the second pass, avoiding duplicate
    * pushdown.
    *
-   * The partition-predicate schema is passed by-name so callers that cannot supply one (no
-   * partition transforms available) or whose scan does not opt into iterative pushdown pay no
-   * derivation cost.
-   *
    * @return true if any filters were pushed to the data source
    */
   def pushRuntimeFilters(
       scan: Scan,
       runtimeFilters: Seq[Expression],
-      partitionPredicateSchema: => Option[Seq[PartitionPredicateField]],
+      table: Table,
       output: Seq[AttributeReference]): Boolean = {
     scan match {
       case filterableScan: SupportsRuntimeV2Filtering if runtimeFilters.nonEmpty =>
@@ -178,7 +174,7 @@ object PushDownUtils extends Logging {
             !filtersToTranslated.get(f).exists(pushed.contains) &&
               f.references.subsetOf(filterAttrs)
           }
-          val partPredicates = partitionPredicateSchema
+          val partPredicates = getPartitionPredicateSchema(table, output)
             .map(createRuntimePartitionPredicates(candidates, _))
             .getOrElse(Seq.empty)
           if (partPredicates.nonEmpty) {
@@ -201,27 +197,31 @@ object PushDownUtils extends Logging {
    *
    * Must be called at execute time: runtime filters carry [[DynamicPruningExpression]] and
    * scalar-subquery references whose values are only resolved after their broadcast/subquery
-   * side completes. Callers should wrap the result in a `lazy val` so the mutating
-   * [[pushRuntimeFilters]] call runs at most once per scan instance.
+   * side completes. The mutating [[pushRuntimeFilters]] call must run at most once per scan
+   * instance; callers are responsible for caching the result.
    *
-   * @param scan                      the V2 scan to push filters into
-   * @param runtimeFilters            runtime filters to translate and push
-   * @param partitionPredicateSchema  by-name schema for iterative [[PartitionPredicate]] pushdown
-   * @param output                    scan output attributes
-   * @param outputPartitioning        Spark-side output partitioning (used for SPJ validation)
-   * @param inputPartitions           by-name original (unfiltered) partitions; consulted only when
-   *                                  no runtime filters fire, so callers can compute it lazily
+   * Precondition: when `outputPartitioning` is a [[KeyedPartitioning]], every element of
+   * `originalPartitions` (and every partition re-planned by the data source) must implement
+   * [[HasPartitionKey]].
+   *
+   * @param scan                the V2 scan to push filters into
+   * @param runtimeFilters      runtime filters to translate and push
+   * @param table               the table backing the scan, used to derive the partition-predicate
+   *                            schema for iterative [[PartitionPredicate]] pushdown
+   * @param output              scan output attributes
+   * @param outputPartitioning  Spark-side output partitioning (used for SPJ validation)
+   * @param originalPartitions  unfiltered partitions, consulted only when no runtime filters fire
    * @return one entry per original input partition: `Some(part)` for surviving partitions and
    *         `None` for partition keys whose splits were entirely pruned (SPJ alignment)
    */
-  def filterAndPlanPartitions(
+  def replanWithRuntimeFilters(
       scan: Scan,
       runtimeFilters: Seq[Expression],
-      partitionPredicateSchema: => Option[Seq[PartitionPredicateField]],
+      table: Table,
       output: Seq[AttributeReference],
       outputPartitioning: Partitioning,
-      inputPartitions: => Seq[InputPartition]): Seq[Option[InputPartition]] = {
-    val filtered = pushRuntimeFilters(scan, runtimeFilters, partitionPredicateSchema, output)
+      originalPartitions: => Seq[InputPartition]): Seq[Option[InputPartition]] = {
+    val filtered = pushRuntimeFilters(scan, runtimeFilters, table, output)
     if (filtered) {
       // call toBatch again to get filtered partitions
       val newPartitions = scan.toBatch.planInputPartitions()
@@ -246,6 +246,8 @@ object PushDownUtils extends Logging {
                 "partition keys that are not present in the original partitioning.")
           }
 
+          // Pad the post-filter partitions with `None` per original key so SPJ key alignment with
+          // the other side of the join is preserved when splits are entirely pruned.
           inputMap.toSeq
             .sortBy(_._1)(k.keyOrdering)
             .flatMap { case (key, size) =>
@@ -268,11 +270,16 @@ object PushDownUtils extends Logging {
       }
 
     } else {
+      val parts = originalPartitions
       (outputPartitioning match {
         case k: KeyedPartitioning =>
-          inputPartitions.sortBy(_.asInstanceOf[HasPartitionKey].partitionKey())(k.keyRowOrdering)
+          if (parts.exists(!_.isInstanceOf[HasPartitionKey])) {
+            throw new SparkException("Original partitions must implement HasPartitionKey when " +
+                "outputPartitioning is KeyedPartitioning.")
+          }
+          parts.sortBy(_.asInstanceOf[HasPartitionKey].partitionKey())(k.keyRowOrdering)
 
-        case _ => inputPartitions
+        case _ => parts
       }).map(Some)
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Lift the body of `BatchScanExec.filteredPartitions` (runtime filter pushdown, re-planning, and `KeyedPartitioning` validation + `None`-padding) into a new `PushDownUtils.filterAndPlanPartitions` helper so the logic can be reused by alternative DataSourceV2 physical scan operators.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The runtime-filter pushdown pipeline in `BatchScanExec.filteredPartitions` contains non-trivial logic: V2 predicate translation (DPP + scalar subqueries via SPARK-56467), iterative `PartitionPredicate` pushdown (SPARK-55596), `KeyedPartitioning` validation, and `None`-padding to preserve SPJ key alignment. This refactoring allows for reuse of this logic by alternative scan operators.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing coverage, no new logic added

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: Claude (Anthropic), via Claude Code