### PR TITLE
[SPARK-48091][SQL] Preserve aliases inside lambda when ExtractGenerator restructures plan

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3260,11 +3260,9 @@ class Analyzer(
       // The star will be expanded differently if we insert `Generate` under `Project` too early.
       case p @ Project(projectList, child) if !projectList.exists(_.exists(_.isInstanceOf[Star])) =>
         val (resolvedGenerator, newProjectList) = projectList
+          .map(trimNonTopLevelAliases)
           .foldLeft((None: Option[Generate], Nil: Seq[NamedExpression])) { (res, e) =>
-            // SPARK-48091: Only trim aliases on the generator expression itself. Trimming
-            // non-generator expressions strips aliases inside lambda functions (e.g.,
-            // struct(x.as("data"))) before they can be resolved into struct field names.
-            trimNonTopLevelAliases(e) match {
+            e match {
               // If there are more than one generator, we only rewrite the first one and wait for
               // the next analyzer iteration to rewrite the next one.
               case AliasedGenerator(generator, names, outer) if res._1.isEmpty &&
@@ -3277,8 +3275,8 @@ class Analyzer(
                   generatorOutput = GeneratorResolution.makeGeneratorOutput(generator, names),
                   child)
                 (Some(g), res._2 ++ g.nullableOutput)
-              case _ =>
-                (res._1, res._2 :+ e)
+              case other =>
+                (res._1, res._2 :+ other)
             }
           }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3260,9 +3260,11 @@ class Analyzer(
       // The star will be expanded differently if we insert `Generate` under `Project` too early.
       case p @ Project(projectList, child) if !projectList.exists(_.exists(_.isInstanceOf[Star])) =>
         val (resolvedGenerator, newProjectList) = projectList
-          .map(trimNonTopLevelAliases)
           .foldLeft((None: Option[Generate], Nil: Seq[NamedExpression])) { (res, e) =>
-            e match {
+            // SPARK-48091: Only trim aliases on the generator expression itself. Trimming
+            // non-generator expressions strips aliases inside lambda functions (e.g.,
+            // struct(x.as("data"))) before they can be resolved into struct field names.
+            trimNonTopLevelAliases(e) match {
               // If there are more than one generator, we only rewrite the first one and wait for
               // the next analyzer iteration to rewrite the next one.
               case AliasedGenerator(generator, names, outer) if res._1.isEmpty &&
@@ -3275,8 +3277,8 @@ class Analyzer(
                   generatorOutput = GeneratorResolution.makeGeneratorOutput(generator, names),
                   child)
                 (Some(g), res._2 ++ g.nullableOutput)
-              case other =>
-                (res._1, res._2 :+ other)
+              case _ =>
+                (res._1, res._2 :+ e)
             }
           }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.expressions
 
 import scala.annotation.tailrec
 
-import org.apache.spark.sql.catalyst.analysis.MultiAlias
+import org.apache.spark.sql.catalyst.analysis.{MultiAlias, UnresolvedFunction}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Project}
 import org.apache.spark.sql.catalyst.trees.CurrentOrigin
@@ -112,6 +112,10 @@ trait AliasHelper {
   }
 
   protected def trimAliases(e: Expression): Expression = e match {
+    // SPARK-48091: Do not descend into unresolved function calls. Aliases inside them
+    // (e.g., UnresolvedFunction("struct", Seq(Alias(x, "data")))) carry semantic information
+    // that ResolveFunctions -> CreateStruct.apply consumes to produce field names.
+    case u: UnresolvedFunction => u
     // The children of `CreateNamedStruct` may use `Alias` to carry metadata and we should not
     // trim them.
     case c: CreateNamedStruct => c.mapChildren {

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
@@ -765,6 +765,37 @@ class GeneratorFunctionSuite extends SharedSparkSession {
       Seq(Row(0, 10, 0, 10), Row(1, 20, 1, 20))
     )
   }
+
+  test("SPARK-48091: explode with transform should preserve struct field aliases") {
+    val df = spark.createDataFrame(Seq((1, Array(1, 2, 3), Array(4, 5, 6))))
+      .toDF("id", "my_array", "my_array2")
+
+    // Without explode - aliases should work (baseline)
+    val good = df.select(
+      transform(col("my_array2"), x => struct(x.as("data"))).as("my_struct")
+    )
+    assert(good.schema("my_struct").dataType.asInstanceOf[types.ArrayType]
+      .elementType.asInstanceOf[StructType].fieldNames.toSeq === Seq("data"))
+
+    // With explode in same select - aliases should still be preserved
+    val result = df.select(
+      explode(col("my_array")).as("exploded"),
+      transform(col("my_array2"), x => struct(x.as("data"))).as("my_struct")
+    )
+    assert(result.schema("my_struct").dataType.asInstanceOf[types.ArrayType]
+      .elementType.asInstanceOf[StructType].fieldNames.toSeq === Seq("data"))
+
+    // Multiple aliases inside struct
+    val result2 = df.select(
+      explode(col("my_array")).as("exploded"),
+      transform(col("my_array2"),
+        x => struct(x.as("value"), col("id").as("key"))
+      ).as("my_struct")
+    )
+    val fields2 = result2.schema("my_struct").dataType.asInstanceOf[types.ArrayType]
+      .elementType.asInstanceOf[StructType].fieldNames.toSeq
+    assert(fields2 === Seq("value", "key"))
+  }
 }
 
 case class EmptyGenerator() extends Generator with LeafLike[Expression] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.trees.LeafLike
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{IntegerType, StructType}
+import org.apache.spark.sql.types.{ArrayType, IntegerType, StructType}
 
 class GeneratorFunctionSuite extends SharedSparkSession {
   import testImplicits._
@@ -774,7 +774,7 @@ class GeneratorFunctionSuite extends SharedSparkSession {
     val good = df.select(
       transform(col("my_array2"), x => struct(x.as("data"))).as("my_struct")
     )
-    assert(good.schema("my_struct").dataType.asInstanceOf[types.ArrayType]
+    assert(good.schema("my_struct").dataType.asInstanceOf[ArrayType]
       .elementType.asInstanceOf[StructType].fieldNames.toSeq === Seq("data"))
 
     // With explode in same select - aliases should still be preserved
@@ -782,7 +782,7 @@ class GeneratorFunctionSuite extends SharedSparkSession {
       explode(col("my_array")).as("exploded"),
       transform(col("my_array2"), x => struct(x.as("data"))).as("my_struct")
     )
-    assert(result.schema("my_struct").dataType.asInstanceOf[types.ArrayType]
+    assert(result.schema("my_struct").dataType.asInstanceOf[ArrayType]
       .elementType.asInstanceOf[StructType].fieldNames.toSeq === Seq("data"))
 
     // Multiple aliases inside struct
@@ -792,7 +792,7 @@ class GeneratorFunctionSuite extends SharedSparkSession {
         x => struct(x.as("value"), col("id").as("key"))
       ).as("my_struct")
     )
-    val fields2 = result2.schema("my_struct").dataType.asInstanceOf[types.ArrayType]
+    val fields2 = result2.schema("my_struct").dataType.asInstanceOf[ArrayType]
       .elementType.asInstanceOf[StructType].fieldNames.toSeq
     assert(fields2 === Seq("value", "key"))
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix `ExtractGenerator` to preserve aliases inside lambda functions when restructuring the plan.

Previously, `ExtractGenerator` called `trimNonTopLevelAliases` on all expressions in the project list before extracting the generator. This stripped aliases inside lambda functions (e.g., struct(x.as("data"))) before `CreateStruct` could resolve them into struct field names.

The fix uses `trimNonTopLevelAliases` only for pattern matching (to detect generators via `AliasedGenerator`), but preserves the original untrimmed expression for non-generator project items.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When using explode together with transform in the same `select statement`, aliases used inside the transformed column's `struct()` are ignored. Field names become auto-generated (x_1, x_2) instead of the user-specified alias. This only happens with the DataFrame/Dataset API, not with SQL.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.


If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Struct field aliases inside transform lambdas are now correctly preserved when explode (or any generator) is in the same `select`.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added a test in `GeneratorFunctionSuite` verifying that struct field aliases are preserved when explode and transform are used together, including single and multiple aliases.



### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes.