### PR TITLE
[SPARK-44734][PYTHON][DOCS] Expand PySpark type conversion guide

### DIFF
--- a/python/docs/source/tutorial/sql/type_conversions.rst
+++ b/python/docs/source/tutorial/sql/type_conversions.rst
@@ -19,9 +19,6 @@
 Python to Spark Type Conversions
 ================================
 
-.. TODO: Add additional information on conversions when Arrow is enabled.
-.. TODO: Add in-depth explanation and table for type conversions (SPARK-44734).
-
 .. currentmodule:: pyspark.sql.types
 
 When working with PySpark, you will often need to consider the conversions between Python-native
@@ -103,7 +100,7 @@ All Conversions
       - DoubleType()
     * - **DecimalType**
       - decimal.Decimal
-      - DecimalType()|
+      - DecimalType()
     * - **StringType**
       - string
       - StringType()
@@ -141,6 +138,35 @@ All Conversions
       - The value type in Python of the data type of this field. For example, Int for a StructField with the data type IntegerType.
       - StructField(*name*, *dataType*, [*nullable*])
           .. note:: The default value of *nullable* is True.
+
+Conversion Rules Worth Remembering
+----------------------------------
+
+The table above shows the nominal Python type for each Spark SQL type, but runtime behavior also
+depends on how Spark obtains the data:
+
+- ``None`` is converted to SQL ``NULL`` for any nullable field.
+- Numeric types with fixed-width storage, such as ``ByteType`` and ``ShortType``, must stay within
+  range or Spark will raise an error while materializing rows.
+- When ``createDataFrame`` infers a schema from local Python data, Spark may inspect multiple rows
+  and multiple array elements to determine a common element type. If a value only contains
+  ``None``, or mixes incompatible shapes, schema inference can fail.
+- ``dict`` values are usually inferred as ``MapType``. Nested dictionaries can instead be inferred
+  as ``StructType`` when ``spark.sql.pyspark.inferNestedDictAsStruct.enabled`` is enabled.
+- ``BinaryType`` values are read back as Python ``bytes`` or ``bytearray`` depending on
+  ``spark.sql.execution.pyspark.binaryAsBytes``.
+
+Arrow-Enabled Python UDFs
+-------------------------
+
+When ``spark.sql.execution.pythonUDF.arrow.enabled`` is enabled, PySpark can use Arrow for Python
+UDF data exchange. This usually improves serialization performance, but Arrow and pickle-based
+execution do not always apply the same coercion rules. In practice, that means a Python UDF whose
+actual return values do not match its declared return type can behave differently depending on
+whether Arrow is enabled.
+
+If you need predictable results, keep the returned Python value aligned with the declared Spark SQL
+return type instead of relying on implicit coercion.
 
 Conversions in Practice - UDFs
 ------------------------------
@@ -217,6 +243,59 @@ you can supply a schema, or allow Spark to infer the schema from the provided da
   # root
   # |-- _1: byte (nullable = true)
   # |-- _2: byte (nullable = true)
+
+Configuration-Specific Examples
+-------------------------------
+
+Some conversions are controlled by SQL configs. The examples below show a few common cases.
+
+Nested dictionaries inferred as ``StructType``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+  from pyspark.sql import Row
+
+  NestedRow = Row("payload")
+
+  spark.conf.set("spark.sql.pyspark.inferNestedDictAsStruct.enabled", True)
+  df = spark.createDataFrame(
+      [NestedRow({"name": "A", "payment": 200.5})]
+  )
+  df.printSchema()
+  # root
+  # |-- payload: struct (nullable = true)
+  # |    |-- name: string (nullable = true)
+  # |    |-- payment: double (nullable = true)
+
+``TIMESTAMP_NTZ`` as the default timestamp type
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+  import datetime
+
+  spark.conf.set("spark.sql.timestampType", "TIMESTAMP_NTZ")
+  spark.createDataFrame(
+      [(datetime.datetime(2024, 1, 1, 12, 0, 0),)],
+      ["ts"],
+  ).printSchema()
+  # root
+  # |-- ts: timestamp_ntz (nullable = true)
+
+Binary values returned as ``bytes`` or ``bytearray``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+  row = spark.createDataFrame([(b"hello",)], ["bin"]).first()
+  type(row.bin)
+  # <class 'bytes'>
+
+  spark.conf.set("spark.sql.execution.pyspark.binaryAsBytes", False)
+  row = spark.createDataFrame([(b"hello",)], ["bin"]).first()
+  type(row.bin)
+  # <class 'bytearray'>
 
 Conversions in Practice - Nested Data Types
 -------------------------------------------


### PR DESCRIPTION
### What changes were proposed in this pull request?

This updates the PySpark type conversion guide to make it more useful for day-to-day users.

Changes:
- remove unfinished TODO placeholders from the page
- fix a small formatting typo in the DecimalType row
- add practical notes about runtime conversion behavior, including:
  - null handling
  - fixed-width numeric limits
  - schema inference pitfalls for local Python data
  - nested dict inference as MapType vs StructType
  - BinaryType behavior under `spark.sql.execution.pyspark.binaryAsBytes`
- add a short section describing Arrow-enabled Python UDF conversion caveats
- add config-driven examples for:
  - `spark.sql.pyspark.inferNestedDictAsStruct.enabled`
  - `spark.sql.timestampType=TIMESTAMP_NTZ`
  - `spark.sql.execution.pyspark.binaryAsBytes`

### Why are the changes needed?

The page had visible TODO markers and was missing several practical conversion cases that commonly confuse PySpark users, especially around schema inference and configuration-dependent behavior.

### Does this PR introduce any user-facing change?

Yes, documentation only.

### How was this patch tested?

Reviewed the rendered diff locally.

Full Spark docs/test validation was not run in this environment because Java is not installed.
