### PR TITLE
[WIP][CONNECT] Support directory uploads in Spark Connect copyFromLocalToFs

### DIFF
--- a/python/pyspark/ml/connect/io_utils.py
+++ b/python/pyspark/ml/connect/io_utils.py
@@ -45,16 +45,21 @@ def _copy_file_from_local_to_fs(local_path: str, dest_path: str) -> None:
 def _copy_dir_from_local_to_fs(local_path: str, dest_path: str) -> None:
     """
     Copy directory from local path to cloud storage path.
-    Limitation: Currently only one level directory is supported.
     """
     assert os.path.isdir(local_path)
 
-    file_list = os.listdir(local_path)
-    for file_name in file_list:
-        file_path = os.path.join(local_path, file_name)
-        dest_file_path = os.path.join(dest_path, file_name)
-        assert os.path.isfile(file_path)
-        _copy_file_from_local_to_fs(file_path, dest_file_path)
+    session = SparkSession.active()
+    if is_remote():
+        session.copyFromLocalToFs(local_path, dest_path)
+        return
+
+    for root, _, file_names in os.walk(local_path):
+        relative_root = os.path.relpath(root, local_path)
+        dest_root = dest_path if relative_root == "." else os.path.join(dest_path, relative_root)
+        for file_name in file_names:
+            file_path = os.path.join(root, file_name)
+            dest_file_path = os.path.join(dest_root, file_name)
+            _copy_file_from_local_to_fs(file_path, dest_file_path)
 
 
 def _get_class(clazz: str) -> Any:

--- a/python/pyspark/sql/connect/client/artifact.py
+++ b/python/pyspark/sql/connect/client/artifact.py
@@ -251,16 +251,28 @@ class ArtifactManager:
 
     def _parse_forward_to_fs_artifacts(self, local_path: str, dest_path: str) -> List[Artifact]:
         abs_path: Path = Path(local_path).absolute()
-        # TODO: Support directory path.
-        assert abs_path.is_file(), "local path must be a file path."
-        storage = LocalFile(str(abs_path))
-
         assert Path(dest_path).is_absolute(), "destination FS path must be an absolute path."
+
+        if abs_path.is_file():
+            return [self._new_forward_to_fs_artifact(abs_path, dest_path)]
+        elif abs_path.is_dir():
+            artifacts = []
+            for child in sorted(abs_path.rglob("*")):
+                if child.is_file():
+                    relative_path = child.relative_to(abs_path)
+                    child_dest_path = Path(dest_path, relative_path.as_posix()).as_posix()
+                    artifacts.append(self._new_forward_to_fs_artifact(child, child_dest_path))
+            return artifacts
+        else:
+            raise FileNotFoundError(local_path)
+
+    def _new_forward_to_fs_artifact(self, local_path: Path, dest_path: str) -> Artifact:
+        storage = LocalFile(str(local_path))
 
         # The `dest_path` is an absolute path, to add the FORWARD_TO_FS_PREFIX,
         # we cannot use `os.path.join`
         artifact_path = FORWARD_TO_FS_PREFIX + dest_path
-        return [Artifact(artifact_path, storage)]
+        return Artifact(artifact_path, storage)
 
     def _create_requests(
         self, *path: str, pyfile: bool, archive: bool, file: bool

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -438,6 +438,28 @@ class ArtifactTests(ArtifactTestsMixin, ReusedConnectTestCase):
                 with open(dest_path, "r") as f:
                     self.assertEqual(f.read(), file_content)
 
+    def test_copy_directory_from_local_to_fs(self):
+        with tempfile.TemporaryDirectory(prefix="test_copy_dir_from_local_to_fs1") as d:
+            with tempfile.TemporaryDirectory(prefix="test_copy_dir_from_local_to_fs2") as d2:
+                src_dir = os.path.join(d, "src")
+                nested_dir = os.path.join(src_dir, "nested")
+                os.makedirs(nested_dir)
+
+                top_level_file = os.path.join(src_dir, "file1.txt")
+                nested_file = os.path.join(nested_dir, "file2.txt")
+                with open(top_level_file, "w") as f:
+                    f.write("top-level")
+                with open(nested_file, "w") as f:
+                    f.write("nested")
+
+                dest_dir = os.path.join(d2, "dest")
+                self.spark.copyFromLocalToFs(src_dir, dest_dir)
+
+                with open(os.path.join(dest_dir, "file1.txt"), "r") as f:
+                    self.assertEqual(f.read(), "top-level")
+                with open(os.path.join(dest_dir, "nested", "file2.txt"), "r") as f:
+                    self.assertEqual(f.read(), "nested")
+
     def test_cache_artifact(self):
         s = "Hello, World!"
         blob = bytearray(s, "utf-8")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change teaches Spark Connect `SparkSession.copyFromLocalToFs` to accept a local directory path in addition to a single file path.

Changes in this PR:
- update the Spark Connect artifact manager to expand a local directory into per-file `forward_to_fs` artifacts while preserving the nested relative layout
- keep the existing file upload path unchanged
- update the PySpark ML Connect helper to use the new recursive directory-copy behavior in remote mode
- remove the old one-level directory limitation from the local ML helper as well
- add a regression test that copies a directory containing a nested file tree and verifies both files arrive at the destination

### Why are the changes needed?

Today the Connect artifact path only accepts a single file for `copyFromLocalToFs`, even though PySpark ML Connect has a directory-copy helper and model save flows naturally need to stage directory trees.

This leaves two rough edges:
- the Connect path cannot directly copy a directory tree
- the ML helper had its own one-level directory workaround instead of reusing a stronger Connect primitive

Supporting recursive directory uploads in the Connect artifact path makes the API more generally useful and removes the need for the shallow workaround in ML Connect.

### Does this PR introduce _any_ user-facing change?

Yes.

Before this change, `SparkSession.copyFromLocalToFs(local_dir, dest_path)` in Spark Connect only supported a single local file path and would not handle a directory tree.

After this change, the same API accepts a local directory and copies all files under it recursively while preserving relative paths under the destination.

### How was this patch tested?

Added a focused regression test in `pyspark.sql.tests.connect.client.test_artifact` covering nested directory copy.

Attempted local verification with:
- `python/run-tests --testnames pyspark.sql.tests.connect.client.test_artifact`
- `build/sbt -Phive package`

In this environment, local verification is currently blocked because Spark is not built and the machine does not have a usable Java runtime configured for `build/sbt`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex GPT-5
