### PR TITLE
[SPARK-56468][UDF] Validate required worker capabilities in direct dispatcher

### DIFF
--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/DirectWorkerDispatcher.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/direct/DirectWorkerDispatcher.scala
@@ -28,7 +28,8 @@ import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 import org.apache.spark.annotation.Experimental
-import org.apache.spark.udf.worker.{ProcessCallable, UDFWorkerSpecification}
+import org.apache.spark.udf.worker.{ProcessCallable, UDFProtoCommunicationPattern,
+  UDFWorkerDataFormat, UDFWorkerSpecification}
 import org.apache.spark.udf.worker.core.{WorkerConnection, WorkerDispatcher,
   WorkerLogger, WorkerSecurityScope, WorkerSession}
 import org.apache.spark.udf.worker.core.direct.DirectWorkerDispatcher.{CallableResult,
@@ -68,6 +69,7 @@ abstract class DirectWorkerDispatcher(
   // TODO: Connection pooling -- reuse idle workers across sessions.
   // TODO: Security scope isolation -- partition pool by WorkerSecurityScope.
 
+  validateWorkerSpec()
   validateTransportSupport()
   validateEnvironmentCallables()
 
@@ -466,6 +468,41 @@ abstract class DirectWorkerDispatcher(
     val env = workerSpec.getEnvironment
     require(!env.hasEnvironmentVerification || env.hasInstallation,
       "WorkerEnvironment.environment_verification requires installation to be set")
+  }
+
+  private def validateWorkerSpec(): Unit = {
+    require(workerSpec.hasDirect,
+      "UDFWorkerSpecification.worker must be set")
+
+    val direct = workerSpec.getDirect
+    require(direct.hasRunner,
+      "DirectWorker.runner must be set")
+
+    val capabilities = workerSpec.getCapabilities
+    require(
+      capabilities.getSupportedDataFormatsCount > 0,
+      "WorkerCapabilities.supported_data_formats must contain at least ARROW")
+    require(
+      !capabilities.getSupportedDataFormatsList.asScala.contains(
+        UDFWorkerDataFormat.UDF_WORKER_DATA_FORMAT_UNSPECIFIED),
+      "WorkerCapabilities.supported_data_formats must not contain UNSPECIFIED")
+    require(
+      capabilities.getSupportedDataFormatsList.asScala.contains(UDFWorkerDataFormat.ARROW),
+      "WorkerCapabilities.supported_data_formats must contain ARROW")
+
+    require(
+      capabilities.getSupportedCommunicationPatternsCount > 0,
+      "WorkerCapabilities.supported_communication_patterns must contain " +
+        "BIDIRECTIONAL_STREAMING")
+    require(
+      !capabilities.getSupportedCommunicationPatternsList.asScala.contains(
+        UDFProtoCommunicationPattern.UDF_PROTO_COMMUNICATION_PATTERN_UNSPECIFIED),
+      "WorkerCapabilities.supported_communication_patterns must not contain UNSPECIFIED")
+    require(
+      capabilities.getSupportedCommunicationPatternsList.asScala.contains(
+        UDFProtoCommunicationPattern.BIDIRECTIONAL_STREAMING),
+      "WorkerCapabilities.supported_communication_patterns must contain " +
+        "BIDIRECTIONAL_STREAMING")
   }
 }
 

--- a/udf/worker/core/src/test/scala/org/apache/spark/udf/worker/core/DirectWorkerDispatcherSuite.scala
+++ b/udf/worker/core/src/test/scala/org/apache/spark/udf/worker/core/DirectWorkerDispatcherSuite.scala
@@ -27,8 +27,9 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.udf.worker.{
-  DirectWorker, LocalTcpConnection, ProcessCallable, UDFWorkerProperties,
-  UDFWorkerSpecification, UnixDomainSocket, WorkerConnectionSpec,
+  DirectWorker, LocalTcpConnection, ProcessCallable, UDFProtoCommunicationPattern,
+  UDFWorkerDataFormat, UDFWorkerProperties, UDFWorkerSpecification, UnixDomainSocket,
+  WorkerCapabilities, WorkerConnectionSpec,
   WorkerEnvironment}
 import org.apache.spark.udf.worker.core.direct.{DirectUnixSocketWorkerDispatcher,
   DirectWorkerException, DirectWorkerProcess, DirectWorkerSession,
@@ -121,8 +122,16 @@ class DirectWorkerDispatcherSuite
   private def directWorker(runner: ProcessCallable): DirectWorker =
     DirectWorker.newBuilder().setRunner(runner).setProperties(udsProperties).build()
 
+  private def defaultCapabilities: WorkerCapabilities =
+    WorkerCapabilities.newBuilder()
+      .addSupportedDataFormats(UDFWorkerDataFormat.ARROW)
+      .addSupportedCommunicationPatterns(
+        UDFProtoCommunicationPattern.BIDIRECTIONAL_STREAMING)
+      .build()
+
   private def specWithRunner(runner: ProcessCallable): UDFWorkerSpecification =
     UDFWorkerSpecification.newBuilder()
+      .setCapabilities(defaultCapabilities)
       .setDirect(directWorker(runner))
       .build()
 
@@ -131,6 +140,7 @@ class DirectWorkerDispatcherSuite
       env: WorkerEnvironment): UDFWorkerSpecification =
     UDFWorkerSpecification.newBuilder()
       .setEnvironment(env)
+      .setCapabilities(defaultCapabilities)
       .setDirect(directWorker(runner))
       .build()
 
@@ -175,6 +185,33 @@ class DirectWorkerDispatcherSuite
 
     session.close()
     assert(worker.activeSessions == 0, "should have 0 sessions after close")
+  }
+
+  test("rejects spec without worker capabilities") {
+    val badSpec = UDFWorkerSpecification.newBuilder()
+      .setDirect(directWorker(defaultRunner))
+      .build()
+
+    val ex = intercept[IllegalArgumentException] {
+      new TestDirectWorkerDispatcher(badSpec)
+    }
+    assert(ex.getMessage.contains("supported_data_formats must contain at least ARROW"))
+  }
+
+  test("rejects unspecified capability enum values") {
+    val badSpec = UDFWorkerSpecification.newBuilder()
+      .setCapabilities(WorkerCapabilities.newBuilder()
+        .addSupportedDataFormats(UDFWorkerDataFormat.UDF_WORKER_DATA_FORMAT_UNSPECIFIED)
+        .addSupportedCommunicationPatterns(
+          UDFProtoCommunicationPattern.UDF_PROTO_COMMUNICATION_PATTERN_UNSPECIFIED)
+        .build())
+      .setDirect(directWorker(defaultRunner))
+      .build()
+
+    val ex = intercept[IllegalArgumentException] {
+      new TestDirectWorkerDispatcher(badSpec)
+    }
+    assert(ex.getMessage.contains("must not contain UNSPECIFIED"))
   }
 
   test("concurrent createSession calls produce distinct workers") {
@@ -267,6 +304,7 @@ class DirectWorkerDispatcherSuite
       .setGracefulTerminationTimeoutMs(500)
       .build()
     val spec = UDFWorkerSpecification.newBuilder()
+      .setCapabilities(defaultCapabilities)
       .setDirect(DirectWorker.newBuilder()
         .setRunner(runner).setProperties(shortGracefulProps).build())
       .build()
@@ -456,6 +494,7 @@ class DirectWorkerDispatcherSuite
       .setGracefulTerminationTimeoutMs(60000)
       .build()
     val spec = UDFWorkerSpecification.newBuilder()
+      .setCapabilities(defaultCapabilities)
       .setDirect(DirectWorker.newBuilder()
         .setRunner(defaultRunner).setProperties(oversizedProps).build())
       .build()
@@ -475,6 +514,7 @@ class DirectWorkerDispatcherSuite
       .setInitializationTimeoutMs(60000)
       .build()
     val spec = UDFWorkerSpecification.newBuilder()
+      .setCapabilities(defaultCapabilities)
       .setDirect(DirectWorker.newBuilder()
         .setRunner(defaultRunner).setProperties(oversizedProps).build())
       .build()
@@ -566,6 +606,7 @@ class DirectWorkerDispatcherSuite
 
   test("DirectWorker without a connection is rejected") {
     val badSpec = UDFWorkerSpecification.newBuilder()
+      .setCapabilities(defaultCapabilities)
       .setDirect(DirectWorker.newBuilder().setRunner(defaultRunner).build())
       .build()
     val ex = intercept[IllegalArgumentException] {
@@ -581,6 +622,7 @@ class DirectWorkerDispatcherSuite
         .setTcp(LocalTcpConnection.getDefaultInstance).build())
       .build()
     val badSpec = UDFWorkerSpecification.newBuilder()
+      .setCapabilities(defaultCapabilities)
       .setDirect(DirectWorker.newBuilder()
         .setRunner(defaultRunner).setProperties(tcpProperties).build())
       .build()
@@ -658,6 +700,7 @@ class DirectWorkerDispatcherSuite
       .setInitializationTimeoutMs(500)
       .build()
     val spec = UDFWorkerSpecification.newBuilder()
+      .setCapabilities(defaultCapabilities)
       .setDirect(DirectWorker.newBuilder()
         .setRunner(hangingRunner).setProperties(shortInitProps).build())
       .build()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR tightens `DirectWorkerDispatcher` validation for the new language-agnostic UDF worker specification.

Specifically, it now rejects direct worker specs that:
- omit worker capabilities entirely
- provide `UNSPECIFIED` enum values in supported data formats or communication patterns
- omit required protocol support for `ARROW`
- omit required protocol support for `BIDIRECTIONAL_STREAMING`

The existing `DirectWorkerDispatcherSuite` fixtures are updated to include explicit capabilities where they were previously constructing minimal specs, and new focused tests cover the new validation paths.

### Why are the changes needed?

`SPARK-56468` is an audit task for the UDF gRPC / worker protocol before the Spark 4.2 protocol boundary hardens.

The protobuf comments already describe these capability fields as required, but the direct dispatcher previously accepted incomplete specs and deferred that inconsistency into later runtime paths. Failing closed here keeps the worker spec self-contained and prevents silently invalid protocol definitions from being treated as usable.

### Does this PR introduce _any_ user-facing change?

No. The UDF worker framework is still experimental and not yet wired into user-facing execution paths.

### How was this patch tested?

Locally on macOS with Homebrew OpenJDK 17:

```bash
export JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home
export PATH="$JAVA_HOME/bin:$PATH"
build/sbt "udf-worker-core/testOnly org.apache.spark.udf.worker.core.DirectWorkerDispatcherSuite"
```

Passed: `DirectWorkerDispatcherSuite` (33 tests)

### Was this patch authored or co-authored using generative AI tooling?

Yes.
