### PR TITLE
[SPARK-56879][CORE][TESTS] Improve `JavaUtilsSuite` to be more robust

### DIFF
--- a/common/network-common/src/test/java/org/apache/spark/network/util/JavaUtilsSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/util/JavaUtilsSuite.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class JavaUtilsSuite {
 
@@ -52,6 +53,10 @@ public class JavaUtilsSuite {
     // 4. The parent directory cannot write
     assertTrue(testDir.canWrite());
     assertTrue(testDir.setWritable(false));
+    // Skip when setWritable(false) has no effect (e.g. running as root,
+    // or on a filesystem that ignores POSIX write bits).
+    assumeFalse(testDir.canWrite(),
+      "setWritable(false) had no effect; skipping write-denied scenario");
     assertThrows(IOException.class,
       () -> JavaUtils.createDirectory(testDirPath, "scenario4"));
     assertTrue(testDir.setWritable(true));


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make `JavaUtilsSuite.testCreateDirectory` scenario 4 skip the `IOException` assertion when running as `root`.

### Why are the changes needed?

`root` bypasses filesystem permission checks, so `setWritable(false)` does not prevent directory creation and the test fails under root (e.g., Docker-based CI).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)