### PR TITLE
[SPARK-56881][CORE][TESTS] Improve `FsHistoryProviderSuite` to be more robust

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -212,6 +212,10 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
       SparkListenerApplicationEnd(2L)
       )
     logFile2.setReadable(false, false)
+    // setReadable(false) is a no-op for root users since they bypass file
+    // permission checks. Skip the test in that case.
+    assume(!logFile2.canRead, "Test requires the file to be unreadable; " +
+      "skipping when running as root.")
 
     updateAndCheck(provider) { list =>
       list.size should be (1)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Skip the `SPARK-3697: ignore files that cannot be read.` test when the file remains readable after `setReadable(false, false)` (i.e. running as `root`).

```scala
    logFile2.setReadable(false, false)
    assume(!logFile2.canRead, "Test requires the file to be unreadable; " +
      "skipping when running as root.")
```

### Why are the changes needed?

`root` bypasses POSIX permission checks, so the test's precondition (unreadable file) does not hold and the assertions fail. This mirrors the existing `assume(!Utils.isWindows)` skip on the line above.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)