### PR TITLE
[SPARK-56885][CORE][TESTS] Make `CompressionCodecSuite` be independent from the default value of io compression codec

### DIFF
--- a/core/src/test/scala/org/apache/spark/io/CompressionCodecSuite.scala
+++ b/core/src/test/scala/org/apache/spark/io/CompressionCodecSuite.scala
@@ -21,7 +21,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.util.Locale
 
 import org.apache.spark.{SparkConf, SparkFunSuite, SparkIllegalArgumentException}
-import org.apache.spark.internal.config.IO_COMPRESSION_ZSTD_BUFFERPOOL_ENABLED
+import org.apache.spark.internal.config.{IO_COMPRESSION_CODEC, IO_COMPRESSION_ZSTD_BUFFERPOOL_ENABLED}
 import org.apache.spark.util.Utils
 
 class CompressionCodecSuite extends SparkFunSuite {
@@ -47,7 +47,9 @@ class CompressionCodecSuite extends SparkFunSuite {
 
   test("default compression codec") {
     val codec = CompressionCodec.createCodec(conf)
-    assert(codec.getClass === classOf[LZ4CompressionCodec])
+    assert(codec.getClass.getName ===
+      CompressionCodec.shortCompressionCodecNames(
+        IO_COMPRESSION_CODEC.defaultValueString))
     testCodec(codec)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes the `default compression codec` test in `CompressionCodecSuite` derive the expected codec class from `IO_COMPRESSION_CODEC.defaultValueString` instead of hard-coding `classOf[LZ4CompressionCodec]`.

### Why are the changes needed?

To keep the test aligned with the actual default of `spark.io.compression.codec` so it survives any future default change without modification.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7