### PR TITLE
[SPARK-56884][BUILD] Upgrade `zstd-jni` to 1.5.7-8

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -287,4 +287,4 @@ xz/1.12//xz-1.12.jar
 zjsonpatch/7.6.1//zjsonpatch-7.6.1.jar
 zookeeper-jute/3.9.5//zookeeper-jute-3.9.5.jar
 zookeeper/3.9.5//zookeeper-3.9.5.jar
-zstd-jni/1.5.7-7//zstd-jni-1.5.7-7.jar
+zstd-jni/1.5.7-8//zstd-jni-1.5.7-8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -899,7 +899,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.7-7</version>
+        <version>1.5.7-8</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `zstd-jni` to `1.5.7-8`.

### Why are the changes needed?

To bring the latest bug fixes and improvements from upstream `zstd-jni` v1.5.7-8. 
- https://github.com/luben/zstd-jni/releases/tag/v1.5.7-8 (2026-05-01)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)