### PR TITLE
[SPARK-56895][SQL] Batch ByteBuffer slice in RLE PACKED decode to reduce allocation overhead

### DIFF
--- a/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-jdk21-results.txt
@@ -2,153 +2,153 @@
 Boolean decode
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 RLE readBooleans decode:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cold reader, trueRatio=0.0                            0              0           0       4886.6           0.2       1.0X
-reused reader, trueRatio=0.0                          0              0           0       4857.7           0.2       1.0X
-cold reader, trueRatio=0.1                            1              1           0       1186.3           0.8       0.2X
-reused reader, trueRatio=0.1                          1              1           0        789.7           1.3       0.2X
-cold reader, trueRatio=0.5                            1              1           0       1335.3           0.7       0.3X
-reused reader, trueRatio=0.5                          1              1           0        855.2           1.2       0.2X
-cold reader, trueRatio=0.9                            1              1           0       1186.3           0.8       0.2X
-reused reader, trueRatio=0.9                          1              1           0        787.6           1.3       0.2X
-cold reader, trueRatio=1.0                            0              0           0       4064.6           0.2       0.8X
-reused reader, trueRatio=1.0                          0              0           0       4855.5           0.2       1.0X
+cold reader, trueRatio=0.0                            0              0           0      12677.1           0.1       1.0X
+reused reader, trueRatio=0.0                          0              0           0      12680.2           0.1       1.0X
+cold reader, trueRatio=0.1                            2              2           0        694.6           1.4       0.1X
+reused reader, trueRatio=0.1                          2              2           0        615.1           1.6       0.0X
+cold reader, trueRatio=0.5                            1              1           0        734.1           1.4       0.1X
+reused reader, trueRatio=0.5                          2              2           0        653.3           1.5       0.1X
+cold reader, trueRatio=0.9                            2              2           0        693.8           1.4       0.1X
+reused reader, trueRatio=0.9                          2              2           0        613.0           1.6       0.0X
+cold reader, trueRatio=1.0                            0              0           0      12675.4           0.1       1.0X
+reused reader, trueRatio=1.0                          0              0           0      12678.7           0.1       1.0X
 
 
 ================================================================================================
 Integer decode
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 RLE readIntegers dictionary-id decode:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-PACKED cold, bitWidth=4                               2              2           0        542.4           1.8       1.0X
-PACKED reused, bitWidth=4                             2              2           0        541.2           1.8       1.0X
-RLE, bitWidth=4                                       0              0           0      23543.9           0.0      43.4X
-PACKED cold, bitWidth=8                               2              2           0        621.3           1.6       1.1X
-PACKED reused, bitWidth=8                             2              2           0        618.1           1.6       1.1X
-RLE, bitWidth=8                                       0              0           0      23511.7           0.0      43.3X
-PACKED cold, bitWidth=12                              2              2           0        482.5           2.1       0.9X
-PACKED reused, bitWidth=12                            2              2           0        480.5           2.1       0.9X
-RLE, bitWidth=12                                      0              0           0      23507.0           0.0      43.3X
-PACKED cold, bitWidth=20                              3              3           0        401.9           2.5       0.7X
-PACKED reused, bitWidth=20                            3              3           0        400.6           2.5       0.7X
-RLE, bitWidth=20                                      0              0           0      23570.4           0.0      43.5X
+PACKED cold, bitWidth=4                               1              1           0        900.8           1.1       1.0X
+PACKED reused, bitWidth=4                             1              1           0        897.1           1.1       1.0X
+RLE, bitWidth=4                                       0              0           0      15764.7           0.1      17.5X
+PACKED cold, bitWidth=8                               1              1           0       1033.6           1.0       1.1X
+PACKED reused, bitWidth=8                             1              1           0       1006.4           1.0       1.1X
+RLE, bitWidth=8                                       0              0           0      20259.6           0.0      22.5X
+PACKED cold, bitWidth=12                              2              2           0        684.1           1.5       0.8X
+PACKED reused, bitWidth=12                            2              2           0        681.5           1.5       0.8X
+RLE, bitWidth=12                                      0              0           0      20220.5           0.0      22.4X
+PACKED cold, bitWidth=20                              2              2           0        523.5           1.9       0.6X
+PACKED reused, bitWidth=20                            2              2           0        522.8           1.9       0.6X
+RLE, bitWidth=20                                      0              0           0      15767.1           0.1      17.5X
 
 
 ================================================================================================
 Nullable batch decode with def-level materialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Nullable batch with def-levels:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       8154.1           0.1       1.0X
-nullRatio=0.1, random                                 7              8           0        140.5           7.1       0.0X
-nullRatio=0.1, clustered                              5              5           0        204.1           4.9       0.0X
-nullRatio=0.3, random                                11             11           0         96.0          10.4       0.0X
-nullRatio=0.3, clustered                              5              5           0        207.8           4.8       0.0X
-nullRatio=0.5, random                                12             12           0         87.4          11.4       0.0X
-nullRatio=0.5, clustered                              5              5           0        213.6           4.7       0.0X
-nullRatio=0.9, random                                 6              7           0        162.1           6.2       0.0X
-nullRatio=0.9, clustered                              4              5           0        235.1           4.3       0.0X
-nullRatio=1.0, random                                 0              0           0      22458.3           0.0       2.8X
+nullRatio=0.0, n/a                                    0              0           0       6620.0           0.2       1.0X
+nullRatio=0.1, random                                 8              8           0        132.9           7.5       0.0X
+nullRatio=0.1, clustered                              5              5           0        193.5           5.2       0.0X
+nullRatio=0.3, random                                12             12           0         91.0          11.0       0.0X
+nullRatio=0.3, clustered                              5              5           0        197.2           5.1       0.0X
+nullRatio=0.5, random                                13             13           0         81.2          12.3       0.0X
+nullRatio=0.5, clustered                              5              5           0        203.5           4.9       0.0X
+nullRatio=0.9, random                                 7              7           0        155.1           6.4       0.0X
+nullRatio=0.9, clustered                              5              5           0        227.8           4.4       0.0X
+nullRatio=1.0, random                                 0              0           0       8305.8           0.1       1.3X
 
 
 ================================================================================================
 Nullable batch decode without def-level materialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Nullable batch without def-levels:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0      12686.2           0.1       1.0X
-nullRatio=0.1, random                                 6              6           0        172.3           5.8       0.0X
-nullRatio=0.1, clustered                              4              4           0        251.2           4.0       0.0X
-nullRatio=0.3, random                                 9              9           0        115.5           8.7       0.0X
-nullRatio=0.3, clustered                              4              4           0        253.9           3.9       0.0X
-nullRatio=0.5, random                                10             10           0        105.1           9.5       0.0X
-nullRatio=0.5, clustered                              4              4           0        259.7           3.9       0.0X
-nullRatio=0.9, random                                 5              5           0        198.9           5.0       0.0X
-nullRatio=0.9, clustered                              4              4           0        282.6           3.5       0.0X
-nullRatio=1.0, random                                 0              0           0      96058.6           0.0       7.6X
+nullRatio=0.0, n/a                                    0              0           0      11471.1           0.1       1.0X
+nullRatio=0.1, random                                 6              6           0        163.2           6.1       0.0X
+nullRatio=0.1, clustered                              4              4           0        244.7           4.1       0.0X
+nullRatio=0.3, random                                10             10           0        109.6           9.1       0.0X
+nullRatio=0.3, clustered                              4              4           0        246.4           4.1       0.0X
+nullRatio=0.5, random                                11             11           0         97.2          10.3       0.0X
+nullRatio=0.5, clustered                              4              4           0        253.4           3.9       0.0X
+nullRatio=0.9, random                                 6              6           0        190.1           5.3       0.0X
+nullRatio=0.9, clustered                              4              4           0        283.7           3.5       0.0X
+nullRatio=1.0, random                                 0              0           0      12006.8           0.1       1.0X
 
 
 ================================================================================================
 Nullable batch decode with row-index filtering (with def-levels)
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Nullable batch with def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                   1              1           0       1247.7           0.8       1.0X
-nullRatio=0.3, contiguous 50%                                   8              8           0        135.1           7.4       0.1X
-nullRatio=0.9, contiguous 50%                                   5              6           0        191.0           5.2       0.2X
-nullRatio=0.0, alt 1000-row windows                             2              2           0        433.2           2.3       0.3X
-nullRatio=0.3, alt 1000-row windows                             9              9           0        113.6           8.8       0.1X
-nullRatio=0.9, alt 1000-row windows                             7              7           0        150.4           6.6       0.1X
+nullRatio=0.0, contiguous 50%                                   1              1           0        765.3           1.3       1.0X
+nullRatio=0.3, contiguous 50%                                   8              9           0        125.3           8.0       0.2X
+nullRatio=0.9, contiguous 50%                                   6              6           0        181.6           5.5       0.2X
+nullRatio=0.0, alt 1000-row windows                             3              3           0        378.3           2.6       0.5X
+nullRatio=0.3, alt 1000-row windows                            10             10           0        106.8           9.4       0.1X
+nullRatio=0.9, alt 1000-row windows                             7              7           0        145.5           6.9       0.2X
 
 
 ================================================================================================
 Nullable batch decode with row-index filtering (without def-levels)
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Nullable batch without def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                      1              1           0       1004.6           1.0       1.0X
-nullRatio=0.3, contiguous 50%                                      7              7           1        154.7           6.5       0.2X
-nullRatio=0.9, contiguous 50%                                      5              5           0        214.0           4.7       0.2X
-nullRatio=0.0, alt 1000-row windows                                2              2           0        464.0           2.2       0.5X
-nullRatio=0.3, alt 1000-row windows                                8              8           0        130.3           7.7       0.1X
-nullRatio=0.9, alt 1000-row windows                                6              6           0        169.6           5.9       0.2X
+nullRatio=0.0, contiguous 50%                                      1              4           1        749.1           1.3       1.0X
+nullRatio=0.3, contiguous 50%                                      7              7           0        146.3           6.8       0.2X
+nullRatio=0.9, contiguous 50%                                      5              5           0        203.9           4.9       0.3X
+nullRatio=0.0, alt 1000-row windows                                3              3           0        382.9           2.6       0.5X
+nullRatio=0.3, alt 1000-row windows                                9              9           0        121.7           8.2       0.2X
+nullRatio=0.9, alt 1000-row windows                                7              7           0        159.7           6.3       0.2X
 
 
 ================================================================================================
 Single-value reads
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBoolean                                           3              3           0        361.8           2.8       1.0X
-readInteger, bitWidth=4                               3              3           0        314.3           3.2       0.9X
-readValueDictionaryId, bitWidth=4                     3              3           0        315.3           3.2       0.9X
-readInteger, bitWidth=8                               3              3           0        339.9           2.9       0.9X
-readValueDictionaryId, bitWidth=8                     3              3           0        339.8           2.9       0.9X
-readInteger, bitWidth=12                              4              4           0        293.8           3.4       0.8X
-readValueDictionaryId, bitWidth=12                    4              4           0        293.9           3.4       0.8X
-readInteger, bitWidth=20                              4              4           0        262.1           3.8       0.7X
-readValueDictionaryId, bitWidth=20                    4              4           0        261.9           3.8       0.7X
+readBoolean                                           2              2           0        441.2           2.3       1.0X
+readInteger, bitWidth=4                               3              3           0        368.7           2.7       0.8X
+readValueDictionaryId, bitWidth=4                     3              3           0        368.9           2.7       0.8X
+readInteger, bitWidth=8                               3              3           0        393.7           2.5       0.9X
+readValueDictionaryId, bitWidth=8                     3              3           0        394.1           2.5       0.9X
+readInteger, bitWidth=12                              3              3           0        330.7           3.0       0.7X
+readValueDictionaryId, bitWidth=12                    3              3           0        329.7           3.0       0.7X
+readInteger, bitWidth=20                              4              4           0        288.4           3.5       0.7X
+readValueDictionaryId, bitWidth=20                    4              4           0        287.8           3.5       0.7X
 
 
 ================================================================================================
 Skip
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-skipBooleans, trueRatio=0.0                           0              0           0   34952533.3           0.0       1.0X
-skipBooleans, trueRatio=0.5                           2              2           0        662.2           1.5       0.0X
-skipBooleans, trueRatio=1.0                           0              0           0   34952533.3           0.0       1.0X
-skipIntegers PACKED, bitWidth=4                       2              2           0        553.8           1.8       0.0X
-skipIntegers RLE, bitWidth=4                          0              0           0   34952533.3           0.0       1.0X
-skipIntegers PACKED, bitWidth=8                       2              2           0        637.9           1.6       0.0X
-skipIntegers RLE, bitWidth=8                          0              0           0   34952533.3           0.0       1.0X
-skipIntegers PACKED, bitWidth=12                      2              2           0        493.4           2.0       0.0X
-skipIntegers RLE, bitWidth=12                         0              0           0   26214400.0           0.0       0.8X
-skipIntegers PACKED, bitWidth=20                      3              3           0        415.6           2.4       0.0X
-skipIntegers RLE, bitWidth=20                         0              0           0   26214400.0           0.0       0.8X
+skipBooleans, trueRatio=0.0                           0              0           0   21399510.2           0.0       1.0X
+skipBooleans, trueRatio=0.5                           1              1           0       1184.1           0.8       0.0X
+skipBooleans, trueRatio=1.0                           0              0           0   21399510.2           0.0       1.0X
+skipIntegers PACKED, bitWidth=4                       1              1           0        924.2           1.1       0.0X
+skipIntegers RLE, bitWidth=4                          0              0           0   21399510.2           0.0       1.0X
+skipIntegers PACKED, bitWidth=8                       1              1           0       1117.6           0.9       0.0X
+skipIntegers RLE, bitWidth=8                          0              0           0   21399510.2           0.0       1.0X
+skipIntegers PACKED, bitWidth=12                      1              1           0        720.0           1.4       0.0X
+skipIntegers RLE, bitWidth=12                         0              0           0   21399510.2           0.0       1.0X
+skipIntegers PACKED, bitWidth=20                      2              2           0        546.7           1.8       0.0X
+skipIntegers RLE, bitWidth=20                         0              0           0   21399510.2           0.0       1.0X
 
 

--- a/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-jdk25-results.txt
@@ -2,153 +2,153 @@
 Boolean decode
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 RLE readBooleans decode:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cold reader, trueRatio=0.0                            0              0           0      64903.2           0.0       1.0X
-reused reader, trueRatio=0.0                          0              0           0      63220.5           0.0       1.0X
-cold reader, trueRatio=0.1                            1              1           0        830.6           1.2       0.0X
-reused reader, trueRatio=0.1                          1              1           0        789.9           1.3       0.0X
-cold reader, trueRatio=0.5                            1              1           0        927.6           1.1       0.0X
-reused reader, trueRatio=0.5                          1              1           0        905.4           1.1       0.0X
-cold reader, trueRatio=0.9                            1              1           0        831.8           1.2       0.0X
-reused reader, trueRatio=0.9                          1              1           0        833.2           1.2       0.0X
-cold reader, trueRatio=1.0                            0              0           0      64176.3           0.0       1.0X
-reused reader, trueRatio=1.0                          0              0           0      62706.4           0.0       1.0X
+cold reader, trueRatio=0.0                            0              0           0      87330.4           0.0       1.0X
+reused reader, trueRatio=0.0                          0              0           0      87033.2           0.0       1.0X
+cold reader, trueRatio=0.1                            1              1           0        716.3           1.4       0.0X
+reused reader, trueRatio=0.1                          1              1           0        716.5           1.4       0.0X
+cold reader, trueRatio=0.5                            1              1           0        805.1           1.2       0.0X
+reused reader, trueRatio=0.5                          1              1           0        804.6           1.2       0.0X
+cold reader, trueRatio=0.9                            1              1           0        716.0           1.4       0.0X
+reused reader, trueRatio=0.9                          1              1           0        712.2           1.4       0.0X
+cold reader, trueRatio=1.0                            0              0           0      87105.5           0.0       1.0X
+reused reader, trueRatio=1.0                          0              0           0      87330.4           0.0       1.0X
 
 
 ================================================================================================
 Integer decode
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 RLE readIntegers dictionary-id decode:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-PACKED cold, bitWidth=4                               2              2           0        534.3           1.9       1.0X
-PACKED reused, bitWidth=4                             2              2           0        522.1           1.9       1.0X
-RLE, bitWidth=4                                       0              0           0       7632.3           0.1      14.3X
-PACKED cold, bitWidth=8                               2              2           0        584.0           1.7       1.1X
-PACKED reused, bitWidth=8                             2              2           0        579.4           1.7       1.1X
-RLE, bitWidth=8                                       0              0           0       7615.7           0.1      14.3X
-PACKED cold, bitWidth=12                              2              2           0        443.8           2.3       0.8X
-PACKED reused, bitWidth=12                            2              3           0        436.4           2.3       0.8X
-RLE, bitWidth=12                                      0              0           0       7589.5           0.1      14.2X
-PACKED cold, bitWidth=20                              3              3           0        378.5           2.6       0.7X
-PACKED reused, bitWidth=20                            3              3           0        382.8           2.6       0.7X
-RLE, bitWidth=20                                      0              0           0       7590.5           0.1      14.2X
+PACKED cold, bitWidth=4                               1              1           0        821.4           1.2       1.0X
+PACKED reused, bitWidth=4                             1              1           0        777.0           1.3       0.9X
+RLE, bitWidth=4                                       0              0           0      18196.9           0.1      22.2X
+PACKED cold, bitWidth=8                               1              1           0        988.6           1.0       1.2X
+PACKED reused, bitWidth=8                             1              1           0        987.4           1.0       1.2X
+RLE, bitWidth=8                                       0              0           0      18146.2           0.1      22.1X
+PACKED cold, bitWidth=12                              2              2           0        625.6           1.6       0.8X
+PACKED reused, bitWidth=12                            2              2           0        623.4           1.6       0.8X
+RLE, bitWidth=12                                      0              0           0      18174.8           0.1      22.1X
+PACKED cold, bitWidth=20                              2              2           0        486.6           2.1       0.6X
+PACKED reused, bitWidth=20                            2              2           0        484.2           2.1       0.6X
+RLE, bitWidth=20                                      0              0           0      18139.9           0.1      22.1X
 
 
 ================================================================================================
 Nullable batch decode with def-level materialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Nullable batch with def-levels:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       5285.1           0.2       1.0X
-nullRatio=0.1, random                                 9              9           0        113.1           8.8       0.0X
-nullRatio=0.1, clustered                              6              6           0        173.0           5.8       0.0X
-nullRatio=0.3, random                                14             14           0         75.5          13.2       0.0X
-nullRatio=0.3, clustered                              6              6           0        173.1           5.8       0.0X
-nullRatio=0.5, random                                15             16           0         67.7          14.8       0.0X
-nullRatio=0.5, clustered                              6              6           0        176.2           5.7       0.0X
-nullRatio=0.9, random                                 8              8           0        128.6           7.8       0.0X
-nullRatio=0.9, clustered                              5              6           0        196.2           5.1       0.0X
-nullRatio=1.0, random                                 0              0           0      35936.0           0.0       6.8X
+nullRatio=0.0, n/a                                    0              0           0       6106.6           0.2       1.0X
+nullRatio=0.1, random                                 8              9           0        124.3           8.0       0.0X
+nullRatio=0.1, clustered                              6              6           0        186.1           5.4       0.0X
+nullRatio=0.3, random                                13             13           0         80.0          12.5       0.0X
+nullRatio=0.3, clustered                              6              6           0        186.7           5.4       0.0X
+nullRatio=0.5, random                                15             15           0         71.1          14.1       0.0X
+nullRatio=0.5, clustered                              6              6           0        190.2           5.3       0.0X
+nullRatio=0.9, random                                 8              8           0        138.5           7.2       0.0X
+nullRatio=0.9, clustered                              5              5           0        209.0           4.8       0.0X
+nullRatio=1.0, random                                 0              0           0      16953.3           0.1       2.8X
 
 
 ================================================================================================
 Nullable batch decode without def-level materialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Nullable batch without def-levels:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       8150.4           0.1       1.0X
-nullRatio=0.1, random                                 7              7           0        147.0           6.8       0.0X
-nullRatio=0.1, clustered                              5              5           0        218.2           4.6       0.0X
-nullRatio=0.3, random                                11             11           0         98.0          10.2       0.0X
-nullRatio=0.3, clustered                              5              5           1        218.0           4.6       0.0X
-nullRatio=0.5, random                                12             12           0         90.0          11.1       0.0X
-nullRatio=0.5, clustered                              5              5           0        221.1           4.5       0.0X
-nullRatio=0.9, random                                 6              6           0        167.0           6.0       0.0X
-nullRatio=0.9, clustered                              4              5           0        237.7           4.2       0.0X
-nullRatio=1.0, random                                 0              0           0     115647.5           0.0      14.2X
+nullRatio=0.0, n/a                                    0              0           0       9549.8           0.1       1.0X
+nullRatio=0.1, random                                 7              7           0        158.5           6.3       0.0X
+nullRatio=0.1, clustered                              4              5           1        244.4           4.1       0.0X
+nullRatio=0.3, random                                10             10           1        101.9           9.8       0.0X
+nullRatio=0.3, clustered                              4              4           0        246.2           4.1       0.0X
+nullRatio=0.5, random                                12             12           0         91.0          11.0       0.0X
+nullRatio=0.5, clustered                              4              4           0        251.4           4.0       0.0X
+nullRatio=0.9, random                                 6              6           0        180.7           5.5       0.0X
+nullRatio=0.9, clustered                              4              4           0        282.8           3.5       0.0X
+nullRatio=1.0, random                                 0              0           0      59527.4           0.0       6.2X
 
 
 ================================================================================================
 Nullable batch decode with row-index filtering (with def-levels)
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Nullable batch with def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                   1              1           0        817.3           1.2       1.0X
-nullRatio=0.3, contiguous 50%                                   9             10           0        111.1           9.0       0.1X
-nullRatio=0.9, contiguous 50%                                   7              7           0        159.5           6.3       0.2X
-nullRatio=0.0, alt 1000-row windows                             3              3           0        327.9           3.1       0.4X
-nullRatio=0.3, alt 1000-row windows                            12             12           1         90.9          11.0       0.1X
-nullRatio=0.9, alt 1000-row windows                             9              9           0        119.7           8.4       0.1X
+nullRatio=0.0, contiguous 50%                                   1              1           0        973.0           1.0       1.0X
+nullRatio=0.3, contiguous 50%                                   9              9           0        122.4           8.2       0.1X
+nullRatio=0.9, contiguous 50%                                   6              6           0        182.9           5.5       0.2X
+nullRatio=0.0, alt 1000-row windows                             3              3           0        384.8           2.6       0.4X
+nullRatio=0.3, alt 1000-row windows                            10             10           0        104.0           9.6       0.1X
+nullRatio=0.9, alt 1000-row windows                             7              8           0        141.8           7.1       0.1X
 
 
 ================================================================================================
 Nullable batch decode with row-index filtering (without def-levels)
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Nullable batch without def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                      1              1           0        842.7           1.2       1.0X
-nullRatio=0.3, contiguous 50%                                      8              8           0        128.2           7.8       0.2X
-nullRatio=0.9, contiguous 50%                                      6              6           0        181.8           5.5       0.2X
-nullRatio=0.0, alt 1000-row windows                                3              3           0        331.8           3.0       0.4X
-nullRatio=0.3, alt 1000-row windows                               10             11           0        102.5           9.8       0.1X
-nullRatio=0.9, alt 1000-row windows                                8              8           0        134.2           7.4       0.2X
+nullRatio=0.0, contiguous 50%                                      2              2           0        685.8           1.5       1.0X
+nullRatio=0.3, contiguous 50%                                      8              8           0        135.6           7.4       0.2X
+nullRatio=0.9, contiguous 50%                                      5              5           0        195.0           5.1       0.3X
+nullRatio=0.0, alt 1000-row windows                                3              3           0        376.3           2.7       0.5X
+nullRatio=0.3, alt 1000-row windows                                9              9           0        112.9           8.9       0.2X
+nullRatio=0.9, alt 1000-row windows                                7              7           0        152.3           6.6       0.2X
 
 
 ================================================================================================
 Single-value reads
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBoolean                                           4              4           0        263.6           3.8       1.0X
-readInteger, bitWidth=4                               3              4           0        301.6           3.3       1.1X
-readValueDictionaryId, bitWidth=4                     3              4           0        300.4           3.3       1.1X
-readInteger, bitWidth=8                               3              4           0        314.9           3.2       1.2X
-readValueDictionaryId, bitWidth=8                     3              3           0        315.7           3.2       1.2X
-readInteger, bitWidth=12                              4              4           0        276.9           3.6       1.1X
-readValueDictionaryId, bitWidth=12                    4              4           0        275.9           3.6       1.0X
-readInteger, bitWidth=20                              4              4           0        249.3           4.0       0.9X
-readValueDictionaryId, bitWidth=20                    4              4           0        247.9           4.0       0.9X
+readBoolean                                           3              3           0        396.4           2.5       1.0X
+readInteger, bitWidth=4                               3              3           0        362.0           2.8       0.9X
+readValueDictionaryId, bitWidth=4                     3              3           0        363.1           2.8       0.9X
+readInteger, bitWidth=8                               3              3           0        396.3           2.5       1.0X
+readValueDictionaryId, bitWidth=8                     3              3           0        396.2           2.5       1.0X
+readInteger, bitWidth=12                              3              3           0        320.6           3.1       0.8X
+readValueDictionaryId, bitWidth=12                    3              3           0        320.4           3.1       0.8X
+readInteger, bitWidth=20                              4              4           0        280.6           3.6       0.7X
+readValueDictionaryId, bitWidth=20                    4              4           0        280.4           3.6       0.7X
 
 
 ================================================================================================
 Skip
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-skipBooleans, trueRatio=0.0                           0              0           0   29959314.3           0.0       1.0X
-skipBooleans, trueRatio=0.5                           2              2           0        611.9           1.6       0.0X
-skipBooleans, trueRatio=1.0                           0              0           0   29959314.3           0.0       1.0X
-skipIntegers PACKED, bitWidth=4                       2              2           0        542.6           1.8       0.0X
-skipIntegers RLE, bitWidth=4                          0              0           0   29959314.3           0.0       1.0X
-skipIntegers PACKED, bitWidth=8                       2              2           0        590.8           1.7       0.0X
-skipIntegers RLE, bitWidth=8                          0              0           0   29959314.3           0.0       1.0X
-skipIntegers PACKED, bitWidth=12                      2              2           0        467.9           2.1       0.0X
-skipIntegers RLE, bitWidth=12                         0              0           0   26214400.0           0.0       0.9X
-skipIntegers PACKED, bitWidth=20                      3              3           0        404.2           2.5       0.0X
-skipIntegers RLE, bitWidth=20                         0              0           0   23831272.7           0.0       0.8X
+skipBooleans, trueRatio=0.0                           0              0           0   20971520.0           0.0       1.0X
+skipBooleans, trueRatio=0.5                           1              1           0       1081.7           0.9       0.0X
+skipBooleans, trueRatio=1.0                           0              0           0   20971520.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=4                       1              1           0        859.8           1.2       0.0X
+skipIntegers RLE, bitWidth=4                          0              0           0   20971520.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=8                       1              1           0       1078.5           0.9       0.0X
+skipIntegers RLE, bitWidth=8                          0              0           0   20971520.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=12                      2              2           0        659.4           1.5       0.0X
+skipIntegers RLE, bitWidth=12                         0              0           0   20971520.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=20                      2              2           0        506.2           2.0       0.0X
+skipIntegers RLE, bitWidth=20                         0              0           0   17476266.7           0.0       0.8X
 
 

--- a/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-jdk25-results.txt
@@ -3,19 +3,19 @@ Boolean decode
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 RLE readBooleans decode:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cold reader, trueRatio=0.0                            0              0           0      87330.4           0.0       1.0X
-reused reader, trueRatio=0.0                          0              0           0      87033.2           0.0       1.0X
-cold reader, trueRatio=0.1                            1              1           0        716.3           1.4       0.0X
-reused reader, trueRatio=0.1                          1              1           0        716.5           1.4       0.0X
-cold reader, trueRatio=0.5                            1              1           0        805.1           1.2       0.0X
-reused reader, trueRatio=0.5                          1              1           0        804.6           1.2       0.0X
-cold reader, trueRatio=0.9                            1              1           0        716.0           1.4       0.0X
-reused reader, trueRatio=0.9                          1              1           0        712.2           1.4       0.0X
-cold reader, trueRatio=1.0                            0              0           0      87105.5           0.0       1.0X
-reused reader, trueRatio=1.0                          0              0           0      87330.4           0.0       1.0X
+cold reader, trueRatio=0.0                            0              0           0      62785.2           0.0       1.0X
+reused reader, trueRatio=0.0                          0              0           0      82280.0           0.0       1.3X
+cold reader, trueRatio=0.1                            2              2           0        662.8           1.5       0.0X
+reused reader, trueRatio=0.1                          2              2           0        655.5           1.5       0.0X
+cold reader, trueRatio=0.5                            1              2           0        710.3           1.4       0.0X
+reused reader, trueRatio=0.5                          1              2           0        700.6           1.4       0.0X
+cold reader, trueRatio=0.9                            2              2           0        662.2           1.5       0.0X
+reused reader, trueRatio=0.9                          2              2           0        655.1           1.5       0.0X
+cold reader, trueRatio=1.0                            0              0           0      82280.0           0.0       1.3X
+reused reader, trueRatio=1.0                          0              0           0      62560.5           0.0       1.0X
 
 
 ================================================================================================
@@ -23,21 +23,21 @@ Integer decode
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 RLE readIntegers dictionary-id decode:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-PACKED cold, bitWidth=4                               1              1           0        821.4           1.2       1.0X
-PACKED reused, bitWidth=4                             1              1           0        777.0           1.3       0.9X
-RLE, bitWidth=4                                       0              0           0      18196.9           0.1      22.2X
-PACKED cold, bitWidth=8                               1              1           0        988.6           1.0       1.2X
-PACKED reused, bitWidth=8                             1              1           0        987.4           1.0       1.2X
-RLE, bitWidth=8                                       0              0           0      18146.2           0.1      22.1X
-PACKED cold, bitWidth=12                              2              2           0        625.6           1.6       0.8X
-PACKED reused, bitWidth=12                            2              2           0        623.4           1.6       0.8X
-RLE, bitWidth=12                                      0              0           0      18174.8           0.1      22.1X
-PACKED cold, bitWidth=20                              2              2           0        486.6           2.1       0.6X
-PACKED reused, bitWidth=20                            2              2           0        484.2           2.1       0.6X
-RLE, bitWidth=20                                      0              0           0      18139.9           0.1      22.1X
+PACKED cold, bitWidth=4                               1              1           0        896.2           1.1       1.0X
+PACKED reused, bitWidth=4                             1              1           0        891.0           1.1       1.0X
+RLE, bitWidth=4                                       0              0           0      15783.5           0.1      17.6X
+PACKED cold, bitWidth=8                               1              1           0       1065.8           0.9       1.2X
+PACKED reused, bitWidth=8                             1              1           0       1049.4           1.0       1.2X
+RLE, bitWidth=8                                       0              0           0      15780.9           0.1      17.6X
+PACKED cold, bitWidth=12                              2              2           0        693.7           1.4       0.8X
+PACKED reused, bitWidth=12                            2              2           0        689.4           1.5       0.8X
+RLE, bitWidth=12                                      0              0           0      15778.5           0.1      17.6X
+PACKED cold, bitWidth=20                              2              2           0        537.3           1.9       0.6X
+PACKED reused, bitWidth=20                            2              2           0        520.2           1.9       0.6X
+RLE, bitWidth=20                                      0              0           0      15783.5           0.1      17.6X
 
 
 ================================================================================================
@@ -45,19 +45,19 @@ Nullable batch decode with def-level materialization
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Nullable batch with def-levels:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       6106.6           0.2       1.0X
-nullRatio=0.1, random                                 8              9           0        124.3           8.0       0.0X
-nullRatio=0.1, clustered                              6              6           0        186.1           5.4       0.0X
-nullRatio=0.3, random                                13             13           0         80.0          12.5       0.0X
-nullRatio=0.3, clustered                              6              6           0        186.7           5.4       0.0X
-nullRatio=0.5, random                                15             15           0         71.1          14.1       0.0X
-nullRatio=0.5, clustered                              6              6           0        190.2           5.3       0.0X
-nullRatio=0.9, random                                 8              8           0        138.5           7.2       0.0X
-nullRatio=0.9, clustered                              5              5           0        209.0           4.8       0.0X
-nullRatio=1.0, random                                 0              0           0      16953.3           0.1       2.8X
+nullRatio=0.0, n/a                                    0              0           0       6836.1           0.1       1.0X
+nullRatio=0.1, random                                 8              8           0        137.1           7.3       0.0X
+nullRatio=0.1, clustered                              5              5           0        203.3           4.9       0.0X
+nullRatio=0.3, random                                11             11           0         92.8          10.8       0.0X
+nullRatio=0.3, clustered                              5              5           0        205.3           4.9       0.0X
+nullRatio=0.5, random                                13             13           0         82.3          12.1       0.0X
+nullRatio=0.5, clustered                              5              5           0        209.5           4.8       0.0X
+nullRatio=0.9, random                                 7              7           1        154.8           6.5       0.0X
+nullRatio=0.9, clustered                              5              5           0        230.2           4.3       0.0X
+nullRatio=1.0, random                                 0              0           0      19063.6           0.1       2.8X
 
 
 ================================================================================================
@@ -65,19 +65,19 @@ Nullable batch decode without def-level materialization
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Nullable batch without def-levels:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       9549.8           0.1       1.0X
-nullRatio=0.1, random                                 7              7           0        158.5           6.3       0.0X
-nullRatio=0.1, clustered                              4              5           1        244.4           4.1       0.0X
-nullRatio=0.3, random                                10             10           1        101.9           9.8       0.0X
-nullRatio=0.3, clustered                              4              4           0        246.2           4.1       0.0X
-nullRatio=0.5, random                                12             12           0         91.0          11.0       0.0X
-nullRatio=0.5, clustered                              4              4           0        251.4           4.0       0.0X
-nullRatio=0.9, random                                 6              6           0        180.7           5.5       0.0X
-nullRatio=0.9, clustered                              4              4           0        282.8           3.5       0.0X
-nullRatio=1.0, random                                 0              0           0      59527.4           0.0       6.2X
+nullRatio=0.0, n/a                                    0              0           0      12591.4           0.1       1.0X
+nullRatio=0.1, random                                 6              6           0        162.5           6.2       0.0X
+nullRatio=0.1, clustered                              4              4           0        253.5           3.9       0.0X
+nullRatio=0.3, random                                 9             10           1        111.1           9.0       0.0X
+nullRatio=0.3, clustered                              4              4           0        253.6           3.9       0.0X
+nullRatio=0.5, random                                11             11           0         98.8          10.1       0.0X
+nullRatio=0.5, clustered                              4              4           0        257.7           3.9       0.0X
+nullRatio=0.9, random                                 6              6           1        186.5           5.4       0.0X
+nullRatio=0.9, clustered                              4              4           0        280.6           3.6       0.0X
+nullRatio=1.0, random                                 0              0           0      66453.9           0.0       5.3X
 
 
 ================================================================================================
@@ -85,15 +85,15 @@ Nullable batch decode with row-index filtering (with def-levels)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Nullable batch with def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                   1              1           0        973.0           1.0       1.0X
-nullRatio=0.3, contiguous 50%                                   9              9           0        122.4           8.2       0.1X
-nullRatio=0.9, contiguous 50%                                   6              6           0        182.9           5.5       0.2X
-nullRatio=0.0, alt 1000-row windows                             3              3           0        384.8           2.6       0.4X
-nullRatio=0.3, alt 1000-row windows                            10             10           0        104.0           9.6       0.1X
-nullRatio=0.9, alt 1000-row windows                             7              8           0        141.8           7.1       0.1X
+nullRatio=0.0, contiguous 50%                                   1              2           0        765.3           1.3       1.0X
+nullRatio=0.3, contiguous 50%                                   8              8           0        134.3           7.4       0.2X
+nullRatio=0.9, contiguous 50%                                   6              6           0        188.3           5.3       0.2X
+nullRatio=0.0, alt 1000-row windows                             2              2           0        435.3           2.3       0.6X
+nullRatio=0.3, alt 1000-row windows                             9              9           0        118.4           8.4       0.2X
+nullRatio=0.9, alt 1000-row windows                             7              7           0        159.2           6.3       0.2X
 
 
 ================================================================================================
@@ -101,15 +101,15 @@ Nullable batch decode with row-index filtering (without def-levels)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Nullable batch without def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                      2              2           0        685.8           1.5       1.0X
-nullRatio=0.3, contiguous 50%                                      8              8           0        135.6           7.4       0.2X
-nullRatio=0.9, contiguous 50%                                      5              5           0        195.0           5.1       0.3X
-nullRatio=0.0, alt 1000-row windows                                3              3           0        376.3           2.7       0.5X
-nullRatio=0.3, alt 1000-row windows                                9              9           0        112.9           8.9       0.2X
-nullRatio=0.9, alt 1000-row windows                                7              7           0        152.3           6.6       0.2X
+nullRatio=0.0, contiguous 50%                                      1              2           0        736.9           1.4       1.0X
+nullRatio=0.3, contiguous 50%                                      7              7           0        143.6           7.0       0.2X
+nullRatio=0.9, contiguous 50%                                      5              5           0        197.3           5.1       0.3X
+nullRatio=0.0, alt 1000-row windows                                2              2           0        442.1           2.3       0.6X
+nullRatio=0.3, alt 1000-row windows                                8              8           0        126.8           7.9       0.2X
+nullRatio=0.9, alt 1000-row windows                                6              6           0        167.1           6.0       0.2X
 
 
 ================================================================================================
@@ -117,18 +117,18 @@ Single-value reads
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBoolean                                           3              3           0        396.4           2.5       1.0X
-readInteger, bitWidth=4                               3              3           0        362.0           2.8       0.9X
-readValueDictionaryId, bitWidth=4                     3              3           0        363.1           2.8       0.9X
-readInteger, bitWidth=8                               3              3           0        396.3           2.5       1.0X
-readValueDictionaryId, bitWidth=8                     3              3           0        396.2           2.5       1.0X
-readInteger, bitWidth=12                              3              3           0        320.6           3.1       0.8X
-readValueDictionaryId, bitWidth=12                    3              3           0        320.4           3.1       0.8X
-readInteger, bitWidth=20                              4              4           0        280.6           3.6       0.7X
-readValueDictionaryId, bitWidth=20                    4              4           0        280.4           3.6       0.7X
+readBoolean                                           2              2           0        427.5           2.3       1.0X
+readInteger, bitWidth=4                               3              3           0        404.5           2.5       0.9X
+readValueDictionaryId, bitWidth=4                     3              3           0        404.5           2.5       0.9X
+readInteger, bitWidth=8                               2              2           0        440.5           2.3       1.0X
+readValueDictionaryId, bitWidth=8                     2              2           0        440.3           2.3       1.0X
+readInteger, bitWidth=12                              3              3           0        359.8           2.8       0.8X
+readValueDictionaryId, bitWidth=12                    3              3           0        359.5           2.8       0.8X
+readInteger, bitWidth=20                              3              3           0        314.1           3.2       0.7X
+readValueDictionaryId, bitWidth=20                    3              3           0        314.1           3.2       0.7X
 
 
 ================================================================================================
@@ -136,19 +136,19 @@ Skip
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-skipBooleans, trueRatio=0.0                           0              0           0   20971520.0           0.0       1.0X
-skipBooleans, trueRatio=0.5                           1              1           0       1081.7           0.9       0.0X
-skipBooleans, trueRatio=1.0                           0              0           0   20971520.0           0.0       1.0X
-skipIntegers PACKED, bitWidth=4                       1              1           0        859.8           1.2       0.0X
-skipIntegers RLE, bitWidth=4                          0              0           0   20971520.0           0.0       1.0X
-skipIntegers PACKED, bitWidth=8                       1              1           0       1078.5           0.9       0.0X
-skipIntegers RLE, bitWidth=8                          0              0           0   20971520.0           0.0       1.0X
-skipIntegers PACKED, bitWidth=12                      2              2           0        659.4           1.5       0.0X
-skipIntegers RLE, bitWidth=12                         0              0           0   20971520.0           0.0       1.0X
-skipIntegers PACKED, bitWidth=20                      2              2           0        506.2           2.0       0.0X
-skipIntegers RLE, bitWidth=20                         0              0           0   17476266.7           0.0       0.8X
+skipBooleans, trueRatio=0.0                           0              0           0   26214400.0           0.0       1.0X
+skipBooleans, trueRatio=0.5                           1              1           0       1192.5           0.8       0.0X
+skipBooleans, trueRatio=1.0                           0              0           0   26214400.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=4                       1              1           0        944.1           1.1       0.0X
+skipIntegers RLE, bitWidth=4                          0              0           0   26214400.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=8                       1              1           0       1175.4           0.9       0.0X
+skipIntegers RLE, bitWidth=8                          0              0           0   26214400.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=12                      1              1           0        733.2           1.4       0.0X
+skipIntegers RLE, bitWidth=12                         0              0           0   21399510.2           0.0       0.8X
+skipIntegers PACKED, bitWidth=20                      2              2           0        560.2           1.8       0.0X
+skipIntegers RLE, bitWidth=20                         0              0           0   21399510.2           0.0       0.8X
 
 

--- a/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-results.txt
+++ b/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-results.txt
@@ -2,153 +2,153 @@
 Boolean decode
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 RLE readBooleans decode:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cold reader, trueRatio=0.0                            0              0           0      25842.3           0.0       1.0X
-reused reader, trueRatio=0.0                          0              0           0      25810.5           0.0       1.0X
-cold reader, trueRatio=0.1                            2              2           0        485.6           2.1       0.0X
-reused reader, trueRatio=0.1                          2              2           0        485.6           2.1       0.0X
-cold reader, trueRatio=0.5                            2              2           0        500.3           2.0       0.0X
-reused reader, trueRatio=0.5                          2              2           0        483.7           2.1       0.0X
-cold reader, trueRatio=0.9                            2              2           0        484.3           2.1       0.0X
-reused reader, trueRatio=0.9                          2              2           0        484.7           2.1       0.0X
-cold reader, trueRatio=1.0                            0              0           0      25804.1           0.0       1.0X
-reused reader, trueRatio=1.0                          0              0           0      25791.4           0.0       1.0X
+cold reader, trueRatio=0.0                            0              0           0      11467.6           0.1       1.0X
+reused reader, trueRatio=0.0                          0              0           0      11358.1           0.1       1.0X
+cold reader, trueRatio=0.1                            1              1           0        990.0           1.0       0.1X
+reused reader, trueRatio=0.1                          1              1           0        987.7           1.0       0.1X
+cold reader, trueRatio=0.5                            1              1           0       1201.3           0.8       0.1X
+reused reader, trueRatio=0.5                          1              1           0       1193.8           0.8       0.1X
+cold reader, trueRatio=0.9                            1              1           0        989.5           1.0       0.1X
+reused reader, trueRatio=0.9                          1              1           0        988.0           1.0       0.1X
+cold reader, trueRatio=1.0                            0              0           0      11358.2           0.1       1.0X
+reused reader, trueRatio=1.0                          0              0           0      11359.4           0.1       1.0X
 
 
 ================================================================================================
 Integer decode
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 RLE readIntegers dictionary-id decode:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-PACKED cold, bitWidth=4                               2              2           0        485.7           2.1       1.0X
-PACKED reused, bitWidth=4                             2              2           0        485.2           2.1       1.0X
-RLE, bitWidth=4                                       0              0           0      20688.1           0.0      42.6X
-PACKED cold, bitWidth=8                               2              2           0        478.8           2.1       1.0X
-PACKED reused, bitWidth=8                             2              2           0        476.5           2.1       1.0X
-RLE, bitWidth=8                                       0              0           0      15710.2           0.1      32.3X
-PACKED cold, bitWidth=12                              3              3           0        357.4           2.8       0.7X
-PACKED reused, bitWidth=12                            3              3           0        357.3           2.8       0.7X
-RLE, bitWidth=12                                      0              0           0      20684.0           0.0      42.6X
-PACKED cold, bitWidth=20                              3              4           0        303.0           3.3       0.6X
-PACKED reused, bitWidth=20                            3              4           0        302.1           3.3       0.6X
-RLE, bitWidth=20                                      0              0           0      20675.9           0.0      42.6X
+PACKED cold, bitWidth=4                               1              1           0        929.3           1.1       1.0X
+PACKED reused, bitWidth=4                             1              1           0        923.5           1.1       1.0X
+RLE, bitWidth=4                                       0              0           0      18214.9           0.1      19.6X
+PACKED cold, bitWidth=8                               1              1           0        894.4           1.1       1.0X
+PACKED reused, bitWidth=8                             1              1           0        891.0           1.1       1.0X
+RLE, bitWidth=8                                       0              0           0      18202.2           0.1      19.6X
+PACKED cold, bitWidth=12                              2              2           0        540.4           1.9       0.6X
+PACKED reused, bitWidth=12                            2              2           0        537.7           1.9       0.6X
+RLE, bitWidth=12                                      0              0           0      18205.4           0.1      19.6X
+PACKED cold, bitWidth=20                              3              3           0        411.0           2.4       0.4X
+PACKED reused, bitWidth=20                            3              3           0        410.0           2.4       0.4X
+RLE, bitWidth=20                                      0              0           0      18919.2           0.1      20.4X
 
 
 ================================================================================================
 Nullable batch decode with def-level materialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Nullable batch with def-levels:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       6435.2           0.2       1.0X
-nullRatio=0.1, random                                10             10           0        106.0           9.4       0.0X
-nullRatio=0.1, clustered                              7              7           0        144.9           6.9       0.0X
-nullRatio=0.3, random                                14             14           0         75.0          13.3       0.0X
-nullRatio=0.3, clustered                              7              7           0        147.9           6.8       0.0X
-nullRatio=0.5, random                                16             16           0         67.5          14.8       0.0X
-nullRatio=0.5, clustered                              7              7           0        151.9           6.6       0.0X
-nullRatio=0.9, random                                 9              9           0        121.9           8.2       0.0X
-nullRatio=0.9, clustered                              6              6           0        166.4           6.0       0.0X
-nullRatio=1.0, random                                 0              0           0       4126.2           0.2       0.6X
+nullRatio=0.0, n/a                                    0              0           0       5915.9           0.2       1.0X
+nullRatio=0.1, random                                10             10           0        110.2           9.1       0.0X
+nullRatio=0.1, clustered                              6              6           0        162.6           6.2       0.0X
+nullRatio=0.3, random                                14             14           0         74.6          13.4       0.0X
+nullRatio=0.3, clustered                              6              6           0        166.0           6.0       0.0X
+nullRatio=0.5, random                                16             16           0         66.6          15.0       0.0X
+nullRatio=0.5, clustered                              6              6           0        170.7           5.9       0.0X
+nullRatio=0.9, random                                 8              8           0        129.7           7.7       0.0X
+nullRatio=0.9, clustered                              5              5           0        194.9           5.1       0.0X
+nullRatio=1.0, random                                 0              0           0       7422.3           0.1       1.3X
 
 
 ================================================================================================
 Nullable batch decode without def-level materialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Nullable batch without def-levels:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0      10982.3           0.1       1.0X
-nullRatio=0.1, random                                 8              8           0        139.7           7.2       0.0X
-nullRatio=0.1, clustered                              5              6           0        191.6           5.2       0.0X
-nullRatio=0.3, random                                11             11           0         98.9          10.1       0.0X
-nullRatio=0.3, clustered                              5              5           0        194.1           5.2       0.0X
-nullRatio=0.5, random                                12             12           0         89.4          11.2       0.0X
-nullRatio=0.5, clustered                              5              5           0        199.1           5.0       0.0X
-nullRatio=0.9, random                                 7              7           0        160.5           6.2       0.0X
-nullRatio=0.9, clustered                              5              5           0        218.1           4.6       0.0X
-nullRatio=1.0, random                                 0              0           0       4916.7           0.2       0.4X
+nullRatio=0.0, n/a                                    0              0           0       9190.6           0.1       1.0X
+nullRatio=0.1, random                                 7              7           0        152.3           6.6       0.0X
+nullRatio=0.1, clustered                              4              5           0        234.4           4.3       0.0X
+nullRatio=0.3, random                                11             11           0         98.4          10.2       0.0X
+nullRatio=0.3, clustered                              4              4           0        239.9           4.2       0.0X
+nullRatio=0.5, random                                12             12           1         89.6          11.2       0.0X
+nullRatio=0.5, clustered                              4              4           0        249.7           4.0       0.0X
+nullRatio=0.9, random                                 6              6           0        185.3           5.4       0.0X
+nullRatio=0.9, clustered                              4              4           0        291.0           3.4       0.0X
+nullRatio=1.0, random                                 0              0           0      10413.7           0.1       1.1X
 
 
 ================================================================================================
 Nullable batch decode with row-index filtering (with def-levels)
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Nullable batch with def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                   1              2           0        759.7           1.3       1.0X
-nullRatio=0.3, contiguous 50%                                  10             10           0        108.5           9.2       0.1X
-nullRatio=0.9, contiguous 50%                                   7              7           0        149.5           6.7       0.2X
-nullRatio=0.0, alt 1000-row windows                             2              3           0        419.6           2.4       0.6X
-nullRatio=0.3, alt 1000-row windows                            11             11           0         96.9          10.3       0.1X
-nullRatio=0.9, alt 1000-row windows                             8              8           0        128.3           7.8       0.2X
+nullRatio=0.0, contiguous 50%                                   1              1           0        955.4           1.0       1.0X
+nullRatio=0.3, contiguous 50%                                   9              9           0        117.6           8.5       0.1X
+nullRatio=0.9, contiguous 50%                                   6              6           0        175.9           5.7       0.2X
+nullRatio=0.0, alt 1000-row windows                             3              3           0        354.1           2.8       0.4X
+nullRatio=0.3, alt 1000-row windows                            11             11           0         97.1          10.3       0.1X
+nullRatio=0.9, alt 1000-row windows                             8              8           0        133.1           7.5       0.1X
 
 
 ================================================================================================
 Nullable batch decode with row-index filtering (without def-levels)
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Nullable batch without def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                      1              1           0        865.3           1.2       1.0X
-nullRatio=0.3, contiguous 50%                                      8              8           0        127.6           7.8       0.1X
-nullRatio=0.9, contiguous 50%                                      6              6           0        174.1           5.7       0.2X
-nullRatio=0.0, alt 1000-row windows                                2              2           0        425.3           2.4       0.5X
-nullRatio=0.3, alt 1000-row windows                                9             10           0        110.5           9.1       0.1X
-nullRatio=0.9, alt 1000-row windows                                7              7           0        143.3           7.0       0.2X
+nullRatio=0.0, contiguous 50%                                      1              1           0        897.4           1.1       1.0X
+nullRatio=0.3, contiguous 50%                                      8              8           0        139.1           7.2       0.2X
+nullRatio=0.9, contiguous 50%                                      5              5           0        205.9           4.9       0.2X
+nullRatio=0.0, alt 1000-row windows                                3              3           0        383.7           2.6       0.4X
+nullRatio=0.3, alt 1000-row windows                                9              9           1        114.4           8.7       0.1X
+nullRatio=0.9, alt 1000-row windows                                7              7           0        156.7           6.4       0.2X
 
 
 ================================================================================================
 Single-value reads
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBoolean                                           4              4           1        272.0           3.7       1.0X
-readInteger, bitWidth=4                               4              4           0        274.0           3.6       1.0X
-readValueDictionaryId, bitWidth=4                     4              4           0        275.2           3.6       1.0X
-readInteger, bitWidth=8                               4              4           0        272.3           3.7       1.0X
-readValueDictionaryId, bitWidth=8                     4              4           0        273.4           3.7       1.0X
-readInteger, bitWidth=12                              5              5           0        228.2           4.4       0.8X
-readValueDictionaryId, bitWidth=12                    5              5           0        228.9           4.4       0.8X
-readInteger, bitWidth=20                              5              5           0        204.3           4.9       0.8X
-readValueDictionaryId, bitWidth=20                    5              5           0        205.5           4.9       0.8X
+readBoolean                                           3              3           0        381.0           2.6       1.0X
+readInteger, bitWidth=4                               3              3           0        360.2           2.8       0.9X
+readValueDictionaryId, bitWidth=4                     3              3           0        360.2           2.8       0.9X
+readInteger, bitWidth=8                               3              3           0        356.1           2.8       0.9X
+readValueDictionaryId, bitWidth=8                     3              3           0        356.1           2.8       0.9X
+readInteger, bitWidth=12                              4              4           0        282.2           3.5       0.7X
+readValueDictionaryId, bitWidth=12                    4              4           0        282.2           3.5       0.7X
+readInteger, bitWidth=20                              4              4           0        242.4           4.1       0.6X
+readValueDictionaryId, bitWidth=20                    4              4           0        242.4           4.1       0.6X
 
 
 ================================================================================================
 Skip
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-skipBooleans, trueRatio=0.0                           0              0           0   21399510.2           0.0       1.0X
-skipBooleans, trueRatio=0.5                           2              2           0        536.1           1.9       0.0X
-skipBooleans, trueRatio=1.0                           0              0           0   21399510.2           0.0       1.0X
-skipIntegers PACKED, bitWidth=4                       2              2           0        502.5           2.0       0.0X
-skipIntegers RLE, bitWidth=4                          0              0           0   20971520.0           0.0       1.0X
-skipIntegers PACKED, bitWidth=8                       2              2           0        497.5           2.0       0.0X
-skipIntegers RLE, bitWidth=8                          0              0           0   21399510.2           0.0       1.0X
-skipIntegers PACKED, bitWidth=12                      3              3           0        367.9           2.7       0.0X
-skipIntegers RLE, bitWidth=12                         0              0           0   17476266.7           0.0       0.8X
-skipIntegers PACKED, bitWidth=20                      3              3           0        310.9           3.2       0.0X
-skipIntegers RLE, bitWidth=20                         0              0           0   17476266.7           0.0       0.8X
+skipBooleans, trueRatio=0.0                           0              0           0   17476266.7           0.0       1.0X
+skipBooleans, trueRatio=0.5                           1              1           0       1179.4           0.8       0.0X
+skipBooleans, trueRatio=1.0                           0              0           0   17476266.7           0.0       1.0X
+skipIntegers PACKED, bitWidth=4                       1              1           0        996.4           1.0       0.0X
+skipIntegers RLE, bitWidth=4                          0              0           0   17476266.7           0.0       1.0X
+skipIntegers PACKED, bitWidth=8                       1              1           0        958.3           1.0       0.0X
+skipIntegers RLE, bitWidth=8                          0              0           0   17476266.7           0.0       1.0X
+skipIntegers PACKED, bitWidth=12                      2              2           0        565.4           1.8       0.0X
+skipIntegers RLE, bitWidth=12                         0              0           0   17476266.7           0.0       1.0X
+skipIntegers PACKED, bitWidth=20                      2              2           0        424.7           2.4       0.0X
+skipIntegers RLE, bitWidth=20                         0              0           0   17476266.7           0.0       1.0X
 
 

--- a/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-results.txt
+++ b/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-results.txt
@@ -6,16 +6,16 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 RLE readBooleans decode:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cold reader, trueRatio=0.0                            0              0           0      45600.2           0.0       1.0X
-reused reader, trueRatio=0.0                          0              0           0      45622.0           0.0       1.0X
-cold reader, trueRatio=0.1                            1              1           0        979.6           1.0       0.0X
-reused reader, trueRatio=0.1                          1              1           0        974.6           1.0       0.0X
-cold reader, trueRatio=0.5                            1              1           0       1195.1           0.8       0.0X
-reused reader, trueRatio=0.5                          1              1           0       1193.2           0.8       0.0X
-cold reader, trueRatio=0.9                            1              1           0        979.2           1.0       0.0X
-reused reader, trueRatio=0.9                          1              1           0        976.7           1.0       0.0X
-cold reader, trueRatio=1.0                            0              0           0      45622.0           0.0       1.0X
-reused reader, trueRatio=1.0                          0              0           0      45641.9           0.0       1.0X
+cold reader, trueRatio=0.0                            0              0           0      29460.2           0.0       1.0X
+reused reader, trueRatio=0.0                          0              0           0      29468.5           0.0       1.0X
+cold reader, trueRatio=0.1                            1              1           0       1156.1           0.9       0.0X
+reused reader, trueRatio=0.1                          1              1           0       1157.6           0.9       0.0X
+cold reader, trueRatio=0.5                            1              1           0       1397.7           0.7       0.0X
+reused reader, trueRatio=0.5                          1              1           0       1398.1           0.7       0.0X
+cold reader, trueRatio=0.9                            1              1           0       1162.3           0.9       0.0X
+reused reader, trueRatio=0.9                          1              1           0       1162.0           0.9       0.0X
+cold reader, trueRatio=1.0                            0              0           0      29468.5           0.0       1.0X
+reused reader, trueRatio=1.0                          0              0           0      29467.6           0.0       1.0X
 
 
 ================================================================================================
@@ -26,18 +26,18 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 RLE readIntegers dictionary-id decode:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-PACKED cold, bitWidth=4                               1              1           0        928.0           1.1       1.0X
-PACKED reused, bitWidth=4                             1              1           0        920.4           1.1       1.0X
-RLE, bitWidth=4                                       0              0           0      18164.7           0.1      19.6X
-PACKED cold, bitWidth=8                               1              1           0        892.8           1.1       1.0X
-PACKED reused, bitWidth=8                             1              1           0        890.0           1.1       1.0X
-RLE, bitWidth=8                                       0              0           0      19022.5           0.1      20.5X
-PACKED cold, bitWidth=12                              2              2           0        514.3           1.9       0.6X
-PACKED reused, bitWidth=12                            2              2           0        512.0           2.0       0.6X
-RLE, bitWidth=12                                      0              0           0      18189.6           0.1      19.6X
-PACKED cold, bitWidth=20                              3              3           0        410.0           2.4       0.4X
-PACKED reused, bitWidth=20                            3              3           0        408.9           2.4       0.4X
-RLE, bitWidth=20                                      0              0           0      18173.8           0.1      19.6X
+PACKED cold, bitWidth=4                               1              1           0       1228.0           0.8       1.0X
+PACKED reused, bitWidth=4                             1              1           0       1212.0           0.8       1.0X
+RLE, bitWidth=4                                       0              0           0      23370.8           0.0      19.0X
+PACKED cold, bitWidth=8                               1              1           0       1179.1           0.8       1.0X
+PACKED reused, bitWidth=8                             1              1           0       1165.0           0.9       0.9X
+RLE, bitWidth=8                                       0              0           0      23412.0           0.0      19.1X
+PACKED cold, bitWidth=12                              2              2           0        671.5           1.5       0.5X
+PACKED reused, bitWidth=12                            2              2           0        666.9           1.5       0.5X
+RLE, bitWidth=12                                      0              0           0      23427.7           0.0      19.1X
+PACKED cold, bitWidth=20                              2              2           0        535.2           1.9       0.4X
+PACKED reused, bitWidth=20                            2              2           0        532.1           1.9       0.4X
+RLE, bitWidth=20                                      0              0           0      23422.4           0.0      19.1X
 
 
 ================================================================================================
@@ -48,16 +48,16 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Nullable batch with def-levels:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       5957.0           0.2       1.0X
-nullRatio=0.1, random                                12             12           0         88.9          11.2       0.0X
-nullRatio=0.1, clustered                              9              9           0        118.8           8.4       0.0X
-nullRatio=0.3, random                                16             16           0         64.0          15.6       0.0X
-nullRatio=0.3, clustered                              9              9           0        121.0           8.3       0.0X
-nullRatio=0.5, random                                18             18           0         58.0          17.2       0.0X
-nullRatio=0.5, clustered                              8              8           0        124.1           8.1       0.0X
-nullRatio=0.9, random                                10             10           0        100.7           9.9       0.0X
-nullRatio=0.9, clustered                              8              8           0        135.6           7.4       0.0X
-nullRatio=1.0, random                                 0              0           0      14250.6           0.1       2.4X
+nullRatio=0.0, n/a                                    0              0           0       7869.8           0.1       1.0X
+nullRatio=0.1, random                                 7              7           0        142.7           7.0       0.0X
+nullRatio=0.1, clustered                              5              5           0        219.4           4.6       0.0X
+nullRatio=0.3, random                                11             11           1         95.4          10.5       0.0X
+nullRatio=0.3, clustered                              5              5           0        222.2           4.5       0.0X
+nullRatio=0.5, random                                12             12           0         85.7          11.7       0.0X
+nullRatio=0.5, clustered                              5              5           0        227.7           4.4       0.0X
+nullRatio=0.9, random                                 6              6           0        165.4           6.0       0.0X
+nullRatio=0.9, clustered                              4              4           0        254.2           3.9       0.0X
+nullRatio=1.0, random                                 0              0           0       9536.3           0.1       1.2X
 
 
 ================================================================================================
@@ -68,16 +68,16 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Nullable batch without def-levels:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       9361.5           0.1       1.0X
-nullRatio=0.1, random                                 9              9           0        113.4           8.8       0.0X
-nullRatio=0.1, clustered                              7              7           0        152.9           6.5       0.0X
-nullRatio=0.3, random                                13             13           0         81.0          12.4       0.0X
-nullRatio=0.3, clustered                              7              7           1        155.7           6.4       0.0X
-nullRatio=0.5, random                                14             14           0         75.1          13.3       0.0X
-nullRatio=0.5, clustered                              7              7           0        160.1           6.2       0.0X
-nullRatio=0.9, random                                 8              8           0        131.9           7.6       0.0X
-nullRatio=0.9, clustered                              6              6           0        175.8           5.7       0.0X
-nullRatio=1.0, random                                 0              0           0      34738.3           0.0       3.7X
+nullRatio=0.0, n/a                                    0              0           0      12214.0           0.1       1.0X
+nullRatio=0.1, random                                 6              6           0        187.4           5.3       0.0X
+nullRatio=0.1, clustered                              4              4           0        288.5           3.5       0.0X
+nullRatio=0.3, random                                 8              9           0        123.4           8.1       0.0X
+nullRatio=0.3, clustered                              4              4           0        292.7           3.4       0.0X
+nullRatio=0.5, random                                 9             10           0        110.7           9.0       0.0X
+nullRatio=0.5, clustered                              4              4           0        299.1           3.3       0.0X
+nullRatio=0.9, random                                 5              5           0        221.8           4.5       0.0X
+nullRatio=0.9, clustered                              3              3           0        335.9           3.0       0.0X
+nullRatio=1.0, random                                 0              0           0      13375.0           0.1       1.1X
 
 
 ================================================================================================
@@ -88,12 +88,12 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Nullable batch with def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                   1              1           0        955.1           1.0       1.0X
-nullRatio=0.3, contiguous 50%                                  11             11           0         93.4          10.7       0.1X
-nullRatio=0.9, contiguous 50%                                   8              8           0        127.8           7.8       0.1X
-nullRatio=0.0, alt 1000-row windows                             3              3           0        333.5           3.0       0.3X
-nullRatio=0.3, alt 1000-row windows                            13             13           0         78.6          12.7       0.1X
-nullRatio=0.9, alt 1000-row windows                            10             10           0        102.0           9.8       0.1X
+nullRatio=0.0, contiguous 50%                                   1              1           0       1264.2           0.8       1.0X
+nullRatio=0.3, contiguous 50%                                   7              7           0        149.7           6.7       0.1X
+nullRatio=0.9, contiguous 50%                                   5              5           0        224.2           4.5       0.2X
+nullRatio=0.0, alt 1000-row windows                             2              2           0        480.5           2.1       0.4X
+nullRatio=0.3, alt 1000-row windows                             8              8           0        125.4           8.0       0.1X
+nullRatio=0.9, alt 1000-row windows                             6              6           0        172.5           5.8       0.1X
 
 
 ================================================================================================
@@ -104,12 +104,12 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Nullable batch without def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                      1              1           0        890.6           1.1       1.0X
-nullRatio=0.3, contiguous 50%                                     10             10           0        105.9           9.4       0.1X
-nullRatio=0.9, contiguous 50%                                      7              7           0        141.5           7.1       0.2X
-nullRatio=0.0, alt 1000-row windows                                3              3           0        337.2           3.0       0.4X
-nullRatio=0.3, alt 1000-row windows                               12             12           0         87.7          11.4       0.1X
-nullRatio=0.9, alt 1000-row windows                                9              9           0        111.7           8.9       0.1X
+nullRatio=0.0, contiguous 50%                                      1              1           0       1001.4           1.0       1.0X
+nullRatio=0.3, contiguous 50%                                      6              6           0        180.8           5.5       0.2X
+nullRatio=0.9, contiguous 50%                                      4              4           0        264.2           3.8       0.3X
+nullRatio=0.0, alt 1000-row windows                                2              2           0        495.4           2.0       0.5X
+nullRatio=0.3, alt 1000-row windows                                7              7           0        148.4           6.7       0.1X
+nullRatio=0.9, alt 1000-row windows                                5              5           0        200.4           5.0       0.2X
 
 
 ================================================================================================
@@ -120,15 +120,15 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBoolean                                           5              5           0        203.2           4.9       1.0X
-readInteger, bitWidth=4                               3              3           0        360.8           2.8       1.8X
-readValueDictionaryId, bitWidth=4                     3              3           0        360.6           2.8       1.8X
-readInteger, bitWidth=8                               3              3           0        356.0           2.8       1.8X
-readValueDictionaryId, bitWidth=8                     3              3           0        356.0           2.8       1.8X
-readInteger, bitWidth=12                              4              4           0        274.8           3.6       1.4X
-readValueDictionaryId, bitWidth=12                    4              4           0        274.9           3.6       1.4X
-readInteger, bitWidth=20                              4              4           0        242.4           4.1       1.2X
-readValueDictionaryId, bitWidth=20                    4              4           0        242.4           4.1       1.2X
+readBoolean                                           2              2           0        466.6           2.1       1.0X
+readInteger, bitWidth=4                               2              2           0        465.1           2.1       1.0X
+readValueDictionaryId, bitWidth=4                     2              2           0        465.1           2.1       1.0X
+readInteger, bitWidth=8                               2              2           0        459.2           2.2       1.0X
+readValueDictionaryId, bitWidth=8                     2              2           0        459.2           2.2       1.0X
+readInteger, bitWidth=12                              3              3           0        356.1           2.8       0.8X
+readValueDictionaryId, bitWidth=12                    3              3           0        355.9           2.8       0.8X
+readInteger, bitWidth=20                              3              3           0        312.8           3.2       0.7X
+readValueDictionaryId, bitWidth=20                    3              3           0        313.0           3.2       0.7X
 
 
 ================================================================================================
@@ -139,16 +139,16 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-skipBooleans, trueRatio=0.0                           0              0           0   17476266.7           0.0       1.0X
-skipBooleans, trueRatio=0.5                           3              3           0        327.5           3.1       0.0X
-skipBooleans, trueRatio=1.0                           0              0           0   17476266.7           0.0       1.0X
-skipIntegers PACKED, bitWidth=4                       1              1           0        996.7           1.0       0.0X
-skipIntegers RLE, bitWidth=4                          0              0           0   17476266.7           0.0       1.0X
-skipIntegers PACKED, bitWidth=8                       1              1           0        958.2           1.0       0.0X
-skipIntegers RLE, bitWidth=8                          0              0           0   17476266.7           0.0       1.0X
-skipIntegers PACKED, bitWidth=12                      2              2           0        538.9           1.9       0.0X
-skipIntegers RLE, bitWidth=12                         0              0           0   17476266.7           0.0       1.0X
-skipIntegers PACKED, bitWidth=20                      2              2           0        424.9           2.4       0.0X
-skipIntegers RLE, bitWidth=20                         0              0           0   17476266.7           0.0       1.0X
+skipBooleans, trueRatio=0.0                           0              0           0   26214400.0           0.0       1.0X
+skipBooleans, trueRatio=0.5                           1              1           0       1518.8           0.7       0.0X
+skipBooleans, trueRatio=1.0                           0              0           0   26214400.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=4                       1              1           0       1291.1           0.8       0.0X
+skipIntegers RLE, bitWidth=4                          0              0           0   26214400.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=8                       1              1           0       1243.4           0.8       0.0X
+skipIntegers RLE, bitWidth=8                          0              0           0   26214400.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=12                      2              2           0        695.3           1.4       0.0X
+skipIntegers RLE, bitWidth=12                         0              0           0   26214400.0           0.0       1.0X
+skipIntegers PACKED, bitWidth=20                      2              2           0        549.1           1.8       0.0X
+skipIntegers RLE, bitWidth=20                         0              0           0   20971520.0           0.0       0.8X
 
 

--- a/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-results.txt
+++ b/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-results.txt
@@ -6,16 +6,16 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 RLE readBooleans decode:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cold reader, trueRatio=0.0                            0              0           0      29460.2           0.0       1.0X
-reused reader, trueRatio=0.0                          0              0           0      29468.5           0.0       1.0X
-cold reader, trueRatio=0.1                            1              1           0       1156.1           0.9       0.0X
-reused reader, trueRatio=0.1                          1              1           0       1157.6           0.9       0.0X
-cold reader, trueRatio=0.5                            1              1           0       1397.7           0.7       0.0X
-reused reader, trueRatio=0.5                          1              1           0       1398.1           0.7       0.0X
-cold reader, trueRatio=0.9                            1              1           0       1162.3           0.9       0.0X
-reused reader, trueRatio=0.9                          1              1           0       1162.0           0.9       0.0X
-cold reader, trueRatio=1.0                            0              0           0      29468.5           0.0       1.0X
-reused reader, trueRatio=1.0                          0              0           0      29467.6           0.0       1.0X
+cold reader, trueRatio=0.0                            0              0           0      22367.2           0.0       1.0X
+reused reader, trueRatio=0.0                          0              0           0      22687.1           0.0       1.0X
+cold reader, trueRatio=0.1                            1              1           0        978.7           1.0       0.0X
+reused reader, trueRatio=0.1                          1              1           0        980.9           1.0       0.0X
+cold reader, trueRatio=0.5                            1              1           0       1189.6           0.8       0.1X
+reused reader, trueRatio=0.5                          1              1           0       1186.0           0.8       0.1X
+cold reader, trueRatio=0.9                            1              1           0        978.3           1.0       0.0X
+reused reader, trueRatio=0.9                          1              1           0        969.1           1.0       0.0X
+cold reader, trueRatio=1.0                            0              0           0      22671.9           0.0       1.0X
+reused reader, trueRatio=1.0                          0              0           0      22676.8           0.0       1.0X
 
 
 ================================================================================================
@@ -26,18 +26,18 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 RLE readIntegers dictionary-id decode:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-PACKED cold, bitWidth=4                               1              1           0       1228.0           0.8       1.0X
-PACKED reused, bitWidth=4                             1              1           0       1212.0           0.8       1.0X
-RLE, bitWidth=4                                       0              0           0      23370.8           0.0      19.0X
-PACKED cold, bitWidth=8                               1              1           0       1179.1           0.8       1.0X
-PACKED reused, bitWidth=8                             1              1           0       1165.0           0.9       0.9X
-RLE, bitWidth=8                                       0              0           0      23412.0           0.0      19.1X
-PACKED cold, bitWidth=12                              2              2           0        671.5           1.5       0.5X
-PACKED reused, bitWidth=12                            2              2           0        666.9           1.5       0.5X
-RLE, bitWidth=12                                      0              0           0      23427.7           0.0      19.1X
-PACKED cold, bitWidth=20                              2              2           0        535.2           1.9       0.4X
-PACKED reused, bitWidth=20                            2              2           0        532.1           1.9       0.4X
-RLE, bitWidth=20                                      0              0           0      23422.4           0.0      19.1X
+PACKED cold, bitWidth=4                               1              1           0        927.1           1.1       1.0X
+PACKED reused, bitWidth=4                             1              1           0        920.3           1.1       1.0X
+RLE, bitWidth=4                                       0              0           0      18151.8           0.1      19.6X
+PACKED cold, bitWidth=8                               1              1           0        885.8           1.1       1.0X
+PACKED reused, bitWidth=8                             1              1           0        888.7           1.1       1.0X
+RLE, bitWidth=8                                       0              0           0      18161.2           0.1      19.6X
+PACKED cold, bitWidth=12                              2              2           0        513.9           1.9       0.6X
+PACKED reused, bitWidth=12                            2              2           0        510.1           2.0       0.6X
+RLE, bitWidth=12                                      0              0           0      18145.2           0.1      19.6X
+PACKED cold, bitWidth=20                              3              3           0        411.0           2.4       0.4X
+PACKED reused, bitWidth=20                            3              3           0        410.3           2.4       0.4X
+RLE, bitWidth=20                                      0              0           0      18205.4           0.1      19.6X
 
 
 ================================================================================================
@@ -48,16 +48,16 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Nullable batch with def-levels:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       7869.8           0.1       1.0X
-nullRatio=0.1, random                                 7              7           0        142.7           7.0       0.0X
-nullRatio=0.1, clustered                              5              5           0        219.4           4.6       0.0X
-nullRatio=0.3, random                                11             11           1         95.4          10.5       0.0X
-nullRatio=0.3, clustered                              5              5           0        222.2           4.5       0.0X
-nullRatio=0.5, random                                12             12           0         85.7          11.7       0.0X
-nullRatio=0.5, clustered                              5              5           0        227.7           4.4       0.0X
-nullRatio=0.9, random                                 6              6           0        165.4           6.0       0.0X
-nullRatio=0.9, clustered                              4              4           0        254.2           3.9       0.0X
-nullRatio=1.0, random                                 0              0           0       9536.3           0.1       1.2X
+nullRatio=0.0, n/a                                    0              0           0       5914.9           0.2       1.0X
+nullRatio=0.1, random                                 9             10           0        110.8           9.0       0.0X
+nullRatio=0.1, clustered                              6              6           0        164.9           6.1       0.0X
+nullRatio=0.3, random                                14             14           0         74.9          13.3       0.0X
+nullRatio=0.3, clustered                              6              6           0        167.6           6.0       0.0X
+nullRatio=0.5, random                                16             16           0         66.4          15.1       0.0X
+nullRatio=0.5, clustered                              6              6           0        172.2           5.8       0.0X
+nullRatio=0.9, random                                 8              8           0        129.0           7.8       0.0X
+nullRatio=0.9, clustered                              5              5           0        193.4           5.2       0.0X
+nullRatio=1.0, random                                 0              0           0      10909.6           0.1       1.8X
 
 
 ================================================================================================
@@ -68,16 +68,16 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Nullable batch without def-levels:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0      12214.0           0.1       1.0X
-nullRatio=0.1, random                                 6              6           0        187.4           5.3       0.0X
-nullRatio=0.1, clustered                              4              4           0        288.5           3.5       0.0X
-nullRatio=0.3, random                                 8              9           0        123.4           8.1       0.0X
-nullRatio=0.3, clustered                              4              4           0        292.7           3.4       0.0X
-nullRatio=0.5, random                                 9             10           0        110.7           9.0       0.0X
-nullRatio=0.5, clustered                              4              4           0        299.1           3.3       0.0X
-nullRatio=0.9, random                                 5              5           0        221.8           4.5       0.0X
-nullRatio=0.9, clustered                              3              3           0        335.9           3.0       0.0X
-nullRatio=1.0, random                                 0              0           0      13375.0           0.1       1.1X
+nullRatio=0.0, n/a                                    0              0           0       9217.3           0.1       1.0X
+nullRatio=0.1, random                                 8              8           0        138.2           7.2       0.0X
+nullRatio=0.1, clustered                              5              5           0        209.1           4.8       0.0X
+nullRatio=0.3, random                                11             11           0         92.1          10.9       0.0X
+nullRatio=0.3, clustered                              5              5           0        214.9           4.7       0.0X
+nullRatio=0.5, random                                12             13           0         84.2          11.9       0.0X
+nullRatio=0.5, clustered                              5              5           0        223.2           4.5       0.0X
+nullRatio=0.9, random                                 6              6           0        168.3           5.9       0.0X
+nullRatio=0.9, clustered                              4              4           0        258.3           3.9       0.0X
+nullRatio=1.0, random                                 0              0           0      19977.1           0.1       2.2X
 
 
 ================================================================================================
@@ -88,12 +88,12 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Nullable batch with def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                   1              1           0       1264.2           0.8       1.0X
-nullRatio=0.3, contiguous 50%                                   7              7           0        149.7           6.7       0.1X
-nullRatio=0.9, contiguous 50%                                   5              5           0        224.2           4.5       0.2X
-nullRatio=0.0, alt 1000-row windows                             2              2           0        480.5           2.1       0.4X
-nullRatio=0.3, alt 1000-row windows                             8              8           0        125.4           8.0       0.1X
-nullRatio=0.9, alt 1000-row windows                             6              6           0        172.5           5.8       0.1X
+nullRatio=0.0, contiguous 50%                                   1              1           0        956.2           1.0       1.0X
+nullRatio=0.3, contiguous 50%                                   9              9           0        117.7           8.5       0.1X
+nullRatio=0.9, contiguous 50%                                   6              6           0        175.8           5.7       0.2X
+nullRatio=0.0, alt 1000-row windows                             3              3           0        352.6           2.8       0.4X
+nullRatio=0.3, alt 1000-row windows                            11             11           0         97.2          10.3       0.1X
+nullRatio=0.9, alt 1000-row windows                             8              8           0        132.9           7.5       0.1X
 
 
 ================================================================================================
@@ -104,12 +104,12 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Nullable batch without def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                      1              1           0       1001.4           1.0       1.0X
-nullRatio=0.3, contiguous 50%                                      6              6           0        180.8           5.5       0.2X
-nullRatio=0.9, contiguous 50%                                      4              4           0        264.2           3.8       0.3X
-nullRatio=0.0, alt 1000-row windows                                2              2           0        495.4           2.0       0.5X
-nullRatio=0.3, alt 1000-row windows                                7              7           0        148.4           6.7       0.1X
-nullRatio=0.9, alt 1000-row windows                                5              5           0        200.4           5.0       0.2X
+nullRatio=0.0, contiguous 50%                                      1              1           0        898.8           1.1       1.0X
+nullRatio=0.3, contiguous 50%                                      8              8           0        137.1           7.3       0.2X
+nullRatio=0.9, contiguous 50%                                      5              5           0        203.1           4.9       0.2X
+nullRatio=0.0, alt 1000-row windows                                3              3           0        383.6           2.6       0.4X
+nullRatio=0.3, alt 1000-row windows                                9              9           0        113.1           8.8       0.1X
+nullRatio=0.9, alt 1000-row windows                                7              7           0        154.9           6.5       0.2X
 
 
 ================================================================================================
@@ -120,15 +120,15 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBoolean                                           2              2           0        466.6           2.1       1.0X
-readInteger, bitWidth=4                               2              2           0        465.1           2.1       1.0X
-readValueDictionaryId, bitWidth=4                     2              2           0        465.1           2.1       1.0X
-readInteger, bitWidth=8                               2              2           0        459.2           2.2       1.0X
-readValueDictionaryId, bitWidth=8                     2              2           0        459.2           2.2       1.0X
-readInteger, bitWidth=12                              3              3           0        356.1           2.8       0.8X
-readValueDictionaryId, bitWidth=12                    3              3           0        355.9           2.8       0.8X
-readInteger, bitWidth=20                              3              3           0        312.8           3.2       0.7X
-readValueDictionaryId, bitWidth=20                    3              3           0        313.0           3.2       0.7X
+readBoolean                                           3              3           0        380.1           2.6       1.0X
+readInteger, bitWidth=4                               3              3           0        360.5           2.8       0.9X
+readValueDictionaryId, bitWidth=4                     3              3           0        360.1           2.8       0.9X
+readInteger, bitWidth=8                               3              3           0        355.9           2.8       0.9X
+readValueDictionaryId, bitWidth=8                     3              3           0        355.9           2.8       0.9X
+readInteger, bitWidth=12                              4              4           0        274.6           3.6       0.7X
+readValueDictionaryId, bitWidth=12                    4              4           0        275.2           3.6       0.7X
+readInteger, bitWidth=20                              4              4           0        242.3           4.1       0.6X
+readValueDictionaryId, bitWidth=20                    4              4           0        242.4           4.1       0.6X
 
 
 ================================================================================================
@@ -139,16 +139,16 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-skipBooleans, trueRatio=0.0                           0              0           0   26214400.0           0.0       1.0X
-skipBooleans, trueRatio=0.5                           1              1           0       1518.8           0.7       0.0X
-skipBooleans, trueRatio=1.0                           0              0           0   26214400.0           0.0       1.0X
-skipIntegers PACKED, bitWidth=4                       1              1           0       1291.1           0.8       0.0X
-skipIntegers RLE, bitWidth=4                          0              0           0   26214400.0           0.0       1.0X
-skipIntegers PACKED, bitWidth=8                       1              1           0       1243.4           0.8       0.0X
-skipIntegers RLE, bitWidth=8                          0              0           0   26214400.0           0.0       1.0X
-skipIntegers PACKED, bitWidth=12                      2              2           0        695.3           1.4       0.0X
-skipIntegers RLE, bitWidth=12                         0              0           0   26214400.0           0.0       1.0X
-skipIntegers PACKED, bitWidth=20                      2              2           0        549.1           1.8       0.0X
-skipIntegers RLE, bitWidth=20                         0              0           0   20971520.0           0.0       0.8X
+skipBooleans, trueRatio=0.0                           0              0           0   17476266.7           0.0       1.0X
+skipBooleans, trueRatio=0.5                           1              1           0       1184.0           0.8       0.0X
+skipBooleans, trueRatio=1.0                           0              0           0   17476266.7           0.0       1.0X
+skipIntegers PACKED, bitWidth=4                       1              1           0        998.2           1.0       0.0X
+skipIntegers RLE, bitWidth=4                          0              0           0   17476266.7           0.0       1.0X
+skipIntegers PACKED, bitWidth=8                       1              1           0        958.0           1.0       0.0X
+skipIntegers RLE, bitWidth=8                          0              0           0   17476266.7           0.0       1.0X
+skipIntegers PACKED, bitWidth=12                      2              2           0        537.9           1.9       0.0X
+skipIntegers RLE, bitWidth=12                         0              0           0   17476266.7           0.0       1.0X
+skipIntegers PACKED, bitWidth=20                      2              2           0        424.8           2.4       0.0X
+skipIntegers RLE, bitWidth=20                         0              0           0   17476266.7           0.0       1.0X
 
 

--- a/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-results.txt
+++ b/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-results.txt
@@ -6,16 +6,16 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 RLE readBooleans decode:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cold reader, trueRatio=0.0                            0              0           0      11467.6           0.1       1.0X
-reused reader, trueRatio=0.0                          0              0           0      11358.1           0.1       1.0X
-cold reader, trueRatio=0.1                            1              1           0        990.0           1.0       0.1X
-reused reader, trueRatio=0.1                          1              1           0        987.7           1.0       0.1X
-cold reader, trueRatio=0.5                            1              1           0       1201.3           0.8       0.1X
-reused reader, trueRatio=0.5                          1              1           0       1193.8           0.8       0.1X
-cold reader, trueRatio=0.9                            1              1           0        989.5           1.0       0.1X
-reused reader, trueRatio=0.9                          1              1           0        988.0           1.0       0.1X
-cold reader, trueRatio=1.0                            0              0           0      11358.2           0.1       1.0X
-reused reader, trueRatio=1.0                          0              0           0      11359.4           0.1       1.0X
+cold reader, trueRatio=0.0                            0              0           0      45600.2           0.0       1.0X
+reused reader, trueRatio=0.0                          0              0           0      45622.0           0.0       1.0X
+cold reader, trueRatio=0.1                            1              1           0        979.6           1.0       0.0X
+reused reader, trueRatio=0.1                          1              1           0        974.6           1.0       0.0X
+cold reader, trueRatio=0.5                            1              1           0       1195.1           0.8       0.0X
+reused reader, trueRatio=0.5                          1              1           0       1193.2           0.8       0.0X
+cold reader, trueRatio=0.9                            1              1           0        979.2           1.0       0.0X
+reused reader, trueRatio=0.9                          1              1           0        976.7           1.0       0.0X
+cold reader, trueRatio=1.0                            0              0           0      45622.0           0.0       1.0X
+reused reader, trueRatio=1.0                          0              0           0      45641.9           0.0       1.0X
 
 
 ================================================================================================
@@ -26,18 +26,18 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 RLE readIntegers dictionary-id decode:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-PACKED cold, bitWidth=4                               1              1           0        929.3           1.1       1.0X
-PACKED reused, bitWidth=4                             1              1           0        923.5           1.1       1.0X
-RLE, bitWidth=4                                       0              0           0      18214.9           0.1      19.6X
-PACKED cold, bitWidth=8                               1              1           0        894.4           1.1       1.0X
-PACKED reused, bitWidth=8                             1              1           0        891.0           1.1       1.0X
-RLE, bitWidth=8                                       0              0           0      18202.2           0.1      19.6X
-PACKED cold, bitWidth=12                              2              2           0        540.4           1.9       0.6X
-PACKED reused, bitWidth=12                            2              2           0        537.7           1.9       0.6X
-RLE, bitWidth=12                                      0              0           0      18205.4           0.1      19.6X
-PACKED cold, bitWidth=20                              3              3           0        411.0           2.4       0.4X
-PACKED reused, bitWidth=20                            3              3           0        410.0           2.4       0.4X
-RLE, bitWidth=20                                      0              0           0      18919.2           0.1      20.4X
+PACKED cold, bitWidth=4                               1              1           0        928.0           1.1       1.0X
+PACKED reused, bitWidth=4                             1              1           0        920.4           1.1       1.0X
+RLE, bitWidth=4                                       0              0           0      18164.7           0.1      19.6X
+PACKED cold, bitWidth=8                               1              1           0        892.8           1.1       1.0X
+PACKED reused, bitWidth=8                             1              1           0        890.0           1.1       1.0X
+RLE, bitWidth=8                                       0              0           0      19022.5           0.1      20.5X
+PACKED cold, bitWidth=12                              2              2           0        514.3           1.9       0.6X
+PACKED reused, bitWidth=12                            2              2           0        512.0           2.0       0.6X
+RLE, bitWidth=12                                      0              0           0      18189.6           0.1      19.6X
+PACKED cold, bitWidth=20                              3              3           0        410.0           2.4       0.4X
+PACKED reused, bitWidth=20                            3              3           0        408.9           2.4       0.4X
+RLE, bitWidth=20                                      0              0           0      18173.8           0.1      19.6X
 
 
 ================================================================================================
@@ -48,16 +48,16 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Nullable batch with def-levels:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       5915.9           0.2       1.0X
-nullRatio=0.1, random                                10             10           0        110.2           9.1       0.0X
-nullRatio=0.1, clustered                              6              6           0        162.6           6.2       0.0X
-nullRatio=0.3, random                                14             14           0         74.6          13.4       0.0X
-nullRatio=0.3, clustered                              6              6           0        166.0           6.0       0.0X
-nullRatio=0.5, random                                16             16           0         66.6          15.0       0.0X
-nullRatio=0.5, clustered                              6              6           0        170.7           5.9       0.0X
-nullRatio=0.9, random                                 8              8           0        129.7           7.7       0.0X
-nullRatio=0.9, clustered                              5              5           0        194.9           5.1       0.0X
-nullRatio=1.0, random                                 0              0           0       7422.3           0.1       1.3X
+nullRatio=0.0, n/a                                    0              0           0       5957.0           0.2       1.0X
+nullRatio=0.1, random                                12             12           0         88.9          11.2       0.0X
+nullRatio=0.1, clustered                              9              9           0        118.8           8.4       0.0X
+nullRatio=0.3, random                                16             16           0         64.0          15.6       0.0X
+nullRatio=0.3, clustered                              9              9           0        121.0           8.3       0.0X
+nullRatio=0.5, random                                18             18           0         58.0          17.2       0.0X
+nullRatio=0.5, clustered                              8              8           0        124.1           8.1       0.0X
+nullRatio=0.9, random                                10             10           0        100.7           9.9       0.0X
+nullRatio=0.9, clustered                              8              8           0        135.6           7.4       0.0X
+nullRatio=1.0, random                                 0              0           0      14250.6           0.1       2.4X
 
 
 ================================================================================================
@@ -68,16 +68,16 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Nullable batch without def-levels:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       9190.6           0.1       1.0X
-nullRatio=0.1, random                                 7              7           0        152.3           6.6       0.0X
-nullRatio=0.1, clustered                              4              5           0        234.4           4.3       0.0X
-nullRatio=0.3, random                                11             11           0         98.4          10.2       0.0X
-nullRatio=0.3, clustered                              4              4           0        239.9           4.2       0.0X
-nullRatio=0.5, random                                12             12           1         89.6          11.2       0.0X
-nullRatio=0.5, clustered                              4              4           0        249.7           4.0       0.0X
-nullRatio=0.9, random                                 6              6           0        185.3           5.4       0.0X
-nullRatio=0.9, clustered                              4              4           0        291.0           3.4       0.0X
-nullRatio=1.0, random                                 0              0           0      10413.7           0.1       1.1X
+nullRatio=0.0, n/a                                    0              0           0       9361.5           0.1       1.0X
+nullRatio=0.1, random                                 9              9           0        113.4           8.8       0.0X
+nullRatio=0.1, clustered                              7              7           0        152.9           6.5       0.0X
+nullRatio=0.3, random                                13             13           0         81.0          12.4       0.0X
+nullRatio=0.3, clustered                              7              7           1        155.7           6.4       0.0X
+nullRatio=0.5, random                                14             14           0         75.1          13.3       0.0X
+nullRatio=0.5, clustered                              7              7           0        160.1           6.2       0.0X
+nullRatio=0.9, random                                 8              8           0        131.9           7.6       0.0X
+nullRatio=0.9, clustered                              6              6           0        175.8           5.7       0.0X
+nullRatio=1.0, random                                 0              0           0      34738.3           0.0       3.7X
 
 
 ================================================================================================
@@ -88,12 +88,12 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Nullable batch with def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                   1              1           0        955.4           1.0       1.0X
-nullRatio=0.3, contiguous 50%                                   9              9           0        117.6           8.5       0.1X
-nullRatio=0.9, contiguous 50%                                   6              6           0        175.9           5.7       0.2X
-nullRatio=0.0, alt 1000-row windows                             3              3           0        354.1           2.8       0.4X
-nullRatio=0.3, alt 1000-row windows                            11             11           0         97.1          10.3       0.1X
-nullRatio=0.9, alt 1000-row windows                             8              8           0        133.1           7.5       0.1X
+nullRatio=0.0, contiguous 50%                                   1              1           0        955.1           1.0       1.0X
+nullRatio=0.3, contiguous 50%                                  11             11           0         93.4          10.7       0.1X
+nullRatio=0.9, contiguous 50%                                   8              8           0        127.8           7.8       0.1X
+nullRatio=0.0, alt 1000-row windows                             3              3           0        333.5           3.0       0.3X
+nullRatio=0.3, alt 1000-row windows                            13             13           0         78.6          12.7       0.1X
+nullRatio=0.9, alt 1000-row windows                            10             10           0        102.0           9.8       0.1X
 
 
 ================================================================================================
@@ -104,12 +104,12 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Nullable batch without def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                      1              1           0        897.4           1.1       1.0X
-nullRatio=0.3, contiguous 50%                                      8              8           0        139.1           7.2       0.2X
-nullRatio=0.9, contiguous 50%                                      5              5           0        205.9           4.9       0.2X
-nullRatio=0.0, alt 1000-row windows                                3              3           0        383.7           2.6       0.4X
-nullRatio=0.3, alt 1000-row windows                                9              9           1        114.4           8.7       0.1X
-nullRatio=0.9, alt 1000-row windows                                7              7           0        156.7           6.4       0.2X
+nullRatio=0.0, contiguous 50%                                      1              1           0        890.6           1.1       1.0X
+nullRatio=0.3, contiguous 50%                                     10             10           0        105.9           9.4       0.1X
+nullRatio=0.9, contiguous 50%                                      7              7           0        141.5           7.1       0.2X
+nullRatio=0.0, alt 1000-row windows                                3              3           0        337.2           3.0       0.4X
+nullRatio=0.3, alt 1000-row windows                               12             12           0         87.7          11.4       0.1X
+nullRatio=0.9, alt 1000-row windows                                9              9           0        111.7           8.9       0.1X
 
 
 ================================================================================================
@@ -120,15 +120,15 @@ OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBoolean                                           3              3           0        381.0           2.6       1.0X
-readInteger, bitWidth=4                               3              3           0        360.2           2.8       0.9X
-readValueDictionaryId, bitWidth=4                     3              3           0        360.2           2.8       0.9X
-readInteger, bitWidth=8                               3              3           0        356.1           2.8       0.9X
-readValueDictionaryId, bitWidth=8                     3              3           0        356.1           2.8       0.9X
-readInteger, bitWidth=12                              4              4           0        282.2           3.5       0.7X
-readValueDictionaryId, bitWidth=12                    4              4           0        282.2           3.5       0.7X
-readInteger, bitWidth=20                              4              4           0        242.4           4.1       0.6X
-readValueDictionaryId, bitWidth=20                    4              4           0        242.4           4.1       0.6X
+readBoolean                                           5              5           0        203.2           4.9       1.0X
+readInteger, bitWidth=4                               3              3           0        360.8           2.8       1.8X
+readValueDictionaryId, bitWidth=4                     3              3           0        360.6           2.8       1.8X
+readInteger, bitWidth=8                               3              3           0        356.0           2.8       1.8X
+readValueDictionaryId, bitWidth=8                     3              3           0        356.0           2.8       1.8X
+readInteger, bitWidth=12                              4              4           0        274.8           3.6       1.4X
+readValueDictionaryId, bitWidth=12                    4              4           0        274.9           3.6       1.4X
+readInteger, bitWidth=20                              4              4           0        242.4           4.1       1.2X
+readValueDictionaryId, bitWidth=20                    4              4           0        242.4           4.1       1.2X
 
 
 ================================================================================================
@@ -140,15 +140,15 @@ AMD EPYC 9V74 80-Core Processor
 Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
 skipBooleans, trueRatio=0.0                           0              0           0   17476266.7           0.0       1.0X
-skipBooleans, trueRatio=0.5                           1              1           0       1179.4           0.8       0.0X
+skipBooleans, trueRatio=0.5                           3              3           0        327.5           3.1       0.0X
 skipBooleans, trueRatio=1.0                           0              0           0   17476266.7           0.0       1.0X
-skipIntegers PACKED, bitWidth=4                       1              1           0        996.4           1.0       0.0X
+skipIntegers PACKED, bitWidth=4                       1              1           0        996.7           1.0       0.0X
 skipIntegers RLE, bitWidth=4                          0              0           0   17476266.7           0.0       1.0X
-skipIntegers PACKED, bitWidth=8                       1              1           0        958.3           1.0       0.0X
+skipIntegers PACKED, bitWidth=8                       1              1           0        958.2           1.0       0.0X
 skipIntegers RLE, bitWidth=8                          0              0           0   17476266.7           0.0       1.0X
-skipIntegers PACKED, bitWidth=12                      2              2           0        565.4           1.8       0.0X
+skipIntegers PACKED, bitWidth=12                      2              2           0        538.9           1.9       0.0X
 skipIntegers RLE, bitWidth=12                         0              0           0   17476266.7           0.0       1.0X
-skipIntegers PACKED, bitWidth=20                      2              2           0        424.7           2.4       0.0X
+skipIntegers PACKED, bitWidth=20                      2              2           0        424.9           2.4       0.0X
 skipIntegers RLE, bitWidth=20                         0              0           0   17476266.7           0.0       1.0X
 
 

--- a/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-results.txt
+++ b/sql/core/benchmarks/VectorizedRleValuesReaderBenchmark-results.txt
@@ -3,19 +3,19 @@ Boolean decode
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 RLE readBooleans decode:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cold reader, trueRatio=0.0                            0              0           0      22367.2           0.0       1.0X
-reused reader, trueRatio=0.0                          0              0           0      22687.1           0.0       1.0X
-cold reader, trueRatio=0.1                            1              1           0        978.7           1.0       0.0X
-reused reader, trueRatio=0.1                          1              1           0        980.9           1.0       0.0X
-cold reader, trueRatio=0.5                            1              1           0       1189.6           0.8       0.1X
-reused reader, trueRatio=0.5                          1              1           0       1186.0           0.8       0.1X
-cold reader, trueRatio=0.9                            1              1           0        978.3           1.0       0.0X
-reused reader, trueRatio=0.9                          1              1           0        969.1           1.0       0.0X
-cold reader, trueRatio=1.0                            0              0           0      22671.9           0.0       1.0X
-reused reader, trueRatio=1.0                          0              0           0      22676.8           0.0       1.0X
+cold reader, trueRatio=0.0                            0              0           0      25855.0           0.0       1.0X
+reused reader, trueRatio=0.0                          0              0           0      25855.0           0.0       1.0X
+cold reader, trueRatio=0.1                            1              1           0       1047.4           1.0       0.0X
+reused reader, trueRatio=0.1                          1              1           0       1045.0           1.0       0.0X
+cold reader, trueRatio=0.5                            1              1           0       1268.1           0.8       0.0X
+reused reader, trueRatio=0.5                          1              1           0       1271.9           0.8       0.0X
+cold reader, trueRatio=0.9                            1              1           0       1045.7           1.0       0.0X
+reused reader, trueRatio=0.9                          1              1           0       1044.1           1.0       0.0X
+cold reader, trueRatio=1.0                            0              0           0      25848.0           0.0       1.0X
+reused reader, trueRatio=1.0                          0              0           0      25861.4           0.0       1.0X
 
 
 ================================================================================================
@@ -23,21 +23,21 @@ Integer decode
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 RLE readIntegers dictionary-id decode:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-PACKED cold, bitWidth=4                               1              1           0        927.1           1.1       1.0X
-PACKED reused, bitWidth=4                             1              1           0        920.3           1.1       1.0X
-RLE, bitWidth=4                                       0              0           0      18151.8           0.1      19.6X
-PACKED cold, bitWidth=8                               1              1           0        885.8           1.1       1.0X
-PACKED reused, bitWidth=8                             1              1           0        888.7           1.1       1.0X
-RLE, bitWidth=8                                       0              0           0      18161.2           0.1      19.6X
-PACKED cold, bitWidth=12                              2              2           0        513.9           1.9       0.6X
-PACKED reused, bitWidth=12                            2              2           0        510.1           2.0       0.6X
-RLE, bitWidth=12                                      0              0           0      18145.2           0.1      19.6X
-PACKED cold, bitWidth=20                              3              3           0        411.0           2.4       0.4X
-PACKED reused, bitWidth=20                            3              3           0        410.3           2.4       0.4X
-RLE, bitWidth=20                                      0              0           0      18205.4           0.1      19.6X
+PACKED cold, bitWidth=4                               1              1           0        984.5           1.0       1.0X
+PACKED reused, bitWidth=4                             1              1           0        980.3           1.0       1.0X
+RLE, bitWidth=4                                       0              0           0      20824.1           0.0      21.2X
+PACKED cold, bitWidth=8                               1              1           0        957.3           1.0       1.0X
+PACKED reused, bitWidth=8                             1              1           0        949.7           1.1       1.0X
+RLE, bitWidth=8                                       0              0           0      20757.7           0.0      21.1X
+PACKED cold, bitWidth=12                              2              2           0        566.9           1.8       0.6X
+PACKED reused, bitWidth=12                            2              2           0        563.8           1.8       0.6X
+RLE, bitWidth=12                                      0              0           0      20189.0           0.0      20.5X
+PACKED cold, bitWidth=20                              2              2           0        448.7           2.2       0.5X
+PACKED reused, bitWidth=20                            2              2           0        441.8           2.3       0.4X
+RLE, bitWidth=20                                      0              0           0      20201.1           0.0      20.5X
 
 
 ================================================================================================
@@ -45,19 +45,19 @@ Nullable batch decode with def-level materialization
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Nullable batch with def-levels:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       5914.9           0.2       1.0X
-nullRatio=0.1, random                                 9             10           0        110.8           9.0       0.0X
-nullRatio=0.1, clustered                              6              6           0        164.9           6.1       0.0X
-nullRatio=0.3, random                                14             14           0         74.9          13.3       0.0X
-nullRatio=0.3, clustered                              6              6           0        167.6           6.0       0.0X
-nullRatio=0.5, random                                16             16           0         66.4          15.1       0.0X
-nullRatio=0.5, clustered                              6              6           0        172.2           5.8       0.0X
-nullRatio=0.9, random                                 8              8           0        129.0           7.8       0.0X
-nullRatio=0.9, clustered                              5              5           0        193.4           5.2       0.0X
-nullRatio=1.0, random                                 0              0           0      10909.6           0.1       1.8X
+nullRatio=0.0, n/a                                    0              0           0       6438.3           0.2       1.0X
+nullRatio=0.1, random                                 9              9           0        111.4           9.0       0.0X
+nullRatio=0.1, clustered                              6              6           0        164.2           6.1       0.0X
+nullRatio=0.3, random                                14             14           0         74.7          13.4       0.0X
+nullRatio=0.3, clustered                              6              6           0        164.3           6.1       0.0X
+nullRatio=0.5, random                                16             16           0         66.9          14.9       0.0X
+nullRatio=0.5, clustered                              6              6           0        172.1           5.8       0.0X
+nullRatio=0.9, random                                 8              8           0        128.9           7.8       0.0X
+nullRatio=0.9, clustered                              5              5           0        194.2           5.1       0.0X
+nullRatio=1.0, random                                 0              0           0      12165.7           0.1       1.9X
 
 
 ================================================================================================
@@ -65,19 +65,19 @@ Nullable batch decode without def-level materialization
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Nullable batch without def-levels:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, n/a                                    0              0           0       9217.3           0.1       1.0X
-nullRatio=0.1, random                                 8              8           0        138.2           7.2       0.0X
-nullRatio=0.1, clustered                              5              5           0        209.1           4.8       0.0X
-nullRatio=0.3, random                                11             11           0         92.1          10.9       0.0X
-nullRatio=0.3, clustered                              5              5           0        214.9           4.7       0.0X
-nullRatio=0.5, random                                12             13           0         84.2          11.9       0.0X
-nullRatio=0.5, clustered                              5              5           0        223.2           4.5       0.0X
-nullRatio=0.9, random                                 6              6           0        168.3           5.9       0.0X
-nullRatio=0.9, clustered                              4              4           0        258.3           3.9       0.0X
-nullRatio=1.0, random                                 0              0           0      19977.1           0.1       2.2X
+nullRatio=0.0, n/a                                    0              0           0      11029.7           0.1       1.0X
+nullRatio=0.1, random                                 7              7           0        159.7           6.3       0.0X
+nullRatio=0.1, clustered                              4              4           0        239.6           4.2       0.0X
+nullRatio=0.3, random                                10             10           0        107.1           9.3       0.0X
+nullRatio=0.3, clustered                              4              4           0        240.9           4.2       0.0X
+nullRatio=0.5, random                                11             11           0         95.9          10.4       0.0X
+nullRatio=0.5, clustered                              4              4           0        248.0           4.0       0.0X
+nullRatio=0.9, random                                 6              6           0        186.4           5.4       0.0X
+nullRatio=0.9, clustered                              4              4           0        279.2           3.6       0.0X
+nullRatio=1.0, random                                 0              0           0      21368.1           0.0       1.9X
 
 
 ================================================================================================
@@ -85,15 +85,15 @@ Nullable batch decode with row-index filtering (with def-levels)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Nullable batch with def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                   1              1           0        956.2           1.0       1.0X
-nullRatio=0.3, contiguous 50%                                   9              9           0        117.7           8.5       0.1X
-nullRatio=0.9, contiguous 50%                                   6              6           0        175.8           5.7       0.2X
-nullRatio=0.0, alt 1000-row windows                             3              3           0        352.6           2.8       0.4X
-nullRatio=0.3, alt 1000-row windows                            11             11           0         97.2          10.3       0.1X
-nullRatio=0.9, alt 1000-row windows                             8              8           0        132.9           7.5       0.1X
+nullRatio=0.0, contiguous 50%                                   1              2           0        761.3           1.3       1.0X
+nullRatio=0.3, contiguous 50%                                   9              9           0        116.5           8.6       0.2X
+nullRatio=0.9, contiguous 50%                                   6              6           0        171.0           5.8       0.2X
+nullRatio=0.0, alt 1000-row windows                             3              3           0        419.3           2.4       0.6X
+nullRatio=0.3, alt 1000-row windows                            10             10           0        103.6           9.7       0.1X
+nullRatio=0.9, alt 1000-row windows                             7              7           0        144.4           6.9       0.2X
 
 
 ================================================================================================
@@ -101,15 +101,15 @@ Nullable batch decode with row-index filtering (without def-levels)
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Nullable batch without def-levels, row-index filtered:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-nullRatio=0.0, contiguous 50%                                      1              1           0        898.8           1.1       1.0X
-nullRatio=0.3, contiguous 50%                                      8              8           0        137.1           7.3       0.2X
-nullRatio=0.9, contiguous 50%                                      5              5           0        203.1           4.9       0.2X
-nullRatio=0.0, alt 1000-row windows                                3              3           0        383.6           2.6       0.4X
-nullRatio=0.3, alt 1000-row windows                                9              9           0        113.1           8.8       0.1X
-nullRatio=0.9, alt 1000-row windows                                7              7           0        154.9           6.5       0.2X
+nullRatio=0.0, contiguous 50%                                      1              1           0        864.1           1.2       1.0X
+nullRatio=0.3, contiguous 50%                                      7              7           0        146.8           6.8       0.2X
+nullRatio=0.9, contiguous 50%                                      5              5           0        208.7           4.8       0.2X
+nullRatio=0.0, alt 1000-row windows                                2              3           0        425.0           2.4       0.5X
+nullRatio=0.3, alt 1000-row windows                                8              8           0        124.5           8.0       0.1X
+nullRatio=0.9, alt 1000-row windows                                6              6           0        167.4           6.0       0.2X
 
 
 ================================================================================================
@@ -117,18 +117,18 @@ Single-value reads
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Single-value reads:                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBoolean                                           3              3           0        380.1           2.6       1.0X
-readInteger, bitWidth=4                               3              3           0        360.5           2.8       0.9X
-readValueDictionaryId, bitWidth=4                     3              3           0        360.1           2.8       0.9X
-readInteger, bitWidth=8                               3              3           0        355.9           2.8       0.9X
-readValueDictionaryId, bitWidth=8                     3              3           0        355.9           2.8       0.9X
-readInteger, bitWidth=12                              4              4           0        274.6           3.6       0.7X
-readValueDictionaryId, bitWidth=12                    4              4           0        275.2           3.6       0.7X
-readInteger, bitWidth=20                              4              4           0        242.3           4.1       0.6X
-readValueDictionaryId, bitWidth=20                    4              4           0        242.4           4.1       0.6X
+readBoolean                                           3              3           0        396.7           2.5       1.0X
+readInteger, bitWidth=4                               3              3           0        376.6           2.7       0.9X
+readValueDictionaryId, bitWidth=4                     3              3           0        376.6           2.7       0.9X
+readInteger, bitWidth=8                               3              3           0        370.6           2.7       0.9X
+readValueDictionaryId, bitWidth=8                     3              3           0        370.9           2.7       0.9X
+readInteger, bitWidth=12                              4              4           0        292.4           3.4       0.7X
+readValueDictionaryId, bitWidth=12                    4              4           1        293.1           3.4       0.7X
+readInteger, bitWidth=20                              4              4           0        258.4           3.9       0.7X
+readValueDictionaryId, bitWidth=20                    4              4           0        258.1           3.9       0.7X
 
 
 ================================================================================================
@@ -136,19 +136,19 @@ Skip
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 Skip:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-skipBooleans, trueRatio=0.0                           0              0           0   17476266.7           0.0       1.0X
-skipBooleans, trueRatio=0.5                           1              1           0       1184.0           0.8       0.0X
-skipBooleans, trueRatio=1.0                           0              0           0   17476266.7           0.0       1.0X
-skipIntegers PACKED, bitWidth=4                       1              1           0        998.2           1.0       0.0X
-skipIntegers RLE, bitWidth=4                          0              0           0   17476266.7           0.0       1.0X
-skipIntegers PACKED, bitWidth=8                       1              1           0        958.0           1.0       0.0X
-skipIntegers RLE, bitWidth=8                          0              0           0   17476266.7           0.0       1.0X
-skipIntegers PACKED, bitWidth=12                      2              2           0        537.9           1.9       0.0X
-skipIntegers RLE, bitWidth=12                         0              0           0   17476266.7           0.0       1.0X
-skipIntegers PACKED, bitWidth=20                      2              2           0        424.8           2.4       0.0X
-skipIntegers RLE, bitWidth=20                         0              0           0   17476266.7           0.0       1.0X
+skipBooleans, trueRatio=0.0                           0              0           0   20971520.0           0.0       1.0X
+skipBooleans, trueRatio=0.5                           1              1           0       1259.5           0.8       0.0X
+skipBooleans, trueRatio=1.0                           0              0           0   21399510.2           0.0       1.0X
+skipIntegers PACKED, bitWidth=4                       1              1           0       1070.0           0.9       0.0X
+skipIntegers RLE, bitWidth=4                          0              0           0   21399510.2           0.0       1.0X
+skipIntegers PACKED, bitWidth=8                       1              1           0       1017.8           1.0       0.0X
+skipIntegers RLE, bitWidth=8                          0              0           0   21399510.2           0.0       1.0X
+skipIntegers PACKED, bitWidth=12                      2              2           0        590.4           1.7       0.0X
+skipIntegers RLE, bitWidth=12                         0              0           0   17476266.7           0.0       0.8X
+skipIntegers PACKED, bitWidth=20                      2              2           0        465.3           2.1       0.0X
+skipIntegers RLE, bitWidth=20                         0              0           0   17476266.7           0.0       0.8X
 
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
@@ -1000,11 +1000,15 @@ public final class VectorizedRleValuesReader extends ValuesReader
             this.currentBuffer = new int[this.currentCount];
           }
           currentBufferIdx = 0;
+          // Slice all packed bytes in one call (numGroups groups x bitWidth bytes each)
+          // instead of one slice per group, avoiding per-group ByteBuffer allocation.
+          int totalBytes = numGroups * bitWidth;
+          ByteBuffer packed = in.slice(totalBytes);
+          int pos = packed.position();
           int valueIndex = 0;
           while (valueIndex < this.currentCount) {
-            // values are bit packed 8 at a time, so reading bitWidth will always work
-            ByteBuffer buffer = in.slice(bitWidth);
-            this.packer.unpack8Values(buffer, buffer.position(), this.currentBuffer, valueIndex);
+            this.packer.unpack8Values(packed, pos, this.currentBuffer, valueIndex);
+            pos += bitWidth;
             valueIndex += 8;
           }
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReaderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReaderSuite.scala
@@ -20,6 +20,8 @@ package org.apache.spark.sql.execution.datasources.parquet
 import java.nio.ByteBuffer
 import java.util.PrimitiveIterator
 
+import scala.jdk.CollectionConverters._
+
 import org.apache.parquet.bytes.ByteBufferInputStream
 
 import org.apache.spark.SparkFunSuite
@@ -127,6 +129,61 @@ class VectorizedRleValuesReaderSuite extends SparkFunSuite {
     val page1 = Array.tabulate(128)(i => i & 1)
     val page2 = Array.fill(64)(1) ++ Array.tabulate(64)(i => i & 1)
     runAndAssertMultiPage(Seq(page1, page2), maxDef = 1, batchSize = 64)
+  }
+
+  test("PACKED: multi-buffer stream with packed run crossing buffer boundary") {
+    // Exercises the MultiBufferInputStream.slice() path where the packed bytes span a buffer
+    // boundary, causing slice() to return a freshly-allocated contiguous buffer with
+    // position() == 0 (the base-0 pos branch in readNextGroup).
+    val n = 256
+    val defLevels = Array.tabulate(n)(i => i & 1)
+    val bitWidth = 1
+    val encoded = encodeRle(defLevels, bitWidth)
+
+    // Split the encoded bytes into small chunks (e.g. 3 bytes each) so the packed data
+    // is guaranteed to span at least one buffer boundary within MultiBufferInputStream.
+    val chunkSize = 3
+    val buffers = encoded.grouped(chunkSize).map { chunk =>
+      ByteBuffer.wrap(chunk)
+    }.toList.asJava
+
+    val nonNullCount = defLevels.count(_ == 1)
+    val plainBytes = plainIntBytes(nonNullCount)(valueAt)
+
+    val reader = new VectorizedRleValuesReader(bitWidth, false)
+    reader.initFromPage(n, ByteBufferInputStream.wrap(buffers))
+    val valueReader = new VectorizedPlainValuesReader
+    valueReader.initFromPage(
+      nonNullCount, ByteBufferInputStream.wrap(ByteBuffer.wrap(plainBytes)))
+    val state = ParquetTestAccess.newState(intColumnDescriptor(1), false)
+    ParquetTestAccess.resetForNewPage(state, n, 0L)
+
+    val batchSize = 64
+    var produced = 0
+    var expectedValueIdx = 0
+    while (produced < n) {
+      val toRead = math.min(batchSize, n - produced)
+      val values = new OnHeapColumnVector(toRead, IntegerType)
+      ParquetTestAccess.resetForNewBatch(state, toRead)
+      ParquetTestAccess.readBatch(reader, state, values, null, valueReader, integerUpdater)
+
+      var i = 0
+      while (i < toRead) {
+        val absPos = produced + i
+        if (defLevels(absPos) == 1) {
+          assert(!values.isNullAt(i), s"pos $absPos should be non-null")
+          val expected = valueAt(expectedValueIdx)
+          assert(
+            values.getInt(i) == expected,
+            s"pos $absPos value mismatch: got ${values.getInt(i)}, expected $expected")
+          expectedValueIdx += 1
+        } else {
+          assert(values.isNullAt(i), s"pos $absPos should be null")
+        }
+        i += 1
+      }
+      produced += toRead
+    }
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `VectorizedRleValuesReader.readNextGroup()`, the PACKED branch previously called `in.slice(bitWidth)` once per group of 8 values, allocating a new `ByteBuffer` view per call. This PR batches all packed bytes into a single `in.slice(numGroups * bitWidth)` call, then indexes into the resulting buffer with an advancing position offset.

The change is 4 lines of net diff in `readNextGroup()`:

```java
// Before: one slice() per group — N ByteBuffer allocations
while (valueIndex < this.currentCount) {
    ByteBuffer buffer = in.slice(bitWidth);
    this.packer.unpack8Values(buffer, buffer.position(), this.currentBuffer, valueIndex);
    valueIndex += 8;
}

// After: single slice() for all groups — 1 ByteBuffer allocation
int totalBytes = numGroups * bitWidth;
ByteBuffer packed = in.slice(totalBytes);
int pos = packed.position();
while (valueIndex < this.currentCount) {
    this.packer.unpack8Values(packed, pos, this.currentBuffer, valueIndex);
    pos += bitWidth;
    valueIndex += 8;
}
```

This works because `BytePacker.unpack8Values(ByteBuffer, int inPos, int[], int)` uses absolute positioning (`inPos` is the absolute offset into the buffer, not relative to `position()`).

### Why are the changes needed?

`ByteBufferInputStream.slice()` calls `buffer.duplicate()` which allocates a new `ByteBuffer` object each time. For a 1M-value PACKED page at bitWidth=4, that is 128K `ByteBuffer` allocations per page. These short-lived objects create GC pressure and prevent `BytePacker.unpack8Values()` from being inlined (the `ByteBuffer` argument escapes through the abstract method call, defeating scalar replacement).

With a single slice, the entire PACKED block shares one `ByteBuffer` view. The `unpack8Values` calls index into it via an advancing absolute position, which C2 can optimize far more aggressively.

Benchmark results on the same machine (AMD EPYC 9V45, JDK 17), before vs after:

**readIntegers (dictionary-id decode, PACKED):**

| bitWidth | Before (M/s) | After (M/s) | Speedup |
|----------|-------------|-------------|---------|
| 4        | 886         | 1862        | 2.1x    |
| 8        | 885         | 2088        | 2.4x    |
| 12       | 609         | 953         | 1.6x    |
| 20       | 518         | 709         | 1.4x    |

**Single-value reads (readInteger, PACKED):**

| bitWidth | Before (M/s) | After (M/s) | Speedup |
|----------|-------------|-------------|---------|
| 4        | 490         | 690         | 1.4x    |
| 8        | 495         | 722         | 1.5x    |
| 12       | 392         | 510         | 1.3x    |
| 20       | 354         | 431         | 1.2x    |

**skipIntegers (PACKED):**

| bitWidth | Before (M/s) | After (M/s) | Speedup |
|----------|-------------|-------------|---------|
| 4        | 916         | 1942        | 2.1x    |
| 8        | 915         | 2238        | 2.4x    |
| 12       | 622         | 988         | 1.6x    |
| 20       | 528         | 722         | 1.4x    |

RLE paths are unaffected (no PACKED decode involved). The benefit is largest at smaller bitWidths where more groups (and therefore more slice calls) are needed per page.

GHA results on AMD EPYC 7763 (PACKED reused, readIntegers):

| bitWidth | JDK 17 Baseline | JDK 17 PR | Speedup | JDK 21 Baseline | JDK 21 PR | Speedup | JDK 25 Baseline | JDK 25 PR | Speedup |
|---|---|---|---|---|---|---|---|---|---|
| 4 | 485.2 | 980.3 | **2.0x** | 541.2 | 897.1 | **1.7x** | 522.1 | 891.0 | **1.7x** |
| 8 | 476.5 | 949.7 | **2.0x** | 618.1 | 1006.4 | **1.6x** | 579.4 | 1049.4 | **1.8x** |
| 12 | 357.3 | 563.8 | **1.6x** | 480.5 | 681.5 | **1.4x** | 436.4 | 689.4 | **1.6x** |
| 20 | 302.1 | 441.8 | **1.5x** | 400.6 | 522.8 | **1.3x** | 382.8 | 520.2 | **1.4x** |

Full committed results: [JDK 17](https://github.com/iemejia/spark/actions/runs/27443135287), [JDK 21](https://github.com/iemejia/spark/actions/runs/27435379671), [JDK 25](https://github.com/iemejia/spark/actions/runs/27437123091)

### Does this PR introduce _any_ user-facing change?

No. This is an internal performance optimization in the Parquet vectorized reader. No API, configuration, or behavioral changes.

### How was this patch tested?

- Existing `VectorizedRleValuesReaderSuite` (14 tests covering PACKED mode, RLE mode, mixed, row-index filtering, multi-page, cross-batch continuity) — all pass.
- Existing `ParquetQuerySuite`, `ParquetIOSuite`, `ParquetEncodingSuite`, `ParquetSchemaSuite` — all 244 tests pass on JDK 17.
- `VectorizedRleValuesReaderBenchmark` — before/after comparison on the same machine shown above.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenCode (Claude claude-opus-4.6)
