### PR TITLE
[SPARK-56897][SQL] Reduce per-value allocations in DELTA_BYTE_ARRAY Parquet decoder

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geography.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geography.java
@@ -84,13 +84,20 @@ public final class Geography implements Geo {
 
   // Returns a Geography object with the specified SRID value by parsing the input WKB.
   public static Geography fromWkb(byte[] wkb, int srid) {
+    return fromWkb(wkb, 0, wkb == null ? 0 : wkb.length, srid);
+  }
+
+  // Returns a Geography object with the specified SRID value by parsing a sub-range
+  // [offset, offset + length) of the input WKB. This lets callers reuse a larger backing
+  // buffer without materializing an exact-size copy of the WKB bytes.
+  public static Geography fromWkb(byte[] wkb, int offset, int length, int srid) {
     try {
       WkbReader reader = new WkbReader(true);
-      reader.read(wkb); // Validate WKB with geography coordinate bounds.
+      reader.read(wkb, offset, length); // Validate WKB with geography coordinate bounds.
 
-      byte[] bytes = new byte[HEADER_SIZE + wkb.length];
+      byte[] bytes = new byte[HEADER_SIZE + length];
       ByteBuffer.wrap(bytes).order(DEFAULT_ENDIANNESS).putInt(srid);
-      System.arraycopy(wkb, 0, bytes, WKB_OFFSET, wkb.length);
+      System.arraycopy(wkb, offset, bytes, WKB_OFFSET, length);
       return fromBytes(bytes);
     } catch (WkbParseException e) {
       throw QueryExecutionErrors.wkbParseError(e.getParseError(), e.getPosition());

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geometry.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/Geometry.java
@@ -84,13 +84,20 @@ public final class Geometry implements Geo {
 
   // Returns a Geometry object with the specified SRID value by parsing the input WKB.
   public static Geometry fromWkb(byte[] wkb, int srid) {
+    return fromWkb(wkb, 0, wkb == null ? 0 : wkb.length, srid);
+  }
+
+  // Returns a Geometry object with the specified SRID value by parsing a sub-range
+  // [offset, offset + length) of the input WKB. This lets callers reuse a larger backing
+  // buffer without materializing an exact-size copy of the WKB bytes.
+  public static Geometry fromWkb(byte[] wkb, int offset, int length, int srid) {
     try {
       WkbReader reader = new WkbReader();
-      reader.read(wkb); // Validate WKB
+      reader.read(wkb, offset, length); // Validate WKB
 
-      byte[] bytes = new byte[HEADER_SIZE + wkb.length];
+      byte[] bytes = new byte[HEADER_SIZE + length];
       ByteBuffer.wrap(bytes).order(DEFAULT_ENDIANNESS).putInt(srid);
-      System.arraycopy(wkb, 0, bytes, WKB_OFFSET, wkb.length);
+      System.arraycopy(wkb, offset, bytes, WKB_OFFSET, length);
       return fromBytes(bytes);
     } catch (WkbParseException e) {
       throw QueryExecutionErrors.wkbParseError(e.getParseError(), e.getPosition());

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/STUtils.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/STUtils.java
@@ -171,6 +171,16 @@ public final class STUtils {
     return toPhysVal(Geography.fromWkb(wkb, srid));
   }
 
+  // Parses a sub-range [offset, offset + length) of the WKB buffer, avoiding an
+  // exact-size copy when the caller reuses a larger backing buffer.
+  public static BinaryView stGeogFromWKB(byte[] wkb, int offset, int length, int srid) {
+    // We only allow setting the SRID to geographic values.
+    if(!GeographyType.isSridSupported(srid)) {
+      throw QueryExecutionErrors.stInvalidSridValueError(srid);
+    }
+    return toPhysVal(Geography.fromWkb(wkb, offset, length, srid));
+  }
+
   // ST_GeomFromWKB
   public static BinaryView stGeomFromWKB(byte[] wkb) {
     return toPhysVal(Geometry.fromWkb(wkb));
@@ -182,6 +192,16 @@ public final class STUtils {
       throw QueryExecutionErrors.stInvalidSridValueError(srid);
     }
     return toPhysVal(Geometry.fromWkb(wkb, srid));
+  }
+
+  // Parses a sub-range [offset, offset + length) of the WKB buffer, avoiding an
+  // exact-size copy when the caller reuses a larger backing buffer.
+  public static BinaryView stGeomFromWKB(byte[] wkb, int offset, int length, int srid) {
+    // We only allow setting the SRID to valid values.
+    if(!GeometryType.isSridSupported(srid)) {
+      throw QueryExecutionErrors.stInvalidSridValueError(srid);
+    }
+    return toPhysVal(Geometry.fromWkb(wkb, offset, length, srid));
   }
 
   // ST_SetSrid

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/geo/WkbReader.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/geo/WkbReader.java
@@ -249,6 +249,16 @@ public class WkbReader {
       throw new WkbParseException("Unexpected end of WKB buffer", 0, currentWkb);
     }
 
+    // Validate that [offset, offset + length) lies within currentWkb before wrapping.
+    // Without this, a bad offset/length would escape as a raw IndexOutOfBoundsException
+    // from ByteBuffer.wrap, which fromWkb's WkbParseException catch would not translate
+    // into WKB_PARSE_ERROR like every other malformed-WKB case. The subtraction avoids
+    // overflow: offset is already known to be >= 0.
+    if (offset < 0 || length > currentWkb.length - offset) {
+      throw new WkbParseException("WKB range [" + offset + ", " + ((long) offset + length)
+        + ") is out of bounds for buffer of length " + currentWkb.length, offset, currentWkb);
+    }
+
     // Create a buffer over just the [offset, offset + length) sub-range. Positions
     // reported in errors stay absolute so they index correctly into currentWkb.
     buffer = ByteBuffer.wrap(currentWkb, offset, length);

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/geo/WkbReader.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/util/geo/WkbReader.java
@@ -130,9 +130,17 @@ public class WkbReader {
    * Reads a geometry from WKB bytes.
    */
   public GeometryModel read(byte[] wkb) {
+    return read(wkb, 0, wkb == null ? 0 : wkb.length);
+  }
+
+  /**
+   * Reads a geometry from a sub-range {@code [offset, offset + length)} of the given byte array.
+   * This lets callers reuse a larger backing buffer without materializing an exact-size copy.
+   */
+  public GeometryModel read(byte[] wkb, int offset, int length) {
     try {
       currentWkb = wkb;
-      return readGeometry(Geometry.DEFAULT_SRID);
+      return readGeometry(offset, length, Geometry.DEFAULT_SRID);
     } finally {
       // Clear references to allow garbage collection
       buffer = null;
@@ -146,7 +154,7 @@ public class WkbReader {
   public GeometryModel read(byte[] wkb, int srid) {
     try {
       currentWkb = wkb;
-      return readGeometry(srid);
+      return readGeometry(0, wkb == null ? 0 : wkb.length, srid);
     } finally {
       // Clear references to allow garbage collection
       buffer = null;
@@ -225,22 +233,25 @@ public class WkbReader {
   /**
    * Reads a geometry from WKB bytes with a specified SRID.
    *
+   * @param offset start index of the WKB data within {@code currentWkb}
+   * @param length number of WKB bytes to read
    * @param defaultSrid srid to use if not specified in WKB
    * @return Geometry object
    */
-  private GeometryModel readGeometry(int defaultSrid) {
+  private GeometryModel readGeometry(int offset, int length, int defaultSrid) {
     // Check that we have data
-    if (currentWkb == null || currentWkb.length < 1) {
+    if (currentWkb == null || length < 1) {
       throw new WkbParseException("WKB data is empty or null", 0, currentWkb);
     }
 
     // Check that we have enough bytes for header (endianness byte + 4-byte type)
-    if (currentWkb.length < WkbUtil.BYTE_SIZE + WkbUtil.TYPE_SIZE) {
+    if (length < WkbUtil.BYTE_SIZE + WkbUtil.TYPE_SIZE) {
       throw new WkbParseException("Unexpected end of WKB buffer", 0, currentWkb);
     }
 
-    // Create buffer wrapping the entire byte array
-    buffer = ByteBuffer.wrap(currentWkb);
+    // Create a buffer over just the [offset, offset + length) sub-range. Positions
+    // reported in errors stay absolute so they index correctly into currentWkb.
+    buffer = ByteBuffer.wrap(currentWkb, offset, length);
 
     // Read endianness and set byte order
     ByteOrder byteOrder = readEndianness();

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StUtilsSuite.java
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StUtilsSuite.java
@@ -249,6 +249,27 @@ class STUtilsSuite {
     assertArrayEquals(testGeographyBytes, geographyVal.getBytes());
   }
 
+  @Test
+  void testStGeomFromWKBWithOutOfBoundsRange() {
+    // A range that escapes the backing array must surface as WKB_PARSE_ERROR, the same as any
+    // other malformed WKB, rather than a raw IndexOutOfBoundsException from ByteBuffer.wrap that
+    // fromWkb's WkbParseException handler would never see. Covers negative offset, offset past
+    // the end, and a length that runs past the end.
+    int[][] badRanges = {
+      {-1, testWkb.length},                 // negative offset
+      {testWkb.length + 1, testWkb.length}, // offset past the end
+      {1, testWkb.length}                   // offset + length past the end
+    };
+    for (int[] range : badRanges) {
+      int offset = range[0];
+      int length = range[1];
+      SparkIllegalArgumentException exception = assertThrows(SparkIllegalArgumentException.class,
+        () -> STUtils.stGeomFromWKB(testWkb, offset, length, testGeometrySrid),
+        "offset=" + offset + ", length=" + length + " should raise WKB_PARSE_ERROR");
+      assertEquals("WKB_PARSE_ERROR", exception.getCondition());
+    }
+  }
+
   // ST_Srid
   @Test
   void testStSridGeography() {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StUtilsSuite.java
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StUtilsSuite.java
@@ -216,6 +216,39 @@ class STUtilsSuite {
     }
   }
 
+  // ST_GeomFromWKB / ST_GeogFromWKB with an offset/length sub-range. These exercise the
+  // overloads used by the vectorized DELTA_BYTE_ARRAY decoder, which assembles each WKB value
+  // into a reusable buffer that may be longer than the value itself. The parse must read only
+  // [offset, offset + length) and ignore any surrounding bytes.
+  @Test
+  void testStGeomFromWKBWithOffsetAndLength() {
+    // Embed testWkb in a larger buffer with leading and trailing filler bytes.
+    int offset = 3;
+    byte[] padded = new byte[offset + testWkb.length + 5];
+    java.util.Arrays.fill(padded, (byte) 0x7F);
+    System.arraycopy(testWkb, 0, padded, offset, testWkb.length);
+
+    BinaryView geometryVal =
+      STUtils.stGeomFromWKB(padded, offset, testWkb.length, testGeometrySrid);
+    assertNotNull(geometryVal);
+    // The parsed physical value must equal the one parsed from the exact-size WKB: the
+    // surrounding filler bytes must not ride along.
+    assertArrayEquals(testGeometryBytes, geometryVal.getBytes());
+  }
+
+  @Test
+  void testStGeogFromWKBWithOffsetAndLength() {
+    int offset = 4;
+    byte[] padded = new byte[offset + testWkb.length + 7];
+    java.util.Arrays.fill(padded, (byte) 0x7F);
+    System.arraycopy(testWkb, 0, padded, offset, testWkb.length);
+
+    BinaryView geographyVal =
+      STUtils.stGeogFromWKB(padded, offset, testWkb.length, testGeographySrid);
+    assertNotNull(geographyVal);
+    assertArrayEquals(testGeographyBytes, geographyVal.getBytes());
+  }
+
   // ST_Srid
   @Test
   void testStSridGeography() {

--- a/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk21-results.txt
@@ -6,14 +6,14 @@ OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT32:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readIntegers, constant                                2              2           0        452.8           2.2       1.0X
-skipIntegers, constant                                2              2           0        526.9           1.9       1.2X
-readIntegers, monotonic                               2              2           0        455.0           2.2       1.0X
-skipIntegers, monotonic                               2              2           0        528.8           1.9       1.2X
-readIntegers, small-delta random                      3              3           0        342.2           2.9       0.8X
-skipIntegers, small-delta random                      3              3           0        359.2           2.8       0.8X
-readIntegers, wide random                             4              4           0        266.0           3.8       0.6X
-skipIntegers, wide random                             4              4           0        288.9           3.5       0.6X
+readIntegers, constant                                3              3           0        317.1           3.2       1.0X
+skipIntegers, constant                                3              3           0        347.0           2.9       1.1X
+readIntegers, monotonic                               3              3           0        318.4           3.1       1.0X
+skipIntegers, monotonic                               3              3           0        347.4           2.9       1.1X
+readIntegers, small-delta random                      4              4           0        258.4           3.9       0.8X
+skipIntegers, small-delta random                      4              4           0        278.1           3.6       0.9X
+readIntegers, wide random                             5              5           0        215.5           4.6       0.7X
+skipIntegers, wide random                             5              5           0        224.6           4.5       0.7X
 
 
 ================================================================================================
@@ -24,14 +24,14 @@ OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT64:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readLongs, constant                                   3              3           1        396.7           2.5       1.0X
-skipLongs, constant                                   2              2           0        519.1           1.9       1.3X
-readLongs, monotonic                                  3              3           0        369.0           2.7       0.9X
-skipLongs, monotonic                                  2              2           0        521.6           1.9       1.3X
-readLongs, small-delta random                         3              3           0        309.9           3.2       0.8X
-skipLongs, small-delta random                         3              3           0        360.6           2.8       0.9X
-readLongs, wide random                                6              6           0        170.2           5.9       0.4X
-skipLongs, wide random                                6              6           0        187.1           5.3       0.5X
+readLongs, constant                                   3              3           0        319.9           3.1       1.0X
+skipLongs, constant                                   3              3           0        335.1           3.0       1.0X
+readLongs, monotonic                                  3              3           0        321.3           3.1       1.0X
+skipLongs, monotonic                                  3              3           0        343.9           2.9       1.1X
+readLongs, small-delta random                         4              4           0        267.5           3.7       0.8X
+skipLongs, small-delta random                         4              4           0        281.0           3.6       0.9X
+readLongs, wide random                                7              7           0        154.9           6.5       0.5X
+skipLongs, wide random                                7              7           0        158.6           6.3       0.5X
 
 
 ================================================================================================
@@ -42,14 +42,14 @@ OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BYTE_ARRAY:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, no overlap, len=16                       29             32           4         35.6          28.1       1.0X
-skipBinary, no overlap, len=16                       32             36           4         32.3          30.9       0.9X
-readBinary, half overlap, len=16                     35             38           2         29.7          33.6       0.8X
-skipBinary, half overlap, len=16                     39             42           3         26.6          37.6       0.7X
-readBinary, full overlap, len=16                     35             41           4         29.5          33.9       0.8X
-skipBinary, full overlap, len=16                     40             40           2         26.4          37.9       0.7X
-readBinary, half overlap, len=64                     36             42           3         29.0          34.5       0.8X
-skipBinary, half overlap, len=64                     39             42           3         26.6          37.6       0.7X
+readBinary, no overlap, len=16                       29             30           2         36.2          27.6       1.0X
+skipBinary, no overlap, len=16                       20             21           1         52.6          19.0       1.5X
+readBinary, half overlap, len=16                     29             30           1         35.7          28.0       1.0X
+skipBinary, half overlap, len=16                     20             20           1         52.9          18.9       1.5X
+readBinary, full overlap, len=16                     28             29           2         37.5          26.6       1.0X
+skipBinary, full overlap, len=16                     20             20           1         52.7          19.0       1.5X
+readBinary, half overlap, len=64                     31             32           1         34.4          29.1       0.9X
+skipBinary, half overlap, len=64                     20             21           3         51.5          19.4       1.4X
 
 
 ================================================================================================
@@ -60,14 +60,14 @@ OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_LENGTH_BYTE_ARRAY:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, payloadLen=8                             16             17           1         64.2          15.6       1.0X
-skipBinary, payloadLen=8                              7              7           1        161.1           6.2       2.5X
-readBinary, payloadLen=32                            17             17           0         63.2          15.8       1.0X
-skipBinary, payloadLen=32                             7              7           1        160.9           6.2       2.5X
-readBinary, payloadLen=128                           19             19           1         55.1          18.2       0.9X
-skipBinary, payloadLen=128                            7              7           1        160.7           6.2       2.5X
-readBinary, payloadLen=512                           39             40           1         27.0          37.0       0.4X
-skipBinary, payloadLen=512                            7              7           0        160.9           6.2       2.5X
+readBinary, payloadLen=8                             25             25           1         42.3          23.6       1.0X
+skipBinary, payloadLen=8                              7              7           0        153.8           6.5       3.6X
+readBinary, payloadLen=32                            25             25           1         42.2          23.7       1.0X
+skipBinary, payloadLen=32                             7              7           0        153.8           6.5       3.6X
+readBinary, payloadLen=128                           28             29           3         38.1          26.3       0.9X
+skipBinary, payloadLen=128                            7              8           2        153.2           6.5       3.6X
+readBinary, payloadLen=512                           47             48           1         22.4          44.7       0.5X
+skipBinary, payloadLen=512                            7              7           0        153.3           6.5       3.6X
 
 
 ================================================================================================
@@ -78,20 +78,20 @@ OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 Variant reads:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------
-readBytes (INT32)                                                      5              5           0        208.1           4.8       1.0X
-readShorts (INT32)                                                     9              9           0        122.0           8.2       0.6X
-readUnsignedIntegers (INT32 -> Long)                                   9              9           0        123.1           8.1       0.6X
-readIntegersAsLongs (INT32 -> Long)                                    4              4           0        259.5           3.9       1.2X
-readIntegersAsLongs (INT32 -> Long, overflow pattern)                  4              4           0        259.9           3.8       1.2X
-readIntegersAsDoubles (INT32 -> Double)                                4              4           0        269.7           3.7       1.3X
-readIntegersAsDoubles (INT32 -> Double, overflow pattern)              4              4           0        269.9           3.7       1.3X
-readUnsignedLongs (INT64 -> Decimal(20,0))                            28             28           0         37.9          26.4       0.2X
-skipBytes                                                              6              6           0        180.8           5.5       0.9X
-skipShorts                                                             6              6           0        189.7           5.3       0.9X
-readByte (INT32 single-value)                                         13             14           2         78.5          12.7       0.4X
-readShort (INT32 single-value)                                        13             14           1         78.5          12.7       0.4X
-readInteger (INT32 single-value)                                      13             14           1         78.5          12.7       0.4X
-readLong (INT64 single-value)                                         16             16           1         67.3          14.9       0.3X
-readBinary(len) (DELTA_BYTE_ARRAY single-value)                       61             67           5         17.1          58.6       0.1X
+readBytes (INT32)                                                      6              6           0        178.5           5.6       1.0X
+readShorts (INT32)                                                     9              9           0        120.4           8.3       0.7X
+readUnsignedIntegers (INT32 -> Long)                                   9              9           0        120.4           8.3       0.7X
+readIntegersAsLongs (INT32 -> Long)                                    5              5           0        203.7           4.9       1.1X
+readIntegersAsLongs (INT32 -> Long, overflow pattern)                  5              5           0        204.0           4.9       1.1X
+readIntegersAsDoubles (INT32 -> Double)                                5              5           0        211.8           4.7       1.2X
+readIntegersAsDoubles (INT32 -> Double, overflow pattern)              5              5           0        211.7           4.7       1.2X
+readUnsignedLongs (INT64 -> Decimal(20,0))                            28             29           0         36.9          27.1       0.2X
+skipBytes                                                              5              5           0        224.6           4.5       1.3X
+skipShorts                                                             5              5           0        224.4           4.5       1.3X
+readByte (INT32 single-value)                                         14             14           1         76.6          13.1       0.4X
+readShort (INT32 single-value)                                        14             14           0         76.7          13.0       0.4X
+readInteger (INT32 single-value)                                      14             14           1         76.8          13.0       0.4X
+readLong (INT64 single-value)                                         15             16           1         68.5          14.6       0.4X
+readBinary(len) (DELTA_BYTE_ARRAY single-value)                       54             61           6         19.4          51.5       0.1X
 
 

--- a/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk25-results.txt
@@ -6,14 +6,14 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT32:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readIntegers, constant                                2              2           0        463.0           2.2       1.0X
-skipIntegers, constant                                1              1           0        785.4           1.3       1.7X
-readIntegers, monotonic                               2              2           0        462.6           2.2       1.0X
-skipIntegers, monotonic                               1              1           0        784.3           1.3       1.7X
-readIntegers, small-delta random                      3              3           0        321.4           3.1       0.7X
-skipIntegers, small-delta random                      2              3           0        421.7           2.4       0.9X
-readIntegers, wide random                             4              4           0        257.0           3.9       0.6X
-skipIntegers, wide random                             4              4           0        299.6           3.3       0.6X
+readIntegers, constant                                2              2           0        475.4           2.1       1.0X
+skipIntegers, constant                                2              2           0        605.5           1.7       1.3X
+readIntegers, monotonic                               2              2           0        475.6           2.1       1.0X
+skipIntegers, monotonic                               2              2           0        605.5           1.7       1.3X
+readIntegers, small-delta random                      3              3           0        332.5           3.0       0.7X
+skipIntegers, small-delta random                      3              3           0        398.9           2.5       0.8X
+readIntegers, wide random                             4              4           0        267.6           3.7       0.6X
+skipIntegers, wide random                             4              4           0        291.8           3.4       0.6X
 
 
 ================================================================================================
@@ -24,14 +24,14 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT64:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readLongs, constant                                   2              2           0        521.0           1.9       1.0X
-skipLongs, constant                                   2              2           0        581.6           1.7       1.1X
-readLongs, monotonic                                  2              2           0        521.1           1.9       1.0X
-skipLongs, monotonic                                  2              2           0        578.1           1.7       1.1X
-readLongs, small-delta random                         3              3           0        382.7           2.6       0.7X
-skipLongs, small-delta random                         3              3           0        412.7           2.4       0.8X
-readLongs, wide random                                5              6           0        190.8           5.2       0.4X
-skipLongs, wide random                                5              5           0        193.8           5.2       0.4X
+readLongs, constant                                   2              2           0        508.8           2.0       1.0X
+skipLongs, constant                                   2              2           0        602.3           1.7       1.2X
+readLongs, monotonic                                  2              2           0        508.6           2.0       1.0X
+skipLongs, monotonic                                  2              2           0        605.2           1.7       1.2X
+readLongs, small-delta random                         3              3           0        361.5           2.8       0.7X
+skipLongs, small-delta random                         3              3           0        396.9           2.5       0.8X
+readLongs, wide random                                6              6           0        190.6           5.2       0.4X
+skipLongs, wide random                                5              5           0        197.0           5.1       0.4X
 
 
 ================================================================================================
@@ -42,14 +42,14 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BYTE_ARRAY:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, no overlap, len=16                       28             33           4         37.7          26.5       1.0X
-skipBinary, no overlap, len=16                       31             32           2         34.3          29.2       0.9X
-readBinary, half overlap, len=16                     35             40           3         30.4          32.9       0.8X
-skipBinary, half overlap, len=16                     37             38           2         28.1          35.6       0.7X
-readBinary, full overlap, len=16                     35             36           2         30.3          33.0       0.8X
-skipBinary, full overlap, len=16                     38             39           3         27.9          35.9       0.7X
-readBinary, half overlap, len=64                     35             41           3         29.7          33.6       0.8X
-skipBinary, half overlap, len=64                     37             38           1         28.4          35.3       0.8X
+readBinary, no overlap, len=16                       25             26           1         41.4          24.2       1.0X
+skipBinary, no overlap, len=16                       17             18           1         60.0          16.7       1.5X
+readBinary, half overlap, len=16                     26             27           1         40.3          24.8       1.0X
+skipBinary, half overlap, len=16                     18             18           1         59.8          16.7       1.4X
+readBinary, full overlap, len=16                     25             25           1         42.5          23.5       1.0X
+skipBinary, full overlap, len=16                     17             18           0         60.2          16.6       1.5X
+readBinary, half overlap, len=64                     27             28           2         39.3          25.5       0.9X
+skipBinary, half overlap, len=64                     18             19           1         57.8          17.3       1.4X
 
 
 ================================================================================================
@@ -60,14 +60,14 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_LENGTH_BYTE_ARRAY:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, payloadLen=8                             16             17           0         65.0          15.4       1.0X
-skipBinary, payloadLen=8                              6              6           0        183.9           5.4       2.8X
-readBinary, payloadLen=32                            16             17           0         64.0          15.6       1.0X
-skipBinary, payloadLen=32                             6              6           0        184.3           5.4       2.8X
-readBinary, payloadLen=128                           19             19           2         56.1          17.8       0.9X
-skipBinary, payloadLen=128                            6              6           1        183.8           5.4       2.8X
-readBinary, payloadLen=512                           41             43           1         25.3          39.5       0.4X
-skipBinary, payloadLen=512                            6              6           0        183.9           5.4       2.8X
+readBinary, payloadLen=8                             16             17           2         64.1          15.6       1.0X
+skipBinary, payloadLen=8                              6              6           1        183.8           5.4       2.9X
+readBinary, payloadLen=32                            16             17           1         64.5          15.5       1.0X
+skipBinary, payloadLen=32                             6              6           1        183.6           5.4       2.9X
+readBinary, payloadLen=128                           19             19           1         55.8          17.9       0.9X
+skipBinary, payloadLen=128                            6              6           1        184.1           5.4       2.9X
+readBinary, payloadLen=512                           39             41           2         26.8          37.2       0.4X
+skipBinary, payloadLen=512                            6              6           1        184.1           5.4       2.9X
 
 
 ================================================================================================
@@ -78,20 +78,20 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 Variant reads:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------
-readBytes (INT32)                                                      5              5           0        216.6           4.6       1.0X
-readShorts (INT32)                                                     8              8           0        135.9           7.4       0.6X
-readUnsignedIntegers (INT32 -> Long)                                   9              9           0        118.7           8.4       0.5X
-readIntegersAsLongs (INT32 -> Long)                                    4              4           0        256.4           3.9       1.2X
-readIntegersAsLongs (INT32 -> Long, overflow pattern)                  4              4           0        257.3           3.9       1.2X
-readIntegersAsDoubles (INT32 -> Double)                                4              4           0        260.3           3.8       1.2X
-readIntegersAsDoubles (INT32 -> Double, overflow pattern)              4              4           0        259.8           3.8       1.2X
-readUnsignedLongs (INT64 -> Decimal(20,0))                            28             28           0         37.5          26.7       0.2X
-skipBytes                                                              5              5           0        209.2           4.8       1.0X
-skipShorts                                                             5              5           0        199.7           5.0       0.9X
-readByte (INT32 single-value)                                         14             14           1         73.6          13.6       0.3X
-readShort (INT32 single-value)                                        15             16           1         67.7          14.8       0.3X
-readInteger (INT32 single-value)                                      15             16           1         67.8          14.8       0.3X
-readLong (INT64 single-value)                                         17             17           2         61.7          16.2       0.3X
-readBinary(len) (DELTA_BYTE_ARRAY single-value)                       65             71           8         16.2          61.9       0.1X
+readBytes (INT32)                                                      5              5           0        213.2           4.7       1.0X
+readShorts (INT32)                                                     8              8           0        129.0           7.8       0.6X
+readUnsignedIntegers (INT32 -> Long)                                   9              9           0        114.4           8.7       0.5X
+readIntegersAsLongs (INT32 -> Long)                                    4              4           0        260.7           3.8       1.2X
+readIntegersAsLongs (INT32 -> Long, overflow pattern)                  4              4           0        260.6           3.8       1.2X
+readIntegersAsDoubles (INT32 -> Double)                                4              4           0        266.7           3.7       1.3X
+readIntegersAsDoubles (INT32 -> Double, overflow pattern)              4              4           0        266.6           3.8       1.3X
+readUnsignedLongs (INT64 -> Decimal(20,0))                            28             29           0         36.8          27.2       0.2X
+skipBytes                                                              9              9           0        120.1           8.3       0.6X
+skipShorts                                                             9              9           0        120.2           8.3       0.6X
+readByte (INT32 single-value)                                         12             12           0         86.4          11.6       0.4X
+readShort (INT32 single-value)                                        13             13           1         81.6          12.2       0.4X
+readInteger (INT32 single-value)                                      14             14           0         74.3          13.5       0.3X
+readLong (INT64 single-value)                                         16             16           0         66.1          15.1       0.3X
+readBinary(len) (DELTA_BYTE_ARRAY single-value)                       52             55           3         20.3          49.3       0.1X
 
 

--- a/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-results.txt
+++ b/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-results.txt
@@ -6,14 +6,14 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT32:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readIntegers, constant                                2              2           0        466.3           2.1       1.0X
-skipIntegers, constant                                3              3           0        398.8           2.5       0.9X
-readIntegers, monotonic                               2              2           0        466.2           2.1       1.0X
-skipIntegers, monotonic                               3              3           0        399.6           2.5       0.9X
-readIntegers, small-delta random                      3              3           0        345.1           2.9       0.7X
-skipIntegers, small-delta random                      3              3           0        313.2           3.2       0.7X
-readIntegers, wide random                             4              4           0        262.7           3.8       0.6X
-skipIntegers, wide random                             4              4           0        251.8           4.0       0.5X
+readIntegers, constant                                2              2           0        438.2           2.3       1.0X
+skipIntegers, constant                                2              2           0        534.1           1.9       1.2X
+readIntegers, monotonic                               2              2           0        436.6           2.3       1.0X
+skipIntegers, monotonic                               2              2           0        537.6           1.9       1.2X
+readIntegers, small-delta random                      3              3           0        312.0           3.2       0.7X
+skipIntegers, small-delta random                      3              3           0        370.8           2.7       0.8X
+readIntegers, wide random                             4              4           0        254.5           3.9       0.6X
+skipIntegers, wide random                             4              4           0        290.7           3.4       0.7X
 
 
 ================================================================================================
@@ -24,14 +24,14 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT64:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readLongs, constant                                   3              3           0        386.5           2.6       1.0X
-skipLongs, constant                                   3              3           0        396.8           2.5       1.0X
-readLongs, monotonic                                  3              3           0        386.2           2.6       1.0X
-skipLongs, monotonic                                  3              3           0        396.4           2.5       1.0X
-readLongs, small-delta random                         3              4           0        303.9           3.3       0.8X
-skipLongs, small-delta random                         3              4           0        304.7           3.3       0.8X
-readLongs, wide random                                6              6           0        166.8           6.0       0.4X
-skipLongs, wide random                                6              6           0        164.9           6.1       0.4X
+readLongs, constant                                   2              2           0        504.4           2.0       1.0X
+skipLongs, constant                                   2              2           0        537.5           1.9       1.1X
+readLongs, monotonic                                  2              2           0        519.2           1.9       1.0X
+skipLongs, monotonic                                  2              2           0        541.2           1.8       1.1X
+readLongs, small-delta random                         3              3           0        347.3           2.9       0.7X
+skipLongs, small-delta random                         3              3           0        370.8           2.7       0.7X
+readLongs, wide random                                6              6           0        181.4           5.5       0.4X
+skipLongs, wide random                                6              6           0        184.5           5.4       0.4X
 
 
 ================================================================================================
@@ -42,14 +42,14 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BYTE_ARRAY:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, no overlap, len=16                       30             30           1         35.2          28.4       1.0X
-skipBinary, no overlap, len=16                       32             33           1         32.3          31.0       0.9X
-readBinary, half overlap, len=16                     36             37           1         28.8          34.7       0.8X
-skipBinary, half overlap, len=16                     40             41           1         26.3          38.1       0.7X
-readBinary, full overlap, len=16                     37             38           1         28.1          35.5       0.8X
-skipBinary, full overlap, len=16                     40             41           1         26.1          38.4       0.7X
-readBinary, half overlap, len=64                     38             38           1         28.0          35.8       0.8X
-skipBinary, half overlap, len=64                     40             40           1         26.4          37.9       0.8X
+readBinary, no overlap, len=16                       27             28           1         39.0          25.7       1.0X
+skipBinary, no overlap, len=16                       18             19           0         58.3          17.2       1.5X
+readBinary, half overlap, len=16                     27             28           1         38.2          26.2       1.0X
+skipBinary, half overlap, len=16                     18             19           1         58.3          17.2       1.5X
+readBinary, full overlap, len=16                     26             27           1         39.7          25.2       1.0X
+skipBinary, full overlap, len=16                     18             19           1         58.3          17.2       1.5X
+readBinary, half overlap, len=64                     29             30           1         36.3          27.6       0.9X
+skipBinary, half overlap, len=64                     19             19           0         55.8          17.9       1.4X
 
 
 ================================================================================================
@@ -60,14 +60,14 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_LENGTH_BYTE_ARRAY:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, payloadLen=8                             17             19           3         62.6          16.0       1.0X
-skipBinary, payloadLen=8                              7              8           3        155.3           6.4       2.5X
-readBinary, payloadLen=32                            17             19           4         62.5          16.0       1.0X
-skipBinary, payloadLen=32                             7              8           3        155.5           6.4       2.5X
-readBinary, payloadLen=128                           19             22           3         54.3          18.4       0.9X
-skipBinary, payloadLen=128                            7              7           1        155.1           6.4       2.5X
-readBinary, payloadLen=512                           42             44           2         24.9          40.1       0.4X
-skipBinary, payloadLen=512                            7              7           1        154.9           6.5       2.5X
+readBinary, payloadLen=8                             16             18           2         65.2          15.3       1.0X
+skipBinary, payloadLen=8                              6              6           0        174.9           5.7       2.7X
+readBinary, payloadLen=32                            16             17           0         64.3          15.6       1.0X
+skipBinary, payloadLen=32                             6              6           0        174.7           5.7       2.7X
+readBinary, payloadLen=128                           19             19           0         55.6          18.0       0.9X
+skipBinary, payloadLen=128                            6              6           0        174.6           5.7       2.7X
+readBinary, payloadLen=512                           38             40           1         27.5          36.3       0.4X
+skipBinary, payloadLen=512                            6              6           0        174.8           5.7       2.7X
 
 
 ================================================================================================
@@ -78,20 +78,20 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 Variant reads:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------
-readBytes (INT32)                                                      6              6           0        178.5           5.6       1.0X
-readShorts (INT32)                                                     8              8           0        135.5           7.4       0.8X
-readUnsignedIntegers (INT32 -> Long)                                   8              8           0        136.8           7.3       0.8X
-readIntegersAsLongs (INT32 -> Long)                                    5              5           0        226.4           4.4       1.3X
-readIntegersAsLongs (INT32 -> Long, overflow pattern)                  5              5           0        226.3           4.4       1.3X
-readIntegersAsDoubles (INT32 -> Double)                                5              5           0        224.4           4.5       1.3X
-readIntegersAsDoubles (INT32 -> Double, overflow pattern)              5              5           0        224.6           4.5       1.3X
-readUnsignedLongs (INT64 -> Decimal(20,0))                            28             28           0         37.8          26.4       0.2X
-skipBytes                                                              9              9           0        122.4           8.2       0.7X
-skipShorts                                                             9              9           0        122.3           8.2       0.7X
-readByte (INT32 single-value)                                         14             14           0         75.2          13.3       0.4X
-readShort (INT32 single-value)                                        14             14           0         75.2          13.3       0.4X
-readInteger (INT32 single-value)                                      14             14           0         75.2          13.3       0.4X
-readLong (INT64 single-value)                                         16             16           0         67.4          14.8       0.4X
-readBinary(len) (DELTA_BYTE_ARRAY single-value)                       62             64           2         16.8          59.5       0.1X
+readBytes (INT32)                                                      5              5           0        207.5           4.8       1.0X
+readShorts (INT32)                                                     9              9           0        119.2           8.4       0.6X
+readUnsignedIntegers (INT32 -> Long)                                   9              9           1        121.6           8.2       0.6X
+readIntegersAsLongs (INT32 -> Long)                                    4              4           0        256.3           3.9       1.2X
+readIntegersAsLongs (INT32 -> Long, overflow pattern)                  4              4           0        256.0           3.9       1.2X
+readIntegersAsDoubles (INT32 -> Double)                                4              4           0        254.7           3.9       1.2X
+readIntegersAsDoubles (INT32 -> Double, overflow pattern)              4              4           0        254.9           3.9       1.2X
+readUnsignedLongs (INT64 -> Decimal(20,0))                            28             28           1         37.9          26.4       0.2X
+skipBytes                                                              6              6           0        171.6           5.8       0.8X
+skipShorts                                                             6              6           0        171.5           5.8       0.8X
+readByte (INT32 single-value)                                         12             12           0         85.2          11.7       0.4X
+readShort (INT32 single-value)                                        12             12           0         84.9          11.8       0.4X
+readInteger (INT32 single-value)                                      12             12           0         84.9          11.8       0.4X
+readLong (INT64 single-value)                                         14             15           0         72.7          13.8       0.4X
+readBinary(len) (DELTA_BYTE_ARRAY single-value)                       53             56           2         19.7          50.7       0.1X
 
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
@@ -29,7 +29,6 @@ import org.apache.spark.sql.types.GeographyType;
 import org.apache.spark.sql.types.GeometryType;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 /**
  * An implementation of the Parquet DELTA_BYTE_ARRAY decoder that supports the vectorized
@@ -41,19 +40,24 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
   private final VectorizedDeltaBinaryPackedReader prefixLengthReader;
   private final VectorizedDeltaLengthByteArrayReader suffixReader;
   private WritableColumnVector prefixLengthVector;
-  private ByteBuffer previous;
+
+  /**
+   * Reusable buffer holding the most recently decoded value. On each iteration the
+   * prefix bytes (shared with the previous value) are already in place at the start
+   * of this buffer, so only the suffix needs to be copied in. This eliminates the
+   * per-value allocation that the old {@code ByteBuffer}-based approach required.
+   */
+  private byte[] prevBuf = new byte[64];
+  private int prevLen = 0;
   private int currentRow = 0;
 
-  // Temporary variable used by readBinary
+  // Temporary variable used by readBinary(int)
   private final WritableColumnVector binaryValVector;
-  // Temporary variable used by skipBinary
-  private final WritableColumnVector tempBinaryValVector;
 
   VectorizedDeltaByteArrayReader() {
     this.prefixLengthReader = new VectorizedDeltaBinaryPackedReader();
     this.suffixReader = new VectorizedDeltaLengthByteArrayReader();
     binaryValVector = new OnHeapColumnVector(1, BinaryType);
-    tempBinaryValVector = new OnHeapColumnVector(1, BinaryType);
   }
 
   @Override
@@ -79,20 +83,25 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
       // value of the page should have an empty prefix, it may not
       // because of PARQUET-246.
       int prefixLength = prefixLengthVector.getInt(currentRow);
-      ByteBuffer suffix = suffixReader.getBytes(currentRow);
-      byte[] suffixArray = suffix.array();
-      int suffixLength = suffix.limit() - suffix.position();
+      int suffixLength = suffixReader.getSuffixLength(currentRow);
       int length = prefixLength + suffixLength;
 
-      // We have to do this to materialize the output
+      // Grow prevBuf if needed, preserving the prefix bytes already in place.
+      if (length > prevBuf.length) {
+        byte[] newBuf = new byte[Math.max(length, prevBuf.length * 2)];
+        System.arraycopy(prevBuf, 0, newBuf, 0, prefixLength);
+        prevBuf = newBuf;
+      }
+      // The prefix bytes (prevBuf[0..prefixLength-1]) are already in place from
+      // the previous iteration. Read the suffix directly after them.
+      suffixReader.getSuffixInto(currentRow, prevBuf, prefixLength);
+      prevLen = length;
+
+      // Write the full assembled value to the output column vector.
       WritableColumnVector arrayData = c.arrayData();
       int offset = arrayData.getElementsAppended();
-      if (prefixLength != 0) {
-        arrayData.appendBytes(prefixLength, previous.array(), previous.position());
-      }
-      arrayData.appendBytes(suffixLength, suffixArray, suffix.position());
+      arrayData.appendBytes(length, prevBuf, 0);
       c.putArray(rowId + i, offset, length);
-      previous = arrayData.getByteBuffer(offset, length);
       currentRow++;
     }
   }
@@ -120,15 +129,14 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
      WKBConverterStrategy converter) {
     for (int i = 0; i < total; i++) {
       int prefixLength = prefixLengthVector.getInt(currentRow);
-      ByteBuffer suffix = suffixReader.getBytes(currentRow);
-      int suffixLength = suffix.limit() - suffix.position();
+      int suffixLength = suffixReader.getSuffixLength(currentRow);
       int length = prefixLength + suffixLength;
 
       byte[] wkb = new byte[length];
       if (prefixLength > 0) {
-        previous.get(wkb, 0, prefixLength);
+        System.arraycopy(prevBuf, 0, wkb, 0, prefixLength);
       }
-      suffix.get(wkb, prefixLength, suffixLength);
+      suffixReader.getSuffixInto(currentRow, wkb, prefixLength);
 
       // Converts WKB into a physical representation of geometry/geography.
       byte[] physicalValue = converter.convert(wkb, srid);
@@ -138,7 +146,11 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
       arrayData.appendBytes(physicalValue.length, physicalValue, 0);
 
       c.putArray(rowId + i, offset, physicalValue.length);
-      previous = ByteBuffer.wrap(wkb);
+
+      // Take ownership of wkb as prevBuf -- it is freshly allocated and
+      // exactly the right size for the next value's prefix.
+      prevBuf = wkb;
+      prevLen = length;
 
       currentRow++;
     }
@@ -154,34 +166,33 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
   @Override
   public void setPreviousReader(ValuesReader reader) {
     if (reader != null) {
-      this.previous = ((VectorizedDeltaByteArrayReader) reader).previous;
+      VectorizedDeltaByteArrayReader prev = (VectorizedDeltaByteArrayReader) reader;
+      if (prev.prevLen > prevBuf.length) {
+        prevBuf = new byte[prev.prevLen];
+      }
+      System.arraycopy(prev.prevBuf, 0, prevBuf, 0, prev.prevLen);
+      prevLen = prev.prevLen;
     }
   }
 
   @Override
   public void skipBinary(int total) {
-    WritableColumnVector c1 = tempBinaryValVector;
-    WritableColumnVector c2 = binaryValVector;
-
     for (int i = 0; i < total; i++) {
       int prefixLength = prefixLengthVector.getInt(currentRow);
-      ByteBuffer suffix = suffixReader.getBytes(currentRow);
-      byte[] suffixArray = suffix.array();
-      int suffixLength = suffix.limit() - suffix.position();
+      int suffixLength = suffixReader.getSuffixLength(currentRow);
       int length = prefixLength + suffixLength;
 
-      WritableColumnVector arrayData = c1.arrayData();
-      c1.reset();
-      if (prefixLength != 0) {
-        arrayData.appendBytes(prefixLength, previous.array(), previous.position());
+      // Grow prevBuf if needed, preserving the prefix bytes already in place.
+      if (length > prevBuf.length) {
+        byte[] newBuf = new byte[Math.max(length, prevBuf.length * 2)];
+        System.arraycopy(prevBuf, 0, newBuf, 0, prefixLength);
+        prevBuf = newBuf;
       }
-      arrayData.appendBytes(suffixLength, suffixArray, suffix.position());
-      previous = arrayData.getByteBuffer(0, length);
+      // Read the suffix directly after the prefix -- keeps prevBuf up-to-date
+      // for the next value (or the next page via setPreviousReader).
+      suffixReader.getSuffixInto(currentRow, prevBuf, prefixLength);
+      prevLen = length;
       currentRow++;
-
-      WritableColumnVector tmp = c1;
-      c1 = c2;
-      c2 = tmp;
     }
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
@@ -132,25 +132,29 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
       int suffixLength = suffixReader.getSuffixLength(currentRow);
       int length = prefixLength + suffixLength;
 
-      byte[] wkb = new byte[length];
-      if (prefixLength > 0) {
-        System.arraycopy(prevBuf, 0, wkb, 0, prefixLength);
+      // Grow prevBuf if needed, preserving the prefix bytes already in place.
+      if (length > prevBuf.length) {
+        byte[] newBuf = new byte[Math.max(length, prevBuf.length * 2)];
+        System.arraycopy(prevBuf, 0, newBuf, 0, prefixLength);
+        prevBuf = newBuf;
       }
-      suffixReader.getSuffixInto(currentRow, wkb, prefixLength);
+      // The prefix bytes (prevBuf[0..prefixLength-1]) are already in place from the
+      // previous iteration. Read the suffix directly after them so the full WKB value
+      // occupies prevBuf[0..length-1]. This shares the reusable-buffer protocol with
+      // readValues/skipBinary, so interleaving skip and read stays consistent.
+      suffixReader.getSuffixInto(currentRow, prevBuf, prefixLength);
+      prevLen = length;
 
-      // Converts WKB into a physical representation of geometry/geography.
-      byte[] physicalValue = converter.convert(wkb, srid);
+      // Convert only the [0, length) sub-range of prevBuf. The offset/length overload
+      // ensures stale trailing bytes (when prevBuf capacity exceeds length) do not ride
+      // along, and avoids allocating an exact-size copy of the WKB per value.
+      byte[] physicalValue = converter.convert(prevBuf, 0, length, srid);
 
       WritableColumnVector arrayData = c.arrayData();
       int offset = arrayData.getElementsAppended();
       arrayData.appendBytes(physicalValue.length, physicalValue, 0);
 
       c.putArray(rowId + i, offset, physicalValue.length);
-
-      // Take ownership of wkb as prevBuf -- it is freshly allocated and
-      // exactly the right size for the next value's prefix.
-      prevBuf = wkb;
-      prevLen = length;
 
       currentRow++;
     }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
@@ -214,17 +214,19 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
   }
 
   /**
-   * Guards against a corrupt page whose {@code prefixLength} exceeds the length of the previously
-   * decoded value ({@code prevLen}). Legal writers never emit this, but because {@code prevBuf} is
-   * pre-zeroed and reused across values, an unchecked prefix would silently pull stale or zero
-   * bytes into the assembled value instead of failing. Throwing here keeps corrupt input a
-   * fail-fast error, matching the pre-buffer-reuse behavior (an NPE on the old {@code previous}).
+   * Guards against a corrupt page whose {@code prefixLength} is out of range: negative, or larger
+   * than the length of the previously decoded value ({@code prevLen}). Legal writers never emit
+   * this, but because {@code prevBuf} is pre-zeroed and reused across values, an unchecked prefix
+   * would silently pull stale or zero bytes into the assembled value instead of failing. Throwing
+   * here keeps corrupt input a fail-fast error, matching the pre-buffer-reuse behavior (an NPE on
+   * the old {@code previous}). The suffix length is validated separately in
+   * {@link VectorizedDeltaLengthByteArrayReader#getSuffixLength}.
    */
   private void checkPrefixLength(int prefixLength) {
-    if (prefixLength > prevLen) {
+    if (prefixLength < 0 || prefixLength > prevLen) {
       throw new ParquetDecodingException(
-          "Prefix length " + prefixLength + " is larger than the previous value length "
-              + prevLen + "; the DELTA_BYTE_ARRAY page is corrupt");
+          "Prefix length " + prefixLength + " is out of range [0, " + prevLen
+              + "]; the DELTA_BYTE_ARRAY page is corrupt");
     }
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
@@ -22,6 +22,7 @@ import static org.apache.spark.sql.types.DataTypes.IntegerType;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.values.RequiresPreviousReader;
 import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.api.Binary;
 import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector;
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
@@ -86,6 +87,12 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
       int suffixLength = suffixReader.getSuffixLength(currentRow);
       int length = prefixLength + suffixLength;
 
+      // The prefix is shared with the previously decoded value, so it can be at most as long
+      // as that value. A larger prefixLength means the file is corrupt (e.g. PARQUET-246 on the
+      // first value of the first page). prevBuf is pre-zeroed and reused, so without this guard
+      // such input would silently assemble stale/zero prefix bytes instead of failing.
+      checkPrefixLength(prefixLength);
+
       // Grow prevBuf if needed, preserving the prefix bytes already in place.
       if (length > prevBuf.length) {
         byte[] newBuf = new byte[Math.max(length, prevBuf.length * 2)];
@@ -131,6 +138,9 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
       int prefixLength = prefixLengthVector.getInt(currentRow);
       int suffixLength = suffixReader.getSuffixLength(currentRow);
       int length = prefixLength + suffixLength;
+
+      // See readValues: guard against a prefix longer than the previous value (corrupt input).
+      checkPrefixLength(prefixLength);
 
       // Grow prevBuf if needed, preserving the prefix bytes already in place.
       if (length > prevBuf.length) {
@@ -186,6 +196,9 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
       int suffixLength = suffixReader.getSuffixLength(currentRow);
       int length = prefixLength + suffixLength;
 
+      // See readValues: guard against a prefix longer than the previous value (corrupt input).
+      checkPrefixLength(prefixLength);
+
       // Grow prevBuf if needed, preserving the prefix bytes already in place.
       if (length > prevBuf.length) {
         byte[] newBuf = new byte[Math.max(length, prevBuf.length * 2)];
@@ -197,6 +210,21 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
       suffixReader.getSuffixInto(currentRow, prevBuf, prefixLength);
       prevLen = length;
       currentRow++;
+    }
+  }
+
+  /**
+   * Guards against a corrupt page whose {@code prefixLength} exceeds the length of the previously
+   * decoded value ({@code prevLen}). Legal writers never emit this, but because {@code prevBuf} is
+   * pre-zeroed and reused across values, an unchecked prefix would silently pull stale or zero
+   * bytes into the assembled value instead of failing. Throwing here keeps corrupt input a
+   * fail-fast error, matching the pre-buffer-reuse behavior (an NPE on the old {@code previous}).
+   */
+  private void checkPrefixLength(int prefixLength) {
+    if (prefixLength > prevLen) {
+      throw new ParquetDecodingException(
+          "Prefix length " + prefixLength + " is larger than the previous value length "
+              + prevLen + "; the DELTA_BYTE_ARRAY page is corrupt");
     }
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
@@ -111,6 +111,33 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
     }
   }
 
+  /**
+   * Returns the suffix length for the given row and reads the suffix bytes directly into
+   * {@code dest} at {@code destOffset}, avoiding the intermediate {@link ByteBuffer}
+   * allocation that {@link #getBytes(int)} performs.
+   */
+  public int getSuffixInto(int rowId, byte[] dest, int destOffset) {
+    int length = lengthsVector.getInt(rowId);
+    int totalRead = 0;
+    try {
+      while (totalRead < length) {
+        int n = in.read(dest, destOffset + totalRead, length - totalRead);
+        if (n < 0) {
+          throw new ParquetDecodingException("Failed to read " + length + " bytes");
+        }
+        totalRead += n;
+      }
+    } catch (IOException e) {
+      throw new ParquetDecodingException("Failed to read " + length + " bytes", e);
+    }
+    return length;
+  }
+
+  /** Returns the suffix length for the given row without consuming the bytes. */
+  public int getSuffixLength(int rowId) {
+    return lengthsVector.getInt(rowId);
+  }
+
   @Override
   public void skipBinary(int total) {
     for (int i = 0; i < total; i++) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
@@ -124,9 +124,32 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
     return length;
   }
 
-  /** Returns the suffix length for the given row without consuming the bytes. */
+  /**
+   * Returns the suffix length for the given row without consuming the bytes.
+   *
+   * <p>Callers size their reusable buffer from this value before reading, so a corrupt length
+   * is validated here rather than at read time. When this is called {@code in} sits exactly at
+   * this row's suffix (all earlier suffixes are already consumed), so {@link
+   * ByteBufferInputStream#available()} is the exact number of bytes left in the page: a negative
+   * length, or one exceeding what remains, means the page is corrupt. Checking up front prevents
+   * a bogus length from driving a huge (up to 2GB) buffer allocation and an {@code
+   * OutOfMemoryError} -- an {@code Error} that {@code ignoreCorruptFiles} cannot catch -- instead
+   * of a plain {@link ParquetDecodingException}. On master this was implicit in the {@code
+   * in.slice(length)} bounds check.
+   */
   public int getSuffixLength(int rowId) {
-    return lengthsVector.getInt(rowId);
+    int length = lengthsVector.getInt(rowId);
+    if (length < 0) {
+      throw new ParquetDecodingException(
+          "Negative suffix length " + length + "; the DELTA_BYTE_ARRAY page is corrupt");
+    }
+    int available = in.available();
+    if (length > available) {
+      throw new ParquetDecodingException(
+          "Suffix length " + length + " exceeds the " + available
+              + " bytes remaining in the page; the DELTA_BYTE_ARRAY page is corrupt");
+    }
+    return length;
   }
 
   @Override

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
@@ -102,19 +102,10 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
     currentRow += total;
   }
 
-  public ByteBuffer getBytes(int rowId) {
-    int length = lengthsVector.getInt(rowId);
-    try {
-      return in.slice(length);
-    } catch (EOFException e) {
-      throw new ParquetDecodingException("Failed to read " + length + " bytes");
-    }
-  }
-
   /**
    * Returns the suffix length for the given row and reads the suffix bytes directly into
    * {@code dest} at {@code destOffset}, avoiding the intermediate {@link ByteBuffer}
-   * allocation that {@link #getBytes(int)} performs.
+   * allocation that a slice-based read would perform.
    */
   public int getSuffixInto(int rowId, byte[] dest, int destOffset) {
     int length = lengthsVector.getInt(rowId);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/WKBConverterStrategy.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/WKBConverterStrategy.java
@@ -23,7 +23,17 @@ import org.apache.spark.sql.catalyst.util.STUtils;
  * Interface for converting a WKB byte array into a physical geometry or geography value.
  */
 interface WKBConverterStrategy {
-  byte[] convert(byte[] wkb, int srid);
+  /**
+   * Converts the WKB bytes in the sub-range {@code [offset, offset + length)} of {@code wkb}
+   * into a physical geometry/geography value. Accepting an offset/length lets callers reuse a
+   * larger backing buffer without materializing an exact-size copy.
+   */
+  byte[] convert(byte[] wkb, int offset, int length, int srid);
+
+  /** Convenience overload that converts the entire {@code wkb} array. */
+  default byte[] convert(byte[] wkb, int srid) {
+    return convert(wkb, 0, wkb.length, srid);
+  }
 }
 
 /**
@@ -33,8 +43,8 @@ enum WKBToGeometryConverter implements WKBConverterStrategy {
   INSTANCE;
 
   @Override
-  public byte[] convert(byte[] wkb, int srid) {
-    return STUtils.stGeomFromWKB(wkb, srid).getBytes();
+  public byte[] convert(byte[] wkb, int offset, int length, int srid) {
+    return STUtils.stGeomFromWKB(wkb, offset, length, srid).getBytes();
   }
 }
 
@@ -45,7 +55,7 @@ enum WKBToGeographyConverter implements WKBConverterStrategy {
   INSTANCE;
 
   @Override
-  public byte[] convert(byte[] wkb, int srid) {
-    return STUtils.stGeogFromWKB(wkb, srid).getBytes();
+  public byte[] convert(byte[] wkb, int offset, int length, int srid) {
+    return STUtils.stGeogFromWKB(wkb, offset, length, srid).getBytes();
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaByteArrayEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaByteArrayEncodingSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.datasources.parquet
 import org.apache.parquet.bytes.DirectByteBufferAllocator
 import org.apache.parquet.column.values.Utils
 import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter
+import org.apache.parquet.io.api.Binary
 
 import org.apache.spark.sql.catalyst.util.STUtils
 import org.apache.spark.sql.execution.vectorized.{OnHeapColumnVector, WritableColumnVector}
@@ -32,6 +33,31 @@ import org.apache.spark.sql.types.{DataType, GeographyType, GeometryType, Intege
 class ParquetDeltaByteArrayEncodingSuite extends ParquetCompatibilityTest with SharedSparkSession {
   val values: Array[String] = Array("parquet-mr", "parquet", "parquet-format");
   val randvalues: Array[String] = Utils.getRandomStringSamples(10000, 32)
+
+  // Values whose total length exceeds prevBuf's initial 64-byte capacity and that
+  // share long (> 64 byte) prefixes. These exercise the prevBuf grow branch in
+  // readBinary/skipBinary, where the already-decoded prefix must be preserved
+  // across the reallocation (System.arraycopy(prevBuf, 0, newBuf, 0, prefixLength)).
+  // An even count is required so assertReadWriteWithSkip (read even, skip odd)
+  // does not run past the last value. The skipped (odd) values also trigger the
+  // grow branch, and the following read validates that skipBinary kept prevBuf
+  // intact across the reallocation.
+  private val longPrefixBase = "a" * 70
+  val longPrefixValues: Array[String] = Array(
+    // len  70: read, grow, prefix 0
+    longPrefixBase,
+    // len 160: skip, grow, prefix 70
+    longPrefixBase + "b" * 90,
+    // len 165: read, shares 160 prefix
+    longPrefixBase + "b" * 90 + "c" * 5,
+    // len 265: skip, grow, prefix 165
+    longPrefixBase + "b" * 90 + "c" * 5 + "d" * 100,
+    // len 270: read, shares 265 prefix
+    longPrefixBase + "b" * 90 + "c" * 5 + "d" * 100 + "e" * 5,
+    // len 271: skip, shares 270 prefix
+    longPrefixBase + "b" * 90 + "c" * 5 + "d" * 100 + "e" * 5 + "f")
+
+
 
   var writer: DeltaByteArrayWriter = _
   var reader: VectorizedDeltaByteArrayReader = _
@@ -57,6 +83,57 @@ class ParquetDeltaByteArrayEncodingSuite extends ParquetCompatibilityTest with S
 
   test("random strings with skipN") {
     assertReadWriteWithSkipN(writer, reader, randvalues)
+  }
+
+  test("buffer grows preserving long shared prefixes") {
+    assertReadWrite(writer, reader, longPrefixValues)
+  }
+
+  test("buffer grows preserving long shared prefixes with skip") {
+    assertReadWriteWithSkip(writer, reader, longPrefixValues)
+  }
+
+  test("setPreviousReader recovers a long previous value across pages (PARQUET-246)") {
+    // Reproduces PARQUET-246: the first value of a page is a delta from the
+    // previous page's last value. The recovered value exceeds the 64-byte prevBuf
+    // capacity, exercising the grow + deep-copy in setPreviousReader.
+    val prefix = "a" * 100
+    val firstPageVals = Array(prefix, prefix + "0")        // last value len 101
+    val secondPageVals = Array(prefix + "1", prefix + "2") // first value deltas off prev page
+
+    val firstWriter =
+      new DeltaByteArrayWriter(64 * 1024, 64 * 1024, new DirectByteBufferAllocator)
+    Utils.writeData(firstWriter, firstPageVals)
+
+    // Corrupt the second writer so its first value shares the first page's last
+    // value prefix (simulating the DeltaByteArrayWriter.reset() bug).
+    val secondWriter =
+      new DeltaByteArrayWriter(64 * 1024, 64 * 1024, new DirectByteBufferAllocator)
+    corruptWriter(secondWriter, firstPageVals.last)
+    Utils.writeData(secondWriter, secondPageVals)
+
+    val firstReader = new VectorizedDeltaByteArrayReader()
+    var vec: WritableColumnVector = new OnHeapColumnVector(firstPageVals.length, StringType)
+    firstReader.initFromPage(firstPageVals.length, firstWriter.getBytes.toInputStream)
+    firstReader.readBinary(firstPageVals.length, vec, 0)
+    for (i <- firstPageVals.indices) {
+      assert(firstPageVals(i).getBytes() sameElements vec.getBinary(i))
+    }
+
+    val secondReader = new VectorizedDeltaByteArrayReader()
+    vec = new OnHeapColumnVector(secondPageVals.length, StringType)
+    secondReader.initFromPage(secondPageVals.length, secondWriter.getBytes.toInputStream)
+    secondReader.setPreviousReader(firstReader)
+    secondReader.readBinary(secondPageVals.length, vec, 0)
+    for (i <- secondPageVals.indices) {
+      assert(secondPageVals(i).getBytes() sameElements vec.getBinary(i))
+    }
+  }
+
+  private def corruptWriter(writer: DeltaByteArrayWriter, data: String): Unit = {
+    val previous = writer.getClass.getDeclaredField("previous")
+    previous.setAccessible(true)
+    previous.set(writer, Binary.fromString(data).getBytesUnsafe())
   }
 
   test("test lengths") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaByteArrayEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaByteArrayEncodingSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.datasources.parquet
 import org.apache.parquet.bytes.DirectByteBufferAllocator
 import org.apache.parquet.column.values.Utils
 import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter
+import org.apache.parquet.io.ParquetDecodingException
 import org.apache.parquet.io.api.Binary
 
 import org.apache.spark.sql.catalyst.util.STUtils
@@ -130,6 +131,38 @@ class ParquetDeltaByteArrayEncodingSuite extends ParquetCompatibilityTest with S
     }
   }
 
+  test("corrupt first value with a non-zero prefix fails fast") {
+    // A legal DELTA_BYTE_ARRAY first-page first value always has an empty prefix. A corrupt page
+    // whose first value carries a non-zero prefixLength references prefix bytes that were never
+    // decoded (prevLen == 0). prevBuf is pre-zeroed and reused, so without a guard the decoder
+    // would silently assemble zero bytes as the shared prefix and return wrong data. The reader
+    // must instead fail fast. A short (<= 64 byte) prefix is used so the value fits prevBuf's
+    // initial capacity, isolating the guard from the grow-branch bounds check.
+    val shared = "abcdefghij" // 10-byte prefix
+    val vals = Array(shared + "1", shared + "2")
+
+    // Corrupt the writer so its first value deltas off `shared`, yielding prefixLength = 10.
+    corruptWriter(writer, shared)
+    Utils.writeData(writer, vals)
+    val bytes = writer.getBytes
+
+    // readBinary path.
+    val readReader = new VectorizedDeltaByteArrayReader()
+    val readVec: WritableColumnVector = new OnHeapColumnVector(vals.length, StringType)
+    readReader.initFromPage(vals.length, bytes.toInputStream)
+    val readEx = intercept[ParquetDecodingException] {
+      readReader.readBinary(vals.length, readVec, 0)
+    }
+    assert(readEx.getMessage.contains("Prefix length"))
+
+    // skipBinary path.
+    val skipReader = new VectorizedDeltaByteArrayReader()
+    skipReader.initFromPage(vals.length, bytes.toInputStream)
+    intercept[ParquetDecodingException] {
+      skipReader.skipBinary(vals.length)
+    }
+  }
+
   private def corruptWriter(writer: DeltaByteArrayWriter, data: String): Unit = {
     corruptWriter(writer, Binary.fromString(data).getBytesUnsafe())
   }
@@ -227,6 +260,25 @@ class ParquetDeltaByteArrayEncodingSuite extends ParquetCompatibilityTest with S
     readGeoInto(secondReader, secondPageVals.length, vec, isGeometry)
     for (i <- secondPageVals.indices) {
       assert(secondPageVals(i) sameElements extractGeoWkb(vec, i, isGeometry, srid))
+    }
+  }
+
+  testGeo("corrupt first geo value with a non-zero prefix fails fast") { geoType =>
+    // The geo path shares the reusable prevBuf protocol, so a corrupt first value carrying a
+    // non-zero prefixLength must fail fast rather than silently assembling zero prefix bytes.
+    val isGeometry = geoType.isInstanceOf[GeometryType]
+    val vals = sharedPrefixPolygons(2)
+
+    // Corrupt the writer so its first value deltas off an unrelated polygon that shares the
+    // long WKB prefix, yielding a non-zero prefixLength against a reader whose prevLen is 0.
+    corruptWriter(writer, sharedPrefixPolygons(1, base = 50).head)
+    writeBinaryData(writer, vals)
+
+    val corruptReader = new VectorizedDeltaByteArrayReader()
+    val vec: WritableColumnVector = new OnHeapColumnVector(vals.length, geoType)
+    corruptReader.initFromPage(vals.length, writer.getBytes.toInputStream)
+    intercept[ParquetDecodingException] {
+      readGeoInto(corruptReader, vals.length, vec, isGeometry)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaByteArrayEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaByteArrayEncodingSuite.scala
@@ -173,6 +173,67 @@ class ParquetDeltaByteArrayEncodingSuite extends ParquetCompatibilityTest with S
     previous.set(writer, data)
   }
 
+  test("corrupt suffix/prefix lengths fail fast without over-allocating") {
+    // The reader now sizes its reusable prevBuf from the decoded prefix/suffix lengths before
+    // reading the bytes. A legal DELTA_BYTE_ARRAY page never encodes a suffix length larger than
+    // the bytes remaining in the page, nor a negative prefix/suffix length; a corrupt one could.
+    // Without the up-front guards a bogus suffix length (up to ~2GB) would drive a huge buffer
+    // allocation / OutOfMemoryError -- an Error that ignoreCorruptFiles cannot catch -- instead of
+    // a plain ParquetDecodingException. These checks keep such input a fail-fast decoding error.
+    val vals = Array("aaaa", "bbbb", "cccc")
+    Utils.writeData(writer, vals)
+    val bytes = writer.getBytes
+
+    // Corrupts the decoded length vectors after initFromPage to simulate a malformed page, since a
+    // conforming writer cannot emit these values.
+    def freshReaderWith(
+        corruptSuffix: Option[Int] = None,
+        corruptPrefix: Option[Int] = None): VectorizedDeltaByteArrayReader = {
+      val reader = new VectorizedDeltaByteArrayReader()
+      reader.initFromPage(vals.length, bytes.toInputStream)
+      corruptSuffix.foreach { len =>
+        val suffixReaderField =
+          classOf[VectorizedDeltaByteArrayReader].getDeclaredField("suffixReader")
+        suffixReaderField.setAccessible(true)
+        val suffixReader = suffixReaderField.get(reader)
+        val lengthsVectorField =
+          classOf[VectorizedDeltaLengthByteArrayReader].getDeclaredField("lengthsVector")
+        lengthsVectorField.setAccessible(true)
+        lengthsVectorField.get(suffixReader).asInstanceOf[WritableColumnVector].putInt(0, len)
+      }
+      corruptPrefix.foreach { len =>
+        val prefixVectorField =
+          classOf[VectorizedDeltaByteArrayReader].getDeclaredField("prefixLengthVector")
+        prefixVectorField.setAccessible(true)
+        prefixVectorField.get(reader).asInstanceOf[WritableColumnVector].putInt(0, len)
+      }
+      reader
+    }
+
+    def readFirst(reader: VectorizedDeltaByteArrayReader): Unit = {
+      val vec: WritableColumnVector = new OnHeapColumnVector(vals.length, StringType)
+      reader.readBinary(vals.length, vec, 0)
+    }
+
+    // Suffix length far beyond the page: must fail before allocating prevBuf.
+    val tooLong = intercept[ParquetDecodingException] {
+      readFirst(freshReaderWith(corruptSuffix = Some(Int.MaxValue)))
+    }
+    assert(tooLong.getMessage.contains("exceeds"))
+
+    // Negative suffix length.
+    val negSuffix = intercept[ParquetDecodingException] {
+      readFirst(freshReaderWith(corruptSuffix = Some(-1)))
+    }
+    assert(negSuffix.getMessage.contains("Negative suffix length"))
+
+    // Negative prefix length (guarded in checkPrefixLength alongside the upper bound).
+    val negPrefix = intercept[ParquetDecodingException] {
+      readFirst(freshReaderWith(corruptPrefix = Some(-1)))
+    }
+    assert(negPrefix.getMessage.contains("out of range"))
+  }
+
   test("test lengths") {
     var reader = new VectorizedDeltaBinaryPackedReader
     Utils.writeData(writer, values)
@@ -218,9 +279,19 @@ class ParquetDeltaByteArrayEncodingSuite extends ParquetCompatibilityTest with S
     // A geometry column with null or skipped rows alternates skipBinary (used for the
     // skipped rows) with readGeometry/readGeography on the same reader. Both paths now
     // share the reusable prevBuf, so the shared prefix carried across a skipped value must
-    // still be honored by the following read. The values also exceed prevBuf's initial
-    // 64-byte capacity, exercising the grow-and-preserve branch under interleaving.
-    assertGeoReadWriteWithSkip(writer, reader, sharedPrefixPolygons(6), geoType)
+    // still be honored by the following read.
+    //
+    // growingPrefixPolygons is shaped like longPrefixValues on the non-geo side so that this
+    // test can actually distinguish a bug from working code:
+    //   - Values differ in length (point count), so a read (readGeoData) crosses prevBuf's
+    //     capacity and takes the grow-and-preserve branch with a non-zero prefixLength -- not
+    //     just the first value at prefixLength 0.
+    //   - Consecutive equal-length polygons share a long prefix while polygons two apart differ
+    //     at the numPoints field (byte 9, a 9-byte prefix). Reading an even row therefore relies
+    //     on the shared prefix left by the odd row that skipBinary just processed; if skipBinary
+    //     stopped maintaining prevBuf, that read would decode wrong bytes (or fail the prefix
+    //     guard) instead of silently passing.
+    assertGeoReadWriteWithSkip(writer, reader, growingPrefixPolygons(), geoType)
   }
 
   testGeo("geo setPreviousReader recovers a long value across pages (PARQUET-246)") { geoType =>
@@ -280,6 +351,40 @@ class ParquetDeltaByteArrayEncodingSuite extends ParquetCompatibilityTest with S
     intercept[ParquetDecodingException] {
       readGeoInto(corruptReader, vals.length, vec, isGeometry)
     }
+  }
+
+  /**
+   * Generates WKB polygons shaped like `longPrefixValues` for the geo interleave test: values of
+   * differing length where consecutive equal-length polygons share a long prefix but polygons two
+   * apart do not. The point counts (8, 12, 12, 16, 30, 30) drive two properties:
+   *
+   *   - The 30-point polygon at an even (read) index exceeds prevBuf's grown capacity, so
+   *     `readGeoData` takes the grow-and-preserve branch with a non-zero prefixLength (the 9-byte
+   *     WKB header shared with the shorter predecessor), not merely the first value at prefix 0.
+   *   - Each equal-length pair (indices 1/2 and 4/5) differs only in a late coordinate, so an
+   *     even row reads with a long prefix against the odd row that `skipBinary` just processed,
+   *     while the even row two positions back has a different point count and diverges at the
+   *     numPoints field (byte 9). A read after a skip therefore genuinely depends on the prefix
+   *     `skipBinary` left in prevBuf; a skip that stopped maintaining prevBuf would decode wrong
+   *     bytes or trip the prefix-length guard rather than pass unnoticed.
+   *
+   * Coordinates stay within geography bounds (lon in [-180, 180], lat in [-90, 90]) so the same
+   * WKB is valid for every geo type. The count is even so the read-even/skip-odd pattern in
+   * `assertGeoReadWriteWithSkip` does not run past the last value.
+   */
+  private def growingPrefixPolygons(): Array[Array[Byte]] = {
+    val counts = Array(8, 12, 12, 16, 30, 30)
+    def basePoint(i: Int): (Double, Double) = (-100.0 + i * 2, -40.0 + i)
+    var variant = 0
+    counts.map { n =>
+      variant += 1
+      val body = (0 until n - 2).map(basePoint)
+      // Nudge the second-to-last point's latitude to distinguish this polygon from its
+      // same-length predecessor; earlier points stay identical so the shared prefix is long.
+      val (lon, lat) = basePoint(n - 2)
+      val ring = (body :+ (lon, lat + variant * 0.001)) :+ basePoint(0)
+      makePolygonWkb(ring: _*)
+    }.toArray
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaByteArrayEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaByteArrayEncodingSuite.scala
@@ -131,9 +131,13 @@ class ParquetDeltaByteArrayEncodingSuite extends ParquetCompatibilityTest with S
   }
 
   private def corruptWriter(writer: DeltaByteArrayWriter, data: String): Unit = {
+    corruptWriter(writer, Binary.fromString(data).getBytesUnsafe())
+  }
+
+  private def corruptWriter(writer: DeltaByteArrayWriter, data: Array[Byte]): Unit = {
     val previous = writer.getClass.getDeclaredField("previous")
     previous.setAccessible(true)
-    previous.set(writer, Binary.fromString(data).getBytesUnsafe())
+    previous.set(writer, data)
   }
 
   test("test lengths") {
@@ -177,6 +181,98 @@ class ParquetDeltaByteArrayEncodingSuite extends ParquetCompatibilityTest with S
       geoType)
   }
 
+  testGeo("geo interleaves skipBinary with readGeoData (null/skipped rows)") { geoType =>
+    // A geometry column with null or skipped rows alternates skipBinary (used for the
+    // skipped rows) with readGeometry/readGeography on the same reader. Both paths now
+    // share the reusable prevBuf, so the shared prefix carried across a skipped value must
+    // still be honored by the following read. The values also exceed prevBuf's initial
+    // 64-byte capacity, exercising the grow-and-preserve branch under interleaving.
+    assertGeoReadWriteWithSkip(writer, reader, sharedPrefixPolygons(6), geoType)
+  }
+
+  testGeo("geo setPreviousReader recovers a long value across pages (PARQUET-246)") { geoType =>
+    // PARQUET-246 on the geo path: the first value of the second page is a delta from the
+    // previous page's last value. The recovered value exceeds the 64-byte prevBuf capacity,
+    // exercising the grow + deep-copy in setPreviousReader before readGeoData reuses it.
+    val (isGeometry, srid) = geoType match {
+      case geom: GeometryType => (true, geom.srid)
+      case geog: GeographyType => (false, geog.srid)
+    }
+    val firstPageVals = sharedPrefixPolygons(2)
+    val secondPageVals = sharedPrefixPolygons(2, base = 100)
+
+    val firstWriter =
+      new DeltaByteArrayWriter(64 * 1024, 64 * 1024, new DirectByteBufferAllocator)
+    writeBinaryData(firstWriter, firstPageVals)
+
+    // Corrupt the second writer so its first value deltas off the first page's last value
+    // (simulating the DeltaByteArrayWriter.reset() bug).
+    val secondWriter =
+      new DeltaByteArrayWriter(64 * 1024, 64 * 1024, new DirectByteBufferAllocator)
+    corruptWriter(secondWriter, firstPageVals.last)
+    writeBinaryData(secondWriter, secondPageVals)
+
+    val firstReader = new VectorizedDeltaByteArrayReader()
+    var vec: WritableColumnVector = new OnHeapColumnVector(firstPageVals.length, geoType)
+    firstReader.initFromPage(firstPageVals.length, firstWriter.getBytes.toInputStream)
+    readGeoInto(firstReader, firstPageVals.length, vec, isGeometry)
+    for (i <- firstPageVals.indices) {
+      assert(firstPageVals(i) sameElements extractGeoWkb(vec, i, isGeometry, srid))
+    }
+
+    val secondReader = new VectorizedDeltaByteArrayReader()
+    vec = new OnHeapColumnVector(secondPageVals.length, geoType)
+    secondReader.initFromPage(secondPageVals.length, secondWriter.getBytes.toInputStream)
+    secondReader.setPreviousReader(firstReader)
+    readGeoInto(secondReader, secondPageVals.length, vec, isGeometry)
+    for (i <- secondPageVals.indices) {
+      assert(secondPageVals(i) sameElements extractGeoWkb(vec, i, isGeometry, srid))
+    }
+  }
+
+  /**
+   * Generates `count` polygons that share a long (> 64 byte) WKB prefix, differing only in a
+   * single trailing coordinate. Exercises the prevBuf grow-and-preserve path where the shared
+   * prefix must survive both reads and skips.
+   */
+  private def sharedPrefixPolygons(count: Int, base: Int = 0): Array[Array[Byte]] = {
+    val head = (0 until 12).map(i => (i.toDouble, i.toDouble))
+    (0 until count).map { k =>
+      // Vary one interior coordinate near the end; keep coords within geography bounds
+      // (lon in [-180, 180], lat in [-90, 90]) so the same data is valid for all geo types.
+      val ring = head.dropRight(1) ++ Seq((100.0, 40.0 + (base + k) * 0.01), head.head)
+      makePolygonWkb(ring: _*)
+    }.toArray
+  }
+
+  private def readGeoInto(
+      reader: VectorizedDeltaByteArrayReader,
+      total: Int,
+      vec: WritableColumnVector,
+      isGeometry: Boolean): Unit = {
+    if (isGeometry) {
+      reader.readGeometry(total, vec, 0)
+    } else {
+      reader.readGeography(total, vec, 0)
+    }
+  }
+
+  private def extractGeoWkb(
+      vec: WritableColumnVector,
+      i: Int,
+      isGeometry: Boolean,
+      srid: Int): Array[Byte] = {
+    if (isGeometry) {
+      val geom = vec.getBinaryView(i)
+      assert(srid === STUtils.stGeomSrid(geom))
+      STUtils.stGeomAsBinary(geom)
+    } else {
+      val geog = vec.getBinaryView(i)
+      assert(srid === STUtils.stGeogSrid(geog))
+      STUtils.stGeogAsBinary(geog)
+    }
+  }
+
   private def assertGeoReadWrite(
       writer: DeltaByteArrayWriter,
       reader: VectorizedDeltaByteArrayReader,
@@ -194,23 +290,49 @@ class ParquetDeltaByteArrayEncodingSuite extends ParquetCompatibilityTest with S
     writableColumnVector = new OnHeapColumnVector(length, dataType)
 
     reader.initFromPage(length, writer.getBytes.toInputStream)
-    if (isGeometry) {
-      reader.readGeometry(length, writableColumnVector, 0)
-    } else {
-      reader.readGeography(length, writableColumnVector, 0)
-    }
+    readGeoInto(reader, length, writableColumnVector, isGeometry)
 
     for (i <- 0 until length) {
-      val actualWkb = if (isGeometry) {
-        val geom = writableColumnVector.getBinaryView(i)
-        assert(srid === STUtils.stGeomSrid(geom))
-        STUtils.stGeomAsBinary(geom)
+      assert(wkbValues(i) sameElements
+        extractGeoWkb(writableColumnVector, i, isGeometry, srid))
+    }
+  }
+
+  /**
+   * Reads even-indexed geo values and skips odd-indexed ones, validating that a value which
+   * shares its prefix with a skipped predecessor is still decoded correctly. This mimics a geo
+   * column with interleaved null/skipped rows. An even count keeps the read/skip pattern from
+   * running past the last value.
+   */
+  private def assertGeoReadWriteWithSkip(
+      writer: DeltaByteArrayWriter,
+      reader: VectorizedDeltaByteArrayReader,
+      wkbValues: Array[Array[Byte]],
+      dataType: DataType): Unit = {
+
+    val (isGeometry, srid) = dataType match {
+      case geom: GeometryType => (true, geom.srid)
+      case geog: GeographyType => (false, geog.srid)
+    }
+
+    val length = wkbValues.length
+    writeBinaryData(writer, wkbValues)
+    writableColumnVector = new OnHeapColumnVector(length, dataType)
+    reader.initFromPage(length, writer.getBytes.toInputStream)
+
+    var i = 0
+    while (i < length) {
+      if (isGeometry) {
+        reader.readGeometry(1, writableColumnVector, i)
       } else {
-        val geog = writableColumnVector.getBinaryView(i)
-        assert(srid === STUtils.stGeogSrid(geog))
-        STUtils.stGeogAsBinary(geog)
+        reader.readGeography(1, writableColumnVector, i)
       }
-      assert(wkbValues(i) sameElements actualWkb)
+      assert(wkbValues(i) sameElements
+        extractGeoWkb(writableColumnVector, i, isGeometry, srid))
+      if (i + 1 < length) {
+        reader.skipBinary(1)
+      }
+      i += 2
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Reduces per-value heap allocations in `VectorizedDeltaByteArrayReader` (the Parquet DELTA_BYTE_ARRAY vectorized decoder) by replacing `ByteBuffer`-based state tracking with a reusable `byte[]` buffer.

Key changes:

1. **Replace `ByteBuffer previous` with `byte[] prevBuf` + `int prevLen`**: The DELTA_BYTE_ARRAY encoding exploits prefix sharing between consecutive values. The old code materialized each decoded value as a `ByteBuffer` obtained from `arrayData.getByteBuffer()` (which allocates ~48 bytes per value via `ByteBuffer.wrap()`). The new approach uses a reusable `byte[]` buffer where the prefix bytes from the previous iteration are already in place at the start -- only the suffix portion needs to be written.

2. **Add `getSuffixInto()` to `VectorizedDeltaLengthByteArrayReader`**: New method that reads suffix bytes directly into a caller-supplied `byte[]` via `InputStream.read()`, avoiding the `ByteBuffer` allocation that `getBytes()` / `in.slice()` performs. Also adds `getSuffixLength()` for cases where only the length is needed.

3. **Rewrite `skipBinary()` to use `prevBuf` directly**: The old implementation was particularly wasteful -- it maintained two `WritableColumnVector` instances (`binaryValVector` and `tempBinaryValVector`), reset one per skipped value, and swapped them after each iteration. The new implementation simply assembles into `prevBuf` without touching any column vectors.

4. **Remove `tempBinaryValVector` field**: No longer needed after the `skipBinary` rewrite.

5. **Extend the reusable buffer to the geometry/geography path**: `readGeoData` previously allocated a `new byte[length]` per row to assemble the WKB value. It now assembles into the same reusable `prevBuf`, sharing the grow-and-preserve protocol with `readBinary`/`skipBinary`. Conversion reads only the `[0, length)` sub-range through new offset/length overloads plumbed through `WKBConverterStrategy.convert`, `STUtils.stGeom/stGeogFromWKB`, `Geometry`/`Geography.fromWkb`, and `WkbReader.read`, so trailing bytes never ride along and no exact-size copy is materialized. This also makes skip/read interleaving on a geo column (null or skipped rows) consistent, since both paths now maintain the same buffer.

6. **Remove the now-unused `getBytes(int)`**: After all three call sites migrated to `getSuffixLength`/`getSuffixInto`, the `ByteBuffer`-allocating `getBytes(int)` on `VectorizedDeltaLengthByteArrayReader` had no callers left (it is package-private and never escapes the parquet package), so it is deleted.

### Why are the changes needed?

The DELTA_BYTE_ARRAY decoder allocated 2 `ByteBuffer` objects per decoded value (one from `in.slice()` for the suffix, one from `arrayData.getByteBuffer()` for the previous-value reference). For a typical 4096-value page, this produced ~8K short-lived objects (~384KB) that stress the young-generation GC.

The `skipBinary` path was even worse: it reset and rebuilt column vectors per skipped value, involving `reserve()`, `Arrays.copyOf()`, and `putArray()` overhead just to maintain the previous-value state.

After this change, the hot path performs zero per-value heap allocations on all three decode paths -- `readBinary`, `skipBinary`, and the geometry/geography path (`readGeoData`) -- since the `prevBuf` array is reused across all values and only grows if a value exceeds its current capacity. The only remaining allocation on the geo path is the physical output value produced by the WKB converter, which is the decoded result itself and is unavoidable for any decoder.

GHA benchmark results on AMD EPYC 7763 (PR vs upstream `master` baseline on the same CPU):

**DELTA_BYTE_ARRAY — readBinary (Best Time in ms, lower is better):**

| Case | JDK 17 Base | JDK 17 PR | Speedup | JDK 21 Base | JDK 21 PR | Speedup | JDK 25 Base | JDK 25 PR | Speedup |
|---|---|---|---|---|---|---|---|---|---|
| no overlap, len=16 | 30 | 27 | **1.11x** | 29 | 29 | **1.00x** | 28 | 25 | **1.12x** |
| half overlap, len=16 | 36 | 27 | **1.33x** | 35 | 29 | **1.21x** | 35 | 26 | **1.35x** |
| full overlap, len=16 | 37 | 26 | **1.42x** | 35 | 28 | **1.25x** | 35 | 25 | **1.40x** |
| half overlap, len=64 | 38 | 29 | **1.31x** | 36 | 31 | **1.16x** | 35 | 27 | **1.30x** |

**DELTA_BYTE_ARRAY — skipBinary (Best Time in ms, lower is better):**

| Case | JDK 17 Base | JDK 17 PR | Speedup | JDK 21 Base | JDK 21 PR | Speedup | JDK 25 Base | JDK 25 PR | Speedup |
|---|---|---|---|---|---|---|---|---|---|
| no overlap, len=16 | 32 | 18 | **1.78x** | 32 | 20 | **1.60x** | 31 | 17 | **1.82x** |
| half overlap, len=16 | 40 | 18 | **2.22x** | 39 | 20 | **1.95x** | 37 | 18 | **2.06x** |
| full overlap, len=16 | 40 | 18 | **2.22x** | 40 | 20 | **2.00x** | 38 | 17 | **2.24x** |
| half overlap, len=64 | 40 | 19 | **2.11x** | 39 | 20 | **1.95x** | 37 | 18 | **2.06x** |

**DELTA_BYTE_ARRAY — readBinary(len) single-value (Best Time in ms, lower is better):**

| JDK 17 Base | JDK 17 PR | Speedup | JDK 21 Base | JDK 21 PR | Speedup | JDK 25 Base | JDK 25 PR | Speedup |
|---|---|---|---|---|---|---|---|---|
| 62 | 53 | **1.17x** | 61 | 54 | **1.13x** | 65 | 52 | **1.25x** |

Full committed results: [JDK 17](https://github.com/iemejia/spark/actions/runs/31322681027), [JDK 21](https://github.com/iemejia/spark/actions/runs/31322568539), [JDK 25](https://github.com/iemejia/spark/actions/runs/31322569698)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Existing tests: `ParquetDeltaByteArrayEncodingSuite`, `ParquetDeltaLengthByteArrayEncodingSuite`, `ParquetEncodingSuite`, `ParquetGeoSuite`, and the WKB/geo suites (`STUtilsSuite`, `Geometry`/`Geography` and `WkbReader` tests) -- all pass.
- New coverage: the `prevBuf` grow branch for `readBinary`/`skipBinary` and cross-page `setPreviousReader` copy; `skipBinary` interleaved with `readGeoData` (null/skipped rows on a geo column); PARQUET-246 cross-page recovery on the geo path; and offset/length `stGeom`/`stGeogFromWKB` ignoring surrounding bytes.
- Benchmark: `VectorizedDeltaReaderBenchmark` Group C (DELTA_BYTE_ARRAY) with four overlap shapes (no overlap, half overlap, full overlap, len=64).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenCode with Claude Opus (claude-opus-4.6)

