### PR TITLE
[SPARK-56905][SQL] Support BYTE_STREAM_SPLIT encoding on Parquet write path

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
@@ -260,4 +260,74 @@ class ParquetEncodingSuite extends ParquetCompatibilityTest with SharedSparkSess
       }
     }
   }
+
+  test("BYTE_STREAM_SPLIT encoding for float and double columns") {
+    val extraOptions = Map[String, String](
+      ParquetOutputFormat.ENABLE_BYTE_STREAM_SPLIT -> "true",
+      ParquetOutputFormat.ENABLE_DICTIONARY -> "false"
+    )
+
+    val hadoopConf = spark.sessionState.newHadoopConfWithOptions(extraOptions)
+    withSQLConf(
+      // Use non-vectorized reader for the read-back since the vectorized reader
+      // does not yet support BYTE_STREAM_SPLIT decoding on this branch.
+      SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false",
+      ParquetOutputFormat.JOB_SUMMARY_LEVEL -> "ALL") {
+      withTempPath { dir =>
+        val path = s"${dir.getCanonicalPath}/test.parquet"
+        val size = 8193
+        val data = (1 to size).map { i =>
+          Row(i, i.toLong, i.toFloat, i.toDouble,
+            if (i % 3 == 0) null else (i * 0.1f),
+            if (i % 5 == 0) null else (i * 0.01))
+        }
+        val schema = new org.apache.spark.sql.types.StructType()
+          .add("i", org.apache.spark.sql.types.IntegerType)
+          .add("l", org.apache.spark.sql.types.LongType)
+          .add("f", org.apache.spark.sql.types.FloatType)
+          .add("d", org.apache.spark.sql.types.DoubleType)
+          .add("f_nullable", org.apache.spark.sql.types.FloatType, nullable = true)
+          .add("d_nullable", org.apache.spark.sql.types.DoubleType, nullable = true)
+
+        spark.createDataFrame(spark.sparkContext.parallelize(data, 1), schema)
+          .write.options(extraOptions).mode("overwrite").parquet(path)
+
+        val blockMetadata = readFooter(new Path(path), hadoopConf).getBlocks.asScala.head
+        val columnChunkMetadataList = blockMetadata.getColumns.asScala
+
+        assert(columnChunkMetadataList.length === 6)
+        // INT32 and INT64 columns should NOT use BYTE_STREAM_SPLIT (boolean flag
+        // only enables it for FLOAT/DOUBLE, not the extended INT32/INT64 mode)
+        assert(!columnChunkMetadataList(0).getEncodings.contains(Encoding.BYTE_STREAM_SPLIT))
+        assert(!columnChunkMetadataList(1).getEncodings.contains(Encoding.BYTE_STREAM_SPLIT))
+        // FLOAT and DOUBLE columns (including nullable ones) should use BYTE_STREAM_SPLIT
+        assert(columnChunkMetadataList(2).getEncodings.contains(Encoding.BYTE_STREAM_SPLIT))
+        assert(columnChunkMetadataList(3).getEncodings.contains(Encoding.BYTE_STREAM_SPLIT))
+        assert(columnChunkMetadataList(4).getEncodings.contains(Encoding.BYTE_STREAM_SPLIT))
+        assert(columnChunkMetadataList(5).getEncodings.contains(Encoding.BYTE_STREAM_SPLIT))
+
+        // Verify round-trip data correctness
+        val actual = spark.read.parquet(path).collect()
+        assert(actual.length === size)
+        val sorted = actual.sortBy(_.getInt(0))
+        (1 to size).foreach { i =>
+          val row = sorted(i - 1)
+          assert(row.getInt(0) === i)
+          assert(row.getLong(1) === i.toLong)
+          assert(row.getFloat(2) === i.toFloat)
+          assert(row.getDouble(3) === i.toDouble)
+          if (i % 3 == 0) {
+            assert(row.isNullAt(4))
+          } else {
+            assert(row.getFloat(4) === i * 0.1f)
+          }
+          if (i % 5 == 0) {
+            assert(row.isNullAt(5))
+          } else {
+            assert(row.getDouble(5) === i * 0.01)
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Documents and tests that Spark supports writing Parquet files with BYTE_STREAM_SPLIT encoding for FLOAT and DOUBLE columns. This encoding de-interleaves value bytes into per-position streams, making each stream highly compressible -- float/double columns typically see 2-4x better compression than PLAIN+zstd for time-series and scientific data.

No Spark code changes are needed because parquet-mr (1.17.0) already includes the BYTE_STREAM_SPLIT encoder, and Spark's existing configuration passthrough mechanism (`DataSourceUtils.mergeWriteOptionsIntoHadoopConf`) already forwards arbitrary `parquet.*` properties to the writer. Setting `parquet.enable.bytestreamsplit=true` (with dictionary disabled) activates BSS encoding for FLOAT and DOUBLE columns.

This PR adds a test to `ParquetEncodingSuite` that:
1. Writes 8193 rows with INT32, INT64, FLOAT, DOUBLE, and nullable FLOAT/DOUBLE columns using BSS encoding
2. Verifies via Parquet metadata that FLOAT/DOUBLE columns use `BYTE_STREAM_SPLIT` encoding while INT32/INT64 columns do not (the boolean flag only enables the `FLOATING_POINT` mode)
3. Reads data back and verifies round-trip correctness including null handling

Users can enable BSS encoding via any of:
- `.option("parquet.enable.bytestreamsplit", "true")` on `DataFrameWriter`
- `withSQLConf("parquet.enable.bytestreamsplit" -> "true")`
- `spark.hadoop.parquet.enable.bytestreamsplit=true` in SparkConf

Dictionary encoding must be disabled for BSS to take effect (BSS replaces the fallback PLAIN encoding, not dictionary encoding).

### Why are the changes needed?

BYTE_STREAM_SPLIT encoding is particularly effective for floating-point data in time-series, scientific, and IoT workloads. The encoding is already supported by parquet-mr and already works through Spark's config passthrough, but this was undocumented and untested. This PR adds test coverage to prevent regressions and documents the capability.

The read-side vectorized decoder for BYTE_STREAM_SPLIT was added in SPARK-56894 (PR #55921).

### Does this PR introduce _any_ user-facing change?

No. The capability already works through the existing config passthrough. This PR only adds test coverage.

### How was this patch tested?

New test case in `ParquetEncodingSuite`: "BYTE_STREAM_SPLIT encoding for float and double columns". Tests write + metadata verification + round-trip read correctness with nullable columns.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenCode with Claude Opus (claude-opus-4.6)