### PR TITLE
fix issue MapType as a type hint for schema 55900

### DIFF
--- a/python/pyspark/sql/functions/__init__.py
+++ b/python/pyspark/sql/functions/__init__.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+
 """PySpark Functions"""
 
 from pyspark.sql.functions.builtin import *  # noqa: F403

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -21042,6 +21042,7 @@ def json_tuple(col: "ColumnOrName", *fields: str) -> Column:
     return _invoke_function("json_tuple", _to_java_column(col), _to_seq(sc, fields))
 
 
+
 @_try_remote_functions
 def from_json(
     col: "ColumnOrName",

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -50,6 +50,7 @@ from pyspark.sql.types import (
     StringType,
     StructType,
     NumericType,
+    MapType
     _from_numpy_type,
 )
 
@@ -21044,7 +21045,7 @@ def json_tuple(col: "ColumnOrName", *fields: str) -> Column:
 @_try_remote_functions
 def from_json(
     col: "ColumnOrName",
-    schema: Union[ArrayType, StructType, Column, str],
+    schema: Union[ArrayType, StructType, Column, str,MapType],
     options: Optional[Mapping[str, str]] = None,
 ) -> Column:
     """


### PR DESCRIPTION
Why are the changes needed?

I have added a one line change to let spark know that u can have MapType also as a schema argument, earlier it did not consider schema argument in the file and niether imported it, i have added those change in the latest commit. please have a look



