### PR TITLE
[SPARK-56907][SQL] Fail fast instead of an unkillable spin when skipping truncated DELTA_LENGTH_BYTE_ARRAY pages

### DIFF
--- a/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk21-results.txt
@@ -6,14 +6,14 @@ OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT32:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readIntegers, constant                                3              3           0        318.7           3.1       1.0X
-skipIntegers, constant                                3              3           0        338.9           3.0       1.1X
-readIntegers, monotonic                               3              3           0        318.0           3.1       1.0X
-skipIntegers, monotonic                               3              3           0        339.4           2.9       1.1X
-readIntegers, small-delta random                      4              4           0        264.6           3.8       0.8X
-skipIntegers, small-delta random                      4              4           0        279.7           3.6       0.9X
-readIntegers, wide random                             5              5           0        215.3           4.6       0.7X
-skipIntegers, wide random                             5              5           0        223.1           4.5       0.7X
+readIntegers, constant                                2              2           0        477.8           2.1       1.0X
+skipIntegers, constant                                2              2           0        529.7           1.9       1.1X
+readIntegers, monotonic                               2              2           0        476.8           2.1       1.0X
+skipIntegers, monotonic                               2              2           0        529.8           1.9       1.1X
+readIntegers, small-delta random                      3              3           0        350.7           2.9       0.7X
+skipIntegers, small-delta random                      3              3           0        379.3           2.6       0.8X
+readIntegers, wide random                             4              4           0        273.2           3.7       0.6X
+skipIntegers, wide random                             4              4           0        289.6           3.5       0.6X
 
 
 ================================================================================================
@@ -24,14 +24,14 @@ OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT64:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readLongs, constant                                   3              3           0        317.0           3.2       1.0X
-skipLongs, constant                                   3              3           0        339.1           2.9       1.1X
-readLongs, monotonic                                  3              3           0        317.4           3.2       1.0X
-skipLongs, monotonic                                  3              3           0        343.8           2.9       1.1X
-readLongs, small-delta random                         4              4           0        265.1           3.8       0.8X
-skipLongs, small-delta random                         4              4           0        280.9           3.6       0.9X
-readLongs, wide random                                7              7           0        153.7           6.5       0.5X
-skipLongs, wide random                                7              7           0        157.1           6.4       0.5X
+readLongs, constant                                   2              2           0        474.1           2.1       1.0X
+skipLongs, constant                                   2              2           0        529.8           1.9       1.1X
+readLongs, monotonic                                  2              2           0        474.6           2.1       1.0X
+skipLongs, monotonic                                  2              2           0        529.3           1.9       1.1X
+readLongs, small-delta random                         3              3           0        344.3           2.9       0.7X
+skipLongs, small-delta random                         3              3           0        378.7           2.6       0.8X
+readLongs, wide random                                6              6           0        182.0           5.5       0.4X
+skipLongs, wide random                                6              6           0        185.5           5.4       0.4X
 
 
 ================================================================================================
@@ -42,14 +42,14 @@ OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BYTE_ARRAY:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, no overlap, len=16                       46             49           3         22.7          44.0       1.0X
-skipBinary, no overlap, len=16                       47             48           3         22.4          44.7       1.0X
-readBinary, half overlap, len=16                     49             50           2         21.5          46.4       0.9X
-skipBinary, half overlap, len=16                     54             56           4         19.2          52.0       0.8X
-readBinary, full overlap, len=16                     49             50           2         21.4          46.7       0.9X
-skipBinary, full overlap, len=16                     55             56           2         19.2          52.1       0.8X
-readBinary, half overlap, len=64                     49             51           3         21.3          47.0       0.9X
-skipBinary, half overlap, len=64                     54             56           3         19.4          51.6       0.9X
+readBinary, no overlap, len=16                       27             28           1         38.6          25.9       1.0X
+skipBinary, no overlap, len=16                       32             32           1         33.1          30.2       0.9X
+readBinary, half overlap, len=16                     34             35           3         30.9          32.4       0.8X
+skipBinary, half overlap, len=16                     43             44           2         24.4          40.9       0.6X
+readBinary, full overlap, len=16                     34             36           2         30.7          32.6       0.8X
+skipBinary, full overlap, len=16                     39             43           3         26.6          37.7       0.7X
+readBinary, half overlap, len=64                     34             35           1         30.7          32.6       0.8X
+skipBinary, half overlap, len=64                     39             41           4         27.1          36.9       0.7X
 
 
 ================================================================================================
@@ -60,14 +60,14 @@ OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_LENGTH_BYTE_ARRAY:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, payloadLen=8                             17             18           0         62.3          16.0       1.0X
-skipBinary, payloadLen=8                              4              4           0        276.2           3.6       4.4X
-readBinary, payloadLen=32                            18             21           1         58.4          17.1       0.9X
-skipBinary, payloadLen=32                             4              4           0        275.7           3.6       4.4X
-readBinary, payloadLen=128                           24             25           0         43.4          23.0       0.7X
-skipBinary, payloadLen=128                            4              4           1        276.4           3.6       4.4X
-readBinary, payloadLen=512                           41             42           1         25.4          39.4       0.4X
-skipBinary, payloadLen=512                            4              4           0        276.1           3.6       4.4X
+readBinary, payloadLen=8                             16             17           0         65.0          15.4       1.0X
+skipBinary, payloadLen=8                              3              3           0        354.7           2.8       5.5X
+readBinary, payloadLen=32                            16             16           0         64.7          15.5       1.0X
+skipBinary, payloadLen=32                             3              3           0        355.3           2.8       5.5X
+readBinary, payloadLen=128                           19             19           1         56.3          17.7       0.9X
+skipBinary, payloadLen=128                            3              3           0        353.3           2.8       5.4X
+readBinary, payloadLen=512                           39             40           1         27.1          36.9       0.4X
+skipBinary, payloadLen=512                            3              3           0        348.9           2.9       5.4X
 
 
 ================================================================================================
@@ -78,20 +78,20 @@ OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 Variant reads:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------
-readBytes (INT32)                                                      6              6           0        178.3           5.6       1.0X
-readShorts (INT32)                                                     9              9           1        120.2           8.3       0.7X
-readUnsignedIntegers (INT32 -> Long)                                   9              9           0        120.5           8.3       0.7X
-readIntegersAsLongs (INT32 -> Long)                                    5              5           0        203.1           4.9       1.1X
-readIntegersAsLongs (INT32 -> Long, overflow pattern)                  5              5           0        203.0           4.9       1.1X
-readIntegersAsDoubles (INT32 -> Double)                                5              5           0        210.2           4.8       1.2X
-readIntegersAsDoubles (INT32 -> Double, overflow pattern)              5              5           0        210.2           4.8       1.2X
-readUnsignedLongs (INT64 -> Decimal(20,0))                            28             29           0         36.9          27.1       0.2X
-skipBytes                                                              5              5           0        223.8           4.5       1.3X
-skipShorts                                                             5              5           0        223.3           4.5       1.3X
-readByte (INT32 single-value)                                         14             14           1         76.5          13.1       0.4X
-readShort (INT32 single-value)                                        14             14           0         76.7          13.0       0.4X
-readInteger (INT32 single-value)                                      14             14           0         76.6          13.1       0.4X
-readLong (INT64 single-value)                                         15             16           0         68.1          14.7       0.4X
-readBinary(len) (DELTA_BYTE_ARRAY single-value)                       80             82           3         13.1          76.3       0.1X
+readBytes (INT32)                                                      5              5           0        219.9           4.5       1.0X
+readShorts (INT32)                                                     7              8           0        143.5           7.0       0.7X
+readUnsignedIntegers (INT32 -> Long)                                   7              8           1        143.9           7.0       0.7X
+readIntegersAsLongs (INT32 -> Long)                                    4              4           0        256.1           3.9       1.2X
+readIntegersAsLongs (INT32 -> Long, overflow pattern)                  4              4           0        255.8           3.9       1.2X
+readIntegersAsDoubles (INT32 -> Double)                                4              4           0        261.2           3.8       1.2X
+readIntegersAsDoubles (INT32 -> Double, overflow pattern)              4              4           0        262.1           3.8       1.2X
+readUnsignedLongs (INT64 -> Decimal(20,0))                            27             27           0         38.9          25.7       0.2X
+skipBytes                                                              8              8           0        134.2           7.5       0.6X
+skipShorts                                                             8              8           0        136.5           7.3       0.6X
+readByte (INT32 single-value)                                         12             13           0         84.3          11.9       0.4X
+readShort (INT32 single-value)                                        12             13           1         84.6          11.8       0.4X
+readInteger (INT32 single-value)                                      12             13           0         84.4          11.8       0.4X
+readLong (INT64 single-value)                                         15             15           4         72.3          13.8       0.3X
+readBinary(len) (DELTA_BYTE_ARRAY single-value)                       58             61           3         18.0          55.4       0.1X
 
 

--- a/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk21-results.txt
@@ -6,14 +6,14 @@ OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT32:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readIntegers, constant                                2              2           0        452.8           2.2       1.0X
-skipIntegers, constant                                2              2           0        526.9           1.9       1.2X
-readIntegers, monotonic                               2              2           0        455.0           2.2       1.0X
-skipIntegers, monotonic                               2              2           0        528.8           1.9       1.2X
-readIntegers, small-delta random                      3              3           0        342.2           2.9       0.8X
-skipIntegers, small-delta random                      3              3           0        359.2           2.8       0.8X
-readIntegers, wide random                             4              4           0        266.0           3.8       0.6X
-skipIntegers, wide random                             4              4           0        288.9           3.5       0.6X
+readIntegers, constant                                3              3           0        318.7           3.1       1.0X
+skipIntegers, constant                                3              3           0        338.9           3.0       1.1X
+readIntegers, monotonic                               3              3           0        318.0           3.1       1.0X
+skipIntegers, monotonic                               3              3           0        339.4           2.9       1.1X
+readIntegers, small-delta random                      4              4           0        264.6           3.8       0.8X
+skipIntegers, small-delta random                      4              4           0        279.7           3.6       0.9X
+readIntegers, wide random                             5              5           0        215.3           4.6       0.7X
+skipIntegers, wide random                             5              5           0        223.1           4.5       0.7X
 
 
 ================================================================================================
@@ -24,14 +24,14 @@ OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT64:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readLongs, constant                                   3              3           1        396.7           2.5       1.0X
-skipLongs, constant                                   2              2           0        519.1           1.9       1.3X
-readLongs, monotonic                                  3              3           0        369.0           2.7       0.9X
-skipLongs, monotonic                                  2              2           0        521.6           1.9       1.3X
-readLongs, small-delta random                         3              3           0        309.9           3.2       0.8X
-skipLongs, small-delta random                         3              3           0        360.6           2.8       0.9X
-readLongs, wide random                                6              6           0        170.2           5.9       0.4X
-skipLongs, wide random                                6              6           0        187.1           5.3       0.5X
+readLongs, constant                                   3              3           0        317.0           3.2       1.0X
+skipLongs, constant                                   3              3           0        339.1           2.9       1.1X
+readLongs, monotonic                                  3              3           0        317.4           3.2       1.0X
+skipLongs, monotonic                                  3              3           0        343.8           2.9       1.1X
+readLongs, small-delta random                         4              4           0        265.1           3.8       0.8X
+skipLongs, small-delta random                         4              4           0        280.9           3.6       0.9X
+readLongs, wide random                                7              7           0        153.7           6.5       0.5X
+skipLongs, wide random                                7              7           0        157.1           6.4       0.5X
 
 
 ================================================================================================
@@ -42,14 +42,14 @@ OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BYTE_ARRAY:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, no overlap, len=16                       29             32           4         35.6          28.1       1.0X
-skipBinary, no overlap, len=16                       32             36           4         32.3          30.9       0.9X
-readBinary, half overlap, len=16                     35             38           2         29.7          33.6       0.8X
-skipBinary, half overlap, len=16                     39             42           3         26.6          37.6       0.7X
-readBinary, full overlap, len=16                     35             41           4         29.5          33.9       0.8X
-skipBinary, full overlap, len=16                     40             40           2         26.4          37.9       0.7X
-readBinary, half overlap, len=64                     36             42           3         29.0          34.5       0.8X
-skipBinary, half overlap, len=64                     39             42           3         26.6          37.6       0.7X
+readBinary, no overlap, len=16                       46             49           3         22.7          44.0       1.0X
+skipBinary, no overlap, len=16                       47             48           3         22.4          44.7       1.0X
+readBinary, half overlap, len=16                     49             50           2         21.5          46.4       0.9X
+skipBinary, half overlap, len=16                     54             56           4         19.2          52.0       0.8X
+readBinary, full overlap, len=16                     49             50           2         21.4          46.7       0.9X
+skipBinary, full overlap, len=16                     55             56           2         19.2          52.1       0.8X
+readBinary, half overlap, len=64                     49             51           3         21.3          47.0       0.9X
+skipBinary, half overlap, len=64                     54             56           3         19.4          51.6       0.9X
 
 
 ================================================================================================
@@ -60,14 +60,14 @@ OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_LENGTH_BYTE_ARRAY:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, payloadLen=8                             16             17           1         64.2          15.6       1.0X
-skipBinary, payloadLen=8                              7              7           1        161.1           6.2       2.5X
-readBinary, payloadLen=32                            17             17           0         63.2          15.8       1.0X
-skipBinary, payloadLen=32                             7              7           1        160.9           6.2       2.5X
-readBinary, payloadLen=128                           19             19           1         55.1          18.2       0.9X
-skipBinary, payloadLen=128                            7              7           1        160.7           6.2       2.5X
-readBinary, payloadLen=512                           39             40           1         27.0          37.0       0.4X
-skipBinary, payloadLen=512                            7              7           0        160.9           6.2       2.5X
+readBinary, payloadLen=8                             17             18           0         62.3          16.0       1.0X
+skipBinary, payloadLen=8                              4              4           0        276.2           3.6       4.4X
+readBinary, payloadLen=32                            18             21           1         58.4          17.1       0.9X
+skipBinary, payloadLen=32                             4              4           0        275.7           3.6       4.4X
+readBinary, payloadLen=128                           24             25           0         43.4          23.0       0.7X
+skipBinary, payloadLen=128                            4              4           1        276.4           3.6       4.4X
+readBinary, payloadLen=512                           41             42           1         25.4          39.4       0.4X
+skipBinary, payloadLen=512                            4              4           0        276.1           3.6       4.4X
 
 
 ================================================================================================
@@ -78,20 +78,20 @@ OpenJDK 64-Bit Server VM 21.0.12+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 Variant reads:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------
-readBytes (INT32)                                                      5              5           0        208.1           4.8       1.0X
-readShorts (INT32)                                                     9              9           0        122.0           8.2       0.6X
-readUnsignedIntegers (INT32 -> Long)                                   9              9           0        123.1           8.1       0.6X
-readIntegersAsLongs (INT32 -> Long)                                    4              4           0        259.5           3.9       1.2X
-readIntegersAsLongs (INT32 -> Long, overflow pattern)                  4              4           0        259.9           3.8       1.2X
-readIntegersAsDoubles (INT32 -> Double)                                4              4           0        269.7           3.7       1.3X
-readIntegersAsDoubles (INT32 -> Double, overflow pattern)              4              4           0        269.9           3.7       1.3X
-readUnsignedLongs (INT64 -> Decimal(20,0))                            28             28           0         37.9          26.4       0.2X
-skipBytes                                                              6              6           0        180.8           5.5       0.9X
-skipShorts                                                             6              6           0        189.7           5.3       0.9X
-readByte (INT32 single-value)                                         13             14           2         78.5          12.7       0.4X
-readShort (INT32 single-value)                                        13             14           1         78.5          12.7       0.4X
-readInteger (INT32 single-value)                                      13             14           1         78.5          12.7       0.4X
-readLong (INT64 single-value)                                         16             16           1         67.3          14.9       0.3X
-readBinary(len) (DELTA_BYTE_ARRAY single-value)                       61             67           5         17.1          58.6       0.1X
+readBytes (INT32)                                                      6              6           0        178.3           5.6       1.0X
+readShorts (INT32)                                                     9              9           1        120.2           8.3       0.7X
+readUnsignedIntegers (INT32 -> Long)                                   9              9           0        120.5           8.3       0.7X
+readIntegersAsLongs (INT32 -> Long)                                    5              5           0        203.1           4.9       1.1X
+readIntegersAsLongs (INT32 -> Long, overflow pattern)                  5              5           0        203.0           4.9       1.1X
+readIntegersAsDoubles (INT32 -> Double)                                5              5           0        210.2           4.8       1.2X
+readIntegersAsDoubles (INT32 -> Double, overflow pattern)              5              5           0        210.2           4.8       1.2X
+readUnsignedLongs (INT64 -> Decimal(20,0))                            28             29           0         36.9          27.1       0.2X
+skipBytes                                                              5              5           0        223.8           4.5       1.3X
+skipShorts                                                             5              5           0        223.3           4.5       1.3X
+readByte (INT32 single-value)                                         14             14           1         76.5          13.1       0.4X
+readShort (INT32 single-value)                                        14             14           0         76.7          13.0       0.4X
+readInteger (INT32 single-value)                                      14             14           0         76.6          13.1       0.4X
+readLong (INT64 single-value)                                         15             16           0         68.1          14.7       0.4X
+readBinary(len) (DELTA_BYTE_ARRAY single-value)                       80             82           3         13.1          76.3       0.1X
 
 

--- a/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk25-results.txt
@@ -6,14 +6,14 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT32:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readIntegers, constant                                2              2           0        477.4           2.1       1.0X
-skipIntegers, constant                                2              2           0        605.8           1.7       1.3X
-readIntegers, monotonic                               2              2           0        476.4           2.1       1.0X
-skipIntegers, monotonic                               2              2           0        608.7           1.6       1.3X
-readIntegers, small-delta random                      3              3           0        334.0           3.0       0.7X
-skipIntegers, small-delta random                      3              3           0        399.9           2.5       0.8X
-readIntegers, wide random                             4              4           0        267.3           3.7       0.6X
-skipIntegers, wide random                             4              4           0        292.5           3.4       0.6X
+readIntegers, constant                                2              2           0        475.1           2.1       1.0X
+skipIntegers, constant                                2              2           0        609.7           1.6       1.3X
+readIntegers, monotonic                               2              2           0        475.2           2.1       1.0X
+skipIntegers, monotonic                               2              2           0        608.8           1.6       1.3X
+readIntegers, small-delta random                      3              3           0        335.6           3.0       0.7X
+skipIntegers, small-delta random                      3              3           0        399.2           2.5       0.8X
+readIntegers, wide random                             4              4           0        268.5           3.7       0.6X
+skipIntegers, wide random                             4              4           0        291.4           3.4       0.6X
 
 
 ================================================================================================
@@ -24,14 +24,14 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT64:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readLongs, constant                                   2              2           0        511.2           2.0       1.0X
-skipLongs, constant                                   2              2           0        604.6           1.7       1.2X
-readLongs, monotonic                                  2              2           0        511.1           2.0       1.0X
-skipLongs, monotonic                                  2              2           0        604.4           1.7       1.2X
-readLongs, small-delta random                         3              3           0        354.8           2.8       0.7X
-skipLongs, small-delta random                         3              3           0        400.4           2.5       0.8X
-readLongs, wide random                                6              6           0        188.8           5.3       0.4X
-skipLongs, wide random                                5              5           0        196.7           5.1       0.4X
+readLongs, constant                                   2              2           0        516.1           1.9       1.0X
+skipLongs, constant                                   2              2           0        603.6           1.7       1.2X
+readLongs, monotonic                                  2              2           0        515.9           1.9       1.0X
+skipLongs, monotonic                                  2              2           0        603.8           1.7       1.2X
+readLongs, small-delta random                         3              3           0        361.8           2.8       0.7X
+skipLongs, small-delta random                         3              3           0        400.6           2.5       0.8X
+readLongs, wide random                                6              6           0        189.2           5.3       0.4X
+skipLongs, wide random                                5              5           0        195.8           5.1       0.4X
 
 
 ================================================================================================
@@ -42,14 +42,14 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BYTE_ARRAY:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, no overlap, len=16                       27             31           2         38.5          26.0       1.0X
-skipBinary, no overlap, len=16                       31             32           1         33.3          30.0       0.9X
-readBinary, half overlap, len=16                     33             34           1         31.6          31.7       0.8X
-skipBinary, half overlap, len=16                     38             39           1         27.6          36.3       0.7X
-readBinary, full overlap, len=16                     33             34           1         31.3          31.9       0.8X
-skipBinary, full overlap, len=16                     38             40           2         27.3          36.6       0.7X
-readBinary, half overlap, len=64                     34             35           1         30.7          32.5       0.8X
-skipBinary, half overlap, len=64                     38             39           2         27.6          36.3       0.7X
+readBinary, no overlap, len=16                       27             28           2         38.4          26.1       1.0X
+skipBinary, no overlap, len=16                       32             32           2         33.2          30.1       0.9X
+readBinary, half overlap, len=16                     33             35           3         31.4          31.9       0.8X
+skipBinary, half overlap, len=16                     38             39           2         27.5          36.4       0.7X
+readBinary, full overlap, len=16                     34             35           2         31.0          32.2       0.8X
+skipBinary, full overlap, len=16                     39             43           3         27.2          36.7       0.7X
+readBinary, half overlap, len=64                     34             39           2         30.7          32.5       0.8X
+skipBinary, half overlap, len=64                     38             40           2         27.4          36.5       0.7X
 
 
 ================================================================================================
@@ -60,14 +60,14 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_LENGTH_BYTE_ARRAY:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, payloadLen=8                             14             15           2         75.0          13.3       1.0X
-skipBinary, payloadLen=8                              3              3           0        410.4           2.4       5.5X
-readBinary, payloadLen=32                            15             17           2         72.0          13.9       1.0X
-skipBinary, payloadLen=32                             3              3           1        407.3           2.5       5.4X
-readBinary, payloadLen=128                           19             21           1         55.4          18.0       0.7X
-skipBinary, payloadLen=128                            3              3           1        403.9           2.5       5.4X
-readBinary, payloadLen=512                           41             42           1         25.6          39.0       0.3X
-skipBinary, payloadLen=512                            3              3           1        401.3           2.5       5.3X
+readBinary, payloadLen=8                             17             17           0         63.5          15.7       1.0X
+skipBinary, payloadLen=8                              3              3           0        354.8           2.8       5.6X
+readBinary, payloadLen=32                            16             17           0         64.1          15.6       1.0X
+skipBinary, payloadLen=32                             3              3           0        357.4           2.8       5.6X
+readBinary, payloadLen=128                           19             19           0         55.4          18.1       0.9X
+skipBinary, payloadLen=128                            3              3           0        355.2           2.8       5.6X
+readBinary, payloadLen=512                           42             43           1         25.2          39.6       0.4X
+skipBinary, payloadLen=512                            3              3           0        354.8           2.8       5.6X
 
 
 ================================================================================================
@@ -78,20 +78,20 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 Variant reads:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------
-readBytes (INT32)                                                      5              5           0        211.7           4.7       1.0X
-readShorts (INT32)                                                     8              8           0        130.1           7.7       0.6X
-readUnsignedIntegers (INT32 -> Long)                                   9              9           0        113.8           8.8       0.5X
-readIntegersAsLongs (INT32 -> Long)                                    4              4           0        261.2           3.8       1.2X
-readIntegersAsLongs (INT32 -> Long, overflow pattern)                  4              4           0        261.2           3.8       1.2X
-readIntegersAsDoubles (INT32 -> Double)                                4              4           0        269.9           3.7       1.3X
-readIntegersAsDoubles (INT32 -> Double, overflow pattern)              4              4           0        266.4           3.8       1.3X
-readUnsignedLongs (INT64 -> Decimal(20,0))                            28             29           1         36.8          27.2       0.2X
-skipBytes                                                              9              9           0        122.2           8.2       0.6X
-skipShorts                                                             9              9           0        122.0           8.2       0.6X
-readByte (INT32 single-value)                                         12             12           1         86.6          11.5       0.4X
-readShort (INT32 single-value)                                        13             13           0         81.6          12.3       0.4X
-readInteger (INT32 single-value)                                      14             14           1         74.4          13.4       0.4X
-readLong (INT64 single-value)                                         16             16           1         66.5          15.0       0.3X
-readBinary(len) (DELTA_BYTE_ARRAY single-value)                       63             64           2         16.7          59.8       0.1X
+readBytes (INT32)                                                      5              5           0        200.5           5.0       1.0X
+readShorts (INT32)                                                     9              9           0        121.0           8.3       0.6X
+readUnsignedIntegers (INT32 -> Long)                                  10             10           0        105.4           9.5       0.5X
+readIntegersAsLongs (INT32 -> Long)                                    4              4           0        260.1           3.8       1.3X
+readIntegersAsLongs (INT32 -> Long, overflow pattern)                  4              4           0        260.1           3.8       1.3X
+readIntegersAsDoubles (INT32 -> Double)                                4              4           0        265.1           3.8       1.3X
+readIntegersAsDoubles (INT32 -> Double, overflow pattern)              4              4           0        265.2           3.8       1.3X
+readUnsignedLongs (INT64 -> Decimal(20,0))                            29             29           0         36.6          27.3       0.2X
+skipBytes                                                              6              7           1        166.8           6.0       0.8X
+skipShorts                                                             6              6           0        166.5           6.0       0.8X
+readByte (INT32 single-value)                                         13             13           1         79.8          12.5       0.4X
+readShort (INT32 single-value)                                        14             15           1         73.0          13.7       0.4X
+readInteger (INT32 single-value)                                      14             15           2         73.2          13.7       0.4X
+readLong (INT64 single-value)                                         16             16           1         66.1          15.1       0.3X
+readBinary(len) (DELTA_BYTE_ARRAY single-value)                       64             67           2         16.5          60.7       0.1X
 
 

--- a/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-jdk25-results.txt
@@ -6,14 +6,14 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT32:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readIntegers, constant                                2              2           0        463.0           2.2       1.0X
-skipIntegers, constant                                1              1           0        785.4           1.3       1.7X
-readIntegers, monotonic                               2              2           0        462.6           2.2       1.0X
-skipIntegers, monotonic                               1              1           0        784.3           1.3       1.7X
-readIntegers, small-delta random                      3              3           0        321.4           3.1       0.7X
-skipIntegers, small-delta random                      2              3           0        421.7           2.4       0.9X
-readIntegers, wide random                             4              4           0        257.0           3.9       0.6X
-skipIntegers, wide random                             4              4           0        299.6           3.3       0.6X
+readIntegers, constant                                2              2           0        477.4           2.1       1.0X
+skipIntegers, constant                                2              2           0        605.8           1.7       1.3X
+readIntegers, monotonic                               2              2           0        476.4           2.1       1.0X
+skipIntegers, monotonic                               2              2           0        608.7           1.6       1.3X
+readIntegers, small-delta random                      3              3           0        334.0           3.0       0.7X
+skipIntegers, small-delta random                      3              3           0        399.9           2.5       0.8X
+readIntegers, wide random                             4              4           0        267.3           3.7       0.6X
+skipIntegers, wide random                             4              4           0        292.5           3.4       0.6X
 
 
 ================================================================================================
@@ -24,14 +24,14 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT64:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readLongs, constant                                   2              2           0        521.0           1.9       1.0X
-skipLongs, constant                                   2              2           0        581.6           1.7       1.1X
-readLongs, monotonic                                  2              2           0        521.1           1.9       1.0X
-skipLongs, monotonic                                  2              2           0        578.1           1.7       1.1X
-readLongs, small-delta random                         3              3           0        382.7           2.6       0.7X
-skipLongs, small-delta random                         3              3           0        412.7           2.4       0.8X
-readLongs, wide random                                5              6           0        190.8           5.2       0.4X
-skipLongs, wide random                                5              5           0        193.8           5.2       0.4X
+readLongs, constant                                   2              2           0        511.2           2.0       1.0X
+skipLongs, constant                                   2              2           0        604.6           1.7       1.2X
+readLongs, monotonic                                  2              2           0        511.1           2.0       1.0X
+skipLongs, monotonic                                  2              2           0        604.4           1.7       1.2X
+readLongs, small-delta random                         3              3           0        354.8           2.8       0.7X
+skipLongs, small-delta random                         3              3           0        400.4           2.5       0.8X
+readLongs, wide random                                6              6           0        188.8           5.3       0.4X
+skipLongs, wide random                                5              5           0        196.7           5.1       0.4X
 
 
 ================================================================================================
@@ -42,14 +42,14 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BYTE_ARRAY:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, no overlap, len=16                       28             33           4         37.7          26.5       1.0X
-skipBinary, no overlap, len=16                       31             32           2         34.3          29.2       0.9X
-readBinary, half overlap, len=16                     35             40           3         30.4          32.9       0.8X
-skipBinary, half overlap, len=16                     37             38           2         28.1          35.6       0.7X
-readBinary, full overlap, len=16                     35             36           2         30.3          33.0       0.8X
-skipBinary, full overlap, len=16                     38             39           3         27.9          35.9       0.7X
-readBinary, half overlap, len=64                     35             41           3         29.7          33.6       0.8X
-skipBinary, half overlap, len=64                     37             38           1         28.4          35.3       0.8X
+readBinary, no overlap, len=16                       27             31           2         38.5          26.0       1.0X
+skipBinary, no overlap, len=16                       31             32           1         33.3          30.0       0.9X
+readBinary, half overlap, len=16                     33             34           1         31.6          31.7       0.8X
+skipBinary, half overlap, len=16                     38             39           1         27.6          36.3       0.7X
+readBinary, full overlap, len=16                     33             34           1         31.3          31.9       0.8X
+skipBinary, full overlap, len=16                     38             40           2         27.3          36.6       0.7X
+readBinary, half overlap, len=64                     34             35           1         30.7          32.5       0.8X
+skipBinary, half overlap, len=64                     38             39           2         27.6          36.3       0.7X
 
 
 ================================================================================================
@@ -60,14 +60,14 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_LENGTH_BYTE_ARRAY:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, payloadLen=8                             16             17           0         65.0          15.4       1.0X
-skipBinary, payloadLen=8                              6              6           0        183.9           5.4       2.8X
-readBinary, payloadLen=32                            16             17           0         64.0          15.6       1.0X
-skipBinary, payloadLen=32                             6              6           0        184.3           5.4       2.8X
-readBinary, payloadLen=128                           19             19           2         56.1          17.8       0.9X
-skipBinary, payloadLen=128                            6              6           1        183.8           5.4       2.8X
-readBinary, payloadLen=512                           41             43           1         25.3          39.5       0.4X
-skipBinary, payloadLen=512                            6              6           0        183.9           5.4       2.8X
+readBinary, payloadLen=8                             14             15           2         75.0          13.3       1.0X
+skipBinary, payloadLen=8                              3              3           0        410.4           2.4       5.5X
+readBinary, payloadLen=32                            15             17           2         72.0          13.9       1.0X
+skipBinary, payloadLen=32                             3              3           1        407.3           2.5       5.4X
+readBinary, payloadLen=128                           19             21           1         55.4          18.0       0.7X
+skipBinary, payloadLen=128                            3              3           1        403.9           2.5       5.4X
+readBinary, payloadLen=512                           41             42           1         25.6          39.0       0.3X
+skipBinary, payloadLen=512                            3              3           1        401.3           2.5       5.3X
 
 
 ================================================================================================
@@ -78,20 +78,20 @@ OpenJDK 64-Bit Server VM 25.0.4+7-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 Variant reads:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------
-readBytes (INT32)                                                      5              5           0        216.6           4.6       1.0X
-readShorts (INT32)                                                     8              8           0        135.9           7.4       0.6X
-readUnsignedIntegers (INT32 -> Long)                                   9              9           0        118.7           8.4       0.5X
-readIntegersAsLongs (INT32 -> Long)                                    4              4           0        256.4           3.9       1.2X
-readIntegersAsLongs (INT32 -> Long, overflow pattern)                  4              4           0        257.3           3.9       1.2X
-readIntegersAsDoubles (INT32 -> Double)                                4              4           0        260.3           3.8       1.2X
-readIntegersAsDoubles (INT32 -> Double, overflow pattern)              4              4           0        259.8           3.8       1.2X
-readUnsignedLongs (INT64 -> Decimal(20,0))                            28             28           0         37.5          26.7       0.2X
-skipBytes                                                              5              5           0        209.2           4.8       1.0X
-skipShorts                                                             5              5           0        199.7           5.0       0.9X
-readByte (INT32 single-value)                                         14             14           1         73.6          13.6       0.3X
-readShort (INT32 single-value)                                        15             16           1         67.7          14.8       0.3X
-readInteger (INT32 single-value)                                      15             16           1         67.8          14.8       0.3X
-readLong (INT64 single-value)                                         17             17           2         61.7          16.2       0.3X
-readBinary(len) (DELTA_BYTE_ARRAY single-value)                       65             71           8         16.2          61.9       0.1X
+readBytes (INT32)                                                      5              5           0        211.7           4.7       1.0X
+readShorts (INT32)                                                     8              8           0        130.1           7.7       0.6X
+readUnsignedIntegers (INT32 -> Long)                                   9              9           0        113.8           8.8       0.5X
+readIntegersAsLongs (INT32 -> Long)                                    4              4           0        261.2           3.8       1.2X
+readIntegersAsLongs (INT32 -> Long, overflow pattern)                  4              4           0        261.2           3.8       1.2X
+readIntegersAsDoubles (INT32 -> Double)                                4              4           0        269.9           3.7       1.3X
+readIntegersAsDoubles (INT32 -> Double, overflow pattern)              4              4           0        266.4           3.8       1.3X
+readUnsignedLongs (INT64 -> Decimal(20,0))                            28             29           1         36.8          27.2       0.2X
+skipBytes                                                              9              9           0        122.2           8.2       0.6X
+skipShorts                                                             9              9           0        122.0           8.2       0.6X
+readByte (INT32 single-value)                                         12             12           1         86.6          11.5       0.4X
+readShort (INT32 single-value)                                        13             13           0         81.6          12.3       0.4X
+readInteger (INT32 single-value)                                      14             14           1         74.4          13.4       0.4X
+readLong (INT64 single-value)                                         16             16           1         66.5          15.0       0.3X
+readBinary(len) (DELTA_BYTE_ARRAY single-value)                       63             64           2         16.7          59.8       0.1X
 
 

--- a/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-results.txt
+++ b/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-results.txt
@@ -6,14 +6,14 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT32:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readIntegers, constant                                2              2           0        441.4           2.3       1.0X
-skipIntegers, constant                                2              2           0        555.5           1.8       1.3X
-readIntegers, monotonic                               2              2           0        440.9           2.3       1.0X
-skipIntegers, monotonic                               2              2           0        554.1           1.8       1.3X
-readIntegers, small-delta random                      3              3           0        333.0           3.0       0.8X
-skipIntegers, small-delta random                      3              3           0        371.1           2.7       0.8X
-readIntegers, wide random                             4              4           0        257.8           3.9       0.6X
-skipIntegers, wide random                             4              4           0        292.9           3.4       0.7X
+readIntegers, constant                                2              2           0        439.2           2.3       1.0X
+skipIntegers, constant                                2              2           0        553.0           1.8       1.3X
+readIntegers, monotonic                               2              2           0        440.6           2.3       1.0X
+skipIntegers, monotonic                               2              2           0        553.4           1.8       1.3X
+readIntegers, small-delta random                      3              3           0        331.5           3.0       0.8X
+skipIntegers, small-delta random                      3              3           0        372.9           2.7       0.8X
+readIntegers, wide random                             4              4           0        260.3           3.8       0.6X
+skipIntegers, wide random                             4              4           0        294.5           3.4       0.7X
 
 
 ================================================================================================
@@ -24,14 +24,14 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT64:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readLongs, constant                                   2              2           0        520.6           1.9       1.0X
-skipLongs, constant                                   2              2           0        551.6           1.8       1.1X
-readLongs, monotonic                                  2              2           0        514.8           1.9       1.0X
-skipLongs, monotonic                                  2              2           0        555.6           1.8       1.1X
-readLongs, small-delta random                         3              3           0        350.7           2.9       0.7X
-skipLongs, small-delta random                         3              3           0        375.2           2.7       0.7X
-readLongs, wide random                                6              6           0        181.2           5.5       0.3X
-skipLongs, wide random                                6              6           0        185.8           5.4       0.4X
+readLongs, constant                                   2              2           0        506.0           2.0       1.0X
+skipLongs, constant                                   2              2           0        551.2           1.8       1.1X
+readLongs, monotonic                                  2              2           0        508.1           2.0       1.0X
+skipLongs, monotonic                                  2              2           0        556.5           1.8       1.1X
+readLongs, small-delta random                         3              3           0        349.3           2.9       0.7X
+skipLongs, small-delta random                         3              3           0        375.0           2.7       0.7X
+readLongs, wide random                                6              6           0        183.1           5.5       0.4X
+skipLongs, wide random                                6              6           0        186.2           5.4       0.4X
 
 
 ================================================================================================
@@ -42,14 +42,14 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BYTE_ARRAY:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, no overlap, len=16                       27             28           0         38.3          26.1       1.0X
-skipBinary, no overlap, len=16                       32             33           1         32.8          30.5       0.9X
-readBinary, half overlap, len=16                     34             34           1         31.1          32.2       0.8X
+readBinary, no overlap, len=16                       27             28           1         38.7          25.9       1.0X
+skipBinary, no overlap, len=16                       33             33           1         32.1          31.1       0.8X
+readBinary, half overlap, len=16                     34             35           1         30.8          32.5       0.8X
 skipBinary, half overlap, len=16                     39             40           1         26.6          37.6       0.7X
-readBinary, full overlap, len=16                     34             34           1         30.8          32.5       0.8X
-skipBinary, full overlap, len=16                     39             40           2         26.7          37.4       0.7X
-readBinary, half overlap, len=64                     34             34           0         31.0          32.3       0.8X
-skipBinary, half overlap, len=64                     39             40           2         26.8          37.3       0.7X
+readBinary, full overlap, len=16                     35             35           1         30.4          32.9       0.8X
+skipBinary, full overlap, len=16                     40             41           1         26.3          38.1       0.7X
+readBinary, half overlap, len=64                     35             36           2         30.3          33.0       0.8X
+skipBinary, half overlap, len=64                     39             41           2         26.6          37.6       0.7X
 
 
 ================================================================================================
@@ -60,14 +60,14 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_LENGTH_BYTE_ARRAY:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, payloadLen=8                             15             17           2         69.5          14.4       1.0X
-skipBinary, payloadLen=8                              3              3           1        357.1           2.8       5.1X
-readBinary, payloadLen=32                            15             17           1         69.5          14.4       1.0X
-skipBinary, payloadLen=32                             3              3           1        357.5           2.8       5.1X
-readBinary, payloadLen=128                           18             20           2         58.3          17.2       0.8X
-skipBinary, payloadLen=128                            3              3           1        358.3           2.8       5.2X
-readBinary, payloadLen=512                           40             42           2         26.3          38.0       0.4X
-skipBinary, payloadLen=512                            3              4           1        353.8           2.8       5.1X
+readBinary, payloadLen=8                             17             18           2         63.3          15.8       1.0X
+skipBinary, payloadLen=8                              3              3           1        352.7           2.8       5.6X
+readBinary, payloadLen=32                            17             17           1         62.3          16.0       1.0X
+skipBinary, payloadLen=32                             3              3           0        351.8           2.8       5.6X
+readBinary, payloadLen=128                           19             19           0         54.6          18.3       0.9X
+skipBinary, payloadLen=128                            3              3           0        353.7           2.8       5.6X
+readBinary, payloadLen=512                           42             44           1         25.2          39.7       0.4X
+skipBinary, payloadLen=512                            3              3           0        349.5           2.9       5.5X
 
 
 ================================================================================================
@@ -78,20 +78,20 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 Variant reads:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------
-readBytes (INT32)                                                      5              5           0        208.9           4.8       1.0X
-readShorts (INT32)                                                     8              8           0        135.8           7.4       0.7X
-readUnsignedIntegers (INT32 -> Long)                                   8              8           1        133.0           7.5       0.6X
-readIntegersAsLongs (INT32 -> Long)                                    4              4           0        240.1           4.2       1.1X
-readIntegersAsLongs (INT32 -> Long, overflow pattern)                  4              4           0        240.3           4.2       1.2X
-readIntegersAsDoubles (INT32 -> Double)                                4              4           0        252.2           4.0       1.2X
-readIntegersAsDoubles (INT32 -> Double, overflow pattern)              4              4           0        252.1           4.0       1.2X
-readUnsignedLongs (INT64 -> Decimal(20,0))                            27             27           0         38.6          25.9       0.2X
-skipBytes                                                              4              4           0        296.9           3.4       1.4X
-skipShorts                                                             4              4           0        297.2           3.4       1.4X
-readByte (INT32 single-value)                                         13             14           1         79.1          12.6       0.4X
-readShort (INT32 single-value)                                        13             14           1         79.0          12.7       0.4X
-readInteger (INT32 single-value)                                      13             14           1         79.5          12.6       0.4X
-readLong (INT64 single-value)                                         15             16           2         68.9          14.5       0.3X
-readBinary(len) (DELTA_BYTE_ARRAY single-value)                       59             60           1         17.8          56.0       0.1X
+readBytes (INT32)                                                      5              5           0        207.7           4.8       1.0X
+readShorts (INT32)                                                     8              8           0        137.7           7.3       0.7X
+readUnsignedIntegers (INT32 -> Long)                                   8              8           0        136.8           7.3       0.7X
+readIntegersAsLongs (INT32 -> Long)                                    4              4           0        254.8           3.9       1.2X
+readIntegersAsLongs (INT32 -> Long, overflow pattern)                  4              4           0        255.1           3.9       1.2X
+readIntegersAsDoubles (INT32 -> Double)                                4              4           0        252.7           4.0       1.2X
+readIntegersAsDoubles (INT32 -> Double, overflow pattern)              4              4           0        255.1           3.9       1.2X
+readUnsignedLongs (INT64 -> Decimal(20,0))                            27             27           0         39.2          25.5       0.2X
+skipBytes                                                              4              4           0        295.5           3.4       1.4X
+skipShorts                                                             4              4           0        295.3           3.4       1.4X
+readByte (INT32 single-value)                                         12             12           1         89.2          11.2       0.4X
+readShort (INT32 single-value)                                        12             12           0         89.4          11.2       0.4X
+readInteger (INT32 single-value)                                      12             12           0         89.6          11.2       0.4X
+readLong (INT64 single-value)                                         14             14           1         76.8          13.0       0.4X
+readBinary(len) (DELTA_BYTE_ARRAY single-value)                       63             67           5         16.7          59.9       0.1X
 
 

--- a/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-results.txt
+++ b/sql/core/benchmarks/VectorizedDeltaReaderBenchmark-results.txt
@@ -6,14 +6,14 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT32:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readIntegers, constant                                2              2           0        466.3           2.1       1.0X
-skipIntegers, constant                                3              3           0        398.8           2.5       0.9X
-readIntegers, monotonic                               2              2           0        466.2           2.1       1.0X
-skipIntegers, monotonic                               3              3           0        399.6           2.5       0.9X
-readIntegers, small-delta random                      3              3           0        345.1           2.9       0.7X
-skipIntegers, small-delta random                      3              3           0        313.2           3.2       0.7X
-readIntegers, wide random                             4              4           0        262.7           3.8       0.6X
-skipIntegers, wide random                             4              4           0        251.8           4.0       0.5X
+readIntegers, constant                                2              2           0        441.4           2.3       1.0X
+skipIntegers, constant                                2              2           0        555.5           1.8       1.3X
+readIntegers, monotonic                               2              2           0        440.9           2.3       1.0X
+skipIntegers, monotonic                               2              2           0        554.1           1.8       1.3X
+readIntegers, small-delta random                      3              3           0        333.0           3.0       0.8X
+skipIntegers, small-delta random                      3              3           0        371.1           2.7       0.8X
+readIntegers, wide random                             4              4           0        257.8           3.9       0.6X
+skipIntegers, wide random                             4              4           0        292.9           3.4       0.7X
 
 
 ================================================================================================
@@ -24,14 +24,14 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BINARY_PACKED INT64:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readLongs, constant                                   3              3           0        386.5           2.6       1.0X
-skipLongs, constant                                   3              3           0        396.8           2.5       1.0X
-readLongs, monotonic                                  3              3           0        386.2           2.6       1.0X
-skipLongs, monotonic                                  3              3           0        396.4           2.5       1.0X
-readLongs, small-delta random                         3              4           0        303.9           3.3       0.8X
-skipLongs, small-delta random                         3              4           0        304.7           3.3       0.8X
-readLongs, wide random                                6              6           0        166.8           6.0       0.4X
-skipLongs, wide random                                6              6           0        164.9           6.1       0.4X
+readLongs, constant                                   2              2           0        520.6           1.9       1.0X
+skipLongs, constant                                   2              2           0        551.6           1.8       1.1X
+readLongs, monotonic                                  2              2           0        514.8           1.9       1.0X
+skipLongs, monotonic                                  2              2           0        555.6           1.8       1.1X
+readLongs, small-delta random                         3              3           0        350.7           2.9       0.7X
+skipLongs, small-delta random                         3              3           0        375.2           2.7       0.7X
+readLongs, wide random                                6              6           0        181.2           5.5       0.3X
+skipLongs, wide random                                6              6           0        185.8           5.4       0.4X
 
 
 ================================================================================================
@@ -42,14 +42,14 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_BYTE_ARRAY:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, no overlap, len=16                       30             30           1         35.2          28.4       1.0X
-skipBinary, no overlap, len=16                       32             33           1         32.3          31.0       0.9X
-readBinary, half overlap, len=16                     36             37           1         28.8          34.7       0.8X
-skipBinary, half overlap, len=16                     40             41           1         26.3          38.1       0.7X
-readBinary, full overlap, len=16                     37             38           1         28.1          35.5       0.8X
-skipBinary, full overlap, len=16                     40             41           1         26.1          38.4       0.7X
-readBinary, half overlap, len=64                     38             38           1         28.0          35.8       0.8X
-skipBinary, half overlap, len=64                     40             40           1         26.4          37.9       0.8X
+readBinary, no overlap, len=16                       27             28           0         38.3          26.1       1.0X
+skipBinary, no overlap, len=16                       32             33           1         32.8          30.5       0.9X
+readBinary, half overlap, len=16                     34             34           1         31.1          32.2       0.8X
+skipBinary, half overlap, len=16                     39             40           1         26.6          37.6       0.7X
+readBinary, full overlap, len=16                     34             34           1         30.8          32.5       0.8X
+skipBinary, full overlap, len=16                     39             40           2         26.7          37.4       0.7X
+readBinary, half overlap, len=64                     34             34           0         31.0          32.3       0.8X
+skipBinary, half overlap, len=64                     39             40           2         26.8          37.3       0.7X
 
 
 ================================================================================================
@@ -60,14 +60,14 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 DELTA_LENGTH_BYTE_ARRAY:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-readBinary, payloadLen=8                             17             19           3         62.6          16.0       1.0X
-skipBinary, payloadLen=8                              7              8           3        155.3           6.4       2.5X
-readBinary, payloadLen=32                            17             19           4         62.5          16.0       1.0X
-skipBinary, payloadLen=32                             7              8           3        155.5           6.4       2.5X
-readBinary, payloadLen=128                           19             22           3         54.3          18.4       0.9X
-skipBinary, payloadLen=128                            7              7           1        155.1           6.4       2.5X
-readBinary, payloadLen=512                           42             44           2         24.9          40.1       0.4X
-skipBinary, payloadLen=512                            7              7           1        154.9           6.5       2.5X
+readBinary, payloadLen=8                             15             17           2         69.5          14.4       1.0X
+skipBinary, payloadLen=8                              3              3           1        357.1           2.8       5.1X
+readBinary, payloadLen=32                            15             17           1         69.5          14.4       1.0X
+skipBinary, payloadLen=32                             3              3           1        357.5           2.8       5.1X
+readBinary, payloadLen=128                           18             20           2         58.3          17.2       0.8X
+skipBinary, payloadLen=128                            3              3           1        358.3           2.8       5.2X
+readBinary, payloadLen=512                           40             42           2         26.3          38.0       0.4X
+skipBinary, payloadLen=512                            3              4           1        353.8           2.8       5.1X
 
 
 ================================================================================================
@@ -78,20 +78,20 @@ OpenJDK 64-Bit Server VM 17.0.20+8-LTS on Linux 6.17.0-1020-azure
 AMD EPYC 7763 64-Core Processor
 Variant reads:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------
-readBytes (INT32)                                                      6              6           0        178.5           5.6       1.0X
-readShorts (INT32)                                                     8              8           0        135.5           7.4       0.8X
-readUnsignedIntegers (INT32 -> Long)                                   8              8           0        136.8           7.3       0.8X
-readIntegersAsLongs (INT32 -> Long)                                    5              5           0        226.4           4.4       1.3X
-readIntegersAsLongs (INT32 -> Long, overflow pattern)                  5              5           0        226.3           4.4       1.3X
-readIntegersAsDoubles (INT32 -> Double)                                5              5           0        224.4           4.5       1.3X
-readIntegersAsDoubles (INT32 -> Double, overflow pattern)              5              5           0        224.6           4.5       1.3X
-readUnsignedLongs (INT64 -> Decimal(20,0))                            28             28           0         37.8          26.4       0.2X
-skipBytes                                                              9              9           0        122.4           8.2       0.7X
-skipShorts                                                             9              9           0        122.3           8.2       0.7X
-readByte (INT32 single-value)                                         14             14           0         75.2          13.3       0.4X
-readShort (INT32 single-value)                                        14             14           0         75.2          13.3       0.4X
-readInteger (INT32 single-value)                                      14             14           0         75.2          13.3       0.4X
-readLong (INT64 single-value)                                         16             16           0         67.4          14.8       0.4X
-readBinary(len) (DELTA_BYTE_ARRAY single-value)                       62             64           2         16.8          59.5       0.1X
+readBytes (INT32)                                                      5              5           0        208.9           4.8       1.0X
+readShorts (INT32)                                                     8              8           0        135.8           7.4       0.7X
+readUnsignedIntegers (INT32 -> Long)                                   8              8           1        133.0           7.5       0.6X
+readIntegersAsLongs (INT32 -> Long)                                    4              4           0        240.1           4.2       1.1X
+readIntegersAsLongs (INT32 -> Long, overflow pattern)                  4              4           0        240.3           4.2       1.2X
+readIntegersAsDoubles (INT32 -> Double)                                4              4           0        252.2           4.0       1.2X
+readIntegersAsDoubles (INT32 -> Double, overflow pattern)              4              4           0        252.1           4.0       1.2X
+readUnsignedLongs (INT64 -> Decimal(20,0))                            27             27           0         38.6          25.9       0.2X
+skipBytes                                                              4              4           0        296.9           3.4       1.4X
+skipShorts                                                             4              4           0        297.2           3.4       1.4X
+readByte (INT32 single-value)                                         13             14           1         79.1          12.6       0.4X
+readShort (INT32 single-value)                                        13             14           1         79.0          12.7       0.4X
+readInteger (INT32 single-value)                                      13             14           1         79.5          12.6       0.4X
+readLong (INT64 single-value)                                         15             16           2         68.9          14.5       0.3X
+readBinary(len) (DELTA_BYTE_ARRAY single-value)                       59             60           1         17.8          56.0       0.1X
 
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaByteArrayReader.java
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet;
 
+import static org.apache.spark.sql.execution.datasources.parquet.VectorizedReaderBase.checkLength;
 import static org.apache.spark.sql.types.DataTypes.BinaryType;
 import static org.apache.spark.sql.types.DataTypes.IntegerType;
 
@@ -78,7 +79,7 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
       // even for the *first* value of a page. Even though the first
       // value of the page should have an empty prefix, it may not
       // because of PARQUET-246.
-      int prefixLength = prefixLengthVector.getInt(currentRow);
+      int prefixLength = checkLength(prefixLengthVector.getInt(currentRow));
       ByteBuffer suffix = suffixReader.getBytes(currentRow);
       byte[] suffixArray = suffix.array();
       int suffixLength = suffix.limit() - suffix.position();
@@ -119,7 +120,7 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
   private void readGeoData(int total, WritableColumnVector c, int rowId, int srid,
      WKBConverterStrategy converter) {
     for (int i = 0; i < total; i++) {
-      int prefixLength = prefixLengthVector.getInt(currentRow);
+      int prefixLength = checkLength(prefixLengthVector.getInt(currentRow));
       ByteBuffer suffix = suffixReader.getBytes(currentRow);
       int suffixLength = suffix.limit() - suffix.position();
       int length = prefixLength + suffixLength;
@@ -164,7 +165,7 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
     WritableColumnVector c2 = binaryValVector;
 
     for (int i = 0; i < total; i++) {
-      int prefixLength = prefixLengthVector.getInt(currentRow);
+      int prefixLength = checkLength(prefixLengthVector.getInt(currentRow));
       ByteBuffer suffix = suffixReader.getBytes(currentRow);
       byte[] suffixArray = suffix.array();
       int suffixLength = suffix.limit() - suffix.position();

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
@@ -54,17 +54,26 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
 
   @Override
   public void readBinary(int total, WritableColumnVector c, int rowId) {
-    ByteBuffer buffer;
-    ByteBufferOutputWriter outputWriter = ByteBufferOutputWriter::writeArrayByteBuffer;
-    int length;
+    // Compute total data length across all values so we can read everything in a single
+    // bulk slice instead of allocating one ByteBuffer per value.
+    int totalDataLen = 0;
     for (int i = 0; i < total; i++) {
-      length = lengthsVector.getInt(currentRow + i);
-      try {
-        buffer = in.slice(length);
-      } catch (EOFException e) {
-        throw new ParquetDecodingException("Failed to read " + length + " bytes");
-      }
-      outputWriter.write(c, rowId + i, buffer, length);
+      totalDataLen += lengthsVector.getInt(currentRow + i);
+    }
+
+    ByteBuffer allData;
+    try {
+      allData = in.slice(totalDataLen);
+    } catch (EOFException e) {
+      throw new ParquetDecodingException("Failed to read " + totalDataLen + " bytes");
+    }
+    byte[] dataArray = allData.array();
+    int dataPos = allData.arrayOffset() + allData.position();
+
+    for (int i = 0; i < total; i++) {
+      int length = lengthsVector.getInt(currentRow + i);
+      c.putByteArray(rowId + i, dataArray, dataPos, length);
+      dataPos += length;
     }
     currentRow += total;
   }
@@ -85,10 +94,8 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
 
   private void readGeoData(int total, WritableColumnVector c, int rowId, int srid,
      WKBConverterStrategy converter) {
-    ByteBufferOutputWriter outputWriter = ByteBufferOutputWriter::writeArrayByteBuffer;
-    int length;
     for (int i = 0; i < total; i++) {
-      length = lengthsVector.getInt(currentRow + i);
+      int length = lengthsVector.getInt(currentRow + i);
       byte[] physicalValue;
       try {
         // Converts WKB into a physical representation of geometry/geography.
@@ -96,8 +103,7 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
       } catch (IOException e) {
         throw new ParquetDecodingException("Failed to read " + length + " bytes");
       }
-
-      outputWriter.write(c, rowId + i, ByteBuffer.wrap(physicalValue), physicalValue.length);
+      c.putByteArray(rowId + i, physicalValue, 0, physicalValue.length);
     }
     currentRow += total;
   }
@@ -113,11 +119,12 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
 
   @Override
   public void skipBinary(int total) {
+    long totalSkip = 0;
     for (int i = 0; i < total; i++) {
-      int remaining = lengthsVector.getInt(currentRow + i);
-      while (remaining > 0) {
-        remaining -= in.skip(remaining);
-      }
+      totalSkip += lengthsVector.getInt(currentRow + i);
+    }
+    while (totalSkip > 0) {
+      totalSkip -= in.skip(totalSkip);
     }
     currentRow += total;
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
@@ -58,7 +58,7 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
     ByteBufferOutputWriter outputWriter = ByteBufferOutputWriter::writeArrayByteBuffer;
     int length;
     for (int i = 0; i < total; i++) {
-      length = lengthsVector.getInt(currentRow + i);
+      length = checkLength(lengthsVector.getInt(currentRow + i));
       try {
         buffer = in.slice(length);
       } catch (EOFException e) {
@@ -88,7 +88,7 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
     ByteBufferOutputWriter outputWriter = ByteBufferOutputWriter::writeArrayByteBuffer;
     int length;
     for (int i = 0; i < total; i++) {
-      length = lengthsVector.getInt(currentRow + i);
+      length = checkLength(lengthsVector.getInt(currentRow + i));
       byte[] physicalValue;
       try {
         // Converts WKB into a physical representation of geometry/geography.
@@ -103,7 +103,7 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
   }
 
   public ByteBuffer getBytes(int rowId) {
-    int length = lengthsVector.getInt(rowId);
+    int length = checkLength(lengthsVector.getInt(rowId));
     try {
       return in.slice(length);
     } catch (EOFException e) {
@@ -115,11 +115,7 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
   public void skipBinary(int total) {
     long totalSkip = 0;
     for (int i = 0; i < total; i++) {
-      int length = lengthsVector.getInt(currentRow + i);
-      if (length < 0) {
-        throw new ParquetDecodingException("Encountered negative length: " + length);
-      }
-      totalSkip += length;
+      totalSkip += checkLength(lengthsVector.getInt(currentRow + i));
     }
     try {
       in.skipFully(totalSkip);
@@ -127,5 +123,18 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
       throw new ParquetDecodingException("Failed to skip " + totalSkip + " bytes", e);
     }
     currentRow += total;
+  }
+
+  /**
+   * Validates a length decoded from the page. Lengths are file-supplied and unverified, so a
+   * negative value (whether crafted or corrupt) must be rejected before it reaches
+   * {@code in.slice}, {@code in.skipFully}, or the column vector, where it would otherwise read
+   * stale bytes, rewind the stream, or move {@code elementsAppended} backwards silently.
+   */
+  private static int checkLength(int length) {
+    if (length < 0) {
+      throw new ParquetDecodingException("Encountered negative length: " + length);
+    }
+    return length;
   }
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet;
 
+import static org.apache.spark.sql.execution.datasources.parquet.VectorizedReaderBase.checkLength;
 import static org.apache.spark.sql.types.DataTypes.IntegerType;
 
 import java.io.EOFException;
@@ -62,7 +63,7 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
       try {
         buffer = in.slice(length);
       } catch (EOFException e) {
-        throw new ParquetDecodingException("Failed to read " + length + " bytes");
+        throw new ParquetDecodingException("Failed to read " + length + " bytes", e);
       }
       outputWriter.write(c, rowId + i, buffer, length);
     }
@@ -94,7 +95,7 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
         // Converts WKB into a physical representation of geometry/geography.
         physicalValue = converter.convert(in.readNBytes(length), srid);
       } catch (IOException e) {
-        throw new ParquetDecodingException("Failed to read " + length + " bytes");
+        throw new ParquetDecodingException("Failed to read " + length + " bytes", e);
       }
 
       outputWriter.write(c, rowId + i, ByteBuffer.wrap(physicalValue), physicalValue.length);
@@ -107,7 +108,7 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
     try {
       return in.slice(length);
     } catch (EOFException e) {
-      throw new ParquetDecodingException("Failed to read " + length + " bytes");
+      throw new ParquetDecodingException("Failed to read " + length + " bytes", e);
     }
   }
 
@@ -123,18 +124,5 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
       throw new ParquetDecodingException("Failed to skip " + totalSkip + " bytes", e);
     }
     currentRow += total;
-  }
-
-  /**
-   * Validates a length decoded from the page. Lengths are file-supplied and unverified, so a
-   * negative value (whether crafted or corrupt) must be rejected before it reaches
-   * {@code in.slice}, {@code in.skipFully}, or the column vector, where it would otherwise read
-   * stale bytes, rewind the stream, or move {@code elementsAppended} backwards silently.
-   */
-  private static int checkLength(int length) {
-    if (length < 0) {
-      throw new ParquetDecodingException("Encountered negative length: " + length);
-    }
-    return length;
   }
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaLengthByteArrayReader.java
@@ -54,26 +54,17 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
 
   @Override
   public void readBinary(int total, WritableColumnVector c, int rowId) {
-    // Compute total data length across all values so we can read everything in a single
-    // bulk slice instead of allocating one ByteBuffer per value.
-    int totalDataLen = 0;
+    ByteBuffer buffer;
+    ByteBufferOutputWriter outputWriter = ByteBufferOutputWriter::writeArrayByteBuffer;
+    int length;
     for (int i = 0; i < total; i++) {
-      totalDataLen += lengthsVector.getInt(currentRow + i);
-    }
-
-    ByteBuffer allData;
-    try {
-      allData = in.slice(totalDataLen);
-    } catch (EOFException e) {
-      throw new ParquetDecodingException("Failed to read " + totalDataLen + " bytes");
-    }
-    byte[] dataArray = allData.array();
-    int dataPos = allData.arrayOffset() + allData.position();
-
-    for (int i = 0; i < total; i++) {
-      int length = lengthsVector.getInt(currentRow + i);
-      c.putByteArray(rowId + i, dataArray, dataPos, length);
-      dataPos += length;
+      length = lengthsVector.getInt(currentRow + i);
+      try {
+        buffer = in.slice(length);
+      } catch (EOFException e) {
+        throw new ParquetDecodingException("Failed to read " + length + " bytes");
+      }
+      outputWriter.write(c, rowId + i, buffer, length);
     }
     currentRow += total;
   }
@@ -94,8 +85,10 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
 
   private void readGeoData(int total, WritableColumnVector c, int rowId, int srid,
      WKBConverterStrategy converter) {
+    ByteBufferOutputWriter outputWriter = ByteBufferOutputWriter::writeArrayByteBuffer;
+    int length;
     for (int i = 0; i < total; i++) {
-      int length = lengthsVector.getInt(currentRow + i);
+      length = lengthsVector.getInt(currentRow + i);
       byte[] physicalValue;
       try {
         // Converts WKB into a physical representation of geometry/geography.
@@ -103,7 +96,8 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
       } catch (IOException e) {
         throw new ParquetDecodingException("Failed to read " + length + " bytes");
       }
-      c.putByteArray(rowId + i, physicalValue, 0, physicalValue.length);
+
+      outputWriter.write(c, rowId + i, ByteBuffer.wrap(physicalValue), physicalValue.length);
     }
     currentRow += total;
   }
@@ -121,10 +115,16 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase i
   public void skipBinary(int total) {
     long totalSkip = 0;
     for (int i = 0; i < total; i++) {
-      totalSkip += lengthsVector.getInt(currentRow + i);
+      int length = lengthsVector.getInt(currentRow + i);
+      if (length < 0) {
+        throw new ParquetDecodingException("Encountered negative length: " + length);
+      }
+      totalSkip += length;
     }
-    while (totalSkip > 0) {
-      totalSkip -= in.skip(totalSkip);
+    try {
+      in.skipFully(totalSkip);
+    } catch (IOException e) {
+      throw new ParquetDecodingException("Failed to skip " + totalSkip + " bytes", e);
     }
     currentRow += total;
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedPlainValuesReader.java
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet;
 
+import static org.apache.spark.sql.execution.datasources.parquet.VectorizedReaderBase.checkLength;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -518,7 +520,7 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
   @Override
   public final void readBinary(int total, WritableColumnVector v, int rowId) {
     for (int i = 0; i < total; i++) {
-      int len = readInteger();
+      int len = checkLength(readInteger());
       ByteBuffer buffer = getBuffer(len);
       if (buffer.hasArray()) {
         v.putByteArray(rowId + i, buffer.array(), buffer.arrayOffset() + buffer.position(), len);
@@ -533,8 +535,14 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
   @Override
   public void skipBinary(int total) {
     for (int i = 0; i < total; i++) {
-      int len = readInteger();
-      in.skip(len);
+      // Validate before skipping: a negative length rewinds a single-buffer stream and is a
+      // silent no-op on a multi-buffer one, and skipFully throws on neither. See checkLength.
+      int len = checkLength(readInteger());
+      try {
+        in.skipFully(len);
+      } catch (IOException e) {
+        throw new ParquetDecodingException("Failed to skip " + len + " bytes", e);
+      }
     }
   }
 
@@ -602,7 +610,7 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
     ByteBufferOutputStream out = new ByteBufferOutputStream();
 
     for (int i = 0; i < total; i++) {
-      int len = readInteger();
+      int len = checkLength(readInteger());
 
       // Converts WKB into a physical representation of geometry/geography.
       byte[] physicalValue = converter.convert(in.readNBytes(len), srid);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedReaderBase.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedReaderBase.java
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution.datasources.parquet;
 
 import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.api.Binary;
 import org.apache.spark.SparkUnsupportedOperationException;
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
@@ -26,6 +27,21 @@ import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
  * of methods that are not supported by concrete implementations
  */
 public class VectorizedReaderBase extends ValuesReader implements VectorizedValuesReader {
+
+  /**
+   * Validates a value length decoded from a page. Parquet stores value lengths in the page
+   * itself, so they are file-supplied and unverified. A negative length (whether crafted or
+   * corrupt) must be rejected before it reaches a stream slice/skip or the column vector, where
+   * it would otherwise read stale bytes, rewind the stream, or move {@code elementsAppended}
+   * backwards silently. Spark's own writers never emit one, so this only guards reads of
+   * third-party or corrupted files.
+   */
+  static int checkLength(int length) {
+    if (length < 0) {
+      throw new ParquetDecodingException("Encountered negative length: " + length);
+    }
+    return length;
+  }
 
   /**
    * Encodes an unsigned long as a minimal big-endian two's-complement byte array

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaByteArrayEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaByteArrayEncodingSuite.scala
@@ -16,9 +16,15 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.parquet.bytes.DirectByteBufferAllocator
+import java.nio.ByteBuffer
+
+import org.apache.parquet.bytes.{ByteBufferInputStream, BytesInput, DirectByteBufferAllocator}
 import org.apache.parquet.column.values.Utils
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger
+import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter
 import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter
+import org.apache.parquet.io.ParquetDecodingException
+import org.apache.parquet.io.api.Binary
 
 import org.apache.spark.sql.catalyst.util.STUtils
 import org.apache.spark.sql.execution.vectorized.{OnHeapColumnVector, WritableColumnVector}
@@ -57,6 +63,47 @@ class ParquetDeltaByteArrayEncodingSuite extends ParquetCompatibilityTest with S
 
   test("random strings with skipN") {
     assertReadWriteWithSkipN(writer, reader, randvalues)
+  }
+
+  test("readBinary rejects a negative decoded length (prefix and suffix)") {
+    // A DELTA_BYTE_ARRAY page is concat(prefixLengthHeader, suffixSection), where the suffix
+    // section is itself a DELTA_LENGTH_BYTE_ARRAY page concat(suffixLengthHeader, suffixData).
+    // Spark's writer never emits a negative length, but a corrupt/third-party file can carry one
+    // in either the prefix or the suffix lengths. Both must be rejected: the suffix through
+    // suffixReader.getBytes, the prefix through the reader's own checkLength guard.
+    val alloc = new DirectByteBufferAllocator()
+    def deltaBinaryPacked(values: Int*): BytesInput = {
+      val w = new DeltaBinaryPackingValuesWriterForInteger(128, 4, 100, 200, alloc)
+      values.foreach(w.writeInteger)
+      w.getBytes
+    }
+    def deltaLengthByteArray(values: String*): BytesInput = {
+      val w = new DeltaLengthByteArrayValuesWriter(64 * 1024, 64 * 1024, alloc)
+      values.foreach(s => w.writeBytes(Binary.fromString(s)))
+      w.getBytes
+    }
+    def firstRowThenNegative(page: Array[Byte]): Unit = {
+      reader = new VectorizedDeltaByteArrayReader()
+      reader.initFromPage(2, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)))
+      val vector = new OnHeapColumnVector(2, StringType)
+      reader.readBinary(1, vector, 0)
+      assert("abc".getBytes() sameElements vector.getBinary(0))
+      val error = intercept[ParquetDecodingException] {
+        reader.readBinary(1, vector, 1)
+      }
+      assert(error.getMessage.contains("negative length"))
+    }
+
+    // Negative prefix length: value 0 has prefix 0 (valid), value 1 has prefix -6.
+    firstRowThenNegative(
+      BytesInput.concat(deltaBinaryPacked(0, -6), deltaLengthByteArray("abc", "def")).toByteArray)
+
+    // Negative suffix length: prefixes are 0, suffix lengths are [3, -6] over data "abc".
+    firstRowThenNegative(
+      BytesInput.concat(
+        deltaBinaryPacked(0, 0),
+        deltaBinaryPacked(3, -6),
+        BytesInput.from("abc".getBytes())).toByteArray)
   }
 
   test("test lengths") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaLengthByteArrayEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaLengthByteArrayEncodingSuite.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution.datasources.parquet
 
 import java.nio.ByteBuffer
-import java.util.Random
+import java.util.{Arrays, Random}
 
 import org.apache.commons.lang3.RandomStringUtils
 import org.apache.parquet.bytes.{ByteBufferInputStream, BytesInput, DirectByteBufferAllocator}
@@ -101,7 +101,7 @@ class ParquetDeltaLengthByteArrayEncodingSuite
     // ParquetDecodingException instead of spinning forever on an exhausted stream.
     writeData(writer, values)
     val fullBytes = writer.getBytes.toByteArray
-    val truncated = java.util.Arrays.copyOf(fullBytes, fullBytes.length - 3)
+    val truncated = Arrays.copyOf(fullBytes, fullBytes.length - 3)
     reader.initFromPage(values.length, ByteBufferInputStream.wrap(ByteBuffer.wrap(truncated)))
     val e = intercept[ParquetDecodingException] {
       reader.skipBinary(values.length)
@@ -111,43 +111,77 @@ class ParquetDeltaLengthByteArrayEncodingSuite
 
   test("readBinary, getBytes and skipBinary reject a negative decoded length") {
     // Spark's own writer never emits a negative length, but a third-party or corrupt file can:
-    // the page is concat(lengthHeader, data), so write the length header directly with a
-    // negative entry. A negative length must be rejected before it reaches in.slice/in.skipFully
+    // the page is concat(lengthHeader, data), so write the length header directly. Lengths are
+    // [3, 0, -6]: two valid entries (a normal value and a legitimate empty one) followed by a
+    // negative one. A negative length must be rejected before it reaches in.slice/in.skipFully
     // or the column vector, where it would otherwise read stale bytes, rewind the stream, or move
-    // elementsAppended backwards silently.
+    // elementsAppended backwards silently. The zero-length entry guards against a check that
+    // wrongly rejects empty values (a < 0 check, not <= 0); the valid entries are read
+    // successfully first so that a check firing too early would fail the test too.
     def negativeLengthPage(): ByteBufferInputStream = {
       val lengthWriter = new DeltaBinaryPackingValuesWriterForInteger(
         128, 4, 100, 200, new DirectByteBufferAllocator())
-      Seq(3, -6, 3).foreach(lengthWriter.writeInteger)
-      val data = "abcdefghi".getBytes()
+      Seq(3, 0, -6).foreach(lengthWriter.writeInteger)
+      val data = "abc".getBytes()
       val page = BytesInput.concat(lengthWriter.getBytes, BytesInput.from(data)).toByteArray
       ByteBufferInputStream.wrap(ByteBuffer.wrap(page))
     }
 
-    // readBinary: the -6 entry is hit on the second value and must throw.
+    // readBinary: rows 0 ("abc") and 1 (empty) read cleanly, then the -6 entry must throw.
     reader.initFromPage(3, negativeLengthPage())
     val readVector = new OnHeapColumnVector(3, StringType)
+    reader.readBinary(2, readVector, 0)
+    assert("abc".getBytes() sameElements readVector.getBinary(0))
+    assert(readVector.getBinary(1).isEmpty)
     val readError = intercept[ParquetDecodingException] {
-      reader.readBinary(3, readVector, 0)
+      reader.readBinary(1, readVector, 2)
     }
     assert(readError.getMessage.contains("negative length"))
 
-    // getBytes: reading the second row directly must throw as well.
+    // getBytes: the two valid rows slice cleanly, reading row 2 directly must throw.
     reader = new VectorizedDeltaLengthByteArrayReader()
     reader.initFromPage(3, negativeLengthPage())
+    assert(reader.getBytes(0).remaining() == 3)
+    assert(reader.getBytes(1).remaining() == 0)
     val getBytesError = intercept[ParquetDecodingException] {
-      reader.getBytes(1)
+      reader.getBytes(2)
     }
     assert(getBytesError.getMessage.contains("negative length"))
 
-    // skipBinary: the check stays per value inside the accumulation loop, so [3, -6, 3] throws
-    // instead of summing to 0 and silently advancing currentRow past an unmoved stream.
+    // skipBinary: the check stays per value inside the accumulation loop, so the -6 entry throws
+    // instead of summing (3 + 0 + -6 = -3, or with a later check summing to a value that silently
+    // advances currentRow past an unmoved stream). Skipping the two valid rows first succeeds.
     reader = new VectorizedDeltaLengthByteArrayReader()
     reader.initFromPage(3, negativeLengthPage())
+    reader.skipBinary(2)
     val skipError = intercept[ParquetDecodingException] {
-      reader.skipBinary(3)
+      reader.skipBinary(1)
     }
     assert(skipError.getMessage.contains("negative length"))
+  }
+
+  test("readGeometry rejects a negative decoded length") {
+    // The geo path decodes lengths through the same checkLength guard (before in.readNBytes,
+    // which would otherwise return a short array rather than signalling truncation). Build a page
+    // whose second length is negative and assert readGeometry throws before converting WKB.
+    val point = makePointWkb(1, 1)
+    def negativeLengthGeoPage(): ByteBufferInputStream = {
+      val lengthWriter = new DeltaBinaryPackingValuesWriterForInteger(
+        128, 4, 100, 200, new DirectByteBufferAllocator())
+      Seq(point.length, -6).foreach(lengthWriter.writeInteger)
+      val page = BytesInput.concat(lengthWriter.getBytes, BytesInput.from(point)).toByteArray
+      ByteBufferInputStream.wrap(ByteBuffer.wrap(page))
+    }
+
+    reader.initFromPage(2, negativeLengthGeoPage())
+    val geoVector = new OnHeapColumnVector(2, GeometryType(0))
+    // Row 0 is a valid point; row 1 has a negative length and must throw.
+    reader.readGeometry(1, geoVector, 0)
+    assert(point sameElements STUtils.stGeomAsBinary(geoVector.getBinaryView(0)))
+    val geoError = intercept[ParquetDecodingException] {
+      reader.readGeometry(1, geoVector, 1)
+    }
+    assert(geoError.getMessage.contains("negative length"))
   }
 
   // Read the lengths from the beginning of the buffer and compare with the lengths of the values

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaLengthByteArrayEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaLengthByteArrayEncodingSuite.scala
@@ -20,8 +20,9 @@ import java.nio.ByteBuffer
 import java.util.Random
 
 import org.apache.commons.lang3.RandomStringUtils
-import org.apache.parquet.bytes.{ByteBufferInputStream, DirectByteBufferAllocator}
+import org.apache.parquet.bytes.{ByteBufferInputStream, BytesInput, DirectByteBufferAllocator}
 import org.apache.parquet.column.values.Utils
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger
 import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter
 import org.apache.parquet.io.ParquetDecodingException
 import org.apache.parquet.io.api.Binary
@@ -106,6 +107,47 @@ class ParquetDeltaLengthByteArrayEncodingSuite
       reader.skipBinary(values.length)
     }
     assert(e.getMessage.contains("Failed to skip"))
+  }
+
+  test("readBinary, getBytes and skipBinary reject a negative decoded length") {
+    // Spark's own writer never emits a negative length, but a third-party or corrupt file can:
+    // the page is concat(lengthHeader, data), so write the length header directly with a
+    // negative entry. A negative length must be rejected before it reaches in.slice/in.skipFully
+    // or the column vector, where it would otherwise read stale bytes, rewind the stream, or move
+    // elementsAppended backwards silently.
+    def negativeLengthPage(): ByteBufferInputStream = {
+      val lengthWriter = new DeltaBinaryPackingValuesWriterForInteger(
+        128, 4, 100, 200, new DirectByteBufferAllocator())
+      Seq(3, -6, 3).foreach(lengthWriter.writeInteger)
+      val data = "abcdefghi".getBytes()
+      val page = BytesInput.concat(lengthWriter.getBytes, BytesInput.from(data)).toByteArray
+      ByteBufferInputStream.wrap(ByteBuffer.wrap(page))
+    }
+
+    // readBinary: the -6 entry is hit on the second value and must throw.
+    reader.initFromPage(3, negativeLengthPage())
+    val readVector = new OnHeapColumnVector(3, StringType)
+    val readError = intercept[ParquetDecodingException] {
+      reader.readBinary(3, readVector, 0)
+    }
+    assert(readError.getMessage.contains("negative length"))
+
+    // getBytes: reading the second row directly must throw as well.
+    reader = new VectorizedDeltaLengthByteArrayReader()
+    reader.initFromPage(3, negativeLengthPage())
+    val getBytesError = intercept[ParquetDecodingException] {
+      reader.getBytes(1)
+    }
+    assert(getBytesError.getMessage.contains("negative length"))
+
+    // skipBinary: the check stays per value inside the accumulation loop, so [3, -6, 3] throws
+    // instead of summing to 0 and silently advancing currentRow past an unmoved stream.
+    reader = new VectorizedDeltaLengthByteArrayReader()
+    reader.initFromPage(3, negativeLengthPage())
+    val skipError = intercept[ParquetDecodingException] {
+      reader.skipBinary(3)
+    }
+    assert(skipError.getMessage.contains("negative length"))
   }
 
   // Read the lengths from the beginning of the buffer and compare with the lengths of the values

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaLengthByteArrayEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaLengthByteArrayEncodingSuite.scala
@@ -16,12 +16,14 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet
 
+import java.nio.ByteBuffer
 import java.util.Random
 
 import org.apache.commons.lang3.RandomStringUtils
 import org.apache.parquet.bytes.{ByteBufferInputStream, DirectByteBufferAllocator}
 import org.apache.parquet.column.values.Utils
 import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter
+import org.apache.parquet.io.ParquetDecodingException
 import org.apache.parquet.io.api.Binary
 
 import org.apache.spark.sql.catalyst.util.STUtils
@@ -90,6 +92,20 @@ class ParquetDeltaLengthByteArrayEncodingSuite
       reader.skipBinary(skipCount)
       i += skipCount + 1
     }
+  }
+
+  test("skipBinary fails cleanly when the data region is truncated") {
+    // The length header is intact but the data region is short, so the lengths decoded from
+    // the page declare more bytes than the stream actually holds. skipBinary must surface a
+    // ParquetDecodingException instead of spinning forever on an exhausted stream.
+    writeData(writer, values)
+    val fullBytes = writer.getBytes.toByteArray
+    val truncated = java.util.Arrays.copyOf(fullBytes, fullBytes.length - 3)
+    reader.initFromPage(values.length, ByteBufferInputStream.wrap(ByteBuffer.wrap(truncated)))
+    val e = intercept[ParquetDecodingException] {
+      reader.skipBinary(values.length)
+    }
+    assert(e.getMessage.contains("Failed to skip"))
   }
 
   // Read the lengths from the beginning of the buffer and compare with the lengths of the values

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetEncodingSuite.scala
@@ -17,17 +17,20 @@
 package org.apache.spark.sql.execution.datasources.parquet
 
 import java.math.BigDecimal
+import java.nio.{ByteBuffer, ByteOrder}
 import java.sql.{Date, Timestamp}
 import java.time.{Duration, Period}
 
 import scala.jdk.CollectionConverters._
 
 import org.apache.hadoop.fs.Path
+import org.apache.parquet.bytes.ByteBufferInputStream
 import org.apache.parquet.column.{Encoding, ParquetProperties}
 import org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0
 import org.apache.parquet.example.data.simple.SimpleGroup
 import org.apache.parquet.hadoop.ParquetOutputFormat
 import org.apache.parquet.hadoop.example.ExampleParquetWriter
+import org.apache.parquet.io.ParquetDecodingException
 import org.apache.parquet.io.api.Binary
 import org.apache.parquet.schema.MessageTypeParser
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
@@ -35,9 +38,11 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 import org.apache.spark.TestUtils
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.catalyst.util.{DateTimeUtils, STUtils}
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{BinaryType, GeometryType}
 
 // TODO: this needs a lot more testing but it's currently not easy to test with the parquet
 // writer abstractions. Revisit.
@@ -556,5 +561,64 @@ class ParquetEncodingSuite extends ParquetCompatibilityTest with SharedSparkSess
         }
       }
     }
+  }
+
+  test("VectorizedPlainValuesReader rejects a negative BYTE_ARRAY length") {
+    // PLAIN BYTE_ARRAY layout is repeated [4-byte little-endian length][data]. A well-formed
+    // writer never emits a negative length, but a corrupt/third-party file can; it must be
+    // rejected before it reaches in.slice / in.skipFully rather than corrupting the batch or
+    // silently no-op-ing the skip (in.skip rewinds a single-buffer stream and returns 0 on a
+    // multi-buffer one for a negative argument, and skipFully throws on neither).
+    def negativeLengthPage(): ByteBufferInputStream = {
+      val buf = ByteBuffer.allocate(4 + 3 + 4).order(ByteOrder.LITTLE_ENDIAN)
+      buf.putInt(3).put("abc".getBytes()) // value 0: length 3
+      buf.putInt(-6) // value 1: negative length
+      buf.flip()
+      ByteBufferInputStream.wrap(buf)
+    }
+
+    // readBinary: value 0 reads cleanly, value 1 must throw.
+    var reader = new VectorizedPlainValuesReader()
+    reader.initFromPage(2, negativeLengthPage())
+    val vector = new OnHeapColumnVector(2, BinaryType)
+    reader.readBinary(1, vector, 0)
+    assert("abc".getBytes() sameElements vector.getBinary(0))
+    val readError = intercept[ParquetDecodingException] {
+      reader.readBinary(1, vector, 1)
+    }
+    assert(readError.getMessage.contains("negative length"))
+
+    // skipBinary: skipping value 0 succeeds, value 1 must throw rather than silently no-op.
+    reader = new VectorizedPlainValuesReader()
+    reader.initFromPage(2, negativeLengthPage())
+    reader.skipBinary(1)
+    val skipError = intercept[ParquetDecodingException] {
+      reader.skipBinary(1)
+    }
+    assert(skipError.getMessage.contains("negative length"))
+  }
+
+  test("VectorizedPlainValuesReader rejects a negative geometry length") {
+    // The PLAIN geometry/geography path decodes a per-value length straight from the stream, just
+    // like readBinary, and must reject a negative one before it reaches in.readNBytes (which would
+    // otherwise return a short array rather than signalling truncation).
+    val point = makePointWkb(1, 1)
+    def negativeLengthGeoPage(): ByteBufferInputStream = {
+      val buf = ByteBuffer.allocate(4 + point.length + 4).order(ByteOrder.LITTLE_ENDIAN)
+      buf.putInt(point.length).put(point) // value 0: a valid point
+      buf.putInt(-6) // value 1: negative length
+      buf.flip()
+      ByteBufferInputStream.wrap(buf)
+    }
+
+    val reader = new VectorizedPlainValuesReader()
+    reader.initFromPage(2, negativeLengthGeoPage())
+    val vector = new OnHeapColumnVector(2, GeometryType(0))
+    reader.readGeometry(1, vector, 0)
+    assert(point sameElements STUtils.stGeomAsBinary(vector.getBinaryView(0)))
+    val geoError = intercept[ParquetDecodingException] {
+      reader.readGeometry(1, vector, 1)
+    }
+    assert(geoError.getMessage.contains("negative length"))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes an unkillable CPU spin in the `skipBinary` path of the DELTA_LENGTH_BYTE_ARRAY vectorized Parquet reader (`VectorizedDeltaLengthByteArrayReader`) and, with the same change, removes the per-value skip overhead.

`master` is not already correct here. On a page whose decoded lengths exceed the data region (a truncated or otherwise malformed third-party file), `master`'s per-value loop does not terminate promptly:

```java
while (remaining > 0) {
  remaining -= in.skip(remaining);   // in.skip returns -1 once the stream is dry
}
```

Once the stream is dry `in.skip` returns `-1`, so `remaining` grows by one per iteration and the loop exits only when the `int` wraps negative at 2^31 -- roughly 2^31 pure-CPU, non-interruptible iterations per short value, during which `killTask` cannot stop the task.

**skipBinary**: Replace the per-value skip loop (N separate `in.skip()` calls) with a single bulk skip by summing all value lengths upfront. The sum is accumulated into a `long`, each length is validated as non-negative, and the skip is performed via `in.skipFully(...)`, wrapping any `IOException` in a `ParquetDecodingException`. This makes the truncated-page case fail fast (a user-facing change, see below) instead of spinning, and as a side effect removes the per-value skip overhead. It also closes two issues that a naive `long` bulk form would introduce on top of the existing spin:

- silent row drift when a negative length cancels positive ones in the same batch, so `currentRow` advances while the stream does not -- guarded by the per-value non-negative check;
- `int` overflow of the summed length -- the sum is accumulated into a `long`.

A naive `long` bulk skip would also turn `master`'s bounded 2^31 spin into a truly unbounded one, since a `long` counter never wraps in practical time; `skipFully` avoids both.

An earlier revision of this PR also rewrote `readBinary` (bulk `slice`) and `readGeoData`. Those were reverted to the `master` implementations after review, since the `readBinary` wall-clock gain was within run-to-run noise and the bulk `slice` introduced an unguarded `ByteBuffer.array()` access and a whole-batch memcpy on the multi-buffer path. The reverted `readBinary` now measures identical to the baseline (see below), confirming it is a true no-op.

### Why are the changes needed?

The DELTA_LENGTH_BYTE_ARRAY encoding is used for binary/string columns in Parquet v2 pages. In the current vectorized reader, `skipBinary` performs a separate stream skip per value. For large batches (e.g. 1M values per page), this adds measurable per-call overhead.

GHA benchmark results on AMD EPYC 7763 (PR branch vs committed upstream baseline, same CPU, Best Time in ms, lower is better):

**DELTA_LENGTH_BYTE_ARRAY - skipBinary:**

| Case | JDK 17 Base | JDK 17 PR | Speedup | JDK 21 Base | JDK 21 PR | Speedup | JDK 25 Base | JDK 25 PR | Speedup |
|---|---|---|---|---|---|---|---|---|---|
| payloadLen=8 | 7 | 3 | **2.33x** | 7 | 3 | **2.33x** | 6 | 3 | **2.00x** |
| payloadLen=32 | 7 | 3 | **2.33x** | 7 | 3 | **2.33x** | 6 | 3 | **2.00x** |
| payloadLen=128 | 7 | 3 | **2.33x** | 7 | 3 | **2.33x** | 6 | 3 | **2.00x** |
| payloadLen=512 | 7 | 3 | **2.33x** | 7 | 3 | **2.33x** | 6 | 3 | **2.00x** |

`skipBinary` shows a consistent improvement across all payload sizes and JDKs, from replacing N per-value stream skips with a single bulk skip. The **bold** speedups in the table above are computed from the integer-millisecond Best Time column and so round high; by the unrounded `Rate(M/s)` column in the same result files the four payload sizes span **1.93x-2.28x** (this is also why JDK 17 and JDK 21 both read 2.33x despite different baseline rates). The mechanism argument is unaffected: post-change `skipBinary` lands at 352.7/354.7/354.8 M/s across the three files, within 0.6% of each other, while same-group `readBinary` stays flat.

**DELTA_LENGTH_BYTE_ARRAY - readBinary (reverted, shown for confirmation):** unchanged versus the baseline (JDK 17/25: 17/17/19/42 ms, JDK 21: 16/16/19/39 ms for payloadLen 8/32/128/512), i.e. 1.0x, confirming the revert changed nothing on that path.

Full committed results: [JDK 17](https://github.com/iemejia/spark/actions/runs/31418519810), [JDK 21](https://github.com/iemejia/spark/actions/runs/31418521986), [JDK 25](https://github.com/iemejia/spark/actions/runs/31418753130)

**PLAIN - skipBinary (`in.skip` -> `skipFully` + per-value non-negative check):** this touched path is a correctness fix, not an optimization, so it was measured only to confirm it is not a regression. `VectorizedPlainValuesReaderBenchmark` (the existing `skipBinary, payloadLen={8,32,128,512}` cases) run locally on the same box (AMD EPYC 9V45, JDK 25), before = `master`'s `in.skip`, after = this PR:

| payloadLen | Before Rate(M/s) | After Rate(M/s) | After/Before |
|---|---|---|---|
| 8 | 348.2 | 339.3 | 0.97x |
| 32 | 346.4 | 338.3 | 0.98x |
| 128 | 110.2 | 111.0 | 1.01x |
| 512 | 99.9 | 97.0 | 0.97x |

Best Time is integer-identical to within 1 ms (before 3/3/10/11, after 3/3/9/11), so the +-3% spread is run-to-run noise: switching to `skipFully` plus one predictable per-value branch leaves the PLAIN skip flat. The committed `VectorizedPlainValuesReaderBenchmark-*-results.txt` files are unchanged by this PR.

### Does this PR introduce _any_ user-facing change?

Yes. All the changes below only affect reads of malformed, truncated, or otherwise malicious third-party Parquet files; Spark's own writers never emit a length that triggers them. In every case the new behavior is a `ParquetDecodingException`, which fails the query by default (`spark.sql.files.ignoreCorruptFiles=false`) or, with `ignoreCorruptFiles=true`, makes `FileScanRDD` skip the remainder of the file so the query returns fewer rows.

**1. DELTA_LENGTH_BYTE_ARRAY `skipBinary` on a truncated page** (page whose decoded lengths declare more bytes than the page holds):

- **Before:** `skipBinary` did not raise; `master`'s per-value loop spun ~2^31 non-interruptible CPU iterations per short value and then returned normally (the `int` counter wraps negative), so a query that only skipped such a page eventually completed with correct rows, after a long unkillable stall.
- **After:** `skipBinary` fails fast with a `ParquetDecodingException` instead of spinning.

**2. PLAIN `skipBinary` on a truncated page:** this reader is also touched (it is the fallback path). It switched from `in.skip(len)` (return value ignored) to `in.skipFully(len)`.

- **Before:** on a truncated page it skipped too few bytes and kept decoding the remaining values from the wrong position, silently returning bytes that belong to other rows.
- **After:** throws a `ParquetDecodingException`.

**3. Negative decoded lengths in PLAIN and DELTA_BYTE_ARRAY:** a per-value non-negative check (`checkLength`) is now applied symmetrically across the vectorized readers.

- **Before:** a negative length in PLAIN silently rewound a single-buffer stream (or was a no-op on a multi-buffer one) and moved `elementsAppended` backwards; in DELTA_BYTE_ARRAY it failed with a different, unrelated exception (e.g. `IndexOutOfBoundsException`, or the vectorized reader's integer-overflow `RuntimeException`) that said nothing about a negative length.
- **After:** both throw a `ParquetDecodingException("Encountered negative length: ...")` before the length reaches a stream slice/skip or the column vector.

### How was this patch tested?

Existing tests: `ParquetDeltaLengthByteArrayEncodingSuite`, `ParquetDeltaByteArrayEncodingSuite`, and `ParquetEncodingSuite` all pass. Added cases covering the truncated-page and negative-length paths across all three affected encodings:

- DELTA_LENGTH_BYTE_ARRAY: `skipBinary fails cleanly when the data region is truncated` decodes a valid length header over a truncated data region and asserts `skipBinary` raises `ParquetDecodingException` instead of spinning; `readBinary, getBytes and skipBinary reject a negative decoded length` and `readGeometry rejects a negative decoded length` build a page with a negative length header directly (via `DeltaBinaryPackingValuesWriterForInteger`, since Spark's writer never emits one) and assert each path raises before consuming the stream;
- DELTA_BYTE_ARRAY: `readBinary rejects a negative decoded length (prefix and suffix)`;
- PLAIN: `VectorizedPlainValuesReader rejects a negative BYTE_ARRAY length` and `VectorizedPlainValuesReader rejects a negative geometry length`.

Benchmarks: `VectorizedDeltaReaderBenchmark` Group D (DELTA_LENGTH_BYTE_ARRAY) run on GHA across JDK 17, 21, and 25.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenCode with Claude Opus (claude-opus-4.6)




