### PR TITLE
[SPARK-53520][SQL] Handle TimeType in javaBoxedType()

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/EncoderUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/EncoderUtils.scala
@@ -123,6 +123,7 @@ object EncoderUtils {
     case _: DecimalType => classOf[Decimal]
     case _: DayTimeIntervalType => classOf[java.lang.Long]
     case _: YearMonthIntervalType => classOf[java.lang.Integer]
+    case _: TimeType => classOf[java.lang.Long]
     case BinaryType => classOf[Array[Byte]]
     case _: StringType => classOf[UTF8String]
     case CalendarIntervalType => classOf[CalendarInterval]

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderUtilsSuite.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.encoders
+
+import org.apache.spark.{SparkFunSuite, SparkRuntimeException}
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.BoundReference
+import org.apache.spark.sql.catalyst.expressions.objects.{GetExternalRowField, ValidateExternalType}
+import org.apache.spark.sql.types.{ObjectType, TimeType}
+
+class EncoderUtilsSuite extends SparkFunSuite {
+
+  test("SPARK-53520: javaBoxedType for TimeType enables correct type validation") {
+    // ValidateExternalType uses javaBoxedType(dataType) in its fallback checkType case.
+    // Without TimeType in javaBoxedType, it returns java.lang.Object, which makes
+    // Object.isInstance(value) always true -- disabling type validation entirely.
+    // With the fix, it returns java.lang.Long, so only Long values pass validation.
+    val inputObject = BoundReference(0, ObjectType(classOf[Row]), nullable = true)
+    val dt = TimeType()
+    val validateType = ValidateExternalType(
+      GetExternalRowField(inputObject, index = 0, fieldName = "t"),
+      dt,
+      dt)
+
+    // Valid: Long value (time as microseconds since midnight) should pass
+    val validRow = InternalRow.fromSeq(Seq(Row(61000000L)))
+    assert(validateType.eval(validRow) === 61000000L)
+
+    // Invalid: String value must be rejected.
+    // Without the fix, javaBoxedType returns Object and this would incorrectly pass.
+    val invalidRow = InternalRow.fromSeq(Seq(Row("not-a-time")))
+    intercept[SparkRuntimeException] {
+      validateType.eval(invalidRow)
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds `TimeType` handling to `javaBoxedType()` in `EncoderUtils.scala`, returning `classOf[java.lang.Long]` since TimeType is internally stored as microseconds since midnight.

### Why are the changes needed?

`javaBoxedType()` does not handle `TimeType`, causing a `MatchError` when encoding Time values. Part of Spark 4.3 release work (SPARK-56754).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added `EncoderUtilsSuite` with a test verifying `javaBoxedType(TimeType)` returns `classOf[java.lang.Long]`. Test fails without the fix (MatchError), passes with it.

### Was this patch authored or co-authored using generative AI tooling?
No