### PR TITLE
[MINOR][BUILD][3.5] Fix linter issue in `AmmoniteReplE2ESuite`

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/AmmoniteReplE2ESuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/AmmoniteReplE2ESuite.scala
@@ -29,7 +29,9 @@ class AmmoniteReplE2ESuite extends ConnectFunSuite with RemoteSparkSession {
     val sparkHome = sys.props.getOrElse(
       "spark.test.home",
       sys.env.getOrElse("SPARK_HOME", fail("spark.test.home or SPARK_HOME not set")))
-    val command = Seq(s"$sparkHome/connector/connect/bin/spark-connect-scala-client", "--remote",
+    val command = Seq(
+      s"$sparkHome/connector/connect/bin/spark-connect-scala-client",
+      "--remote",
       s"sc://localhost:$serverPort")
 
     val process = new ProcessBuilder(command: _*).start()


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR reformats a `Seq(...)` argument list in `AmmoniteReplE2ESuite` so that each element is on its own line.

### Why are the changes needed?
To fix a minor linter (scalastyle) issue.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Opus 4.7
