### PR TITLE
[SPARK-56889][INFRA][FOLLOWUP] Install `python3-pyparsing` before `add-apt-repository`

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -63,6 +63,7 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     python3.11 \
     python3-psutil \
+    python3-pyparsing \
     qpdf \
     r-base \
     ruby \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to install `python3-pyparsing` before invoking `add-apt-repository`.

### Why are the changes needed?

To avoid `ModuleNotFoundError: No module named 'pyparsing'` error inside `add-apt-repository`.

```
#19 [13/32] RUN add-apt-repository ppa:deadsnakes/ppa
#19 0.509 Traceback (most recent call last):
#19 0.509   File "/usr/lib/python3/dist-packages/launchpadlib/launchpad.py", line 34, in <module>
#19 0.509     from httplib2 import proxy_info_from_environment
#19 0.509   File "/usr/lib/python3/dist-packages/httplib2/__init__.py", line 52, in <module>
#19 0.509     from . import auth
#19 0.509   File "/usr/lib/python3/dist-packages/httplib2/auth.py", line 4, in <module>
#19 0.509     import pyparsing as pp
#19 0.509 ModuleNotFoundError: No module named 'pyparsing'
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.