### PR TITLE
[SPARK-35158][INFRA] Add guidance to retrigger forked workflow runs

### DIFF
--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -156,7 +156,11 @@ jobs:
                 status: status,
                 output: {
                   title: 'Test results',
-                  summary: '[See test results](' + check_run_url + ')',
+                  summary: '[See test results](' + check_run_url + ')\n\n'
+                    + 'If the tests fail for reasons unrelated to this pull request, '
+                    + 'please rerun the workflow in your forked repository.\n'
+                    + 'If the failures are related to this pull request, '
+                    + 'please investigate them and push follow-up changes.',
                   text: JSON.stringify({
                     owner: context.payload.pull_request.head.repo.owner.login,
                     repo: context.payload.pull_request.head.repo.name,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the `Test results` check summary in `notify_test_workflow.yml` to guide pull request authors on what to do after checking the forked workflow run.

### Why are the changes needed?

SPARK-35158 notes that only pull request authors can rerun workflow runs in their forks. The check summary currently links to the test results, but does not tell authors to rerun unrelated failures or push follow-up changes for related failures.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually verified with:

```bash
ruby -ryaml -e 'YAML.load_file(".github/workflows/notify_test_workflow.yml"); puts "YAML OK"'
node --check <(ruby -ryaml -e 'script = YAML.load_file(".github/workflows/notify_test_workflow.yml").dig("jobs", "notify", "steps", 0, "with", "script"); puts "async function __check() {"; puts script; puts "}"')
git diff --check
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: GPT-5
