### PR TITLE
[SPARK-54476][PYTHON][TEST] Add coverage test for try_mod

### DIFF
--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -948,6 +948,14 @@ class FunctionsTestsMixin:
         actual = df.select(F.isnull(F.try_make_interval("num")))
         assertDataFrameEqual([Row(True)], actual)
 
+    def test_try_mod_function(self):
+        df = self.spark.createDataFrame([(6000, 15), (3, 2), (1234, 0)], ["a", "b"])
+        actual = df.select(F.try_mod("a", "b").alias("r"))
+        assertDataFrameEqual([Row(r=0), Row(r=1), Row(r=None)], actual)
+
+        actual = df.select(F.try_mod(F.col("a"), F.lit(2)).alias("r"))
+        assertDataFrameEqual([Row(r=0), Row(r=1), Row(r=0)], actual)
+
     def test_octet_length_function(self):
         # SPARK-36751: add octet length api for python
         df = self.spark.createDataFrame([("cat",), ("\U0001f408",)], ["cat"])


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds PySpark SQL function coverage for `try_mod` in `test_functions.py`. The test covers column-name operands, `Column` plus literal operands, and division by zero returning null.

### Why are the changes needed?
SPARK-54476 tracks adding `try_mod` coverage in `test_functions.py`. This adds direct coverage for the PySpark function wrapper.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
env JAVA_HOME=/opt/homebrew/opt/openjdk PATH=/opt/homebrew/opt/openjdk/bin:$PATH ./build/mvn -DskipTests package
env JAVA_HOME=/opt/homebrew/opt/openjdk PATH=/opt/homebrew/opt/openjdk/bin:$PATH OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES python3 python/run-tests.py --testnames "pyspark.sql.tests.test_functions FunctionsTests.test_try_mod_function" --python-executables python3
git diff --check
python3 -m py_compile python/pyspark/sql/tests/test_functions.py
```

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: GPT-5.5 xhigh
