### PR TITLE
[SPARK-56932][SQL] Rewrite top-level single-column NOT IN subqueries with UNION

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -371,11 +371,23 @@ abstract class Optimizer(catalogManager: CatalogManager)
     }
 
     private def optimizeSubquery(s: SubqueryExpression): SubqueryExpression = {
+      val hasRowLimitingOperator = s match {
+        case _: ListQuery =>
+          s.plan.exists {
+            case _: GlobalLimit | _: LocalLimit | _: Offset => true
+            case _ => false
+          }
+        case _ => false
+      }
       val Subquery(newPlan, _) = Optimizer.this.execute(Subquery.fromExpression(s))
       // At this point we have an optimized subquery plan that we are going to attach
       // to this subquery expression. Here we can safely remove any top level sort
       // in the plan as tuples produced by a subquery are un-ordered.
-      s.withNewPlan(removeTopLevelSort(newPlan))
+      val optimizedPlan = removeTopLevelSort(newPlan)
+      if (hasRowLimitingOperator) {
+        optimizedPlan.setTagValue(RewritePredicateSubquery.NOT_IN_SUBQUERY_WITH_ROW_LIMIT, ())
+      }
+      s.withNewPlan(optimizedPlan)
     }
 
     // optimizes subquery expressions, ignoring row-level operation conditions

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.planning.PhysicalAggregation
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.trees.TreePattern.{EXISTS_SUBQUERY, IN_SUBQUERY, LATERAL_JOIN, LIST_SUBQUERY, PLAN_EXPRESSION, SCALAR_SUBQUERY}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
@@ -55,6 +56,9 @@ import org.apache.spark.util.Utils
  */
 object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper
   with JoinSelectionHelper {
+
+  private[optimizer] val NOT_IN_SUBQUERY_WITH_ROW_LIMIT =
+    TreeNodeTag[Unit]("notInSubqueryWithRowLimit")
 
   private def existenceScalarSubquery(
       plan: LogicalPlan,
@@ -137,7 +141,8 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper
     //   2. whether it contains a NULL key, and
     //   3. the anti-join branch over non-null keys.
     // Only duplicate plans whose repeated evaluation preserves the original NOT IN semantics.
-    subplan.deterministic && !subplan.exists {
+    !subplan.containsTag(NOT_IN_SUBQUERY_WITH_ROW_LIMIT) &&
+      subplan.deterministic && !subplan.exists {
       // LIMIT / OFFSET are order- or cardinality-sensitive when re-evaluated independently, so
       // duplicating them across those branches can change which RHS rows each branch observes.
       case _: GlobalLimit | _: LocalLimit | _: Offset => true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -133,6 +133,9 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper
       // LIMIT / OFFSET are order- or cardinality-sensitive when re-evaluated independently, so
       // duplicating them across those branches can change which RHS rows each branch observes.
       case _: GlobalLimit | _: LocalLimit | _: Offset => true
+      // An unseeded sample resolves its random seed in physical planning. Duplicating the RHS
+      // would let the scalar subqueries and anti-join branch observe different sampled rows.
+      case Sample(_, _, _, None, _, _) => true
       case _ => false
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -109,11 +109,19 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper
     val inConditions = values.zip(subplan.output).map(EqualTo.tupled)
     val (joinCond, rewrittenOuterPlan) =
       rewriteExistentialExpr(inConditions, outerPlan)
-    // Expand each equality to the NULL-aware predicate used by NOT IN:
-    //   a = b  ->  a = b OR ISNULL(a = b)
+    // Expand the NOT IN expression with the NULL-aware semantic
+    // to its full form. That is from:
+    //   (a1,a2,...) = (b1,b2,...)
+    // to
+    //   (a1=b1 OR isnull(a1=b1)) AND (a2=b2 OR isnull(a2=b2)) AND ...
     val baseJoinConds = splitConjunctivePredicates(joinCond.get)
     val nullAwareJoinConds = baseJoinConds.map(c => Or(c, IsNull(c)))
-    // Correlated predicates stay as ordinary join conjuncts beside the NULL-aware key check.
+    // After that, add back the correlated join predicate(s) in the subquery
+    // Example:
+    // SELECT ... FROM A WHERE A.A1 NOT IN
+    // (SELECT B.B1 FROM B WHERE B.B2 = A.A2 AND B.B3 > 1)
+    // will have the final conditions in the LEFT ANTI as
+    // (A.A1 = B.B1 OR ISNULL(A.A1 = B.B1)) AND (B.B2 = A.A2) AND B.B3 > 1
     val finalJoinCond = (nullAwareJoinConds ++ conditions).reduceLeft(And)
     Join(
       rewrittenOuterPlan,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -55,6 +55,64 @@ import org.apache.spark.util.Utils
  */
 object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
 
+  private def existenceScalarSubquery(
+      plan: LogicalPlan,
+      hint: Option[HintInfo]): ScalarSubquery = {
+    ScalarSubquery(
+      plan = Limit(Literal(1), Project(Seq(Alias(Literal(1), "col")()), plan)),
+      hint = hint)
+  }
+
+  private def rewriteSingleColumnNotIn(
+      outerPlan: LogicalPlan,
+      value: Expression,
+      subplan: LogicalPlan,
+      subHint: Option[HintInfo]): LogicalPlan = {
+    val rightKey = subplan.output.head
+    val rightExists = existenceScalarSubquery(subplan, subHint)
+    val rightNullKeyExists =
+      existenceScalarSubquery(Filter(IsNull(rightKey), subplan), subHint)
+
+    // NULL-aware NOT IN has two mutually exclusive result-producing cases:
+    //   1. The right side is empty, so every left row passes.
+    //   2. The right side is non-empty, has no NULL key, the left key is non-null,
+    //      and no equality match exists.
+    val emptyRightBranch = Project(
+      outerPlan.output,
+      Filter(IsNull(rightExists), outerPlan))
+
+    val leftBranch = Filter(
+      And(
+        And(IsNotNull(rightExists), IsNull(rightNullKeyExists)),
+        IsNotNull(value)),
+      outerPlan)
+    val rightBranch = Filter(IsNotNull(rightKey), subplan)
+    val antiJoinBranch = Project(
+      outerPlan.output,
+      Join(
+        leftBranch,
+        rightBranch,
+        LeftAnti,
+        Some(EqualTo(value, rightKey)),
+        JoinHint(None, subHint)))
+
+    Union(Seq(emptyRightBranch, antiJoinBranch))
+  }
+
+  private def isSafeToDuplicateNotInSubquery(subplan: LogicalPlan): Boolean = {
+    // The UNION rewrite evaluates the RHS in multiple places:
+    //   1. whether the RHS is empty,
+    //   2. whether it contains a NULL key, and
+    //   3. the anti-join branch over non-null keys.
+    // Only duplicate plans whose repeated evaluation preserves the original NOT IN semantics.
+    subplan.deterministic && !subplan.exists {
+      // LIMIT / OFFSET are order- or cardinality-sensitive when re-evaluated independently, so
+      // duplicating them across those branches can change which RHS rows each branch observes.
+      case _: GlobalLimit | _: LocalLimit | _: Offset => true
+      case _ => false
+    }
+  }
+
   private def buildJoin(
       outerPlan: LogicalPlan,
       subplan: LogicalPlan,
@@ -149,6 +207,17 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
         case Nil => child
         case conditions => Filter(conditions.reduce(And), child)
       }
+      // Avoid nesting Union rewrites, or duplicating other top-level subquery rewrites across the
+      // Union branches, which would repeatedly duplicate the evolving outer plan.
+      val hasSingleTopLevelSubquery = withSubquery.lengthCompare(1) == 0
+      val singleColumnNotInRewriteCandidateCount = withSubquery.count {
+        case Not(InSubquery(values,
+            ListQuery(sub, outerAttrs, _, _, conditions, _))) =>
+          values.length == 1 && values.head.deterministic &&
+            outerAttrs.isEmpty && conditions.isEmpty &&
+            isSafeToDuplicateNotInSubquery(sub)
+        case _ => false
+      }
 
       // Filter the plan by applying left semi and left anti joins.
       withSubquery.foldLeft(newFilter) {
@@ -170,6 +239,16 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
           val join = Join(outerPlan, rewriteDomainJoinsIfPresent(outerPlan, newSub, joinCond),
             LeftSemi, joinCond, JoinHint(None, subHint))
           Project(p.output, join)
+        case (p, Not(InSubquery(values,
+            ListQuery(sub, outerAttrs, _, _, conditions, subHint))))
+            if conf.optimizeTopLevelSingleColumnNotInWithUnion &&
+              hasSingleTopLevelSubquery &&
+              singleColumnNotInRewriteCandidateCount == 1 &&
+              values.length == 1 && values.head.deterministic &&
+              outerAttrs.isEmpty && conditions.isEmpty &&
+              isSafeToDuplicateNotInSubquery(sub) =>
+          val newSub = dedupSubqueryOnSelfJoin(p, sub, Some(values))
+          rewriteSingleColumnNotIn(p, values.head, newSub, subHint)
         case (p, Not(InSubquery(values, ListQuery(sub, _, _, _, conditions, subHint)))) =>
           // This is a NULL-aware (left) anti join (NAAJ) e.g. col NOT IN expr
           // Construct the condition. A NULL in one of the conditions is regarded as a positive

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -53,7 +53,8 @@ import org.apache.spark.util.Utils
  *    be pulled out as join conditions, value = selected column will also be used as join
  *    condition.
  */
-object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
+object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper
+  with JoinSelectionHelper {
 
   private def existenceScalarSubquery(
       plan: LogicalPlan,
@@ -97,6 +98,29 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
         JoinHint(None, subHint)))
 
     Union(Seq(emptyRightBranch, antiJoinBranch))
+  }
+
+  private def rewriteTopLevelNotInAsNullAwareAntiJoin(
+      outerPlan: LogicalPlan,
+      values: Seq[Expression],
+      subplan: LogicalPlan,
+      conditions: Seq[Expression],
+      subHint: Option[HintInfo]): Join = {
+    val inConditions = values.zip(subplan.output).map(EqualTo.tupled)
+    val (joinCond, rewrittenOuterPlan) =
+      rewriteExistentialExpr(inConditions, outerPlan)
+    // Expand each equality to the NULL-aware predicate used by NOT IN:
+    //   a = b  ->  a = b OR ISNULL(a = b)
+    val baseJoinConds = splitConjunctivePredicates(joinCond.get)
+    val nullAwareJoinConds = baseJoinConds.map(c => Or(c, IsNull(c)))
+    // Correlated predicates stay as ordinary join conjuncts beside the NULL-aware key check.
+    val finalJoinCond = (nullAwareJoinConds ++ conditions).reduceLeft(And)
+    Join(
+      rewrittenOuterPlan,
+      rewriteDomainJoinsIfPresent(rewrittenOuterPlan, subplan, Some(finalJoinCond)),
+      LeftAnti,
+      Option(finalJoinCond),
+      JoinHint(None, subHint))
   }
 
   private def isSafeToDuplicateNotInSubquery(subplan: LogicalPlan): Boolean = {
@@ -248,7 +272,13 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
               outerAttrs.isEmpty && conditions.isEmpty &&
               isSafeToDuplicateNotInSubquery(sub) =>
           val newSub = dedupSubqueryOnSelfJoin(p, sub, Some(values))
-          rewriteSingleColumnNotIn(p, values.head, newSub, subHint)
+          val nullAwareAntiJoin =
+            rewriteTopLevelNotInAsNullAwareAntiJoin(p, values, newSub, conditions, subHint)
+          if (canPlanAsBroadcastHashJoin(nullAwareAntiJoin, conf)) {
+            nullAwareAntiJoin
+          } else {
+            rewriteSingleColumnNotIn(p, values.head, newSub, subHint)
+          }
         case (p, Not(InSubquery(values, ListQuery(sub, _, _, _, conditions, subHint)))) =>
           // This is a NULL-aware (left) anti join (NAAJ) e.g. col NOT IN expr
           // Construct the condition. A NULL in one of the conditions is regarded as a positive
@@ -259,23 +289,7 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
 
           // Deduplicate conflicting attributes if any.
           val newSub = dedupSubqueryOnSelfJoin(p, sub, Some(values))
-          val inConditions = values.zip(newSub.output).map(EqualTo.tupled)
-          val (joinCond, outerPlan) = rewriteExistentialExpr(inConditions, p)
-          // Expand the NOT IN expression with the NULL-aware semantic
-          // to its full form. That is from:
-          //   (a1,a2,...) = (b1,b2,...)
-          // to
-          //   (a1=b1 OR isnull(a1=b1)) AND (a2=b2 OR isnull(a2=b2)) AND ...
-          val baseJoinConds = splitConjunctivePredicates(joinCond.get)
-          val nullAwareJoinConds = baseJoinConds.map(c => Or(c, IsNull(c)))
-          // After that, add back the correlated join predicate(s) in the subquery
-          // Example:
-          // SELECT ... FROM A WHERE A.A1 NOT IN (SELECT B.B1 FROM B WHERE B.B2 = A.A2 AND B.B3 > 1)
-          // will have the final conditions in the LEFT ANTI as
-          // (A.A1 = B.B1 OR ISNULL(A.A1 = B.B1)) AND (B.B2 = A.A2) AND B.B3 > 1
-          val finalJoinCond = (nullAwareJoinConds ++ conditions).reduceLeft(And)
-          Join(outerPlan, rewriteDomainJoinsIfPresent(outerPlan, newSub, Some(finalJoinCond)),
-            LeftAnti, Option(finalJoinCond), JoinHint(None, subHint))
+          rewriteTopLevelNotInAsNullAwareAntiJoin(p, values, newSub, conditions, subHint)
         case (p, predicate) =>
           val (newCond, inputPlan) = rewriteExistentialExpr(Seq(predicate), p)
           Project(p.output, Filter(newCond.get, inputPlan))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6403,6 +6403,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION =
+    buildConf("spark.sql.optimizeTopLevelSingleColumnNotInWithUnion")
+      .internal()
+      .doc("When true, deterministic top-level single-column NOT IN subqueries without " +
+        "correlation predicates are rewritten into a UNION that separates the empty-right " +
+        "case from a regular equi left anti join.")
+      .booleanConf
+      .createWithDefault(false)
+
   val LEGACY_COMPLEX_TYPES_TO_STRING =
     buildConf("spark.sql.legacy.castComplexTypesToString.enabled")
       .internal()
@@ -8448,6 +8457,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def legacyDuplicateBetweenInput: Boolean =
     getConf(SQLConf.LEGACY_DUPLICATE_BETWEEN_INPUT)
+
+  def optimizeTopLevelSingleColumnNotInWithUnion: Boolean =
+    getConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION)
 
   def legacyPathOptionBehavior: Boolean = getConf(SQLConf.LEGACY_PATH_OPTION_BEHAVIOR)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6406,6 +6406,7 @@ object SQLConf {
   val OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION =
     buildConf("spark.sql.optimizeTopLevelSingleColumnNotInWithUnion")
       .internal()
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .doc("When true, deterministic top-level single-column NOT IN subqueries without " +
         "correlation predicates may be rewritten into a UNION fallback that separates the " +
         "empty-right case from a regular equi left anti join when the broadcast null-aware " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6407,8 +6407,9 @@ object SQLConf {
     buildConf("spark.sql.optimizeTopLevelSingleColumnNotInWithUnion")
       .internal()
       .doc("When true, deterministic top-level single-column NOT IN subqueries without " +
-        "correlation predicates are rewritten into a UNION that separates the empty-right " +
-        "case from a regular equi left anti join.")
+        "correlation predicates may be rewritten into a UNION fallback that separates the " +
+        "empty-right case from a regular equi left anti join when the broadcast null-aware " +
+        "anti join path is unavailable.")
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
@@ -79,7 +79,9 @@ class RewriteSubquerySuite extends PlanTest {
 
     val query = relation1.where(Not($"a".in(ListQuery(relation2)))).select($"a")
     var optimized: LogicalPlan = null
-    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+    withSQLConf(
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+      SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
       optimized = Optimize.execute(query.analyze)
     }
 
@@ -105,6 +107,21 @@ class RewriteSubquerySuite extends PlanTest {
     val query = relation1.where(Not($"a".in(ListQuery(relation2)))).select($"a")
     var optimized: LogicalPlan = null
     withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "false") {
+      optimized = Optimize.execute(query.analyze)
+    }
+
+    assert(!optimized.exists(_.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+  }
+
+  test("single-column top-level NOT IN keeps broadcast null-aware anti join when available") {
+    val relation1 = LocalRelation($"a".int, $"b".int)
+    val relation2 = LocalRelation($"c".int)
+
+    val query = relation1.where(Not($"a".in(ListQuery(relation2)))).select($"a")
+    var optimized: LogicalPlan = null
+    withSQLConf(
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString,
+      SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
       optimized = Optimize.execute(query.analyze)
     }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
@@ -188,6 +188,26 @@ class RewriteSubquerySuite extends PlanTest {
     assert(!optimized.exists(_.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
   }
 
+  test("single-column top-level NOT IN with unseeded RHS sample skips union rewrite") {
+    val relation1 = LocalRelation($"a".int, $"b".int)
+    val relation2 = LocalRelation($"c".int)
+
+    val sampledRelation2 =
+      org.apache.spark.sql.catalyst.plans.logical.Sample(
+        lowerBound = 0.0,
+        upperBound = 0.5,
+        withReplacement = false,
+        seed = None,
+        child = relation2)
+    val query = relation1.where(Not($"a".in(ListQuery(sampledRelation2)))).select($"a")
+    var optimized: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      optimized = Optimize.execute(query.analyze)
+    }
+
+    assert(!optimized.exists(_.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+  }
+
   test("SPARK-34598: Filters without subquery must not be modified by RewritePredicateSubquery") {
     val relation = LocalRelation($"a".int, $"b".int, $"c".int, $"d".int)
     val query = relation.where(($"a" === 1 || $"b" === 2)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
@@ -23,8 +23,8 @@ import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions.{Cast, EqualTo, IsNull, ListQuery, Not}
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, LeftAnti, LeftSemi, PlanTest}
 import org.apache.spark.sql.catalyst.plans.logical.{Join, LocalRelation, LogicalPlan}
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.LongType
 
 
@@ -180,6 +180,20 @@ class RewriteSubquerySuite extends PlanTest {
 
     val query = relation1.where(
       Not($"a".in(ListQuery(relation2.offset(1))))).select($"a")
+    var optimized: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      optimized = Optimize.execute(query.analyze)
+    }
+
+    assert(!optimized.exists(_.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+  }
+
+  test("single-column top-level NOT IN with preserved RHS row-limit marker skips union rewrite") {
+    val relation1 = LocalRelation($"a".int, $"b".int)
+    val relation2 = LocalRelation($"c".int)
+    relation2.setTagValue(RewritePredicateSubquery.NOT_IN_SUBQUERY_WITH_ROW_LIMIT, ())
+
+    val query = relation1.where(Not($"a".in(ListQuery(relation2)))).select($"a")
     var optimized: LogicalPlan = null
     withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
       optimized = Optimize.execute(query.analyze)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
@@ -20,9 +20,10 @@ package org.apache.spark.sql.catalyst.optimizer
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.{Cast, IsNull, ListQuery, Not}
-import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, LeftSemi, PlanTest}
-import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.expressions.{Cast, EqualTo, IsNull, ListQuery, Not}
+import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, LeftAnti, LeftSemi, PlanTest}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LocalRelation, LogicalPlan}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.types.LongType
 
@@ -70,6 +71,104 @@ class RewriteSubquerySuite extends PlanTest {
     val optimized = Optimize.execute(query.analyze)
 
     comparePlans(optimized, correctAnswer)
+  }
+
+  test("single-column top-level NOT IN decomposes into a union and equi anti join") {
+    val relation1 = LocalRelation($"a".int, $"b".int)
+    val relation2 = LocalRelation($"c".int)
+
+    val query = relation1.where(Not($"a".in(ListQuery(relation2)))).select($"a")
+    var optimized: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      optimized = Optimize.execute(query.analyze)
+    }
+
+    assert(optimized.exists(_.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+    assert(optimized.exists {
+      case Join(_, _, LeftAnti, Some(_: EqualTo), _) => true
+      case _ => false
+    })
+    assert(!optimized.exists {
+      case Join(_, _, LeftAnti, Some(condition), _) =>
+        condition.exists {
+          case IsNull(_: EqualTo) => true
+          case _ => false
+        }
+      case _ => false
+    })
+  }
+
+  test("single-column top-level NOT IN union rewrite can be disabled") {
+    val relation1 = LocalRelation($"a".int, $"b".int)
+    val relation2 = LocalRelation($"c".int)
+
+    val query = relation1.where(Not($"a".in(ListQuery(relation2)))).select($"a")
+    var optimized: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "false") {
+      optimized = Optimize.execute(query.analyze)
+    }
+
+    assert(!optimized.exists(_.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+  }
+
+  test("multiple single-column top-level NOT IN predicates skip union rewrite") {
+    val relation1 = LocalRelation($"a".int, $"b".int)
+    val relation2 = LocalRelation($"c".int)
+    val relation3 = LocalRelation($"d".int)
+
+    val query = relation1
+      .where(Not($"a".in(ListQuery(relation2))) && Not($"b".in(ListQuery(relation3))))
+      .select($"a")
+    var optimized: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      optimized = Optimize.execute(query.analyze)
+    }
+
+    assert(!optimized.exists(_.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+  }
+
+  test("single-column top-level NOT IN with another top-level subquery skips union rewrite") {
+    val relation1 = LocalRelation($"a".int, $"b".int)
+    val relation2 = LocalRelation($"c".int)
+    val relation3 = LocalRelation($"d".int)
+
+    val query = relation1
+      .where(Not($"a".in(ListQuery(relation2))) && $"b".in(ListQuery(relation3)))
+      .select($"a")
+    var optimized: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      optimized = Optimize.execute(query.analyze)
+    }
+
+    assert(!optimized.exists(_.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+  }
+
+  test("single-column top-level NOT IN with RHS limit skips union rewrite") {
+    val relation1 = LocalRelation($"a".int, $"b".int)
+    val relation2 = LocalRelation($"c".int)
+
+    val query = relation1.where(
+      Not($"a".in(ListQuery(relation2.limit(1))))).select($"a")
+    var optimized: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      optimized = Optimize.execute(query.analyze)
+    }
+
+    assert(!optimized.exists(_.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+  }
+
+  test("single-column top-level NOT IN with RHS offset skips union rewrite") {
+    val relation1 = LocalRelation($"a".int, $"b".int)
+    val relation2 = LocalRelation($"c".int)
+
+    val query = relation1.where(
+      Not($"a".in(ListQuery(relation2.offset(1))))).select($"a")
+    var optimized: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      optimized = Optimize.execute(query.analyze)
+    }
+
+    assert(!optimized.exists(_.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
   }
 
   test("SPARK-34598: Filters without subquery must not be modified by RewritePredicateSubquery") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2068,6 +2068,19 @@ class SubquerySuite extends SharedSparkSession
       _.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
   }
 
+  test("single-column top-level NOT IN with unseeded RHS TABLESAMPLE skips union rewrite") {
+    var optimizedPlan: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      optimizedPlan =
+        sql("select * from l where a not in " +
+          "(select c from r tablesample (50 percent))")
+          .queryExecution.optimizedPlan
+    }
+
+    assert(!optimizedPlan.exists(
+      _.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+  }
+
   test("single-column top-level NOT IN with another top-level subquery skips union rewrite") {
     var optimizedPlan: LogicalPlan = null
     withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -312,6 +312,14 @@ class SubquerySuite extends SharedSparkSession
       sql("select a from l l1 where a in (select a from l where a < 3 group by a)"),
       Row(1) :: Row(1) :: Row(2) :: Row(2) :: Nil
     )
+
+    withSQLConf(
+      SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      val df = sql("select a from l l1 where a not in " +
+        "(select a from l where a < 3 group by a)")
+      checkAnswer(df, Row(3) :: Row(6) :: Nil)
+      assert(df.queryExecution.optimizedPlan.exists(_.isInstanceOf[Union]))
+    }
   }
 
   test("having with function in subquery") {
@@ -1961,6 +1969,133 @@ class SubquerySuite extends SharedSparkSession
         }
       }
     }
+  }
+
+  test("single-column top-level NOT IN union rewrite can plan a regular anti hash join") {
+    withSQLConf(
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString,
+      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "false",
+      SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      val df = sql("select * from l where a not in (select c from r where d < 6.0)")
+      checkAnswer(df, Seq.empty)
+      assert(df.queryExecution.optimizedPlan.exists(_.isInstanceOf[Union]))
+
+      val regularAntiHashJoin = collect(df.queryExecution.sparkPlan) {
+        case join: BroadcastHashJoinExec
+            if join.joinType == LeftAnti && !join.isNullAwareAntiJoin => join
+      }
+      assert(regularAntiHashJoin.nonEmpty)
+      assert(collect(df.queryExecution.sparkPlan) {
+        case _: BroadcastNestedLoopJoinExec => true
+      }.isEmpty)
+    }
+  }
+
+  test("single-column top-level NOT IN union rewrite preserves empty RHS semantics") {
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      val df = sql("select * from l where a not in (select c from r where c > 10)")
+      checkAnswer(df, spark.table("l"))
+      assert(df.queryExecution.optimizedPlan.exists(_.isInstanceOf[Union]))
+    }
+  }
+
+  test("single-column top-level NOT IN with nondeterministic RHS skips union rewrite") {
+    var optimizedPlan: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      optimizedPlan = sql(
+        "select * from l where a not in " +
+          "(select cast(rand() * 10 as int) from range(1))")
+        .queryExecution.optimizedPlan
+    }
+
+    assert(!optimizedPlan.exists(
+      _.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+  }
+
+  test("single-column top-level NOT IN with nondeterministic LHS skips union rewrite") {
+    var optimizedPlan: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      optimizedPlan = sql(
+        "select * from l where if(rand() > 0.5, 1, null) not in " +
+          "(select 1 from r)")
+        .queryExecution.optimizedPlan
+    }
+
+    assert(!optimizedPlan.exists(
+      _.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+  }
+
+  test("single-column top-level NOT IN with RHS limit skips union rewrite") {
+    var optimizedPlan: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      optimizedPlan =
+        sql("select * from l where a not in (select c from r limit 1)")
+          .queryExecution.optimizedPlan
+    }
+
+    assert(!optimizedPlan.exists(
+      _.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+  }
+
+  test("single-column top-level NOT IN with RHS offset skips union rewrite") {
+    var optimizedPlan: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      optimizedPlan =
+        sql("select * from l where a not in (select c from r offset 1)")
+          .queryExecution.optimizedPlan
+    }
+
+    assert(!optimizedPlan.exists(
+      _.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+  }
+
+  test("single-column top-level NOT IN with another top-level subquery skips union rewrite") {
+    var optimizedPlan: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      optimizedPlan =
+        sql("select * from l where a not in (select c from r) " +
+          "and b in (select d from r)")
+          .queryExecution.optimizedPlan
+    }
+
+    assert(!optimizedPlan.exists(
+      _.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+  }
+
+  test("correlated single-column top-level NOT IN skips union rewrite") {
+    var optimizedPlan: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      optimizedPlan =
+        sql("select * from l where a not in (select c from r where d = b + 10)")
+          .queryExecution.optimizedPlan
+    }
+
+    assert(!optimizedPlan.exists(
+      _.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+  }
+
+  test("multi-column top-level NOT IN skips union rewrite") {
+    var optimizedPlan: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      optimizedPlan =
+        sql("select * from l where (a, b) not in (select c, d from r where c > 10)")
+          .queryExecution.optimizedPlan
+    }
+
+    assert(!optimizedPlan.exists(
+      _.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
+  }
+
+  test("single-column top-level NOT IN union rewrite can be disabled") {
+    var optimizedPlan: LogicalPlan = null
+    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "false") {
+      optimizedPlan =
+        sql("select * from l where a = 1 and a not in (select c from r where c is not null)")
+          .queryExecution.optimizedPlan
+    }
+
+    assert(!optimizedPlan.exists(
+      _.isInstanceOf[org.apache.spark.sql.catalyst.plans.logical.Union]))
   }
 
   test("SPARK-28379: non-aggregated zero row scalar subquery") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -314,6 +314,7 @@ class SubquerySuite extends SharedSparkSession
     )
 
     withSQLConf(
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
       SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
       val df = sql("select a from l l1 where a not in " +
         "(select a from l where a < 3 group by a)")
@@ -1992,10 +1993,28 @@ class SubquerySuite extends SharedSparkSession
   }
 
   test("single-column top-level NOT IN union rewrite preserves empty RHS semantics") {
-    withSQLConf(SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+    withSQLConf(
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+      SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
       val df = sql("select * from l where a not in (select c from r where c > 10)")
       checkAnswer(df, spark.table("l"))
       assert(df.queryExecution.optimizedPlan.exists(_.isInstanceOf[Union]))
+    }
+  }
+
+  test("single-column top-level NOT IN keeps broadcast null-aware anti join when available") {
+    withSQLConf(
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString,
+      SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      val df = sql("select * from l where a not in (select c from r where d < 6.0)")
+      checkAnswer(df, Seq.empty)
+      assert(!df.queryExecution.optimizedPlan.exists(_.isInstanceOf[Union]))
+
+      val nullAwareAntiHashJoin = collect(df.queryExecution.sparkPlan) {
+        case join: BroadcastHashJoinExec
+            if join.joinType == LeftAnti && join.isNullAwareAntiJoin => join
+      }
+      assert(nullAwareAntiHashJoin.nonEmpty)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.{SparkConf, SparkException, SparkIllegalArgumentExceptio
 import org.apache.spark.sql.{AnalysisException, DataFrame, ExplainSuiteHelper, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{CannotReplaceMissingTableException, IndexAlreadyExistsException, NoSuchIndexException}
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, GlobalLimit, LocalLimit, Offset, Sort}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, GlobalLimit, LocalLimit, Offset, Sort, Union}
 import org.apache.spark.sql.connector.{IntegralAverage, StrLen}
 import org.apache.spark.sql.connector.catalog.{Catalogs, Identifier, TableCatalog}
 import org.apache.spark.sql.connector.catalog.functions.{ScalarFunction, UnboundFunction}
@@ -803,6 +803,39 @@ class JDBCV2Suite extends SharedSparkSession with ExplainSuiteHelper {
     checkOffsetRemoved(df11, false)
     checkPushedInfo(df11, "PushedFilters: []")
     checkAnswer(df11, Seq(Row(9000.00, 1200.0, "cat")))
+  }
+
+  test("NOT IN skips UNION rewrite after JDBC pushes RHS LIMIT away") {
+    withSQLConf(
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+      SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      val df = sql(
+        "SELECT id FROM h2.test.people " +
+          "WHERE id NOT IN (SELECT dept FROM h2.test.employee LIMIT 1)")
+      val optimizedPlan = df.queryExecution.optimizedPlan
+
+      assert(!optimizedPlan.exists(_.isInstanceOf[Union]))
+      assert(!optimizedPlan.exists {
+        case _: GlobalLimit | _: LocalLimit => true
+        case _ => false
+      })
+      checkPushedInfo(df, "PushedLimit: LIMIT 1")
+    }
+  }
+
+  test("NOT IN skips UNION rewrite after JDBC pushes RHS OFFSET away") {
+    withSQLConf(
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+      SQLConf.OPTIMIZE_TOP_LEVEL_SINGLE_COLUMN_NOT_IN_WITH_UNION.key -> "true") {
+      val df = sql(
+        "SELECT id FROM h2.test.people " +
+          "WHERE id NOT IN (SELECT dept FROM h2.test.employee OFFSET 1)")
+      val optimizedPlan = df.queryExecution.optimizedPlan
+
+      assert(!optimizedPlan.exists(_.isInstanceOf[Union]))
+      assert(!optimizedPlan.exists(_.isInstanceOf[Offset]))
+      checkPushedInfo(df, "PushedOffset: OFFSET 1")
+    }
   }
 
   private def checkSortRemoved(df: DataFrame, removed: Boolean = true): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds an opt-in fallback rewrite for top-level, single-column `NOT IN` subqueries under `spark.sql.optimizeTopLevelSingleColumnNotInWithUnion`.

For a supported predicate such as:

```sql
SELECT *
FROM fact_events e
WHERE e.user_id NOT IN (
  SELECT blocked_user_id
  FROM blocked_users
)
```

Spark can preserve `NOT IN` null semantics by splitting the result into two disjoint cases:

1. The subquery result is empty.
2. The subquery result is non-empty, the left-hand value is non-null, the right-hand side contains no null key, and there is no equal right-hand value.

That fallback lets the optimizer express the predicate as a `UNION` of:

- an empty-RHS branch, and
- a regular equi `LeftAnti` branch with explicit null checks.

The second branch exposes an equality anti join instead of forcing the whole predicate through the null-aware nested-loop anti join shape.

The rewrite is intentionally conservative. It only applies to:

- top-level filter predicates,
- exactly one top-level subquery predicate in that filter,
- single-column `NOT IN`,
- uncorrelated subqueries,
- deterministic left-hand expressions,
- deterministic duplicated RHS plans,
- RHS plans without `LIMIT` or `OFFSET`, and
- RHS plans without unseeded `TABLESAMPLE`, whose sampled rows are not stable across duplicated evaluations.

When Spark can already plan the original `NOT IN` predicate as a broadcast null-aware anti hash join, this PR keeps that existing fast path instead of applying the `UNION` fallback.

This keeps the rewrite from duplicating other top-level subquery rewrites across the generated `UNION` branches, and avoids duplicating RHS plans whose repeated evaluation could change query results.

This PR also adds optimizer and end-to-end SQL coverage for the enabled fallback rewrite, disabled rewrite, preserved broadcast null-aware anti join path, self-subquery cases, empty-RHS cases, mixed top-level subqueries, and the safety guards above.

JIRA: https://issues.apache.org/jira/browse/SPARK-56932

### Why are the changes needed?

Without this rewrite, eligible `NOT IN` queries can retain a null-aware anti join shape that Spark may plan as a `BroadcastNestedLoopJoin`. That plan is materially less favorable than an equi anti join for larger inputs.

The rewrite keeps SQL semantics intact while exposing a more optimizer-friendly physical shape for the fallback case where Spark cannot retain its broadcast null-aware anti hash join path. In practice, it gives Spark a path to plan the expensive branch as a standard equality anti join instead of evaluating the whole predicate through a nested-loop join.

### Does this PR introduce _any_ user-facing change?

Yes.

This adds a new opt-in SQL configuration:

```text
spark.sql.optimizeTopLevelSingleColumnNotInWithUnion
```

When enabled, supported top-level single-column `NOT IN` subqueries may use a `UNION`-based fallback plan that exposes an equi anti join while preserving `NOT IN` semantics. Spark still keeps the existing broadcast null-aware anti hash join path when that plan is available.

The feature is disabled by default.

### How was this patch tested?

Focused Spark SQL tests:

```bash
build/sbt 'catalyst/testOnly org.apache.spark.sql.catalyst.optimizer.RewriteSubquerySuite -- -z "unseeded RHS sample skips union rewrite"'
build/sbt 'sql/testOnly org.apache.spark.sql.SubquerySuite -- -z "single-column top-level NOT IN keeps broadcast null-aware anti join when available"'
build/sbt 'sql/testOnly org.apache.spark.sql.SubquerySuite -- -z "unseeded RHS TABLESAMPLE skips union rewrite"'
```

Additional focused suite coverage was used during development for `SubquerySuite` and `RewriteSubquerySuite`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex
