### PR TITLE
[SPARK-56936][PYTHON][TESTS] Fix PandasUDFReturnTypeTests for pandas 3

### DIFF
--- a/python/pyspark/sql/tests/coercion/test_pandas_udf_return_type.py
+++ b/python/pyspark/sql/tests/coercion/test_pandas_udf_return_type.py
@@ -19,6 +19,7 @@ import concurrent.futures
 from decimal import Decimal
 import itertools
 import os
+import re
 import unittest
 
 from pyspark.sql.functions import pandas_udf
@@ -151,6 +152,48 @@ class PandasUDFReturnTypeTests(GoldenFileTestMixin, ReusedSQLTestCase):
     def _run_pandas_udf_return_type_coercion(self, golden_file, test_name):
         self._compare_or_generate_golden(golden_file, test_name)
 
+    def _patch_golden_for_pandas3(self, golden):
+        # Rename columns whose key differs between pandas 2 and pandas 3:
+        # datetime64 ndarrays default to [us] instead of [ns], and Categorical
+        # categories default to str instead of object.
+        rename = {}
+        for value in self.test_data:
+            if isinstance(value, np.ndarray) and value.dtype.kind == "M":
+                new_key = self.repr_value(value)
+                old_key = self.repr_value(value.astype("datetime64[ns]"))
+            elif isinstance(value, pd.Categorical) and value.categories.dtype != object:
+                new_key = self.repr_value(value)
+                old_key = self.repr_value(
+                    pd.Categorical(
+                        value.tolist(),
+                        categories=pd.Index(value.categories.tolist(), dtype=object),
+                    )
+                )
+            else:
+                continue
+            if old_key != new_key:
+                rename[old_key] = new_key
+        if rename:
+            golden.rename(columns=rename, inplace=True)
+
+        # Scale ns->us in datetime64 / Timedelta columns: any 13+ digit integer
+        # in those cells is a pandas-2 nanosecond value; the pandas-3 cast
+        # returns microseconds (1000x smaller).
+        def _ns_to_us(s):
+            return re.sub(r"\d{13,}", lambda m: str(int(m.group()) // 1000), s)
+
+        scale_cols = [
+            c for c in golden.columns if "@ndarray[datetime64[" in c or c.startswith("[Timedelta(")
+        ]
+        for col in scale_cols:
+            golden[col] = golden[col].map(_ns_to_us)
+
+        # Pandas 3 succeeds at coercing string list -> Decimal where pandas 2
+        # errored, so the corresponding cell flips from "X" to the new repr.
+        decimal_col = "['12', '34']@list"
+        if "decimal(10,0)" in golden.index and decimal_col in golden.columns:
+            golden.loc["decimal(10,0)", decimal_col] = "[Decimal('12'), Decimal('34')]"
+
     def _compare_or_generate_golden(self, golden_file, test_name):
         generating = self.is_generating_golden()
 
@@ -162,33 +205,10 @@ class PandasUDFReturnTypeTests(GoldenFileTestMixin, ReusedSQLTestCase):
             golden = self.load_golden_csv(golden_csv)
             # The golden file was generated under pandas 2, where the default
             # dtypes differ from pandas >= 3.0 (datetime64[ns] vs [us]; object
-            # vs str for categorical categories). Remap the affected columns
-            # so the same file works under both versions.
+            # vs str for categorical categories). Patch the loaded golden in
+            # memory so the same file works under both versions.
             if LooseVersion(pd.__version__) >= LooseVersion("3.0.0"):
-                rename = {}
-                for value in self.test_data:
-                    if isinstance(value, np.ndarray) and value.dtype.kind == "M":
-                        new_key = self.repr_value(value)
-                        old_key = self.repr_value(value.astype("datetime64[ns]"))
-                    elif (
-                        isinstance(value, pd.Categorical)
-                        and value.categories.dtype != object
-                    ):
-                        new_key = self.repr_value(value)
-                        old_key = self.repr_value(
-                            pd.Categorical(
-                                value.tolist(),
-                                categories=pd.Index(
-                                    value.categories.tolist(), dtype=object
-                                ),
-                            )
-                        )
-                    else:
-                        continue
-                    if old_key != new_key:
-                        rename[old_key] = new_key
-                if rename:
-                    golden = golden.rename(columns=rename)
+                self._patch_golden_for_pandas3(golden)
 
         def work(arg):
             spark_type, value = arg

--- a/python/pyspark/sql/tests/coercion/test_pandas_udf_return_type.py
+++ b/python/pyspark/sql/tests/coercion/test_pandas_udf_return_type.py
@@ -19,7 +19,6 @@ import concurrent.futures
 from decimal import Decimal
 import itertools
 import os
-import re
 import unittest
 
 from pyspark.sql.functions import pandas_udf
@@ -152,48 +151,6 @@ class PandasUDFReturnTypeTests(GoldenFileTestMixin, ReusedSQLTestCase):
     def _run_pandas_udf_return_type_coercion(self, golden_file, test_name):
         self._compare_or_generate_golden(golden_file, test_name)
 
-    def _patch_golden_for_pandas3(self, golden):
-        # Rename columns whose key differs between pandas 2 and pandas 3:
-        # datetime64 ndarrays default to [us] instead of [ns], and Categorical
-        # categories default to str instead of object.
-        rename = {}
-        for value in self.test_data:
-            if isinstance(value, np.ndarray) and value.dtype.kind == "M":
-                new_key = self.repr_value(value)
-                old_key = self.repr_value(value.astype("datetime64[ns]"))
-            elif isinstance(value, pd.Categorical) and value.categories.dtype != object:
-                new_key = self.repr_value(value)
-                old_key = self.repr_value(
-                    pd.Categorical(
-                        value.tolist(),
-                        categories=pd.Index(value.categories.tolist(), dtype=object),
-                    )
-                )
-            else:
-                continue
-            if old_key != new_key:
-                rename[old_key] = new_key
-        if rename:
-            golden.rename(columns=rename, inplace=True)
-
-        # Scale ns->us in datetime64 / Timedelta columns: any 13+ digit integer
-        # in those cells is a pandas-2 nanosecond value; the pandas-3 cast
-        # returns microseconds (1000x smaller).
-        def _ns_to_us(s):
-            return re.sub(r"\d{13,}", lambda m: str(int(m.group()) // 1000), s)
-
-        scale_cols = [
-            c for c in golden.columns if "@ndarray[datetime64[" in c or c.startswith("[Timedelta(")
-        ]
-        for col in scale_cols:
-            golden[col] = golden[col].map(_ns_to_us)
-
-        # Pandas 3 succeeds at coercing string list -> Decimal where pandas 2
-        # errored, so the corresponding cell flips from "X" to the new repr.
-        decimal_col = "['12', '34']@list"
-        if "decimal(10,0)" in golden.index and decimal_col in golden.columns:
-            golden.loc["decimal(10,0)", decimal_col] = "[Decimal('12'), Decimal('34')]"
-
     def _compare_or_generate_golden(self, golden_file, test_name):
         generating = self.is_generating_golden()
 
@@ -203,12 +160,52 @@ class PandasUDFReturnTypeTests(GoldenFileTestMixin, ReusedSQLTestCase):
         golden = None
         if not generating:
             golden = self.load_golden_csv(golden_csv)
-            # The golden file was generated under pandas 2, where the default
-            # dtypes differ from pandas >= 3.0 (datetime64[ns] vs [us]; object
-            # vs str for categorical categories). Patch the loaded golden in
-            # memory so the same file works under both versions.
+            # The golden file was generated under pandas 2; patch the loaded
+            # copy in memory so the same file works under pandas >= 3.0.
             if LooseVersion(pd.__version__) >= LooseVersion("3.0.0"):
-                self._patch_golden_for_pandas3(golden)
+                # Rename columns whose key differs between the two versions:
+                # datetime64 ndarrays default to [us] instead of [ns], and
+                # Categorical categories default to str instead of object.
+                rename = {}
+                for value in self.test_data:
+                    if isinstance(value, np.ndarray) and value.dtype.kind == "M":
+                        new_key = self.repr_value(value)
+                        old_key = self.repr_value(value.astype("datetime64[ns]"))
+                    elif isinstance(value, pd.Categorical) and value.categories.dtype != object:
+                        new_key = self.repr_value(value)
+                        old_key = self.repr_value(
+                            pd.Categorical(
+                                value.tolist(),
+                                categories=pd.Index(value.categories.tolist(), dtype=object),
+                            )
+                        )
+                    else:
+                        continue
+                    if old_key != new_key:
+                        rename[old_key] = new_key
+                if rename:
+                    golden.rename(columns=rename, inplace=True)
+
+                # Scale ns->us in datetime64 / Timedelta columns: any 13+ digit
+                # integer in those cells is a pandas-2 nanosecond value; the
+                # pandas-3 cast returns microseconds (1000x smaller).
+                scale_cols = [
+                    c
+                    for c in golden.columns
+                    if "@ndarray[datetime64[" in c or c.startswith("[Timedelta(")
+                ]
+                for col in scale_cols:
+                    golden[col] = golden[col].str.replace(
+                        r"\d{13,}",
+                        lambda m: str(int(m.group()) // 1000),
+                        regex=True,
+                    )
+
+                # Pandas 3 succeeds at coercing string list -> Decimal where
+                # pandas 2 errored, so the corresponding cell flips from "X".
+                decimal_col = "['12', '34']@list"
+                if "decimal(10,0)" in golden.index and decimal_col in golden.columns:
+                    golden.loc["decimal(10,0)", decimal_col] = "[Decimal('12'), Decimal('34')]"
 
         def work(arg):
             spark_type, value = arg

--- a/python/pyspark/sql/tests/coercion/test_pandas_udf_return_type.py
+++ b/python/pyspark/sql/tests/coercion/test_pandas_udf_return_type.py
@@ -104,7 +104,7 @@ class PandasUDFReturnTypeTests(GoldenFileTestMixin, ReusedSQLTestCase):
             np.arange(1, 3).astype("complex128"),
             [np.array([1, 2, 3], dtype=np.int32), np.array([1, 2, 3], dtype=np.int32)],
             pd.date_range("19700101", periods=2).values,
-            pd.date_range("19700101", periods=2, tz="US/Eastern").values,
+            pd.date_range("19700101", periods=2, tz="America/New_York").values,
             [pd.Timedelta("1 day"), pd.Timedelta("2 days")],
             pd.Categorical(["A", "B"]),
             pd.DataFrame({"_1": [1, 2]}),
@@ -160,6 +160,35 @@ class PandasUDFReturnTypeTests(GoldenFileTestMixin, ReusedSQLTestCase):
         golden = None
         if not generating:
             golden = self.load_golden_csv(golden_csv)
+            # The golden file was generated under pandas 2, where the default
+            # dtypes differ from pandas >= 3.0 (datetime64[ns] vs [us]; object
+            # vs str for categorical categories). Remap the affected columns
+            # so the same file works under both versions.
+            if LooseVersion(pd.__version__) >= LooseVersion("3.0.0"):
+                rename = {}
+                for value in self.test_data:
+                    if isinstance(value, np.ndarray) and value.dtype.kind == "M":
+                        new_key = self.repr_value(value)
+                        old_key = self.repr_value(value.astype("datetime64[ns]"))
+                    elif (
+                        isinstance(value, pd.Categorical)
+                        and value.categories.dtype != object
+                    ):
+                        new_key = self.repr_value(value)
+                        old_key = self.repr_value(
+                            pd.Categorical(
+                                value.tolist(),
+                                categories=pd.Index(
+                                    value.categories.tolist(), dtype=object
+                                ),
+                            )
+                        )
+                    else:
+                        continue
+                    if old_key != new_key:
+                        rename[old_key] = new_key
+                if rename:
+                    golden = golden.rename(columns=rename)
 
         def work(arg):
             spark_type, value = arg

--- a/python/pyspark/sql/tests/coercion/test_pandas_udf_return_type.py
+++ b/python/pyspark/sql/tests/coercion/test_pandas_udf_return_type.py
@@ -161,39 +161,35 @@ class PandasUDFReturnTypeTests(GoldenFileTestMixin, ReusedSQLTestCase):
         if not generating:
             golden = self.load_golden_csv(golden_csv)
             # The golden file was generated under pandas 2; patch the loaded
-            # copy in memory so the same file works under pandas >= 3.0.
+            # copy in memory so the same file works under pandas >= 3.0, where
+            # the defaults differ: datetime64 ndarrays use [us] instead of [ns],
+            # Categorical categories use str instead of object, and the same
+            # casts return microseconds instead of nanoseconds.
             if LooseVersion(pd.__version__) >= LooseVersion("3.0.0"):
-                # Rename columns whose key differs between the two versions:
-                # datetime64 ndarrays default to [us] instead of [ns], and
-                # Categorical categories default to str instead of object.
                 rename = {}
+                scale_cols = []
                 for value in self.test_data:
+                    new_key = self.repr_value(value)
                     if isinstance(value, np.ndarray) and value.dtype.kind == "M":
-                        new_key = self.repr_value(value)
                         old_key = self.repr_value(value.astype("datetime64[ns]"))
+                        if old_key != new_key:
+                            rename[old_key] = new_key
+                        scale_cols.append(new_key)
                     elif isinstance(value, pd.Categorical) and value.categories.dtype != object:
-                        new_key = self.repr_value(value)
                         old_key = self.repr_value(
                             pd.Categorical(
                                 value.tolist(),
                                 categories=pd.Index(value.categories.tolist(), dtype=object),
                             )
                         )
-                    else:
-                        continue
-                    if old_key != new_key:
-                        rename[old_key] = new_key
+                        if old_key != new_key:
+                            rename[old_key] = new_key
+                    elif isinstance(value, list) and value and isinstance(value[0], pd.Timedelta):
+                        scale_cols.append(new_key)
+
                 if rename:
                     golden.rename(columns=rename, inplace=True)
 
-                # Scale ns->us in datetime64 / Timedelta columns: any 13+ digit
-                # integer in those cells is a pandas-2 nanosecond value; the
-                # pandas-3 cast returns microseconds (1000x smaller).
-                scale_cols = [
-                    c
-                    for c in golden.columns
-                    if "@ndarray[datetime64[" in c or c.startswith("[Timedelta(")
-                ]
                 for col in scale_cols:
                     golden[col] = golden[col].str.replace(
                         r"\d{13,}",
@@ -203,9 +199,10 @@ class PandasUDFReturnTypeTests(GoldenFileTestMixin, ReusedSQLTestCase):
 
                 # Pandas 3 succeeds at coercing string list -> Decimal where
                 # pandas 2 errored, so the corresponding cell flips from "X".
-                decimal_col = "['12', '34']@list"
-                if "decimal(10,0)" in golden.index and decimal_col in golden.columns:
-                    golden.loc["decimal(10,0)", decimal_col] = "[Decimal('12'), Decimal('34')]"
+                decimal_idx = self.repr_type(DecimalType(10, 0))
+                decimal_col = self.repr_value(["12", "34"])
+                if decimal_idx in golden.index and decimal_col in golden.columns:
+                    golden.loc[decimal_idx, decimal_col] = "[Decimal('12'), Decimal('34')]"
 
         def work(arg):
             spark_type, value = arg


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make `pyspark.sql.tests.coercion.test_pandas_udf_return_type.PandasUDFReturnTypeTests` work under pandas >= 3.0 and on systems whose `tzdata` package no longer ships the legacy `US/*` aliases (e.g. Ubuntu 24.04 / noble).

1. **Switch the tz-aware fixture from `US/Eastern` to `America/New_York`.** The values returned by `pd.date_range(...).values` are identical for the two aliases (same zone, same DST rules), so the on-disk golden file does not need to be regenerated.

2. **Patch the loaded golden DataFrame in memory for pandas >= 3.0.** The golden file was generated under pandas 2 and the on-disk content is unchanged. At load time, when running under pandas >= 3.0, the test:
   - Renames column keys whose representation differs between the two versions: datetime64 ndarrays default to `[us]` instead of `[ns]`, and `pd.Categorical` keeps `str`-dtyped categories instead of `object`.
   - Scales 13+ digit integers in cells of datetime64 / Timedelta-list columns by 1/1000. Pandas 3 returns microseconds where pandas 2 returned nanoseconds for the same cast (e.g. `bigint <- pd.date_range(...).values` flips from `86_400_000_000_000` to `86_400_000_000`).
   - Overrides the single `decimal(10,0) x ['12','34']@list` cell, which flipped from `X` (pandas 2 errored) to `[Decimal('12'), Decimal('34')]` (pandas 3 succeeds at the string -> Decimal coercion).

### Why are the changes needed?

The scheduled CI run on the `python-312-pandas-3` image fails in this suite, e.g. https://github.com/apache/spark/actions/runs/26002965955/job/76430490989. Root causes:

- `pd.date_range("19700101", periods=2, tz="US/Eastern").values` raises `zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key US/Eastern'`. Pandas 3 dropped `pytz` as a hard dependency and now resolves tz names through stdlib `zoneinfo`, which on Ubuntu 24.04 cannot find `US/Eastern` because Ubuntu moved the legacy aliases out of `tzdata` into a separate `tzdata-legacy` package that the CI image does not install.
- After the alias fix, `golden.loc[str_t, str_v]` raises `KeyError` because the column keys in the golden file are pandas-2-shaped (`datetime64[ns]`, `Categorical(..., object)`) but the lookup keys built at runtime are pandas-3-shaped (`datetime64[us]`, `Categorical(..., str)`).
- After the key rename, assertions still fail because the cast result values themselves changed: nanoseconds -> microseconds for datetime / Timedelta inputs, and one cell where pandas 3 now succeeds where pandas 2 errored.

### Does this PR introduce _any_ user-facing change?

No. Test-only change.

### How was this patch tested?

Ran the suite locally under two envs:

```
# pandas 2.3.3 / Python 3.13
$ python/run-tests --testnames "pyspark.sql.tests.coercion.test_pandas_udf_return_type PandasUDFReturnTypeTests"
...
Tests passed in 31 seconds

# pandas 3.0.2 / Python 3.13
$ python/run-tests --testnames "pyspark.sql.tests.coercion.test_pandas_udf_return_type PandasUDFReturnTypeTests"
...
Tests passed in 30 seconds
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code