### PR TITLE
[SPARK-33902][SQL][FOLLOWUP] Add createTableLike delegation to DelegatingCatalogExtension

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DelegatingCatalogExtension.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DelegatingCatalogExtension.java
@@ -112,6 +112,19 @@ public abstract class DelegatingCatalogExtension implements CatalogExtension {
   }
 
   @Override
+  public Table createTable(Identifier ident, TableInfo tableInfo)
+      throws TableAlreadyExistsException, NoSuchNamespaceException {
+    return asTableCatalog().createTable(ident, tableInfo);
+  }
+
+  @Override
+  public Table createTableLike(
+      Identifier ident, TableInfo tableInfo, Table sourceTable)
+      throws TableAlreadyExistsException, NoSuchNamespaceException {
+    return asTableCatalog().createTableLike(ident, tableInfo, sourceTable);
+  }
+
+  @Override
   public Table alterTable(
       Identifier ident,
       TableChange... changes) throws NoSuchTableException {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DelegatingCatalogExtension.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DelegatingCatalogExtension.java
@@ -112,12 +112,6 @@ public abstract class DelegatingCatalogExtension implements CatalogExtension {
   }
 
   @Override
-  public Table createTable(Identifier ident, TableInfo tableInfo)
-      throws TableAlreadyExistsException, NoSuchNamespaceException {
-    return asTableCatalog().createTable(ident, tableInfo);
-  }
-
-  @Override
   public Table createTableLike(
       Identifier ident, TableInfo tableInfo, Table sourceTable)
       throws TableAlreadyExistsException, NoSuchNamespaceException {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds the missing `createTableLike(Identifier, TableInfo, Table)` delegation to `DelegatingCatalogExtension`.

### Why are the changes needed?
`DelegatingCatalogExtension` maintains the contract that all `TableCatalog` operations are delegated to the underlying catalog, so that subclasses only need to override methods where they want custom logic, and can call `super.createTableLike(...)` from their own override to reach the delegate.

`createTableLike` was added to `TableCatalog` in SPARK-33902 but the corresponding delegation in `DelegatingCatalogExtension` was not added. This breaks the contract: subclasses cannot rely on the base class to forward `createTableLike` to the delegate, nor can they call `super.createTableLike(...)` and get meaningful behavior.

This is the same class of issue that was fixed in SPARK-42398 (#40369), where the `createTable(Column[])` overload was added to `TableCatalog` but the delegation in `DelegatingCatalogExtension` was missed.

Note: `createTable(Identifier, TableInfo)` (added in 4.1.0) is intentionally *not* delegated here. Its default implementation in `TableCatalog` falls back to `createTable(ident, columns, partitions, properties)`, which is already delegated. Explicitly delegating `createTable(TableInfo)` would bypass subclass overrides of `createTable(Column[])`.


### Does this PR introduce _any_ user-facing change?
No. `CREATE TABLE LIKE` for DSv2 is a new feature in Spark 4.2 and it's not been released yet.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude (via Kiro CLI, auto model selection)