### PR TITLE
[SPARK-56942][SQL] Widen DSv2 row-id resolution to support nested columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
@@ -91,9 +91,9 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
       relation: DataSourceV2Relation,
       operation: SupportsDelta): Seq[AttributeReference] = {
 
-    val rowIdAttrs = V2ExpressionUtils.resolveRefs[AttributeReference](
+    val rowIdAttrs = V2ExpressionUtils.resolveRefs[NamedExpression](
       operation.rowId.toImmutableArraySeq,
-      relation)
+      relation).map(_.toAttribute.asInstanceOf[AttributeReference])
 
     val nullableRowIdAttrs = rowIdAttrs.filter(_.nullable)
     if (nullableRowIdAttrs.nonEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -495,9 +495,9 @@ case class WriteDelta(
 
   // validates row ID projection output is compatible with row ID attributes
   private def rowIdAttrsResolved: Boolean = {
-    val outRowIdAttrs = V2ExpressionUtils.resolveRefs[AttributeReference](
+    val outRowIdAttrs = V2ExpressionUtils.resolveRefs[NamedExpression](
       operation.rowId.toImmutableArraySeq,
-      originalTable)
+      originalTable).map(_.toAttribute)
     val inRowIdAttrs = DataTypeUtils.toAttributes(projections.rowIdProjection.schema)
     areCompatible(inRowIdAttrs, outRowIdAttrs)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtilsSuite.scala
@@ -59,7 +59,7 @@ class V2ExpressionUtilsSuite extends SparkFunSuite {
         assert(child == structAttr)
         assert(name == "inner")
       case other =>
-        fail(s"expected Alias(GetStructField(...), \"inner\"), got: $other")
+        fail(s"expected Alias(GetStructField(...), inner), got: $other")
     }
 
     val flat = resolved.map(_.toAttribute)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtilsSuite.scala
@@ -45,9 +45,13 @@ class V2ExpressionUtilsSuite extends SparkFunSuite {
     val nestedRef = FieldReference(Seq("outer", "inner"))
 
     // A nested reference resolves to an Alias(GetStructField(...)), not an AttributeReference,
-    // so casting the result to AttributeReference fails.
+    // so the caller's checkcast fails when it dereferences an element as AttributeReference.
+    // (The `asInstanceOf[T]` inside `resolveRef` is erased to the `NamedExpression` upper bound,
+    // so the CCE fires at the call site, not inside the helper.)
     intercept[ClassCastException] {
-      V2ExpressionUtils.resolveRefs[AttributeReference](Seq(nestedRef), plan)
+      val resolvedAsAttr: AttributeReference =
+        V2ExpressionUtils.resolveRefs[AttributeReference](Seq(nestedRef), plan).head
+      resolvedAsAttr
     }
 
     // Widening the type parameter to NamedExpression preserves both flat and nested refs,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtilsSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.connector.expressions._
-import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 class V2ExpressionUtilsSuite extends SparkFunSuite {
 
@@ -36,5 +36,46 @@ class V2ExpressionUtilsSuite extends SparkFunSuite {
         LocalRelation.apply(AttributeReference("a", StringType)()))
     }
     assert(exc.message.contains("v2Fun(a) ASC NULLS FIRST is not currently supported"))
+  }
+
+  test("resolveRefs[NamedExpression] handles nested field references") {
+    val structType = StructType(Seq(StructField("inner", IntegerType, nullable = false)))
+    val structAttr = AttributeReference("outer", structType, nullable = false)()
+    val plan = LocalRelation(structAttr)
+    val nestedRef = FieldReference(Seq("outer", "inner"))
+
+    // A nested reference resolves to an Alias(GetStructField(...)), not an AttributeReference,
+    // so casting the result to AttributeReference fails.
+    intercept[ClassCastException] {
+      V2ExpressionUtils.resolveRefs[AttributeReference](Seq(nestedRef), plan)
+    }
+
+    // Widening the type parameter to NamedExpression preserves both flat and nested refs,
+    // and toAttribute flattens the Alias back to an AttributeReference of the inner type.
+    val resolved = V2ExpressionUtils.resolveRefs[NamedExpression](Seq(nestedRef), plan)
+    assert(resolved.size == 1)
+    resolved.head match {
+      case Alias(GetStructField(child, 0, _), name) =>
+        assert(child == structAttr)
+        assert(name == "inner")
+      case other =>
+        fail(s"expected Alias(GetStructField(...), \"inner\"), got: $other")
+    }
+
+    val flat = resolved.map(_.toAttribute)
+    assert(flat.size == 1)
+    assert(flat.head.name == "inner")
+    assert(flat.head.dataType == IntegerType)
+    assert(!flat.head.nullable)
+  }
+
+  test("resolveRefs[NamedExpression] continues to handle flat references") {
+    val intAttr = AttributeReference("pk", IntegerType, nullable = false)()
+    val plan = LocalRelation(intAttr)
+    val flatRef = FieldReference("pk")
+
+    val resolved = V2ExpressionUtils.resolveRefs[NamedExpression](Seq(flatRef), plan)
+    assert(resolved == Seq(intAttr))
+    assert(resolved.map(_.toAttribute) == Seq(intAttr))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

DSv2 connectors that implement SupportsDelta currently must use a top-level column for `rowId()`. If a connector returns a multi-segment field reference (e.g. a nested struct field, or `_metadata.row_index` on a file-source-backed table), analysis fails with a ClassCastException because Spark calls `V2ExpressionUtils.resolveRefs[AttributeReference]`, while nested references resolve to `Alias(GetStructField(...))`.

Widen `RewriteRowLevelCommand.resolveRowIdAttrs` and `WriteDelta.rowIdAttrsResolved` to resolve as `NamedExpression` and flatten back via `.toAttribute`. This supports both flat and nested row-id columns; flat-column behavior is unchanged.
        
Why are the changes needed?

To unblocks Delta Lake DSv2 connectors that identify rows by file-source metadata such as `(_metadata.file_path, _metadata.row_index)`.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

New tests are added to make sure it works for nested and flat cases.


### Was this patch authored or co-authored using generative AI tooling?

Yes, generated by Claude.
