### PR TITLE
[SPARK-55791][PYTHON] Fix pandas-on-Spark equality comparisons under ANSI mode

### DIFF
--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -137,6 +137,11 @@ def _should_return_all_false(left: IndexOpsLike, right: Any) -> bool:
     return left_dtype != right_dtype and not are_both_numeric(left_dtype, right_dtype)
 
 
+def _raise_type_error_for_ordered_comparison(left: IndexOpsLike, right: Any) -> None:
+    if _should_return_all_false(left, right):
+        raise TypeError("Comparison can not be applied to given types.")
+
+
 def _as_categorical_type(
     index_ops: IndexOpsLike, dtype: CategoricalDtype, spark_type: DataType
 ) -> IndexOpsLike:

--- a/python/pyspark/pandas/data_type_ops/boolean_ops.py
+++ b/python/pyspark/pandas/data_type_ops/boolean_ops.py
@@ -35,6 +35,7 @@ from pyspark.pandas.data_type_ops.base import (
     _sanitize_list_like,
     _is_valid_for_logical_operator,
     _is_boolean_type,
+    _raise_type_error_for_ordered_comparison,
 )
 from pyspark.pandas.typedef.typehints import (
     as_spark_type,
@@ -380,18 +381,22 @@ class BooleanOps(DataTypeOps):
 
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
+        _raise_type_error_for_ordered_comparison(left, right)
         return column_op(PySparkColumn.__lt__)(left, right)
 
     def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
+        _raise_type_error_for_ordered_comparison(left, right)
         return column_op(PySparkColumn.__le__)(left, right)
 
     def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
+        _raise_type_error_for_ordered_comparison(left, right)
         return column_op(PySparkColumn.__ge__)(left, right)
 
     def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
+        _raise_type_error_for_ordered_comparison(left, right)
         return column_op(PySparkColumn.__gt__)(left, right)
 
     def invert(self, operand: IndexOpsLike) -> IndexOpsLike:

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -45,6 +45,7 @@ from pyspark.pandas.data_type_ops.base import (
     _is_valid_for_logical_operator,
     _is_boolean_type,
     _should_return_all_false,
+    _raise_type_error_for_ordered_comparison,
 )
 from pyspark.pandas.typedef.typehints import (
     as_spark_type,
@@ -282,18 +283,22 @@ class NumericOps(DataTypeOps):
 
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
+        _raise_type_error_for_ordered_comparison(left, right)
         return pyspark_column_op("__lt__", left, right, fillna=False)
 
     def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
+        _raise_type_error_for_ordered_comparison(left, right)
         return pyspark_column_op("__le__", left, right, fillna=False)
 
     def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
+        _raise_type_error_for_ordered_comparison(left, right)
         return pyspark_column_op("__ge__", left, right, fillna=False)
 
     def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
+        _raise_type_error_for_ordered_comparison(left, right)
         return pyspark_column_op("__gt__", left, right, fillna=False)
 
 

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -32,6 +32,7 @@ from pyspark.pandas.data_type_ops.base import (
     _as_categorical_type,
     _as_other_type,
     _as_string_type,
+    _raise_type_error_for_ordered_comparison,
     _sanitize_list_like,
 )
 from pyspark.pandas.typedef import (
@@ -109,18 +110,22 @@ class StringOps(DataTypeOps):
 
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
+        _raise_type_error_for_ordered_comparison(left, right)
         return pyspark_column_op("__lt__", left, right)
 
     def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
+        _raise_type_error_for_ordered_comparison(left, right)
         return pyspark_column_op("__le__", left, right)
 
     def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
+        _raise_type_error_for_ordered_comparison(left, right)
         return pyspark_column_op("__ge__", left, right)
 
     def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
+        _raise_type_error_for_ordered_comparison(left, right)
         return pyspark_column_op("__gt__", left, right)
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -384,6 +384,8 @@ class BooleanOpsTestsMixin:
         psser, other_psser = psdf["this"], psdf["that"]
         self.assert_eq(pser < other_pser, psser < other_psser)
         self.assert_eq(pser < pser, psser < psser)
+        self.assertRaises(TypeError, lambda: self.psdf["bool"] < self.psdf["string"])
+        self.assertRaises(TypeError, lambda: self.psdf["bool"] < "True")
 
     def test_le(self):
         pdf, psdf = self.bool_pdf, self.bool_psdf
@@ -391,6 +393,8 @@ class BooleanOpsTestsMixin:
         psser, other_psser = psdf["this"], psdf["that"]
         self.assert_eq(pser <= other_pser, psser <= other_psser)
         self.assert_eq(pser <= pser, psser <= psser)
+        self.assertRaises(TypeError, lambda: self.psdf["bool"] <= self.psdf["string"])
+        self.assertRaises(TypeError, lambda: self.psdf["bool"] <= "True")
 
     def test_gt(self):
         pdf, psdf = self.bool_pdf, self.bool_psdf
@@ -398,6 +402,8 @@ class BooleanOpsTestsMixin:
         psser, other_psser = psdf["this"], psdf["that"]
         self.assert_eq(pser > other_pser, psser > other_psser)
         self.assert_eq(pser > pser, psser > psser)
+        self.assertRaises(TypeError, lambda: self.psdf["bool"] > self.psdf["string"])
+        self.assertRaises(TypeError, lambda: self.psdf["bool"] > "True")
 
     def test_ge(self):
         pdf, psdf = self.bool_pdf, self.bool_psdf
@@ -405,6 +411,8 @@ class BooleanOpsTestsMixin:
         psser, other_psser = psdf["this"], psdf["that"]
         self.assert_eq(pser >= other_pser, psser >= other_psser)
         self.assert_eq(pser >= pser, psser >= psser)
+        self.assertRaises(TypeError, lambda: self.psdf["bool"] >= self.psdf["string"])
+        self.assertRaises(TypeError, lambda: self.psdf["bool"] >= "True")
 
 
 @unittest.skipIf(

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -23,7 +23,6 @@ import numpy as np
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
-from pyspark.testing.utils import is_ansi_mode_test
 from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
 from pyspark.pandas.typedef.typehints import (
     extension_dtypes_available,
@@ -141,10 +140,22 @@ class NumOpsTestsMixin:
         self.assert_eq(pdf["int"] == pdf["bool"], psdf["int"] == psdf["bool"])
         self.assert_eq(pdf["bool"] == pdf["int"], psdf["bool"] == psdf["int"])
         self.assert_eq(pdf["int"] == pdf["float"], psdf["int"] == psdf["float"])
-        if is_ansi_mode_test:  # TODO: match non-ansi behavior with pandas
-            self.assert_eq(pdf["int"] == pdf["str"], psdf["int"] == psdf["str"])
+        self.assert_eq(pdf["int"] == pdf["str"], psdf["int"] == psdf["str"])
+        self.assert_eq(pdf["str"] == pdf["int"], psdf["str"] == psdf["int"])
+        self.assert_eq(pdf["int"] != pdf["str"], psdf["int"] != psdf["str"])
+        self.assert_eq(pdf["str"] != pdf["int"], psdf["str"] != psdf["int"])
+        self.assert_eq(pdf["int"] == "1", psdf["int"] == "1")
+        self.assert_eq(pdf["int"] != "1", psdf["int"] != "1")
+        self.assert_eq(pdf["str"] == 1, psdf["str"] == 1)
+        self.assert_eq(pdf["str"] != 1, psdf["str"] != 1)
         self.assert_eq(pdf["float"] == pdf["bool"], psdf["float"] == psdf["bool"])
         self.assert_eq(pdf["str"] == "x", psdf["str"] == "x")
+
+        for op in ["lt", "le", "gt", "ge"]:
+            self.assertRaises(TypeError, lambda: getattr(psdf["int"], op)(psdf["str"]))
+            self.assertRaises(TypeError, lambda: getattr(psdf["str"], op)(psdf["int"]))
+            self.assertRaises(TypeError, lambda: getattr(psdf["int"], op)("1"))
+            self.assertRaises(TypeError, lambda: getattr(psdf["str"], op)(1))
 
     def test_eq(self):
         pdf, psdf = self.pdf, self.psdf


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes pandas-on-Spark equality and inequality comparisons between incompatible dtypes under ANSI mode.

The change makes pandas-on-Spark return pandas-compatible boolean results for incompatible dtype comparisons instead of delegating them to Spark SQL casting behavior:

- `eq` returns all `False`
- `ne` returns all `True`

This covers comparisons such as numeric Series/Index against string Series/Index or string scalar values.

### Why are the changes needed?

ANSI mode should not change pandas API on Spark behavior. Without this fix, Spark SQL may try to cast incompatible operands under ANSI mode, which can produce behavior that differs from pandas or raise errors for comparisons where pandas would simply return boolean results.

### Does this PR introduce any user-facing change?

Yes. pandas-on-Spark comparison behavior becomes more consistent with pandas under ANSI mode for incompatible dtype equality and inequality comparisons.

### How was this patch tested?

Ran:

```bash

python3 python/run-tests.py --testnames pyspark.pandas.tests.data_type_ops.test_num_ops
python3 python/run-tests.py --testnames pyspark.pandas.tests.data_type_ops.test_boolean_ops