### PR TITLE
[SPARK-56955][CORE] Add --sun-misc-unsafe-memory-access=allow for JDK 25+

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java
@@ -49,17 +49,29 @@ public class JavaModuleOptions {
       "-Dio.netty.noUnsafe=false",
       "--enable-native-access=ALL-UNNAMED"};
 
+    // JDK 25+ restricts unsafe memory access by default, breaking Arrow/Netty.
+    private static final String[] JDK25_OPTIONS = {
+      "--sun-misc-unsafe-memory-access=allow"
+    };
+
     /**
      * Returns the default JVM runtime options used by Spark.
      */
     public static String defaultModuleOptions() {
-      return String.join(" ", DEFAULT_MODULE_OPTIONS);
+      return String.join(" ", defaultModuleOptionArray());
     }
 
     /**
      * Returns the default JVM runtime option array used by Spark.
      */
     public static String[] defaultModuleOptionArray() {
+      if (Runtime.version().feature() >= 25) {
+        String[] combined = new String[DEFAULT_MODULE_OPTIONS.length + JDK25_OPTIONS.length];
+        System.arraycopy(DEFAULT_MODULE_OPTIONS, 0, combined, 0, DEFAULT_MODULE_OPTIONS.length);
+        System.arraycopy(JDK25_OPTIONS, 0, combined, DEFAULT_MODULE_OPTIONS.length,
+          JDK25_OPTIONS.length);
+        return combined;
+      }
       return DEFAULT_MODULE_OPTIONS;
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `--sun-misc-unsafe-memory-access=allow` to JVM options when running on JDK 25+, in `JavaModuleOptions.java`.

### Why are the changes needed?

JDK 25 restricts unsafe memory access by default, breaking Arrow/Netty memory allocator initialization (`EmptyByteBuf.memoryAddress()` throws `UnsupportedOperationException`). This affects `spark-shell --remote` and any code path that initializes Arrow.

Found by @dongjoon-hyun, confirmed by @attilapiros who identified the fix flag. Same issue as https://github.com/apache/iceberg/issues/15930.

### Does this PR introduce _any_ user-facing change?

No. Spark will work correctly on JDK 25 without requiring users to manually add JVM flags.

### How was this patch tested?

- `AmmoniteReplE2ESuite` passes on JDK 17 (unchanged behavior)
- `AmmoniteReplE2ESuite` passes on JDK 25 (was failing without the flag)

### Was this patch authored or co-authored using generative AI tooling?

No.