### PR TITLE
[SPARK-56960][SQL][TESTS] Support custom Ivy settings file in `HiveVersionSuite` via environment variable

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientBuilder.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientBuilder.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.util.VersionInfo
 
 import org.apache.spark.SparkConf
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{MavenUtils, Utils}
 
 private[client] object HiveClientBuilder {
   // In order to speed up test execution during development or in Jenkins, you can specify the path
@@ -32,6 +32,11 @@ private[client] object HiveClientBuilder {
     sys.env.get("SPARK_VERSIONS_SUITE_IVY_PATH").orElse(
       Some(new File(sys.props("java.io.tmpdir"), "hive-ivy-cache").getAbsolutePath))
   }
+
+  // Path to a custom Ivy settings file for testing in environments that require
+  // authenticated access to private repositories:
+  private val ivySettingsPath: Option[String] =
+    sys.env.get("SPARK_VERSIONS_SUITE_IVY_SETTINGS")
 
   private[client] def buildConf(extraConf: Map[String, String]): Map[String, String] = {
     lazy val warehousePath = Utils.createTempDir()
@@ -47,10 +52,12 @@ private[client] object HiveClientBuilder {
       version: String,
       hadoopConf: Configuration,
       extraConf: Map[String, String] = Map.empty): HiveClient = {
+    val sparkConf = new SparkConf()
+    ivySettingsPath.foreach(sparkConf.set(MavenUtils.JAR_IVY_SETTING_PATH_KEY, _))
     IsolatedClientLoader.forVersion(
       hiveMetastoreVersion = version,
       hadoopVersion = VersionInfo.getVersion,
-      sparkConf = new SparkConf(),
+      sparkConf = sparkConf,
       hadoopConf = hadoopConf,
       config = buildConf(extraConf),
       ivyPath = ivyPath).createClient()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientBuilder.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientBuilder.scala
@@ -36,7 +36,7 @@ private[client] object HiveClientBuilder {
   // Path to a custom Ivy settings file for testing in environments that require
   // authenticated access to private repositories:
   private val ivySettingsPath: Option[String] =
-    sys.env.get("SPARK_VERSIONS_SUITE_IVY_SETTINGS")
+    sys.env.get("SPARK_TEST_VERSIONS_SUITE_IVY_SETTINGS")
 
   private[client] def buildConf(extraConf: Map[String, String]): Map[String, String] = {
     lazy val warehousePath = Utils.createTempDir()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientBuilder.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientBuilder.scala
@@ -53,7 +53,7 @@ private[client] object HiveClientBuilder {
       hadoopConf: Configuration,
       extraConf: Map[String, String] = Map.empty): HiveClient = {
     val sparkConf = new SparkConf()
-    ivySettingsPath.foreach(sparkConf.set(MavenUtils.JAR_IVY_SETTING_PATH_KEY, _))
+    ivySettingsPath.foreach(sparkConf.setIfMissing(MavenUtils.JAR_IVY_SETTING_PATH_KEY, _))
     IsolatedClientLoader.forVersion(
       hiveMetastoreVersion = version,
       hadoopVersion = VersionInfo.getVersion,


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds support for the `SPARK_TEST_VERSIONS_SUITE_IVY_SETTINGS` environment variable in `HiveClientBuilder`. When set, its value is used as the path to a custom Ivy settings file (`spark.jars.ivySettings`) for Hive metastore jar resolution during tests.

### Why are the changes needed?
After SPARK-56867(#55881) added support for `spark.jars.ivySettings` in `IsolatedClientLoader`, the test infrastructure should also be able to leverage this configuration. In closed environments where only authenticated private repositories are accessible, tests that download Hive metastore jars (e.g., `HiveClientSuite`, `HivePartitionFilteringSuite`) would fail without a way to specify credentials. This environment variable allows such environments to provide a custom Ivy settings file with the necessary authentication configuration.

This follows the same pattern as the existing `SPARK_VERSIONS_SUITE_IVY_PATH` environment variable, which allows specifying a custom Ivy cache path for the same set of tests.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Confirmed it works with a private repository which requires authentication.
```
$ SPARK_TEST_VERSIONS_SUITE_IVY_SETTINGS=/path/to/ivy-settings.xml build/sbt 'testOnly org.apache.spark.sql.hive.client.HivePartitionLocationSuites'
```

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude (via Kiro CLI, auto model selection)
