### PR TITLE
[SPARK-56977][SQL] RewriteNearestByJoin should respect joinType in the synthetic join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteNearestByJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteNearestByJoin.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.catalyst.rules._
  *         +- Aggregate [__qid],
  *              [first(left.col0) AS left.col0, ..., first(left.colN-1) AS left.colN-1,
  *               max_by(struct(right.*), expr, k) AS _matches]
- *             +- Join LeftOuter
+ *             +- Join Inner   // or LeftOuter for `LEFT OUTER NEAREST BY`
  *                :- Project [left.*, uuid() AS __qid]
  *                :  +- left
  *                +- right
@@ -79,18 +79,18 @@ object RewriteNearestByJoin extends Rule[LogicalPlan] {
       val taggedLeft = Project(left.output :+ qidAlias, left)
       val qidAttr = qidAlias.toAttribute
 
-      // 2. LEFT OUTER-join the tagged left with right (no join condition). LEFT OUTER
-      //    (rather than INNER) preserves left rows even when `right` is empty, so that a
-      //    `LEFT OUTER NEAREST BY` query still returns those rows with `NULL` right-side
-      //    columns after the aggregate + inline below. When `right` is non-empty every left
-      //    row already has right-row pairings, so LEFT OUTER and INNER are equivalent.
+      // 2. Join the tagged left with right (no join condition), using the user's join type.
+      //    For `LEFT OUTER`, left rows with no right-side match are preserved with `NULL`
+      //    right-side columns through the aggregate + inline below; for `INNER`, such rows
+      //    are dropped. When `right` is non-empty every left row already has right-row
+      //    pairings, so `LEFT OUTER` and `INNER` are equivalent in that case.
       //
       //    This synthetic join is an unconditioned cross-product, so `NEAREST BY` queries
       //    are subject to `CheckCartesianProducts` and will be rejected when the user has
       //    set `spark.sql.crossJoin.enabled = false`. That is intentional: if the user has
       //    opted out of cross-products, the NEAREST BY rewrite -- which is itself a bounded
       //    cross-product today -- should not silently bypass that choice.
-      val join = Join(taggedLeft, right, LeftOuter, None, JoinHint.NONE)
+      val join = Join(taggedLeft, right, joinType, None, JoinHint.NONE)
 
       val (aggInput, rankingForAgg) = if (!rankingExpression.deterministic) {
         val rankingAlias = Alias(rankingExpression, "__ranking__")()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteNearestByJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteNearestByJoinSuite.scala
@@ -162,6 +162,13 @@ class RewriteNearestByJoinSuite extends PlanTest {
         s"expected exactly one synthetic Join in the rewritten plan, got ${syntheticJoin.size}")
       assert(syntheticJoin.head.joinType == joinType,
         s"expected synthetic Join to use $joinType, got ${syntheticJoin.head.joinType}")
+
+      val generate = rewritten.collect { case g: Generate => g }
+      assert(generate.size == 1,
+        s"expected exactly one Generate in the rewritten plan, got ${generate.size}")
+      val expectedOuter = joinType == LeftOuter
+      assert(generate.head.outer == expectedOuter,
+        s"expected Generate.outer == $expectedOuter for $joinType, got ${generate.head.outer}")
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteNearestByJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteNearestByJoinSuite.scala
@@ -145,6 +145,26 @@ class RewriteNearestByJoinSuite extends PlanTest {
     comparePlans(normalizeUuidSeed(rewritten), expected, checkAnalysis = false)
   }
 
+  test("synthetic Join uses the user's joinType") {
+    // Locks in that the rewrite's synthetic Join carries the user's `joinType`
+    // (Inner or LeftOuter).
+    val left = LocalRelation($"a".int, $"b".int)
+    val right = LocalRelation($"x".int, $"y".int)
+    Seq(Inner, LeftOuter).foreach { joinType =>
+      val query = NearestByJoin(
+        left, right, joinType, approx = true, numResults = 1,
+        rankingExpression = left.output(0) + right.output(0),
+        direction = NearestBySimilarity)
+
+      val rewritten = RewriteNearestByJoin(query.analyze)
+      val syntheticJoin = rewritten.collect { case j: Join => j }
+      assert(syntheticJoin.size == 1,
+        s"expected exactly one synthetic Join in the rewritten plan, got ${syntheticJoin.size}")
+      assert(syntheticJoin.head.joinType == joinType,
+        s"expected synthetic Join to use $joinType, got ${syntheticJoin.head.joinType}")
+    }
+  }
+
   test("EXACT (approx = false) produces the same rewrite as APPROX") {
     // Locks in the current invariant that APPROX and EXACT lower through the same
     // brute-force rewrite. If a future change diverges them (e.g. an APPROX-only

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteNearestByJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteNearestByJoinSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, CreateStruct, Inline, Literal, Rand, Uuid}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, First, MaxMinByK}
-import org.apache.spark.sql.catalyst.plans.{Inner, LeftOuter, NearestByDistance, NearestBySimilarity, PlanTest}
+import org.apache.spark.sql.catalyst.plans.{Inner, JoinType, LeftOuter, NearestByDistance, NearestBySimilarity, PlanTest}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Generate, Join, JoinHint, LocalRelation, NearestByJoin, Project}
 import org.apache.spark.sql.types.IntegerType
 
@@ -41,10 +41,10 @@ class RewriteNearestByJoinSuite extends PlanTest {
       numResults: Int,
       ranking: org.apache.spark.sql.catalyst.expressions.Expression,
       reverse: Boolean,
-      outer: Boolean) = {
+      joinType: JoinType) = {
     val qidAlias = Alias(Uuid(Some(0L)), "__qid")()
     val taggedLeft = Project(left.output :+ qidAlias, left)
-    val join = Join(taggedLeft, right, LeftOuter, None, JoinHint.NONE)
+    val join = Join(taggedLeft, right, joinType, None, JoinHint.NONE)
 
     val rightStruct = CreateStruct(right.output)
     val topKAgg = MaxMinByK(
@@ -66,7 +66,7 @@ class RewriteNearestByJoinSuite extends PlanTest {
     val generate = Generate(
       Inline(matchesAlias.toAttribute),
       unrequiredChildIndex = Seq(aggregate.output.indexOf(matchesAlias.toAttribute)),
-      outer = outer,
+      outer = joinType == LeftOuter,
       qualifier = None,
       generatorOutput = generatorOutput,
       child = aggregate)
@@ -89,7 +89,7 @@ class RewriteNearestByJoinSuite extends PlanTest {
     val expected = expectedRewrite(
       left, right, 5,
       ranking = left.output(0) + right.output(0),
-      reverse = false, outer = false)
+      reverse = false, joinType = Inner)
 
     comparePlans(normalizeUuidSeed(rewritten), expected, checkAnalysis = false)
   }
@@ -106,7 +106,7 @@ class RewriteNearestByJoinSuite extends PlanTest {
     val expected = expectedRewrite(
       left, right, 3,
       ranking = left.output(0) - right.output(0),
-      reverse = true, outer = false)
+      reverse = true, joinType = Inner)
 
     comparePlans(normalizeUuidSeed(rewritten), expected, checkAnalysis = false)
   }
@@ -123,7 +123,7 @@ class RewriteNearestByJoinSuite extends PlanTest {
     val expected = expectedRewrite(
       left, right, 1,
       ranking = left.output(0) + right.output(0),
-      reverse = false, outer = true)
+      reverse = false, joinType = LeftOuter)
 
     comparePlans(normalizeUuidSeed(rewritten), expected, checkAnalysis = false)
   }
@@ -140,7 +140,7 @@ class RewriteNearestByJoinSuite extends PlanTest {
     val expected = expectedRewrite(
       left, right, 2,
       ranking = left.output(0) - right.output(0),
-      reverse = true, outer = true)
+      reverse = true, joinType = LeftOuter)
 
     comparePlans(normalizeUuidSeed(rewritten), expected, checkAnalysis = false)
   }
@@ -160,7 +160,7 @@ class RewriteNearestByJoinSuite extends PlanTest {
     val expected = expectedRewrite(
       left, right, 5,
       ranking = left.output(0) + right.output(0),
-      reverse = false, outer = false)
+      reverse = false, joinType = Inner)
 
     comparePlans(normalizeUuidSeed(rewritten), expected, checkAnalysis = false)
   }
@@ -177,7 +177,7 @@ class RewriteNearestByJoinSuite extends PlanTest {
     val expected = expectedRewrite(
       left, right, 1,
       ranking = left.output(0) + right.output(0),
-      reverse = false, outer = false)
+      reverse = false, joinType = Inner)
 
     comparePlans(normalizeUuidSeed(rewritten), expected, checkAnalysis = false)
   }
@@ -194,7 +194,7 @@ class RewriteNearestByJoinSuite extends PlanTest {
     val expected = expectedRewrite(
       left, right, NearestByJoin.MaxNumResults,
       ranking = left.output(0) + right.output(0),
-      reverse = false, outer = false)
+      reverse = false, joinType = Inner)
 
     comparePlans(normalizeUuidSeed(rewritten), expected, checkAnalysis = false)
   }
@@ -214,7 +214,7 @@ class RewriteNearestByJoinSuite extends PlanTest {
     val expected = expectedRewrite(
       t, tDup, 1,
       ranking = t.output(0) + tDup.output(0),
-      reverse = false, outer = false)
+      reverse = false, joinType = Inner)
 
     comparePlans(normalizeUuidSeed(rewritten), expected, checkAnalysis = false)
   }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/join-nearest-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/join-nearest-by.sql.out
@@ -131,6 +131,27 @@ Project [user_id#x, product#x]
 
 -- !query
 SELECT u.user_id, p.product
+FROM users u INNER JOIN (SELECT * FROM products WHERE false) p
+  APPROX NEAREST 1 BY SIMILARITY -abs(u.score - p.pscore)
+-- !query analysis
+Project [user_id#x, product#x]
++- NearestByJoin Inner, true, 1, -abs((score#x - pscore#x)), NearestBySimilarity
+   :- SubqueryAlias u
+   :  +- SubqueryAlias spark_catalog.default.users
+   :     +- View (`spark_catalog`.`default`.`users`, [user_id#x, score#x])
+   :        +- Project [cast(col1#x as int) AS user_id#x, cast(col2#x as decimal(3,1)) AS score#x]
+   :           +- LocalRelation [col1#x, col2#x]
+   +- SubqueryAlias p
+      +- Project [product#x, pscore#x]
+         +- Filter false
+            +- SubqueryAlias spark_catalog.default.products
+               +- View (`spark_catalog`.`default`.`products`, [product#x, pscore#x])
+                  +- Project [cast(col1#x as string) AS product#x, cast(col2#x as decimal(3,1)) AS pscore#x]
+                     +- LocalRelation [col1#x, col2#x]
+
+
+-- !query
+SELECT u.user_id, p.product
 FROM users u INNER JOIN products p
   APPROX NEAREST 1 BY DISTANCE abs(u.score - p.pscore)
 -- !query analysis

--- a/sql/core/src/test/resources/sql-tests/inputs/join-nearest-by.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/join-nearest-by.sql
@@ -36,6 +36,11 @@ SELECT u.user_id, p.product
 FROM users u LEFT OUTER JOIN (SELECT * FROM products WHERE false) p
   APPROX NEAREST 1 BY SIMILARITY -abs(u.score - p.pscore);
 
+-- INNER JOIN with NEAREST BY, empty right side
+SELECT u.user_id, p.product
+FROM users u INNER JOIN (SELECT * FROM products WHERE false) p
+  APPROX NEAREST 1 BY SIMILARITY -abs(u.score - p.pscore);
+
 -- Explicit INNER keyword
 SELECT u.user_id, p.product
 FROM users u INNER JOIN products p

--- a/sql/core/src/test/resources/sql-tests/results/join-nearest-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/join-nearest-by.sql.out
@@ -286,12 +286,12 @@ AdaptiveSparkPlan isFinalPlan=false
                   +- SortAggregate(key=[__qid#x], functions=[partial_first(user_id#x, false), partial_max_by(named_struct(product, product#x, pscore, pscore#x), __ranking__#x, 1, false, 0, 0)])
                      +- Sort [__qid#x ASC NULLS FIRST], false, 0
                         +- Project [user_id#x, __qid#x, product#x, pscore#x, (rand(0) + cast(pscore#x as double)) AS __ranking__#x]
-                           +- BroadcastNestedLoopJoin BuildRight, Inner
-                              :- Project [col1#x AS user_id#x, uuid(Some(x)) AS __qid#x]
-                              :  +- LocalTableScan [col1#x, col2#x]
-                              +- BroadcastExchange IdentityBroadcastMode, [plan_id=x]
-                                 +- Project [col1#x AS product#x, col2#x AS pscore#x]
-                                    +- LocalTableScan [col1#x, col2#x]
+                           +- BroadcastNestedLoopJoin BuildLeft, Inner
+                              :- BroadcastExchange IdentityBroadcastMode, [plan_id=x]
+                              :  +- Project [col1#x AS user_id#x, uuid(Some(x)) AS __qid#x]
+                              :     +- LocalTableScan [col1#x, col2#x]
+                              +- Project [col1#x AS product#x, col2#x AS pscore#x]
+                                 +- LocalTableScan [col1#x, col2#x]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/join-nearest-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/join-nearest-by.sql.out
@@ -286,7 +286,7 @@ AdaptiveSparkPlan isFinalPlan=false
                   +- SortAggregate(key=[__qid#x], functions=[partial_first(user_id#x, false), partial_max_by(named_struct(product, product#x, pscore, pscore#x), __ranking__#x, 1, false, 0, 0)])
                      +- Sort [__qid#x ASC NULLS FIRST], false, 0
                         +- Project [user_id#x, __qid#x, product#x, pscore#x, (rand(0) + cast(pscore#x as double)) AS __ranking__#x]
-                           +- BroadcastNestedLoopJoin BuildRight, LeftOuter
+                           +- BroadcastNestedLoopJoin BuildRight, Inner
                               :- Project [col1#x AS user_id#x, uuid(Some(x)) AS __qid#x]
                               :  +- LocalTableScan [col1#x, col2#x]
                               +- BroadcastExchange IdentityBroadcastMode, [plan_id=x]
@@ -313,7 +313,7 @@ AdaptiveSparkPlan isFinalPlan=false
                +- Exchange hashpartitioning(__qid#x, 4), ENSURE_REQUIREMENTS, [plan_id=x]
                   +- SortAggregate(key=[__qid#x], functions=[partial_first(user_id#x, false), partial_min_by(named_struct(product, product#x, pscore, pscore#x), abs((score#x - pscore#x)), 2, true, 0, 0)])
                      +- Sort [__qid#x ASC NULLS FIRST], false, 0
-                        +- BroadcastNestedLoopJoin BuildRight, LeftOuter
+                        +- BroadcastNestedLoopJoin BuildRight, Inner
                            :- Filter (user_id#x > 1)
                            :  +- Project [col1#x AS user_id#x, col2#x AS score#x, uuid(Some(x)) AS __qid#x]
                            :     +- LocalTableScan [col1#x, col2#x]
@@ -342,7 +342,7 @@ AdaptiveSparkPlan isFinalPlan=false
                   +- Exchange hashpartitioning(__qid#x, 4), ENSURE_REQUIREMENTS, [plan_id=x]
                      +- SortAggregate(key=[__qid#x], functions=[partial_first(user_id#x, false), partial_min_by(named_struct(product, product#x, pscore, pscore#x), abs((score#x - pscore#x)), 2, true, 0, 0)])
                         +- Sort [__qid#x ASC NULLS FIRST], false, 0
-                           +- BroadcastNestedLoopJoin BuildRight, LeftOuter
+                           +- BroadcastNestedLoopJoin BuildRight, Inner
                               :- Project [col1#x AS user_id#x, col2#x AS score#x, uuid(Some(x)) AS __qid#x]
                               :  +- LocalTableScan [col1#x, col2#x]
                               +- BroadcastExchange IdentityBroadcastMode, [plan_id=x]

--- a/sql/core/src/test/resources/sql-tests/results/join-nearest-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/join-nearest-by.sql.out
@@ -92,6 +92,16 @@ struct<user_id:int,product:string>
 
 -- !query
 SELECT u.user_id, p.product
+FROM users u INNER JOIN (SELECT * FROM products WHERE false) p
+  APPROX NEAREST 1 BY SIMILARITY -abs(u.score - p.pscore)
+-- !query schema
+struct<user_id:int,product:string>
+-- !query output
+
+
+
+-- !query
+SELECT u.user_id, p.product
 FROM users u INNER JOIN products p
   APPROX NEAREST 1 BY DISTANCE abs(u.score - p.pscore)
 -- !query schema


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This PR changes `RewriteNearestByJoin` to construct its synthetic cross-join with the user's `joinType` (`Inner` or `LeftOuter`) instead of always using `LeftOuter`. The `Generate` operator's `outer` flag continues to be derived from `joinType == LeftOuter`, so the externally observable semantics are unchanged.

### Why are the changes needed?

The original implementation hardcoded the synthetic join to `LeftOuter` and justified it on the grounds that `LEFT OUTER` and `INNER` are equivalent for an unconditioned join when the right side is non-empty, and `Generate(outer = false)` would drop unwanted rows for `INNER` when right is empty.

That reasoning holds for correctness but has a major performance cost:

- **`INNER NEAREST BY` cannot be planned as a Cartesian product.** Spark's strategy picks `CartesianProductExec` only for `Inner` joins with no condition; an unconditioned `LeftOuter` join falls back to `BroadcastNestedLoopJoin`, which tries to broadcast the right side. When the right relation is large, the broadcast either OOMs or exceeds `spark.sql.autoBroadcastJoinThreshold` and the planner is left with no good option. `CartesianProductExec` partitions both sides and streams pairs, so it scales naturally with right-side size. Respecting the user's `INNER` join type re-enables this strategy for the common `INNER NEAREST BY` case.
- It also makes the EXPLAIN output misleading (shows `LeftOuter` even though the user wrote `INNER`).
- For `INNER` with an empty right side, the old plan generates one row per left input and then filters them away via `Generate(outer = false)` and the `size(matches) > 0` filter -- extra work that respecting `joinType` avoids at the source.

### Does this PR introduce _any_ user-facing change?

No change in query results. `EXPLAIN` output for `INNER NEAREST BY` queries now shows `Inner` rather than `LeftOuter` for the synthetic join node, and the physical plan for such queries can now use `CartesianProductExec` instead of `BroadcastNestedLoopJoin` when the right relation is too large to broadcast.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

- `RewriteNearestByJoinSuite`: `expectedRewrite` now takes a `joinType: JoinType` and the existing tests (similarity/distance x inner/leftouter, EXACT, boundary k, self-join, nondeterministic ranking) assert the synthetic join matches the user's join type.
- Golden file `sql-tests/results/join-nearest-by.sql.out`

### Was this patch authored or co-authored using generative AI tooling?

Coauthored-by: Claude Code (Opus 4.7), human-reviewed and tested