### PR TITLE
[SPARK-56820][SQL] Change counter_diff available since version from 4.2 to 4.3 in doc comments

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -6481,7 +6481,7 @@ def counter_diff(value: "ColumnOrName", startTime: Optional["ColumnOrName"] = No
     Use the ORDER BY clause of the window to order the observations by the associated timestamp
     in ascending order.
 
-    .. versionadded:: 4.2.0
+    .. versionadded:: 4.3.0
 
     Parameters
     ----------

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -2553,7 +2553,7 @@ object functions {
    *   according to the order defined by the window's ORDER BY clause.
    *
    * @group window_funcs
-   * @since 4.2.0
+   * @since 4.3.0
    */
   def counter_diff(value: Column): Column = Column.fn("counter_diff", value)
 
@@ -2583,7 +2583,7 @@ object functions {
    *   according to the order defined by the window's ORDER BY clause.
    *
    * @group window_funcs
-   * @since 4.2.0
+   * @since 4.3.0
    */
   def counter_diff(value: Column, startTime: Column): Column =
     Column.fn("counter_diff", value, startTime)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CounterDiff.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CounterDiff.scala
@@ -327,7 +327,7 @@ case class CounterDiffWithStartTime(
     2. The current start time is greater than the previous start time, if start_time was provided.
   """,
   group = "window_funcs",
-  since = "4.2.0"
+  since = "4.3.0"
 )
 // scalastyle:on line.size.limit line.contains.tab
 object CounterDiffExpressionBuilder extends ExpressionBuilder {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Changes the _"available since version"_ for the window function `counter_diff` from 4.2 to 4.3 in the code comments and descriptions.

**Original PR:** #55828 

### Why are the changes needed?

`counter_diff` was not merged in 4.2.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Comment changes only, no testing needed.

### Was this patch authored or co-authored using generative AI tooling?

No.