### PR TITLE
[SPARK-56966][SPARK-56967][CORE] Auto-create event log and history se…

### DIFF
--- a/build/sbt
+++ b/build/sbt
@@ -72,7 +72,7 @@ Usage: $script_name [options]
                      prepended to the runner args
   /etc/sbt/sbtopts   if this file exists, it is prepended to the runner args
   -Dkey=val          pass -Dkey=val directly to the java runtime
-  -J-X               pass option -X directly to the java runtime
+  -J-X               pass option -X directly to the java runtimegit status --short
                      (-J is stripped)
   -S-X               add -X to sbt's scalacOptions (-S is stripped)
   -PmavenProfiles    Enable a maven profile for the build.

--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
@@ -80,7 +80,11 @@ abstract class EventLogFileWriter(
   protected var writer: Option[PrintWriter] = None
 
   protected def requireLogBaseDirAsDirectory(): Unit = {
-    if (!fileSystem.getFileStatus(new Path(logBaseDir)).isDirectory) {
+    val basePath = new Path(logBaseDir)
+    if (!fileSystem.exists(basePath)) {
+      FileSystem.mkdirs(fileSystem, basePath, EventLogFileWriter.LOG_FOLDER_PERMISSIONS)
+    }
+    if (!fileSystem.getFileStatus(basePath).isDirectory) {
       throw new IllegalArgumentException(s"Log directory $logBaseDir is not a directory.")
     }
   }

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -349,12 +349,17 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         }
       } catch {
         case f: FileNotFoundException =>
-          var msg = s"Log directory specified does not exist: $dir"
-          if (dir == DEFAULT_LOG_DIR) {
-            msg += " Did you configure the correct one through spark.history.fs.logDirectory?"
+         if (FileSystem.mkdirs(dirFs, path, EventLogFileWriter.LOG_FOLDER_PERMISSIONS)) {
+            logInfo(log"Created missing history log directory ${MDC(HISTORY_DIR, dir)}.")
+            true
+          } else {
+            var msg = s"Log directory specified does not exist: $dir"
+            if (dir == DEFAULT_LOG_DIR) {
+              msg += " Did you configure the correct one through spark.history.fs.logDirectory?"
+            }
+            logWarning(msg)
+            false
           }
-          logWarning(msg)
-          false
       }
     }
     require(validDirs.nonEmpty,

--- a/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileWritersSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileWritersSuite.scala
@@ -100,6 +100,25 @@ abstract class EventLogFileWritersSuite extends SparkFunSuite with LocalSparkCon
     }
   }
 
+  test("create missing spark.eventLog.dir automatically") {
+    val appId = getUniqueApplicationId
+    val attemptId = None
+    val missingDir = new File(testDir, "missing-event-log-dir")
+    val missingDirPath = new Path(missingDir.getAbsolutePath)
+    assert(!missingDir.exists())
+
+    val conf = getLoggingConf(missingDirPath, None)
+    val writer = createWriter(appId, attemptId, missingDirPath.toUri, conf,
+      SparkHadoopUtil.get.newConfiguration(conf))
+
+    writer.start()
+    writer.writeEvent("dummy", flushLogger = true)
+    writer.stop()
+    
+    assert(missingDir.isDirectory)
+  }
+
+
   test("Use the default value of spark.eventLog.compression.codec") {
     val conf = new SparkConf
     conf.set(EVENT_LOG_COMPRESS, true)

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -2266,6 +2266,29 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     }
   }
 
+  test("create missing spark.history.fs.logDirectory automatically") {
+    val missingDir = Utils.createTempDir(namePrefix = "missingHistoryDir")
+    val missingDirPath = missingDir.getAbsolutePath
+    Utils.deleteRecursively(missingDir)
+    assert(!new File(missingDirPath).exists())
+    
+    val conf = createTestConf().set(HISTORY_LOG_DIR, missingDirPath)
+    val provider = new FsHistoryProvider(conf)
+    try {
+      updateAndCheck(provider) { list =>
+        list.size should be(0)
+      }
+      new File(missingDirPath).isDirectory should be(true)
+    } finally {
+      provider.stop()
+      val recreatedDir = new File(missingDirPath)
+      if (recreatedDir.exists()) {
+        Utils.deleteRecursively(recreatedDir)
+      }
+    }
+  }
+
+
   test("SPARK-55864: directory temporarily inaccessible then recovers") {
     val dir2 = Utils.createTempDir(namePrefix = "logDir2")
     try {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Auto-create the event log directory (`spark.eventLog.dir`) and the
history server log directory (`spark.history.fs.logDirectory`) if they
do not exist at startup, instead of failing with a `FileNotFoundException`.

**FsHistoryProvider** (`SPARK-56966`): In `startPolling()`, the
`FileNotFoundException` catch block now calls `FileSystem.mkdirs` with
`LOG_FOLDER_PERMISSIONS` before giving up. If creation succeeds the
directory is treated as valid; if it fails, the original warning-and-skip
behavior is preserved.

**EventLogFileWriters** (`SPARK-56967`): `requireLogBaseDirAsDirectory()`
now checks `fileSystem.exists` first and calls `FileSystem.mkdirs` if the
path is absent. This works for local FS, HDFS, and S3-compatible paths.

### Why are the changes needed?

Users frequently see startup failures because the log directory has not
been pre-created, even when the path and permissions are otherwise correct.
Auto-creating it reduces operational friction with no behavioral regression
for directories that already exist.

### Does this PR introduce _any_ user-facing change?

Yes — previously both code paths threw/warned on a missing directory.
Now they silently create it. The behavior when a directory exists is
unchanged.

### How was this patch tested?

- [ ] Unit tests for `FsHistoryProviderSuite` covering the new mkdir path
- [ ] Unit tests for `EventLogFileWritersSuite` covering auto-creation
- [ ] Manual test with a non-existent local path and an S3 path

Closes #<PR number>

Resolves https://issues.apache.org/jira/browse/SPARK-56966
Resolves https://issues.apache.org/jira/browse/SPARK-56967