### PR TITLE
[MINOR][PYTHON][TESTS] Rename TVFParityTestsMixin to TVFParityTests

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_tvf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_tvf.py
@@ -19,7 +19,7 @@ from pyspark.sql.tests.test_tvf import TVFTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
-class TVFParityTestsMixin(TVFTestsMixin, ReusedConnectTestCase):
+class TVFParityTests(TVFTestsMixin, ReusedConnectTestCase):
     pass
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the class in `python/pyspark/sql/tests/connect/test_parity_tvf.py` from `TVFParityTestsMixin` to `TVFParityTests`.

### Why are the changes needed?

`TVFParityTestsMixin` is actually the concrete Connect parity test case for the file — it inherits from `ReusedConnectTestCase` (a `unittest.TestCase`) and `TVFTestsMixin`, so the tests are picked up and run by the default `unittest` loader. The `Mixin` suffix is misleading and inconsistent with every other Connect parity file (`TypesParityTests`, `ConfParityTests`, etc.), all of which use a plain `*ParityTests` name. This is a naming-convention fix; no test behavior changes.

I scanned all 780 registered test modules in `dev/sparktestsupport/modules.py` for the same pattern (file where every top-level class is suffixed `Mixin`). `test_parity_tvf.py` is the only occurrence.

### Does this PR introduce _any_ user-facing change?

No. Test-only change.

### How was this patch tested?

Existing tests. The class and its inherited test cases were already being collected by `unittest`; only the class name changes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code claude-opus-4-7