### PR TITLE
[SPARK-56999][PYTHON] Fix mapInArrow opaque getInt error by coercing output to declared schema

### DIFF
--- a/python/pyspark/sql/tests/arrow/test_arrow_map.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow_map.py
@@ -79,6 +79,26 @@ class MapInArrowTestsMixin:
         expected = df.collect()
         self.assertEqual(actual, expected)
 
+    def test_coerce_output_type_to_declared_schema(self):
+        # Regression test: when the user yields a batch whose Arrow type does
+        # not match the declared output schema, the worker should coerce it
+        # rather than letting the JVM fail later with an opaque getInt error
+        # on the wrong ArrowColumnVector accessor.
+        from pyspark.sql.types import IntegerType, StructField, StructType
+
+        def double_x(iter_batches):
+            for batch in iter_batches:
+                # The input column is long (int64); produce int64 output even
+                # though the declared schema is IntegerType (int32).
+                yield pa.RecordBatch.from_arrays(
+                    [pa.array([v * 2 for v in batch.column("x").to_pylist()], type=pa.int64())],
+                    names=["x"],
+                )
+
+        src = self.spark.createDataFrame([(1,), (2,), (3,)], ["x"])
+        out = src.mapInArrow(double_x, schema=StructType([StructField("x", IntegerType())]))
+        self.assertEqual([r.x for r in out.collect()], [2, 4, 6])
+
     def test_large_variable_width_types(self):
         with self.sql_conf({"spark.sql.execution.arrow.useLargeVarTypes": True}):
             data = [("foo", b"foo"), (None, None), ("bar", b"bar")]
@@ -213,16 +233,18 @@ class MapInArrowTestsMixin:
                 MapInArrowTests.test_map_in_arrow(self)
 
     def test_nested_extraneous_field(self):
-        with self.sql_conf({"spark.sql.execution.arrow.pyspark.validateSchema.enabled": True}):
+        # The worker now coerces each output batch against the declared output
+        # schema. pyarrow's struct cast silently drops fields that are not in
+        # the target type, so an extraneous nested field no longer reaches the
+        # JVM and the JVM-side validateSchema check has nothing to catch.
+        def func(iterator):
+            for _ in iterator:
+                struct_arr = pa.StructArray.from_arrays([[1, 2], [3, 4]], names=["a", "b"])
+                yield pa.RecordBatch.from_arrays([struct_arr], ["x"])
 
-            def func(iterator):
-                for _ in iterator:
-                    struct_arr = pa.StructArray.from_arrays([[1, 2], [3, 4]], names=["a", "b"])
-                    yield pa.RecordBatch.from_arrays([struct_arr], ["x"])
-
-            df = self.spark.range(1)
-            with self.assertRaisesRegex(Exception, r"ARROW_TYPE_MISMATCH.*SQL_MAP_ARROW_ITER_UDF"):
-                df.mapInArrow(func, "x struct<b:int>").collect()
+        df = self.spark.range(1)
+        rows = df.mapInArrow(func, "x struct<b:int>").collect()
+        self.assertEqual([r.x.b for r in rows], [3, 4])
 
     def test_top_level_wrong_order(self):
         with self.sql_conf({"spark.sql.execution.arrow.pyspark.validateSchema.enabled": True}):

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -989,7 +989,7 @@ def read_single_udf(pickleSer, udf_info, eval_type, runner_conf, udf_index):
     elif eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF:
         return args_offsets, wrap_pandas_batch_iter_udf(func, return_type, runner_conf)
     elif eval_type == PythonEvalType.SQL_MAP_ARROW_ITER_UDF:
-        return func, None, None, None
+        return func, None, None, return_type
     elif eval_type in (
         PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF,
         PythonEvalType.SQL_GROUPED_MAP_PANDAS_ITER_UDF,
@@ -2371,6 +2371,17 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
 
         assert num_udfs == 1, "One MAP_ARROW_ITER UDF expected here."
         udf_func: Callable[[Iterator[pa.RecordBatch]], Iterator[pa.RecordBatch]] = udfs[0][0]
+        return_type = udfs[0][3]
+
+        # Pre-compute target schema so each output batch can be coerced to the
+        # declared output types (e.g. int64 -> int32 from a pandas roundtrip).
+        # Without this, a type mismatch only surfaces deep in the JVM as an
+        # opaque getInt error on the wrong ArrowColumnVector accessor.
+        return_schema = to_arrow_schema(
+            return_type,
+            timezone="UTC",
+            prefers_large_types=runner_conf.use_large_var_types,
+        )
 
         def func(split_index: int, data: Iterator[pa.RecordBatch]) -> Iterator[pa.RecordBatch]:
             """Apply mapInArrow UDF"""
@@ -2388,7 +2399,20 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 output_batches,
                 Iterator[pa.RecordBatch],  # type: ignore[type-abstract]
             )
-            yield from map(ArrowBatchTransformer.wrap_struct, verified_iter)
+            # mapInArrow has historically used positional column matching
+            # (the user's batch column names need not match the declared output
+            # schema names; the JVM struct vector is read by child index). Keep
+            # that contract -- reorder_by_name=False -- and only rely on the
+            # column-count check and the per-column type cast.
+            coerced_iter = (
+                ArrowBatchTransformer.enforce_schema(
+                    batch,
+                    return_schema,
+                    reorder_by_name=False,
+                )
+                for batch in verified_iter
+            )
+            yield from map(ArrowBatchTransformer.wrap_struct, coerced_iter)
 
         # profiling is not supported for UDF
         return func, None, ser, ser


### PR DESCRIPTION
### What changes were proposed in this pull request?

Coerce each output `pa.RecordBatch` from a `mapInArrow` UDF against the declared output schema in `python/pyspark/worker.py`, via `ArrowBatchTransformer.enforce_schema(..., reorder_by_name=False)` (positional matching, default `arrow_cast=True` + `safecheck=True`) before `wrap_struct`.

### Why are the changes needed?

Without coercion, an Arrow type mismatch between the UDF output and the declared output schema surfaces in the JVM as an opaque accessor error: `[UNSUPPORTED_CALL.WITHOUT_SUGGESTION] Cannot call the method "getInt" of the class "org.apache.spark.sql.vectorized.ArrowColumnVector$ArrowVectorAccessor".`

Repro:

```python
import pyarrow as pa
from pyspark.sql.types import StructType, StructField, IntegerType

def double_x(iter_batches):
    for batch in iter_batches:
        df = batch.to_pandas()
        df["x"] = df["x"] * 2
        yield pa.RecordBatch.from_pandas(df[["x"]])

src = spark.createDataFrame([(1,), (2,), (3,)], ["x"])  # x is long (int64)
src.mapInArrow(double_x, schema=StructType([StructField("x", IntegerType())])).show()
```

`createDataFrame` infers `x` as `LongType`; the pandas roundtrip preserves int64; the declared schema is int32; the JVM picks `LongAccessor` for a `BigIntVector` and the outer scan calls `getInt` on it, hitting the no-op base accessor.

### Does this PR introduce _any_ user-facing change?

Yes. Output batches that previously triggered an opaque JVM accessor failure are now coerced in Python: compatible types (e.g. int64 -> int32) are cast with `safecheck=True` (overflows still raise); columns are matched by position so existing batches whose names differ from the declared schema keep working; column-count or per-column cast failures now raise `RESULT_COLUMN_SCHEMA_MISMATCH` / `RESULT_COLUMN_TYPES_MISMATCH` instead of failing in the JVM.

### How was this patch tested?

`python/run-tests --testnames pyspark.sql.tests.arrow.test_arrow_map` (81 tests pass). Added `test_coerce_output_type_to_declared_schema` for the int64 -> int32 case; updated `test_nested_extraneous_field` to reflect that pyarrow's struct cast silently drops fields outside the target type.

### Was this patch authored or co-authored using generative AI tooling?

No.