### PR TITLE
[SPARK-52498][SQL] Fix false ambiguous self-join error with foldable condition

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/analysis/DetectAmbiguousSelfJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/analysis/DetectAmbiguousSelfJoin.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, Cast, Equality, Expression, ExprId}
-import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.classic.Dataset
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -153,9 +153,29 @@ object DetectAmbiguousSelfJoin extends Rule[LogicalPlan] {
           }
           condition.toSeq.flatMap(getAmbiguousAttrs)
 
-        case _ => ambiguousColRefs.toSeq.map { ref =>
-          colRefAttrs.find(attr => toColumnReference(attr) == ref).get
-        }
+        case _ =>
+          // SPARK-52498: For a Project on top of a self-join with a foldable join condition
+          // (e.g., df.join(df, df("col") === 0).select(df("col"))), the column references
+          // in the select are not ambiguous because the foldable condition means it doesn't
+          // matter which side the column comes from.
+          val isProjectOverFoldableSelfJoin = plan match {
+            case Project(_, Join(
+                LogicalPlanWithDatasetId(_, leftId),
+                LogicalPlanWithDatasetId(_, rightId),
+                _, Some(condition), _)) if leftId == rightId =>
+              condition.collectFirst {
+                case Equality(_, b) if b.foldable => true
+                case Equality(a, _) if a.foldable => true
+              }.isDefined
+            case _ => false
+          }
+          if (isProjectOverFoldableSelfJoin) {
+            Nil
+          } else {
+            ambiguousColRefs.toSeq.map { ref =>
+              colRefAttrs.find(attr => toColumnReference(attr) == ref).get
+            }
+          }
       }
 
       if (ambiguousAttrs.nonEmpty) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSelfJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSelfJoinSuite.scala
@@ -553,4 +553,18 @@ class DataFrameSelfJoinSuite extends SharedSparkSession {
           .count() == 1)
     }
   }
+
+  test("SPARK-52498: self join with foldable condition and select should not be ambiguous") {
+    withSQLConf(SQLConf.FAIL_AMBIGUOUS_SELF_JOIN_ENABLED.key -> "true") {
+      val df1 = spark.range(3).toDF("col1")
+
+      // Self-join with foldable condition + select from one side
+      val df2 = df1.join(df1, df1("col1") === 0).select(df1("col1"))
+      df2.queryExecution.analyzed
+
+      // Multi-layer self-join
+      val df3 = df2.join(df2, df2("col1") === 0).select(df2("col1"))
+      df3.queryExecution.analyzed
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix `DetectAmbiguousSelfJoin` to not flag column references as ambiguous when the root plan is a Project on top of a self-join with a foldable join condition `(e.g., df.join(df, df("col") === 0).select(df("col")))`.

When the join condition compares a column to a literal, it doesn't matter which side the column comes from - both sides have identical data. The ambiguity check was incorrectly rejecting this pattern.


### Why are the changes needed?
`df.join(df, df("col") === 0).select(df("col"))` throws `AnalysisException: Column are ambiguous with the regular resolver when spark.sql.analyzer.failAmbiguousSelfJoin is true`. The single-pass resolver handles this correctly. This inconsistency breaks multi-layer self-join patterns that work fine with the single-pass resolver.

### Does this PR introduce _any_ user-facing change?
Yes. Self-join queries with foldable conditions followed by select no longer throw a false ambiguity error.

### Design approach
First attempted a broader fix: skip ambiguity check for any column reference whose `exprId` matches the plan's output `(outputExprIds.contains(attr.exprId))`. This was too permissive - broke 4 existing tests (SPARK-28344: fail ambiguous self join - column ref in Project, join three tables, SPARK-33071, SPARK-35454: join four tables) because it suppressed legitimate ambiguity errors where the user genuinely needs to alias.

Narrowed to the specific case: only skip when the root plan is a Project directly on top of a `self-join (leftId == rightId)` with a foldable join condition. This correctly targets the false positive without affecting real ambiguity detection.


### How was this patch tested?
Added a test in `DataFrameSelfJoinSuite` verifying single-layer and multi-layer self-joins with foldable conditions. All 23 existing self-join tests are passing.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes.
