### PR TITLE
[SPARK-50520][PySpark] Respect timeout in df.rdd.countApprox()

### DIFF
--- a/python/pyspark/core/rdd.py
+++ b/python/pyspark/core/rdd.py
@@ -4843,7 +4843,8 @@ class RDD(Generic[T_co]):
         jrdd = self.mapPartitions(lambda it: [float(sum(it))])._to_java_object_rdd()
         assert self.ctx._jvm is not None
         jdrdd = self.ctx._jvm.JavaDoubleRDD.fromRDD(jrdd.rdd())
-        r = jdrdd.sumApprox(timeout, confidence).getFinalValue()
+        partial = jdrdd.sumApprox(timeout, confidence)
+        r = partial.initialValue()
         return BoundedFloat(r.mean(), r.confidence(), r.low(), r.high())
 
     def meanApprox(

--- a/python/pyspark/core/rdd.py
+++ b/python/pyspark/core/rdd.py
@@ -4882,7 +4882,8 @@ class RDD(Generic[T_co]):
         jrdd = self.map(float)._to_java_object_rdd()
         assert self.ctx._jvm is not None
         jdrdd = self.ctx._jvm.JavaDoubleRDD.fromRDD(jrdd.rdd())
-        r = jdrdd.meanApprox(timeout, confidence).getFinalValue()
+        partial = jdrdd.meanApprox(timeout, confidence)
+        r = partial.initialValue()
         return BoundedFloat(r.mean(), r.confidence(), r.low(), r.high())
 
     def countApproxDistinct(self: "RDD[T]", relativeSD: float = 0.05) -> int:

--- a/python/pyspark/tests/test_rdd.py
+++ b/python/pyspark/tests/test_rdd.py
@@ -638,6 +638,18 @@ class RDDTests(ReusedPySparkTestCase):
         self.assertEqual(result.getNumPartitions(), 5)
         self.assertEqual(result.count(), 3)
 
+    def test_count_approx_respects_timeout(self):
+        rdd = self.sc.range(1000000, numSlices=8)
+        start = time.time()
+        result = rdd.countApprox(timeout=100)
+        elapsed = time.time() - start
+        self.assertLess(elapsed, 10)
+        self.assertIsNotNone(result)
+
+    def test_count_approx_returns_exact_when_completed(self):
+        rdd = self.sc.parallelize(range(1000), 8)
+        self.assertEqual(rdd.countApprox(timeout=5000), 1000)
+
     def test_external_group_by_key(self):
         self.sc._conf.set("spark.python.worker.memory", "1m")
         N = 2000001

--- a/python/pyspark/tests/test_rdd.py
+++ b/python/pyspark/tests/test_rdd.py
@@ -639,16 +639,34 @@ class RDDTests(ReusedPySparkTestCase):
         self.assertEqual(result.count(), 3)
 
     def test_count_approx_respects_timeout(self):
-        rdd = self.sc.range(1000000, numSlices=8)
+        def slow(x):
+            time.sleep(1)
+            return x
+
+        rdd = self.sc.parallelize(range(20), 20).map(slow)
         start = time.time()
-        result = rdd.countApprox(timeout=100)
+        rdd.countApprox(timeout=100)
         elapsed = time.time() - start
-        self.assertLess(elapsed, 10)
-        self.assertIsNotNone(result)
+        self.assertLess(elapsed, 2)
+        # Cancel the background approximate job before subsequent tests run.
+        self.sc.cancelAllJobs()
 
     def test_count_approx_returns_exact_when_completed(self):
         rdd = self.sc.parallelize(range(1000), 8)
         self.assertEqual(rdd.countApprox(timeout=5000), 1000)
+
+    def test_mean_approx_respects_timeout(self):
+        def slow(x):
+            time.sleep(1)
+            return float(x)
+
+        rdd = self.sc.parallelize(range(20), 20).map(slow)
+        start = time.time()
+        rdd.meanApprox(timeout=100)
+        elapsed = time.time() - start
+        self.assertLess(elapsed, 2)
+        # Cancel the background approximate job before subsequent tests run.
+        self.sc.cancelAllJobs()
 
     def test_external_group_by_key(self):
         self.sc._conf.set("spark.python.worker.memory", "1m")


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
PySpark approximate RDD actions currently call getFinalValue() on the PartialResult returned by Spark approximate job APIs. This introduces blocking behavior and causes APIs such as countApprox(timeout=...), sumApprox(timeout=...), and meanApprox(timeout=...) to wait for full job completion instead of respecting timeout semantics. This PR updates PySpark to use PartialResult.initialValue(), which contains the timeout-aware approximation produced by ApproximateActionListener.awaitResult(). As a result, approximate RDD actions now return the partial result available at the specified timeout while still returning exact results when the computation completes within the timeout.
Additionally, regression tests were added and strengthened to validate:
- timeout-aware approximate behavior for both countApprox and meanApprox using deliberately slow workloads,
- exact results when computation completes successfully,
- cleanup of background approximate jobs to avoid interference with subsequent tests.


### Why are the changes needed?
Spark approximate actions are designed to return partial results after the specified timeout. Scala APIs already expose this behavior through PartialResult, but PySpark currently forces blocking completion by calling getFinalValue(). As a result, PySpark approximate actions ignore timeout semantics and wait for the entire job to finish, which is inconsistent with the intended behavior of Spark's approximate execution APIs.


### Does this PR introduce _any_ user-facing change?
Yes. PySpark approximate RDD actions (countApprox, sumApprox, and meanApprox) now correctly respect timeout semantics and may return timeout-aware approximate results instead of blocking until full job completion.


### How was this patch tested?
- Reproduced the issue locally using a slow-running RDD workload.
- Verified timeout behavior before and after the fix.
- Verified exact results are still returned when the computation completes within the timeout.
- Added regression tests in python/pyspark/tests/test_rdd.py.
- Ran: python/run-tests.py --testnames pyspark.tests.test_rdd
- Manually validated timeout and completed-result behavior for countApprox, sumApprox, and meanApprox.


### Was this patch authored or co-authored using generative AI tooling?
No
