### PR TITLE
[SPARK-57035][DOCS] Always target /docs/latest/ in DocSearch index

### DIFF
--- a/dev/create-release/release-tag.sh
+++ b/dev/create-release/release-tag.sh
@@ -84,7 +84,6 @@ fi
 # Set the release version in docs
 sed -i".tmp1" 's/SPARK_VERSION:.*$/SPARK_VERSION: '"$RELEASE_VERSION"'/g' docs/_config.yml
 sed -i".tmp2" 's/SPARK_VERSION_SHORT:.*$/SPARK_VERSION_SHORT: '"$RELEASE_VERSION"'/g' docs/_config.yml
-sed -i".tmp3" "s/'facetFilters':.*$/'facetFilters': [\"version:$RELEASE_VERSION\"]/g" docs/_config.yml
 sed -i".tmp4" 's/__version__: str = .*$/__version__: str = "'"$RELEASE_VERSION"'"/' python/pyspark/version.py
 
 git commit -a -m "Preparing Spark release $RELEASE_TAG"
@@ -104,8 +103,6 @@ sed -i".tmp6" 's/__version__: str = .*$/__version__: str = "'"$R_NEXT_VERSION.de
 sed -i".tmp7" 's/SPARK_VERSION:.*$/SPARK_VERSION: '"$NEXT_VERSION"'/g' docs/_config.yml
 # Use R version for short version
 sed -i".tmp8" 's/SPARK_VERSION_SHORT:.*$/SPARK_VERSION_SHORT: '"$R_NEXT_VERSION"'/g' docs/_config.yml
-# Update the version index of DocSearch as the short version
-sed -i".tmp9" "s/'facetFilters':.*$/'facetFilters': [\"version:$R_NEXT_VERSION\"]/g" docs/_config.yml
 
 git commit -a -m "Preparing development version $NEXT_VERSION"
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -25,12 +25,10 @@ SCALA_BINARY_VERSION: "2.13"
 SCALA_VERSION: "2.13.18"
 SPARK_ISSUE_TRACKER_URL: https://issues.apache.org/jira/browse/SPARK
 SPARK_GITHUB_URL: https://github.com/apache/spark
-# Before a new release, we should:
-#   1. update the `version` array for the new Spark documentation
-#      on https://github.com/algolia/docsearch-configs/blob/master/configs/apache_spark.json.
-#   2. update the value of `facetFilters.version` in `algoliaOptions` on the new release branch.
-# Otherwise, after release, the search results are always based on the latest documentation
-# (https://spark.apache.org/docs/latest/) even when visiting the documentation of previous releases.
+# The DocSearch index is maintained by the Algolia crawler at https://crawler.algolia.com/.
+# The crawler indexes only https://spark.apache.org/docs/latest/ and tags every page with
+# `version:latest`. All release branches share this single index, so `facetFilters` stays
+# pinned to `version:latest` everywhere and no per-release update is required.
 DOCSEARCH_SCRIPT: |
   docsearch({
       apiKey: 'd62f962a82bc9abb53471cb7b89da35e',


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Stop `dev/create-release/release-tag.sh` from rewriting `'facetFilters'` in `docs/_config.yml` at release-cut and post-release-bump time. The line stays pinned to `"version:latest"` on every branch going forward.
- Refresh the stale comment in `docs/_config.yml` to point at https://crawler.algolia.com/ instead of the legacy DocSearch v1 config repo.

### Why are the changes needed?

We are moving DocSearch to a single shared index built from https://spark.apache.org/docs/latest/, used by every release. With a shared index, all branches should pin `facetFilters` to `"version:latest"`, so the per-release rewrite in the release script is no longer needed.

The crawler-side change is being made separately on https://crawler.algolia.com/.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A - documentation config and release-script change only.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)