### PR TITLE
[SPARK-57036][SQL] Use intrinsic bulk-fill APIs for constant-value WritableColumnVector methods

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
@@ -298,9 +298,7 @@ public final class VectorizedRleValuesReader extends ValuesReader
         } while (currentBufferIdx < bufEnd
             && currentBuffer[currentBufferIdx] != maxDefLevel);
         int runLen = currentBufferIdx - runStart;
-        for (int k = 0; k < runLen; k++) {
-          nulls.putNull(valueOff + k);
-        }
+        nulls.putNulls(valueOff, runLen);
         valueOff += runLen;
       }
     }
@@ -714,14 +712,10 @@ public final class VectorizedRleValuesReader extends ValuesReader
           updater.readValues(runLen, valueOff, values, valueReader);
         }
       } else {
-        for (int k = 0; k < runLen; k++) {
-          nulls.putNull(valueOff + k);
-        }
+        nulls.putNulls(valueOff, runLen);
       }
       valueOff += runLen;
-      for (int k = 0; k < runLen; k++) {
-        defLevels.putInt(levelIdx + k, runValue);
-      }
+      defLevels.putInts(levelIdx, runLen, runValue);
       levelIdx += runLen;
     }
     state.valueOffset = valueOff;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -33,12 +33,12 @@ public final class OffHeapColumnVector extends WritableColumnVector {
   private static final boolean bigEndianPlatform =
     ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN);
 
-  // Below this count, putNulls writes bytes in an inline loop. At or above this count, it
-  // calls Platform.setMemory which lowers to a native memset. The JNI fixed cost of
-  // setMemory dominates for very short fills; on the benchmarked hardware (Apple M4 Max +
-  // OpenJDK 21) the crossover sits between 64 and 512, so 128 is a conservative choice
-  // that avoids regression at small counts (common for random null patterns where RLE
-  // runs are short) while retaining the bulk of the asymptotic gain.
+  // Below this count, byte-fill methods (putBytes / putBooleans / putNulls) write bytes in
+  // an inline loop. At or above this count, they call Platform.setMemory which lowers to a
+  // native memset. The JNI fixed cost of setMemory dominates for very short fills; on the
+  // benchmarked hardware (Apple M4 Max + OpenJDK 21) the crossover sits between 64 and
+  // 512, so 128 is a conservative choice that avoids regression at small counts while
+  // retaining the bulk of the asymptotic gain.
   private static final int SET_MEMORY_THRESHOLD = 128;
 
   /**
@@ -163,9 +163,13 @@ public final class OffHeapColumnVector extends WritableColumnVector {
 
   @Override
   public void putBooleans(int rowId, int count, boolean value) {
-    byte v = (byte)((value) ? 1 : 0);
-    for (int i = 0; i < count; ++i) {
-      Platform.putByte(null, data + rowId + i, v);
+    byte v = (byte) (value ? 1 : 0);
+    if (count < SET_MEMORY_THRESHOLD) {
+      for (int i = 0; i < count; ++i) {
+        Platform.putByte(null, data + rowId + i, v);
+      }
+    } else {
+      Platform.setMemory(data + rowId, v, count);
     }
   }
 
@@ -205,8 +209,12 @@ public final class OffHeapColumnVector extends WritableColumnVector {
 
   @Override
   public void putBytes(int rowId, int count, byte value) {
-    for (int i = 0; i < count; ++i) {
-      Platform.putByte(null, data + rowId + i, value);
+    if (count < SET_MEMORY_THRESHOLD) {
+      for (int i = 0; i < count; ++i) {
+        Platform.putByte(null, data + rowId + i, value);
+      }
+    } else {
+      Platform.setMemory(data + rowId, value, count);
     }
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -33,6 +33,14 @@ public final class OffHeapColumnVector extends WritableColumnVector {
   private static final boolean bigEndianPlatform =
     ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN);
 
+  // Below this count, putNulls writes bytes in an inline loop. At or above this count, it
+  // calls Platform.setMemory which lowers to a native memset. The JNI fixed cost of
+  // setMemory dominates for very short fills; on the benchmarked hardware (Apple M4 Max +
+  // OpenJDK 21) the crossover sits between 64 and 512, so 128 is a conservative choice
+  // that avoids regression at small counts (common for random null patterns where RLE
+  // runs are short) while retaining the bulk of the asymptotic gain.
+  private static final int SET_MEMORY_THRESHOLD = 128;
+
   /**
    * Allocates columns to store elements of each field of the schema off heap.
    * Capacity is the initial capacity of the vector and it will grow as necessary. Capacity is
@@ -119,9 +127,13 @@ public final class OffHeapColumnVector extends WritableColumnVector {
   @Override
   public void putNulls(int rowId, int count) {
     if (isAllNull()) return; // Skip writing nulls to all-null vector.
-    long offset = nulls + rowId;
-    for (int i = 0; i < count; ++i, ++offset) {
-      Platform.putByte(null, offset, (byte) 1);
+    if (count < SET_MEMORY_THRESHOLD) {
+      long offset = nulls + rowId;
+      for (int i = 0; i < count; ++i, ++offset) {
+        Platform.putByte(null, offset, (byte) 1);
+      }
+    } else {
+      Platform.setMemory(nulls + rowId, (byte) 1, count);
     }
     numNulls += count;
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -116,9 +116,7 @@ public final class OnHeapColumnVector extends WritableColumnVector {
   @Override
   public void putNulls(int rowId, int count) {
     if (isAllNull()) return; // Skip writing nulls to all-null vector.
-    for (int i = 0; i < count; ++i) {
-      nulls[rowId + i] = (byte)1;
-    }
+    java.util.Arrays.fill(nulls, rowId, rowId + count, (byte) 1);
     numNulls += count;
   }
 
@@ -319,9 +317,7 @@ public final class OnHeapColumnVector extends WritableColumnVector {
 
   @Override
   public void putInts(int rowId, int count, int value) {
-    for (int i = 0; i < count; ++i) {
-      intData[i + rowId] = value;
-    }
+    java.util.Arrays.fill(intData, rowId, rowId + count, value);
   }
 
   @Override

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -144,10 +144,8 @@ public final class OnHeapColumnVector extends WritableColumnVector {
 
   @Override
   public void putBooleans(int rowId, int count, boolean value) {
-    byte v = (byte)((value) ? 1 : 0);
-    for (int i = 0; i < count; ++i) {
-      byteData[i + rowId] = v;
-    }
+    byte v = (byte) (value ? 1 : 0);
+    java.util.Arrays.fill(byteData, rowId, rowId + count, v);
   }
 
   @Override
@@ -189,9 +187,7 @@ public final class OnHeapColumnVector extends WritableColumnVector {
 
   @Override
   public void putBytes(int rowId, int count, byte value) {
-    for (int i = 0; i < count; ++i) {
-      byteData[i + rowId] = value;
-    }
+    java.util.Arrays.fill(byteData, rowId, rowId + count, value);
   }
 
   @Override
@@ -251,9 +247,7 @@ public final class OnHeapColumnVector extends WritableColumnVector {
 
   @Override
   public void putShorts(int rowId, int count, short value) {
-    for (int i = 0; i < count; ++i) {
-      shortData[i + rowId] = value;
-    }
+    java.util.Arrays.fill(shortData, rowId, rowId + count, value);
   }
 
   @Override
@@ -391,9 +385,7 @@ public final class OnHeapColumnVector extends WritableColumnVector {
 
   @Override
   public void putLongs(int rowId, int count, long value) {
-    for (int i = 0; i < count; ++i) {
-      longData[i + rowId] = value;
-    }
+    java.util.Arrays.fill(longData, rowId, rowId + count, value);
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to #56072 (SPARK-57024). That PR fixed the degenerate
per-element loops in three bulk-fill methods (`OnHeap.putNulls`,
`OnHeap.putInts(rowId, count, value)`, `OffHeap.putNulls`). The same
pattern exists in six sibling methods; this PR applies the same
intrinsic substitutions:

| Method | Substitution |
| --- | --- |
| `OnHeapColumnVector.putBooleans(rowId, count, value)` | `Arrays.fill(byte[], ..., (byte) v)` |
| `OnHeapColumnVector.putBytes(rowId, count, value)` | `Arrays.fill(byte[], ...)` |
| `OnHeapColumnVector.putShorts(rowId, count, value)` | `Arrays.fill(short[], ...)` |
| `OnHeapColumnVector.putLongs(rowId, count, value)` | `Arrays.fill(long[], ...)` |
| `OffHeapColumnVector.putBooleans(rowId, count, value)` | `Platform.setMemory` with `SET_MEMORY_THRESHOLD` fallback |
| `OffHeapColumnVector.putBytes(rowId, count, value)` | `Platform.setMemory` with `SET_MEMORY_THRESHOLD` fallback |

The two OffHeap methods reuse the `SET_MEMORY_THRESHOLD = 128` constant
introduced in #56072 for `OffHeap.putNulls`. Below the threshold, an
inline byte loop avoids the JNI fixed cost of `Unsafe.setMemory`; at or
above, `setMemory` dominates and the gain accelerates up to ~10x at
`count >= 4096`.

This PR is based on top of #56072 since the threshold constant is
defined there. If #56072 lands first, this PR rebases cleanly onto
master.

### Why are the changes needed?

The bulk-fill APIs on `WritableColumnVector` are the natural call to
make from any column writer, but their implementations were per-element
loops. Switching to intrinsics:

- `Arrays.fill` is backed by HotSpot's `_jbyte_fill` / `_jshort_fill` /
  `_jlong_fill` intrinsic stubs; on byte/short arrays C2 can usually
  auto-vectorize the original loop and gains are modest, but for
  `long[]` and at small counts the intrinsic is meaningfully faster.
- `Unsafe.setMemory` lowers to a native memset. For OffHeap byte fills
  this is dramatic at large counts because the original per-byte
  `Platform.putByte` loop cannot be vectorized through the JNI call.

Measured on Apple M4 Max + OpenJDK 21.0.8, using a new
`WritableColumnVectorBulkFillBenchmark` (added in a separate change,
not part of this PR), Rate (M elements/s):

**OffHeap byte fills (putBytes / putBooleans)**, threshold path:

| count   | baseline | patched | delta |
| ------: | -------: | ------: | ----- |
| 8       | ~1,900   | ~1,840  | parity (small-count fallback) |
| 64      | ~3,800   | ~3,760  | parity |
| 512     | ~4,150   | ~13,100 | +3.2x |
| 4,096   | ~4,340   | ~31,900 | +7.4x |
| 65,536  | ~4,275   | ~43,700 | +10.2x |

**OnHeap byte fills**:

| count   | baseline | patched | delta |
| ------: | -------: | ------: | ----- |
| 8       | ~2,620   | ~3,230  | +23%  |
| 64      | ~19,000  | ~25,400 | +33%  |
| 512     | ~68,800  | ~86,200 | +25%  |
| 4,096   | ~128,400 | ~133,300| +4%   |
| 65,536  | ~143,200 | ~143,600| saturated (byte memory bandwidth) |

**OnHeap longs**: +1-14% in the small/medium range, saturated by
memory bandwidth at large counts. Included for consistency with the
byte methods.

OffHeap multi-byte fills (putShorts / putInts / putLongs / putFloats /
putDoubles) are out of scope: `Platform.setMemory` is byte-only and the
value=0 short-circuit alternative was prototyped under SPARK-57024 and
showed no measurable gain.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests; no behavior change. Ran locally on top of #56072:

- `VectorizedRleValuesReaderSuite`
- `ColumnVectorSuite`
- `ColumnarBatchSuite`
- `ParquetIOSuite`

237 tests, all pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.7)
