### PR TITLE
[SPARK-56739][SQL] Normalize CTE ids of orphan CTERelationRef in NormalizeCTEIds

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/normalizer/NormalizeCTEIds.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/normalizer/NormalizeCTEIds.scala
@@ -35,18 +35,33 @@ object NormalizeCTEIds extends Rule[LogicalPlan] {
       plan: LogicalPlan,
       curId: AtomicLong,
       cteIdToNewId: mutable.Map[Long, Long]): LogicalPlan = {
-    plan transformDownWithSubqueries {
+    val newIdValues = mutable.Set.empty[Long]
+    val normalized = plan transformDownWithSubqueries {
       case ctas @ CacheTableAsSelect(_, plan, _, _, _, _, _) =>
         ctas.copy(plan = applyInternal(plan, curId, cteIdToNewId))
 
       case withCTE @ WithCTE(plan, cteDefs) =>
         val newCteDefs = cteDefs.map { cteDef =>
           cteIdToNewId.getOrElseUpdate(cteDef.id, curId.getAndIncrement())
+          newIdValues += cteIdToNewId(cteDef.id)
           val normalizedCteDef = canonicalizeCTE(cteDef.child, cteIdToNewId)
           cteDef.copy(child = normalizedCteDef, id = cteIdToNewId(cteDef.id))
         }
         val normalizedPlan = canonicalizeCTE(plan, cteIdToNewId)
         withCTE.copy(plan = normalizedPlan, cteDefs = newCteDefs)
+    }
+    // SPARK-56739: Second pass to normalize orphan CTERelationRefs that exist outside any
+    // WithCTE node (e.g., after InlineCTE or MergeSubplans removes the parent WithCTE).
+    // Skip refs whose cteId is already a normalized value (to avoid double-normalization
+    // when original IDs and new IDs overlap).
+    if (cteIdToNewId.nonEmpty) {
+      normalized.transformDownWithSubqueries {
+        case ref: CTERelationRef
+            if cteIdToNewId.contains(ref.cteId) && !newIdValues.contains(ref.cteId) =>
+          ref.copy(cteId = cteIdToNewId(ref.cteId))
+      }
+    } else {
+      normalized
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/normalizer/NormalizeCTEIdsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/normalizer/NormalizeCTEIdsSuite.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.normalizer
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.{CTERelationDef, CTERelationRef, LocalRelation, Union, WithCTE}
+import org.apache.spark.sql.types.IntegerType
+
+class NormalizeCTEIdsSuite extends SparkFunSuite {
+  test("SPARK-56739: orphan CTERelationRef outside WithCTE should be normalized") {
+    val attr = AttributeReference("id", IntegerType)()
+    val relation = LocalRelation(attr)
+
+    // CTE def with a high ID (simulates real usage where IDs are large)
+    val cteDef = CTERelationDef(relation, id = 100L)
+
+    // WithCTE with a ref inside
+    val innerRef = CTERelationRef(100L, _resolved = true, output = Seq(attr), isStreaming = false)
+    val withCTE = WithCTE(innerRef, Seq(cteDef))
+
+    // Orphan ref OUTSIDE the WithCTE (simulates post-InlineCTE/MergeSubplans state)
+    val orphanRef = CTERelationRef(100L, _resolved = true, output = Seq(attr), isStreaming = false)
+
+    // Plan: Union of WithCTE and orphan ref
+    val plan = Union(Seq(withCTE, orphanRef))
+
+    val normalized = NormalizeCTEIds(plan)
+
+    // Collect all CTERelationRef IDs in the normalized plan
+    val refIds = normalized.collect {
+      case ref: CTERelationRef => ref.cteId
+    }
+
+    // The ref inside WithCTE gets normalized to 0. The orphan should also be 0.
+    assert(refIds.nonEmpty, "Should have CTERelationRefs in the plan")
+    assert(refIds.forall(_ == 0L),
+      s"All CTERelationRef IDs should be normalized to 0 but got: $refIds")
+  }
+}


### PR DESCRIPTION

### What changes were proposed in this pull request?
Normalize CTE IDs of orphan `CTERelationRef` nodes in `NormalizeCTEIds`. Previously, only `CTERelationRef` nodes inside `WithCTE` were normalized via `canonicalizeCTE`. Refs that exist outside any `WithCTE` (orphans) kept their original IDs.

### Why are the changes needed?
After `InlineCTE` or `MergeSubplans` runs, some `CTERelationRef` nodes can end up outside their parent `WithCTE` node. When `NormalizeCTEIds` processes the plan, these orphan refs are skipped, leaving non-normalized IDs. This breaks plan comparison and caching because the same logical plan gets different CTE IDs across sessions (since `CTERelationDef` uses a global monotonically increasing counter).


### Does this PR introduce _any_ user-facing change?
No. This is an internal plan normalization fix that affects plan caching correctness.


### How was this patch tested?
Added `NormalizeCTEIdsSuite` with a test that constructs a plan with a `CTERelationRef` outside `WithCTE` and verifies all ref IDs are normalized. Without the fix, the orphan ref retains its original ID (100); with the fix, it's normalized to 0.

### Was this patch authored or co-authored using generative AI tooling?
Yes.
