### PR TITLE
[SPARK-57037][CORE][TESTS] Force GC before allocating large array in SorterSuite to fix flaky OOM

### DIFF
--- a/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ContextCleanerSuite.scala
@@ -17,9 +17,6 @@
 
 package org.apache.spark
 
-import java.lang.ref.WeakReference
-import java.util.concurrent.TimeUnit
-
 import scala.collection.mutable.HashSet
 import scala.util.Random
 
@@ -94,18 +91,6 @@ abstract class ContextCleanerSuiteBase(val shuffleManager: Class[_] = classOf[So
     if (Random.nextBoolean()) rdd.persist()
     rdd.count()
     rdd
-  }
-
-  /** Run GC and make sure it actually has run */
-  protected def runGC(): Unit = {
-    val weakRef = new WeakReference(new Object())
-    val startTimeNs = System.nanoTime()
-    System.gc() // Make a best effort to run the garbage collection. It *usually* runs GC.
-    // Wait until a weak reference object has been GCed
-    while (System.nanoTime() - startTimeNs < TimeUnit.SECONDS.toNanos(10) && weakRef.get != null) {
-      System.gc()
-      Thread.sleep(200)
-    }
   }
 
   protected def cleaner = sc.cleaner.get

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark
 
+import java.lang.ref.WeakReference
+import java.util.concurrent.TimeUnit
+
 import scala.annotation.tailrec
 
 import org.scalactic.source.Position
@@ -95,6 +98,28 @@ abstract class SparkFunSuite
     testFun: A => Unit): Unit = {
     for (param <- params) {
       test(testNamePrefix + s" ${param._1}", testTags: _*)(testFun(param._2))
+    }
+  }
+
+  /** Run GC and make sure it actually has run. */
+  protected def runGC(): Unit = {
+    val weakRef = new WeakReference(new Object())
+    val startTimeNs = System.nanoTime()
+    System.gc() // Make a best effort to run the garbage collection. It *usually* runs GC.
+    // Wait until a weak reference object has been GCed
+    while (System.nanoTime() - startTimeNs < TimeUnit.SECONDS.toNanos(10) && weakRef.get != null) {
+      System.gc()
+      Thread.sleep(200)
+    }
+  }
+
+  /** Run `body`; if it throws OutOfMemoryError, force a GC and retry once. */
+  protected def retryOnOOM[T](body: => T): T = {
+    try body
+    catch {
+      case _: OutOfMemoryError =>
+        runGC()
+        body
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
@@ -17,25 +17,12 @@
 
 package org.apache.spark.util.collection
 
-import java.lang.ref.WeakReference
 import java.util.Arrays
-import java.util.concurrent.TimeUnit
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.util.random.XORShiftRandom
 
 class SorterSuite extends SparkFunSuite {
-
-  /** Run GC and wait until it has actually run, to free memory used by prior tests. */
-  private def runGC(): Unit = {
-    val weakRef = new WeakReference(new Object())
-    val startTimeNs = System.nanoTime()
-    System.gc()
-    while (System.nanoTime() - startTimeNs < TimeUnit.SECONDS.toNanos(10) && weakRef.get != null) {
-      System.gc()
-      Thread.sleep(200)
-    }
-  }
 
   test("equivalent to Arrays.sort") {
     val rand = new XORShiftRandom(123)
@@ -152,16 +139,10 @@ class SorterSuite extends SparkFunSuite {
       21, 20, 22, 18, 452, 114, 95, 18, 17, 21, 36, 18, 17, 115, 76, 144, 44, 38, 61,20, 19, 21, 17)
     // scalastyle:on
     val arrayToSortSize = 1091482190
-    // Retry once after forcing GC: memory held by the previous test (e.g. the ~256 MB
-    // int array in "SPARK-5984 TimSort bug") may not be reclaimed before this >1 GB
-    // allocation, causing flaky OOM in CI.
-    val arrayToSort = try {
-      new Array[Byte](arrayToSortSize)
-    } catch {
-      case _: OutOfMemoryError =>
-        runGC()
-        new Array[Byte](arrayToSortSize)
-    }
+    // Memory held by the previous test (e.g. the ~256 MB int array in "SPARK-5984
+    // TimSort bug") may not be reclaimed before this >1 GB allocation, causing flaky
+    // OOM in CI. Force a GC and retry once on OOM.
+    val arrayToSort = retryOnOOM(new Array[Byte](arrayToSortSize))
     var sum: Int = -1
     for (i <- runLengths) {
       sum += i

--- a/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/SorterSuite.scala
@@ -17,12 +17,25 @@
 
 package org.apache.spark.util.collection
 
+import java.lang.ref.WeakReference
 import java.util.Arrays
+import java.util.concurrent.TimeUnit
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.util.random.XORShiftRandom
 
 class SorterSuite extends SparkFunSuite {
+
+  /** Run GC and wait until it has actually run, to free memory used by prior tests. */
+  private def runGC(): Unit = {
+    val weakRef = new WeakReference(new Object())
+    val startTimeNs = System.nanoTime()
+    System.gc()
+    while (System.nanoTime() - startTimeNs < TimeUnit.SECONDS.toNanos(10) && weakRef.get != null) {
+      System.gc()
+      Thread.sleep(200)
+    }
+  }
 
   test("equivalent to Arrays.sort") {
     val rand = new XORShiftRandom(123)
@@ -71,7 +84,6 @@ class SorterSuite extends SparkFunSuite {
   }
 
   test("java.lang.ArrayIndexOutOfBoundsException in TimSort") {
-    System.gc()
     // scalastyle:off
     val runLengths = Array(76405736, 74830360, 1181532, 787688, 1575376, 2363064, 3938440, 6301504,
       1181532, 393844, 15753760, 1575376, 787688, 393844, 1969220, 3150752, 1181532,787688, 5513816, 3938440,
@@ -140,7 +152,16 @@ class SorterSuite extends SparkFunSuite {
       21, 20, 22, 18, 452, 114, 95, 18, 17, 21, 36, 18, 17, 115, 76, 144, 44, 38, 61,20, 19, 21, 17)
     // scalastyle:on
     val arrayToSortSize = 1091482190
-    val arrayToSort = new Array[Byte](arrayToSortSize)
+    // Retry once after forcing GC: memory held by the previous test (e.g. the ~256 MB
+    // int array in "SPARK-5984 TimSort bug") may not be reclaimed before this >1 GB
+    // allocation, causing flaky OOM in CI.
+    val arrayToSort = try {
+      new Array[Byte](arrayToSortSize)
+    } catch {
+      case _: OutOfMemoryError =>
+        runGC()
+        new Array[Byte](arrayToSortSize)
+    }
     var sum: Int = -1
     for (i <- runLengths) {
       sum += i


### PR DESCRIPTION
### What changes were proposed in this pull request?

`SorterSuite`'s `"java.lang.ArrayIndexOutOfBoundsException in TimSort"` test allocates a ~1 GB byte array. Previously this test called `System.gc()` unconditionally before the allocation, but `System.gc()` is only a hint and may not actually run before the next allocation.

This PR:

- Lifts `runGC()` (a `WeakReference` busy-wait that ensures GC has actually run) from `ContextCleanerSuiteBase` to `SparkFunSuite`, so all test suites can reuse it. `ContextCleanerSuite`'s callers now inherit the same method.
- Adds a `retryOnOOM[T](body: => T): T` helper on `SparkFunSuite` that runs `body` and, if it throws `OutOfMemoryError`, calls `runGC()` and retries once.
- In `SorterSuite`, replaces the unconditional `System.gc()` call before the allocation with `retryOnOOM(new Array[Byte](arrayToSortSize))`, so the GC only fires on the slow path.

### Why are the changes needed?

The test is flaky in CI with `java.lang.OutOfMemoryError: Java heap space`. The preceding test `"SPARK-5984 TimSort bug"` allocates a ~256 MB int array, which may not be reclaimed before this test's >1 GB allocation if GC has not actually run.

Example failed job: https://github.com/gengliangwang/spark/actions/runs/26343824415/job/77552562041

A previous fix (`0390e4b44aa`) added `System.gc()` before the allocation, but that is only a hint and does not guarantee GC has run. Forcing the GC only on the failure path also avoids paying the cost on the happy path.

### Does this PR introduce _any_ user-facing change?

No. Test-only change.

### How was this patch tested?

Monitor CI stability.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code