### PR TITLE
[SPARK-51377][DOCS] Fix PYTHONPATH shell command in PySpark installation docs

### DIFF
--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -188,7 +188,7 @@ One example of doing this is shown below:
 
     cd spark-\ |release|\-bin-hadoop3
     export SPARK_HOME=`pwd`
-    export PYTHONPATH=$(ZIPS=("$SPARK_HOME"/python/lib/*.zip); IFS=:; echo "${ZIPS[*]}"):$PYTHONPATH
+    export PYTHONPATH=$(ZIPS=("$SPARK_HOME"/python/lib/*.zip); IFS=":"; echo "${ZIPS[*]}"):$PYTHONPATH
 
 
 Installing from Source


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a shell syntax issue in the PySpark installation documentation. The `IFS` delimiter in the `PYTHONPATH` export command was not quoted, which can cause unexpected behavior in certain shell environments.

**Before:**
```bash
export PYTHONPATH=$(ZIPS=("$SPARK_HOME"/python/lib/*.zip); IFS=:; echo "${ZIPS[*]}"):$PYTHONPATH
```

**After:**
```bash
export PYTHONPATH=$(ZIPS=("$SPARK_HOME"/python/lib/*.zip); IFS=":"; echo "${ZIPS[*]}"):$PYTHONPATH
```

### Why are the changes needed?

As reported in [SPARK-51377](https://issues.apache.org/jira/browse/SPARK-51377), the unquoted `IFS=:` can lead to inconsistent behavior. Quoting the delimiter (`IFS=":"`) ensures proper shell behavior across different environments (bash, zsh, etc.).

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only change.

### How was this patch tested?

Manually verified the corrected command works in both bash and zsh shells.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-5-20251101)

This pull request and its description were written by Isaac.