### PR TITLE
[SPARK-57052][SS] Add state row format validation to multiGet in RocksDBStateStoreProvider

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -276,7 +276,15 @@ private[sql] class RocksDBStateStoreProvider
       val kvEncoder = keyValueEncoderMap.get(colFamilyName)
       val encodedKeys = keys.map(kvEncoder._1.encodeKey)
       val encodedValues = rocksDB.multiGet(encodedKeys, colFamilyName)
-      encodedValues.map(kvEncoder._2.decodeValue)
+      encodedValues.zipWithIndex.map { case (encoded, idx) =>
+        val value = kvEncoder._2.decodeValue(encoded)
+        if (!isValidated && value != null && !useColumnFamilies) {
+          StateStoreProvider.validateStateRowFormat(
+            keys(idx), keySchema, value, valueSchema, stateStoreId, storeConf)
+          isValidated = true
+        }
+        value
+      }
     }
 
     override def keyExists(key: UnsafeRow, colFamilyName: String): Boolean = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -1938,6 +1938,43 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     }
   }
 
+  test("SPARK-57052: multiGet triggers validateStateRowFormat on schema mismatch") {
+    val storeId = StateStoreId(newDir(), Random.nextInt(), 0)
+    val conf = new Configuration
+    conf.set(StreamExecution.RUN_ID_KEY, UUID.randomUUID().toString)
+
+    // Step 1: Write data with correct schema and commit
+    val provider1 = new RocksDBStateStoreProvider()
+    provider1.init(storeId, keySchema, valueSchema,
+      NoPrefixKeyStateEncoderSpec(keySchema), useColumnFamilies = false,
+      new StateStoreConf(SQLConf.get), conf, useMultipleValuesPerKey = false,
+      stateSchemaProvider = Some(new TestStateSchemaProvider))
+    val store1 = provider1.getStore(0)
+    store1.put(dataToKeyRow("a", 1), dataToValueRow(1))
+    store1.put(dataToKeyRow("b", 2), dataToValueRow(2))
+    store1.commit()
+    provider1.close()
+
+    // Step 2: Reopen with a wrong valueSchema (StringType instead of IntegerType)
+    val wrongValueSchema = StructType(Seq(StructField("v1", StringType, true)))
+    val provider2 = new RocksDBStateStoreProvider()
+    provider2.init(storeId, keySchema, wrongValueSchema,
+      NoPrefixKeyStateEncoderSpec(keySchema), useColumnFamilies = false,
+      new StateStoreConf(SQLConf.get), conf, useMultipleValuesPerKey = false,
+      stateSchemaProvider = Some(new TestStateSchemaProvider))
+    val store2 = provider2.getStore(1)
+    try {
+      intercept[StateStoreValueRowFormatValidationFailure] {
+        store2.multiGet(
+          Array(dataToKeyRow("a", 1), dataToKeyRow("b", 2)),
+          StateStore.DEFAULT_COL_FAMILY_NAME).toSeq
+      }
+    } finally {
+      store2.abort()
+      provider2.close()
+    }
+  }
+
   testWithColumnFamiliesAndEncodingTypes(
     "rocksdb key and value schema encoders for column families",
     TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `validateStateRowFormat` to `multiGet()` in `RocksDBStateStoreProvider`, consistent with existing validation in `get()`, `iterator()`, `prefixScan()`, and `rangeScan()`.

### Why are the changes needed?

`multiGet()` decodes values via `kvEncoder._2.decodeValue` but never calls `validateStateRowFormat`. If a stateful operator evolves its schema between restarts, `multiGet()` will silently return corrupted data instead of failing fast with `StateStoreValueRowFormatValidationFailure`.

All other read-path methods that decode rows already perform this validation. `multiGet()` is the only inconsistency:

| Method | Decodes rows? | Has validation? |
|--------|:---:|:---:|
| `get()` | Yes | Yes |
| `iterator()` | Yes | Yes |
| `prefixScan()` | Yes | Yes (SPARK-56539) |
| `rangeScan()` | Yes | Yes (SPARK-56539) |
| `multiGet()` | Yes | (this PR) |

### Does this PR introduce _any_ user-facing change?

No. The validation is gated behind the existing `spark.sql.streaming.stateStore.formatValidation.enabled` config (default: true in testing mode).

### How was this patch tested?

Added test in `RocksDBStateStoreSuite` that writes data with one schema, reopens with a mismatched schema, and verifies `multiGet()` throws `StateStoreValueRowFormatValidationFailure`. The test follows the same pattern as the existing SPARK-56539 tests for `prefixScan` and `rangeScan`.

- Without fix: `multiGet()` silently returns corrupted rows
- With fix: `StateStoreValueRowFormatValidationFailure` thrown on first decoded value

### Was this patch authored or co-authored using generative AI tooling?

Generated by: Claude Opus 4.7