### PR TITLE
[SPARK-57065][PYTHON][TESTS] Add with_sql_conf decorator in SQLTestUtils

### DIFF
--- a/python/pyspark/sql/tests/connect/arrow/test_parity_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/connect/arrow/test_parity_arrow_python_udf.py
@@ -19,35 +19,16 @@ import unittest
 
 from pyspark.sql.tests.connect.test_parity_udf import UDFParityTests
 from pyspark.sql.tests.arrow.test_arrow_python_udf import ArrowPythonUDFTestsMixin
+from pyspark.testing.sqlutils import with_class_conf
 
 
+@with_class_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
 class ArrowPythonUDFParityTests(UDFParityTests, ArrowPythonUDFTestsMixin):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.spark.conf.set("spark.sql.execution.pythonUDF.arrow.enabled", "true")
-
-    @classmethod
-    def tearDownClass(cls):
-        try:
-            cls.spark.conf.unset("spark.sql.execution.pythonUDF.arrow.enabled")
-        finally:
-            super().tearDownClass()
+    pass
 
 
+@with_class_conf({"spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled": "true"})
 class ArrowPythonUDFParityLegacyTestsMixin(ArrowPythonUDFTestsMixin):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.spark.conf.set("spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled", "true")
-
-    @classmethod
-    def tearDownClass(cls):
-        try:
-            cls.spark.conf.unset("spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled")
-        finally:
-            super().tearDownClass()
-
     @unittest.skip("Duplicate test as it is already tested in ArrowPythonUDFLegacyTests.")
     def test_udf_binary_type(self):
         super().test_udf_binary_type(self)
@@ -57,21 +38,8 @@ class ArrowPythonUDFParityLegacyTestsMixin(ArrowPythonUDFTestsMixin):
         super().test_udf_binary_type_in_nested_structures(self)
 
 
+@with_class_conf({"spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled": "false"})
 class ArrowPythonUDFParityNonLegacyTestsMixin(ArrowPythonUDFTestsMixin):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.spark.conf.set(
-            "spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled", "false"
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        try:
-            cls.spark.conf.unset("spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled")
-        finally:
-            super().tearDownClass()
-
     @unittest.skip("Duplicate test as it is already tested in ArrowPythonUDFNonLegacyTests.")
     def test_udf_binary_type(self):
         super().test_udf_binary_type(self)
@@ -81,32 +49,14 @@ class ArrowPythonUDFParityNonLegacyTestsMixin(ArrowPythonUDFTestsMixin):
         super().test_udf_binary_type_in_nested_structures(self)
 
 
+@with_class_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
 class ArrowPythonUDFParityLegacyTests(UDFParityTests, ArrowPythonUDFParityLegacyTestsMixin):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.spark.conf.set("spark.sql.execution.pythonUDF.arrow.enabled", "true")
-
-    @classmethod
-    def tearDownClass(cls):
-        try:
-            cls.spark.conf.unset("spark.sql.execution.pythonUDF.arrow.enabled")
-        finally:
-            super().tearDownClass()
+    pass
 
 
+@with_class_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
 class ArrowPythonUDFParityNonLegacyTests(UDFParityTests, ArrowPythonUDFParityNonLegacyTestsMixin):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.spark.conf.set("spark.sql.execution.pythonUDF.arrow.enabled", "true")
-
-    @classmethod
-    def tearDownClass(cls):
-        try:
-            cls.spark.conf.unset("spark.sql.execution.pythonUDF.arrow.enabled")
-        finally:
-            super().tearDownClass()
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/arrow/test_parity_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/connect/arrow/test_parity_arrow_python_udf.py
@@ -19,15 +19,17 @@ import unittest
 
 from pyspark.sql.tests.connect.test_parity_udf import UDFParityTests
 from pyspark.sql.tests.arrow.test_arrow_python_udf import ArrowPythonUDFTestsMixin
-from pyspark.testing.sqlutils import with_class_conf
+from pyspark.testing.sqlutils import SQLTestUtils
 
 
-@with_class_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
+@SQLTestUtils.with_sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
 class ArrowPythonUDFParityTests(UDFParityTests, ArrowPythonUDFTestsMixin):
     pass
 
 
-@with_class_conf({"spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled": "true"})
+@SQLTestUtils.with_sql_conf(
+    {"spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled": "true"}
+)
 class ArrowPythonUDFParityLegacyTestsMixin(ArrowPythonUDFTestsMixin):
     @unittest.skip("Duplicate test as it is already tested in ArrowPythonUDFLegacyTests.")
     def test_udf_binary_type(self):
@@ -38,7 +40,9 @@ class ArrowPythonUDFParityLegacyTestsMixin(ArrowPythonUDFTestsMixin):
         super().test_udf_binary_type_in_nested_structures(self)
 
 
-@with_class_conf({"spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled": "false"})
+@SQLTestUtils.with_sql_conf(
+    {"spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled": "false"}
+)
 class ArrowPythonUDFParityNonLegacyTestsMixin(ArrowPythonUDFTestsMixin):
     @unittest.skip("Duplicate test as it is already tested in ArrowPythonUDFNonLegacyTests.")
     def test_udf_binary_type(self):
@@ -49,12 +53,12 @@ class ArrowPythonUDFParityNonLegacyTestsMixin(ArrowPythonUDFTestsMixin):
         super().test_udf_binary_type_in_nested_structures(self)
 
 
-@with_class_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
+@SQLTestUtils.with_sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
 class ArrowPythonUDFParityLegacyTests(UDFParityTests, ArrowPythonUDFParityLegacyTestsMixin):
     pass
 
 
-@with_class_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
+@SQLTestUtils.with_sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
 class ArrowPythonUDFParityNonLegacyTests(UDFParityTests, ArrowPythonUDFParityNonLegacyTestsMixin):
     pass
 

--- a/python/pyspark/sql/tests/connect/arrow/test_parity_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/connect/arrow/test_parity_arrow_python_udf.py
@@ -19,9 +19,7 @@ import unittest
 
 from pyspark.sql.tests.connect.test_parity_udf import UDFParityTests
 from pyspark.sql.tests.arrow.test_arrow_python_udf import ArrowPythonUDFTestsMixin
-from pyspark.testing.sqlutils import SQLTestUtils
-
-with_sql_conf = SQLTestUtils.with_sql_conf
+from pyspark.testing.sqlutils import with_sql_conf
 
 
 @with_sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})

--- a/python/pyspark/sql/tests/connect/arrow/test_parity_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/connect/arrow/test_parity_arrow_python_udf.py
@@ -21,15 +21,15 @@ from pyspark.sql.tests.connect.test_parity_udf import UDFParityTests
 from pyspark.sql.tests.arrow.test_arrow_python_udf import ArrowPythonUDFTestsMixin
 from pyspark.testing.sqlutils import SQLTestUtils
 
+with_sql_conf = SQLTestUtils.with_sql_conf
 
-@SQLTestUtils.with_sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
+
+@with_sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
 class ArrowPythonUDFParityTests(UDFParityTests, ArrowPythonUDFTestsMixin):
     pass
 
 
-@SQLTestUtils.with_sql_conf(
-    {"spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled": "true"}
-)
+@with_sql_conf({"spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled": "true"})
 class ArrowPythonUDFParityLegacyTestsMixin(ArrowPythonUDFTestsMixin):
     @unittest.skip("Duplicate test as it is already tested in ArrowPythonUDFLegacyTests.")
     def test_udf_binary_type(self):
@@ -40,9 +40,7 @@ class ArrowPythonUDFParityLegacyTestsMixin(ArrowPythonUDFTestsMixin):
         super().test_udf_binary_type_in_nested_structures(self)
 
 
-@SQLTestUtils.with_sql_conf(
-    {"spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled": "false"}
-)
+@with_sql_conf({"spark.sql.legacy.execution.pythonUDF.pandas.conversion.enabled": "false"})
 class ArrowPythonUDFParityNonLegacyTestsMixin(ArrowPythonUDFTestsMixin):
     @unittest.skip("Duplicate test as it is already tested in ArrowPythonUDFNonLegacyTests.")
     def test_udf_binary_type(self):
@@ -53,12 +51,12 @@ class ArrowPythonUDFParityNonLegacyTestsMixin(ArrowPythonUDFTestsMixin):
         super().test_udf_binary_type_in_nested_structures(self)
 
 
-@SQLTestUtils.with_sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
+@with_sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
 class ArrowPythonUDFParityLegacyTests(UDFParityTests, ArrowPythonUDFParityLegacyTestsMixin):
     pass
 
 
-@SQLTestUtils.with_sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
+@with_sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
 class ArrowPythonUDFParityNonLegacyTests(UDFParityTests, ArrowPythonUDFParityNonLegacyTestsMixin):
     pass
 

--- a/python/pyspark/sql/tests/connect/test_parity_column.py
+++ b/python/pyspark/sql/tests/connect/test_parity_column.py
@@ -19,10 +19,10 @@ import unittest
 
 from pyspark.sql.tests.test_column import ColumnTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
-from pyspark.testing.sqlutils import with_class_conf
+from pyspark.testing.sqlutils import SQLTestUtils
 
 
-@with_class_conf({"spark.sql.analyzer.strictDataFrameColumnResolution": "true"})
+@SQLTestUtils.with_sql_conf({"spark.sql.analyzer.strictDataFrameColumnResolution": "true"})
 class ColumnParityTests(ColumnTestsMixin, ReusedConnectTestCase):
     @unittest.skip("Requires JVM access.")
     def test_validate_column_types(self):
@@ -35,7 +35,7 @@ class ColumnParityTests(ColumnTestsMixin, ReusedConnectTestCase):
         )
 
 
-@with_class_conf({"spark.sql.analyzer.strictDataFrameColumnResolution": "false"})
+@SQLTestUtils.with_sql_conf({"spark.sql.analyzer.strictDataFrameColumnResolution": "false"})
 class ColumnParityTestsWithNonStrictDFColResolution(ColumnParityTests):
     """Re-run the Column parity tests with
     `spark.sql.analyzer.strictDataFrameColumnResolution=false` to exercise the

--- a/python/pyspark/sql/tests/connect/test_parity_column.py
+++ b/python/pyspark/sql/tests/connect/test_parity_column.py
@@ -19,21 +19,11 @@ import unittest
 
 from pyspark.sql.tests.test_column import ColumnTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
+from pyspark.testing.sqlutils import with_class_conf
 
 
+@with_class_conf({"spark.sql.analyzer.strictDataFrameColumnResolution": "true"})
 class ColumnParityTests(ColumnTestsMixin, ReusedConnectTestCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.spark.conf.set("spark.sql.analyzer.strictDataFrameColumnResolution", "true")
-
-    @classmethod
-    def tearDownClass(cls):
-        try:
-            cls.spark.conf.unset("spark.sql.analyzer.strictDataFrameColumnResolution")
-        finally:
-            super().tearDownClass()
-
     @unittest.skip("Requires JVM access.")
     def test_validate_column_types(self):
         super().test_validate_column_types()
@@ -45,22 +35,11 @@ class ColumnParityTests(ColumnTestsMixin, ReusedConnectTestCase):
         )
 
 
+@with_class_conf({"spark.sql.analyzer.strictDataFrameColumnResolution": "false"})
 class ColumnParityTestsWithNonStrictDFColResolution(ColumnParityTests):
     """Re-run the Column parity tests with
     `spark.sql.analyzer.strictDataFrameColumnResolution=false` to exercise the
     name-based fallback path for tagged UnresolvedAttributes."""
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.spark.conf.set("spark.sql.analyzer.strictDataFrameColumnResolution", "false")
-
-    @classmethod
-    def tearDownClass(cls):
-        try:
-            cls.spark.conf.unset("spark.sql.analyzer.strictDataFrameColumnResolution")
-        finally:
-            super().tearDownClass()
 
     def test_df_col_resolution_mode(self):
         self.assertEqual(

--- a/python/pyspark/sql/tests/connect/test_parity_column.py
+++ b/python/pyspark/sql/tests/connect/test_parity_column.py
@@ -21,8 +21,10 @@ from pyspark.sql.tests.test_column import ColumnTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
+with_sql_conf = SQLTestUtils.with_sql_conf
 
-@SQLTestUtils.with_sql_conf({"spark.sql.analyzer.strictDataFrameColumnResolution": "true"})
+
+@with_sql_conf({"spark.sql.analyzer.strictDataFrameColumnResolution": "true"})
 class ColumnParityTests(ColumnTestsMixin, ReusedConnectTestCase):
     @unittest.skip("Requires JVM access.")
     def test_validate_column_types(self):
@@ -35,7 +37,7 @@ class ColumnParityTests(ColumnTestsMixin, ReusedConnectTestCase):
         )
 
 
-@SQLTestUtils.with_sql_conf({"spark.sql.analyzer.strictDataFrameColumnResolution": "false"})
+@with_sql_conf({"spark.sql.analyzer.strictDataFrameColumnResolution": "false"})
 class ColumnParityTestsWithNonStrictDFColResolution(ColumnParityTests):
     """Re-run the Column parity tests with
     `spark.sql.analyzer.strictDataFrameColumnResolution=false` to exercise the

--- a/python/pyspark/sql/tests/connect/test_parity_column.py
+++ b/python/pyspark/sql/tests/connect/test_parity_column.py
@@ -19,9 +19,7 @@ import unittest
 
 from pyspark.sql.tests.test_column import ColumnTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
-
-with_sql_conf = SQLTestUtils.with_sql_conf
+from pyspark.testing.sqlutils import with_sql_conf
 
 
 @with_sql_conf({"spark.sql.analyzer.strictDataFrameColumnResolution": "true"})

--- a/python/pyspark/sql/tests/connect/test_parity_udf_combinations.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udf_combinations.py
@@ -18,9 +18,7 @@
 
 from pyspark.sql.tests.test_udf_combinations import UDFCombinationsTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
-from pyspark.testing.sqlutils import SQLTestUtils
-
-with_sql_conf = SQLTestUtils.with_sql_conf
+from pyspark.testing.sqlutils import with_sql_conf
 
 
 @with_sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "false"})

--- a/python/pyspark/sql/tests/connect/test_parity_udf_combinations.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udf_combinations.py
@@ -18,13 +18,12 @@
 
 from pyspark.sql.tests.test_udf_combinations import UDFCombinationsTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
+from pyspark.testing.sqlutils import with_class_conf
 
 
+@with_class_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "false"})
 class UDFCombinationsParityTests(UDFCombinationsTestsMixin, ReusedConnectTestCase):
-    @classmethod
-    def setUpClass(cls):
-        ReusedConnectTestCase.setUpClass()
-        cls.spark.conf.set("spark.sql.execution.pythonUDF.arrow.enabled", "false")
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/test_parity_udf_combinations.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udf_combinations.py
@@ -18,10 +18,10 @@
 
 from pyspark.sql.tests.test_udf_combinations import UDFCombinationsTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
-from pyspark.testing.sqlutils import with_class_conf
+from pyspark.testing.sqlutils import SQLTestUtils
 
 
-@with_class_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "false"})
+@SQLTestUtils.with_sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "false"})
 class UDFCombinationsParityTests(UDFCombinationsTestsMixin, ReusedConnectTestCase):
     pass
 

--- a/python/pyspark/sql/tests/connect/test_parity_udf_combinations.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udf_combinations.py
@@ -20,8 +20,10 @@ from pyspark.sql.tests.test_udf_combinations import UDFCombinationsTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
+with_sql_conf = SQLTestUtils.with_sql_conf
 
-@SQLTestUtils.with_sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "false"})
+
+@with_sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "false"})
 class UDFCombinationsParityTests(UDFCombinationsTestsMixin, ReusedConnectTestCase):
     pass
 

--- a/python/pyspark/sql/tests/connect/test_parity_utils.py
+++ b/python/pyspark/sql/tests/connect/test_parity_utils.py
@@ -16,11 +16,24 @@
 #
 
 from pyspark.testing.connectutils import ReusedConnectTestCase
+from pyspark.testing.sqlutils import with_sql_conf
 from pyspark.sql.tests.test_utils import UtilsTestsMixin
 
 
 class UtilsParityTests(UtilsTestsMixin, ReusedConnectTestCase):
     pass
+
+
+@with_sql_conf(
+    {
+        "spark.sql.test.with_sql_conf.key1": "v1",
+        "spark.sql.test.with_sql_conf.key2": "v2",
+    }
+)
+class WithSqlConfParityTests(ReusedConnectTestCase):
+    def test_confs_applied(self):
+        self.assertEqual(self.spark.conf.get("spark.sql.test.with_sql_conf.key1"), "v1")
+        self.assertEqual(self.spark.conf.get("spark.sql.test.with_sql_conf.key2"), "v2")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -38,6 +38,8 @@ from pyspark.testing.utils import (
     have_pyarrow,
 )
 from pyspark.testing.sqlutils import ReusedSQLTestCase, SQLTestUtils
+
+with_sql_conf = SQLTestUtils.with_sql_conf
 from pyspark.sql import Row
 import pyspark.sql.functions as F
 from pyspark.sql.functions import to_date, unix_timestamp, from_unixtime
@@ -1876,7 +1878,7 @@ class UtilsTests(UtilsTestsMixin, ReusedSQLTestCase):
     pass
 
 
-@SQLTestUtils.with_sql_conf(
+@with_sql_conf(
     {
         "spark.sql.test.with_sql_conf.key1": "v1",
         "spark.sql.test.with_sql_conf.key2": "v2",

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -37,7 +37,7 @@ from pyspark.testing.utils import (
     have_pandas,
     have_pyarrow,
 )
-from pyspark.testing.sqlutils import ReusedSQLTestCase
+from pyspark.testing.sqlutils import ReusedSQLTestCase, with_class_conf
 from pyspark.sql import Row
 import pyspark.sql.functions as F
 from pyspark.sql.functions import to_date, unix_timestamp, from_unixtime
@@ -1874,6 +1874,18 @@ class UtilsTestsMixin:
 
 class UtilsTests(UtilsTestsMixin, ReusedSQLTestCase):
     pass
+
+
+@with_class_conf(
+    {
+        "spark.sql.test.with_class_conf.key1": "v1",
+        "spark.sql.test.with_class_conf.key2": "v2",
+    }
+)
+class WithClassConfTests(ReusedSQLTestCase):
+    def test_confs_applied(self):
+        self.assertEqual(self.spark.conf.get("spark.sql.test.with_class_conf.key1"), "v1")
+        self.assertEqual(self.spark.conf.get("spark.sql.test.with_class_conf.key2"), "v2")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -37,9 +37,7 @@ from pyspark.testing.utils import (
     have_pandas,
     have_pyarrow,
 )
-from pyspark.testing.sqlutils import ReusedSQLTestCase, SQLTestUtils
-
-with_sql_conf = SQLTestUtils.with_sql_conf
+from pyspark.testing.sqlutils import ReusedSQLTestCase, with_sql_conf
 from pyspark.sql import Row
 import pyspark.sql.functions as F
 from pyspark.sql.functions import to_date, unix_timestamp, from_unixtime

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -37,7 +37,7 @@ from pyspark.testing.utils import (
     have_pandas,
     have_pyarrow,
 )
-from pyspark.testing.sqlutils import ReusedSQLTestCase, with_class_conf
+from pyspark.testing.sqlutils import ReusedSQLTestCase, SQLTestUtils
 from pyspark.sql import Row
 import pyspark.sql.functions as F
 from pyspark.sql.functions import to_date, unix_timestamp, from_unixtime
@@ -1876,16 +1876,16 @@ class UtilsTests(UtilsTestsMixin, ReusedSQLTestCase):
     pass
 
 
-@with_class_conf(
+@SQLTestUtils.with_sql_conf(
     {
-        "spark.sql.test.with_class_conf.key1": "v1",
-        "spark.sql.test.with_class_conf.key2": "v2",
+        "spark.sql.test.with_sql_conf.key1": "v1",
+        "spark.sql.test.with_sql_conf.key2": "v2",
     }
 )
-class WithClassConfTests(ReusedSQLTestCase):
+class WithSqlConfTests(ReusedSQLTestCase):
     def test_confs_applied(self):
-        self.assertEqual(self.spark.conf.get("spark.sql.test.with_class_conf.key1"), "v1")
-        self.assertEqual(self.spark.conf.get("spark.sql.test.with_class_conf.key2"), "v2")
+        self.assertEqual(self.spark.conf.get("spark.sql.test.with_sql_conf.key1"), "v1")
+        self.assertEqual(self.spark.conf.get("spark.sql.test.with_sql_conf.key2"), "v2")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/testing/sqlutils.py
+++ b/python/pyspark/testing/sqlutils.py
@@ -361,6 +361,9 @@ class SQLTestUtils:
         assert sum(diff) == len(a), f"sum: {sum(diff)}, len: {len(a)}"
 
 
+with_sql_conf = SQLTestUtils.with_sql_conf
+
+
 class ReusedSQLTestCase(ReusedPySparkTestCase, SQLTestUtils, PySparkErrorTestUtils):
     @classmethod
     def setUpClass(cls):

--- a/python/pyspark/testing/sqlutils.py
+++ b/python/pyspark/testing/sqlutils.py
@@ -170,58 +170,58 @@ except Exception as e:
 test_compiled = not test_not_compiled_message
 
 
+def with_sql_conf(pairs):
+    """
+    Class decorator that sets the given Spark confs in ``setUpClass`` and unsets them in
+    ``tearDownClass``, around the calls to the inherited ``setUpClass``/``tearDownClass``.
+
+    The decorated class is expected to expose ``cls.spark`` (a ``SparkSession``) after the
+    inherited ``setUpClass`` runs — typically by extending ``ReusedSQLTestCase`` or
+    ``ReusedConnectTestCase``.
+
+    If the decorated class defines its own ``setUpClass``/``tearDownClass``, those are
+    called instead of the inherited ones; the conf set/unset happens after setUpClass
+    and before tearDownClass respectively.
+    """
+    assert isinstance(pairs, dict), "pairs should be a dictionary."
+
+    def decorator(cls):
+        own_setup = cls.__dict__.get("setUpClass")
+        own_teardown = cls.__dict__.get("tearDownClass")
+
+        @classmethod
+        def setUpClass(klass):
+            if own_setup is not None:
+                own_setup.__func__(klass)
+            else:
+                super(cls, klass).setUpClass()
+            for key, value in pairs.items():
+                klass.spark.conf.set(key, value)
+
+        @classmethod
+        def tearDownClass(klass):
+            try:
+                for key in pairs:
+                    klass.spark.conf.unset(key)
+            finally:
+                if own_teardown is not None:
+                    own_teardown.__func__(klass)
+                else:
+                    super(cls, klass).tearDownClass()
+
+        cls.setUpClass = setUpClass
+        cls.tearDownClass = tearDownClass
+        return cls
+
+    return decorator
+
+
 class SQLTestUtils:
     """
     This util assumes the instance of this to have 'spark' attribute, having a spark session.
     It is usually used with 'ReusedSQLTestCase' class but can be used if you feel sure the
     the implementation of this class has 'spark' attribute.
     """
-
-    @staticmethod
-    def with_sql_conf(pairs):
-        """
-        Class decorator that sets the given Spark confs in ``setUpClass`` and unsets them in
-        ``tearDownClass``, around the calls to the inherited ``setUpClass``/``tearDownClass``.
-
-        The decorated class is expected to expose ``cls.spark`` (a ``SparkSession``) after the
-        inherited ``setUpClass`` runs — typically by extending ``ReusedSQLTestCase`` or
-        ``ReusedConnectTestCase``.
-
-        If the decorated class defines its own ``setUpClass``/``tearDownClass``, those are
-        called instead of the inherited ones; the conf set/unset happens after setUpClass
-        and before tearDownClass respectively.
-        """
-        assert isinstance(pairs, dict), "pairs should be a dictionary."
-
-        def decorator(cls):
-            own_setup = cls.__dict__.get("setUpClass")
-            own_teardown = cls.__dict__.get("tearDownClass")
-
-            @classmethod
-            def setUpClass(klass):
-                if own_setup is not None:
-                    own_setup.__func__(klass)
-                else:
-                    super(cls, klass).setUpClass()
-                for key, value in pairs.items():
-                    klass.spark.conf.set(key, value)
-
-            @classmethod
-            def tearDownClass(klass):
-                try:
-                    for key in pairs:
-                        klass.spark.conf.unset(key)
-                finally:
-                    if own_teardown is not None:
-                        own_teardown.__func__(klass)
-                    else:
-                        super(cls, klass).tearDownClass()
-
-            cls.setUpClass = setUpClass
-            cls.tearDownClass = tearDownClass
-            return cls
-
-        return decorator
 
     @contextmanager
     def sql_conf(self, pairs):
@@ -359,9 +359,6 @@ class SQLTestUtils:
         c = [j[0] for j in b]
         diff = [abs(v - c[k]) < 1e-6 if math.isfinite(v) else v == c[k] for k, v in enumerate(a)]
         assert sum(diff) == len(a), f"sum: {sum(diff)}, len: {len(a)}"
-
-
-with_sql_conf = SQLTestUtils.with_sql_conf
 
 
 class ReusedSQLTestCase(ReusedPySparkTestCase, SQLTestUtils, PySparkErrorTestUtils):

--- a/python/pyspark/testing/sqlutils.py
+++ b/python/pyspark/testing/sqlutils.py
@@ -170,58 +170,58 @@ except Exception as e:
 test_compiled = not test_not_compiled_message
 
 
-def with_class_conf(pairs):
-    """
-    Class decorator that sets the given Spark confs in ``setUpClass`` and unsets them in
-    ``tearDownClass``, around the calls to the inherited ``setUpClass``/``tearDownClass``.
-
-    The decorated class is expected to expose ``cls.spark`` (a ``SparkSession``) after the
-    inherited ``setUpClass`` runs — typically by extending ``ReusedSQLTestCase`` or
-    ``ReusedConnectTestCase``.
-
-    If the decorated class defines its own ``setUpClass``/``tearDownClass``, those are called
-    instead of the inherited ones; the conf set/unset happens after setUpClass and before
-    tearDownClass respectively.
-    """
-    assert isinstance(pairs, dict), "pairs should be a dictionary."
-
-    def decorator(cls):
-        own_setup = cls.__dict__.get("setUpClass")
-        own_teardown = cls.__dict__.get("tearDownClass")
-
-        @classmethod
-        def setUpClass(klass):
-            if own_setup is not None:
-                own_setup.__func__(klass)
-            else:
-                super(cls, klass).setUpClass()
-            for key, value in pairs.items():
-                klass.spark.conf.set(key, value)
-
-        @classmethod
-        def tearDownClass(klass):
-            try:
-                for key in pairs:
-                    klass.spark.conf.unset(key)
-            finally:
-                if own_teardown is not None:
-                    own_teardown.__func__(klass)
-                else:
-                    super(cls, klass).tearDownClass()
-
-        cls.setUpClass = setUpClass
-        cls.tearDownClass = tearDownClass
-        return cls
-
-    return decorator
-
-
 class SQLTestUtils:
     """
     This util assumes the instance of this to have 'spark' attribute, having a spark session.
     It is usually used with 'ReusedSQLTestCase' class but can be used if you feel sure the
     the implementation of this class has 'spark' attribute.
     """
+
+    @staticmethod
+    def with_sql_conf(pairs):
+        """
+        Class decorator that sets the given Spark confs in ``setUpClass`` and unsets them in
+        ``tearDownClass``, around the calls to the inherited ``setUpClass``/``tearDownClass``.
+
+        The decorated class is expected to expose ``cls.spark`` (a ``SparkSession``) after the
+        inherited ``setUpClass`` runs — typically by extending ``ReusedSQLTestCase`` or
+        ``ReusedConnectTestCase``.
+
+        If the decorated class defines its own ``setUpClass``/``tearDownClass``, those are
+        called instead of the inherited ones; the conf set/unset happens after setUpClass
+        and before tearDownClass respectively.
+        """
+        assert isinstance(pairs, dict), "pairs should be a dictionary."
+
+        def decorator(cls):
+            own_setup = cls.__dict__.get("setUpClass")
+            own_teardown = cls.__dict__.get("tearDownClass")
+
+            @classmethod
+            def setUpClass(klass):
+                if own_setup is not None:
+                    own_setup.__func__(klass)
+                else:
+                    super(cls, klass).setUpClass()
+                for key, value in pairs.items():
+                    klass.spark.conf.set(key, value)
+
+            @classmethod
+            def tearDownClass(klass):
+                try:
+                    for key in pairs:
+                        klass.spark.conf.unset(key)
+                finally:
+                    if own_teardown is not None:
+                        own_teardown.__func__(klass)
+                    else:
+                        super(cls, klass).tearDownClass()
+
+            cls.setUpClass = setUpClass
+            cls.tearDownClass = tearDownClass
+            return cls
+
+        return decorator
 
     @contextmanager
     def sql_conf(self, pairs):

--- a/python/pyspark/testing/sqlutils.py
+++ b/python/pyspark/testing/sqlutils.py
@@ -170,6 +170,52 @@ except Exception as e:
 test_compiled = not test_not_compiled_message
 
 
+def with_class_conf(pairs):
+    """
+    Class decorator that sets the given Spark confs in ``setUpClass`` and unsets them in
+    ``tearDownClass``, around the calls to the inherited ``setUpClass``/``tearDownClass``.
+
+    The decorated class is expected to expose ``cls.spark`` (a ``SparkSession``) after the
+    inherited ``setUpClass`` runs — typically by extending ``ReusedSQLTestCase`` or
+    ``ReusedConnectTestCase``.
+
+    If the decorated class defines its own ``setUpClass``/``tearDownClass``, those are called
+    instead of the inherited ones; the conf set/unset happens after setUpClass and before
+    tearDownClass respectively.
+    """
+    assert isinstance(pairs, dict), "pairs should be a dictionary."
+
+    def decorator(cls):
+        own_setup = cls.__dict__.get("setUpClass")
+        own_teardown = cls.__dict__.get("tearDownClass")
+
+        @classmethod
+        def setUpClass(klass):
+            if own_setup is not None:
+                own_setup.__func__(klass)
+            else:
+                super(cls, klass).setUpClass()
+            for key, value in pairs.items():
+                klass.spark.conf.set(key, value)
+
+        @classmethod
+        def tearDownClass(klass):
+            try:
+                for key in pairs:
+                    klass.spark.conf.unset(key)
+            finally:
+                if own_teardown is not None:
+                    own_teardown.__func__(klass)
+                else:
+                    super(cls, klass).tearDownClass()
+
+        cls.setUpClass = setUpClass
+        cls.tearDownClass = tearDownClass
+        return cls
+
+    return decorator
+
+
 class SQLTestUtils:
     """
     This util assumes the instance of this to have 'spark' attribute, having a spark session.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds `with_sql_conf({K: V, ...})` as a class decorator in
`pyspark.testing.sqlutils` that wraps `setUpClass` / `tearDownClass`
to apply and revert Spark confs around the inherited fixtures.
Migrates three parity files as proof of usage:

- `test_parity_column.py` (2 classes)
- `test_parity_udf_combinations.py` (1 class — also makes the
  previously asymmetric set-without-unset pair symmetric)
- `test_parity_arrow_python_udf.py` (5 classes)

Usage:

```python
from pyspark.testing.sqlutils import with_sql_conf

@with_sql_conf({"spark.sql.execution.pythonUDF.arrow.enabled": "true"})
class MyParityTests(SomeMixin, ReusedConnectTestCase):
    pass
```

### Why are the changes needed?

Many parity tests override `setUpClass` / `tearDownClass` solely to
set one or two Spark confs and unset them on teardown. Each such
override is ~10 lines of identical-shape boilerplate, and the
hand-written `set` / `unset` pairs are easy to drift apart (one such
asymmetric pair is fixed by this PR). Consolidating to a single
declarative decorator removes the duplication and provides a common
seam for migrating the remaining callsites in a follow-up.

### Does this PR introduce _any_ user-facing change?

No — test infrastructure only.

### How was this patch tested?

- `WithSqlConfTests` in `python/pyspark/sql/tests/test_utils.py`
  exercises the decorator end-to-end against `ReusedSQLTestCase`,
  asserting both decorator-set keys land via
  `self.spark.conf.get(...)`.
- `WithSqlConfParityTests` in
  `python/pyspark/sql/tests/connect/test_parity_utils.py` is the
  Connect counterpart, exercising the decorator against
  `ReusedConnectTestCase`.
- All three migrated parity files were run locally against a real
  session; in particular `ColumnParityTests.test_df_col_resolution_mode`
  and its `WithNonStrictDFColResolution` subclass read the
  decorator-set conf back through `self.spark.conf.get(...)` and pass,
  confirming the decorator composes through layered subclassing.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (model: claude-opus-4-7)