### PR TITLE
[SPARK-56830][INFRA] Share SBT compile artifact with python hosted runner CI jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1784,15 +1784,3 @@ jobs:
           cd ui-test
           npm install --save-dev
           node --experimental-vm-modules node_modules/.bin/jest
-
-  # TEMP for PR validation: exercise the python_hosted_runner_test.yml
-  # precompile changes on macos-26 as part of the PR builder. REVERT before
-  # marking this PR ready for review.
-  python-macos:
-    name: Python on macOS
-    uses: ./.github/workflows/python_hosted_runner_test.yml
-    with:
-      java: ${{ inputs.java }}
-      branch: ${{ inputs.branch }}
-      hadoop: ${{ inputs.hadoop }}
-      os: macos-26

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1784,3 +1784,15 @@ jobs:
           cd ui-test
           npm install --save-dev
           node --experimental-vm-modules node_modules/.bin/jest
+
+  # TEMP for PR validation: exercise the python_hosted_runner_test.yml
+  # precompile changes on macos-26 as part of the PR builder. REVERT before
+  # marking this PR ready for review.
+  python-macos:
+    name: Python on macOS
+    uses: ./.github/workflows/python_hosted_runner_test.yml
+    with:
+      java: ${{ inputs.java }}
+      branch: ${{ inputs.branch }}
+      hadoop: ${{ inputs.hadoop }}
+      os: macos-26

--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -102,9 +102,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/coursier
-          key: precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+          key: ${{ runner.os }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
           restore-keys: |
-            precompile-coursier-
+            ${{ runner.os }}-coursier-
       - name: Install Java ${{ inputs.java }}
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -56,8 +56,83 @@ on:
         type: string
         default: '{}'
 jobs:
+  # Precompile Spark with SBT once and publish target/ as an artifact for the
+  # matrix entries below to consume. Optional: any failure here degrades the
+  # matrix to its original local SBT build path.
+  precompile:
+    name: "Precompile Spark"
+    runs-on: ${{ inputs.os }}
+    # If this job fails or is cancelled, the matrix entries fall back to
+    # running the SBT build locally as before.
+    continue-on-error: true
+    env:
+      HADOOP_PROFILE: ${{ inputs.hadoop }}
+      HIVE_PROFILE: hive2.3
+      SPARK_LOCAL_IP: localhost
+      GITHUB_PREV_SHA: ${{ github.event.before }}
+    steps:
+      - name: Checkout Spark repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          repository: apache/spark
+          ref: ${{ inputs.branch }}
+      - name: Sync the current branch with the latest in Apache Spark
+        if: github.repository != 'apache/spark'
+        run: |
+          echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+          git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
+          git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+      - name: Cache SBT and Maven
+        # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
+        if: ${{ runner.os != 'macOS' }}
+        uses: actions/cache@v5
+        with:
+          path: |
+            build/apache-maven-*
+            build/*.jar
+            ~/.sbt
+          key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          restore-keys: |
+            build-
+      - name: Cache Coursier local repository
+        # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
+        if: ${{ runner.os != 'macOS' }}
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/coursier
+          key: precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+          restore-keys: |
+            precompile-coursier-
+      - name: Install Java ${{ inputs.java }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: ${{ inputs.java }}
+      - name: Build Spark
+        run: |
+          ./build/sbt -Phadoop-3 -Pyarn -Pspark-ganglia-lgpl -Phadoop-cloud -Phive \
+            -Pkubernetes -Pjvm-profiler -Pkinesis-asl -Phive-thriftserver \
+            -Pdocker-integration-tests -Pvolcano \
+            Test/package streaming-kinesis-asl-assembly/assembly connect/assembly assembly/package
+      - name: Package compile output
+        run: |
+          find . -type d -name target -not -path './build/*' -not -path './.git/*' -print0 \
+            | tar --null -czf compile-artifact.tar.gz -T -
+          ls -lh compile-artifact.tar.gz
+      - name: Upload compile artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: spark-compile-${{ inputs.os }}-${{ inputs.branch }}-${{ github.run_id }}
+          path: compile-artifact.tar.gz
+          retention-days: 1
+          if-no-files-found: error
+
   build:
     name: "Build modules: ${{ matrix.modules }}"
+    needs: precompile
+    if: (!cancelled())
     runs-on: ${{ inputs.os }}
     # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
     # timeout-minutes: 150
@@ -159,10 +234,28 @@ jobs:
           python${{matrix.python}} -m pip cache purge
       - name: List Python packages
         run: python${{matrix.python}} -m pip list
+      - name: Download precompiled artifact
+        id: download-precompiled
+        if: needs.precompile.result == 'success'
+        continue-on-error: true
+        uses: actions/download-artifact@v6
+        with:
+          name: spark-compile-${{ inputs.os }}-${{ inputs.branch }}-${{ github.run_id }}
+      - name: Extract precompiled artifact
+        id: extract-precompiled
+        if: steps.download-precompiled.outcome == 'success'
+        continue-on-error: true
+        run: |
+          tar -xzf compile-artifact.tar.gz
+          rm compile-artifact.tar.gz
       # Run the tests.
       - name: Run tests
         env: ${{ fromJSON(inputs.envs) }}
         run: |
+          if [ "${{ steps.extract-precompiled.outcome }}" = "success" ]; then
+            export SKIP_SCALA_BUILD=true
+            echo "Reusing precompiled artifact, skipping local SBT build."
+          fi
           if [[ "$MODULES_TO_TEST" == *"pyspark-errors"* ]]; then
             export SKIP_PACKAGING=false
             echo "Python Packaging Tests Enabled!"

--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -93,18 +93,18 @@ jobs:
             build/apache-maven-*
             build/*.jar
             ~/.sbt
-          key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          key: build-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
           restore-keys: |
-            build-
+            build-${{ runner.os }}-
       - name: Cache Coursier local repository
         # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
         if: ${{ runner.os != 'macOS' }}
         uses: actions/cache@v5
         with:
           path: ~/.cache/coursier
-          key: ${{ runner.os }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+          key: coursier-${{ runner.os }}-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
           restore-keys: |
-            ${{ runner.os }}-coursier-
+            coursier-${{ runner.os }}-
       - name: Install Java ${{ inputs.java }}
         uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extends the SBT precompile-sharing pattern (parent: [SPARK-56830](https://issues.apache.org/jira/browse/SPARK-56830), pyspark: [SPARK-56768](https://issues.apache.org/jira/browse/SPARK-56768)) to the python-only macOS / ARM workflows that run via `.github/workflows/python_hosted_runner_test.yml`.

Concretely:

- New `precompile` job in `python_hosted_runner_test.yml` runs Spark's SBT build once on `${{ inputs.os }}`:
  ```
  ./build/sbt -Phadoop-3 -Pyarn -Pspark-ganglia-lgpl -Phadoop-cloud -Phive \
    -Pkubernetes -Pjvm-profiler -Pkinesis-asl -Phive-thriftserver \
    -Pdocker-integration-tests -Pvolcano \
    Test/package streaming-kinesis-asl-assembly/assembly connect/assembly assembly/package
  ```
  It tars every `target/` directory (excluding `./build/` and `./.git/`) with `tar -czf`, uploads as `spark-compile-<os>-<branch>-<run_id>` with `retention-days: 1`.
- The 9 pyspark matrix entries in the same workflow add `precompile` to `needs:` and `if: (!cancelled())`, download/extract the artifact (with graceful fallback), and export `SKIP_SCALA_BUILD=true` so `dev/run-tests.py` skips `build_apache_spark` and `build_spark_assembly_sbt`.
- Cache steps in the new precompile job are gated `if: ${{ runner.os != 'macOS' }}` to match the existing TODO(SPARK-54466) pattern in this file: on `macos-26` the precompile runs without GHA cache; on `ubuntu-24.04-arm` it caches as expected.
- Artifact name includes `${{ inputs.os }}` so the two callers (`build_python_3.12_macos26.yml` and `build_python_3.12_arm.yml`) cannot collide.

This benefits both callers of the reusable workflow:
- `.github/workflows/build_python_3.12_macos26.yml` (macos-26)
- `.github/workflows/build_python_3.12_arm.yml` (ubuntu-24.04-arm)

### Optional: graceful fallback if precompile fails

Same pattern as SPARK-56768:
- `precompile` has `continue-on-error: true` so a failed or cancelled precompile does not fail the workflow run.
- The matrix's "Download precompiled artifact" step is gated on `needs.precompile.result == 'success'` and itself has `continue-on-error: true`.
- The "Extract precompiled artifact" step is gated on the download succeeding, and also has `continue-on-error: true`.
- Inside the "Run tests" bash block, `SKIP_SCALA_BUILD=true` is exported only when `steps.extract-precompiled.outcome == 'success'`. Otherwise it stays unset and `dev/run-tests.py` falls back to the original local SBT build.

### Why are the changes needed?

Today every one of the 9 pyspark matrix entries in `python_hosted_runner_test.yml` runs the same SBT build from scratch. Sharing the compile artifact once across the matrix avoids 8x duplicate SBT compile work per scheduled run of `build_python_3.12_macos26.yml` (and `build_python_3.12_arm.yml`). This mirrors the savings already realized for the Linux pyspark matrix in SPARK-56768.

### Does this PR introduce _any_ user-facing change?

No. CI infrastructure change only.

### How was this patch tested?

The change is exercised by the CI run of this PR itself. To validate the `macos-26` path specifically, a temporary PR-builder hook ran `python_hosted_runner_test.yml` on `macos-26` (dropped before merge); all 9 `Python on macOS` pyspark matrix entries passed while reusing the shared precompiled artifact:

https://github.com/zhengruifeng/spark/actions/runs/27010550379

If the precompile job is forced to fail (or its artifact is missing), the matrix entries should still pass via the fallback path. The "Run tests" step logs `Reusing precompiled artifact, skipping local SBT build.` to make the fast path visible per matrix entry.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)
