### PR TITLE
[SPARK-57066][SECURITY] Use constant-time comparison for authentication secrets

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/r/RBackendAuthHandler.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RBackendAuthHandler.scala
@@ -19,6 +19,7 @@ package org.apache.spark.api.r
 
 import java.io.{ByteArrayOutputStream, DataOutputStream}
 import java.nio.charset.StandardCharsets.UTF_8
+import java.security.MessageDigest
 
 import io.netty.channel.{Channel, ChannelHandlerContext, SimpleChannelInboundHandler}
 
@@ -34,7 +35,8 @@ private class RBackendAuthHandler(secret: String)
     // The R code adds a null terminator to serialized strings, so ignore it here.
     val clientSecret = new String(msg, 0, msg.length - 1, UTF_8)
     try {
-      require(secret == clientSecret, "Auth secret mismatch.")
+      require(MessageDigest.isEqual(secret.getBytes(UTF_8), clientSecret.getBytes(UTF_8)),
+        "Auth secret mismatch.")
       ctx.pipeline().remove(this)
       writeReply("ok", ctx.channel())
     } catch {

--- a/core/src/main/scala/org/apache/spark/security/SocketAuthHelper.scala
+++ b/core/src/main/scala/org/apache/spark/security/SocketAuthHelper.scala
@@ -21,6 +21,7 @@ import java.io.{DataInputStream, DataOutputStream}
 import java.net.Socket
 import java.nio.channels.SocketChannel
 import java.nio.charset.StandardCharsets.UTF_8
+import java.security.MessageDigest
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.config.Python.{PYTHON_UNIX_DOMAIN_SOCKET_DIR, PYTHON_UNIX_DOMAIN_SOCKET_ENABLED}
@@ -65,7 +66,7 @@ private[spark] class SocketAuthHelper(val conf: SparkConf) {
       try {
         s.setSoTimeout(10000)
         val clientSecret = readUtf8(s)
-        if (secret == clientSecret) {
+        if (MessageDigest.isEqual(secret.getBytes(UTF_8), clientSecret.getBytes(UTF_8))) {
           writeUtf8("ok", s)
           shouldClose = false
         } else {

--- a/python/pyspark/accumulators.py
+++ b/python/pyspark/accumulators.py
@@ -17,6 +17,7 @@
 
 import os
 import sys
+import hmac
 import select
 import struct
 import socketserver
@@ -310,7 +311,7 @@ class UpdateRequestHandler(socketserver.StreamRequestHandler):
             received_token: Union[bytes, str] = self.rfile.read(len(auth_token))
             if isinstance(received_token, bytes):
                 received_token = received_token.decode("utf-8")
-            if received_token == auth_token:
+            if hmac.compare_digest(received_token, auth_token):
                 accum_updates()
                 # we've authenticated, we can break out of the first loop now
                 return True

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/PreSharedKeyAuthenticationInterceptor.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/PreSharedKeyAuthenticationInterceptor.scala
@@ -40,7 +40,8 @@ class PreSharedKeyAuthenticationInterceptor(token: String) extends ServerInterce
       call.close(status, new Metadata())
       new ServerCall.Listener[ReqT]() {}
     } else if (!MessageDigest.isEqual(
-        authHeaderValue.getBytes(UTF_8), expectedValue.getBytes(UTF_8))) {
+        authHeaderValue.getBytes(UTF_8),
+        expectedValue.getBytes(UTF_8))) {
       val status = Status.UNAUTHENTICATED.withDescription("Invalid authentication token")
       call.close(status, new Metadata())
       new ServerCall.Listener[ReqT]() {}

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/PreSharedKeyAuthenticationInterceptor.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/PreSharedKeyAuthenticationInterceptor.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql.connect.service
 
+import java.nio.charset.StandardCharsets.UTF_8
+import java.security.MessageDigest
+
 import io.grpc.{Metadata, ServerCall, ServerCallHandler, ServerInterceptor, Status}
 
 class PreSharedKeyAuthenticationInterceptor(token: String) extends ServerInterceptor {
@@ -36,7 +39,8 @@ class PreSharedKeyAuthenticationInterceptor(token: String) extends ServerInterce
       val status = Status.UNAUTHENTICATED.withDescription("No authentication token provided")
       call.close(status, new Metadata())
       new ServerCall.Listener[ReqT]() {}
-    } else if (authHeaderValue != expectedValue) {
+    } else if (!MessageDigest.isEqual(
+        authHeaderValue.getBytes(UTF_8), expectedValue.getBytes(UTF_8))) {
       val status = Status.UNAUTHENTICATED.withDescription("Invalid authentication token")
       call.close(status, new Metadata())
       new ServerCall.Listener[ReqT]() {}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use constant-time comparison for authentication secret/token validation in all occurrences:

- `SocketAuthHelper.scala`: socket authentication between Spark processes (`MessageDigest.isEqual`)
- `PreSharedKeyAuthenticationInterceptor.scala`: Spark Connect pre-shared key authentication (`MessageDigest.isEqual`)
- `RBackendAuthHandler.scala`: R backend authentication (`MessageDigest.isEqual`)
- `python/pyspark/accumulators.py`: accumulator server token authentication (`hmac.compare_digest`)

All previously used standard string equality (`==` / `!=`), which is vulnerable to timing attacks. An attacker can infer the correct secret one character at a time by measuring response time differences.

### Why are the changes needed?

Standard string comparison short-circuits on the first mismatched character, leaking information about how many leading characters are correct. This reduces the brute-force complexity from O(C^N) to O(C*N) where C is the character set size and N is the secret length.

`java.security.MessageDigest.isEqual()` (Scala/Java) and `hmac.compare_digest()` (Python) always compare all bytes regardless of content, eliminating the timing side channel.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude (via Kiro CLI, auto model selection)
