### PR TITLE
[SPARK-57073][SS][PYTHON][TESTS] Skip flaky test_listener_events_spark_command on macOS

### DIFF
--- a/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
@@ -17,6 +17,7 @@
 
 import sys
 import time
+import unittest
 
 import pyspark.cloudpickle
 from pyspark.sql.tests.streaming.test_streaming_listener import StreamingListenerTestsMixin
@@ -217,8 +218,8 @@ class StreamingListenerParityTests(StreamingListenerTestsMixin, ReusedConnectTes
             for q in self.spark.streams.active:
                 q.stop()
 
-    # TODO(SPARK-57145): Unskip once the flakiness on macOS is resolved.
-    @unittest.skipIf(sys.platform == "darwin", "Flaky on macOS (SPARK-57145)")
+    # TODO(SPARK-57145): Flaky on macOS, should be fixed in SPARK-57145.
+    @unittest.skipIf(sys.platform == "darwin", "Flaky on macOS")
     def test_listener_events_spark_command(self):
         test_listener = TestListenerSpark()
 

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import sys
 import time
 
 import pyspark.cloudpickle
@@ -216,6 +217,8 @@ class StreamingListenerParityTests(StreamingListenerTestsMixin, ReusedConnectTes
             for q in self.spark.streams.active:
                 q.stop()
 
+    # TODO(SPARK-57145): Unskip once the flakiness on macOS is resolved.
+    @unittest.skipIf(sys.platform == "darwin", "Flaky on macOS (SPARK-57145)")
     def test_listener_events_spark_command(self):
         test_listener = TestListenerSpark()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Skip `test_listener_events_spark_command` on macOS runners and add a TODO pointing to SPARK-57145.

### Why are the changes needed?

The test has been flaky on the `Build / Python-only (master, Python 3.12, MacOS26)` scheduled workflow:

- 2026-05-23 — https://github.com/apache/spark/actions/runs/26346300968/job/77556662680
- 2026-05-25 — https://github.com/apache/spark/actions/runs/26423905857/job/77783724134

Both failed with `AnalysisException: TABLE_OR_VIEW_NOT_FOUND` on `listener_terminated_events`: the `onQueryTerminated` callback fires asynchronously after `q.stop()` returns and writes the table via `saveAsTable`, but on slower macOS runners the read races the write.

SPARK-57145 tracks the proper fix.

### Does this PR introduce _any_ user-facing change?

No, test-only change.

### How was this patch tested?

The test is skipped on macOS via `@unittest.skipIf(sys.platform == "darwin", ...)`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 4.6