### PR TITLE
[SPARK-57070][PYTHON][DOCS] Add `time_(from|to)_*` functions to Python API reference

### DIFF
--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -301,6 +301,12 @@ Date and Timestamp Functions
     timestamp_seconds
     time_bucket
     time_diff
+    time_from_micros
+    time_from_millis
+    time_from_seconds
+    time_to_micros
+    time_to_millis
+    time_to_seconds
     time_trunc
     to_date
     to_time


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the six time numeric conversion functions to the PySpark Python API reference (`python/docs/source/reference/pyspark.sql/functions.rst`):

- `time_from_seconds`
- `time_from_millis`
- `time_from_micros`
- `time_to_seconds`
- `time_to_millis`
- `time_to_micros`

### Why are the changes needed?

These functions were added in Spark 4.2 (SPARK-54442) and are exported from `pyspark.sql.functions`, but the entries were missing from the API reference autosummary, so they do not show up in the rendered Python docs.

### Does this PR introduce _any_ user-facing change?

Documentation-only change; the functions themselves are unchanged.

### How was this patch tested?

Docs-only change. Verified the new entries are in alphabetical order, matching the order in `python/pyspark/sql/functions/__init__.py`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (model: claude-opus-4-7)