### PR TITLE
[SPARK-57072][PYTHON][DOCS] Add missing 4.2 methods to PySpark API reference

### DIFF
--- a/python/docs/source/reference/pyspark.sql/dataframe.rst
+++ b/python/docs/source/reference/pyspark.sql/dataframe.rst
@@ -141,6 +141,7 @@ DataFrame
     DataFrame.writeTo
     DataFrame.mergeInto
     DataFrame.pandas_api
+    DataFrame.zipWithIndex
     DataFrameNaFunctions.drop
     DataFrameNaFunctions.fill
     DataFrameNaFunctions.replace

--- a/python/docs/source/reference/pyspark.sql/datasource.rst
+++ b/python/docs/source/reference/pyspark.sql/datasource.rst
@@ -35,10 +35,12 @@ Python Data Source
     DataSourceReader.read
     DataSourceRegistration.register
     DataSourceStreamReader.commit
+    DataSourceStreamReader.getDefaultReadLimit
     DataSourceStreamReader.initialOffset
     DataSourceStreamReader.latestOffset
     DataSourceStreamReader.partitions
     DataSourceStreamReader.read
+    DataSourceStreamReader.reportLatestOffset
     DataSourceStreamReader.stop
     DataSourceWriter.abort
     DataSourceWriter.commit

--- a/python/docs/source/reference/pyspark.sql/io.rst
+++ b/python/docs/source/reference/pyspark.sql/io.rst
@@ -24,6 +24,7 @@ Input/Output
 .. autosummary::
     :toctree: api/
 
+    DataFrameReader.changes
     DataFrameReader.csv
     DataFrameReader.format
     DataFrameReader.jdbc

--- a/python/docs/source/reference/pyspark.ss/io.rst
+++ b/python/docs/source/reference/pyspark.ss/io.rst
@@ -30,6 +30,7 @@ Input/Output
     DataStreamReader.format
     DataStreamReader.json
     DataStreamReader.load
+    DataStreamReader.name
     DataStreamReader.option
     DataStreamReader.options
     DataStreamReader.orc

--- a/python/docs/source/reference/pyspark.ss/io.rst
+++ b/python/docs/source/reference/pyspark.ss/io.rst
@@ -25,6 +25,7 @@ Input/Output
 .. autosummary::
     :toctree: api/
 
+    DataStreamReader.changes
     DataStreamReader.csv
     DataStreamReader.format
     DataStreamReader.json


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add public PySpark APIs that were added in Spark 4.2 but missing from the rendered Python API reference. This PR is documentation-only.

`python/docs/source/reference/pyspark.sql/dataframe.rst`:
- `DataFrame.zipWithIndex`

`python/docs/source/reference/pyspark.sql/datasource.rst`:
- `DataSourceStreamReader.getDefaultReadLimit`
- `DataSourceStreamReader.reportLatestOffset`

`python/docs/source/reference/pyspark.sql/io.rst`:
- `DataFrameReader.changes`

`python/docs/source/reference/pyspark.ss/io.rst`:
- `DataStreamReader.changes`
- `DataStreamReader.name`

### Why are the changes needed?

All of the above are public, marked `.. versionadded:: 4.2.0`, and reachable through their respective public modules, but the autosummary entries were never added so they do not appear in the rendered API reference.

Original JIRAs:
- `DataFrame.zipWithIndex` — SPARK-55229 / SPARK-55231
- `DataSourceStreamReader.getDefaultReadLimit` / `reportLatestOffset` — SPARK-55304
- `DataFrameReader.changes` / `DataStreamReader.changes` — SPARK-55950
- `DataStreamReader.name` — SPARK-55121

### Does this PR introduce _any_ user-facing change?

Documentation-only change; the methods themselves are unchanged.

### How was this patch tested?

Docs-only change. New entries inserted alphabetically within each autosummary block (`DataFrame.zipWithIndex` is appended after the existing trailing `DataFrame.pandas_api` since it is alphabetically last).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (model: claude-opus-4-7)