### PR TITLE
[SPARK-57074][INFRA] Skip Build workflow on fork master pushes

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -29,4 +29,8 @@ jobs:
     permissions:
       packages: write
     name: Run
+    # Skip pushes to `master` on forks: the "Sync fork" button mirrors
+    # apache/spark and would otherwise re-run the full build on every sync.
+    # Upstream pushes and pushes to non-master branches on forks are unaffected.
+    if: github.repository == 'apache/spark' || github.ref != 'refs/heads/master'
     uses: ./.github/workflows/build_and_test.yml


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a job-level `if:` guard on `.github/workflows/build_main.yml` so that the `Build` workflow does not run on pushes to `master` on a fork:

```yaml
if: github.repository == 'apache/spark' || github.ref != 'refs/heads/master'
```

### Why are the changes needed?

When a contributor clicks the "Sync fork" button on their fork's `master` (which mirrors `apache/spark`), GitHub records it as a push to `master` and fires `build_main.yml`, running the entire build/test matrix on the fork — duplicating work that already ran upstream. The pattern is already used in the per-branch workflows (`build_branch*.yml` gate with `if: github.repository == 'apache/spark'`); this extends the same idea to `build_main.yml`, but only for the `master` branch on forks so that dev branches on forks continue to be tested.

Behavior after this change:

| Where | Action | Branch pushed | Job runs? |
|---|---|---|---|
| `apache/spark` | any push | any | runs (unchanged) |
| fork | click "Sync fork" on master page | `master` | **skipped** |
| fork | push to dev branch | `<dev-branch>` | runs |
| fork | merge `upstream/master` into dev branch, push | `<dev-branch>` | runs |
| fork | rebase dev branch on `upstream/master`, force-push | `<dev-branch>` | runs |
| fork | push directly to fork's `master` | `master` | **skipped** |

The guard is purely branch-name-based — only the literal ref `refs/heads/master` is suppressed. A branch named `master-foo` or `branch-4.x` is unaffected.

### Does this PR introduce _any_ user-facing change?

No. CI behavior only.

### How was this patch tested?

Inspected the condition manually against each scenario in the table above:
- `github.repository == 'apache/spark'` — first clause true → runs.
- Fork, `github.ref == 'refs/heads/master'` — both clauses false → skipped.
- Fork, `github.ref == 'refs/heads/<dev-branch>'` — second clause true → runs (covers rebases against upstream master and merges of upstream master into a dev branch, since those still push to the dev branch ref).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)
