### PR TITLE
[SPARK-57075][INFRA] Share precompile Coursier cache with host-runner SBT jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -745,8 +745,6 @@ jobs:
         key: pyspark-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           pyspark-coursier-
-          precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
-          precompile-coursier-
     - name: Free up disk space
       shell: 'script -q -e -c "bash {0}"'
       run: ./dev/free_disk_space_container
@@ -897,8 +895,6 @@ jobs:
         key: sparkr-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           sparkr-coursier-
-          precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
-          precompile-coursier-
     - name: Free up disk space
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
@@ -1050,8 +1046,6 @@ jobs:
         key: docs-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           docs-coursier-
-          precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
-          precompile-coursier-
     - name: Cache Maven local repository
       uses: actions/cache@v5
       with:
@@ -1251,8 +1245,6 @@ jobs:
         key: docs-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           docs-coursier-
-          precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
-          precompile-coursier-
     - name: Cache Maven local repository
       uses: actions/cache@v5
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -385,6 +385,8 @@ jobs:
         key: ${{ matrix.java }}-${{ matrix.hadoop }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           ${{ matrix.java }}-${{ matrix.hadoop }}-coursier-
+          precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+          precompile-coursier-
     - name: Free up disk space
       run: |
         if [ -f ./dev/free_disk_space ]; then
@@ -743,6 +745,8 @@ jobs:
         key: pyspark-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           pyspark-coursier-
+          precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+          precompile-coursier-
     - name: Free up disk space
       shell: 'script -q -e -c "bash {0}"'
       run: ./dev/free_disk_space_container
@@ -893,6 +897,8 @@ jobs:
         key: sparkr-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           sparkr-coursier-
+          precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+          precompile-coursier-
     - name: Free up disk space
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1050,6 +1050,8 @@ jobs:
         key: docs-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           docs-coursier-
+          precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+          precompile-coursier-
     - name: Cache Maven local repository
       uses: actions/cache@v5
       with:
@@ -1249,6 +1251,8 @@ jobs:
         key: docs-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           docs-coursier-
+          precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+          precompile-coursier-
     - name: Cache Maven local repository
       uses: actions/cache@v5
       with:
@@ -1444,6 +1448,8 @@ jobs:
         key: tpcds-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           tpcds-coursier-
+          precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+          precompile-coursier-
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v5
       with:
@@ -1562,6 +1568,8 @@ jobs:
         key: docker-integration-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           docker-integration-coursier-
+          precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+          precompile-coursier-
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v5
       with:
@@ -1648,6 +1656,8 @@ jobs:
           key: k8s-integration-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
           restore-keys: |
             k8s-integration-coursier-
+            precompile-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+            precompile-coursier-
       - name: Free up disk space
         run: |
           if [ -f ./dev/free_disk_space ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `precompile-coursier-<hash>` and `precompile-coursier-` as restore-key fallbacks on `Cache Coursier local repository` for the four host-runner SBT jobs: `build` (Scala tests), `tpcds-1g`, `docker-integration-tests`, `k8s-integration-tests`. The primary key and existing prefix fallback are unchanged — the new entries are pure fallback.

### Why are the changes needed?

The `precompile` job already resolves all dependencies and writes them to `~/.cache/coursier`, but it saves under the key prefix `precompile-coursier-`, while the downstream test jobs read from `<matrix.java>-<matrix.hadoop>-coursier-`, `tpcds-coursier-`, etc. So on cold caches (new branch, modified `pom.xml` / `plugins.sbt`), the downstream jobs re-download dependencies that the precompile job already resolved minutes earlier in the same workflow.

### Does this PR introduce _any_ user-facing change?

No. CI-only.

### How was this patch tested?

Verified on https://github.com/zhengruifeng/spark/actions/runs/26564295518 (commit `919909f5cb9`): 12/12 host-runner SBT jobs restored a Coursier cache without re-downloading from Maven Central. 9 of the 12 fell back to the new `precompile-coursier-<hash>` cache; the other 3 found their own per-job cache from a prior run.

Container jobs (`pyspark`, `sparkr`, `lint`, `docs`) are excluded — their Coursier cache step is a no-op due to a host↔container `$HOME` path mismatch (host writes `/home/runner/.cache/coursier`, container looks at `/github/home/.cache/coursier`). Independent of this PR; can be addressed in a follow-up.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.7)