### PR TITLE
[SPARK-57076][SQL] Add session-level default collation support

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8137,6 +8137,11 @@
           "Default collation for the specified schema."
         ]
       },
+      "SESSION_LEVEL_COLLATIONS" : {
+        "message" : [
+          "Setting a non-UTF8_BINARY collation as the session default collation."
+        ]
+      },
       "SET_NAMESPACE_PROPERTY" : {
         "message" : [
           "<property> is a reserved namespace property, <msg>."

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -449,6 +449,7 @@ streamRelationPrimary
 
 setResetStatement
     : SET ROLE .*?                                                     #failSetRole
+    | SET COLLATION collationName=identifier                           #setCollation
     | SET TIME ZONE interval                                           #setTimeZone
     | SET TIME ZONE timezone                                           #setTimeZone
     | SET TIME ZONE .*?                                                #setTimeZone

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -250,6 +250,9 @@ object AnalysisContext {
     set(context)
     try f finally { set(originContext) }
   }
+
+  /** @return true if we are inside view resolution. */
+  def `isInsideViewResolution`: Boolean = get.nestedViewDepth > 0
 }
 
 object Analyzer {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyDefaultCollation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ApplyDefaultCollation.scala
@@ -21,11 +21,11 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.expressions.{Cast, DefaultStringProducingExpression, Expression, Literal, SubqueryExpression}
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumns, AlterColumnSpec, AlterViewAs, ColumnDefinition, CreateTable, CreateTableAsSelect, CreateTempView, CreateUserDefinedFunction, CreateView, LogicalPlan, QualifiedColType, ReplaceColumns, ReplaceTable, ReplaceTableAsSelect, TableSpec, V2CreateTablePlan}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumns, AlterColumns, AlterColumnSpec, AlterViewAs, ColumnDefinition, CreatePipelineDataset, CreateTable, CreateTableAsSelect, CreateTempView, CreateUserDefinedFunction, CreateView, DeserializeToObject, LogicalPlan, QualifiedColType, ReplaceColumns, ReplaceTable, ReplaceTableAsSelect, SerializeFromObject, SupportsDefaultCollation, TableSpec}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.{areSameBaseType, isDefaultStringCharOrVarcharType, replaceDefaultStringCharAndVarcharTypes}
-import org.apache.spark.sql.catalyst.util.CharVarcharUtils
+import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, CollationFactory}
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, SupportsNamespaces, TableCatalog, V1ViewInfo, ViewInfo}
 import org.apache.spark.sql.types.{DataType, StringHelper, StringType}
 
@@ -38,10 +38,15 @@ import org.apache.spark.sql.types.{DataType, StringHelper, StringType}
  */
 object ApplyDefaultCollation extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = {
+    if (shouldSkipApplyingDefaultCollation(plan)) {
+      return plan
+    }
     val preprocessedPlan = resolveDefaultCollation(pruneRedundantAlterColumnTypes(plan))
 
     fetchDefaultCollation(preprocessedPlan) match {
-      case Some(collation) =>
+      // No need to explicitly apply UTF8_BINARY collation.
+      case Some(collation) if CollationFactory.collationNameToId(collation) !=
+          CollationFactory.UTF8_BINARY_COLLATION_ID =>
         val transformedPlan = transform(preprocessedPlan, collation)
         if (preprocessedPlan fastEquals transformedPlan) {
           preprocessedPlan
@@ -80,7 +85,7 @@ object ApplyDefaultCollation extends Rule[LogicalPlan] {
           // expect resolved expressions can be applied.
           CollationTypeCasts(transformedPlan)
         }
-      case None => preprocessedPlan
+      case _ => preprocessedPlan
     }
   }
 
@@ -105,26 +110,31 @@ object ApplyDefaultCollation extends Rule[LogicalPlan] {
    */
   private def fetchDefaultCollation(plan: LogicalPlan): Option[String] = {
     plan match {
-      case CreateTable(_: ResolvedIdentifier, _, _, tableSpec: TableSpec, _) =>
-        tableSpec.collation
+      case createTable: CreateTable =>
+        createTable.tableSpec.collation
 
-      case CreateTableAsSelect(_: ResolvedIdentifier, _, _, tableSpec: TableSpec, _, _, _) =>
-        tableSpec.collation
+      case createTableAsSelect: CreateTableAsSelect =>
+        createTableAsSelect.tableSpec.collation
 
-      case ReplaceTableAsSelect(_: ResolvedIdentifier, _, _, tableSpec: TableSpec, _, _, _) =>
-        tableSpec.collation
+      case replaceTableAsSelect: ReplaceTableAsSelect =>
+        replaceTableAsSelect.tableSpec.collation
 
       // CreateView also handles CREATE OR REPLACE VIEW
       case createView: CreateView =>
         createView.collation
 
-      case ReplaceTable(_: ResolvedIdentifier, _, _, tableSpec: TableSpec, _) =>
-        tableSpec.collation
+      case replaceTable: ReplaceTable =>
+        replaceTable.tableSpec.collation
 
       // Temporary views are created via CreateViewCommand, which we can't import here.
       // Instead, we use the CreateTempView trait to access the collation.
       case createTempView: CreateTempView =>
         createTempView.collation
+
+      // Matches sql/core commands (CreateViewCommand, CreateSQLFunctionCommand) that expose their
+      // collation through the SupportsDefaultCollation trait.
+      case plan: SupportsDefaultCollation =>
+        plan.collation
 
       // In `transform` we handle these 3 ALTER TABLE commands.
       case cmd: AddColumns => getCollationFromTableProps(cmd.table)
@@ -140,11 +150,17 @@ object ApplyDefaultCollation extends Rule[LogicalPlan] {
           case _ => None
         }
 
-      // Check if view has default collation
-      case _ if AnalysisContext.get.collation.isDefined =>
+      // Inside a view body or SQL function body: use the object's own collation if set;
+      // do not fall back to session collation. AnalysisContext.collation is populated by
+      // `withAnalysisContext(viewDesc)` for views and `withAnalysisContext(function)` for
+      // SQL functions before the body is resolved.
+      case _ if AnalysisContext.isInsideViewResolution ||
+          SQLFunctionContext.isInsideSQLFunctionResolution =>
         AnalysisContext.get.collation
 
-      case _ => None
+      // For top-level queries and standalone SQL scripting, use session collation.
+      case _ =>
+        Some(conf.sessionDefaultCollation)
     }
   }
 
@@ -257,6 +273,17 @@ object ApplyDefaultCollation extends Rule[LogicalPlan] {
           newCreateUserDefinedFunction.copyTagsFrom(createUserDefinedFunction)
           newCreateUserDefinedFunction
 
+        // Temporary views and functions inherit session collation when no explicit collation is
+        // set. They are created via CreateViewCommand and CreateSQLFunctionCommand, but those
+        // commands can't be matched directly in this rule, so we use the SupportsDefaultCollation
+        // trait instead.
+        case plan: SupportsDefaultCollation if plan.isTemp && plan.collation.isEmpty =>
+          val newPlan = CurrentOrigin.withOrigin(plan.origin) {
+            plan.withCollation(Some(conf.sessionDefaultCollation))
+          }
+          newPlan.copyTagsFrom(plan)
+          newPlan
+
         case other =>
           other
       }
@@ -276,25 +303,15 @@ object ApplyDefaultCollation extends Rule[LogicalPlan] {
     Option(metadata.get(TableCatalog.PROP_COLLATION))
   }
 
-  private def isCreateOrAlterPlan(plan: LogicalPlan): Boolean = plan match {
-    // For CREATE TABLE, only v2 CREATE TABLE command is supported.
-    case _: V2CreateTablePlan | _: ReplaceTable | _: CreateView | _: AlterViewAs |
-         _: CreateTempView => true
-    case _ => false
-  }
-
   private def transform(plan: LogicalPlan, collation: String): LogicalPlan = {
     plan resolveOperators {
-      case p if isCreateOrAlterPlan(p) || AnalysisContext.get.collation.isDefined =>
-        transformPlan(p, collation)
-
       case addCols: AddColumns =>
         addCols.copy(columnsToAdd = replaceColumnTypes(addCols.columnsToAdd, collation))
 
       case replaceCols: ReplaceColumns =>
         replaceCols.copy(columnsToAdd = replaceColumnTypes(replaceCols.columnsToAdd, collation))
 
-      case a @ AlterColumns(ResolvedTable(_, _, _, _), specs: Seq[AlterColumnSpec]) =>
+      case a @ AlterColumns(_, specs: Seq[AlterColumnSpec]) =>
         val newSpecs = specs.map {
           case spec if shouldApplyDefaultCollationToAlterColumn(spec) =>
             spec.copy(newDataType =
@@ -302,6 +319,23 @@ object ApplyDefaultCollation extends Rule[LogicalPlan] {
           case col => col
         }
         a.copy(specs = newSpecs)
+
+      case p =>
+        transformPlan(p, collation)
+    }
+  }
+
+  /**
+   * Returns true if applying the default collation should be skipped for the given plan.
+   *
+   * Plans originating from internal components (Delta, optimizers, pipeline systems, etc.) should
+   * skip this rule. Applying the default collation to internal plans could lead to incorrect
+   * behavior. The list may need to be extended as more such plans are discovered.
+   */
+  private def shouldSkipApplyingDefaultCollation(plan: LogicalPlan): Boolean = {
+    plan match {
+      case _: DeserializeToObject | _: SerializeFromObject | _: CreatePipelineDataset => true
+      case _ => false
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/SQLFunctionExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/SQLFunctionExpression.scala
@@ -94,4 +94,7 @@ object SQLFunctionContext {
     set(context)
     try f finally { set(originContext) }
   }
+
+  /** @return true if we are inside SQL function resolution. */
+  def isInsideSQLFunctionResolution: Boolean = get.nestedSQLFunctionDepth > 0
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/DefaultCollationTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/DefaultCollationTypeCoercion.scala
@@ -23,13 +23,14 @@ import org.apache.spark.sql.catalyst.expressions.{
   Expression,
   Literal
 }
+import org.apache.spark.sql.catalyst.util.CollationFactory
 import org.apache.spark.sql.types.{DataType, StringType}
 
 /**
  * This type coercion object is only used in the single-pass analyzer and is not part of the
  * [[TypeCoercion]] rules used in the fixed-point analyzer.
  *
- * When the database object (e.g. [[View]]) has a custom default collation and a
+ * When the database object (e.g. [[View]]) or the session has a custom default collation and a
  * resolving expression's dataType is the companion object [[StringType]], we need to treat the
  * dataType as a collated [[StringType]]. To do this, we wrap the expression with a cast to a
  * [[StringType]] with the default collation or change the dataType to [[StringType]] with the
@@ -40,12 +41,23 @@ import org.apache.spark.sql.types.{DataType, StringType}
 object DefaultCollationTypeCoercion {
 
   /**
-   * Apply [[View]]'s default collation to the expression.
+   * Apply default collation (from a [[View]] or the session) to the expression.
+   *
+   * If the default collation is UTF8_BINARY, it does not need to be applied since it's a noop.
    */
   def apply(expression: Expression, collation: String): Expression = {
+    if (CollationFactory.collationNameToId(collation) ==
+        CollationFactory.UTF8_BINARY_COLLATION_ID) {
+      expression
+    } else {
+      applyCollation(expression, collation)
+    }
+  }
+
+  private def applyCollation(expression: Expression, collation: String): Expression = {
     val collatedStringType = StringType(collation)
     expression match {
-      case _: DefaultStringProducingExpression if collatedStringType != StringType =>
+      case _: DefaultStringProducingExpression =>
         Cast(child = expression, dataType = collatedStringType)
       case literal: Literal if hasDefaultStringType(literal.dataType) =>
         literal.copy(dataType = replaceDefaultStringType(literal.dataType, collatedStringType))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ExpressionResolver.scala
@@ -655,7 +655,7 @@ class ExpressionResolver(
   ): (Expression, ExpressionResolutionContext) = {
     traversals.withNewTraversal(
       parentOperator = parentOperator,
-      defaultCollation = resolver.getViewResolver.getViewResolutionContext.flatMap(_.collation),
+      defaultCollation = getDefaultCollation,
       isFilterOnTopOfAggregate = isFilterOnTopOfAggregate(parentOperator),
       isSortOnTopOfAggregate = isSortOnTopOfAggregate(parentOperator)
     ) {
@@ -979,6 +979,24 @@ class ExpressionResolver(
     parentOperator match {
       case _: Sort if scopes.current.baseAggregate.isDefined => true
       case _ => false
+    }
+  }
+
+  /**
+   * Returns the default collation to apply to default-typed string expressions during single-pass
+   * resolution.
+   *
+   *  1. View collation - if we are inside a view resolution, use the view's collation. If the
+   *     view does not have a custom collation, return [[None]] rather than falling back to the
+   *     session collation.
+   *  2. Session collation - for top-level queries and standalone SQL scripting, use the session's
+   *     default collation from [[SQLConf]].
+   */
+  private def getDefaultCollation: Option[String] = {
+    if (resolver.getViewResolver.getViewResolutionContext.isDefined) {
+      resolver.getViewResolver.getViewResolutionContext.get.collation
+    } else {
+      Some(conf.sessionDefaultCollation)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1911,6 +1911,19 @@ trait CreateTempView {
 }
 
 /**
+ * Used by [[ApplyDefaultCollation]] to read and update the default collation on commands that are
+ * defined in the sql/core module (e.g. CreateViewCommand, CreateSQLFunctionCommand) and therefore
+ * cannot be referenced directly from sql/catalyst. Implementations should report whether the
+ * created object is a temporary (session-scoped) object, since session collation is inherited only
+ * for temporary objects.
+ */
+trait SupportsDefaultCollation { self: LogicalPlan =>
+  def collation: Option[String]
+  def isTemp: Boolean
+  def withCollation(collation: Option[String]): LogicalPlan
+}
+
+/**
  * The logical plan of the ALTER VIEW ... SET TBLPROPERTIES command.
  */
 case class SetViewProperties(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -396,6 +396,13 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     )
   }
 
+  def sessionLevelCollationsNotEnabledError(): Throwable = {
+    new AnalysisException(
+      errorClass = "UNSUPPORTED_FEATURE.SESSION_LEVEL_COLLATIONS",
+      messageParameters = Map.empty
+    )
+  }
+
   def trailingCommaInSelectError(origin: Origin): Throwable = {
     new AnalysisException(
       errorClass = "TRAILING_COMMA_IN_SELECT",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -45,7 +45,7 @@ import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.plans.logical.HintErrorHandler
-import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.catalyst.util.{CollationFactory, DateTimeUtils}
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.connector.catalog.PathElement.PathRef
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
@@ -1176,6 +1176,40 @@ object SQLConf {
       .version("4.1.0")
       .booleanConf
       .createWithDefault(false)
+
+  val SESSION_LEVEL_COLLATIONS_ENABLED =
+    buildConf("spark.sql.collation.sessionLevel.enabled")
+      .internal()
+      .doc(
+        "Session level collations feature is under development and its use should be done " +
+          "under this feature flag. The feature allows setting default collation for the " +
+          "current session via SET COLLATION or spark.sql.session.collation.default. " +
+          "The session collation applies to string literals and builtin functions within " +
+          "queries in the session."
+      )
+      .version("4.2.0")
+      .booleanConf
+      .createWithDefault(true)
+
+  val DEFAULT_COLLATION =
+    buildConf("spark.sql.session.collation.default")
+      .internal()
+      .doc("The default collation for the current session. Can also be set via SET COLLATION. " +
+        "Applies to string literals and builtin functions within queries in the session.")
+      .version("4.2.0")
+      .stringConf
+      .transform { collation =>
+        // Validates the collation name and returns its canonical form.
+        // Throws COLLATION_INVALID_NAME if the collation name is invalid.
+        val collationId = CollationFactory.collationNameToId(collation)
+        // Allow UTF8_BINARY regardless of feature flag, block non-UTF8_BINARY when disabled.
+        if (collationId != CollationFactory.UTF8_BINARY_COLLATION_ID &&
+            !SQLConf.get.sessionLevelCollationsEnabled) {
+          throw QueryCompilationErrors.sessionLevelCollationsNotEnabledError()
+        }
+        CollationFactory.fetchCollation(collationId).collationName
+      }
+      .createWithDefault("UTF8_BINARY")
 
   val COLLATION_AWARE_HASHING_ENABLED =
     buildConf("spark.sql.legacy.collationAwareHashFunctions")
@@ -7780,6 +7814,10 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def objectLevelCollationsEnabled: Boolean = getConf(OBJECT_LEVEL_COLLATIONS_ENABLED)
 
   def schemaLevelCollationsEnabled: Boolean = getConf(SCHEMA_LEVEL_COLLATIONS_ENABLED)
+
+  def sessionLevelCollationsEnabled: Boolean = getConf(SESSION_LEVEL_COLLATIONS_ENABLED)
+
+  def sessionDefaultCollation: String = getConf(DEFAULT_COLLATION)
 
   def adaptiveExecutionEnabled: Boolean = getConf(ADAPTIVE_EXECUTION_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.catalyst.parser.SqlBaseParser
 import org.apache.spark.sql.catalyst.parser.SqlBaseParser._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
-import org.apache.spark.sql.catalyst.util.DateTimeConstants
+import org.apache.spark.sql.catalyst.util.{CollationFactory, DateTimeConstants}
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryParsingErrors}
 import org.apache.spark.sql.execution.command._
@@ -308,6 +308,24 @@ class SparkSqlAstBuilder extends AstBuilder {
         case _ => throw QueryParsingErrors.unexpectedFormatForSetConfigurationError(ctx)
       }
     }
+  }
+
+  /**
+   * Create a [[SetCommand]] logical plan to set [[SQLConf.DEFAULT_COLLATION]].
+   * Example SQL:
+   * {{{
+   *   SET COLLATION UTF8_LCASE;
+   *   SET COLLATION `UTF8_BINARY`;
+   *   SET COLLATION UNICODE;
+   * }}}
+   */
+  override def visitSetCollation(ctx: SetCollationContext): LogicalPlan = withOrigin(ctx) {
+    if (!SQLConf.get.sessionLevelCollationsEnabled) {
+      throw QueryCompilationErrors.sessionLevelCollationsNotEnabledError()
+    }
+    val collationName = getIdentifierText(ctx.collationName)
+    val validatedName = CollationFactory.fetchCollation(collationName).collationName
+    SetCommand(Some(SQLConf.DEFAULT_COLLATION.key -> Some(validatedName)))
   }
 
   override def visitSetQuotedConfiguration(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CreateSQLFunctionCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CreateSQLFunctionCommand.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.catalog.UserDefinedFunction._
 import org.apache.spark.sql.catalyst.expressions.{Alias, Cast, Expression, Generator, LateralSubquery, Literal, ScalarSubquery, SubqueryExpression, WindowExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.Inner
-import org.apache.spark.sql.catalyst.plans.logical.{LateralJoin, LocalRelation, LogicalPlan, OneRowRelation, Project, Range, UnresolvedWith, View}
+import org.apache.spark.sql.catalyst.plans.logical.{LateralJoin, LocalRelation, LogicalPlan, OneRowRelation, Project, Range, SupportsDefaultCollation, UnresolvedWith, View}
 import org.apache.spark.sql.catalyst.trees.TreePattern.UNRESOLVED_ATTRIBUTE
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdentifierHelper
@@ -64,9 +64,13 @@ case class CreateSQLFunctionCommand(
     isTemp: Boolean,
     ignoreIfExists: Boolean,
     replace: Boolean)
-    extends CreateUserDefinedFunctionCommand {
+    extends CreateUserDefinedFunctionCommand
+    with SupportsDefaultCollation {
 
   import SQLFunction._
+
+  override def withCollation(newCollation: Option[String]): LogicalPlan =
+    copy(collation = newCollation)
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val parser = sparkSession.sessionState.sqlParser

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.analysis.{AnalysisContext, GlobalTempView, 
 import org.apache.spark.sql.catalyst.analysis.V2TableReference
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, TemporaryViewRelation}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, SubqueryExpression, VariableReference}
-import org.apache.spark.sql.catalyst.plans.logical.{AlterViewAs, AnalysisOnlyCommand, CreateTempView, CreateView, CTEInChildren, CTERelationDef, LogicalPlan, Project, View, WithCTE}
+import org.apache.spark.sql.catalyst.plans.logical.{AlterViewAs, AnalysisOnlyCommand, CreateTempView, CreateView, CTEInChildren, CTERelationDef, LogicalPlan, Project, SupportsDefaultCollation, View, WithCTE}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.classic.ClassicConversions.castToImpl
 import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogPlugin, Identifier, ViewCatalog}
@@ -88,7 +88,8 @@ case class CreateViewCommand(
   extends RunnableCommand
   with AnalysisOnlyCommand
   with CTEInChildren
-  with CreateTempView {
+  with CreateTempView
+  with SupportsDefaultCollation {
 
   import ViewHelper._
 
@@ -109,6 +110,11 @@ case class CreateViewCommand(
   }
 
   private def isTemporary = viewType == LocalTempView || viewType == GlobalTempView
+
+  override def isTemp: Boolean = isTemporary
+
+  override def withCollation(newCollation: Option[String]): LogicalPlan =
+    copy(collation = newCollation)
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     if (!isAnalyzed) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -472,6 +472,16 @@ trait QueryTestBase
   }
 
   /**
+   * Restores session collation to its previous value after calling `f`.
+   */
+  protected def withSessionCollation(f: => Unit): Unit = {
+    val originalCollation = spark.conf.get(SQLConf.DEFAULT_COLLATION.key)
+    Utils.tryWithSafeFinally(f) {
+      spark.sql(s"SET COLLATION $originalCollation")
+    }
+  }
+
+  /**
    * Enables Locale `language` before executing `f`, then switches back to the default locale of
    * JVM after `f` returns.
    */

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/SessionDefaultCollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/SessionDefaultCollationSuite.scala
@@ -1,0 +1,319 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.collation
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class SessionDefaultCollationSuite extends QueryTest with SharedSparkSession {
+
+  private val prefix = "SYSTEM.BUILTIN"
+  private val testTableName = "test_table"
+  private val testViewName = "test_view"
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    spark.conf.set(SQLConf.SESSION_LEVEL_COLLATIONS_ENABLED.key, "true")
+  }
+
+  test("SELECT with literal gets session collation") {
+    withSessionCollation {
+      sql("SET COLLATION sr_AI")
+      checkAnswer(
+        sql("SELECT COLLATION('hello')"),
+        Row(s"$prefix.sr_AI")
+      )
+    }
+  }
+
+  test("SELECT with WHERE clause comparing literals applies session collation") {
+    withSessionCollation {
+      sql("SET COLLATION UTF8_LCASE")
+      withTable(testTableName) {
+        sql(s"CREATE TABLE $testTableName (id INT) USING parquet")
+        sql(s"INSERT INTO $testTableName VALUES (1), (2), (3)")
+
+        checkAnswer(
+          sql(
+            s"""SELECT id, 'result' AS c1, COLLATION('result')
+               |FROM $testTableName
+               |WHERE 'hello' = 'HELLO' AND 'test' = 'TEST'""".stripMargin),
+          Seq(
+            Row(1, "result", s"$prefix.UTF8_LCASE"),
+            Row(2, "result", s"$prefix.UTF8_LCASE"),
+            Row(3, "result", s"$prefix.UTF8_LCASE")
+          )
+        )
+      }
+    }
+  }
+
+  test("SELECT with subquery returning literals gets session collation") {
+    withSessionCollation {
+      sql("SET COLLATION UTF8_LCASE")
+      checkAnswer(
+        sql(
+          """SELECT COLLATION(c1), COLLATION(c2), c1 = 'HELLO', c2 = 'WORLD'
+            |FROM (SELECT 'hello' AS c1, 'world' AS c2)""".stripMargin),
+        Row(s"$prefix.UTF8_LCASE", s"$prefix.UTF8_LCASE", true, true)
+      )
+    }
+  }
+
+  test("SELECT with nested subqueries applies session collation") {
+    withSessionCollation {
+      sql("SET COLLATION UTF8_LCASE")
+      checkAnswer(
+        sql(
+          """SELECT COLLATION(result), result = 'INNER', result = 'INNER' COLLATE UNICODE
+            |FROM (
+            |  SELECT inner_col AS result
+            |  FROM (SELECT 'inner' AS inner_col)
+            |)""".stripMargin),
+        Row(s"$prefix.UTF8_LCASE", true, false)
+      )
+    }
+  }
+
+  test("SELECT with string-producing expressions applies session collation") {
+    withSessionCollation {
+      sql("SET COLLATION UTF8_LCASE")
+      checkAnswer(
+        sql(
+          """SELECT
+            |  COLLATION(current_database()),
+            |  COLLATION(current_catalog()),
+            |  COLLATION(current_user()),
+            |  current_database() = upper(current_database()),
+            |  current_catalog() = upper(current_catalog())""".stripMargin),
+        Row(s"$prefix.UTF8_LCASE", s"$prefix.UTF8_LCASE", s"$prefix.UTF8_LCASE", true, true)
+      )
+    }
+  }
+
+  test("SELECT combining literals and string functions") {
+    withSessionCollation {
+      sql("SET COLLATION UTF8_LCASE")
+      checkAnswer(
+        sql(
+          """SELECT
+            |  COLLATION('prefix_' || current_database()),
+            |  ('prefix_' || current_database()) = upper('prefix_' || current_database())
+            |""".stripMargin),
+        Row(s"$prefix.UTF8_LCASE", true)
+      )
+    }
+  }
+
+  test("SELECT with WHERE comparing columns to literals uses column collation") {
+    withSessionCollation {
+      sql("SET COLLATION UTF8_LCASE")
+      withTable(testTableName) {
+        sql(
+          s"""CREATE TABLE $testTableName (
+             |  c1 STRING,
+             |  c2 STRING COLLATE UTF8_BINARY,
+             |  c3 STRING COLLATE UNICODE,
+             |  c4 STRING COLLATE UTF8_LCASE
+             |) USING parquet""".stripMargin)
+        sql(s"INSERT INTO $testTableName VALUES ('hello', 'hello', 'hello', 'hello')")
+
+        checkAnswer(
+          sql(
+            s"""SELECT COLLATION(c1), COLLATION(c2), COLLATION(c3), COLLATION(c4)
+               |FROM $testTableName
+               |WHERE c1 != 'HELLO' AND c2 != 'HELLO'
+               |  AND c3 != 'HELLO' AND c4 = 'HELLO'
+               |  AND 'a' = 'A'""".stripMargin),
+          Row(s"$prefix.UTF8_BINARY", s"$prefix.UTF8_BINARY",
+            s"$prefix.UNICODE", s"$prefix.UTF8_LCASE")
+        )
+      }
+    }
+  }
+
+  test("CASE expression on literals applies session collation") {
+    withSessionCollation {
+      sql("SET COLLATION UTF8_LCASE")
+      checkAnswer(
+        sql(
+          """SELECT CASE
+            |  WHEN 'hello' = 'HELLO' THEN 'matched'
+            |  ELSE 'no_match'
+            |END AS result,
+            |COLLATION('literal')""".stripMargin),
+        Row("matched", s"$prefix.UTF8_LCASE")
+      )
+    }
+  }
+
+  test("DML with COALESCE on literals applies session collation") {
+    withSessionCollation {
+      sql("SET COLLATION UTF8_LCASE")
+      checkAnswer(
+        sql(
+          """SELECT COLLATION(COALESCE(NULL, 'fallback')),
+            |  COALESCE(NULL, 'hello') = 'HELLO'""".stripMargin),
+        Row(s"$prefix.UTF8_LCASE", true)
+      )
+    }
+  }
+
+  test("SET COLLATION UTF8_BINARY restores default behavior") {
+    withSessionCollation {
+      sql("SET COLLATION UTF8_LCASE")
+      checkAnswer(sql("SELECT 'hello' = 'HELLO'"), Row(true))
+    }
+    // After withSessionCollation resets to UTF8_BINARY
+    checkAnswer(sql("SELECT 'hello' = 'HELLO'"), Row(false))
+  }
+
+  test("session collation does not affect explicit COLLATE on literals") {
+    withSessionCollation {
+      sql("SET COLLATION UTF8_LCASE")
+      checkAnswer(
+        sql("SELECT COLLATION('hello' COLLATE UNICODE_CI)"),
+        Row(s"$prefix.UNICODE_CI")
+      )
+      checkAnswer(
+        sql("SELECT COLLATION('hello' COLLATE UTF8_BINARY)"),
+        Row(s"$prefix.UTF8_BINARY")
+      )
+    }
+  }
+
+  test("spark.conf.set with valid collation succeeds when feature flag enabled") {
+    withSessionCollation {
+      spark.conf.set(SQLConf.DEFAULT_COLLATION.key, "UTF8_LCASE")
+      checkAnswer(
+        sql("SELECT COLLATION('hello')"),
+        Row(s"$prefix.UTF8_LCASE")
+      )
+    }
+  }
+
+  test("spark.conf.set with invalid collation fails") {
+    val e = intercept[SparkException] {
+      spark.conf.set(SQLConf.DEFAULT_COLLATION.key, "INVALID_COLLATION")
+    }
+    assert(e.getCondition == "COLLATION_INVALID_NAME")
+  }
+
+  test("spark.conf.set with UTF8_BINARY succeeds regardless of feature flag") {
+    Seq("true", "false").foreach { flag =>
+      withSQLConf(SQLConf.SESSION_LEVEL_COLLATIONS_ENABLED.key -> flag) {
+        spark.conf.set(SQLConf.DEFAULT_COLLATION.key, "UTF8_BINARY")
+        assert(spark.conf.get(SQLConf.DEFAULT_COLLATION.key) == "UTF8_BINARY")
+      }
+    }
+  }
+
+  test("spark.conf.set with non-UTF8_BINARY collation fails when feature flag disabled") {
+    withSQLConf(SQLConf.SESSION_LEVEL_COLLATIONS_ENABLED.key -> "false") {
+      val e = intercept[AnalysisException] {
+        spark.conf.set(SQLConf.DEFAULT_COLLATION.key, "UTF8_LCASE")
+      }
+      assert(e.getCondition == "UNSUPPORTED_FEATURE.SESSION_LEVEL_COLLATIONS")
+    }
+  }
+
+  test("NULLIF column against literal with session collation") {
+    withSessionCollation {
+      sql("SET COLLATION UTF8_LCASE")
+      withTable(testTableName) {
+        sql(s"CREATE TABLE $testTableName (c1 STRING) USING parquet")
+        sql(s"INSERT INTO $testTableName VALUES ('hello')")
+        checkAnswer(
+          sql(s"SELECT NULLIF(c1, 'HELLO') FROM $testTableName"),
+          Row(null)
+        )
+      }
+    }
+  }
+
+  test("CTAS persists string columns under session collation") {
+    withSessionCollation {
+      sql("SET COLLATION UTF8_LCASE")
+      withTable(testTableName) {
+        sql(s"CREATE TABLE $testTableName USING parquet AS SELECT 'a' AS c1")
+        // CTAS is a DDL command; session collation should NOT be applied to column types.
+        checkAnswer(
+          sql(s"SELECT COLLATION(c1) FROM $testTableName"),
+          Row(s"$prefix.UTF8_BINARY")
+        )
+      }
+    }
+  }
+
+  test("temp view inherits session collation for literals") {
+    Seq("", "OR REPLACE").foreach { replace =>
+      withSessionCollation {
+        sql("SET COLLATION UTF8_LCASE")
+        withTempView(testViewName) {
+          sql(
+            s"""CREATE $replace TEMPORARY VIEW $testViewName AS
+               |SELECT 'hello' AS c1,
+               |  'hello' COLLATE UTF8_BINARY AS c2
+               |WHERE 'a' = 'A'""".stripMargin)
+          checkAnswer(
+            sql(s"""SELECT COLLATION(c1), COLLATION(c2),
+                   |  c1 = 'HELLO', c2 = 'HELLO'
+                   |FROM $testViewName""".stripMargin),
+            Row(s"$prefix.UTF8_LCASE", s"$prefix.UTF8_BINARY", true, false)
+          )
+        }
+      }
+    }
+  }
+
+  test("temp view retains its collation after session collation changes") {
+    withSessionCollation {
+      sql("SET COLLATION UTF8_LCASE")
+      withTempView(testViewName) {
+        sql(
+          s"""CREATE TEMPORARY VIEW $testViewName AS
+             |SELECT 'hello' AS c1
+             |WHERE 'a' = 'A'""".stripMargin)
+        sql("SET COLLATION UTF8_BINARY")
+        checkAnswer(
+          sql(s"SELECT COLLATION(c1), c1 = 'HELLO' FROM $testViewName"),
+          Row(s"$prefix.UTF8_LCASE", true)
+        )
+      }
+    }
+  }
+
+  test("temp view with explicit DEFAULT COLLATION ignores session collation") {
+    withSessionCollation {
+      sql("SET COLLATION UTF8_LCASE")
+      withTempView(testViewName) {
+        sql(
+          s"""CREATE TEMPORARY VIEW $testViewName
+             |DEFAULT COLLATION UNICODE AS
+             |SELECT 'hello' AS c1
+             |WHERE 'a' != 'A'""".stripMargin)
+        checkAnswer(
+          sql(s"SELECT COLLATION(c1) FROM $testViewName"),
+          Row(s"$prefix.UNICODE")
+        )
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.execution
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.{SparkConf, SparkThrowable}
+import org.apache.spark.{SparkConf, SparkException, SparkThrowable}
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.internal.config.ConfigEntry
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, UnresolvedAlias,
@@ -409,6 +410,60 @@ class SparkSqlParserSuite extends AnalysisTest with SharedSparkSession {
         fragment = "SET `a`=1;2",
         start = 0,
         stop = 10))
+  }
+
+  test("SET COLLATION - feature flag enabled with valid collation") {
+    withSQLConf(SQLConf.SESSION_LEVEL_COLLATIONS_ENABLED.key -> "true") {
+      assertEqual("SET COLLATION UTF8_LCASE",
+        SetCommand(Some(SQLConf.DEFAULT_COLLATION.key -> Some("UTF8_LCASE"))))
+      assertEqual("SET COLLATION UTF8_BINARY",
+        SetCommand(Some(SQLConf.DEFAULT_COLLATION.key -> Some("UTF8_BINARY"))))
+      assertEqual("SET COLLATION UNICODE",
+        SetCommand(Some(SQLConf.DEFAULT_COLLATION.key -> Some("UNICODE"))))
+      assertEqual("SET COLLATION `UNICODE`",
+        SetCommand(Some(SQLConf.DEFAULT_COLLATION.key -> Some("UNICODE"))))
+      assertEqual("SET COLLATION `uniCODe`",
+        SetCommand(Some(SQLConf.DEFAULT_COLLATION.key -> Some("UNICODE"))))
+      assertEqual("SET COLLATION utf8_lcase",
+        SetCommand(Some(SQLConf.DEFAULT_COLLATION.key -> Some("UTF8_LCASE"))))
+      assertEqual("SET COLLATION `UtF8_BinaRY`",
+        SetCommand(Some(SQLConf.DEFAULT_COLLATION.key -> Some("UTF8_BINARY"))))
+    }
+  }
+
+  test("SET COLLATION - feature flag enabled with invalid collation") {
+    withSQLConf(SQLConf.SESSION_LEVEL_COLLATIONS_ENABLED.key -> "true") {
+      checkError(
+        exception = intercept[SparkException] {
+          sql("SET COLLATION INVALID_COLLATION").collect()
+        },
+        condition = "COLLATION_INVALID_NAME",
+        parameters = Map(
+          "collationName" -> "INVALID_COLLATION",
+          "proposals" -> "id_IDN"))
+    }
+  }
+
+  test("SET COLLATION - feature flag disabled with valid collation") {
+    withSQLConf(SQLConf.SESSION_LEVEL_COLLATIONS_ENABLED.key -> "false") {
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("SET COLLATION UTF8_LCASE").collect()
+        },
+        condition = "UNSUPPORTED_FEATURE.SESSION_LEVEL_COLLATIONS",
+        parameters = Map.empty)
+    }
+  }
+
+  test("SET COLLATION - feature flag disabled with invalid collation") {
+    withSQLConf(SQLConf.SESSION_LEVEL_COLLATIONS_ENABLED.key -> "false") {
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("SET COLLATION INVALID_COLLATION").collect()
+        },
+        condition = "UNSUPPORTED_FEATURE.SESSION_LEVEL_COLLATIONS",
+        parameters = Map.empty)
+    }
   }
 
   test("refresh resource") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuiteBase.scala
@@ -350,6 +350,7 @@ trait ShowTablesSuiteBase extends QueryTest with DDLCommandTestUtils {
              |Last Access: <last access>
              |Created By: <created by>
              |Type: VIEW
+             |Collation: UTF8_BINARY
              |View Text: SELECT id FROM $catalog.$namespace.$table
              |View Schema Mode: BINDING
              |View Catalog and Namespace: spark_catalog.default
@@ -377,6 +378,7 @@ trait ShowTablesSuiteBase extends QueryTest with DDLCommandTestUtils {
              |Last Access: <last access>
              |Created By: <created by>
              |Type: VIEW
+             |Collation: UTF8_BINARY
              |View Text: SELECT id FROM $catalog.$namespace.$table
              |View Schema Mode: BINDING
              |View Catalog and Namespace: spark_catalog.default
@@ -395,6 +397,7 @@ trait ShowTablesSuiteBase extends QueryTest with DDLCommandTestUtils {
              |Last Access: <last access>
              |Created By: <created by>
              |Type: VIEW
+             |Collation: UTF8_BINARY
              |View Text: SELECT id FROM $catalog.$namespace.$table
              |View Schema Mode: BINDING
              |View Catalog and Namespace: spark_catalog.default


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adds session-level default collation. New `SET COLLATION <name>` SQL command (gated by `spark.sql.collation.sessionLevel.enabled`). The session collation is applied to string literals and string-producing built-in functions in top-level queries. Temp views and temp SQL UDFs created without an explicit collation inherit it at creation time. Persistent objects, view/UDF body resolution, and explicit `COLLATE` are unaffected.

### Why are the changes needed?
Lets users opt into a non-UTF8_BINARY default for an entire session without rewriting individual queries or recreating tables.

### Does this PR introduce _any_ user-facing change?
Yes — adds the `SET COLLATION <name>` command.

### How was this patch tested?
New `SessionDefaultCollationSuite`; additional cases in `SparkSqlParserSuite`.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code