### PR TITLE
[SPARK-56132][SS] Call pruneColumns on V2 streaming to fix metadata reading issue 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3445,6 +3445,16 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val STREAMING_V2_PRUNE_COLUMNS_ENABLED =
+    buildConf("spark.sql.streaming.v2.pruneColumns.enabled")
+      .internal()
+      .doc("When true, pruneColumns is called on V2 streaming scan builders that implement " +
+        "SupportsPushDownRequiredColumns. This communicates metadata columns to the scan " +
+        "builder so they appear in readSchema(). Disable if a connector's pruneColumns " +
+        "implementation is not compatible with being called in the streaming path.")
+      .booleanConf
+      .createWithDefault(true)
+
   val STREAMING_TRIGGER_AVAILABLE_NOW_WRAPPER_ENABLED =
     buildConf("spark.sql.streaming.triggerAvailableNowWrapper.enabled")
       .internal()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3452,8 +3452,8 @@ object SQLConf {
         "SupportsPushDownRequiredColumns. This communicates metadata columns to the scan " +
         "builder so they appear in readSchema(). Disable if a connector's pruneColumns " +
         "implementation is not compatible with being called in the streaming path.")
-      .booleanConf
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .booleanConf
       .createWithDefault(true)
 
   val STREAMING_TRIGGER_AVAILABLE_NOW_WRAPPER_ENABLED =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3445,17 +3445,6 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val STREAMING_V2_PRUNE_COLUMNS_ENABLED =
-    buildConf("spark.sql.streaming.v2.pruneColumns.enabled")
-      .internal()
-      .doc("When true, pruneColumns is called on V2 streaming scan builders that implement " +
-        "SupportsPushDownRequiredColumns. This communicates metadata columns to the scan " +
-        "builder so they appear in readSchema(). Disable if a connector's pruneColumns " +
-        "implementation is not compatible with being called in the streaming path.")
-      .withBindingPolicy(ConfigBindingPolicy.SESSION)
-      .booleanConf
-      .createWithDefault(true)
-
   val STREAMING_TRIGGER_AVAILABLE_NOW_WRAPPER_ENABLED =
     buildConf("spark.sql.streaming.triggerAvailableNowWrapper.enabled")
       .internal()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3453,6 +3453,7 @@ object SQLConf {
         "builder so they appear in readSchema(). Disable if a connector's pruneColumns " +
         "implementation is not compatible with being called in the streaming path.")
       .booleanConf
+      .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .createWithDefault(true)
 
   val STREAMING_TRIGGER_AVAILABLE_NOW_WRAPPER_ENABLED =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -545,7 +545,8 @@ abstract class InMemoryBaseTable(
     override def json(): String = rowCount.toString
   }
 
-  class InMemoryMicroBatchStream extends MicroBatchStream {
+  class InMemoryMicroBatchStream(readSchema: StructType, tableSchema: StructType)
+      extends MicroBatchStream {
     override def initialOffset(): Offset = new InMemoryTableOffset(0)
     override def latestOffset(): Offset =
       new InMemoryTableOffset(InMemoryBaseTable.this.rows.size.toLong)
@@ -554,14 +555,16 @@ abstract class InMemoryBaseTable(
       val e = end.asInstanceOf[InMemoryTableOffset].rowCount.toInt
       Array(InMemoryMicroBatchPartition(InMemoryBaseTable.this.rows.slice(s, e)))
     }
-    override def createReaderFactory(): PartitionReaderFactory = { partition =>
-      val rows = partition.asInstanceOf[InMemoryMicroBatchPartition].rows
-      new PartitionReader[InternalRow] {
-        private var idx = -1
-        override def next(): Boolean = { idx += 1; idx < rows.size }
-        override def get(): InternalRow = rows(idx)
-        override def close(): Unit = {}
+    override def createReaderFactory(): PartitionReaderFactory = {
+      val metadataColNames = new mutable.ArrayBuffer[String]()
+      val nonMetadataFields = readSchema.filter {
+        case MetadataStructFieldWithLogicalName(_, name) => metadataColNames += name; false
+        case _ => true
       }
+      new InMemoryMicroBatchReaderFactory(
+        nonMetadataFields.map(f => tableSchema.fieldIndex(f.name)).toArray,
+        tableSchema.fields,
+        metadataColNames.toArray)
     }
     override def deserializeOffset(json: String): Offset = new InMemoryTableOffset(json.toLong)
     override def commit(end: Offset): Unit = {}
@@ -655,7 +658,7 @@ abstract class InMemoryBaseTable(
     }
 
     override def toMicroBatchStream(checkpointLocation: String): MicroBatchStream =
-      new InMemoryMicroBatchStream
+      new InMemoryMicroBatchStream(readSchema, tableSchema)
   }
 
   case class InMemoryBatchScan(
@@ -952,6 +955,34 @@ class BufferedRows(val key: Seq[Any], val schema: StructType)
   override def filesCount(): OptionalLong = OptionalLong.of(100L)
 
   def clear(): Unit = rows.clear()
+}
+
+private class InMemoryMicroBatchReaderFactory(
+    fieldIndices: Array[Int],
+    tableFields: Array[StructField],
+    metaNames: Array[String]) extends PartitionReaderFactory with Serializable {
+  override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
+    val rows = partition.asInstanceOf[InMemoryMicroBatchPartition].rows
+    new PartitionReader[InternalRow] {
+      private var idx = -1
+      override def next(): Boolean = { idx += 1; idx < rows.size }
+      override def get(): InternalRow = {
+        val rawRow = rows(idx)
+        val dataRow = new GenericInternalRow(
+          fieldIndices.map(i => rawRow.get(i, tableFields(i).dataType)))
+        if (metaNames.isEmpty) dataRow
+        else {
+          val metaRow = new GenericInternalRow(metaNames.map {
+            case "index" => idx.asInstanceOf[Any]
+            case "_partition" => UTF8String.fromString("").asInstanceOf[Any]
+            case _ => null
+          })
+          new JoinedRow(dataRow, metaRow)
+        }
+      }
+      override def close(): Unit = {}
+    }
+  }
 }
 
 object BufferedRows {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -557,14 +557,11 @@ abstract class InMemoryBaseTable(
     }
     override def createReaderFactory(): PartitionReaderFactory = {
       val metadataColNames = new mutable.ArrayBuffer[String]()
-      val nonMetadataFields = readSchema.filter {
-        case MetadataStructFieldWithLogicalName(_, name) => metadataColNames += name; false
-        case _ => true
+      readSchema.foreach {
+        case MetadataStructFieldWithLogicalName(_, name) => metadataColNames += name
+        case _ =>
       }
-      new InMemoryMicroBatchReaderFactory(
-        nonMetadataFields.map(f => tableSchema.fieldIndex(f.name)).toArray,
-        tableSchema.fields,
-        metadataColNames.toArray)
+      new InMemoryMicroBatchReaderFactory(metadataColNames.toArray)
     }
     override def deserializeOffset(json: String): Offset = new InMemoryTableOffset(json.toLong)
     override def commit(end: Offset): Unit = {}
@@ -958,8 +955,6 @@ class BufferedRows(val key: Seq[Any], val schema: StructType)
 }
 
 private class InMemoryMicroBatchReaderFactory(
-    fieldIndices: Array[Int],
-    tableFields: Array[StructField],
     metaNames: Array[String]) extends PartitionReaderFactory with Serializable {
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
     val rows = partition.asInstanceOf[InMemoryMicroBatchPartition].rows
@@ -968,16 +963,14 @@ private class InMemoryMicroBatchReaderFactory(
       override def next(): Boolean = { idx += 1; idx < rows.size }
       override def get(): InternalRow = {
         val rawRow = rows(idx)
-        val dataRow = new GenericInternalRow(
-          fieldIndices.map(i => rawRow.get(i, tableFields(i).dataType)))
-        if (metaNames.isEmpty) dataRow
+        if (metaNames.isEmpty) rawRow
         else {
           val metaRow = new GenericInternalRow(metaNames.map {
             case "index" => idx.asInstanceOf[Any]
             case "_partition" => UTF8String.fromString("").asInstanceOf[Any]
             case _ => null
           })
-          new JoinedRow(dataRow, metaRow)
+          new JoinedRow(rawRow, metaRow)
         }
       }
       override def close(): Unit = {}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, PartitionOffset, ReadLimit, SparkDataStream}
 import org.apache.spark.sql.connector.write.{RequiresDistributionAndOrdering, Write}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.datasources.v2.{StreamingDataSourceV2Relation, StreamingDataSourceV2ScanRelation}
 import org.apache.spark.sql.execution.streaming._
@@ -96,10 +97,12 @@ class ContinuousExecution(
           // Passes the full output schema (not a pruned subset) so that connectors
           // implementing SupportsMetadataColumns can include metadata columns in readSchema().
           val scanBuilder = table.newScanBuilder(options)
-          scanBuilder match {
-            case r: SupportsPushDownRequiredColumns =>
-              r.pruneColumns(output.toStructType)
-            case _ =>
+          if (sparkSession.sessionState.conf.getConf(SQLConf.STREAMING_V2_PRUNE_COLUMNS_ENABLED)) {
+            scanBuilder match {
+              case r: SupportsPushDownRequiredColumns =>
+                r.pruneColumns(output.toStructType)
+              case _ =>
+            }
           }
           val scan = scanBuilder.build()
           val stream = scan.toContinuousStream(metadataPath)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
@@ -39,10 +39,10 @@ import org.apache.spark.sql.connector.write.{RequiresDistributionAndOrdering, Wr
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.datasources.v2.{StreamingDataSourceV2Relation, StreamingDataSourceV2ScanRelation}
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.checkpointing.{CommitMetadata, OffsetSeq}
 import org.apache.spark.sql.execution.streaming.runtime.{AcceptsLatestSeenOffsetHandler, ACTIVE, ContinuousExecutionContext, IncrementalExecution, ProcessingTimeExecutor, RECONFIGURING, State, StreamExecution, StreamExecutionContext, TERMINATED, WatermarkPropagator}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.Trigger
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Clock

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
@@ -93,6 +93,8 @@ class ContinuousExecution(
             log"from DataSourceV2 named '${MDC(STREAMING_DATA_SOURCE_NAME, sourceName)}' " +
             log"${MDC(STREAMING_DATA_SOURCE_DESCRIPTION, dsStr)}")
           // TODO: operator pushdown.
+          // Passes the full output schema (not a pruned subset) so that connectors
+          // implementing SupportsMetadataColumns can include metadata columns in readSchema().
           val scanBuilder = table.newScanBuilder(options)
           scanBuilder match {
             case r: SupportsPushDownRequiredColumns =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
@@ -37,9 +37,9 @@ import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, PartitionOffset, ReadLimit, SparkDataStream}
 import org.apache.spark.sql.connector.write.{RequiresDistributionAndOrdering, Write}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.datasources.v2.{StreamingDataSourceV2Relation, StreamingDataSourceV2ScanRelation}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.checkpointing.{CommitMetadata, OffsetSeq}
 import org.apache.spark.sql.execution.streaming.runtime.{AcceptsLatestSeenOffsetHandler, ACTIVE, ContinuousExecutionContext, IncrementalExecution, ProcessingTimeExecutor, RECONFIGURING, State, StreamExecution, StreamExecutionContext, TERMINATED, WatermarkPropagator}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.CURRENT_LIKE
 import org.apache.spark.sql.classic.SparkSession
 import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, TableCapability}
 import org.apache.spark.sql.connector.distributions.UnspecifiedDistribution
+import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, PartitionOffset, ReadLimit, SparkDataStream}
 import org.apache.spark.sql.connector.write.{RequiresDistributionAndOrdering, Write}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
@@ -92,7 +93,13 @@ class ContinuousExecution(
             log"from DataSourceV2 named '${MDC(STREAMING_DATA_SOURCE_NAME, sourceName)}' " +
             log"${MDC(STREAMING_DATA_SOURCE_DESCRIPTION, dsStr)}")
           // TODO: operator pushdown.
-          val scan = table.newScanBuilder(options).build()
+          val scanBuilder = table.newScanBuilder(options)
+          scanBuilder match {
+            case r: SupportsPushDownRequiredColumns =>
+              r.pruneColumns(output.toStructType)
+            case _ =>
+          }
+          val scan = scanBuilder.build()
           val stream = scan.toContinuousStream(metadataPath)
           val relation = StreamingDataSourceV2Relation(
               table, output, catalog, identifier, options, metadataPath)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
@@ -42,7 +42,6 @@ import org.apache.spark.sql.execution.datasources.v2.{StreamingDataSourceV2Relat
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.checkpointing.{CommitMetadata, OffsetSeq}
 import org.apache.spark.sql.execution.streaming.runtime.{AcceptsLatestSeenOffsetHandler, ACTIVE, ContinuousExecutionContext, IncrementalExecution, ProcessingTimeExecutor, RECONFIGURING, State, StreamExecution, StreamExecutionContext, TERMINATED, WatermarkPropagator}
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.Trigger
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Clock
@@ -97,12 +96,10 @@ class ContinuousExecution(
           // Passes the full output schema (not a pruned subset) so that connectors
           // implementing SupportsMetadataColumns can include metadata columns in readSchema().
           val scanBuilder = table.newScanBuilder(options)
-          if (sparkSession.sessionState.conf.getConf(SQLConf.STREAMING_V2_PRUNE_COLUMNS_ENABLED)) {
-            scanBuilder match {
-              case r: SupportsPushDownRequiredColumns =>
-                r.pruneColumns(output.toStructType)
-              case _ =>
-            }
+          scanBuilder match {
+            case r: SupportsPushDownRequiredColumns =>
+              r.pruneColumns(output.toStructType)
+            case _ =>
           }
           val scan = scanBuilder.build()
           val stream = scan.toContinuousStream(metadataPath)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -228,7 +228,9 @@ class MicroBatchExecution(
             // Passes the full output schema (not a pruned subset) so that connectors
             // implementing SupportsMetadataColumns can include metadata columns in readSchema().
             val scanBuilder = table.newScanBuilder(options)
-            if (sparkSession.sessionState.conf.getConf(SQLConf.STREAMING_V2_PRUNE_COLUMNS_ENABLED)) {
+            val pruneColumnsEnabled =
+              sparkSession.sessionState.conf.getConf(SQLConf.STREAMING_V2_PRUNE_COLUMNS_ENABLED)
+            if (pruneColumnsEnabled) {
               scanBuilder match {
                 case r: SupportsPushDownRequiredColumns =>
                   r.pruneColumns(output.toStructType)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -225,6 +225,8 @@ class MicroBatchExecution(
               log"from DataSourceV2 named '${MDC(LogKeys.STREAMING_DATA_SOURCE_NAME, srcName)}' " +
               log"${MDC(LogKeys.STREAMING_DATA_SOURCE_DESCRIPTION, dsStr)}")
             // TODO: operator pushdown.
+            // Passes the full output schema (not a pruned subset) so that connectors
+            // implementing SupportsMetadataColumns can include metadata columns in readSchema().
             val scanBuilder = table.newScanBuilder(options)
             scanBuilder match {
               case r: SupportsPushDownRequiredColumns =>
@@ -246,8 +248,6 @@ class MicroBatchExecution(
                 },
                 sourceIdentifyingName
               )
-            // output is trusted to match scan.readSchema() because pruneColumns was called
-            // with output.toStructType, so a well-behaved connector will produce the same fields.
             StreamingDataSourceV2ScanRelation(relation, scan, output, stream)
           })
         } else if (v1.isEmpty) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -246,6 +246,8 @@ class MicroBatchExecution(
                 },
                 sourceIdentifyingName
               )
+            // output is trusted to match scan.readSchema() because pruneColumns was called
+            // with output.toStructType, so a well-behaved connector will produce the same fields.
             StreamingDataSourceV2ScanRelation(relation, scan, output, stream)
           })
         } else if (v1.isEmpty) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -228,14 +228,10 @@ class MicroBatchExecution(
             // Passes the full output schema (not a pruned subset) so that connectors
             // implementing SupportsMetadataColumns can include metadata columns in readSchema().
             val scanBuilder = table.newScanBuilder(options)
-            val pruneColumnsEnabled =
-              sparkSession.sessionState.conf.getConf(SQLConf.STREAMING_V2_PRUNE_COLUMNS_ENABLED)
-            if (pruneColumnsEnabled) {
-              scanBuilder match {
-                case r: SupportsPushDownRequiredColumns =>
-                  r.pruneColumns(output.toStructType)
-                case _ =>
-              }
+            scanBuilder match {
+              case r: SupportsPushDownRequiredColumns =>
+                r.pruneColumns(output.toStructType)
+              case _ =>
             }
             val scan = scanBuilder.build()
             val stream = scan.toMicroBatchStream(metadataPath)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -39,6 +39,7 @@ import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.classic.{Dataset, SparkSession}
 import org.apache.spark.sql.classic.ClassicConversions.castToImpl
 import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, TableCapability, TransactionalCatalogPlugin}
+import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns
 import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, Offset => OffsetV2, ReadLimit, SparkDataStream, SupportsAdmissionControl, SupportsRealTimeMode, SupportsTriggerAvailableNow}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
@@ -224,7 +225,13 @@ class MicroBatchExecution(
               log"from DataSourceV2 named '${MDC(LogKeys.STREAMING_DATA_SOURCE_NAME, srcName)}' " +
               log"${MDC(LogKeys.STREAMING_DATA_SOURCE_DESCRIPTION, dsStr)}")
             // TODO: operator pushdown.
-            val scan = table.newScanBuilder(options).build()
+            val scanBuilder = table.newScanBuilder(options)
+            scanBuilder match {
+              case r: SupportsPushDownRequiredColumns =>
+                r.pruneColumns(output.toStructType)
+              case _ =>
+            }
+            val scan = scanBuilder.build()
             val stream = scan.toMicroBatchStream(metadataPath)
             val relation = StreamingDataSourceV2Relation(
                 table,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala
@@ -228,10 +228,12 @@ class MicroBatchExecution(
             // Passes the full output schema (not a pruned subset) so that connectors
             // implementing SupportsMetadataColumns can include metadata columns in readSchema().
             val scanBuilder = table.newScanBuilder(options)
-            scanBuilder match {
-              case r: SupportsPushDownRequiredColumns =>
-                r.pruneColumns(output.toStructType)
-              case _ =>
+            if (sparkSession.sessionState.conf.getConf(SQLConf.STREAMING_V2_PRUNE_COLUMNS_ENABLED)) {
+              scanBuilder match {
+                case r: SupportsPushDownRequiredColumns =>
+                  r.pruneColumns(output.toStructType)
+                case _ =>
+              }
             }
             val scan = scanBuilder.build()
             val stream = scan.toMicroBatchStream(metadataPath)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MetadataColumnSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MetadataColumnSuite.scala
@@ -416,10 +416,9 @@ class MetadataColumnSuite extends DatasourceV2SQLBase {
             .option("checkpointLocation", checkpointDir.getCanonicalPath)
             .start()
           try {
-            val ex = intercept[StreamingQueryException] {
+            intercept[StreamingQueryException] {
               q.processAllAvailable()
             }
-            assert(ex.getMessage.contains("ArrayIndexOutOfBoundsException"))
           } finally {
             q.stop()
           }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MetadataColumnSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MetadataColumnSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.connector
 
 import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.streaming.StreamingQueryException
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -380,6 +381,7 @@ class MetadataColumnSuite extends DatasourceV2SQLBase {
     withTable(tbl) {
       prepareTable()
       withTempDir { checkpointDir =>
+        // "index" is a metadata column (not in the table schema); "id" and "data" are data columns.
         val df = spark.readStream.table(tbl).select("id", "data", "index")
         val q = df.writeStream
           .format("memory")
@@ -396,6 +398,31 @@ class MetadataColumnSuite extends DatasourceV2SQLBase {
             "index metadata column should be non-null in streaming output")
         } finally {
           q.stop()
+        }
+      }
+    }
+  }
+
+  test("SPARK-56132: streaming read of metadata columns fails when pruneColumns disabled") {
+    withSQLConf(SQLConf.STREAMING_V2_PRUNE_COLUMNS_ENABLED.key -> "false") {
+      withTable(tbl) {
+        prepareTable()
+        withTempDir { checkpointDir =>
+          // With the flag disabled, pruneColumns is not called on the streaming scan builder.
+          val df = spark.readStream.table(tbl).select("id", "data", "index")
+          val q = df.writeStream
+            .format("memory")
+            .queryName("result_56132_disabled")
+            .option("checkpointLocation", checkpointDir.getCanonicalPath)
+            .start()
+          try {
+            val ex = intercept[StreamingQueryException] {
+              q.processAllAvailable()
+            }
+            assert(ex.getMessage.contains("ArrayIndexOutOfBoundsException"))
+          } finally {
+            q.stop()
+          }
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MetadataColumnSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MetadataColumnSuite.scala
@@ -19,11 +19,11 @@ package org.apache.spark.sql.connector
 
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
-import org.apache.spark.sql.streaming.StreamingQueryException
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.functions.{col, struct}
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.streaming.StreamingQueryException
 import org.apache.spark.sql.types.IntegerType
 
 class MetadataColumnSuite extends DatasourceV2SQLBase {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MetadataColumnSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MetadataColumnSuite.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.functions.{col, struct}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.streaming.StreamingQueryException
 import org.apache.spark.sql.types.IntegerType
 
 class MetadataColumnSuite extends DatasourceV2SQLBase {
@@ -398,30 +397,6 @@ class MetadataColumnSuite extends DatasourceV2SQLBase {
             "index metadata column should be non-null in streaming output")
         } finally {
           q.stop()
-        }
-      }
-    }
-  }
-
-  test("SPARK-56132: streaming read of metadata columns fails when pruneColumns disabled") {
-    withSQLConf(SQLConf.STREAMING_V2_PRUNE_COLUMNS_ENABLED.key -> "false") {
-      withTable(tbl) {
-        prepareTable()
-        withTempDir { checkpointDir =>
-          // With the flag disabled, pruneColumns is not called on the streaming scan builder.
-          val df = spark.readStream.table(tbl).select("id", "data", "index")
-          val q = df.writeStream
-            .format("memory")
-            .queryName("result_56132_disabled")
-            .option("checkpointLocation", checkpointDir.getCanonicalPath)
-            .start()
-          try {
-            intercept[StreamingQueryException] {
-              q.processAllAvailable()
-            }
-          } finally {
-            q.stop()
-          }
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MetadataColumnSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MetadataColumnSuite.scala
@@ -376,6 +376,31 @@ class MetadataColumnSuite extends DatasourceV2SQLBase {
     }
   }
 
+  test("SPARK-56132: streaming read of metadata columns from V2 source") {
+    withTable(tbl) {
+      prepareTable()
+      withTempDir { checkpointDir =>
+        val df = spark.readStream.table(tbl).select("id", "data", "index")
+        val q = df.writeStream
+          .format("memory")
+          .queryName("result_56132")
+          .option("checkpointLocation", checkpointDir.getCanonicalPath)
+          .start()
+        try {
+          q.processAllAvailable()
+          val result = spark.table("result_56132")
+          // Verify data columns arrive correctly and index (metadata) is non-null.
+          checkAnswer(result.select("id", "data").orderBy("id"),
+            Seq(Row(1, "a"), Row(2, "b"), Row(3, "c")))
+          assert(result.select("index").collect().forall(!_.isNullAt(0)),
+            "index metadata column should be non-null in streaming output")
+        } finally {
+          q.stop()
+        }
+      }
+    }
+  }
+
   test("SPARK-43123: Metadata column related field metadata should not be leaked to catalogs") {
     withTable(tbl, "testcat.target") {
       prepareTable()

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MetadataColumnSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MetadataColumnSuite.scala
@@ -18,8 +18,8 @@
 package org.apache.spark.sql.connector
 
 import org.apache.spark.sql.{AnalysisException, Row}
-import org.apache.spark.sql.streaming.StreamingQueryException
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+import org.apache.spark.sql.streaming.StreamingQueryException
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.functions.{col, struct}

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
@@ -565,7 +565,8 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
     }
   }
 
-  test("SPARK-56132: pruneColumns called on SupportsPushDownRequiredColumns V2 streaming scan builder") {
+  test("SPARK-56132: pruneColumns called on SupportsPushDownRequiredColumns " +
+      "V2 streaming scan builder") {
     val tblName = "teststream.table_name"
     withTable(tblName) {
       spark.sql(s"CREATE TABLE $tblName (data int) USING foo")

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.connector.{FakeV2Provider, FakeV2ProviderWithCustomS
 import org.apache.spark.sql.connector.catalog.{Column, Identifier, InMemoryTable, InMemoryTableCatalog, MetadataColumn, SupportsMetadataColumns, SupportsRead, Table, TableCapability, TableInfo, V2TableWithV1Fallback}
 import org.apache.spark.sql.connector.expressions.{ClusterByTransform, FieldReference, Transform}
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownRequiredColumns}
+import org.apache.spark.sql.connector.read.streaming.MicroBatchStream
 import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, MemoryStreamScanBuilder, StreamingQueryWrapper}
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.SQLConf
@@ -564,7 +565,7 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
     }
   }
 
-  test("pruneColumns called on SupportsPushDownRequiredColumns V2 streaming scan builder") {
+  test("SPARK-56132: pruneColumns called on SupportsPushDownRequiredColumns V2 streaming scan builder") {
     val tblName = "teststream.table_name"
     withTable(tblName) {
       spark.sql(s"CREATE TABLE $tblName (data int) USING foo")
@@ -585,10 +586,11 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
           .option("checkpointLocation", checkpointDir.getCanonicalPath)
           .start()
         try {
-          stream.addData(1, 2, 3)
-          q.processAllAvailable()
-          assert(recorded.called, "pruneColumns should have been called on the streaming scan builder")
-          // Output schema includes both the data column and the metadata column
+          // logicalPlan is initialized lazily when the query thread starts; wait for it.
+          eventually(timeout(streamingTimeout)) {
+            assert(recorded.called,
+              "pruneColumns should have been called on the streaming scan builder")
+          }
           assert(recorded.schema.fieldNames.toSet === Set("value", "_seq"),
             s"Expected pruneColumns to receive {value, _seq}, got ${recorded.schema}")
         } finally {
@@ -755,7 +757,20 @@ class RecordingPruneScanBuilder(inner: MemoryStreamScanBuilder, recorder: Pruned
     recorder.schema = requiredSchema
   }
 
-  override def build(): Scan = inner.build()
+  override def build(): Scan = {
+    val innerScan = inner.build()
+    val prunedSchema = recorder.schema
+    // Return a scan whose readSchema() reflects the pruned schema so the streaming plan
+    // and scan agree on output columns. Without the fix, pruneColumns is never called and
+    // readSchema() defaults to the full table schema, causing ArrayIndexOutOfBoundsException
+    // when metadata columns are in the plan output but absent from the scan output.
+    new Scan {
+      override def readSchema(): StructType =
+        if (recorder.called) prunedSchema else innerScan.readSchema()
+      override def toMicroBatchStream(checkpointLocation: String): MicroBatchStream =
+        innerScan.toMicroBatchStream(checkpointLocation)
+    }
+  }
 }
 
 class NonStreamV2Table(override val name: String)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.connector.{FakeV2Provider, FakeV2ProviderWithCustomSchema, InMemoryTableSessionCatalog}
 import org.apache.spark.sql.connector.catalog.{Column, Identifier, InMemoryTable, InMemoryTableCatalog, MetadataColumn, SupportsMetadataColumns, SupportsRead, Table, TableCapability, TableInfo, V2TableWithV1Fallback}
 import org.apache.spark.sql.connector.expressions.{ClusterByTransform, FieldReference, Transform}
-import org.apache.spark.sql.connector.read.ScanBuilder
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownRequiredColumns}
 import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, MemoryStreamScanBuilder, StreamingQueryWrapper}
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.SQLConf
@@ -564,6 +564,40 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
     }
   }
 
+  test("pruneColumns called on SupportsPushDownRequiredColumns V2 streaming scan builder") {
+    val tblName = "teststream.table_name"
+    withTable(tblName) {
+      spark.sql(s"CREATE TABLE $tblName (data int) USING foo")
+      val stream = MemoryStream[Int]
+      val testCatalog = spark.sessionState.catalogManager.catalog("teststream").asTableCatalog
+      val table = testCatalog.loadTable(Identifier.of(Array(), "table_name"))
+        .asInstanceOf[InMemoryStreamTable]
+      table.setStream(stream)
+
+      // Wrap the table's scan builder so we can record pruneColumns calls.
+      val recorded = new PrunedSchemaRecorder
+      table.scanBuilderWrapper = Some(inner => new RecordingPruneScanBuilder(inner, recorded))
+
+      withTempDir { checkpointDir =>
+        val q = spark.readStream.table(tblName)
+          .select("value", "_seq")
+          .writeStream.format("noop")
+          .option("checkpointLocation", checkpointDir.getCanonicalPath)
+          .start()
+        try {
+          stream.addData(1, 2, 3)
+          q.processAllAvailable()
+          assert(recorded.called, "pruneColumns should have been called on the streaming scan builder")
+          // Output schema includes both the data column and the metadata column
+          assert(recorded.schema.fieldNames.toSet === Set("value", "_seq"),
+            s"Expected pruneColumns to receive {value, _seq}, got ${recorded.schema}")
+        } finally {
+          q.stop()
+        }
+      }
+    }
+  }
+
   private def checkForStreamTable(dir: Option[File], tableName: String): Unit = {
     val memory = MemoryStream[Int]
     val dsw = memory.toDS().writeStream.format("parquet")
@@ -683,6 +717,7 @@ class InMemoryStreamTable(override val name: String)
   with SupportsRead
   with SupportsMetadataColumns {
   var stream: MemoryStream[Int] = _
+  var scanBuilderWrapper: Option[MemoryStreamScanBuilder => ScanBuilder] = None
 
   def setStream(inputData: MemoryStream[Int]): Unit = stream = inputData
 
@@ -693,7 +728,8 @@ class InMemoryStreamTable(override val name: String)
   }
 
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
-    new MemoryStreamScanBuilder(stream)
+    val inner = new MemoryStreamScanBuilder(stream)
+    scanBuilderWrapper.map(_(inner)).getOrElse(inner)
   }
 
   private object SeqColumn extends MetadataColumn {
@@ -703,6 +739,23 @@ class InMemoryStreamTable(override val name: String)
   }
 
   override val metadataColumns: Array[MetadataColumn] = Array(SeqColumn)
+}
+
+class PrunedSchemaRecorder {
+  @volatile var called = false
+  @volatile var schema: StructType = new StructType()
+}
+
+class RecordingPruneScanBuilder(inner: MemoryStreamScanBuilder, recorder: PrunedSchemaRecorder)
+    extends ScanBuilder
+    with SupportsPushDownRequiredColumns {
+
+  override def pruneColumns(requiredSchema: StructType): Unit = {
+    recorder.called = true
+    recorder.schema = requiredSchema
+  }
+
+  override def build(): Scan = inner.build()
 }
 
 class NonStreamV2Table(override val name: String)


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `MicroBatchExecution.logicalPlan`, before calling `build()` on the V2 streaming scan
builder, call `SupportsPushDownRequiredColumns.pruneColumns(output.toStructType)` if the
builder supports it. `output` is the analyzed relation output, which already includes any
metadata columns the query references (added by the `AddMetadataColumns` rule).

### Why are the changes needed?

1. **Metadata column reads in V2 streaming crash with `ArrayIndexOutOfBoundsException`.**
   When a query selects a metadata column (e.g. `_metadata.row_id`) from a V2 streaming
   source that implements both `SupportsMetadataColumns` and `SupportsPushDownRequiredColumns`,
   the analyzed plan expects the metadata column in the scan output, but `Scan.readSchema()`
   does not include it. Spark tries to read a column at an index the scan never produced.

2. **Root cause: `pruneColumns` is never called in streaming.**
   In batch, `V2ScanRelationPushDown` calls `SupportsPushDownRequiredColumns.pruneColumns`
   with the required schema (which includes metadata columns resolved by `AddMetadataColumns`)
   before `build()`. In `MicroBatchExecution.logicalPlan`, the scan is built directly with
   `table.newScanBuilder(options).build()` — no pushdown of any kind is applied (a
   `// TODO: operator pushdown` comment marks this). Connectors that use `pruneColumns` to
   configure `readSchema()` — including whether to produce metadata columns — are never
   informed of what the query needs.

3. **This change fixes metadata column reads only, not column pruning.**
   We call `pruneColumns(output.toStructType)` where `output` is the full analyzed relation
   output — all data columns plus any metadata columns added by `AddMetadataColumns`. This
   communicates required metadata columns to the scan builder so they appear in `readSchema()`,
   but does not prune data columns. Full column pruning in streaming, along with filter and
   aggregate pushdown, is deferred to the existing TODO.

### Does this PR introduce _any_ user-facing change?

Yes. Fixes a bug associated with metadata columns. 

### How was this patch tested?

Added a test in `DataStreamTableAPISuite`.

### Was this patch authored or co-authored using generative AI tooling?

Yes