### PR TITLE
Add regression test for issue #55392 - Named parameters without legacy config

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
@@ -2706,4 +2706,17 @@ class ParametersSuite extends SharedSparkSession {
       case _ =>
     }
   }
+  test("named parameters without legacy config - issue #55392 regression") {
+    // Regression test for https://github.com/apache/spark/issues/55392
+    // PySpark 4.1.1 incorrectly rejected named parameters like :x
+    // even when provided in the args dict.
+    checkAnswer(
+      spark.sql("SELECT :x", args = Map("x" -> 1)),
+      Row(1))
+    
+    checkAnswer(
+      spark.sql("SELECT :x, :y", args = Map("x" -> 1, "y" -> 2)),
+      Row(1, 2))
+  }
+}
 }


### PR DESCRIPTION
This test verifies that spark.sql("SELECT :x", args=Map("x" -> 1)) works correctly
without requiring the legacy parameter substitution configuration.

The test covers:
- Single named parameter: spark.sql("SELECT :x", args=Map("x" -> 1))
- Multiple named parameters: spark.sql("SELECT :x, :y", args=Map("x" -> 1, "y" -> 2))

This is a regression test for issue #55392.