### PR TITLE
[SPARK-XXXXX][INFRA] Document canonical and primary component tags in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,9 @@ Each annotation contains the test class, test name, and failure message.
 
 ## Pull Request Workflow
 
-PR title format is `[SPARK-xxxx][COMPONENT] Title`. The component tag is derived from the JIRA component name: take the last word and uppercase it (e.g. `Project Infra` → `[INFRA]`, `Spark Core` → `[CORE]`, `Structured Streaming` → `[STREAMING]`, `SQL` → `[SQL]`).
+PR title format is `[SPARK-XXXXX][COMPONENT] Title`. Use the canonical PR-title tag from the `COMPONENTS` table in `dev/merge_spark_pr.py` — not the JIRA component name verbatim, and not an alias. Many tags are just the last word of the JIRA name uppercased (e.g. `Project Infra` → `[INFRA]`, `Spark Core` → `[CORE]`, `SQL` → `[SQL]`), but several are not: `PySpark` → `[PYTHON]` (not `[PYSPARK]`), `Documentation` → `[DOC]` (not `[DOCS]`), `Structured Streaming` → `[SS]` (not `[STREAMING]`), `DStreams` → `[STREAMING]`, `Pandas API on Spark` → `[PS]`, `Declarative Pipelines` → `[SDP]`.
+
+The title must include at least one *primary* component tag. The primary tags are: `[BUILD]`, `[CONNECT]`, `[CORE]`, `[DOC]`, `[DOCKER]`, `[GRAPHX]`, `[INFRA]`, `[K8S]`, `[ML]`, `[MLLIB]`, `[PS]`, `[PYTHON]`, `[R]`, `[SDP]`, `[SECURITY]`, `[SQL]`, `[SS]`, `[STREAMING]`, `[UI]`, `[WINDOWS]`, `[YARN]`. Non-primary JIRA components (e.g. `[TEST]`, `[SHUFFLE]`, `[DEPLOY]`) are still recognized but must be paired with a primary tag (e.g. `[SQL][TEST]`).
 
 Infer the PR title from the changes. If no ticket ID is given, create one using `dev/create_spark_jira.py`, using the PR title (without the JIRA ID and component tag) as the ticket title.
 


### PR DESCRIPTION
> Draft: JIRA ID is a placeholder (`SPARK-XXXXX`); will be filled in before the PR is marked ready.

### What changes were proposed in this pull request?

Update the "Pull Request Workflow" section of `AGENTS.md`:

- Replace the "take the last word and uppercase it" heuristic with explicit guidance to use the canonical tag from the `COMPONENTS` table in `dev/merge_spark_pr.py`, calling out the non-obvious mappings: `PySpark` → `[PYTHON]`, `Documentation` → `[DOC]`, `Structured Streaming` → `[SS]`, `DStreams` → `[STREAMING]`, `Pandas API on Spark` → `[PS]`, `Declarative Pipelines` → `[SDP]`.
- Fix `Structured Streaming → [STREAMING]`; the script reserves `[STREAMING]` for DStreams and uses `[SS]` for Structured Streaming.
- Add the full list of primary component tags and state that the title must include at least one.
- Switch the placeholder format from `[SPARK-xxxx]` to `[SPARK-XXXXX]`.

### Why are the changes needed?

The previous "last word and uppercase" heuristic gives the wrong tag for several JIRA components — most notably `Structured Streaming`, which is `[SS]`, not `[STREAMING]`. The `primary` flag introduced in `dev/merge_spark_pr.py` is also not documented in `AGENTS.md`, so agents have no way to know that a primary tag is required in the title. Aligning the docs with the script prevents agents from producing titles that the merge step would otherwise have to fix up.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only.

### How was this patch tested?

Cross-checked every tag and the primary list against the `COMPONENTS` table in `dev/merge_spark_pr.py`. Verified `AGENTS.md` introduces only the same class of non-ASCII characters (em-dashes and arrows) already present in the file.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)