### PR TITLE
[SPARK-57104][SQL] Enable schema-level collations by default

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1179,7 +1179,7 @@ object SQLConf {
       )
       .version("4.1.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val COLLATION_AWARE_HASHING_ENABLED =
     buildConf("spark.sql.legacy.collationAwareHashFunctions")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -177,7 +177,6 @@ class SQLQueryTestSuite extends SharedSparkSession
     // SPARK-39564: don't print out serde to avoid introducing complicated and error-prone
     // regex magic.
     .set("spark.test.noSerdeInExplain", "true")
-    .set(SQLConf.SCHEMA_LEVEL_COLLATIONS_ENABLED, true)
 
   // SPARK-32106 Since we add SQL test 'transform.sql' will use `cat` command,
   // here we need to ignore it.

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DefaultCollationTestSuite.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.catalyst.plans.logical.Project
 import org.apache.spark.sql.catalyst.util.CollationFactory
 import org.apache.spark.sql.connector.DatasourceV2SQLBase
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{BooleanType, StringType, StructType}
 
@@ -34,17 +33,11 @@ abstract class DefaultCollationTestSuite extends SharedSparkSession {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    spark.conf.set(SQLConf.SCHEMA_LEVEL_COLLATIONS_ENABLED, true)
 
     if (resetCatalog) {
       sql(s"CREATE NAMESPACE IF NOT EXISTS $testCatalog.$DEFAULT_DATABASE")
       sql(s"USE $testCatalog.$DEFAULT_DATABASE")
     }
-  }
-
-  override def afterEach(): Unit = {
-    spark.conf.set(SQLConf.SCHEMA_LEVEL_COLLATIONS_ENABLED, false)
-    super.afterEach()
   }
 
   val defaultStringProducingExpressions: Seq[String] = Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -893,17 +893,18 @@ class QueryCompilationErrorsSuite
     }
   }
 
-  test("SPARK-52219: the schema level collations feature is unsupported") {
-    // TODO: when schema level collations are supported, change this test to set the flag to false
-    Seq(
-      "CREATE SCHEMA test_schema DEFAULT COLLATION UNICODE",
-      "ALTER SCHEMA test_schema DEFAULT COLLATION UNICODE"
-    ).foreach {
-      sqlText =>
-        checkError(
-          exception = intercept[AnalysisException](sql(sqlText)),
-          condition = "UNSUPPORTED_FEATURE.SCHEMA_LEVEL_COLLATIONS"
-        )
+  test("SPARK-52219: the schema level collations feature is unsupported when flag is disabled") {
+    withSQLConf(SQLConf.SCHEMA_LEVEL_COLLATIONS_ENABLED.key -> "false") {
+      Seq(
+        "CREATE SCHEMA test_schema DEFAULT COLLATION UNICODE",
+        "ALTER SCHEMA test_schema DEFAULT COLLATION UNICODE"
+      ).foreach {
+        sqlText =>
+          checkError(
+            exception = intercept[AnalysisException](sql(sqlText)),
+            condition = "UNSUPPORTED_FEATURE.SCHEMA_LEVEL_COLLATIONS"
+          )
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterViewAsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterViewAsSuite.scala
@@ -31,26 +31,24 @@ class AlterViewAsSuite extends command.AlterViewAsSuiteBase with ViewCommandSuit
     // unset). Then set the namespace default and ALTER VIEW AS -- the new ViewInfo must end
     // up with PROP_COLLATION = UTF8_LCASE (so v1Table.toCatalogTable's `collation` field is
     // set, and view-read time picks up UTF8_LCASE via AnalysisContext.collation).
-    withSQLConf(SQLConf.SCHEMA_LEVEL_COLLATIONS_ENABLED.key -> "true") {
-      val viewName = "v2_alter_collation_inherit"
-      val view = s"$catalog.$namespace.$viewName"
-      sql(s"CREATE VIEW $view AS SELECT 'a' AS c1")
-      assert(Option(viewCatalog
-        .getStoredView(Array(namespace), viewName)
-        .properties()
-        .get(TableCatalog.PROP_COLLATION))
-        .isEmpty)
+    val viewName = "v2_alter_collation_inherit"
+    val view = s"$catalog.$namespace.$viewName"
+    sql(s"CREATE VIEW $view AS SELECT 'a' AS c1")
+    assert(Option(viewCatalog
+      .getStoredView(Array(namespace), viewName)
+      .properties()
+      .get(TableCatalog.PROP_COLLATION))
+      .isEmpty)
 
-      sql(s"ALTER NAMESPACE $catalog.$namespace DEFAULT COLLATION UTF8_LCASE")
-      sql(s"ALTER VIEW $view AS SELECT 'x' AS c1, 'y' AS c2")
+    sql(s"ALTER NAMESPACE $catalog.$namespace DEFAULT COLLATION UTF8_LCASE")
+    sql(s"ALTER VIEW $view AS SELECT 'x' AS c1, 'y' AS c2")
 
-      val stored = viewCatalog.getStoredView(Array(namespace), viewName)
-      assert(stored.properties().get(TableCatalog.PROP_COLLATION) == "UTF8_LCASE")
-      // Read-time the view body's literal types reflect the inherited collation.
-      val df = spark.table(view)
-      assert(df.schema("c1").dataType === StringType("UTF8_LCASE"))
-      assert(df.schema("c2").dataType === StringType("UTF8_LCASE"))
-    }
+    val stored = viewCatalog.getStoredView(Array(namespace), viewName)
+    assert(stored.properties().get(TableCatalog.PROP_COLLATION) == "UTF8_LCASE")
+    // Read-time the view body's literal types reflect the inherited collation.
+    val df = spark.table(view)
+    assert(df.schema("c1").dataType === StringType("UTF8_LCASE"))
+    assert(df.schema("c2").dataType === StringType("UTF8_LCASE"))
   }
 
   test("V2: ALTER VIEW preserves PROP_OWNER (v1-parity)") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Flip the default of `spark.sql.collation.schemaLevel.enabled` from `false` to `true` and remove now-redundant flag toggling in tests.

### Why are the changes needed?

Enable the schema-level collations feature by default.

### Does this PR introduce _any_ user-facing change?

Yes. `CREATE/ALTER SCHEMA ... DEFAULT COLLATION ...` now works without setting the flag. Set `spark.sql.collation.schemaLevel.enabled=false` to opt out.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)