### PR TITLE
[SPARK-57105][SQL] Fix `StringIndexOutOfBoundsException` in parameterized SQL scripts

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/PositionMapper.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/PositionMapper.scala
@@ -91,6 +91,32 @@ case class PositionMapper(
   }
 
   /**
+   * Extract the original text fragment corresponding to a range in the substituted text.
+   * Maps both start and stop positions back to the original text and returns the substring.
+   *
+   * For the stop position, mapToOriginal maps positions within a substitution range to the
+   * start of the original marker. To get the correct end, we map stopIndex + 1 (which lands
+   * in the unmapped region after the substitution) and subtract 1.
+   *
+   * @param substitutedStart
+   *   Inclusive start position in the substituted text
+   * @param substitutedStop
+   *   Inclusive stop position in the substituted text
+   * @return
+   *   The corresponding fragment from the original text
+   */
+  def originalFragment(substitutedStart: Int, substitutedStop: Int): String = {
+    val mappedStart = mapToOriginal(substitutedStart)
+    val mappedStop =
+      if (substitutedStop + 1 < substitutedText.length) {
+        mapToOriginal(substitutedStop + 1) - 1
+      } else {
+        originalText.length - 1
+      }
+    originalText.substring(mappedStart, mappedStop + 1)
+  }
+
+  /**
    * Build sparse position ranges using functional approach. O(k) space complexity where k =
    * number of substitutions.
    *

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/PositionMapper.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/PositionMapper.scala
@@ -91,12 +91,12 @@ case class PositionMapper(
   }
 
   /**
-   * Extract the original text fragment corresponding to a range in the substituted text.
-   * Maps both start and stop positions back to the original text and returns the substring.
+   * Extract the original text fragment corresponding to a range in the substituted text. Maps
+   * both start and stop positions back to the original text and returns the substring.
    *
-   * For the stop position, mapToOriginal maps positions within a substitution range to the
-   * start of the original marker. To get the correct end, we map stopIndex + 1 (which lands
-   * in the unmapped region after the substitution) and subtract 1.
+   * For the stop position, mapToOriginal maps positions within a substitution range to the start
+   * of the original marker. To get the correct end, we map stopIndex + 1 (which lands in the
+   * unmapped region after the substitution) and subtract 1.
    *
    * @param substitutedStart
    *   Inclusive start position in the substituted text

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
@@ -49,7 +49,12 @@ case class SingleStatement(parsedPlan: LogicalPlan)
    */
   def getText: String = {
     assert(origin.sqlText.isDefined && origin.startIndex.isDefined && origin.stopIndex.isDefined)
-    origin.sqlText.get.substring(origin.startIndex.get, origin.stopIndex.get + 1)
+    origin.positionMapper match {
+      case Some(mapper) =>
+        mapper.originalFragment(origin.startIndex.get, origin.stopIndex.get)
+      case None =>
+        origin.sqlText.get.substring(origin.startIndex.get, origin.stopIndex.get + 1)
+    }
   }
 
   override def output: Seq[Attribute] = parsedPlan.output

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -87,7 +87,13 @@ class SparkSqlParser extends AbstractSqlParser {
       parameterContext: ParameterContext): LogicalPlan = {
     parseWithParameters(sqlText, parameterContext) { parser =>
       val ctx = parser.compoundOrSingleStatement()
-      withErrorHandling(ctx, Some(sqlText)) {
+      val contextHasParams = parameterContext match {
+        case NamedParameterContext(params) => params.nonEmpty
+        case PositionalParameterContext(params) => params.nonEmpty
+        case HybridParameterContext(args, _) => args.nonEmpty
+      }
+      val errorHandlingSqlText = if (contextHasParams) None else Some(sqlText)
+      withErrorHandling(ctx, errorHandlingSqlText) {
         astBuilder.visitCompoundOrSingleStatement(ctx) match {
           case compoundBody: CompoundPlanStatement => compoundBody
           case plan: LogicalPlan => plan

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -186,7 +186,12 @@ class SingleStatementExec(
    */
   def getText: String = {
     assert(origin.sqlText.isDefined && origin.startIndex.isDefined && origin.stopIndex.isDefined)
-    origin.sqlText.get.substring(origin.startIndex.get, origin.stopIndex.get + 1)
+    origin.positionMapper match {
+      case Some(mapper) =>
+        mapper.originalFragment(origin.startIndex.get, origin.stopIndex.get)
+      case None =>
+        origin.sqlText.get.substring(origin.startIndex.get, origin.stopIndex.get + 1)
+    }
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
@@ -437,58 +437,6 @@ class SqlScriptingE2eSuite extends SharedSparkSession {
     verifySqlScriptResultWithNamedParams(sqlScriptText, Seq(Row("smaller")), args)
   }
 
-  // Parameterized SQL scripts where substituted values are longer than the parameter
-  // markers should not cause StringIndexOutOfBoundsException.
-  test("named params - substituted value longer than short marker") {
-    val sqlScriptText = "BEGIN SELECT :x; END"
-    val args: Map[String, Any] = Map("x" -> ("y" * 200))
-    verifySqlScriptResultWithNamedParams(sqlScriptText, Seq(Row("y" * 200)), args)
-  }
-
-  test("named params - long marker name") {
-    val sqlScriptText = "BEGIN SELECT :longParamName; END"
-    val args: Map[String, Any] = Map("longParamName" -> ("y" * 200))
-    verifySqlScriptResultWithNamedParams(sqlScriptText, Seq(Row("y" * 200)), args)
-  }
-
-  test("named params - multiple long markers") {
-    val sqlScriptText = "BEGIN SELECT :firstName, :lastName; END"
-    val args: Map[String, Any] = Map(
-      "firstName" -> ("x" * 100),
-      "lastName" -> ("y" * 100))
-    verifySqlScriptResultWithNamedParams(
-      sqlScriptText, Seq(Row("x" * 100, "y" * 100)), args)
-  }
-
-  test("named params - long value inside IF control flow") {
-    val sqlScriptText =
-      """
-        |BEGIN
-        |  IF :condition = 'yes' THEN
-        |    SELECT :value;
-        |  END IF;
-        |END
-        |""".stripMargin
-    val args: Map[String, Any] = Map(
-      "condition" -> "yes",
-      "value" -> ("z" * 200))
-    verifySqlScriptResultWithNamedParams(sqlScriptText, Seq(Row("z" * 200)), args)
-  }
-
-  test("named params - two statements each with a long param") {
-    val sqlScriptText =
-      """
-        |BEGIN
-        |  SELECT :firstName;
-        |  SELECT :lastName;
-        |END
-        |""".stripMargin
-    val args: Map[String, Any] = Map(
-      "firstName" -> ("a" * 200),
-      "lastName" -> ("b" * 200))
-    verifySqlScriptResultWithNamedParams(sqlScriptText, Seq(Row("b" * 200)), args)
-  }
-
   test("positional params") {
     val sqlScriptText =
       """

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
@@ -437,6 +437,58 @@ class SqlScriptingE2eSuite extends SharedSparkSession {
     verifySqlScriptResultWithNamedParams(sqlScriptText, Seq(Row("smaller")), args)
   }
 
+  // Parameterized SQL scripts where substituted values are longer than the parameter
+  // markers should not cause StringIndexOutOfBoundsException.
+  test("named params - substituted value longer than short marker") {
+    val sqlScriptText = "BEGIN SELECT :x; END"
+    val args: Map[String, Any] = Map("x" -> ("y" * 200))
+    verifySqlScriptResultWithNamedParams(sqlScriptText, Seq(Row("y" * 200)), args)
+  }
+
+  test("named params - long marker name") {
+    val sqlScriptText = "BEGIN SELECT :longParamName; END"
+    val args: Map[String, Any] = Map("longParamName" -> ("y" * 200))
+    verifySqlScriptResultWithNamedParams(sqlScriptText, Seq(Row("y" * 200)), args)
+  }
+
+  test("named params - multiple long markers") {
+    val sqlScriptText = "BEGIN SELECT :firstName, :lastName; END"
+    val args: Map[String, Any] = Map(
+      "firstName" -> ("x" * 100),
+      "lastName" -> ("y" * 100))
+    verifySqlScriptResultWithNamedParams(
+      sqlScriptText, Seq(Row("x" * 100, "y" * 100)), args)
+  }
+
+  test("named params - long value inside IF control flow") {
+    val sqlScriptText =
+      """
+        |BEGIN
+        |  IF :condition = 'yes' THEN
+        |    SELECT :value;
+        |  END IF;
+        |END
+        |""".stripMargin
+    val args: Map[String, Any] = Map(
+      "condition" -> "yes",
+      "value" -> ("z" * 200))
+    verifySqlScriptResultWithNamedParams(sqlScriptText, Seq(Row("z" * 200)), args)
+  }
+
+  test("named params - two statements each with a long param") {
+    val sqlScriptText =
+      """
+        |BEGIN
+        |  SELECT :firstName;
+        |  SELECT :lastName;
+        |END
+        |""".stripMargin
+    val args: Map[String, Any] = Map(
+      "firstName" -> ("a" * 200),
+      "lastName" -> ("b" * 200))
+    verifySqlScriptResultWithNamedParams(sqlScriptText, Seq(Row("b" * 200)), args)
+  }
+
   test("positional params") {
     val sqlScriptText =
       """

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -21,8 +21,9 @@ import scala.collection.mutable.ListBuffer
 
 import org.apache.spark.{SparkArithmeticException, SparkConf}
 import org.apache.spark.sql.{AnalysisException, Row}
-import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
+import org.apache.spark.sql.catalyst.parser.NamedParameterContext
+import org.apache.spark.sql.catalyst.plans.logical.{CompoundBody, SingleStatement}
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLId
 import org.apache.spark.sql.exceptions.SqlScriptingException
 import org.apache.spark.sql.internal.SQLConf
@@ -4326,5 +4327,94 @@ class SqlScriptingExecutionSuite extends SharedSparkSession {
         |""".stripMargin
       verifySqlScriptResult(sqlScript2, expected)
     }
+  }
+
+  // Parameterized SQL scripts where substituted values are longer than the parameter
+  // markers should not cause StringIndexOutOfBoundsException.
+  test("parameterized script - short marker") {
+    val scriptText = "BEGIN SELECT :x; END"
+    val args = Map("x" -> ("y" * 200))
+    checkAnswer(spark.sql(scriptText, args), Row("y" * 200))
+  }
+
+  test("parameterized script - long marker name") {
+    val scriptText = "BEGIN SELECT :longParamName; END"
+    val args = Map("longParamName" -> ("y" * 200))
+    checkAnswer(spark.sql(scriptText, args), Row("y" * 200))
+  }
+
+  test("parameterized script - multiple long markers") {
+    val scriptText = "BEGIN SELECT :firstName, :lastName; END"
+    val args = Map("firstName" -> ("x" * 100), "lastName" -> ("y" * 100))
+    checkAnswer(spark.sql(scriptText, args), Row("x" * 100, "y" * 100))
+  }
+
+  test("parameterized script - IF control flow") {
+    val scriptText =
+      """
+        |BEGIN
+        |  IF :condition = 'yes' THEN
+        |    SELECT :value;
+        |  END IF;
+        |END
+        |""".stripMargin
+    val args = Map("condition" -> "yes", "value" -> ("z" * 200))
+    checkAnswer(spark.sql(scriptText, args), Row("z" * 200))
+  }
+
+  test("parameterized script - two statements each with a param") {
+    val scriptText =
+      """
+        |BEGIN
+        |  SELECT :firstName;
+        |  SELECT :lastName;
+        |END
+        |""".stripMargin
+    val args = Map("firstName" -> ("a" * 200), "lastName" -> ("b" * 200))
+    checkAnswer(spark.sql(scriptText, args), Row("b" * 200))
+  }
+
+  private def getStatementTexts(
+      scriptText: String,
+      args: Map[String, Expression]): Seq[String] = {
+    val compoundBody = spark.sessionState.sqlParser
+      .parsePlanWithParameters(scriptText, NamedParameterContext(args))
+      .asInstanceOf[CompoundBody]
+    compoundBody.collection.collect { case s: SingleStatement => s.getText }
+  }
+
+  test("getText returns original text with short marker") {
+    val texts = getStatementTexts(
+      "BEGIN SELECT :x; END",
+      Map("x" -> Literal("y" * 200)))
+    assert(texts == Seq("SELECT :x"))
+  }
+
+  test("getText returns original text with long marker name") {
+    val texts = getStatementTexts(
+      "BEGIN SELECT :longParamName; END",
+      Map("longParamName" -> Literal("y" * 200)))
+    assert(texts == Seq("SELECT :longParamName"))
+  }
+
+  test("getText returns original text with multiple long markers") {
+    val texts = getStatementTexts(
+      "BEGIN SELECT :firstName, :lastName; END",
+      Map("firstName" -> Literal("a" * 200), "lastName" -> Literal("b" * 200)))
+    assert(texts == Seq("SELECT :firstName, :lastName"))
+  }
+
+  test("getText - two statements each with param") {
+    val scriptText =
+      """
+        |BEGIN
+        |  SELECT :firstName;
+        |  SELECT :lastName;
+        |END
+        |""".stripMargin
+    val texts = getStatementTexts(
+      scriptText,
+      Map("firstName" -> Literal("a" * 200), "lastName" -> Literal("b" * 200)))
+    assert(texts == Seq("SELECT :firstName", "SELECT :lastName"))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `StringIndexOutOfBoundsException` in `SingleStatementExec.getText()` (and `SingleStatement.getText()`) when parameterized SQL scripts (BEGIN...END) have substituted values longer than the parameter markers.

After pre-parser parameter substitution was introduced, ANTLR token indices refer to the substituted text, but `origin.sqlText` holds the original text. When the substituted value is longer than the marker (e.g. `:x` replaced by a 200-char string), `substring()` calls go out of bounds.

Changes:
- In `parsePlanWithParameters`, stop overriding `CurrentOrigin.sqlText` (set to substituted text by `parseInternal`) with the original text when parameters are present.
- In `getText()` methods (`SingleStatementExec`, `SingleStatement`), use `PositionMapper.originalFragment()` to correctly extract the original text fragment by mapping substituted positions back to original positions.
- Added `originalFragment()` helper to `PositionMapper` that correctly handles range-end mapping.

### Why are the changes needed?

Parameterized SQL scripts crash with `StringIndexOutOfBoundsException` whenever a substituted parameter value is longer than its marker.

### Does this PR introduce _any_ user-facing change?

No (bug fix).

### How was this patch tested?

Added tests in `SqlScriptingE2eSuite` covering: short marker, long marker name, multiple long markers, IF control flow, and two statements each with a long parameter value.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Anthropic)
