### PR TITLE
[PYTHON] Improve static typing for methods behind is_remote_only

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -2412,7 +2412,7 @@ class DataFrame(ParentDataFrame):
     def toJSON(self) -> ParentDataFrame:
         return self.select(F.to_json(F.struct(F.col("*"))).alias("value"))
 
-    if not is_remote_only():
+    if TYPE_CHECKING or not is_remote_only():
 
         @property
         def rdd(self) -> "RDD[Row]":

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -170,7 +170,7 @@ class DataFrame:
         """
         ...
 
-    if not is_remote_only():
+    if TYPE_CHECKING or not is_remote_only():
 
         @property
         def rdd(self) -> "RDD[Row]":

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -712,7 +712,7 @@ class SparkSession(SparkConversionMixin):
         """Accessor for the JVM SQL-specific configurations"""
         return self._jsparkSession.sessionState().conf()
 
-    if not is_remote_only():
+    if TYPE_CHECKING or not is_remote_only():
 
         def newSession(self) -> "SparkSession":
             """
@@ -800,7 +800,7 @@ class SparkSession(SparkConversionMixin):
                 )
         return session
 
-    if not is_remote_only():
+    if TYPE_CHECKING or not is_remote_only():
 
         @property
         def sparkContext(self) -> "SparkContext":

--- a/python/pyspark/sql/tests/typing/test_dataframe.yml
+++ b/python/pyspark/sql/tests/typing/test_dataframe.yml
@@ -132,3 +132,14 @@
     df.fillna(value=1, subset="id1")
     df.fillna(value=1, subset=("id1", "id2"))
     df.fillna(value=1, subset=["id1"])
+
+
+- case: dfRddFlatMap
+  main: |
+    from pyspark.sql import SparkSession
+
+    spark = SparkSession.builder.getOrCreate()
+    df = spark.range(5)
+    rdd = df.rdd
+    rdd.flatMap(lambda x: [x])
+

--- a/python/pyspark/sql/tests/typing/test_session.yml
+++ b/python/pyspark/sql/tests/typing/test_session.yml
@@ -98,3 +98,16 @@
         spark.sparkContext.emptyRDD(),
         schema=StructType(),
     )
+
+
+- case: sessionContextAndNewSession
+  main: |
+    from pyspark.sql import SparkSession
+
+    spark = SparkSession.builder.getOrCreate()
+    sc = spark.sparkContext
+    _parallelism = sc.defaultParallelism
+    
+    new_spark = spark.newSession()
+    _df = new_spark.range(1)
+


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR improves static typing support for PySpark methods conditionally defined behind is_remote_only().

Previously, methods such as:
- DataFrame.rdd
- SparkSession.newSession
- SparkSession.sparkContext

were defined inside:

python if not is_remote_only(): 

Static type checkers such as mypy cannot statically evaluate is_remote_only(), which causes these methods to fall back to __getattr__ resolution during type analysis. As a result, attributes such as df.rdd could be inferred as incorrect union types (for example Union[RDD[Row], Column]).

This PR updates those conditional definitions to:

python if TYPE_CHECKING or not is_remote_only(): 

This allows static analyzers to unconditionally resolve the methods during type checking while preserving the existing runtime behavior for Spark Connect and remote-only environments.

Additionally, typing regression tests were added for:
- DataFrame.rdd
- SparkSession.sparkContext
- SparkSession.newSession

### Why are the changes needed?

The existing conditional definitions are difficult for static analyzers to evaluate because is_remote_only() is a runtime condition.

For example:

python from pyspark.sql import SparkSession  spark = SparkSession.builder.getOrCreate() df = spark.range(5)  reveal_type(df.rdd) 

Before this change, static analyzers could infer df.rdd as a union involving Column due to __getattr__ fallback resolution.

Using TYPE_CHECKING is a standard Python typing pattern that exposes these definitions to static analyzers without changing runtime semantics.

### Does this PR introduce any user-facing change?

No.

This change only affects static type analysis behavior and does not modify runtime behavior.

### How was this patch tested?

Verified with targeted PySpark typing regression tests:

bash export PYTHONPATH=$(pwd)/python  MYPYPATH=python pytest \ python/pyspark/sql/tests/typing/test_dataframe.yml \ python/pyspark/sql/tests/typing/test_session.yml 

Result:

text 13 passed 

Also verified modified files with mypy using Spark's typing configuration.

Closes #56141 
