### PR TITLE
[SPARK-56975][SS][FOLLOWUP] Gate user-specified schema rejection in DataStreamReader.table() behind a config

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -7153,6 +7153,13 @@
     ],
     "sqlState" : "55019"
   },
+  "STREAMING_USER_SPECIFIED_SCHEMA_NOT_ALLOWED_IN_TABLE" : {
+    "message" : [
+      "User specified schema is not allowed with DataStreamReader.table(). Catalog tables declare their own schema, so the schema passed to DataStreamReader.schema(...) is ignored.",
+      "Remove the .schema(...) call, or set '<config>' to false to restore the previous behavior of silently ignoring the user-specified schema."
+    ],
+    "sqlState" : "42K03"
+  },
   "STREAM_FAILED" : {
     "message" : [
       "Query [id = <id>, runId = <runId>] terminated with exception: <message>"

--- a/docs/streaming/ss-migration-guide.md
+++ b/docs/streaming/ss-migration-guide.md
@@ -23,6 +23,10 @@ Note that this migration guide describes the items specific to Structured Stream
 Many items of SQL migration can be applied when migrating Structured Streaming to higher versions.
 Please refer [Migration Guide: SQL, Datasets and DataFrame](../sql-migration-guide.html).
 
+## Upgrading from Structured Streaming 4.1 to 4.2
+
+- Since Spark 4.2, `DataStreamReader.table(tableName)` rejects user-specified schemas with an `AnalysisException` (error class `STREAMING_USER_SPECIFIED_SCHEMA_NOT_ALLOWED_IN_TABLE`). Catalog tables declare their own schema, so any schema passed to `DataStreamReader.schema(...)` was always silently dropped; the new check surfaces this misconfiguration as a clear error instead. To restore the previous behavior of silently ignoring the user-specified schema, set `spark.sql.streaming.disallowUserSpecifiedSchemaInTable.enabled` to `false`.
+
 ## Upgrading from Structured Streaming 4.0 to 4.1
 
 - Since Spark 4.1, AQE is supported for stateless workloads, and it could affect the behavior of the query after upgrade (especially since AQE is turned on by default). In general, it helps to achieve better performance including resolution of skewed partition, but you can turn off AQE via changing `spark.sql.adaptive.streaming.stateless.enabled` to `false` to restore the behavior if you see regression.

--- a/docs/streaming/ss-migration-guide.md
+++ b/docs/streaming/ss-migration-guide.md
@@ -25,7 +25,7 @@ Please refer [Migration Guide: SQL, Datasets and DataFrame](../sql-migration-gui
 
 ## Upgrading from Structured Streaming 4.1 to 4.2
 
-- Since Spark 4.2, `DataStreamReader.table(tableName)` rejects user-specified schemas with an `AnalysisException` (error class `STREAMING_USER_SPECIFIED_SCHEMA_NOT_ALLOWED_IN_TABLE`). Catalog tables declare their own schema, so any schema passed to `DataStreamReader.schema(...)` was always silently dropped; the new check surfaces this misconfiguration as a clear error instead. To restore the previous behavior of silently ignoring the user-specified schema, set `spark.sql.streaming.disallowUserSpecifiedSchemaInTable.enabled` to `false`.
+- Since Spark 4.2, calling `DataStreamReader.schema(...)` before `DataStreamReader.table(tableName)` raises an `AnalysisException` (error class `STREAMING_USER_SPECIFIED_SCHEMA_NOT_ALLOWED_IN_TABLE`); previously the user-specified schema was silently ignored. Remove the `.schema(...)` call to fix this — the stream still gets its schema from the catalog table, exactly as before. To restore the previous behavior of silently ignoring the user-specified schema, set `spark.sql.streaming.disallowUserSpecifiedSchemaInTable.enabled` to `false`.
 
 ## Upgrading from Structured Streaming 4.0 to 4.1
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2472,6 +2472,13 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     DataTypeErrors.userSpecifiedSchemaUnsupportedError(operation)
   }
 
+  def streamingUserSpecifiedSchemaNotAllowedInTableError(): Throwable = {
+    new AnalysisException(
+      errorClass = "STREAMING_USER_SPECIFIED_SCHEMA_NOT_ALLOWED_IN_TABLE",
+      messageParameters = Map(
+        "config" -> SQLConf.STREAMING_DISALLOW_USER_SPECIFIED_SCHEMA_IN_TABLE_ENABLED.key))
+  }
+
   def tempViewNotSupportStreamingWriteError(viewName: String): Throwable = {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1190",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3882,6 +3882,17 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val STREAMING_DISALLOW_USER_SPECIFIED_SCHEMA_IN_TABLE_ENABLED =
+    buildConf("spark.sql.streaming.disallowUserSpecifiedSchemaInTable.enabled")
+      .doc("When true, DataStreamReader.table() throws an analysis error if the caller " +
+        "supplied a user-specified schema via DataStreamReader.schema(...). Catalog tables " +
+        "declare their own schema and any user-specified schema is silently dropped, so this " +
+        "guards against misconfigurations. Set this to false to restore the pre-4.2 behavior " +
+        "of silently ignoring the user-specified schema.")
+      .version("4.2.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val STREAMING_POLLING_DELAY =
     buildConf("spark.sql.streaming.pollingDelay")
       .internal()
@@ -7716,6 +7727,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def fileSourceLogCleanupDelay: Long = getConf(FILE_SOURCE_LOG_CLEANUP_DELAY)
 
   def streamingSchemaInference: Boolean = getConf(STREAMING_SCHEMA_INFERENCE)
+
+  def streamingDisallowUserSpecifiedSchemaInTableEnabled: Boolean =
+    getConf(STREAMING_DISALLOW_USER_SPECIFIED_SCHEMA_IN_TABLE_ENABLED)
 
   def streamingPollingDelay: Long = getConf(STREAMING_POLLING_DELAY)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3884,6 +3884,7 @@ object SQLConf {
 
   val STREAMING_DISALLOW_USER_SPECIFIED_SCHEMA_IN_TABLE_ENABLED =
     buildConf("spark.sql.streaming.disallowUserSpecifiedSchemaInTable.enabled")
+      .internal()
       .doc("When true, DataStreamReader.table() throws an analysis error if the caller " +
         "supplied a user-specified schema via DataStreamReader.schema(...). Catalog tables " +
         "declare their own schema and any user-specified schema is silently dropped, so this " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/DataStreamReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/DataStreamReader.scala
@@ -102,7 +102,10 @@ final class DataStreamReader private[sql](sparkSession: SparkSession)
   /** @inheritdoc */
   def table(tableName: String): DataFrame = {
     require(tableName != null, "The table name can't be null")
-    assertNoSpecifiedSchema("table")
+    if (sparkSession.sessionState.conf.streamingDisallowUserSpecifiedSchemaInTableEnabled &&
+        userSpecifiedSchema.nonEmpty) {
+      throw QueryCompilationErrors.streamingUserSpecifiedSchemaNotAllowedInTableError()
+    }
     val identifier = sparkSession.sessionState.sqlParser.parseMultipartIdentifier(tableName)
     val unresolved = UnresolvedRelation(
       identifier,

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
@@ -94,8 +94,27 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
       }
       checkError(
         exception = e,
-        condition = "_LEGACY_ERROR_TEMP_1189",
-        parameters = Map("operation" -> "table"))
+        condition = "STREAMING_USER_SPECIFIED_SCHEMA_NOT_ALLOWED_IN_TABLE",
+        parameters = Map(
+          "config" ->
+            SQLConf.STREAMING_DISALLOW_USER_SPECIFIED_SCHEMA_IN_TABLE_ENABLED.key))
+    }
+  }
+
+  test("read: user-specified schema is silently ignored when flag is flipped off") {
+    val tblName = "my_table"
+    withTable(tblName) {
+      spark.range(3).write.format("parquet").saveAsTable(tblName)
+      withSQLConf(
+          SQLConf.STREAMING_DISALLOW_USER_SPECIFIED_SCHEMA_IN_TABLE_ENABLED.key -> "false") {
+        testStream(
+            spark.readStream
+              .schema(new StructType().add("a", IntegerType))
+              .table(tblName))(
+          ProcessAllAvailable(),
+          CheckAnswer(Row(0), Row(1), Row(2))
+        )
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.streaming.sources.FakeScanBuilder
-import org.apache.spark.sql.types.{DataType, IntegerType, StructType}
+import org.apache.spark.sql.types.{DataType, IntegerType, LongType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.tags.SlowSQLTest
 import org.apache.spark.util.Utils
@@ -98,6 +98,14 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
         parameters = Map(
           "config" ->
             SQLConf.STREAMING_DISALLOW_USER_SPECIFIED_SCHEMA_IN_TABLE_ENABLED.key))
+
+      // After removing the user-specified schema, the query runs using the table's schema.
+      val df = spark.readStream.table(tblName)
+      assert(df.schema === new StructType().add("id", LongType, nullable = false))
+      testStream(df)(
+        ProcessAllAvailable(),
+        CheckAnswer(Row(0), Row(1), Row(2))
+      )
     }
   }
 
@@ -107,10 +115,12 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
       spark.range(3).write.format("parquet").saveAsTable(tblName)
       withSQLConf(
           SQLConf.STREAMING_DISALLOW_USER_SPECIFIED_SCHEMA_IN_TABLE_ENABLED.key -> "false") {
-        testStream(
-            spark.readStream
-              .schema(new StructType().add("a", IntegerType))
-              .table(tblName))(
+        val df = spark.readStream
+          .schema(new StructType().add("a", IntegerType))
+          .table(tblName)
+        // The user-specified `a: Int` is dropped; the catalog table's `id: Long` is used.
+        assert(df.schema === new StructType().add("id", LongType, nullable = false))
+        testStream(df)(
           ProcessAllAvailable(),
           CheckAnswer(Row(0), Row(1), Row(2))
         )


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to [SPARK-56975](https://issues.apache.org/jira/browse/SPARK-56975), which made `DataStreamReader.table(tableName)` reject any user-specified schema (set via `.schema(...)`) via `assertNoSpecifiedSchema("table")`. This PR addresses review feedback raised after the original change merged:

1. **Gate the new behavior behind a config.** Adds an internal conf `spark.sql.streaming.disallowUserSpecifiedSchemaInTable.enabled` (default `true`). Setting it to `false` restores the pre-4.2 behavior of silently ignoring the user-specified schema.
2. **Make the error self-explanatory.** Introduces a new error class `STREAMING_USER_SPECIFIED_SCHEMA_NOT_ALLOWED_IN_TABLE`. The message tells users the actual fix (remove the `.schema(...)` call) and names the conf so users hitting it in production have a quick escape hatch.
3. **Document the change.** Adds an entry under "Upgrading from Structured Streaming 4.1 to 4.2" in `docs/streaming/ss-migration-guide.md`.

Example:

```scala
spark.readStream
  .schema(new StructType().add("a", IntegerType))   // ignored before; now an error
  .table("some_table")
```

### Why are the changes needed?

SPARK-56975 shipped the rejection behavior without a flag or migration note. Reviewers on the original PR ([#56017](https://github.com/apache/spark/pull/56017)) asked for:
- A conf so users running into the new error in production have an escape hatch.
- An error message that surfaces the conf, so users learn how to opt out without having to read the source.
- A migration guide entry.

### Does this PR introduce _any_ user-facing change?

Yes. This PR lands in Spark 4.2+ alongside [SPARK-56975](https://github.com/apache/spark/pull/56017). The combined surface that 4.2 will ship is:

- `DataStreamReader.table()` rejects any user-specified schema with the new error class `STREAMING_USER_SPECIFIED_SCHEMA_NOT_ALLOWED_IN_TABLE`. The message tells the user to remove the `.schema(...)` call and names the new conf as the escape hatch. (This PR replaces the `_LEGACY_ERROR_TEMP_1189` originally used by SPARK-56975; neither has been released.)
- A new conf `spark.sql.streaming.disallowUserSpecifiedSchemaInTable.enabled` (default `true`). Setting it to `false` restores the silent-ignore behavior of Spark <= 4.1.

Streams that don't call `.schema(...)` before `.table()` are unaffected.

### How was this patch tested?

In `DataStreamTableAPISuite`:
- Updated `"read: user-specified schema is not allowed with table API"` to assert the new error class and verify that removing `.schema(...)` lets the query run with the catalog table's schema.
- Added `"read: user-specified schema is silently ignored when flag is flipped off"`, which sets the new conf to `false` and asserts the catalog table's schema (`id: Long`) is used while the user-specified schema (`a: Int`) is dropped.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)