### PR TITLE
[SPARK-57110][BUILD] Simplify `jjwt` deps management by using BOM

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -144,10 +144,12 @@
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt-impl</artifactId>
+      <scope>${jjwt.deps.scope}</scope>
     </dependency>
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt-jackson</artifactId>
+      <scope>${jjwt.deps.scope}</scope>
     </dependency>
 
     <!-- Jetty dependencies promoted to compile here so they are shaded

--- a/pom.xml
+++ b/pom.xml
@@ -744,23 +744,6 @@
         <version>${ivy.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.jsonwebtoken</groupId>
-        <artifactId>jjwt-api</artifactId>
-        <version>${jjwt.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jsonwebtoken</groupId>
-        <artifactId>jjwt-impl</artifactId>
-        <version>${jjwt.version}</version>
-        <scope>${jjwt.deps.scope}</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.jsonwebtoken</groupId>
-        <artifactId>jjwt-jackson</artifactId>
-        <version>${jjwt.version}</version>
-        <scope>${jjwt.deps.scope}</scope>
-      </dependency>
-      <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>${jsr305.version}</version>
@@ -1118,6 +1101,13 @@
         <version>${fasterxml.jackson.version}</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-bom</artifactId>
+        <version>${jjwt.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.ws.xmlschema</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `jjwt-bom` to manage `io.jsonwebtoken` artifact versions, replacing per-artifact `<version>` declarations. Since a BOM only manages versions, the `<scope>${jjwt.deps.scope}</scope>` declarations for `jjwt-impl` and `jjwt-jackson` move from the root `<dependencyManagement>` to `core/pom.xml` so the `jjwt-provided` profile keeps working.

### Why are the changes needed?

Simplify dependency management.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)