### PR TITLE
[SPARK-57111][SQL] Use intrinsic bulk-fill APIs for putNotNulls

### DIFF
--- a/sql/core/benchmarks/WritableColumnVectorBulkFillBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/WritableColumnVectorBulkFillBenchmark-jdk21-results.txt
@@ -2,298 +2,298 @@
 WritableColumnVector bulk fill
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putBooleans (boolean) count=1:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
 OnHeap                                                0              0           0        412.2           2.4       1.0X
-OffHeap                                               0              0           0        394.9           2.5       1.0X
+OffHeap                                               0              0           0        377.2           2.7       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putBooleans (boolean) count=8:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1520.7           0.7       1.0X
-OffHeap                                               0              0           0       1632.8           0.6       1.1X
+OnHeap                                                0              0           0       1431.9           0.7       1.0X
+OffHeap                                               0              0           0       1222.1           0.8       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putBooleans (boolean) count=64:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2586.6           0.4       1.0X
-OffHeap                                               0              0           0       2550.2           0.4       1.0X
+OnHeap                                                0              0           0       2803.9           0.4       1.0X
+OffHeap                                               0              0           0       1514.9           0.7       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putBooleans (boolean) count=512:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2701.3           0.4       1.0X
-OffHeap                                               0              0           0      19325.0           0.1       7.2X
+OnHeap                                                0              0           0       3041.6           0.3       1.0X
+OffHeap                                               0              0           0      20244.3           0.0       6.7X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putBooleans (boolean) count=4096:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2776.8           0.4       1.0X
-OffHeap                                               0              0           0      39185.2           0.0      14.1X
+OnHeap                                                1              1           0       3114.5           0.3       1.0X
+OffHeap                                               0              0           0      40351.2           0.0      13.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putBooleans (boolean) count=65536:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           0       2787.9           0.4       1.0X
-OffHeap                                               2              2           0      44303.2           0.0      15.9X
+OnHeap                                               21             21           0       3146.3           0.3       1.0X
+OffHeap                                               1              1           0      50285.0           0.0      16.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putBytes (byte) count=1:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        188.3           5.3       1.0X
-OffHeap                                               0              0           0        158.8           6.3       0.8X
+OnHeap                                                0              0           0        161.0           6.2       1.0X
+OffHeap                                               0              0           0        170.1           5.9       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putBytes (byte) count=8:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1173.6           0.9       1.0X
-OffHeap                                               0              0           0        849.4           1.2       0.7X
+OnHeap                                                0              0           0       1126.4           0.9       1.0X
+OffHeap                                               0              0           0        996.0           1.0       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putBytes (byte) count=64:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2480.6           0.4       1.0X
-OffHeap                                               0              0           0       1331.2           0.8       0.5X
+OnHeap                                                0              0           0       2626.1           0.4       1.0X
+OffHeap                                               0              0           0       2530.5           0.4       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putBytes (byte) count=512:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2676.7           0.4       1.0X
-OffHeap                                               0              0           0      18703.9           0.1       7.0X
+OnHeap                                                0              0           0       3008.2           0.3       1.0X
+OffHeap                                               0              0           0      19733.1           0.1       6.6X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putBytes (byte) count=4096:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2772.6           0.4       1.0X
-OffHeap                                               0              0           0      39243.8           0.0      14.2X
+OnHeap                                                1              1           0       3099.7           0.3       1.0X
+OffHeap                                               0              0           0      40088.9           0.0      12.9X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putBytes (byte) count=65536:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           0       2788.2           0.4       1.0X
-OffHeap                                               2              2           0      44300.3           0.0      15.9X
+OnHeap                                               21             21           0       3143.8           0.3       1.0X
+OffHeap                                               1              1           0      50075.3           0.0      15.9X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putShorts (short) count=1:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        130.1           7.7       1.0X
-OffHeap                                               0              0           0        102.4           9.8       0.8X
+OnHeap                                                0              0           0        140.6           7.1       1.0X
+OffHeap                                               0              0           0        108.1           9.3       0.8X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putShorts (short) count=8:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        763.8           1.3       1.0X
-OffHeap                                               0              0           0        588.5           1.7       0.8X
+OnHeap                                                0              0           0        809.6           1.2       1.0X
+OffHeap                                               0              0           0        632.4           1.6       0.8X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putShorts (short) count=64:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2212.3           0.5       1.0X
-OffHeap                                               0              0           0       1208.5           0.8       0.5X
+OnHeap                                                0              0           0       2358.1           0.4       1.0X
+OffHeap                                               0              0           0       1330.6           0.8       0.6X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putShorts (short) count=512:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2625.8           0.4       1.0X
-OffHeap                                               0              0           0       1377.4           0.7       0.5X
+OnHeap                                                0              0           0       2947.2           0.3       1.0X
+OffHeap                                               0              0           0       1553.6           0.6       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putShorts (short) count=4096:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2773.7           0.4       1.0X
-OffHeap                                               3              3           0       1407.6           0.7       0.5X
+OnHeap                                                1              1           0       3107.7           0.3       1.0X
+OffHeap                                               3              3           0       1588.8           0.6       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putShorts (short) count=65536:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           1       2794.1           0.4       1.0X
-OffHeap                                              48             48           1       1409.4           0.7       0.5X
+OnHeap                                               21             21           0       3153.4           0.3       1.0X
+OffHeap                                              42             42           0       1592.4           0.6       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putInts (int) count=1:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        106.0           9.4       1.0X
-OffHeap                                               0              0           0         79.7          12.5       0.8X
+OnHeap                                                0              0           0        140.8           7.1       1.0X
+OffHeap                                               0              0           0         77.2          13.0       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putInts (int) count=8:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        763.8           1.3       1.0X
-OffHeap                                               0              0           0        294.3           3.4       0.4X
+OnHeap                                                0              0           0        836.1           1.2       1.0X
+OffHeap                                               0              0           0        308.8           3.2       0.4X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putInts (int) count=64:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2212.3           0.5       1.0X
-OffHeap                                               0              0           0        440.6           2.3       0.2X
+OnHeap                                                0              0           0       2384.8           0.4       1.0X
+OffHeap                                               0              0           0        472.9           2.1       0.2X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putInts (int) count=512:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2626.6           0.4       1.0X
-OffHeap                                               1              1           0        401.7           2.5       0.2X
+OnHeap                                                0              0           0       2922.4           0.3       1.0X
+OffHeap                                               1              1           0        453.2           2.2       0.2X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putInts (int) count=4096:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2767.7           0.4       1.0X
-OffHeap                                               9              9           0        473.3           2.1       0.2X
+OnHeap                                                1              1           0       3108.7           0.3       1.0X
+OffHeap                                               8              8           0        527.7           1.9       0.2X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putInts (int) count=65536:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           0       2788.4           0.4       1.0X
-OffHeap                                             142            142           0        473.6           2.1       0.2X
+OnHeap                                               21             21           0       3150.1           0.3       1.0X
+OffHeap                                             133            133           0        504.5           2.0       0.2X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putLongs (long) count=1:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        106.0           9.4       1.0X
-OffHeap                                               0              0           0         84.4          11.8       0.8X
+OnHeap                                                0              0           0        111.7           9.0       1.0X
+OffHeap                                               0              0           0         83.2          12.0       0.7X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putLongs (long) count=8:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        661.8           1.5       1.0X
-OffHeap                                               0              0           0        478.4           2.1       0.7X
+OnHeap                                                0              0           0        682.0           1.5       1.0X
+OffHeap                                               0              0           0        529.6           1.9       0.8X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putLongs (long) count=64:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1974.6           0.5       1.0X
-OffHeap                                               0              0           0       1148.1           0.9       0.6X
+OnHeap                                                0              0           0       2139.1           0.5       1.0X
+OffHeap                                               0              0           0       1242.9           0.8       0.6X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putLongs (long) count=512:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2605.6           0.4       1.0X
-OffHeap                                               0              0           0       1365.9           0.7       0.5X
+OnHeap                                                0              0           0       2926.1           0.3       1.0X
+OffHeap                                               0              0           0       1542.1           0.6       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putLongs (long) count=4096:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2744.1           0.4       1.0X
-OffHeap                                               3              3           0       1397.2           0.7       0.5X
+OnHeap                                                1              1           0       3071.3           0.3       1.0X
+OffHeap                                               3              3           0       1579.9           0.6       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putLongs (long) count=65536:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           1       2789.8           0.4       1.0X
-OffHeap                                              48             49           4       1407.8           0.7       0.5X
+OnHeap                                               22             22           0       3117.5           0.3       1.0X
+OffHeap                                              42             42           0       1585.2           0.6       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putNulls ((no value)) count=1:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0         95.4          10.5       1.0X
-OffHeap                                               0              0           0         66.7          15.0       0.7X
+OnHeap                                                0              0           0         98.1          10.2       1.0X
+OffHeap                                               0              0           0         63.6          15.7       0.6X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putNulls ((no value)) count=8:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        620.7           1.6       1.0X
-OffHeap                                               0              0           0        478.4           2.1       0.8X
+OnHeap                                                0              0           0        647.9           1.5       1.0X
+OffHeap                                               0              0           0        304.8           3.3       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putNulls ((no value)) count=64:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1933.2           0.5       1.0X
-OffHeap                                               0              0           0       1733.1           0.6       0.9X
+OnHeap                                                0              0           0       2074.7           0.5       1.0X
+OffHeap                                               0              0           0        463.4           2.2       0.2X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putNulls ((no value)) count=512:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2596.1           0.4       1.0X
-OffHeap                                               0              0           0      13000.3           0.1       5.0X
+OnHeap                                                0              0           0       2923.2           0.3       1.0X
+OffHeap                                               0              0           0      14687.6           0.1       5.0X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putNulls ((no value)) count=4096:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2760.9           0.4       1.0X
-OffHeap                                               0              0           0      34880.4           0.0      12.6X
+OnHeap                                                1              1           0       3093.8           0.3       1.0X
+OffHeap                                               0              0           0      36784.7           0.0      11.9X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putNulls ((no value)) count=65536:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           0       2785.2           0.4       1.0X
-OffHeap                                               2              2           0      43781.3           0.0      15.7X
+OnHeap                                               21             21           0       3145.9           0.3       1.0X
+OffHeap                                               1              1           0      49323.8           0.0      15.7X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putNotNulls ((no value)) count=1:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0         98.8          10.1       1.0X
-OffHeap                                               0              0           0         89.6          11.2       0.9X
+OnHeap                                                0              0           0        101.2           9.9       1.0X
+OffHeap                                               0              0           0         66.2          15.1       0.7X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putNotNulls ((no value)) count=8:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        620.1           1.6       1.0X
-OffHeap                                               0              0           0        534.0           1.9       0.9X
+OnHeap                                                0              0           0        631.9           1.6       1.0X
+OffHeap                                               0              0           0        303.3           3.3       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putNotNulls ((no value)) count=64:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1933.2           0.5       1.0X
-OffHeap                                               0              0           0       1162.5           0.9       0.6X
+OnHeap                                                0              0           0       2034.0           0.5       1.0X
+OffHeap                                               0              0           0        465.4           2.1       0.2X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putNotNulls ((no value)) count=512:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2600.5           0.4       1.0X
-OffHeap                                               0              0           0       1371.0           0.7       0.5X
+OnHeap                                                0              0           0       2913.4           0.3       1.0X
+OffHeap                                               0              0           0      14185.7           0.1       4.9X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putNotNulls ((no value)) count=4096:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2767.4           0.4       1.0X
-OffHeap                                               3              3           0       1407.1           0.7       0.5X
+OnHeap                                                1              1           0       3100.7           0.3       1.0X
+OffHeap                                               0              0           0      36768.3           0.0      11.9X
 
-OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 7763 64-Core Processor
 putNotNulls ((no value)) count=65536:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           0       2791.4           0.4       1.0X
-OffHeap                                              48             48           0       1410.1           0.7       0.5X
+OnHeap                                               21             22           2       3153.0           0.3       1.0X
+OffHeap                                               1              1           0      49509.1           0.0      15.7X
 
 

--- a/sql/core/benchmarks/WritableColumnVectorBulkFillBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/WritableColumnVectorBulkFillBenchmark-jdk25-results.txt
@@ -3,297 +3,297 @@ WritableColumnVector bulk fill
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putBooleans (boolean) count=1:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        426.0           2.3       1.0X
-OffHeap                                               0              0           0        450.5           2.2       1.1X
+OnHeap                                                0              0           0        429.5           2.3       1.0X
+OffHeap                                               0              0           0        473.2           2.1       1.1X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putBooleans (boolean) count=8:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1526.1           0.7       1.0X
-OffHeap                                               0              0           0       1272.2           0.8       0.8X
+OnHeap                                                0              0           0       1519.9           0.7       1.0X
+OffHeap                                               0              0           0       1437.2           0.7       0.9X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putBooleans (boolean) count=64:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2622.8           0.4       1.0X
-OffHeap                                               0              0           0       1391.7           0.7       0.5X
+OnHeap                                                0              0           0       2841.7           0.4       1.0X
+OffHeap                                               0              0           0       1549.0           0.6       0.5X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putBooleans (boolean) count=512:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2736.8           0.4       1.0X
-OffHeap                                               0              0           0      27180.7           0.0       9.9X
+OnHeap                                                0              0           0       3075.4           0.3       1.0X
+OffHeap                                               0              0           0      30162.7           0.0       9.8X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putBooleans (boolean) count=4096:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2780.4           0.4       1.0X
-OffHeap                                               0              0           0      41934.2           0.0      15.1X
+OnHeap                                                1              1           0       3138.5           0.3       1.0X
+OffHeap                                               0              0           0      46036.1           0.0      14.7X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putBooleans (boolean) count=65536:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           0       2791.6           0.4       1.0X
-OffHeap                                               1              2           0      44784.3           0.0      16.0X
+OnHeap                                               21             21           0       3153.2           0.3       1.0X
+OffHeap                                               1              1           0      50368.0           0.0      16.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putBytes (byte) count=1:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        182.9           5.5       1.0X
-OffHeap                                               0              0           0        190.8           5.2       1.0X
+OnHeap                                                0              0           0        168.1           5.9       1.0X
+OffHeap                                               0              0           0        201.6           5.0       1.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putBytes (byte) count=8:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        882.4           1.1       1.0X
-OffHeap                                               0              0           0       1040.8           1.0       1.2X
+OnHeap                                                0              0           0       1176.7           0.8       1.0X
+OffHeap                                               0              0           0       1126.4           0.9       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putBytes (byte) count=64:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1331.1           0.8       1.0X
-OffHeap                                               0              0           0       2353.9           0.4       1.8X
+OnHeap                                                0              0           0       2626.1           0.4       1.0X
+OffHeap                                               0              0           0       2561.3           0.4       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putBytes (byte) count=512:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1391.8           0.7       1.0X
-OffHeap                                               0              0           0      28220.9           0.0      20.3X
+OnHeap                                                0              0           0       3041.6           0.3       1.0X
+OffHeap                                               0              0           0      31910.4           0.0      10.5X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putBytes (byte) count=4096:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                3              3           0       1409.9           0.7       1.0X
-OffHeap                                               0              0           0      41980.8           0.0      29.8X
+OnHeap                                                1              1           0       3134.8           0.3       1.0X
+OffHeap                                               0              0           0      47612.2           0.0      15.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putBytes (byte) count=65536:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               48             48           0       1410.1           0.7       1.0X
-OffHeap                                               1              2           0      44877.9           0.0      31.8X
+OnHeap                                               21             21           0       3151.5           0.3       1.0X
+OffHeap                                               1              1           0      50400.6           0.0      16.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putShorts (short) count=1:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        119.3           8.4       1.0X
-OffHeap                                               0              0           0        102.3           9.8       0.9X
+OnHeap                                                0              0           0        129.6           7.7       1.0X
+OffHeap                                               0              0           0        115.6           8.6       0.9X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putShorts (short) count=8:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        716.3           1.4       1.0X
-OffHeap                                               0              0           0        654.9           1.5       0.9X
+OnHeap                                                0              0           0        785.5           1.3       1.0X
+OffHeap                                               0              0           0        740.6           1.4       0.9X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putShorts (short) count=64:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2177.6           0.5       1.0X
-OffHeap                                               0              0           0       2017.2           0.5       0.9X
+OnHeap                                                0              0           0       2331.2           0.4       1.0X
+OffHeap                                               0              0           0       2231.1           0.4       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putShorts (short) count=512:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2633.6           0.4       1.0X
-OffHeap                                               0              0           0       2605.6           0.4       1.0X
+OnHeap                                                0              0           0       2959.9           0.3       1.0X
+OffHeap                                               0              0           0       2873.3           0.3       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putShorts (short) count=4096:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2770.5           0.4       1.0X
-OffHeap                                               2              2           0       2763.1           0.4       1.0X
+OnHeap                                                1              1           0       3104.6           0.3       1.0X
+OffHeap                                               1              1           0       3093.6           0.3       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putShorts (short) count=65536:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           0       2791.9           0.4       1.0X
-OffHeap                                              24             24           0       2786.8           0.4       1.0X
+OnHeap                                               21             21           0       3150.3           0.3       1.0X
+OffHeap                                              21             21           0       3143.3           0.3       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putInts (int) count=1:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        124.5           8.0       1.0X
-OffHeap                                               0              0           0         77.6          12.9       0.6X
+OnHeap                                                0              0           0        140.8           7.1       1.0X
+OffHeap                                               0              0           0         73.7          13.6       0.5X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putInts (int) count=8:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        739.6           1.4       1.0X
-OffHeap                                               0              0           0        546.4           1.8       0.7X
+OnHeap                                                0              0           0        836.0           1.2       1.0X
+OffHeap                                               0              0           0        324.2           3.1       0.4X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putInts (int) count=64:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2193.7           0.5       1.0X
-OffHeap                                               0              0           0       1624.2           0.6       0.7X
+OnHeap                                                0              0           0       2384.9           0.4       1.0X
+OffHeap                                               0              0           0        468.1           2.1       0.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putInts (int) count=512:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2600.8           0.4       1.0X
-OffHeap                                               0              0           0       1926.8           0.5       0.7X
+OnHeap                                                0              0           0       2918.2           0.3       1.0X
+OffHeap                                               1              1           0        529.2           1.9       0.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putInts (int) count=4096:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2765.2           0.4       1.0X
-OffHeap                                               2              2           0       1992.3           0.5       0.7X
+OnHeap                                                1              1           0       3097.3           0.3       1.0X
+OffHeap                                               8              8           0        535.2           1.9       0.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putInts (int) count=65536:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           0       2787.1           0.4       1.0X
-OffHeap                                              33             33           0       2034.2           0.5       0.7X
+OnHeap                                               21             21           0       3146.5           0.3       1.0X
+OffHeap                                             126            126           0        532.9           1.9       0.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putLongs (long) count=1:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0         95.7          10.4       1.0X
-OffHeap                                               0              0           0         73.6          13.6       0.8X
+OnHeap                                                0              0           0        108.1           9.3       1.0X
+OffHeap                                               0              0           0         83.2          12.0       0.8X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putLongs (long) count=8:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        636.6           1.6       1.0X
-OffHeap                                               0              0           0        294.2           3.4       0.5X
+OnHeap                                                0              0           0        671.9           1.5       1.0X
+OffHeap                                               0              0           0        341.3           2.9       0.5X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putLongs (long) count=64:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1941.2           0.5       1.0X
-OffHeap                                               0              0           0        443.7           2.3       0.2X
+OnHeap                                                0              0           0       2117.0           0.5       1.0X
+OffHeap                                               0              0           0        503.8           2.0       0.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putLongs (long) count=512:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2605.2           0.4       1.0X
-OffHeap                                               1              1           0        466.1           2.1       0.2X
+OnHeap                                                0              0           0       2913.3           0.3       1.0X
+OffHeap                                               1              1           0        524.7           1.9       0.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putLongs (long) count=4096:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2740.7           0.4       1.0X
-OffHeap                                               9              9           0        461.1           2.2       0.2X
+OnHeap                                                1              1           0       3063.6           0.3       1.0X
+OffHeap                                               8              8           0        534.9           1.9       0.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putLongs (long) count=65536:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           0       2787.5           0.4       1.0X
-OffHeap                                             142            142           0        473.2           2.1       0.2X
+OnHeap                                               21             22           0       3128.4           0.3       1.0X
+OffHeap                                             127            127           0        529.8           1.9       0.2X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putNulls ((no value)) count=1:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0         92.5          10.8       1.0X
-OffHeap                                               0              0           0         58.7          17.0       0.6X
+OnHeap                                                0              0           0         93.5          10.7       1.0X
+OffHeap                                               0              0           0         58.6          17.1       0.6X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putNulls ((no value)) count=8:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        554.2           1.8       1.0X
-OffHeap                                               0              0           0        273.0           3.7       0.5X
+OnHeap                                                0              0           0        589.6           1.7       1.0X
+OffHeap                                               0              0           0        290.0           3.4       0.5X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putNulls ((no value)) count=64:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1172.3           0.9       1.0X
-OffHeap                                               0              0           0        468.6           2.1       0.4X
+OnHeap                                                0              0           0       1281.4           0.8       1.0X
+OffHeap                                               0              0           0        489.6           2.0       0.4X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putNulls ((no value)) count=512:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1372.2           0.7       1.0X
-OffHeap                                               0              0           0      17345.6           0.1      12.6X
+OnHeap                                                0              0           0       1550.7           0.6       1.0X
+OffHeap                                               0              0           0      18797.7           0.1      12.1X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putNulls ((no value)) count=4096:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                3              3           0       1407.0           0.7       1.0X
-OffHeap                                               0              0           0      37753.5           0.0      26.8X
+OnHeap                                                3              3           0       1588.0           0.6       1.0X
+OffHeap                                               0              0           0      42545.9           0.0      26.8X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putNulls ((no value)) count=65536:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               48             48           0       1408.8           0.7       1.0X
-OffHeap                                               2              2           0      43484.6           0.0      30.9X
+OnHeap                                               42             42           0       1592.5           0.6       1.0X
+OffHeap                                               1              1           0      48779.8           0.0      30.6X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putNotNulls ((no value)) count=1:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0         94.2          10.6       1.0X
-OffHeap                                               0              0           0         89.6          11.2       1.0X
+OnHeap                                                0              0           0        100.2          10.0       1.0X
+OffHeap                                               0              0           0         90.1          11.1       0.9X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putNotNulls ((no value)) count=8:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        541.3           1.8       1.0X
-OffHeap                                               0              0           0        521.7           1.9       1.0X
+OnHeap                                                0              0           0        632.4           1.6       1.0X
+OffHeap                                               0              0           0        617.1           1.6       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putNotNulls ((no value)) count=64:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1145.8           0.9       1.0X
-OffHeap                                               0              0           0       1162.5           0.9       1.0X
+OnHeap                                                0              0           0       2074.7           0.5       1.0X
+OffHeap                                               0              0           0       2074.7           0.5       1.0X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putNotNulls ((no value)) count=512:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1373.5           0.7       1.0X
-OffHeap                                               0              0           0       1369.7           0.7       1.0X
+OnHeap                                                0              0           0       2923.2           0.3       1.0X
+OffHeap                                               0              0           0      19332.2           0.1       6.6X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putNotNulls ((no value)) count=4096:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                3              3           0       1407.5           0.7       1.0X
-OffHeap                                               3              3           0       1407.1           0.7       1.0X
+OnHeap                                                1              1           0       3090.5           0.3       1.0X
+OffHeap                                               0              0           0      42429.3           0.0      13.7X
 
 OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
-AMD EPYC 9V74 80-Core Processor
+AMD EPYC 7763 64-Core Processor
 putNotNulls ((no value)) count=65536:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               48             48           0       1410.4           0.7       1.0X
-OffHeap                                              48             48           0       1410.3           0.7       1.0X
+OnHeap                                               21             21           0       3149.5           0.3       1.0X
+OffHeap                                               1              1           0      49672.9           0.0      15.8X
 
 

--- a/sql/core/benchmarks/WritableColumnVectorBulkFillBenchmark-results.txt
+++ b/sql/core/benchmarks/WritableColumnVectorBulkFillBenchmark-results.txt
@@ -2,298 +2,298 @@
 WritableColumnVector bulk fill
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=1:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        527.0           1.9       1.0X
-OffHeap                                               0              0           0        369.0           2.7       0.7X
+OnHeap                                                0              0           0        408.9           2.4       1.0X
+OffHeap                                               0              0           0        288.9           3.5       0.7X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=8:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1961.7           0.5       1.0X
-OffHeap                                               0              0           0       1343.2           0.7       0.7X
+OnHeap                                                0              0           0       1523.2           0.7       1.0X
+OffHeap                                               0              0           0       1523.2           0.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=64:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       3330.3           0.3       1.0X
-OffHeap                                               0              0           0       3328.6           0.3       1.0X
+OnHeap                                                0              0           0       2586.5           0.4       1.0X
+OffHeap                                               0              0           0       2578.3           0.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=512:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1801.4           0.6       1.0X
-OffHeap                                               0              0           0      26642.0           0.0      14.8X
+OnHeap                                                0              0           0       2701.2           0.4       1.0X
+OffHeap                                               0              0           0      19777.0           0.1       7.3X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=4096:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       1815.9           0.6       1.0X
-OffHeap                                               0              0           0      51468.9           0.0      28.3X
+OnHeap                                                2              2           0       2777.8           0.4       1.0X
+OffHeap                                               0              0           0      39438.7           0.0      14.2X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=65536:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               19             19           0       3592.2           0.3       1.0X
-OffHeap                                               1              1           0      57532.7           0.0      16.0X
+OnHeap                                               24             24           0       2791.5           0.4       1.0X
+OffHeap                                               2              2           0      44624.1           0.0      16.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=1:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        234.0           4.3       1.0X
-OffHeap                                               0              0           0        245.2           4.1       1.0X
+OnHeap                                                0              0           0        181.9           5.5       1.0X
+OffHeap                                               0              0           0        184.6           5.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=8:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1473.9           0.7       1.0X
-OffHeap                                               0              0           0       1341.0           0.7       0.9X
+OnHeap                                                0              0           0       1145.7           0.9       1.0X
+OffHeap                                               0              0           0       1042.1           1.0       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=64:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       3110.2           0.3       1.0X
-OffHeap                                               0              0           0       3029.6           0.3       1.0X
+OnHeap                                                0              0           0       2416.5           0.4       1.0X
+OffHeap                                               0              0           0       2353.9           0.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=512:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       3438.4           0.3       1.0X
-OffHeap                                               0              0           0      24508.6           0.0       7.1X
+OnHeap                                                0              0           0       2676.5           0.4       1.0X
+OffHeap                                               0              0           0      19288.8           0.1       7.2X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=4096:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3564.1           0.3       1.0X
-OffHeap                                               0              0           0      49898.3           0.0      14.0X
+OnHeap                                                2              2           0       2775.3           0.4       1.0X
+OffHeap                                               0              0           0      39059.7           0.0      14.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=65536:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               19             19           0       3595.3           0.3       1.0X
-OffHeap                                               1              1           0      57106.2           0.0      15.9X
+OnHeap                                               24             24           0       2790.7           0.4       1.0X
+OffHeap                                               2              2           0      44435.8           0.0      15.9X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=1:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        175.4           5.7       1.0X
-OffHeap                                               0              0           0        160.3           6.2       0.9X
+OnHeap                                                0              0           0        131.6           7.6       1.0X
+OffHeap                                               0              0           0        124.5           8.0       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=8:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1048.8           1.0       1.0X
-OffHeap                                               0              0           0       1052.8           0.9       1.0X
+OnHeap                                                0              0           0        817.2           1.2       1.0X
+OffHeap                                               0              0           0        818.8           1.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=64:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2848.9           0.4       1.0X
-OffHeap                                               0              0           0       2749.5           0.4       1.0X
+OnHeap                                                0              0           0       2213.0           0.5       1.0X
+OffHeap                                               0              0           0       2135.7           0.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=512:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       3401.6           0.3       1.0X
-OffHeap                                               0              0           0       3358.3           0.3       1.0X
+OnHeap                                                0              0           0       2633.0           0.4       1.0X
+OffHeap                                               0              0           0       2596.3           0.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=4096:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3568.4           0.3       1.0X
-OffHeap                                               1              1           0       3551.8           0.3       1.0X
+OnHeap                                                2              2           0       2771.3           0.4       1.0X
+OffHeap                                               2              2           0       2759.5           0.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=65536:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               19             19           0       3600.0           0.3       1.0X
-OffHeap                                              19             19           0       3589.7           0.3       1.0X
+OnHeap                                               24             24           0       2791.0           0.4       1.0X
+OffHeap                                              24             24           0       2783.0           0.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putInts (int) count=1:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        170.7           5.9       1.0X
-OffHeap                                               0              0           0        123.2           8.1       0.7X
+OnHeap                                                0              0           0        132.6           7.5       1.0X
+OffHeap                                               0              0           0         84.4          11.8       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putInts (int) count=8:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1052.7           0.9       1.0X
-OffHeap                                               0              0           0        778.3           1.3       0.7X
+OnHeap                                                0              0           0        818.0           1.2       1.0X
+OffHeap                                               0              0           0        620.7           1.6       0.8X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putInts (int) count=64:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2848.9           0.4       1.0X
-OffHeap                                               0              0           0       2100.7           0.5       0.7X
+OnHeap                                                0              0           0       2213.0           0.5       1.0X
+OffHeap                                               0              0           0       2455.5           0.4       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putInts (int) count=512:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       3359.2           0.3       1.0X
-OffHeap                                               0              0           0       2285.5           0.4       0.7X
+OnHeap                                                0              0           0       2587.1           0.4       1.0X
+OffHeap                                               0              0           0       4574.9           0.2       1.8X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putInts (int) count=4096:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3556.8           0.3       1.0X
-OffHeap                                               2              2           0       2251.7           0.4       0.6X
+OnHeap                                                2              2           0       2766.7           0.4       1.0X
+OffHeap                                               1              1           0       5530.9           0.2       2.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putInts (int) count=65536:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               19             19           0       3594.3           0.3       1.0X
-OffHeap                                              31             31           0       2199.8           0.5       0.6X
+OnHeap                                               24             24           0       2790.2           0.4       1.0X
+OffHeap                                              12             12           0       5652.5           0.2       2.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=1:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        171.3           5.8       1.0X
-OffHeap                                               0              0           0        108.8           9.2       0.6X
+OnHeap                                                0              0           0        132.6           7.5       1.0X
+OffHeap                                               0              0           0         84.4          11.8       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=8:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1052.8           0.9       1.0X
-OffHeap                                               0              0           0        778.3           1.3       0.7X
+OnHeap                                                0              0           0        813.9           1.2       1.0X
+OffHeap                                               0              0           0        637.6           1.6       0.8X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=64:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2848.9           0.4       1.0X
-OffHeap                                               0              0           0       2100.8           0.5       0.7X
+OnHeap                                                0              0           0       2213.0           0.5       1.0X
+OffHeap                                               0              0           0       2510.0           0.4       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=512:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       3347.2           0.3       1.0X
-OffHeap                                               0              0           0       2257.4           0.4       0.7X
+OnHeap                                                0              0           0       2600.9           0.4       1.0X
+OffHeap                                               0              0           0       4574.0           0.2       1.8X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=4096:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3525.4           0.3       1.0X
-OffHeap                                               2              2           0       2208.7           0.5       0.6X
+OnHeap                                                2              2           0       2733.1           0.4       1.0X
+OffHeap                                               1              1           0       5370.1           0.2       2.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=65536:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               19             19           0       3592.5           0.3       1.0X
-OffHeap                                              31             31           0       2198.2           0.5       0.6X
+OnHeap                                               24             24           0       2790.0           0.4       1.0X
+OffHeap                                              12             12           0       5633.2           0.2       2.0X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=1:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        152.6           6.6       1.0X
-OffHeap                                               0              0           0        112.0           8.9       0.7X
+OnHeap                                                0              0           0        118.5           8.4       1.0X
+OffHeap                                               0              0           0         82.0          12.2       0.7X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=8:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        951.2           1.1       1.0X
-OffHeap                                               0              0           0        671.6           1.5       0.7X
+OnHeap                                                0              0           0        674.9           1.5       1.0X
+OffHeap                                               0              0           0        588.5           1.7       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=64:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2781.1           0.4       1.0X
-OffHeap                                               0              0           0       1487.2           0.7       0.5X
+OnHeap                                                0              0           0       1249.8           0.8       1.0X
+OffHeap                                               0              0           0       1874.5           0.5       1.5X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=512:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       3354.9           0.3       1.0X
-OffHeap                                               0              0           0      19822.6           0.1       5.9X
+OnHeap                                                0              0           0       2600.6           0.4       1.0X
+OffHeap                                               0              0           0      14688.8           0.1       5.6X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=4096:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3566.6           0.3       1.0X
-OffHeap                                               0              0           0      47694.0           0.0      13.4X
+OnHeap                                                2              2           0       2762.3           0.4       1.0X
+OffHeap                                               0              0           0      36662.9           0.0      13.3X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=65536:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               19             19           0       3601.3           0.3       1.0X
-OffHeap                                               1              1           0      56536.2           0.0      15.7X
+OnHeap                                               24             24           0       2785.5           0.4       1.0X
+OffHeap                                               2              2           0      43888.1           0.0      15.8X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putNotNulls ((no value)) count=1:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        157.6           6.3       1.0X
-OffHeap                                               0              0           0        108.7           9.2       0.7X
+OnHeap                                                0              0           0        118.3           8.5       1.0X
+OffHeap                                               0              0           0         86.9          11.5       0.7X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putNotNulls ((no value)) count=8:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        923.3           1.1       1.0X
-OffHeap                                               0              0           0        758.1           1.3       0.8X
+OnHeap                                                0              0           0        739.0           1.4       1.0X
+OffHeap                                               0              0           0        604.1           1.7       0.8X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putNotNulls ((no value)) count=64:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1619.4           0.6       1.0X
-OffHeap                                               0              0           0       2412.1           0.4       1.5X
+OnHeap                                                0              0           0       2160.4           0.5       1.0X
+OffHeap                                               0              0           0       1893.4           0.5       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putNotNulls ((no value)) count=512:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1766.1           0.6       1.0X
-OffHeap                                               0              0           0       3322.9           0.3       1.9X
+OnHeap                                                0              0           0       1380.0           0.7       1.0X
+OffHeap                                               0              0           0      15370.1           0.1      11.1X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putNotNulls ((no value)) count=4096:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       1812.1           0.6       1.0X
-OffHeap                                               1              1           0       3545.6           0.3       2.0X
+OnHeap                                                3              3           0       1408.8           0.7       1.0X
+OffHeap                                               0              0           0      33700.8           0.0      23.9X
 
-OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 9V74 80-Core Processor
 putNotNulls ((no value)) count=65536:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               37             37           0       1818.7           0.5       1.0X
-OffHeap                                              19             19           0       3587.4           0.3       2.0X
+OnHeap                                               48             48           0       1410.1           0.7       1.0X
+OffHeap                                               2              2           0      43906.5           0.0      31.1X
 
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -33,13 +33,13 @@ public final class OffHeapColumnVector extends WritableColumnVector {
   private static final boolean bigEndianPlatform =
     ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN);
 
-  // Below this count, byte-fill methods (putBytes / putBooleans / putNulls) write bytes in
-  // an inline loop. At or above this count, they call Platform.setMemory which lowers to a
-  // native memset. The JNI fixed cost of setMemory dominates for very short fills; on the
-  // benchmarked hardware (Apple M4 Max + OpenJDK 21) the crossover sits between 64 and
-  // 512, so 128 is a conservative choice that avoids regression at small counts (common
-  // for random null patterns where RLE runs are short) while retaining the bulk of the
-  // asymptotic gain.
+  // Below this count, byte-fill methods (putBytes / putBooleans / putNulls / putNotNulls)
+  // write bytes in an inline loop. At or above this count, they call Platform.setMemory
+  // which lowers to a native memset. The JNI fixed cost of setMemory dominates for very
+  // short fills; on the benchmarked hardware (Apple M4 Max + OpenJDK 21) the crossover
+  // sits between 64 and 512, so 128 is a conservative choice that avoids regression at
+  // small counts (common for random null patterns where RLE runs are short) while
+  // retaining the bulk of the asymptotic gain.
   private static final int SET_MEMORY_THRESHOLD = 128;
 
   /**
@@ -142,9 +142,13 @@ public final class OffHeapColumnVector extends WritableColumnVector {
   @Override
   public void putNotNulls(int rowId, int count) {
     if (!hasNull()) return;
-    long offset = nulls + rowId;
-    for (int i = 0; i < count; ++i, ++offset) {
-      Platform.putByte(null, offset, (byte) 0);
+    if (count < SET_MEMORY_THRESHOLD) {
+      long offset = nulls + rowId;
+      for (int i = 0; i < count; ++i, ++offset) {
+        Platform.putByte(null, offset, (byte) 0);
+      }
+    } else {
+      Platform.setMemory(nulls + rowId, (byte) 0, count);
     }
   }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -123,9 +123,7 @@ public final class OnHeapColumnVector extends WritableColumnVector {
   @Override
   public void putNotNulls(int rowId, int count) {
     if (!hasNull()) return;
-    for (int i = 0; i < count; ++i) {
-      nulls[rowId + i] = (byte)0;
-    }
+    Arrays.fill(nulls, rowId, rowId + count, (byte) 0);
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to #56072 (SPARK-57024) and #56082 (SPARK-57036).

`WritableColumnVector.putNotNulls(rowId, count)` clears a run of the
nulls bitmap. It is called once per batch from
`WritableColumnVector.reset()` (when `numNulls > 0`) and from the
`appendNotNulls()` path. Both OnHeap and OffHeap implementations are
per-element byte loops — the same degenerate pattern that SPARK-57024
fixed for `putNulls` and SPARK-57036 fixed for `putBytes` / `putBooleans`.

This change applies the same intrinsic substitutions:

| Method | Substitution |
| --- | --- |
| `OnHeapColumnVector.putNotNulls(rowId, count)` | `Arrays.fill(byte[], ..., (byte) 0)` |
| `OffHeapColumnVector.putNotNulls(rowId, count)` | `Platform.setMemory(addr, (byte) 0, count)` with small-count fallback |

The OffHeap variant reuses the existing `SET_MEMORY_THRESHOLD = 128`
constant introduced for `putNulls` in SPARK-57024. Below the threshold,
an inline byte loop avoids the JNI fixed cost of `Unsafe.setMemory`; at
or above, `setMemory` dominates.

Also extends `WritableColumnVectorBulkFillBenchmark` (added in
SPARK-57042 / #56084, extended for `putNulls` in SPARK-57036 / #56082)
with a `putNotNulls` case mirroring the existing `putNulls` case, so
this change has direct before/after numbers in the benchmark.

### Why are the changes needed?

`putNotNulls` runs once per batch in the vectorized reader path
(`WritableColumnVector.reset()` is called from `ColumnarBatch.close()`
and via `releaseColumns()`, both of which happen at batch boundaries).
The original per-byte loop is meaningfully slower than a `memset` for
the typical batch capacity (4096 elements).

Measured on Apple M4 Max + OpenJDK 21 via
`WritableColumnVectorBulkFillBenchmark` (the `putNotNulls` case added
by this PR), Rate (M elements/s):

| count   | OnHeap baseline | OnHeap patched | OffHeap baseline | OffHeap patched | OffHeap delta |
| ------: | --------------: | -------------: | ---------------: | --------------: | ------------: |
| 1       | 228             | 228            | 182              | 218             | +20% |
| 8       | 1,548           | 1,524          | 647              | 1,404           | +117% (within small-count fallback) |
| 64      | 11,651          | 11,155         | 990              | 3,480           | +3.5x (still below threshold; JIT noise) |
| 512     | 27,060          | 26,491         | 1,055            | 12,205          | **+11.6x** |
| 4,096   | 78,952          | 80,531         | 1,029            | 30,784          | **+29.9x** |
| 65,536  | 241,689         | 238,644        | 1,000            | 42,647          | **+42.7x** |

OnHeap is at parity across the count sweep: the C2 compiler already
auto-vectorizes the original byte loop near the byte memory-bandwidth
ceiling on this hardware, so `Arrays.fill` adds no measurable
throughput; the change is kept for idiomatic consistency with the
other byte-fill methods (`putNulls`, `putBytes`, `putBooleans`) which
all use `Arrays.fill`.

GHA `Run benchmarks` numbers will land on this PR shortly via the
auto-commit workflow (same flow as #56072 / #56082).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests; no behavior change. Ran locally:

- `VectorizedRleValuesReaderSuite`
- `ColumnVectorSuite`
- `ColumnarBatchSuite`
- `ParquetIOSuite`

237 tests, all pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.7)
