### PR TITLE
[SPARK-57112][SQL][TESTS] Add putNotNulls case to WritableColumnVectorBulkFillBenchmark

### DIFF
--- a/sql/core/benchmarks/WritableColumnVectorBulkFillBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/WritableColumnVectorBulkFillBenchmark-jdk21-results.txt
@@ -6,85 +6,85 @@ OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=1:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        410.6           2.4       1.0X
-OffHeap                                               0              0           0        462.7           2.2       1.1X
+OnHeap                                                0              0           0        412.2           2.4       1.0X
+OffHeap                                               0              0           0        394.9           2.5       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=8:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
 OnHeap                                                0              0           0       1520.7           0.7       1.0X
-OffHeap                                               0              0           0       1147.3           0.9       0.8X
+OffHeap                                               0              0           0       1632.8           0.6       1.1X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=64:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2562.2           0.4       1.0X
-OffHeap                                               0              0           0       1391.7           0.7       0.5X
+OnHeap                                                0              0           0       2586.6           0.4       1.0X
+OffHeap                                               0              0           0       2550.2           0.4       1.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=512:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2696.6           0.4       1.0X
-OffHeap                                               0              0           0      19703.4           0.1       7.3X
+OnHeap                                                0              0           0       2701.3           0.4       1.0X
+OffHeap                                               0              0           0      19325.0           0.1       7.2X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=4096:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2775.4           0.4       1.0X
-OffHeap                                               0              0           0      39447.6           0.0      14.2X
+OnHeap                                                2              2           0       2776.8           0.4       1.0X
+OffHeap                                               0              0           0      39185.2           0.0      14.1X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=65536:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           0       2788.3           0.4       1.0X
-OffHeap                                               2              2           0      44456.3           0.0      15.9X
+OnHeap                                               24             24           0       2787.9           0.4       1.0X
+OffHeap                                               2              2           0      44303.2           0.0      15.9X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=1:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        185.2           5.4       1.0X
-OffHeap                                               0              0           0        122.9           8.1       0.7X
+OnHeap                                                0              0           0        188.3           5.3       1.0X
+OffHeap                                               0              0           0        158.8           6.3       0.8X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=8:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1144.1           0.9       1.0X
-OffHeap                                               0              0           0        954.6           1.0       0.8X
+OnHeap                                                0              0           0       1173.6           0.9       1.0X
+OffHeap                                               0              0           0        849.4           1.2       0.7X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=64:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2416.5           0.4       1.0X
-OffHeap                                               0              0           0       2294.5           0.4       0.9X
+OnHeap                                                0              0           0       2480.6           0.4       1.0X
+OffHeap                                               0              0           0       1331.2           0.8       0.5X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=512:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2671.7           0.4       1.0X
-OffHeap                                               0              0           0      17075.0           0.1       6.4X
+OnHeap                                                0              0           0       2676.7           0.4       1.0X
+OffHeap                                               0              0           0      18703.9           0.1       7.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=4096:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2773.4           0.4       1.0X
-OffHeap                                               0              0           0      37922.5           0.0      13.7X
+OnHeap                                                2              2           0       2772.6           0.4       1.0X
+OffHeap                                               0              0           0      39243.8           0.0      14.2X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=65536:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           0       2790.7           0.4       1.0X
-OffHeap                                               2              2           0      44412.4           0.0      15.9X
+OnHeap                                               24             24           0       2788.2           0.4       1.0X
+OffHeap                                               2              2           0      44300.3           0.0      15.9X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
@@ -97,49 +97,49 @@ OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=8:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        763.1           1.3       1.0X
+OnHeap                                                0              0           0        763.8           1.3       1.0X
 OffHeap                                               0              0           0        588.5           1.7       0.8X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=64:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2186.4           0.5       1.0X
-OffHeap                                               0              0           0       1216.6           0.8       0.6X
+OnHeap                                                0              0           0       2212.3           0.5       1.0X
+OffHeap                                               0              0           0       1208.5           0.8       0.5X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=512:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2631.3           0.4       1.0X
-OffHeap                                               0              0           0       1377.5           0.7       0.5X
+OnHeap                                                0              0           0       2625.8           0.4       1.0X
+OffHeap                                               0              0           0       1377.4           0.7       0.5X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=4096:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2775.6           0.4       1.0X
-OffHeap                                               3              3           0       1407.7           0.7       0.5X
+OnHeap                                                2              2           0       2773.7           0.4       1.0X
+OffHeap                                               3              3           0       1407.6           0.7       0.5X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=65536:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           0       2795.6           0.4       1.0X
-OffHeap                                              48             48           0       1410.0           0.7       0.5X
+OnHeap                                               24             24           1       2794.1           0.4       1.0X
+OffHeap                                              48             48           1       1409.4           0.7       0.5X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putInts (int) count=1:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0         99.0          10.1       1.0X
-OffHeap                                               0              0           0         75.6          13.2       0.8X
+OnHeap                                                0              0           0        106.0           9.4       1.0X
+OffHeap                                               0              0           0         79.7          12.5       0.8X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putInts (int) count=8:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        790.4           1.3       1.0X
+OnHeap                                                0              0           0        763.8           1.3       1.0X
 OffHeap                                               0              0           0        294.3           3.4       0.4X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
@@ -153,105 +153,147 @@ OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putInts (int) count=512:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2638.3           0.4       1.0X
-OffHeap                                               1              1           0        402.2           2.5       0.2X
+OnHeap                                                0              0           0       2626.6           0.4       1.0X
+OffHeap                                               1              1           0        401.7           2.5       0.2X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putInts (int) count=4096:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2768.3           0.4       1.0X
-OffHeap                                               9              9           0        474.0           2.1       0.2X
+OnHeap                                                2              2           0       2767.7           0.4       1.0X
+OffHeap                                               9              9           0        473.3           2.1       0.2X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putInts (int) count=65536:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           0       2787.8           0.4       1.0X
-OffHeap                                             142            142           0        473.8           2.1       0.2X
+OnHeap                                               24             24           0       2788.4           0.4       1.0X
+OffHeap                                             142            142           0        473.6           2.1       0.2X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=1:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        101.6           9.8       1.0X
-OffHeap                                               0              0           0         82.0          12.2       0.8X
+OnHeap                                                0              0           0        106.0           9.4       1.0X
+OffHeap                                               0              0           0         84.4          11.8       0.8X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=8:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        604.2           1.7       1.0X
-OffHeap                                               0              0           0        302.1           3.3       0.5X
+OnHeap                                                0              0           0        661.8           1.5       1.0X
+OffHeap                                               0              0           0        478.4           2.1       0.7X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=64:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1954.0           0.5       1.0X
-OffHeap                                               0              0           0        443.8           2.3       0.2X
+OnHeap                                                0              0           0       1974.6           0.5       1.0X
+OffHeap                                               0              0           0       1148.1           0.9       0.6X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=512:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2596.3           0.4       1.0X
-OffHeap                                               1              1           0        467.6           2.1       0.2X
+OnHeap                                                0              0           0       2605.6           0.4       1.0X
+OffHeap                                               0              0           0       1365.9           0.7       0.5X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=4096:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2744.3           0.4       1.0X
-OffHeap                                               9              9           0        473.2           2.1       0.2X
+OnHeap                                                2              2           0       2744.1           0.4       1.0X
+OffHeap                                               3              3           0       1397.2           0.7       0.5X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=65536:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           0       2790.2           0.4       1.0X
-OffHeap                                             142            142           0        472.1           2.1       0.2X
+OnHeap                                               24             24           1       2789.8           0.4       1.0X
+OffHeap                                              48             49           4       1407.8           0.7       0.5X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=1:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0         98.7          10.1       1.0X
-OffHeap                                               0              0           0         54.2          18.5       0.5X
+OnHeap                                                0              0           0         95.4          10.5       1.0X
+OffHeap                                               0              0           0         66.7          15.0       0.7X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=8:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        600.6           1.7       1.0X
-OffHeap                                               0              0           0        252.3           4.0       0.4X
+OnHeap                                                0              0           0        620.7           1.6       1.0X
+OffHeap                                               0              0           0        478.4           2.1       0.8X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=64:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1933.3           0.5       1.0X
-OffHeap                                               0              0           0        382.0           2.6       0.2X
+OnHeap                                                0              0           0       1933.2           0.5       1.0X
+OffHeap                                               0              0           0       1733.1           0.6       0.9X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=512:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2585.9           0.4       1.0X
-OffHeap                                               1              1           0        402.4           2.5       0.2X
+OnHeap                                                0              0           0       2596.1           0.4       1.0X
+OffHeap                                               0              0           0      13000.3           0.1       5.0X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=4096:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                2              2           0       2769.8           0.4       1.0X
-OffHeap                                              10             10           0        406.4           2.5       0.1X
+OnHeap                                                2              2           0       2760.9           0.4       1.0X
+OffHeap                                               0              0           0      34880.4           0.0      12.6X
 
 OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
 AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=65536:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               24             24           0       2793.3           0.4       1.0X
-OffHeap                                             165            165           0        406.2           2.5       0.1X
+OnHeap                                               24             24           0       2785.2           0.4       1.0X
+OffHeap                                               2              2           0      43781.3           0.0      15.7X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=1:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                                0              0           0         98.8          10.1       1.0X
+OffHeap                                               0              0           0         89.6          11.2       0.9X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=8:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                                0              0           0        620.1           1.6       1.0X
+OffHeap                                               0              0           0        534.0           1.9       0.9X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=64:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                                0              0           0       1933.2           0.5       1.0X
+OffHeap                                               0              0           0       1162.5           0.9       0.6X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=512:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                                0              0           0       2600.5           0.4       1.0X
+OffHeap                                               0              0           0       1371.0           0.7       0.5X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=4096:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                                2              2           0       2767.4           0.4       1.0X
+OffHeap                                               3              3           0       1407.1           0.7       0.5X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=65536:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                               24             24           0       2791.4           0.4       1.0X
+OffHeap                                              48             48           0       1410.1           0.7       0.5X
 
 

--- a/sql/core/benchmarks/WritableColumnVectorBulkFillBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/WritableColumnVectorBulkFillBenchmark-jdk25-results.txt
@@ -2,256 +2,298 @@
 WritableColumnVector bulk fill
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=1:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        422.4           2.4       1.0X
-OffHeap                                               0              0           0        448.3           2.2       1.1X
+OnHeap                                                0              0           0        426.0           2.3       1.0X
+OffHeap                                               0              0           0        450.5           2.2       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=8:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1523.0           0.7       1.0X
-OffHeap                                               0              0           0       1854.2           0.5       1.2X
+OnHeap                                                0              0           0       1526.1           0.7       1.0X
+OffHeap                                               0              0           0       1272.2           0.8       0.8X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=64:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2842.8           0.4       1.0X
-OffHeap                                               0              0           0       2880.3           0.3       1.0X
+OnHeap                                                0              0           0       2622.8           0.4       1.0X
+OffHeap                                               0              0           0       1391.7           0.7       0.5X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=512:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       3069.8           0.3       1.0X
-OffHeap                                               0              0           0      25540.1           0.0       8.3X
+OnHeap                                                0              0           0       2736.8           0.4       1.0X
+OffHeap                                               0              0           0      27180.7           0.0       9.9X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=4096:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3133.9           0.3       1.0X
-OffHeap                                               0              0           0      45804.3           0.0      14.6X
+OnHeap                                                2              2           0       2780.4           0.4       1.0X
+OffHeap                                               0              0           0      41934.2           0.0      15.1X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=65536:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               21             21           0       3152.6           0.3       1.0X
-OffHeap                                               1              1           0      50577.0           0.0      16.0X
+OnHeap                                               24             24           0       2791.6           0.4       1.0X
+OffHeap                                               1              2           0      44784.3           0.0      16.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=1:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        160.2           6.2       1.0X
-OffHeap                                               0              0           0        195.4           5.1       1.2X
+OnHeap                                                0              0           0        182.9           5.5       1.0X
+OffHeap                                               0              0           0        190.8           5.2       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=8:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1126.4           0.9       1.0X
-OffHeap                                               0              0           0        864.4           1.2       0.8X
+OnHeap                                                0              0           0        882.4           1.1       1.0X
+OffHeap                                               0              0           0       1040.8           1.0       1.2X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=64:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2626.1           0.4       1.0X
-OffHeap                                               0              0           0       1421.8           0.7       0.5X
+OnHeap                                                0              0           0       1331.1           0.8       1.0X
+OffHeap                                               0              0           0       2353.9           0.4       1.8X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=512:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       3036.3           0.3       1.0X
-OffHeap                                               0              0           0      29634.2           0.0       9.8X
+OnHeap                                                0              0           0       1391.8           0.7       1.0X
+OffHeap                                               0              0           0      28220.9           0.0      20.3X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=4096:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3131.8           0.3       1.0X
-OffHeap                                               0              0           0      47278.4           0.0      15.1X
+OnHeap                                                3              3           0       1409.9           0.7       1.0X
+OffHeap                                               0              0           0      41980.8           0.0      29.8X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=65536:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               21             21           0       3148.1           0.3       1.0X
-OffHeap                                               1              1           0      49712.8           0.0      15.8X
+OnHeap                                               48             48           0       1410.1           0.7       1.0X
+OffHeap                                               1              2           0      44877.9           0.0      31.8X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=1:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        129.6           7.7       1.0X
-OffHeap                                               0              0           0        111.7           9.0       0.9X
+OnHeap                                                0              0           0        119.3           8.4       1.0X
+OffHeap                                               0              0           0        102.3           9.8       0.9X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=8:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        785.5           1.3       1.0X
-OffHeap                                               0              0           0        632.9           1.6       0.8X
+OnHeap                                                0              0           0        716.3           1.4       1.0X
+OffHeap                                               0              0           0        654.9           1.5       0.9X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=64:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2331.2           0.4       1.0X
-OffHeap                                               0              0           0       1339.4           0.7       0.6X
+OnHeap                                                0              0           0       2177.6           0.5       1.0X
+OffHeap                                               0              0           0       2017.2           0.5       0.9X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=512:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2964.6           0.3       1.0X
-OffHeap                                               0              0           0       1556.5           0.6       0.5X
+OnHeap                                                0              0           0       2633.6           0.4       1.0X
+OffHeap                                               0              0           0       2605.6           0.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=4096:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3106.0           0.3       1.0X
-OffHeap                                               3              3           0       1590.0           0.6       0.5X
+OnHeap                                                2              2           0       2770.5           0.4       1.0X
+OffHeap                                               2              2           0       2763.1           0.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=65536:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               21             21           0       3154.1           0.3       1.0X
-OffHeap                                              42             42           0       1593.6           0.6       0.5X
+OnHeap                                               24             24           0       2791.9           0.4       1.0X
+OffHeap                                              24             24           0       2786.8           0.4       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putInts (int) count=1:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        147.1           6.8       1.0X
-OffHeap                                               0              0           0         85.4          11.7       0.6X
+OnHeap                                                0              0           0        124.5           8.0       1.0X
+OffHeap                                               0              0           0         77.6          12.9       0.6X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putInts (int) count=8:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        861.6           1.2       1.0X
-OffHeap                                               0              0           0        341.3           2.9       0.4X
+OnHeap                                                0              0           0        739.6           1.4       1.0X
+OffHeap                                               0              0           0        546.4           1.8       0.7X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putInts (int) count=64:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2412.9           0.4       1.0X
-OffHeap                                               0              0           0        472.9           2.1       0.2X
+OnHeap                                                0              0           0       2193.7           0.5       1.0X
+OffHeap                                               0              0           0       1624.2           0.6       0.7X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putInts (int) count=512:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2933.5           0.3       1.0X
-OffHeap                                               1              1           0        530.7           1.9       0.2X
+OnHeap                                                0              0           0       2600.8           0.4       1.0X
+OffHeap                                               0              0           0       1926.8           0.5       0.7X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putInts (int) count=4096:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3095.4           0.3       1.0X
-OffHeap                                               8              8           0        526.8           1.9       0.2X
+OnHeap                                                2              2           0       2765.2           0.4       1.0X
+OffHeap                                               2              2           0       1992.3           0.5       0.7X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putInts (int) count=65536:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               21             21           0       3143.6           0.3       1.0X
-OffHeap                                             126            126           0        531.7           1.9       0.2X
+OnHeap                                               24             24           0       2787.1           0.4       1.0X
+OffHeap                                              33             33           0       2034.2           0.5       0.7X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=1:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        108.1           9.3       1.0X
-OffHeap                                               0              0           0         92.7          10.8       0.9X
+OnHeap                                                0              0           0         95.7          10.4       1.0X
+OffHeap                                               0              0           0         73.6          13.6       0.8X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=8:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        671.4           1.5       1.0X
-OffHeap                                               0              0           0        518.8           1.9       0.8X
+OnHeap                                                0              0           0        636.6           1.6       1.0X
+OffHeap                                               0              0           0        294.2           3.4       0.5X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=64:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2117.7           0.5       1.0X
-OffHeap                                               0              0           0       1265.8           0.8       0.6X
+OnHeap                                                0              0           0       1941.2           0.5       1.0X
+OffHeap                                               0              0           0        443.7           2.3       0.2X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=512:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2923.4           0.3       1.0X
-OffHeap                                               0              0           0       1549.3           0.6       0.5X
+OnHeap                                                0              0           0       2605.2           0.4       1.0X
+OffHeap                                               1              1           0        466.1           2.1       0.2X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=4096:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3062.8           0.3       1.0X
-OffHeap                                               3              3           0       1580.4           0.6       0.5X
+OnHeap                                                2              2           0       2740.7           0.4       1.0X
+OffHeap                                               9              9           0        461.1           2.2       0.2X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=65536:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               21             22           0       3126.5           0.3       1.0X
-OffHeap                                              42             42           0       1587.4           0.6       0.5X
+OnHeap                                               24             24           0       2787.5           0.4       1.0X
+OffHeap                                             142            142           0        473.2           2.1       0.2X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=1:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        100.2          10.0       1.0X
-OffHeap                                               0              0           0         75.4          13.3       0.8X
+OnHeap                                                0              0           0         92.5          10.8       1.0X
+OffHeap                                               0              0           0         58.7          17.0       0.6X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=8:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        647.9           1.5       1.0X
-OffHeap                                               0              0           0        308.8           3.2       0.5X
+OnHeap                                                0              0           0        554.2           1.8       1.0X
+OffHeap                                               0              0           0        273.0           3.7       0.5X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=64:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2117.0           0.5       1.0X
-OffHeap                                               0              0           0        467.5           2.1       0.2X
+OnHeap                                                0              0           0       1172.3           0.9       1.0X
+OffHeap                                               0              0           0        468.6           2.1       0.4X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=512:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2918.5           0.3       1.0X
-OffHeap                                               1              1           0        529.5           1.9       0.2X
+OnHeap                                                0              0           0       1372.2           0.7       1.0X
+OffHeap                                               0              0           0      17345.6           0.1      12.6X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=4096:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3083.6           0.3       1.0X
-OffHeap                                               8              8           0        525.8           1.9       0.2X
+OnHeap                                                3              3           0       1407.0           0.7       1.0X
+OffHeap                                               0              0           0      37753.5           0.0      26.8X
 
-OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=65536:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               21             21           0       3152.7           0.3       1.0X
-OffHeap                                             125            126           0        534.9           1.9       0.2X
+OnHeap                                               48             48           0       1408.8           0.7       1.0X
+OffHeap                                               2              2           0      43484.6           0.0      30.9X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=1:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                                0              0           0         94.2          10.6       1.0X
+OffHeap                                               0              0           0         89.6          11.2       1.0X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=8:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                                0              0           0        541.3           1.8       1.0X
+OffHeap                                               0              0           0        521.7           1.9       1.0X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=64:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                                0              0           0       1145.8           0.9       1.0X
+OffHeap                                               0              0           0       1162.5           0.9       1.0X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=512:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                                0              0           0       1373.5           0.7       1.0X
+OffHeap                                               0              0           0       1369.7           0.7       1.0X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=4096:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                                3              3           0       1407.5           0.7       1.0X
+OffHeap                                               3              3           0       1407.1           0.7       1.0X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=65536:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                               48             48           0       1410.4           0.7       1.0X
+OffHeap                                              48             48           0       1410.3           0.7       1.0X
 
 

--- a/sql/core/benchmarks/WritableColumnVectorBulkFillBenchmark-results.txt
+++ b/sql/core/benchmarks/WritableColumnVectorBulkFillBenchmark-results.txt
@@ -3,255 +3,297 @@ WritableColumnVector bulk fill
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=1:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        410.6           2.4       1.0X
-OffHeap                                               0              0           0        276.2           3.6       0.7X
+OnHeap                                                0              0           0        527.0           1.9       1.0X
+OffHeap                                               0              0           0        369.0           2.7       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=8:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1434.7           0.7       1.0X
-OffHeap                                               0              0           0       1616.1           0.6       1.1X
+OnHeap                                                0              0           0       1961.7           0.5       1.0X
+OffHeap                                               0              0           0       1343.2           0.7       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=64:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2803.9           0.4       1.0X
-OffHeap                                               0              0           0       2842.8           0.4       1.0X
+OnHeap                                                0              0           0       3330.3           0.3       1.0X
+OffHeap                                               0              0           0       3328.6           0.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=512:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       3041.4           0.3       1.0X
-OffHeap                                               0              0           0      20236.5           0.0       6.7X
+OnHeap                                                0              0           0       1801.4           0.6       1.0X
+OffHeap                                               0              0           0      26642.0           0.0      14.8X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=4096:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3133.4           0.3       1.0X
-OffHeap                                               0              0           0      40173.8           0.0      12.8X
+OnHeap                                                2              2           0       1815.9           0.6       1.0X
+OffHeap                                               0              0           0      51468.9           0.0      28.3X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putBooleans (boolean) count=65536:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               21             21           0       3145.6           0.3       1.0X
-OffHeap                                               1              1           0      50338.2           0.0      16.0X
+OnHeap                                               19             19           0       3592.2           0.3       1.0X
+OffHeap                                               1              1           0      57532.7           0.0      16.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=1:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        168.7           5.9       1.0X
-OffHeap                                               0              0           0        189.3           5.3       1.1X
+OnHeap                                                0              0           0        234.0           4.3       1.0X
+OffHeap                                               0              0           0        245.2           4.1       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=8:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       1080.2           0.9       1.0X
-OffHeap                                               0              0           0        864.4           1.2       0.8X
+OnHeap                                                0              0           0       1473.9           0.7       1.0X
+OffHeap                                               0              0           0       1341.0           0.7       0.9X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=64:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2593.8           0.4       1.0X
-OffHeap                                               0              0           0       1421.8           0.7       0.5X
+OnHeap                                                0              0           0       3110.2           0.3       1.0X
+OffHeap                                               0              0           0       3029.6           0.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=512:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2997.7           0.3       1.0X
-OffHeap                                               0              0           0      18259.6           0.1       6.1X
+OnHeap                                                0              0           0       3438.4           0.3       1.0X
+OffHeap                                               0              0           0      24508.6           0.0       7.1X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=4096:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                3              3           0       1591.4           0.6       1.0X
-OffHeap                                               0              0           0      40100.4           0.0      25.2X
+OnHeap                                                1              1           0       3564.1           0.3       1.0X
+OffHeap                                               0              0           0      49898.3           0.0      14.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putBytes (byte) count=65536:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               42             42           0       1593.2           0.6       1.0X
-OffHeap                                               1              1           0      50028.8           0.0      31.4X
+OnHeap                                               19             19           0       3595.3           0.3       1.0X
+OffHeap                                               1              1           0      57106.2           0.0      15.9X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=1:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        147.1           6.8       1.0X
-OffHeap                                               0              0           0        129.6           7.7       0.9X
+OnHeap                                                0              0           0        175.4           5.7       1.0X
+OffHeap                                               0              0           0        160.3           6.2       0.9X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=8:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        857.1           1.2       1.0X
-OffHeap                                               0              0           0        836.1           1.2       1.0X
+OnHeap                                                0              0           0       1048.8           1.0       1.0X
+OffHeap                                               0              0           0       1052.8           0.9       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=64:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2413.0           0.4       1.0X
-OffHeap                                               0              0           0       2331.2           0.4       1.0X
+OnHeap                                                0              0           0       2848.9           0.4       1.0X
+OffHeap                                               0              0           0       2749.5           0.4       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=512:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2973.5           0.3       1.0X
-OffHeap                                               0              0           0       2957.7           0.3       1.0X
+OnHeap                                                0              0           0       3401.6           0.3       1.0X
+OffHeap                                               0              0           0       3358.3           0.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=4096:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3107.5           0.3       1.0X
-OffHeap                                               1              1           0       3105.3           0.3       1.0X
+OnHeap                                                1              1           0       3568.4           0.3       1.0X
+OffHeap                                               1              1           0       3551.8           0.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putShorts (short) count=65536:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               21             22           1       3154.3           0.3       1.0X
-OffHeap                                              21             21           0       3145.2           0.3       1.0X
+OnHeap                                               19             19           0       3600.0           0.3       1.0X
+OffHeap                                              19             19           0       3589.7           0.3       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putInts (int) count=1:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        153.9           6.5       1.0X
-OffHeap                                               0              0           0         92.7          10.8       0.6X
+OnHeap                                                0              0           0        170.7           5.9       1.0X
+OffHeap                                               0              0           0        123.2           8.1       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putInts (int) count=8:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        893.7           1.1       1.0X
-OffHeap                                               0              0           0        618.1           1.6       0.7X
+OnHeap                                                0              0           0       1052.7           0.9       1.0X
+OffHeap                                               0              0           0        778.3           1.3       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putInts (int) count=64:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2413.0           0.4       1.0X
-OffHeap                                               0              0           0       2695.3           0.4       1.1X
+OnHeap                                                0              0           0       2848.9           0.4       1.0X
+OffHeap                                               0              0           0       2100.7           0.5       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putInts (int) count=512:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2940.0           0.3       1.0X
-OffHeap                                               0              0           0       5336.1           0.2       1.8X
+OnHeap                                                0              0           0       3359.2           0.3       1.0X
+OffHeap                                               0              0           0       2285.5           0.4       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putInts (int) count=4096:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3097.0           0.3       1.0X
-OffHeap                                               1              1           0       6240.5           0.2       2.0X
+OnHeap                                                1              1           0       3556.8           0.3       1.0X
+OffHeap                                               2              2           0       2251.7           0.4       0.6X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putInts (int) count=65536:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               21             21           0       3144.7           0.3       1.0X
-OffHeap                                              11             11           1       6387.9           0.2       2.0X
+OnHeap                                               19             19           0       3594.3           0.3       1.0X
+OffHeap                                              31             31           0       2199.8           0.5       0.6X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=1:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        145.6           6.9       1.0X
-OffHeap                                               0              0           0         95.4          10.5       0.7X
+OnHeap                                                0              0           0        171.3           5.8       1.0X
+OffHeap                                               0              0           0        108.8           9.2       0.6X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=8:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        863.5           1.2       1.0X
-OffHeap                                               0              0           0        632.9           1.6       0.7X
+OnHeap                                                0              0           0       1052.8           0.9       1.0X
+OffHeap                                               0              0           0        778.3           1.3       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=64:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2413.0           0.4       1.0X
-OffHeap                                               0              0           0       2075.4           0.5       0.9X
+OnHeap                                                0              0           0       2848.9           0.4       1.0X
+OffHeap                                               0              0           0       2100.8           0.5       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=512:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2939.0           0.3       1.0X
-OffHeap                                               0              0           0       2923.1           0.3       1.0X
+OnHeap                                                0              0           0       3347.2           0.3       1.0X
+OffHeap                                               0              0           0       2257.4           0.4       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=4096:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3066.8           0.3       1.0X
-OffHeap                                               1              1           0       3063.4           0.3       1.0X
+OnHeap                                                1              1           0       3525.4           0.3       1.0X
+OffHeap                                               2              2           0       2208.7           0.5       0.6X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putLongs (long) count=65536:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               21             22           0       3125.9           0.3       1.0X
-OffHeap                                              22             22           0       3116.3           0.3       1.0X
+OnHeap                                               19             19           0       3592.5           0.3       1.0X
+OffHeap                                              31             31           0       2198.2           0.5       0.6X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=1:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        128.6           7.8       1.0X
-OffHeap                                               0              0           0         92.7          10.8       0.7X
+OnHeap                                                0              0           0        152.6           6.6       1.0X
+OffHeap                                               0              0           0        112.0           8.9       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=8:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0        762.8           1.3       1.0X
-OffHeap                                               0              0           0        518.8           1.9       0.7X
+OnHeap                                                0              0           0        951.2           1.1       1.0X
+OffHeap                                               0              0           0        671.6           1.5       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=64:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2305.8           0.4       1.0X
-OffHeap                                               0              0           0       1258.2           0.8       0.5X
+OnHeap                                                0              0           0       2781.1           0.4       1.0X
+OffHeap                                               0              0           0       1487.2           0.7       0.5X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=512:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                0              0           0       2928.8           0.3       1.0X
-OffHeap                                               0              0           0       1543.5           0.6       0.5X
+OnHeap                                                0              0           0       3354.9           0.3       1.0X
+OffHeap                                               0              0           0      19822.6           0.1       5.9X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=4096:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                                1              1           0       3106.4           0.3       1.0X
-OffHeap                                               3              3           0       1587.6           0.6       0.5X
+OnHeap                                                1              1           0       3566.6           0.3       1.0X
+OffHeap                                               0              0           0      47694.0           0.0      13.4X
 
 OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
-AMD EPYC 7763 64-Core Processor
+AMD EPYC 9V74 80-Core Processor
 putNulls ((no value)) count=65536:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-OnHeap                                               21             21           0       3150.1           0.3       1.0X
-OffHeap                                              42             42           0       1593.1           0.6       0.5X
+OnHeap                                               19             19           0       3601.3           0.3       1.0X
+OffHeap                                               1              1           0      56536.2           0.0      15.7X
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=1:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                                0              0           0        157.6           6.3       1.0X
+OffHeap                                               0              0           0        108.7           9.2       0.7X
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=8:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                                0              0           0        923.3           1.1       1.0X
+OffHeap                                               0              0           0        758.1           1.3       0.8X
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=64:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                                0              0           0       1619.4           0.6       1.0X
+OffHeap                                               0              0           0       2412.1           0.4       1.5X
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=512:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                                0              0           0       1766.1           0.6       1.0X
+OffHeap                                               0              0           0       3322.9           0.3       1.9X
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=4096:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                                2              2           0       1812.1           0.6       1.0X
+OffHeap                                               1              1           0       3545.6           0.3       2.0X
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1013-azure
+AMD EPYC 9V74 80-Core Processor
+putNotNulls ((no value)) count=65536:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+OnHeap                                               37             37           0       1818.7           0.5       1.0X
+OffHeap                                              19             19           0       3587.4           0.3       2.0X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/WritableColumnVectorBulkFillBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/WritableColumnVectorBulkFillBenchmark.scala
@@ -150,6 +150,23 @@ object WritableColumnVectorBulkFillBenchmark extends BenchmarkBase {
         () => new OffHeapColumnVector(CAPACITY, IntegerType),
         (v, n) => v.putNulls(0, n),
         (v, idx) => intSink = if (v.isNullAt(idx)) 1 else 0)
+
+      // putNotNulls(rowId, count) -- the inverse of putNulls; called from
+      // WritableColumnVector.reset() once per batch. It early-outs unless numNulls > 0,
+      // so the factories seed one null before measurement begins.
+      runFor("putNotNulls", "(no value)",
+        () => {
+          val v = new OnHeapColumnVector(CAPACITY, IntegerType)
+          v.putNull(0)
+          v
+        },
+        () => {
+          val v = new OffHeapColumnVector(CAPACITY, IntegerType)
+          v.putNull(0)
+          v
+        },
+        (v, n) => v.putNotNulls(0, n),
+        (v, idx) => intSink = if (v.isNullAt(idx)) 1 else 0)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a `putNotNulls` case to `WritableColumnVectorBulkFillBenchmark`
(introduced in SPARK-57042 / #56084). The case mirrors the existing
`putNulls` case and exercises both `OnHeapColumnVector.putNotNulls` and
`OffHeapColumnVector.putNotNulls` across the standard count sweep
(1, 8, 64, 512, 4096, 65536).

`putNotNulls` early-outs unless `numNulls > 0`, so the OnHeap / OffHeap
factories seed one null into the column vector at setup before the
measured loop begins.

### Why are the changes needed?

`putNotNulls` is the inverse of `putNulls` and runs once per batch
from `WritableColumnVector.reset()` when `numNulls > 0`. SPARK-57111
(#56156) is switching its implementation from a per-byte loop to
`Arrays.fill` / `Platform.setMemory` (with the `SET_MEMORY_THRESHOLD`
fallback). Landing the benchmark case in master first means SPARK-57111
will produce a like-for-like `Run benchmarks` GHA baseline → patched
comparison, the same way SPARK-57042 / #56084 enabled the comparison
for SPARK-57036 / #56082.

### Does this PR introduce _any_ user-facing change?

No. Benchmark-only.

### How was this patch tested?

The benchmark compiles and runs:

```
build/sbt "sql/Test/runMain org.apache.spark.sql.execution.vectorized.WritableColumnVectorBulkFillBenchmark"
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.7)
