### PR TITLE
[SPARK-57117][BUILD] Upgrade `zstd-jni` to 1.5.7-9

### DIFF
--- a/core/benchmarks/ZStandardBenchmark-jdk21-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk21-results.txt
@@ -2,81 +2,81 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            639            659          14          0.0       63911.4       1.0X
-Compression 10000 times at level 2 without buffer pool            701            704           3          0.0       70100.0       0.9X
-Compression 10000 times at level 3 without buffer pool            795            796           1          0.0       79524.8       0.8X
-Compression 10000 times at level 1 with buffer pool               593            594           1          0.0       59304.9       1.1X
-Compression 10000 times at level 2 with buffer pool               626            627           1          0.0       62575.0       1.0X
-Compression 10000 times at level 3 with buffer pool               730            730           0          0.0       72959.7       0.9X
+Compression 10000 times at level 1 without buffer pool           1707           1708           2          0.0      170666.5       1.0X
+Compression 10000 times at level 2 without buffer pool           1739           1739           0          0.0      173941.7       1.0X
+Compression 10000 times at level 3 without buffer pool           1843           1846           4          0.0      184333.1       0.9X
+Compression 10000 times at level 1 with buffer pool              1568           1568           0          0.0      156772.4       1.1X
+Compression 10000 times at level 2 with buffer pool              1596           1597           0          0.0      159630.3       1.1X
+Compression 10000 times at level 3 with buffer pool              1706           1706           0          0.0      170629.3       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            816            817           0          0.0       81627.3       1.0X
-Decompression 10000 times from level 2 without buffer pool            816            817           1          0.0       81624.6       1.0X
-Decompression 10000 times from level 3 without buffer pool            817            819           4          0.0       81661.5       1.0X
-Decompression 10000 times from level 1 with buffer pool               749            749           1          0.0       74885.1       1.1X
-Decompression 10000 times from level 2 with buffer pool               749            750           2          0.0       74877.8       1.1X
-Decompression 10000 times from level 3 with buffer pool               749            751           1          0.0       74925.2       1.1X
+Decompression 10000 times from level 1 without buffer pool           1665           1668           5          0.0      166500.7       1.0X
+Decompression 10000 times from level 2 without buffer pool           1661           1663           2          0.0      166089.7       1.0X
+Decompression 10000 times from level 3 without buffer pool           1660           1661           1          0.0      166034.4       1.0X
+Decompression 10000 times from level 1 with buffer pool              1531           1531           1          0.0      153087.3       1.1X
+Decompression 10000 times from level 2 with buffer pool              1529           1530           0          0.0      152931.3       1.1X
+Decompression 10000 times from level 3 with buffer pool              1529           1529           0          0.0      152851.6       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Parallel Compression at level 3:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parallel Compression with 0 workers                  64             66           1          0.0      502592.0       1.0X
-Parallel Compression with 1 workers                  53             55           2          0.0      413662.7       1.2X
-Parallel Compression with 2 workers                  44             45           1          0.0      342870.1       1.5X
-Parallel Compression with 4 workers                  39             40           1          0.0      301287.7       1.7X
-Parallel Compression with 8 workers                  41             42           1          0.0      318268.9       1.6X
-Parallel Compression with 16 workers                 44             47           1          0.0      341979.2       1.5X
+Parallel Compression with 0 workers                  85             86           1          0.0      664268.9       1.0X
+Parallel Compression with 1 workers                  53             57           2          0.0      410899.6       1.6X
+Parallel Compression with 2 workers                  57             62           3          0.0      443643.2       1.5X
+Parallel Compression with 4 workers                  64             66           1          0.0      499176.6       1.3X
+Parallel Compression with 8 workers                  64             70           2          0.0      503423.0       1.3X
+Parallel Compression with 16 workers                 71             76           1          0.0      554935.6       1.2X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Parallel Compression at level 9:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parallel Compression with 0 workers                 232            233           1          0.0     1809165.8       1.0X
-Parallel Compression with 1 workers                 250            251           1          0.0     1954225.1       0.9X
-Parallel Compression with 2 workers                 139            142           3          0.0     1084544.7       1.7X
-Parallel Compression with 4 workers                 126            130           3          0.0      981957.2       1.8X
-Parallel Compression with 8 workers                 127            131           2          0.0      994423.7       1.8X
-Parallel Compression with 16 workers                128            131           2          0.0      999291.6       1.8X
+Parallel Compression with 0 workers                 286            286           1          0.0     2231032.2       1.0X
+Parallel Compression with 1 workers                 239            243           5          0.0     1870943.8       1.2X
+Parallel Compression with 2 workers                 149            151           1          0.0     1163131.7       1.9X
+Parallel Compression with 4 workers                 145            152           9          0.0     1133950.3       2.0X
+Parallel Compression with 8 workers                 148            152           2          0.0     1154424.0       1.9X
+Parallel Compression with 16 workers                149            152           2          0.0     1163126.3       1.9X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Compression at level 1:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Compression by strategy -1                           52             54           1          0.0      408642.2       1.0X
-Compression by strategy 1                            53             54           1          0.0      411199.8       1.0X
-Compression by strategy 3                            87             88           1          0.0      679667.3       0.6X
-Compression by strategy 5                           224            226           1          0.0     1752490.3       0.2X
-Compression by strategy 7                           254            255           1          0.0     1987032.5       0.2X
-Compression by strategy 9                           253            258           9          0.0     1979440.2       0.2X
+Compression by strategy -1                           67             68           1          0.0      523301.8       1.0X
+Compression by strategy 1                            67             69           1          0.0      526139.7       1.0X
+Compression by strategy 3                            98             99           1          0.0      761834.2       0.7X
+Compression by strategy 5                           259            259           0          0.0     2021048.2       0.3X
+Compression by strategy 7                           281            282           0          0.0     2198582.0       0.2X
+Compression by strategy 9                           282            283           1          0.0     2202061.8       0.2X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Compression at level 3:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Compression by strategy -1                           64             66           1          0.0      502266.0       1.0X
-Compression by strategy 1                            49             50           1          0.0      379198.4       1.3X
-Compression by strategy 3                            85             86           1          0.0      662928.8       0.8X
-Compression by strategy 5                           223            224           1          0.0     1740092.5       0.3X
-Compression by strategy 7                           270            272           1          0.0     2111038.7       0.2X
-Compression by strategy 9                           270            272           1          0.0     2111123.1       0.2X
+Compression by strategy -1                           86             86           0          0.0      668424.0       1.0X
+Compression by strategy 1                            71             72           0          0.0      555990.4       1.2X
+Compression by strategy 3                           104            106           1          0.0      812706.3       0.8X
+Compression by strategy 5                           276            277           1          0.0     2159788.5       0.3X
+Compression by strategy 7                           280            280           0          0.0     2184722.3       0.3X
+Compression by strategy 9                           280            281           1          0.0     2186926.2       0.3X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Compression at level 9:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Compression by strategy -1                          224            227           1          0.0     1753793.7       1.0X
-Compression by strategy 1                            49             50           1          0.0      379265.7       4.6X
-Compression by strategy 3                            86             88           2          0.0      669232.7       2.6X
-Compression by strategy 5                           227            229           1          0.0     1771444.5       1.0X
-Compression by strategy 7                           273            274           1          0.0     2130331.0       0.8X
-Compression by strategy 9                           274            275           1          0.0     2136838.9       0.8X
+Compression by strategy -1                          280            282           1          0.0     2190654.4       1.0X
+Compression by strategy 1                            72             73           1          0.0      560859.9       3.9X
+Compression by strategy 3                           104            105           0          0.0      813945.6       2.7X
+Compression by strategy 5                           280            281           1          0.0     2188744.6       1.0X
+Compression by strategy 7                           279            281           2          0.0     2181254.5       1.0X
+Compression by strategy 9                           280            281           1          0.0     2191251.5       1.0X
 
 

--- a/core/benchmarks/ZStandardBenchmark-jdk25-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk25-results.txt
@@ -2,81 +2,81 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            684            688           5          0.0       68373.3       1.0X
-Compression 10000 times at level 2 without buffer pool            705            706           1          0.0       70477.2       1.0X
-Compression 10000 times at level 3 without buffer pool            808            811           4          0.0       80840.4       0.8X
-Compression 10000 times at level 1 with buffer pool               607            608           1          0.0       60689.7       1.1X
-Compression 10000 times at level 2 with buffer pool               642            644           3          0.0       64249.8       1.1X
-Compression 10000 times at level 3 with buffer pool               755            756           1          0.0       75526.9       0.9X
+Compression 10000 times at level 1 without buffer pool            683            690           6          0.0       68255.2       1.0X
+Compression 10000 times at level 2 without buffer pool            716            718           1          0.0       71635.2       1.0X
+Compression 10000 times at level 3 without buffer pool            841            842           1          0.0       84108.8       0.8X
+Compression 10000 times at level 1 with buffer pool               610            611           2          0.0       60970.3       1.1X
+Compression 10000 times at level 2 with buffer pool               639            640           2          0.0       63880.2       1.1X
+Compression 10000 times at level 3 with buffer pool               771            772           1          0.0       77149.2       0.9X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            641            642           1          0.0       64127.5       1.0X
-Decompression 10000 times from level 2 without buffer pool            638            638           0          0.0       63773.7       1.0X
-Decompression 10000 times from level 3 without buffer pool            639            642           4          0.0       63885.6       1.0X
-Decompression 10000 times from level 1 with buffer pool               573            573           0          0.0       57305.5       1.1X
-Decompression 10000 times from level 2 with buffer pool               572            572           1          0.0       57182.2       1.1X
-Decompression 10000 times from level 3 with buffer pool               573            573           0          0.0       57254.9       1.1X
+Decompression 10000 times from level 1 without buffer pool            651            652           1          0.0       65146.4       1.0X
+Decompression 10000 times from level 2 without buffer pool            651            652           1          0.0       65148.3       1.0X
+Decompression 10000 times from level 3 without buffer pool            650            651           1          0.0       65045.6       1.0X
+Decompression 10000 times from level 1 with buffer pool               577            578           0          0.0       57705.2       1.1X
+Decompression 10000 times from level 2 with buffer pool               578            578           0          0.0       57807.0       1.1X
+Decompression 10000 times from level 3 with buffer pool               578            578           0          0.0       57802.2       1.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 Parallel Compression at level 3:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parallel Compression with 0 workers                  65             66           1          0.0      508811.1       1.0X
-Parallel Compression with 1 workers                  53             55           2          0.0      417964.2       1.2X
-Parallel Compression with 2 workers                  44             45           1          0.0      340066.6       1.5X
-Parallel Compression with 4 workers                  39             41           1          0.0      303600.2       1.7X
-Parallel Compression with 8 workers                  40             42           1          0.0      314390.5       1.6X
-Parallel Compression with 16 workers                 44             46           1          0.0      341098.9       1.5X
+Parallel Compression with 0 workers                  76             77           1          0.0      591741.3       1.0X
+Parallel Compression with 1 workers                  55             57           2          0.0      429490.3       1.4X
+Parallel Compression with 2 workers                  45             46           1          0.0      353098.4       1.7X
+Parallel Compression with 4 workers                  41             43           1          0.0      321250.6       1.8X
+Parallel Compression with 8 workers                  42             44           1          0.0      330586.1       1.8X
+Parallel Compression with 16 workers                 45             47           1          0.0      353341.8       1.7X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 Parallel Compression at level 9:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parallel Compression with 0 workers                 233            234           1          0.0     1817871.6       1.0X
-Parallel Compression with 1 workers                 256            257           2          0.0     1998441.4       0.9X
-Parallel Compression with 2 workers                 139            143           4          0.0     1083158.0       1.7X
-Parallel Compression with 4 workers                 125            129           2          0.0      977189.6       1.9X
-Parallel Compression with 8 workers                 129            131           2          0.0     1004162.1       1.8X
-Parallel Compression with 16 workers                128            131           2          0.0      998834.2       1.8X
+Parallel Compression with 0 workers                 287            287           0          0.0     2238563.6       1.0X
+Parallel Compression with 1 workers                 248            249           2          0.0     1935532.2       1.2X
+Parallel Compression with 2 workers                 138            144          11          0.0     1078306.5       2.1X
+Parallel Compression with 4 workers                 128            134           6          0.0      999184.4       2.2X
+Parallel Compression with 8 workers                 131            136           4          0.0     1026792.9       2.2X
+Parallel Compression with 16 workers                130            134           2          0.0     1012679.1       2.2X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 Compression at level 1:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Compression by strategy -1                           53             54           1          0.0      412288.7       1.0X
-Compression by strategy 1                            53             54           1          0.0      412148.9       1.0X
-Compression by strategy 3                            87             88           1          0.0      677620.0       0.6X
-Compression by strategy 5                           232            234           4          0.0     1815805.6       0.2X
-Compression by strategy 7                           258            259           1          0.0     2017867.7       0.2X
-Compression by strategy 9                           259            260           1          0.0     2023238.5       0.2X
+Compression by strategy -1                           61             62           1          0.0      479263.0       1.0X
+Compression by strategy 1                            62             63           1          0.0      480939.6       1.0X
+Compression by strategy 3                            95             96           1          0.0      745416.7       0.6X
+Compression by strategy 5                           267            268           0          0.0     2087747.8       0.2X
+Compression by strategy 7                           256            257           0          0.0     2001652.5       0.2X
+Compression by strategy 9                           256            257           1          0.0     1999104.1       0.2X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 Compression at level 3:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Compression by strategy -1                           65             66           2          0.0      507586.3       1.0X
-Compression by strategy 1                            49             50           1          0.0      382064.8       1.3X
-Compression by strategy 3                            85             86           1          0.0      666476.1       0.8X
-Compression by strategy 5                           231            232           1          0.0     1803639.7       0.3X
-Compression by strategy 7                           271            272           1          0.0     2119308.7       0.2X
-Compression by strategy 9                           271            272           1          0.0     2121016.4       0.2X
+Compression by strategy -1                           76             77           0          0.0      596186.6       1.0X
+Compression by strategy 1                            60             61           1          0.0      466862.0       1.3X
+Compression by strategy 3                            96             99           5          0.0      746795.6       0.8X
+Compression by strategy 5                           283            286           7          0.0     2214165.7       0.3X
+Compression by strategy 7                           253            257           6          0.0     1977937.0       0.3X
+Compression by strategy 9                           254            256           2          0.0     1982177.3       0.3X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 Compression at level 9:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Compression by strategy -1                          233            234           1          0.0     1817542.6       1.0X
-Compression by strategy 1                            49             50           1          0.0      384895.0       4.7X
-Compression by strategy 3                            86             87           1          0.0      668682.2       2.7X
-Compression by strategy 5                           232            234           1          0.0     1816299.4       1.0X
-Compression by strategy 7                           273            274           2          0.0     2131039.6       0.9X
-Compression by strategy 9                           273            274           1          0.0     2133140.7       0.9X
+Compression by strategy -1                          288            291           2          0.0     2247367.6       1.0X
+Compression by strategy 1                            61             62           1          0.0      475286.1       4.7X
+Compression by strategy 3                            97             98           1          0.0      760263.8       3.0X
+Compression by strategy 5                           287            288           2          0.0     2239179.6       1.0X
+Compression by strategy 7                           254            254           1          0.0     1982545.0       1.1X
+Compression by strategy 9                           255            267          20          0.0     1994917.8       1.1X
 
 

--- a/core/benchmarks/ZStandardBenchmark-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-results.txt
@@ -2,81 +2,81 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            648            653           6          0.0       64756.8       1.0X
-Compression 10000 times at level 2 without buffer pool            688            688           1          0.0       68788.7       0.9X
-Compression 10000 times at level 3 without buffer pool            804            810          10          0.0       80354.7       0.8X
-Compression 10000 times at level 1 with buffer pool               580            582           2          0.0       58024.5       1.1X
-Compression 10000 times at level 2 with buffer pool               610            611           1          0.0       61046.7       1.1X
-Compression 10000 times at level 3 with buffer pool               734            736           2          0.0       73390.5       0.9X
+Compression 10000 times at level 1 without buffer pool            687            687           0          0.0       68705.4       1.0X
+Compression 10000 times at level 2 without buffer pool            714            724          16          0.0       71438.4       1.0X
+Compression 10000 times at level 3 without buffer pool            815            816           2          0.0       81459.3       0.8X
+Compression 10000 times at level 1 with buffer pool               638            639           1          0.0       63763.0       1.1X
+Compression 10000 times at level 2 with buffer pool               660            661           1          0.0       66018.3       1.0X
+Compression 10000 times at level 3 with buffer pool               759            760           1          0.0       75930.7       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            595            597           3          0.0       59453.4       1.0X
-Decompression 10000 times from level 2 without buffer pool            594            595           1          0.0       59429.2       1.0X
-Decompression 10000 times from level 3 without buffer pool            595            596           1          0.0       59501.2       1.0X
-Decompression 10000 times from level 1 with buffer pool               542            543           1          0.0       54194.0       1.1X
-Decompression 10000 times from level 2 with buffer pool               542            543           0          0.0       54209.3       1.1X
-Decompression 10000 times from level 3 with buffer pool               542            542           0          0.0       54210.6       1.1X
+Decompression 10000 times from level 1 without buffer pool            656            657           1          0.0       65553.3       1.0X
+Decompression 10000 times from level 2 without buffer pool            655            657           1          0.0       65535.6       1.0X
+Decompression 10000 times from level 3 without buffer pool            656            665          15          0.0       65639.4       1.0X
+Decompression 10000 times from level 1 with buffer pool               611            612           1          0.0       61096.7       1.1X
+Decompression 10000 times from level 2 with buffer pool               610            617           8          0.0       60990.4       1.1X
+Decompression 10000 times from level 3 with buffer pool               610            621          10          0.0       61018.9       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 Parallel Compression at level 3:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parallel Compression with 0 workers                  64             65           1          0.0      502291.5       1.0X
-Parallel Compression with 1 workers                  53             55           2          0.0      414525.0       1.2X
-Parallel Compression with 2 workers                  43             45           1          0.0      337092.9       1.5X
-Parallel Compression with 4 workers                  38             40           1          0.0      300240.6       1.7X
-Parallel Compression with 8 workers                  40             42           1          0.0      314416.1       1.6X
-Parallel Compression with 16 workers                 43             46           1          0.0      338892.4       1.5X
+Parallel Compression with 0 workers                  84             85           0          0.0      656955.3       1.0X
+Parallel Compression with 1 workers                  55             56           2          0.0      425987.8       1.5X
+Parallel Compression with 2 workers                  46             47           1          0.0      358017.7       1.8X
+Parallel Compression with 4 workers                  42             43           1          0.0      330348.1       2.0X
+Parallel Compression with 8 workers                  43             45           1          0.0      337350.6       1.9X
+Parallel Compression with 16 workers                 46             48           1          0.0      361237.1       1.8X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 Parallel Compression at level 9:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parallel Compression with 0 workers                 235            236           1          0.0     1833106.6       1.0X
-Parallel Compression with 1 workers                 248            249           1          0.0     1939503.4       0.9X
-Parallel Compression with 2 workers                 138            140           4          0.0     1074484.8       1.7X
-Parallel Compression with 4 workers                 125            129           3          0.0      977541.2       1.9X
-Parallel Compression with 8 workers                 129            132           2          0.0     1005593.0       1.8X
-Parallel Compression with 16 workers                127            132           3          0.0      992889.3       1.8X
+Parallel Compression with 0 workers                 320            320           1          0.0     2496114.8       1.0X
+Parallel Compression with 1 workers                 278            282           8          0.0     2170258.8       1.2X
+Parallel Compression with 2 workers                 151            155           4          0.0     1180443.3       2.1X
+Parallel Compression with 4 workers                 134            140           5          0.0     1044463.2       2.4X
+Parallel Compression with 8 workers                 136            141           5          0.0     1065996.9       2.3X
+Parallel Compression with 16 workers                136            139           3          0.0     1065641.4       2.3X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 Compression at level 1:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Compression by strategy -1                           52             54           1          0.0      407386.0       1.0X
-Compression by strategy 1                            53             54           1          0.0      410161.4       1.0X
-Compression by strategy 3                            89             90           1          0.0      692501.6       0.6X
-Compression by strategy 5                           235            236           1          0.0     1836451.2       0.2X
-Compression by strategy 7                           252            254           1          0.0     1971543.3       0.2X
-Compression by strategy 9                           253            254           1          0.0     1975866.4       0.2X
+Compression by strategy -1                           67             68           0          0.0      521490.6       1.0X
+Compression by strategy 1                            67             68           1          0.0      526160.8       1.0X
+Compression by strategy 3                           105            106           0          0.0      819844.8       0.6X
+Compression by strategy 5                           297            298           1          0.0     2323708.0       0.2X
+Compression by strategy 7                           281            282           0          0.0     2196106.6       0.2X
+Compression by strategy 9                           281            281           0          0.0     2194552.6       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 Compression at level 3:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Compression by strategy -1                           65             66           1          0.0      505123.2       1.0X
-Compression by strategy 1                            49             50           1          0.0      379054.8       1.3X
-Compression by strategy 3                            86             87           1          0.0      668557.9       0.8X
-Compression by strategy 5                           232            233           1          0.0     1812682.0       0.3X
-Compression by strategy 7                           270            272           1          0.0     2111320.4       0.2X
-Compression by strategy 9                           271            272           1          0.0     2114300.7       0.2X
+Compression by strategy -1                           83             85           1          0.0      649376.5       1.0X
+Compression by strategy 1                            66             67           1          0.0      518372.6       1.3X
+Compression by strategy 3                           107            108           1          0.0      834510.8       0.8X
+Compression by strategy 5                           317            320           8          0.0     2473396.7       0.3X
+Compression by strategy 7                           283            284           1          0.0     2207977.0       0.3X
+Compression by strategy 9                           283            284           1          0.0     2210026.6       0.3X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 Compression at level 9:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Compression by strategy -1                          235            236           1          0.0     1832077.7       1.0X
-Compression by strategy 1                            49             50           1          0.0      383163.5       4.8X
-Compression by strategy 3                            86             87           1          0.0      668834.4       2.7X
-Compression by strategy 5                           235            236           1          0.0     1832360.3       1.0X
-Compression by strategy 7                           273            275           1          0.0     2134035.8       0.9X
-Compression by strategy 9                           273            275           1          0.0     2132675.0       0.9X
+Compression by strategy -1                          320            320           0          0.0     2498988.8       1.0X
+Compression by strategy 1                            67             68           1          0.0      519770.5       4.8X
+Compression by strategy 3                           107            108           1          0.0      836189.9       3.0X
+Compression by strategy 5                           320            321           1          0.0     2499396.4       1.0X
+Compression by strategy 7                           284            285           1          0.0     2222027.8       1.1X
+Compression by strategy 9                           285            286           0          0.0     2226676.6       1.1X
 
 

--- a/core/benchmarks/ZStandardTPCDSDataBenchmark-jdk21-results.txt
+++ b/core/benchmarks/ZStandardTPCDSDataBenchmark-jdk21-results.txt
@@ -2,48 +2,48 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Compression:                                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-Compression 4 times at level 1 without buffer pool           2543           2543           0          0.0   635767583.8       1.0X
-Compression 4 times at level 2 without buffer pool           4190           4192           3          0.0  1047556973.5       0.6X
-Compression 4 times at level 3 without buffer pool           6292           6294           3          0.0  1572949305.0       0.4X
-Compression 4 times at level 1 with buffer pool              2544           2546           3          0.0   635932485.8       1.0X
-Compression 4 times at level 2 with buffer pool              4187           4191           6          0.0  1046688801.5       0.6X
-Compression 4 times at level 3 with buffer pool              6287           6287           0          0.0  1571742510.7       0.4X
+Compression 4 times at level 1 without buffer pool           2517           2518           2          0.0   629250174.5       1.0X
+Compression 4 times at level 2 without buffer pool           3905           3905           1          0.0   976131153.8       0.6X
+Compression 4 times at level 3 without buffer pool           5325           5376          71          0.0  1331330159.5       0.5X
+Compression 4 times at level 1 with buffer pool              2516           2517           0          0.0   629106044.3       1.0X
+Compression 4 times at level 2 with buffer pool              3918           3918           1          0.0   979446706.3       0.6X
+Compression 4 times at level 3 with buffer pool              5325           5327           2          0.0  1331359973.0       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Decompression:                                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Decompression 4 times from level 1 without buffer pool            865            877          11          0.0   216260003.0       1.0X
-Decompression 4 times from level 2 without buffer pool           1130           1133           5          0.0   282427765.3       0.8X
-Decompression 4 times from level 3 without buffer pool           1374           1375           1          0.0   343502982.8       0.6X
-Decompression 4 times from level 1 with buffer pool               846            857          10          0.0   211546056.8       1.0X
-Decompression 4 times from level 2 with buffer pool              1118           1128          13          0.0   279547492.5       0.8X
-Decompression 4 times from level 3 with buffer pool              1370           1371           1          0.0   342473746.0       0.6X
+Decompression 4 times from level 1 without buffer pool           1024           1049          35          0.0   255987056.0       1.0X
+Decompression 4 times from level 2 without buffer pool           1368           1372           6          0.0   342037553.8       0.7X
+Decompression 4 times from level 3 without buffer pool           1647           1650           4          0.0   411759793.3       0.6X
+Decompression 4 times from level 1 with buffer pool              1035           1037           2          0.0   258858886.3       1.0X
+Decompression 4 times from level 2 with buffer pool              1370           1374           7          0.0   342426423.0       0.7X
+Decompression 4 times from level 3 with buffer pool              1672           1673           2          0.0   417941590.0       0.6X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Parallel Compression at level 3:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parallel Compression with 0 workers                2112           2112           1          0.0   527923441.8       1.0X
-Parallel Compression with 1 workers                2095           2098           3          0.0   523843126.8       1.0X
-Parallel Compression with 2 workers                1062           1071          12          0.0   265474207.3       2.0X
-Parallel Compression with 4 workers                 742            747           4          0.0   185442064.2       2.8X
-Parallel Compression with 8 workers                 740            746           7          0.0   184978431.5       2.9X
-Parallel Compression with 16 workers                822            837          15          0.0   205399159.5       2.6X
+Parallel Compression with 0 workers                1781           1782           2          0.0   445337898.3       1.0X
+Parallel Compression with 1 workers                1521           1521           0          0.0   380137917.3       1.2X
+Parallel Compression with 2 workers                 799            804           5          0.0   199851421.5       2.2X
+Parallel Compression with 4 workers                 738            743           6          0.0   184412369.5       2.4X
+Parallel Compression with 8 workers                 756            772          14          0.0   189053821.8       2.4X
+Parallel Compression with 16 workers                790            812          19          0.0   197470363.0       2.3X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1015-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Parallel Compression at level 9:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parallel Compression with 0 workers                8187           8190           4          0.0  2046772669.8       1.0X
-Parallel Compression with 1 workers                6890           6890           0          0.0  1722525912.7       1.2X
-Parallel Compression with 2 workers                3547           3549           2          0.0   886846287.5       2.3X
-Parallel Compression with 4 workers                3020           3029          13          0.0   755079730.5       2.7X
-Parallel Compression with 8 workers                3352           3354           2          0.0   838062733.3       2.4X
-Parallel Compression with 16 workers               3627           3646          28          0.0   906687213.3       2.3X
+Parallel Compression with 0 workers                8304           8305           2          0.0  2075989562.2       1.0X
+Parallel Compression with 1 workers                6985           6999          20          0.0  1746241689.7       1.2X
+Parallel Compression with 2 workers                3550           3562          17          0.0   887528608.8       2.3X
+Parallel Compression with 4 workers                3219           3220           1          0.0   804794456.5       2.6X
+Parallel Compression with 8 workers                3531           3539          11          0.0   882763912.3       2.4X
+Parallel Compression with 16 workers               4135           4162          37          0.0  1033785804.5       2.0X
 
 

--- a/core/benchmarks/ZStandardTPCDSDataBenchmark-jdk25-results.txt
+++ b/core/benchmarks/ZStandardTPCDSDataBenchmark-jdk25-results.txt
@@ -2,48 +2,48 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 Compression:                                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-Compression 4 times at level 1 without buffer pool           2563           2564           2          0.0   640678929.3       1.0X
-Compression 4 times at level 2 without buffer pool           4175           4176           1          0.0  1043694084.8       0.6X
-Compression 4 times at level 3 without buffer pool           6278           6279           2          0.0  1569384290.5       0.4X
-Compression 4 times at level 1 with buffer pool              2563           2564           1          0.0   640717901.0       1.0X
-Compression 4 times at level 2 with buffer pool              4177           4178           2          0.0  1044180994.0       0.6X
-Compression 4 times at level 3 with buffer pool              6277           6280           4          0.0  1569310272.0       0.4X
+Compression 4 times at level 1 without buffer pool           2577           2577           0          0.0   644134142.3       1.0X
+Compression 4 times at level 2 without buffer pool           4194           4196           3          0.0  1048471607.5       0.6X
+Compression 4 times at level 3 without buffer pool           6231           6241          14          0.0  1557667092.3       0.4X
+Compression 4 times at level 1 with buffer pool              2579           2579           0          0.0   644779114.0       1.0X
+Compression 4 times at level 2 with buffer pool              4175           4176           2          0.0  1043641907.5       0.6X
+Compression 4 times at level 3 with buffer pool              6212           6225          18          0.0  1553055229.5       0.4X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 Decompression:                                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Decompression 4 times from level 1 without buffer pool            848            869          20          0.0   211906407.2       1.0X
-Decompression 4 times from level 2 without buffer pool           1095           1112          24          0.0   273679919.2       0.8X
-Decompression 4 times from level 3 without buffer pool           1344           1361          24          0.0   336096769.5       0.6X
-Decompression 4 times from level 1 with buffer pool               837            857          22          0.0   209332055.5       1.0X
-Decompression 4 times from level 2 with buffer pool              1117           1129          17          0.0   279233593.8       0.8X
-Decompression 4 times from level 3 with buffer pool              1351           1352           1          0.0   337755217.5       0.6X
+Decompression 4 times from level 1 without buffer pool            859            865          11          0.0   214700464.3       1.0X
+Decompression 4 times from level 2 without buffer pool           1143           1143           0          0.0   285665894.8       0.8X
+Decompression 4 times from level 3 without buffer pool           1373           1374           2          0.0   343196795.3       0.6X
+Decompression 4 times from level 1 with buffer pool               860            879          22          0.0   214939094.8       1.0X
+Decompression 4 times from level 2 with buffer pool              1152           1163          16          0.0   288071891.8       0.7X
+Decompression 4 times from level 3 with buffer pool              1355           1366          16          0.0   338782682.3       0.6X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 Parallel Compression at level 3:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parallel Compression with 0 workers                2081           2086           7          0.0   520246872.0       1.0X
-Parallel Compression with 1 workers                2106           2107           2          0.0   526479842.3       1.0X
-Parallel Compression with 2 workers                1090           1092           3          0.0   272445371.0       1.9X
-Parallel Compression with 4 workers                 759            771          19          0.0   189775705.3       2.7X
-Parallel Compression with 8 workers                 776            784           8          0.0   193907564.8       2.7X
-Parallel Compression with 16 workers                888            896           7          0.0   222053162.3       2.3X
+Parallel Compression with 0 workers                2096           2096           1          0.0   523895360.0       1.0X
+Parallel Compression with 1 workers                1890           1891           2          0.0   472430425.7       1.1X
+Parallel Compression with 2 workers                 976            981           8          0.0   243959449.5       2.1X
+Parallel Compression with 4 workers                 709            714           5          0.0   177327324.3       3.0X
+Parallel Compression with 8 workers                 784            802          26          0.0   196036047.0       2.7X
+Parallel Compression with 16 workers                798            826          28          0.0   199589171.3       2.6X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1015-azure
 AMD EPYC 7763 64-Core Processor
 Parallel Compression at level 9:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parallel Compression with 0 workers                8321           8325           6          0.0  2080279947.5       1.0X
-Parallel Compression with 1 workers                6909           6911           3          0.0  1727358566.5       1.2X
-Parallel Compression with 2 workers                3646           3653          10          0.0   911618765.8       2.3X
-Parallel Compression with 4 workers                3108           3115           9          0.0   777076163.8       2.7X
-Parallel Compression with 8 workers                3462           3469           9          0.0   865546341.3       2.4X
-Parallel Compression with 16 workers               3705           3723          26          0.0   926138190.7       2.2X
+Parallel Compression with 0 workers                8053           8078          35          0.0  2013222657.8       1.0X
+Parallel Compression with 1 workers                6908           6912           7          0.0  1726939967.8       1.2X
+Parallel Compression with 2 workers                3534           3553          27          0.0   883480920.5       2.3X
+Parallel Compression with 4 workers                3090           3109          27          0.0   772521046.0       2.6X
+Parallel Compression with 8 workers                3519           3541          32          0.0   879746664.0       2.3X
+Parallel Compression with 16 workers               3839           3847          13          0.0   959649252.0       2.1X
 
 

--- a/core/benchmarks/ZStandardTPCDSDataBenchmark-results.txt
+++ b/core/benchmarks/ZStandardTPCDSDataBenchmark-results.txt
@@ -2,48 +2,48 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 Compression:                                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-Compression 4 times at level 1 without buffer pool           2570           2571           2          0.0   642375576.3       1.0X
-Compression 4 times at level 2 without buffer pool           4278           4283           8          0.0  1069398736.0       0.6X
-Compression 4 times at level 3 without buffer pool           6440           6449          12          0.0  1610096766.3       0.4X
-Compression 4 times at level 1 with buffer pool              2576           2577           1          0.0   643879912.8       1.0X
-Compression 4 times at level 2 with buffer pool              4258           4270          17          0.0  1064521217.3       0.6X
-Compression 4 times at level 3 with buffer pool              6456           6462           9          0.0  1613996641.0       0.4X
+Compression 4 times at level 1 without buffer pool           2704           2704           0          0.0   675940288.5       1.0X
+Compression 4 times at level 2 without buffer pool           4277           4284          10          0.0  1069128803.5       0.6X
+Compression 4 times at level 3 without buffer pool           6107           6109           3          0.0  1526701108.3       0.4X
+Compression 4 times at level 1 with buffer pool              2701           2701           1          0.0   675173219.8       1.0X
+Compression 4 times at level 2 with buffer pool              4270           4277           9          0.0  1067480704.2       0.6X
+Compression 4 times at level 3 with buffer pool              6126           6135          12          0.0  1531530628.8       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 Decompression:                                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Decompression 4 times from level 1 without buffer pool            890            895           7          0.0   222494107.0       1.0X
-Decompression 4 times from level 2 without buffer pool           1165           1165           0          0.0   291254646.8       0.8X
-Decompression 4 times from level 3 without buffer pool           1393           1395           2          0.0   348353764.0       0.6X
-Decompression 4 times from level 1 with buffer pool               891            894           3          0.0   222658148.0       1.0X
-Decompression 4 times from level 2 with buffer pool              1164           1168           6          0.0   291077496.5       0.8X
-Decompression 4 times from level 3 with buffer pool              1397           1400           5          0.0   349212480.5       0.6X
+Decompression 4 times from level 1 without buffer pool            885            887           1          0.0   221368491.3       1.0X
+Decompression 4 times from level 2 without buffer pool           1159           1175          23          0.0   289813587.2       0.8X
+Decompression 4 times from level 3 without buffer pool           1394           1394           0          0.0   348496892.0       0.6X
+Decompression 4 times from level 1 with buffer pool               882            884           2          0.0   220595464.5       1.0X
+Decompression 4 times from level 2 with buffer pool              1159           1163           5          0.0   289819551.3       0.8X
+Decompression 4 times from level 3 with buffer pool              1400           1400           1          0.0   349885028.5       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 Parallel Compression at level 3:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parallel Compression with 0 workers                2163           2172          12          0.0   540856011.3       1.0X
-Parallel Compression with 1 workers                2143           2145           2          0.0   535794767.0       1.0X
-Parallel Compression with 2 workers                1108           1114           9          0.0   276926063.5       2.0X
-Parallel Compression with 4 workers                 766            768           2          0.0   191392818.5       2.8X
-Parallel Compression with 8 workers                 782            809          26          0.0   195506227.0       2.8X
-Parallel Compression with 16 workers                932            933           1          0.0   232965931.3       2.3X
+Parallel Compression with 0 workers                2053           2055           2          0.0   513342804.2       1.0X
+Parallel Compression with 1 workers                1756           1758           3          0.0   439080919.3       1.2X
+Parallel Compression with 2 workers                 905            907           3          0.0   226149462.0       2.3X
+Parallel Compression with 4 workers                 697            701           5          0.0   174265164.0       2.9X
+Parallel Compression with 8 workers                 720            722           2          0.0   180057395.8       2.9X
+Parallel Compression with 16 workers                866            874          10          0.0   216606903.5       2.4X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1015-azure
+AMD EPYC 9V74 80-Core Processor
 Parallel Compression at level 9:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parallel Compression with 0 workers                8582           8586           6          0.0  2145496765.5       1.0X
-Parallel Compression with 1 workers                7024           7031          11          0.0  1755924567.5       1.2X
-Parallel Compression with 2 workers                3751           3755           6          0.0   937713509.0       2.3X
-Parallel Compression with 4 workers                3150           3163          19          0.0   787409382.0       2.7X
-Parallel Compression with 8 workers                3521           3541          28          0.0   880238157.8       2.4X
-Parallel Compression with 16 workers               3762           3771          12          0.0   940589370.5       2.3X
+Parallel Compression with 0 workers                8975           9004          41          0.0  2243754236.8       1.0X
+Parallel Compression with 1 workers                7469           7481          17          0.0  1867170605.5       1.2X
+Parallel Compression with 2 workers                3921           3930          13          0.0   980264699.0       2.3X
+Parallel Compression with 4 workers                3137           3180          62          0.0   784135346.5       2.9X
+Parallel Compression with 8 workers                3559           3594          49          0.0   889846584.8       2.5X
+Parallel Compression with 16 workers               4172           4174           3          0.0  1043076901.5       2.2X
 
 

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -294,4 +294,4 @@ xz/1.12//xz-1.12.jar
 zjsonpatch/7.7.0//zjsonpatch-7.7.0.jar
 zookeeper-jute/3.9.5//zookeeper-jute-3.9.5.jar
 zookeeper/3.9.5//zookeeper-3.9.5.jar
-zstd-jni/1.5.7-8//zstd-jni-1.5.7-8.jar
+zstd-jni/1.5.7-9//zstd-jni-1.5.7-9.jar

--- a/pom.xml
+++ b/pom.xml
@@ -882,7 +882,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.7-8</version>
+        <version>1.5.7-9</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `zstd-jni` to `1.5.7-9` for Apache Spark 5.

### Why are the changes needed?

To bring the latest bug fixes and improvements from upstream `zstd-jni` v1.5.7-9.
- https://github.com/luben/zstd-jni/releases/tag/v1.5.7-9 (2026-05-20)
  - [Fix some possible int overflows](https://github.com/luben/zstd-jni/commit/6660ec34c6188dfa390872d865f4c748d1b4a725)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)