### PR TITLE
[SPARK-55347][SQL] Pass Generated Column as Expression to DSV2

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Column.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Column.java
@@ -59,7 +59,7 @@ public interface Column {
         nullable,
         comment,
         /* defaultValue = */ null,
-        /* generationExpression = */ null,
+        /* columnGenerationExpression = */ null,
         /* identityColumnSpec = */ null,
         metadataInJSON,
         /* id = */ null);
@@ -78,18 +78,52 @@ public interface Column {
         nullable,
         comment,
         defaultValue,
-        /* generationExpression = */ null,
+        /* columnGenerationExpression = */ null,
         /* identityColumnSpec = */ null,
         metadataInJSON,
         /* id = */ null);
   }
 
+  /**
+   * Creates a column with a generation expression in SQL string form.
+   *
+   * @since 4.1.0
+   * @deprecated Use
+   *   {@link #create(String, DataType, boolean, String, GenerationExpression, String)} instead.
+   */
+  @Deprecated
   static Column create(
       String name,
       DataType dataType,
       boolean nullable,
       String comment,
       String generationExpression,
+      String metadataInJSON) {
+    GenerationExpression genExpr = generationExpression != null
+        ? new GenerationExpression(generationExpression) : null;
+    return new ColumnImpl(
+        name,
+        dataType,
+        nullable,
+        comment,
+        /* defaultValue = */ null,
+        genExpr,
+        /* identityColumnSpec = */ null,
+        metadataInJSON,
+        /* id = */ null);
+  }
+
+  /**
+   * Creates a column with a generation expression object.
+   *
+   * @since 4.1.0
+   */
+  static Column create(
+      String name,
+      DataType dataType,
+      boolean nullable,
+      String comment,
+      GenerationExpression generationExpression,
       String metadataInJSON) {
     return new ColumnImpl(
         name,
@@ -116,7 +150,7 @@ public interface Column {
         nullable,
         comment,
         /* defaultValue = */ null,
-        /* generationExpression = */ null,
+        /* columnGenerationExpression = */ null,
         identityColumnSpec,
         metadataInJSON,
         /* id = */ null);
@@ -156,7 +190,25 @@ public interface Column {
    * expression compatibility and reject writes as necessary.
    */
   @Nullable
-  String generationExpression();
+  default String generationExpression() {
+    return columnGenerationExpression() != null ? columnGenerationExpression().getSql() : null;
+  }
+
+  /**
+   * Returns the generation expression of this table column as an {@link GenerationExpression}.
+   * <p>
+   * The default implementation wraps {@link #generationExpression()} for backward compatibility
+   * with custom {@link Column} implementations that only override the string form. New code
+   * should override this method (or use {@link Column#create} with a {@link GenerationExpression})
+   * to also supply a connector {@link org.apache.spark.sql.connector.expressions.Expression}.
+   *
+   * @since 4.1.0
+   */
+  @Nullable
+  default GenerationExpression columnGenerationExpression() {
+    String sql = generationExpression();
+    return sql != null ? new GenerationExpression(sql) : null;
+  }
 
   /**
    * Returns the identity column specification of this table column. Null means no identity column.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/GenerationExpression.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/GenerationExpression.java
@@ -21,33 +21,35 @@ import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.Expression;
 
 /**
- * A class that represents default values.
+ * A class that represents generation expressions for computed/generated columns.
  * <p>
- * Connectors can define default values using either a SQL string (Spark SQL dialect) or an
- * {@link Expression expression} if the default value can be expressed as a supported connector
- * expression. If both the SQL string and the expression are provided, Spark first attempts to
- * convert the given expression to its internal representation. If the expression cannot be
- * converted, and a SQL string is provided, Spark will fall back to parsing the SQL string.
+ * Connectors can define generation expressions using either a SQL string (Spark SQL dialect) or an
+ * {@link Expression expression} if the generation expression can be expressed as a supported
+ * connector expression. If both the SQL string and the expression are provided, Spark first
+ * attempts to convert the given expression to its internal representation. If the expression
+ * cannot be converted, and a SQL string is provided, Spark will fall back to parsing the SQL
+ * string.
  *
  * @since 4.1.0
  */
 @Evolving
-public class DefaultValue extends SqlOrExpression {
+public class GenerationExpression extends SqlOrExpression {
 
-  public DefaultValue(String sql) {
+  public GenerationExpression(String sql) {
     this(sql, null /* no expression */);
   }
 
-  public DefaultValue(Expression expr) {
+  public GenerationExpression(Expression expr) {
     this(null /* no sql */, expr);
   }
 
-  public DefaultValue(String sql, Expression expr) {
+  public GenerationExpression(String sql, Expression expr) {
     super(sql, expr);
   }
 
   @Override
   public String toString() {
-    return String.format("DefaultValue{sql=%s, expression=%s}", getSql(), getExpression());
+    return String.format(
+        "GenerationExpression{sql=%s, expression=%s}", getSql(), getExpression());
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SqlOrExpression.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SqlOrExpression.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog;
+
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+import org.apache.spark.SparkIllegalArgumentException;
+import org.apache.spark.sql.connector.expressions.Expression;
+
+/**
+ * Base type for connector catalog values that can be represented as Spark SQL and/or a connector
+ * {@link Expression}.
+ */
+abstract class SqlOrExpression {
+  private final String sql;
+  private final Expression expr;
+
+  SqlOrExpression(String sql, Expression expr) {
+    if (sql == null && expr == null) {
+      throw new SparkIllegalArgumentException(
+          "INTERNAL_ERROR",
+          Map.of("message", "SQL and expression can't be both null"));
+    }
+    this.sql = sql;
+    this.expr = expr;
+  }
+
+  /**
+   * Returns the SQL representation (Spark SQL dialect), if provided.
+   */
+  @Nullable
+  public final String getSql() {
+    return sql;
+  }
+
+  /**
+   * Returns the connector expression, if provided.
+   */
+  @Nullable
+  public final Expression getExpression() {
+    return expr;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) return true;
+    if (other == null || getClass() != other.getClass()) return false;
+    SqlOrExpression that = (SqlOrExpression) other;
+    return Objects.equals(sql, that.sql) && Objects.equals(expr, that.expr);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sql, expr);
+  }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Extract.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Extract.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.connector.expressions;
 
+import java.util.Objects;
+
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.internal.connector.ExpressionWithToString;
 
@@ -58,4 +60,17 @@ public class Extract extends ExpressionWithToString {
 
   @Override
   public Expression[] children() { return new Expression[]{ source() }; }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) return true;
+    if (other == null || getClass() != other.getClass()) return false;
+    Extract that = (Extract) other;
+    return Objects.equals(field, that.field) && Objects.equals(source, that.source);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(field, source);
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ColumnDefinition.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdenti
 import org.apache.spark.sql.connector.expressions.LiteralValue
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.connector.ColumnImpl
-import org.apache.spark.sql.types.{DataType, Metadata, MetadataBuilder, StructField}
+import org.apache.spark.sql.types.{DataType, Metadata, MetadataBuilder, StructField, StructType}
 
 /**
  * User-specified column definition for CREATE/REPLACE TABLE commands. This is an expression so that
@@ -60,14 +60,17 @@ case class ColumnDefinition(
     copy(defaultValue = newChildren.headOption.map(_.asInstanceOf[DefaultValueExpression]))
   }
 
-  def toV2Column(statement: String): V2Column = {
+  def toV2Column(statement: String, tableSchema: StructType): V2Column = {
+    val columnGenerationExpression = generationExpression.map { sql =>
+      GeneratedColumn.toGenerationExpression(sql, name, dataType, tableSchema, statement)
+    }.orNull
     ColumnImpl(
       name,
       dataType,
       nullable,
       comment.orNull,
       defaultValue.map(_.toV2(statement, name)).orNull,
-      generationExpression.orNull,
+      columnGenerationExpression,
       identityColumnSpec.orNull,
       if (metadata == Metadata.empty) null else metadata.json)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/GeneratedColumn.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/GeneratedColumn.scala
@@ -22,10 +22,10 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.Analyzer
 import org.apache.spark.sql.catalyst.expressions.{Alias, Cast, Expression}
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
-import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, Project}
+import org.apache.spark.sql.catalyst.plans.logical.{ColumnDefinition, LocalRelation, Project}
 import org.apache.spark.sql.catalyst.trees.TreePattern.PLAN_EXPRESSION
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns.BuiltInFunctionCatalog
-import org.apache.spark.sql.connector.catalog.{DefaultCatalogManager, Identifier, TableCatalog, TableCatalogCapability}
+import org.apache.spark.sql.connector.catalog.{Column => V2Column, DefaultCatalogManager, GenerationExpression, Identifier, TableCatalog, TableCatalogCapability}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
@@ -71,6 +71,32 @@ object GeneratedColumn {
   }
 
   /**
+   * Parse and analyze `expressionStr`, verify it is a valid generation expression, and convert it
+   * to a connector [[GenerationExpression]] with an optional DSV2 [[Expression]] when the analyzed
+   * Catalyst expression can be translated via [[V2ExpressionBuilder]].
+   *
+   * Verification rules:
+   * - The expression cannot reference itself
+   * - The expression cannot reference other generated columns
+   * - No user-defined expressions
+   * - The expression must be deterministic
+   * - The expression data type can be safely up-cast to the destination column data type
+   * - No subquery expressions
+   *
+   * Throws an [[AnalysisException]] if the expression cannot be converted or is invalid.
+   */
+  def toGenerationExpression(
+      expressionStr: String,
+      fieldName: String,
+      dataType: DataType,
+      schema: StructType,
+      statementType: String): GenerationExpression = {
+    val analyzed = analyzeExpression(expressionStr, fieldName, dataType, schema, statementType)
+    val connectorExpr = new V2ExpressionBuilder(analyzed).build().orNull
+    new GenerationExpression(expressionStr, connectorExpr)
+  }
+
+  /**
    * Parse and analyze `expressionStr` and perform verification. This means:
    * - The expression cannot reference itself
    * - The expression cannot reference other generated columns
@@ -82,12 +108,12 @@ object GeneratedColumn {
    * Throws an [[AnalysisException]] if the expression cannot be converted or is an invalid
    * generation expression according to the above rules.
    */
-  private def analyzeAndVerifyExpression(
+  private def analyzeExpression(
       expressionStr: String,
       fieldName: String,
       dataType: DataType,
       schema: StructType,
-      statementType: String): Unit = {
+      statementType: String): Expression = {
     def unsupportedExpressionError(reason: String): AnalysisException = {
       new AnalysisException(
         errorClass = "UNSUPPORTED_EXPRESSION_GENERATED_COLUMN",
@@ -167,37 +193,27 @@ object GeneratedColumn {
       throw unsupportedExpressionError(
         "generation expression cannot contain non utf8 binary collated string type")
     }
+    analyzed
   }
 
   /**
-   * For any generated columns in `schema`, parse, analyze and verify the generation expression.
+   * If `schema` contains generated columns, verify the catalog supports them, then build the V2
+   * columns from `columns`. Per-column generation expressions are parsed, analyzed, and verified
+   * via [[toGenerationExpression]] inside [[ColumnDefinition.toV2Column]].
    */
-  private def verifyGeneratedColumns(schema: StructType, statementType: String): Unit = {
-    schema.foreach { field =>
-      getGenerationExpression(field).foreach { expressionStr =>
-        analyzeAndVerifyExpression(expressionStr, field.name, field.dataType, schema, statementType)
-      }
-    }
-  }
-
-  /**
-   * If `schema` contains any generated columns:
-   * 1) Check whether the table catalog supports generated columns. Otherwise throw an error.
-   * 2) Parse, analyze and verify the generation expressions for any generated columns.
-   */
-  def validateGeneratedColumns(
+  def validateAndBuildV2Columns(
+      columns: Seq[ColumnDefinition],
       schema: StructType,
       catalog: TableCatalog,
       ident: Identifier,
-      statementType: String): Unit = {
-    if (hasGeneratedColumns(schema)) {
-      if (!catalog.capabilities().contains(
-        TableCatalogCapability.SUPPORTS_CREATE_TABLE_WITH_GENERATED_COLUMNS)) {
-        throw QueryCompilationErrors.unsupportedTableOperationError(
-          catalog, ident, "generated columns")
-      }
-      GeneratedColumn.verifyGeneratedColumns(schema, statementType)
+      statementType: String): Array[V2Column] = {
+    if (hasGeneratedColumns(schema) &&
+        !catalog.capabilities().contains(
+          TableCatalogCapability.SUPPORTS_CREATE_TABLE_WITH_GENERATED_COLUMNS)) {
+      throw QueryCompilationErrors.unsupportedTableOperationError(
+        catalog, ident, "generated columns")
     }
+    columns.map(_.toV2Column(statementType, schema)).toArray
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -704,10 +704,10 @@ private[sql] object CatalogV2Util {
    * createTable and related APIs.
    */
   def structTypeToV2Columns(schema: StructType): Array[Column] = {
-    schema.fields.map(structFieldToV2Column)
+    schema.fields.map(f => structFieldToV2Column(f, schema))
   }
 
-  private def structFieldToV2Column(f: StructField): Column = {
+  private def structFieldToV2Column(f: StructField, schema: StructType): Column = {
     def metadataAsJson(metadata: Metadata): String = {
       if (metadata == Metadata.empty) {
         null
@@ -748,8 +748,14 @@ private[sql] object CatalogV2Util {
     } else if (isGeneratedColumn) {
       val cleanedMetadata = metadataWithKeysRemoved(
         Seq("comment", GeneratedColumn.GENERATION_EXPRESSION_METADATA_KEY))
+      val generationExpression = GeneratedColumn.toGenerationExpression(
+        GeneratedColumn.getGenerationExpression(f).get,
+        f.name,
+        f.dataType,
+        schema,
+        statementType = "Column analysis")
       Column.create(f.name, f.dataType, f.nullable, f.getComment().orNull,
-        GeneratedColumn.getGenerationExpression(f).get, metadataAsJson(cleanedMetadata))
+        generationExpression, metadataAsJson(cleanedMetadata))
     } else if (isIdentityColumn) {
       val cleanedMetadata = metadataWithKeysRemoved(
         Seq("comment",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/ColumnImpl.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/ColumnImpl.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.internal.connector
 
 import java.util.Objects
 
-import org.apache.spark.sql.connector.catalog.{Column, ColumnDefaultValue, IdentityColumnSpec}
+import org.apache.spark.sql.connector.catalog.{Column, ColumnDefaultValue, GenerationExpression, IdentityColumnSpec}
 import org.apache.spark.sql.types.DataType
 
 // The standard concrete implementation of data source V2 column.
@@ -29,7 +29,7 @@ case class ColumnImpl(
     nullable: Boolean,
     comment: String,
     defaultValue: ColumnDefaultValue,
-    generationExpression: String,
+    override val columnGenerationExpression: GenerationExpression,
     identityColumnSpec: IdentityColumnSpec,
     metadataInJSON: String,
     override val id: String = null) extends Column {
@@ -47,7 +47,7 @@ case class ColumnImpl(
         nullable == that.nullable &&
         comment == that.comment &&
         defaultValue == that.defaultValue &&
-        generationExpression == that.generationExpression &&
+        columnGenerationExpression == that.columnGenerationExpression &&
         identityColumnSpec == that.identityColumnSpec &&
         metadataInJSON == that.metadataInJSON
     case _ => false
@@ -60,7 +60,7 @@ case class ColumnImpl(
       Boolean.box(nullable),
       comment,
       defaultValue,
-      generationExpression,
+      columnGenerationExpression,
       identityColumnSpec,
       metadataInJSON)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/V2TableUtilSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/V2TableUtilSuite.scala
@@ -706,7 +706,7 @@ class V2TableUtilSuite extends SparkFunSuite {
       nullable = nullable,
       comment = null,
       defaultValue = null,
-      generationExpression = null,
+      columnGenerationExpression = null,
       identityColumnSpec = null,
       metadataInJSON = null,
       id = id)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -241,14 +241,13 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       ResolveTableConstraints.validateCatalogForTableConstraint(
         tableSpec.constraints, tableCatalog, ident)
       val statementType = "CREATE TABLE"
-      GeneratedColumn.validateGeneratedColumns(
-        c.tableSchema, tableCatalog, ident, statementType)
       IdentityColumn.validateIdentityColumn(c.tableSchema, tableCatalog, ident)
 
       CreateTableExec(
-        catalog.asTableCatalog,
+        tableCatalog,
         ident,
-        columns.map(_.toV2Column(statementType)).toArray,
+        GeneratedColumn.validateAndBuildV2Columns(
+          columns, c.tableSchema, tableCatalog, ident, statementType),
         partitioning,
         qualifyLocInTableSpec(tableSpec),
         ifNotExists) :: Nil
@@ -299,11 +298,10 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       ResolveTableConstraints.validateCatalogForTableConstraint(
         tableSpec.constraints, tableCatalog, ident)
       val statementType = "REPLACE TABLE"
-      GeneratedColumn.validateGeneratedColumns(
-        c.tableSchema, tableCatalog, ident, statementType)
       IdentityColumn.validateIdentityColumn(c.tableSchema, tableCatalog, ident)
 
-      val v2Columns = columns.map(_.toV2Column(statementType)).toArray
+      val v2Columns = GeneratedColumn.validateAndBuildV2Columns(
+        columns, c.tableSchema, tableCatalog, ident, statementType)
       catalog match {
         case staging: StagingTableCatalog =>
           AtomicReplaceTableExec(staging, ident, v2Columns, parts,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
@@ -28,13 +28,13 @@ import org.apache.spark.sql.{AnalysisException, DataFrame, Row, SaveMode, SparkS
 import org.apache.spark.sql.QueryTest.withQueryExecutionsCaptured
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, CreateTableAsSelect, LogicalPlan, ReplaceTableAsSelect}
-import org.apache.spark.sql.connector.catalog.{CachingInMemoryTableCatalog, Column, ColumnDefaultValue, ComposedColumnIdTableCatalog, DefaultValue, Identifier, InMemoryTableCatalog, MixedColumnIdTableCatalog, NullColumnIdInMemoryTableCatalog, NullTableIdInMemoryTableCatalog, SupportsV1OverwriteWithSaveAsTable, TableCatalog, TableInfo, TypeChangeResetsColIdTableCatalog}
+import org.apache.spark.sql.connector.catalog.{CachingInMemoryTableCatalog, Column, ColumnDefaultValue, ComposedColumnIdTableCatalog, DefaultValue, GenerationExpression, Identifier, InMemoryTableCatalog, MixedColumnIdTableCatalog, NullColumnIdInMemoryTableCatalog, NullTableIdInMemoryTableCatalog, SupportsV1OverwriteWithSaveAsTable, TableCatalog, TableInfo, TypeChangeResetsColIdTableCatalog}
 import org.apache.spark.sql.connector.catalog.BasicInMemoryTableCatalog
 import org.apache.spark.sql.connector.catalog.TableChange.{AddColumn, UpdateColumnDefaultValue}
 import org.apache.spark.sql.connector.catalog.TableChange
 import org.apache.spark.sql.connector.catalog.TableWritePrivilege
 import org.apache.spark.sql.connector.catalog.TruncatableTable
-import org.apache.spark.sql.connector.expressions.{ApplyTransform, GeneralScalarExpression, LiteralValue, Transform}
+import org.apache.spark.sql.connector.expressions.{ApplyTransform, Extract, FieldReference, GeneralScalarExpression, LiteralValue, Transform}
 import org.apache.spark.sql.connector.expressions.filter.{AlwaysFalse, AlwaysTrue}
 import org.apache.spark.sql.execution.{QueryExecution, SparkPlan}
 import org.apache.spark.sql.execution.ExplainUtils.stripAQEPlan
@@ -593,6 +593,87 @@ class DataSourceV2DataFrameSuite
       checkAnswer(
         sql(s"SELECT * FROM $tableName"),
         Seq(Row(1, 100, "unknown", false)))
+    }
+  }
+
+  test("create/replace table with generated column DSV2 expressions") {
+    val tableName = "testcat.ns1.ns2.tbl"
+    withTable(tableName) {
+      val createExec = executeAndKeepPhysicalPlan[CreateTableExec] {
+        sql(
+          s"""
+             |CREATE TABLE $tableName (
+             |  eventDate DATE,
+             |  eventYear INT GENERATED ALWAYS AS (year(eventDate))
+             |) USING foo
+             |""".stripMargin)
+      }
+
+      val eventYear = createExec.columns.find(_.name() == "eventYear").get
+      assert(compareGenerationExpression(
+        eventYear.columnGenerationExpression(),
+        new GenerationExpression(
+          "year(eventDate)",
+          new Extract("YEAR", FieldReference("eventDate")))))
+
+      val replaceExec = executeAndKeepPhysicalPlan[ReplaceTableExec] {
+        sql(
+          s"""
+             |REPLACE TABLE $tableName (
+             |  eventDate DATE,
+             |  eventMonth INT GENERATED ALWAYS AS (month(eventDate))
+             |) USING foo
+             |""".stripMargin)
+      }
+
+      val eventMonth = replaceExec.columns.find(_.name() == "eventMonth").get
+      assert(compareGenerationExpression(
+        eventMonth.columnGenerationExpression(),
+        new GenerationExpression(
+          "month(eventDate)",
+          new Extract("MONTH", FieldReference("eventDate")))))
+    }
+  }
+
+  test("create table with foldable generated column DSV2 expression") {
+    val tableName = "testcat.ns1.ns2.tbl"
+    withTable(tableName) {
+      val createExec = executeAndKeepPhysicalPlan[CreateTableExec] {
+        sql(
+          s"""
+             |CREATE TABLE $tableName (
+             |  id INT,
+             |  genValue INT GENERATED ALWAYS AS ((100 + 23))
+             |) USING foo
+             |""".stripMargin)
+      }
+
+      val genValue = createExec.columns.find(_.name() == "genValue").get
+      assert(compareGenerationExpression(
+        genValue.columnGenerationExpression(),
+        new GenerationExpression(
+          "(100 + 23)",
+          LiteralValue(123, IntegerType))))
+    }
+  }
+
+  test("create table with generated column without translatable DSV2 expression") {
+    val tableName = "testcat.ns1.ns2.tbl"
+    withTable(tableName) {
+      val createExec = executeAndKeepPhysicalPlan[CreateTableExec] {
+        sql(
+          s"""
+             |CREATE TABLE $tableName (
+             |  id INT,
+             |  cat STRING GENERATED ALWAYS AS (current_catalog())
+             |) USING foo
+             |""".stripMargin)
+      }
+
+      val cat = createExec.columns.find(_.name() == "cat").get
+      assert(compareGenerationExpression(
+        cat.columnGenerationExpression(),
+        new GenerationExpression("current_catalog()", null /* No V2 Expression */)))
     }
   }
 
@@ -1216,6 +1297,16 @@ class DataSourceV2DataFrameSuite
       case _ => left.getSql == right.getSql &&
         left.getExpression == right.getExpression &&
         (!compareValue || left.getValue == right.getValue)
+    }
+  }
+
+  private def compareGenerationExpression(
+      left: GenerationExpression,
+      right: GenerationExpression): Boolean = {
+    (left, right) match {
+      case (null, null) => true
+      case (null, _) | (_, null) => false
+      case _ => left.getSql == right.getSql && left.getExpression == right.getExpression
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Extend the DSV2 `Column` API so that a generated column carries both its SQL text and (when translatable) a Spark-analyzed connector `Expression`, mirroring how `DefaultValue` already works.

- Add `GenerationExpression` and a shared `SqlOrExpression` base class under `org.apache.spark.sql.connector.catalog`. `DefaultValue` is refactored to extend `SqlOrExpression` for symmetry.
- `Column.columnGenerationExpression()` now returns a `GenerationExpression` with both the original SQL and an optional V2 `Expression`. A `Column.create(...)` overload accepts it.
- Wire generation expression analysis into the create/replace table path. `GeneratedColumn.toGenerationExpression(sql, name, dataType, schema, statementType)` parses, analyzes, and verifies the expression once, then translates the analyzed Catalyst expression to V2 form via `V2ExpressionBuilder` (returning `null` for the V2 form when the expression is not translatable).
- Replace `validateGeneratedColumns` with a single helper `GeneratedColumn.validateAndBuildV2Columns(columns, schema, catalog, ident, statementType)` that performs the catalog capability check and builds the V2 columns in one place; `DataSourceV2Strategy` calls it for both `CreateTable` and `ReplaceTable`.
- `CatalogV2Util.structFieldToV2Column` now also analyzes generated columns when materializing V2 columns from a `StructType`, so the default `Table.columns()` implementation surfaces the Expression form on the read path too.
- Add `equals`/`hashCode` to `Extract` for value-based comparison of V2 expressions in tests.

### Why are the changes needed?

Today, DSV2 connectors only see the raw SQL string for a generated column and have to parse and translate it themselves. Many connectors prefer the Spark-analyzed `Expression` form so they can apply partitioning, statistics, or rewrite logic uniformly with how default values are already handled. Carrying the analyzed expression in the `Column` API lets connectors consume it directly, and lets Spark reuse the analysis it already performs at create-table time instead of discarding the result.

### Does this PR introduce _any_ user-facing change?

Yes. `Column.columnGenerationExpression()` now returns a `GenerationExpression` with both SQL and (optionally) a connector `Expression`. The default `Column` builder still accepts SQL only, so existing connectors are source-compatible. `DefaultValue` now extends the shared `SqlOrExpression` base class; its public surface is unchanged.

### How was this patch tested?

- Added `DataSourceV2DataFrameSuite` tests covering create/replace table with a translatable generation expression, a foldable generation expression, and a non-translatable generation expression.
- Updated `V2TableUtilSuite` for the new column-generation-expression field.
- Existing generated-column tests in `DataSourceV2SQLSuiteV1Filter` remain green.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor (Claude Opus 4.7)