### PR TITLE
[SPARK-57120][INFRA] Use `ubuntu-slim` for GitHub Actions `update_build_status.yml` workflow

### DIFF
--- a/.github/workflows/update_build_status.yml
+++ b/.github/workflows/update_build_status.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   update:
     name: Update build status
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       actions: read
       checks: write


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `ubuntu-slim` for GitHub Actions `update_build_status.yml` workflow whose running time is less than **6 minutes** consistently.

- https://github.com/apache/spark/actions/workflows/update_build_status.yml

<img width="1077" height="579" alt="Screenshot 2026-05-27 at 20 08 59" src="https://github.com/user-attachments/assets/787d3e16-3f75-4065-bc39-68e9a568f5b9" />

### Why are the changes needed?

`ubuntu-slim` is a new cost-efficient runner to fit small jobs like this scheduled status updater (runs every 15 minutes, only makes GitHub API calls). We had better use this to save ASF infra usage (if possible).
- https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/
- https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md

| Feature | `ubuntu-slim` | `ubuntu-latest` |
| :--- | :---: | :---: |
| **Cost (per minute)** | **$0.002** | **$0.012** |
| **Cost for 1,000 mins** | **$2.00** | **$12.00** |
| **CPU** | 1 vCPU | 4 vCPU |
| **Memory (RAM)** | 5 GB | 16 GB |
| **Storage (SSD)** | 14 GB | 14 GB |
| **Maximum Runtime** | **15 Minutes** | 6 Hours |
| **Isolation Type** | Container-based (L2) | Dedicated VM |

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Claude Opus 4.7` on `Claude Code`