### PR TITLE
[SPARK-43847][PYTHON] Throw structured error when reading Protobuf descriptor file fails

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -579,6 +579,7 @@ pyspark_sql = Module(
         "pyspark.sql.tests.test_dataframe_query_context",
         "pyspark.sql.tests.test_listener",
         "pyspark.sql.tests.test_observation",
+        "pyspark.sql.tests.test_protobuf",
         "pyspark.sql.tests.test_repartition",
         "pyspark.sql.tests.test_stat",
         "pyspark.sql.tests.test_datasources",

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -678,6 +678,7 @@ pyspark_sql = Module(
         "pyspark.sql.tests.test_dataframe_query_context",
         "pyspark.sql.tests.test_listener",
         "pyspark.sql.tests.test_observation",
+        "pyspark.sql.tests.test_protobuf",
         "pyspark.sql.tests.test_repartition",
         "pyspark.sql.tests.test_stat",
         "pyspark.sql.tests.test_datasources",

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -785,6 +785,12 @@
       "Column <col_name> must be one of <valid_types> for plotting, got <col_type>."
     ]
   },
+  "PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND": {
+    "message": [
+      "Error reading Protobuf descriptor file at path: <filePath>."
+    ],
+    "sqlState": "42K0G"
+  },
   "PROTOCOL_ERROR": {
     "message": [
       "<failure>. This usually indicates that the message does not conform to the protocol."

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -795,6 +795,12 @@
       "Column <col_name> must be one of <valid_types> for plotting, got <col_type>."
     ]
   },
+  "PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND": {
+    "message": [
+      "Error reading Protobuf descriptor file at path: <filePath>."
+    ],
+    "sqlState": "42K0G"
+  },
   "PROTOCOL_ERROR": {
     "message": [
       "<failure>. This usually indicates that the message does not conform to the protocol."

--- a/python/pyspark/sql/connect/protobuf/functions.py
+++ b/python/pyspark/sql/connect/protobuf/functions.py
@@ -40,7 +40,7 @@ def from_protobuf(
     if binaryDescriptorSet is not None:
         binary_proto = binaryDescriptorSet
     elif descFilePath is not None:
-        binary_proto = _read_descriptor_set_file(descFilePath)
+        binary_proto = PyProtobufFunctions._read_descriptor_set_file(descFilePath)
 
     # TODO: simplify the code when _invoke_function() supports None as input.
     if binary_proto is not None:
@@ -79,7 +79,7 @@ def to_protobuf(
     if binaryDescriptorSet is not None:
         binary_proto = binaryDescriptorSet
     elif descFilePath is not None:
-        binary_proto = _read_descriptor_set_file(descFilePath)
+        binary_proto = PyProtobufFunctions._read_descriptor_set_file(descFilePath)
 
     # TODO: simplify the code when _invoke_function() supports None as input.
     if binary_proto is not None:
@@ -105,11 +105,6 @@ def to_protobuf(
 
 
 to_protobuf.__doc__ = PyProtobufFunctions.to_protobuf.__doc__
-
-
-def _read_descriptor_set_file(filePath: str) -> bytes:
-    with open(filePath, "rb") as f:
-        return f.read()
 
 
 def _test() -> None:

--- a/python/pyspark/sql/protobuf/functions.py
+++ b/python/pyspark/sql/protobuf/functions.py
@@ -21,6 +21,7 @@ A collections of builtin protobuf functions
 
 from typing import Dict, Optional, TYPE_CHECKING, cast
 
+from pyspark.errors import PySparkRuntimeError
 from pyspark.sql.column import Column
 from pyspark.sql.utils import get_active_spark_context, try_remote_protobuf_functions
 from pyspark.util import _print_missing_jar
@@ -286,9 +287,14 @@ def to_protobuf(
 
 
 def _read_descriptor_set_file(filePath: str) -> bytes:
-    # TODO(SPARK-43847): Throw structured errors like "PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND" etc.
-    with open(filePath, "rb") as f:
-        return f.read()
+    try:
+        with open(filePath, "rb") as f:
+            return f.read()
+    except OSError as e:
+        raise PySparkRuntimeError(
+            errorClass="PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND",
+            messageParameters={"filePath": filePath},
+        ) from e
 
 
 def _test() -> None:

--- a/python/pyspark/sql/protobuf/functions.py
+++ b/python/pyspark/sql/protobuf/functions.py
@@ -21,6 +21,7 @@ A collections of builtin protobuf functions
 
 from typing import TYPE_CHECKING, Dict, Optional, cast
 
+from pyspark.errors import PySparkRuntimeError
 from pyspark.sql.column import Column
 from pyspark.sql.utils import get_active_spark_context, try_remote_protobuf_functions
 from pyspark.util import _print_missing_jar
@@ -288,9 +289,14 @@ def to_protobuf(
 
 
 def _read_descriptor_set_file(filePath: str) -> bytes:
-    # TODO(SPARK-43847): Throw structured errors like "PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND" etc.
-    with open(filePath, "rb") as f:
-        return f.read()
+    try:
+        with open(filePath, "rb") as f:
+            return f.read()
+    except FileNotFoundError as e:
+        raise PySparkRuntimeError(
+            errorClass="PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND",
+            messageParameters={"filePath": filePath},
+        ) from e
 
 
 def _test() -> None:

--- a/python/pyspark/sql/tests/test_protobuf.py
+++ b/python/pyspark/sql/tests/test_protobuf.py
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from pyspark.errors import PySparkRuntimeError
+from pyspark.sql.protobuf.functions import _read_descriptor_set_file
+from pyspark.testing.utils import PySparkErrorTestUtils
+
+
+class ProtobufFunctionsTests(unittest.TestCase, PySparkErrorTestUtils):
+    def test_read_descriptor_set_file_not_found(self):
+        with self.assertRaises(PySparkRuntimeError) as pe:
+            _read_descriptor_set_file("/nonexistent/path/file.desc")
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND",
+            messageParameters={"filePath": "/nonexistent/path/file.desc"},
+        )
+
+
+if __name__ == "__main__":
+    from pyspark.testing import main
+
+    main()

--- a/python/pyspark/sql/tests/test_protobuf.py
+++ b/python/pyspark/sql/tests/test_protobuf.py
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from pyspark.errors import PySparkRuntimeError
+from pyspark.sql.protobuf.functions import _read_descriptor_set_file
+from pyspark.testing.connectutils import should_test_connect
+from pyspark.testing.utils import PySparkErrorTestUtils
+
+
+class ProtobufFunctionsTests(unittest.TestCase, PySparkErrorTestUtils):
+    def check_descriptor_file_not_found(self, func):
+        with self.assertRaises(PySparkRuntimeError) as pe:
+            func("/nonexistent/path/file.desc")
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND",
+            messageParameters={"filePath": "/nonexistent/path/file.desc"},
+        )
+
+    def test_read_descriptor_set_file_not_found(self):
+        self.check_descriptor_file_not_found(_read_descriptor_set_file)
+
+    @unittest.skipIf(not should_test_connect, "Connect dependencies are not installed")
+    def test_descriptor_file_not_found_connect(self):
+        # The descriptor file is read before the session is touched, so this needs no server.
+        from pyspark.sql.connect.protobuf import functions as connect_functions
+
+        for func in [connect_functions.from_protobuf, connect_functions.to_protobuf]:
+            with self.subTest(func=func.__name__):
+                self.check_descriptor_file_not_found(
+                    lambda path: func("value", "SimpleMessage", descFilePath=path)
+                )
+
+
+if __name__ == "__main__":
+    from pyspark.testing import main
+
+    main()


### PR DESCRIPTION
### What changes were proposed in this pull request?

`_read_descriptor_set_file()` in `pyspark.sql.protobuf.functions` now raises
`PySparkRuntimeError` with error class `PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND`
instead of propagating a raw Python `FileNotFoundError` when the descriptor
file does not exist. Only `FileNotFoundError` is mapped to this error class;
other `OSError` subclasses (`PermissionError`, `IsADirectoryError`, ...) are
unrelated failure modes and keep propagating unchanged.

The Spark Connect protobuf module carried its own duplicate copy of
`_read_descriptor_set_file()`, so it would not have picked up the change. That
copy is removed and `pyspark.sql.connect.protobuf.functions` now imports the
Classic implementation, giving both paths a single implementation and the same
structured error.

The error class and its message already existed on the Scala side
(`common/utils/src/main/resources/error/error-conditions.json`); this PR adds
the matching entry to `python/pyspark/errors/error-conditions.json` and wires
it up in the Python code.

### Why are the changes needed?

Before this fix, users who pass a wrong or missing descriptor file path get a
bare Python OS error with no Spark context:

```
FileNotFoundError: [Errno 2] No such file or directory: '/path/to/file.desc'
```

After this fix they get a structured Spark error consistent with the rest of
the PySpark error framework:

```
PySparkRuntimeError: [PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND]
Error reading Protobuf descriptor file at path: /path/to/file.desc.
```

### Does this PR introduce _any_ user-facing change?

Yes, in both Classic PySpark and Spark Connect. Users who catch
`FileNotFoundError` around `from_protobuf` / `to_protobuf` calls that supply a
`descFilePath` will now need to catch `PySparkRuntimeError` instead (or the
common base `PySparkException`). The error message is clearer and includes the
file path.

### How was this patch tested?

Added `python/pyspark/sql/tests/test_protobuf.py`, which asserts that a missing
path raises `PySparkRuntimeError` with the correct error class and `filePath`
message parameter. The same assertion runs against both the Classic and the
Connect module; the Connect case is guarded by `should_test_connect`.

Run locally with:
```
PYTHONPATH=python python3 -m unittest pyspark.sql.tests.test_protobuf -v
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5
