### PR TITLE
[SPARK-57122][BUILD] Upgrade `gson` to 2.14.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -74,7 +74,7 @@ grpc-api/1.76.0//grpc-api-1.76.0.jar
 grpc-protobuf-lite/1.76.0//grpc-protobuf-lite-1.76.0.jar
 grpc-protobuf/1.76.0//grpc-protobuf-1.76.0.jar
 grpc-stub/1.76.0//grpc-stub-1.76.0.jar
-gson/2.13.2//gson-2.13.2.jar
+gson/2.14.0//gson-2.14.0.jar
 guava/33.6.0-jre//guava-33.6.0-jre.jar
 hadoop-aliyun/3.5.0//hadoop-aliyun-3.5.0.jar
 hadoop-annotations/3.5.0//hadoop-annotations-3.5.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
     <datanucleus-core.version>4.1.17</datanucleus-core.version>
     <guava.version>33.6.0-jre</guava.version>
     <guava.failureaccess.version>1.0.3</guava.failureaccess.version>
-    <gson.version>2.13.2</gson.version>
+    <gson.version>2.14.0</gson.version>
     <janino.version>3.1.9</janino.version>
     <jersey.version>3.1.11</jersey.version>
     <joda.version>2.14.1</joda.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade `gson` to `2.14.0` for Apache Spark 5.

### Why are the changes needed?
To bring the latest bug fixes.
- https://github.com/google/gson/releases/tag/gson-parent-2.14.0 (2026-04-23)
  - https://github.com/google/gson/pull/3006
  - https://github.com/google/gson/pull/2995
  - https://github.com/google/gson/pull/2925
  - https://github.com/google/gson/pull/2864

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Opus 4.7