### PR TITLE
[SPARK-57124][INFRA] Fix `update_build_status.yml` to map non-standard workflow run statuses

### DIFF
--- a/.github/workflows/update_build_status.yml
+++ b/.github/workflows/update_build_status.yml
@@ -89,13 +89,16 @@ jobs:
                           details_url: run.data.details_url
                         })
                       } else {
-                        console.log('    Run ' + cr.id + ': set status (' + run.data.status + ')')
+                        // PATCH /check-runs accepts only queued | in_progress | completed,
+                        // but workflow_run may also report requested / waiting / pending.
+                        const status = run.data.status == 'in_progress' ? 'in_progress' : 'queued'
+                        console.log('    Run ' + cr.id + ': set status (' + run.data.status + ' -> ' + status + ')')
                         const response = await github.request('PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}', {
                           owner: context.repo.owner,
                           repo: context.repo.repo,
                           check_run_id: cr.id,
                           output: cr.output,
-                          status: run.data.status,
+                          status: status,
                           details_url: run.data.details_url
                         })
                       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the `update_build_status.yml` so that it coerces non-standard workflow run statuses (`requested`, `waiting`, `pending`) to a value accepted by the `PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}` endpoint.

The `else` branch now maps `run.data.status` to either `in_progress` (when it is exactly `in_progress`) or `queued` (for any other non-`completed` value), instead of passing the raw value through.

### Why are the changes needed?

The scheduled job has been failing intermittently with HTTP 422.

- https://github.com/apache/spark/actions/workflows/update_build_status.yml?query=is%3Afailure

<img width="1184" height="1040" alt="Screenshot 2026-05-27 at 21 31 50" src="https://github.com/user-attachments/assets/9a8501d6-be43-4dc4-b6d2-7550ca3ff513" />

For example, run [26552065653](https://github.com/apache/spark/actions/runs/26552065653/job/78216028779) failed with:

```
Run 78216352873: set status (pending)
RequestError [HttpError]: Invalid request.
  No subschema in "anyOf" matched.
  pending is not a member of ["queued", "in_progress", "completed"].
```

`GET /repos/{owner}/{repo}/actions/runs/{run_id}` can return any of `completed`, `in_progress`, `queued`, `requested`, `waiting`, or `pending`, while `PATCH /check-runs/{id}` only accepts `queued`, `in_progress`, or `completed`. Forwarding the raw value caused the workflow to crash whenever a fork's run was in `pending` (or `requested`/`waiting`) state, and the corresponding PR check-runs were not synchronized for that cycle.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review of the workflow script. The change is limited to mapping a string value before passing it to the GitHub REST API; behavior for the existing `completed` and `in_progress` paths is unchanged.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7