### PR TITLE
[SPARK-57127][SQL]. Fixing the canonicalization of JoinExec nodes as it does…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BaseJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BaseJoinExec.scala
@@ -30,13 +30,20 @@ trait BaseJoinExec extends BinaryExecNode {
   def leftKeys: Seq[Expression]
   def rightKeys: Seq[Expression]
 
+  protected def doCanonicalizePart2(
+      part1Canonicalized: BaseJoinExec,
+      leftCanonicalizedKeys: Seq[Expression],
+      rightCanonicalizedKeys: Seq[Expression]): BaseJoinExec = {
+    part1Canonicalized
+  }
+
   override def doCanonicalize(): BaseJoinExec = {
-    val baseCanonicalized = super.doCanonicalize().asInstanceOf[BroadcastHashJoinExec]
+    val baseCanonicalized = super.doCanonicalize().asInstanceOf[BaseJoinExec]
     val (newLeft, newRight) = baseCanonicalized.leftKeys.zip(baseCanonicalized.rightKeys)
       .sortBy {
         case (l, _) => l.hashCode()
       }.unzip
-    baseCanonicalized.copy(leftKeys = newLeft, rightKeys = newRight)
+    doCanonicalizePart2(baseCanonicalized, newLeft, newRight)
   }
 
   override def simpleStringWithNodeId(): String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BaseJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BaseJoinExec.scala
@@ -39,11 +39,11 @@ trait BaseJoinExec extends BinaryExecNode {
 
   override def doCanonicalize(): BaseJoinExec = {
     val baseCanonicalized = super.doCanonicalize().asInstanceOf[BaseJoinExec]
-    val (newLeft, newRight) = baseCanonicalized.leftKeys.zip(baseCanonicalized.rightKeys)
+    val (newLeftKeys, newRightKeys) = baseCanonicalized.leftKeys.zip(baseCanonicalized.rightKeys)
       .sortBy {
         case (l, _) => l.hashCode()
       }.unzip
-    doCanonicalizePart2(baseCanonicalized, newLeft, newRight)
+    doCanonicalizePart2(baseCanonicalized, newLeftKeys, newRightKeys)
   }
 
   override def simpleStringWithNodeId(): String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BaseJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BaseJoinExec.scala
@@ -30,6 +30,15 @@ trait BaseJoinExec extends BinaryExecNode {
   def leftKeys: Seq[Expression]
   def rightKeys: Seq[Expression]
 
+  override def doCanonicalize(): BaseJoinExec = {
+    val baseCanonicalized = super.doCanonicalize().asInstanceOf[BroadcastHashJoinExec]
+    val (newLeft, newRight) = baseCanonicalized.leftKeys.zip(baseCanonicalized.rightKeys)
+      .sortBy {
+        case (l, _) => l.hashCode()
+      }.unzip
+    baseCanonicalized.copy(leftKeys = newLeft, rightKeys = newRight)
+  }
+
   override def simpleStringWithNodeId(): String = {
     val opId = ExplainUtils.getOpId(this)
     s"$nodeName $joinType ($opId)".trim

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
@@ -61,6 +61,14 @@ case class BroadcastHashJoinExec private(
     require(condition.isEmpty, "null aware anti join optimize condition should be empty.")
   }
 
+  override protected def doCanonicalizePart2(
+      part1Canonicalized: BaseJoinExec,
+      leftCanonicalizedKeys: Seq[Expression],
+      rightCanonicalizedKeys: Seq[Expression]): BaseJoinExec = {
+    part1Canonicalized.asInstanceOf[BroadcastHashJoinExec].copy(
+      leftKeys = leftCanonicalizedKeys, rightKeys = rightCanonicalizedKeys)
+  }
+
   override lazy val metrics = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -46,6 +46,14 @@ case class ShuffledHashJoinExec private (
     isSkewJoin: Boolean = false)
   extends HashJoin with ShuffledJoin {
 
+  override protected def doCanonicalizePart2(
+      part1Canonicalized: BaseJoinExec,
+      leftCanonicalizedKeys: Seq[Expression],
+      rightCanonicalizedKeys: Seq[Expression]): BaseJoinExec = {
+    part1Canonicalized.asInstanceOf[ShuffledHashJoinExec].copy(
+      leftKeys = leftCanonicalizedKeys, rightKeys = rightCanonicalizedKeys)
+  }
+
   override lazy val metrics = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "buildDataSize" -> SQLMetrics.createSizeMetric(sparkContext, "data size of build side"),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -45,6 +45,14 @@ case class SortMergeJoinExec(
     right: SparkPlan,
     isSkewJoin: Boolean = false) extends ShuffledJoin {
 
+  override protected def doCanonicalizePart2(
+      part1Canonicalized: BaseJoinExec,
+      leftCanonicalizedKeys: Seq[Expression],
+      rightCanonicalizedKeys: Seq[Expression]): BaseJoinExec = {
+    part1Canonicalized.asInstanceOf[SortMergeJoinExec].copy(
+      leftKeys = leftCanonicalizedKeys, rightKeys = rightCanonicalizedKeys)
+  }
+
   override lazy val metrics = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "spillSize" -> SQLMetrics.createSizeMetric(sparkContext, "spill size"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/JoinExecCanonicalizationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/JoinExecCanonicalizationSuite.scala
@@ -29,7 +29,7 @@ class JoinExecCanonicalizationSuite  extends SparkPlanTest with SharedSparkSessi
       sparkContext.parallelize(Seq(
         Row(1, 1.0, "a"),
         Row(2, 2.0, "b" ),
-        Row(3, 3.0, "c" ),
+        Row(3, 3.0, "c" )
       )),
       new StructType().add("a1", IntegerType).add("b1", DoubleType).add("c1", StringType))
       .createOrReplaceTempView("table1")
@@ -41,7 +41,7 @@ class JoinExecCanonicalizationSuite  extends SparkPlanTest with SharedSparkSessi
       sparkContext.parallelize(Seq(
         Row(1, 1.0, "a"),
         Row(2, 2.0, "b"),
-        Row(3, 3.0, "c"),
+        Row(3, 3.0, "c")
       )),
       new StructType().add("a2", IntegerType).add("b2", DoubleType).add("c2", StringType))
         .createOrReplaceTempView("table2")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/JoinExecCanonicalizationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/JoinExecCanonicalizationSuite.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.SparkPlanTest
+import org.apache.spark.sql.functions.broadcast
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType, StructType}
+
+class JoinExecCanonicalizationSuite  extends SparkPlanTest with SharedSparkSession {
+  private lazy val left = {
+    spark.createDataFrame(
+      sparkContext.parallelize(Seq(
+        Row(1, 1.0, "a"),
+        Row(2, 2.0, "b" ),
+        Row(3, 3.0, "c" ),
+      )),
+      new StructType().add("a1", IntegerType).add("b1", DoubleType).add("c1", StringType))
+      .createOrReplaceTempView("table1")
+    spark.table("table1")
+  }
+
+  private lazy val right = {
+    spark.createDataFrame(
+      sparkContext.parallelize(Seq(
+        Row(1, 1.0, "a"),
+        Row(2, 2.0, "b"),
+        Row(3, 3.0, "c"),
+      )),
+      new StructType().add("a2", IntegerType).add("b2", DoubleType).add("c2", StringType))
+        .createOrReplaceTempView("table2")
+    spark.table("table2")
+  }
+
+  private lazy val joinExpression1 = left("a1") === right("a2") && left("b1") === right("b2") &&
+    left("c1") === right("c2")
+
+  private lazy val joinExpression2 = left("c1") === right("c2") && left("a1") === right("a2") &&
+    left("b1") === right("b2")
+
+  test("SPARK-57127: BroadcastHashJoinExec Canonicalization") {
+     val join1 = left.join(broadcast(right), joinExpression1, "inner").queryExecution.sparkPlan
+    val join2 = left.join(broadcast(right), joinExpression2, "inner").queryExecution.sparkPlan
+    assert(join1.isInstanceOf[BroadcastHashJoinExec])
+    assert(join2.isInstanceOf[BroadcastHashJoinExec])
+    assert(join1.sameResult(join2))
+  }
+
+  test("SPARK-57127: ShuffledHashJoinExec Canonicalization") {
+    val join1 = left.hint("shuffle_hash").join(right, joinExpression1, "inner").queryExecution
+      .sparkPlan
+    val join2 = left.hint("shuffle_hash").join(right, joinExpression2, "inner").queryExecution
+      .sparkPlan
+    assert(join1.isInstanceOf[ShuffledHashJoinExec])
+    assert(join2.isInstanceOf[ShuffledHashJoinExec])
+    assert(join1.sameResult(join2))
+  }
+
+  test("SPARK-57127: SortMergeJoinExec Canonicalization") {
+    val join1 = left.hint("merge").join(right, joinExpression1, "inner").queryExecution
+      .sparkPlan
+    val join2 = left.hint("merge").join(right, joinExpression2, "inner").queryExecution
+      .sparkPlan
+    assert(join1.isInstanceOf[SortMergeJoinExec])
+    assert(join2.isInstanceOf[SortMergeJoinExec])
+    assert(join1.sameResult(join2))
+  }
+
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/JoinExecCanonicalizationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/JoinExecCanonicalizationSuite.scala
@@ -81,5 +81,4 @@ class JoinExecCanonicalizationSuite  extends SparkPlanTest with SharedSparkSessi
     assert(join2.isInstanceOf[SortMergeJoinExec])
     assert(join1.sameResult(join2))
   }
-
 }


### PR DESCRIPTION
… not take into account the order of join keys
### What changes were proposed in this pull request?
The canonicalization of JoinExec nodes should ensure that join keys are canonicalized in an ordered way, so that the pairs when compared with structurally same Join node, does not result in mismatch, due to ordering issue.

### Why are the changes needed?
To ensure that re-use of exchange works efficiently.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
One Bug test added in the PR for SPARK-57126. Will be adding more unit tests.

### Was this patch authored or co-authored using generative AI tooling?
No
