### PR TITLE
[SPARK-57128][SQL][TESTS] SQLQueryTestHelper --SET parser must preserve commas in config values

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelper.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelper.scala
@@ -474,7 +474,12 @@ trait SQLQueryTestHelper extends SQLConfHelper with Logging {
 
   protected def getSparkSettings(comments: Array[String]): Array[(String, String)] = {
     val settingLines = comments.filter(_.startsWith("--SET ")).map(_.substring(6))
-    settingLines.flatMap(_.split(",").map { kv =>
+    // Split on commas that are followed by what looks like a new `key=`. This preserves
+    // commas inside config values such as
+    //   --SET spark.sql.optimizer.excludedRules=Rule1,Rule2
+    // while still supporting the documented multi-setting form
+    //   --SET key1=v1,key2=v2
+    settingLines.flatMap(_.split(",(?=[\\w.]+=)").map { kv =>
       val (conf, value) = kv.span(_ != '=')
       conf.trim -> value.substring(1).trim
     })

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelperSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelperSuite.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.SparkFunSuite
+
+class SQLQueryTestHelperSuite extends SparkFunSuite with SQLQueryTestHelper {
+
+  test("getSparkSettings: single key=value") {
+    val result = getSparkSettings(Array("--SET spark.sql.foo=1"))
+    assert(result.toSeq === Seq("spark.sql.foo" -> "1"))
+  }
+
+  test("getSparkSettings: multiple key=value pairs in one --SET (documented form)") {
+    val result = getSparkSettings(Array("--SET spark.sql.foo=1,spark.sql.bar=2"))
+    assert(result.toSeq === Seq("spark.sql.foo" -> "1", "spark.sql.bar" -> "2"))
+  }
+
+  test("getSparkSettings: multiple --SET statements") {
+    val result = getSparkSettings(
+      Array("--SET spark.sql.foo=1", "--SET spark.sql.bar=2"))
+    assert(result.toSeq === Seq("spark.sql.foo" -> "1", "spark.sql.bar" -> "2"))
+  }
+
+  test("getSparkSettings: value containing commas (e.g. excludedRules list)") {
+    val excludedRules =
+      "org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation," +
+        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding"
+    val result = getSparkSettings(
+      Array(s"--SET spark.sql.optimizer.excludedRules=$excludedRules"))
+    assert(result.toSeq === Seq("spark.sql.optimizer.excludedRules" -> excludedRules))
+  }
+
+  test("getSparkSettings: mixed -- multiple settings where one value contains commas") {
+    val excludedRules =
+      "org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation," +
+        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding"
+    val result = getSparkSettings(
+      Array(s"--SET spark.sql.optimizer.excludedRules=$excludedRules,spark.sql.foo=1"))
+    assert(result.toSeq === Seq(
+      "spark.sql.optimizer.excludedRules" -> excludedRules,
+      "spark.sql.foo" -> "1"))
+  }
+
+  test("getSparkSettings: ignores non --SET comments") {
+    val result = getSparkSettings(
+      Array("-- a comment", "--SET spark.sql.foo=1", "-- another"))
+    assert(result.toSeq === Seq("spark.sql.foo" -> "1"))
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

`SQLQueryTestHelper.getSparkSettings` splits `--SET` directive values on every comma:

```scala
val settingLines = comments.filter(_.startsWith("--SET ")).map(_.substring(6))
settingLines.flatMap(_.split(",").map { kv =>
  val (conf, value) = kv.span(_ != '=')
  conf.trim -> value.substring(1).trim
})
```

This breaks for any setting whose value itself contains a comma (e.g. `spark.sql.optimizer.excludedRules`, which is documented as a comma-separated list of rule names). The parser splits inside the value, the next segment has no `=`, and `value.substring(1)` then throws `StringIndexOutOfBoundsException`.

This PR changes the split to only occur at commas that are immediately followed by what looks like a new `key=`:

```scala
settingLines.flatMap(_.split(",(?=[\\w.]+=)").map { ... })
```

The positive lookahead `(?=[\w.]+=)` peeks at the following characters and only splits when they form a config key followed by `=`, without consuming those characters. This preserves the documented multi-setting form `--SET k1=v1,k2=v2` while now also correctly handling values that themselves contain commas.

### Why are the changes needed?

Several Spark configs take comma-separated lists as values — `spark.sql.optimizer.excludedRules` being the most common one. SQL test files currently cannot express such a value in a `--SET` directive at all; the parser fails before the test even runs, forcing authors to scope `--SET` down to one excluded rule per directive.

This was surfaced while writing a per-file workaround in Apache Gluten ([apache/incubator-gluten#12165](https://github.com/apache/incubator-gluten/pull/12165)), which reuses this test helper and needs to exclude multiple rules at once.

### Does this PR introduce _any_ user-facing change?

No. Test-framework-only change. All existing `--SET` directives in the SQL test corpus continue to parse identically.

### How was this patch tested?

Added `SQLQueryTestHelperSuite` (new file) with focused unit tests covering:

- single `key=value`
- documented multi-setting form `k1=v1,k2=v2` in a single `--SET`
- multiple `--SET` lines
- a value containing commas (e.g. `excludedRules=Rule1,Rule2`) — fails on `master`, passes after the fix
- mixed: multi-setting where one of the values itself contains commas
- non-`--SET` comments are ignored

All 6 tests pass with the fix applied.