### PR TITLE
[SPARK-57129][INFRA] Disable post-merge CI on branch-4.x

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -29,8 +29,12 @@ jobs:
     permissions:
       packages: write
     name: Run
-    # Skip pushes to `master` on forks: the "Sync fork" button mirrors
-    # apache/spark and would otherwise re-run the full build on every sync.
-    # Upstream pushes and pushes to non-master branches on forks are unaffected.
-    if: github.repository == 'apache/spark' || github.ref != 'refs/heads/master'
+    # Skip:
+    #   - pushes to `branch-4.x` on apache/spark: post-merge CI on this
+    #     integration/staging branch is disabled to save resources.
+    #   - pushes to `master` on forks: the "Sync fork" button mirrors
+    #     apache/spark and would otherwise re-run the full build on every sync.
+    if: >-
+      (github.repository == 'apache/spark' && github.ref != 'refs/heads/branch-4.x')
+      || (github.repository != 'apache/spark' && github.ref != 'refs/heads/master')
     uses: ./.github/workflows/build_and_test.yml


### PR DESCRIPTION
### What changes were proposed in this pull request?

Skip `call-build-and-test` in `.github/workflows/build_main.yml` for pushes to `branch-4.x` on `apache/spark`:

```yaml
if: >-
  (github.repository == 'apache/spark' && github.ref != 'refs/heads/branch-4.x')
  || (github.repository != 'apache/spark' && github.ref != 'refs/heads/master')
```

This PR lands the change on `master`. The behavioral effect comes from the equivalent change being backported to `branch-4.x`'s own `.github/workflows/build_main.yml` (where post-merge `Build` runs are read from).

### Why are the changes needed?

To save CI resources. Every post-merge commit on `branch-4.x` currently triggers the full `Build` workflow.

PRs targeting `branch-4.x` are unaffected: their CI runs on the contributor's fork, where `github.repository != 'apache/spark'` and the second clause runs the build for any non-master ref.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Workflow change; verifiable by reading the `if:` expression.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7