### PR TITLE
[SPARK-57132][SQL] Rename _LEGACY_ERROR_TEMP_1037 and add sqlState

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -7494,6 +7494,12 @@
     ],
     "sqlState" : "42K0E"
   },
+  "WINDOW_FUNCTION_REQUIRES_ORDER_BY" : {
+    "message" : [
+      "Window function <funcName> requires window to be ordered, please add ORDER BY clause. For example SELECT <funcName>(value_expr) OVER (PARTITION BY window_partition ORDER BY window_ordering) from table."
+    ],
+    "sqlState" : "42601"
+  },
   "WINDOW_FUNCTION_WITHOUT_OVER_CLAUSE" : {
     "message" : [
       "Window function <funcName> requires an OVER clause."
@@ -7771,11 +7777,6 @@
   "_LEGACY_ERROR_TEMP_1036" : {
     "message" : [
       "Window Frame <wf> must match the required frame <required>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1037" : {
-    "message" : [
-      "Window function <wf> requires window to be ordered, please add ORDER BY clause. For example SELECT <wf>(value_expr) OVER (PARTITION BY window_partition ORDER BY window_ordering) from table."
     ]
   },
   "_LEGACY_ERROR_TEMP_1039" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -871,8 +871,8 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def windowFunctionWithWindowFrameNotOrderedError(wf: WindowFunction): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1037",
-      messageParameters = Map("wf" -> wf.toString))
+      errorClass = "WINDOW_FUNCTION_REQUIRES_ORDER_BY",
+      messageParameters = Map("funcName" -> wf.toString))
   }
 
   def multiTimeWindowExpressionsNotSupportedError(t: TreeNode[_]): Throwable = {

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udf/udf-window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udf/udf-window.sql.out
@@ -421,9 +421,10 @@ SELECT udf(val), cate, row_number() OVER(PARTITION BY cate) FROM testData ORDER 
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1037",
+  "errorClass" : "WINDOW_FUNCTION_REQUIRES_ORDER_BY",
+  "sqlState" : "42601",
   "messageParameters" : {
-    "wf" : "row_number()"
+    "funcName" : "row_number()"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/window.sql.out
@@ -616,9 +616,10 @@ SELECT val, cate, row_number() OVER(PARTITION BY cate) FROM testData ORDER BY ca
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1037",
+  "errorClass" : "WINDOW_FUNCTION_REQUIRES_ORDER_BY",
+  "sqlState" : "42601",
   "messageParameters" : {
-    "wf" : "row_number()"
+    "funcName" : "row_number()"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-window.sql.out
@@ -421,9 +421,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1037",
+  "errorClass" : "WINDOW_FUNCTION_REQUIRES_ORDER_BY",
+  "sqlState" : "42601",
   "messageParameters" : {
-    "wf" : "row_number()"
+    "funcName" : "row_number()"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/window.sql.out
@@ -599,9 +599,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1037",
+  "errorClass" : "WINDOW_FUNCTION_REQUIRES_ORDER_BY",
+  "sqlState" : "42601",
   "messageParameters" : {
-    "wf" : "row_number()"
+    "funcName" : "row_number()"
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
@@ -74,7 +74,10 @@ class DataFrameWindowFunctionsSuite extends QueryTest
     val e = intercept[AnalysisException](
       // Here we missed .orderBy("key")!
       df.select(row_number().over(Window.partitionBy("value"))).collect())
-    assert(e.message.contains("requires window to be ordered"))
+    checkError(
+      exception = e,
+      condition = "WINDOW_FUNCTION_REQUIRES_ORDER_BY",
+      parameters = Map("funcName" -> "row_number()"))
   }
 
   test("corr, covar_pop, stddev_pop functions in specific window") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Renamed `_LEGACY_ERROR_TEMP_1037` to `WINDOW_FUNCTION_REQUIRES_ORDER_BY` and added sqlState `42601`.

The changes include:
- New error class `WINDOW_FUNCTION_REQUIRES_ORDER_BY` in `error-conditions.json` with sqlState `42601`.
- Updated `QueryCompilationErrors.windowFunctionWithWindowFrameNotOrderedError` to reference the new error class and renamed the message parameter `wf` -> `funcName` for consistency with neighboring window error classes.
- Refreshed four SQL golden files (`window.sql.out` and `udf/udf-window.sql.out` under both `results/` and `analyzer-results/`).
- Refactored the existing string-match `assert` in `DataFrameWindowFunctionsSuite` to use `checkError()` for structured validation of the error class and parameters.

### Why are the changes needed?

`_LEGACY_ERROR_TEMP_1037` is a legacy error code with no sqlState, which makes it harder to handle programmatically and reduces JDBC/ODBC tooling compatibility. The new name is descriptive, follows the convention used by neighboring window-related error classes (`WINDOW_FUNCTION_AND_FRAME_MISMATCH`, `WINDOW_FUNCTION_WITHOUT_OVER_CLAUSE`), and adds the standard SQLSTATE `42601` (syntax error / missing required clause).

### Does this PR introduce any user-facing change?

No. The error message text stays the same. Users will see the same message, but the underlying error class is now properly named and includes a sqlState for better tooling support.

### How was this patch tested?

- `SparkThrowableSuite` — 25 tests, all passing (validates `error-conditions.json` structure and invariants).
- `DataFrameWindowFunctionsSuite` — 44 tests, all passing (covers the refactored `checkError()` assertion).
- `SQLQueryTestSuite -z window.sql` — 4 suites (`window.sql`, `window.sql_analyzer_test`, plus the UDF variants), all passing.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code

Co-authored-by: Isaac

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
