### PR TITLE
[SPARK-57136][INFRA] Disable `build-core-utils` in Non-ANSI scheduled builds

### DIFF
--- a/.github/workflows/build_branch40_non_ansi.yml
+++ b/.github/workflows/build_branch40_non_ansi.yml
@@ -44,6 +44,7 @@ jobs:
       jobs: >-
         {
           "build": "true",
+          "build-core-utils": "false",
           "docs": "true",
           "pyspark": "true",
           "sparkr": "true",

--- a/.github/workflows/build_branch41_non_ansi.yml
+++ b/.github/workflows/build_branch41_non_ansi.yml
@@ -44,6 +44,7 @@ jobs:
       jobs: >-
         {
           "build": "true",
+          "build-core-utils": "false",
           "docs": "true",
           "pyspark": "true",
           "sparkr": "true",

--- a/.github/workflows/build_branch42_non_ansi.yml
+++ b/.github/workflows/build_branch42_non_ansi.yml
@@ -44,6 +44,7 @@ jobs:
       jobs: >-
         {
           "build": "true",
+          "build-core-utils": "false",
           "docs": "true",
           "pyspark": "true",
           "sparkr": "true",

--- a/.github/workflows/build_non_ansi.yml
+++ b/.github/workflows/build_non_ansi.yml
@@ -45,6 +45,7 @@ jobs:
       jobs: >-
         {
           "build": "true",
+          "build-core-utils": "false",
           "docs": "true",
           "pyspark": "true",
           "pyspark-pandas": "true",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR sets `build-core-utils` to `false` in the four scheduled Non-ANSI build workflows.

### Why are the changes needed?

To save CI resources by skipping the redundant core/utils module build in the Non-ANSI scheduled runs.

For non-ANSI combination tests, we only need to validate SQL-dependent tests.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.7)