### PR TITLE
[SPARK-57140][INFRA] Disable merge button in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,8 +31,8 @@ github:
     - spark
   enabled_merge_buttons:
     merge: false
-    squash: true
-    rebase: true
+    squash: false
+    rebase: false
   ghp_branch: master
   ghp_path: /docs
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR disables all GitHub merge buttons in `.asf.yaml` by setting `squash` and `rebase` to `false` (in addition to the existing `merge: false`):

```yaml
  enabled_merge_buttons:
    merge: false
    squash: false
    rebase: false
```

### Why are the changes needed?

Apache Spark merges pull requests exclusively through the `dev/merge_spark_pr.py` script, not through GitHub's web UI merge button. The current `.asf.yaml` still exposes the Squash and Rebase merge buttons, which can mislead committers into merging a PR directly from the GitHub UI and bypassing the canonical merge tooling. Disabling all merge buttons leaves the merge script as the only supported path to land a PR.

### Does this PR introduce _any_ user-facing change?

No. This only affects committer-facing repository settings on GitHub.

### How was this patch tested?

Not applicable; this is a configuration-only change to `.asf.yaml`. The YAML was validated to parse correctly and to set all three merge buttons to `false`.

### Was this patch authored or co-authored using generative AI tooling?

No.
