### PR TITLE
[WIP][SPARK-57101][SQL] Wire codegen and row accessors through the Types Framework (TypeOps)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
@@ -146,28 +146,32 @@ object InternalRow {
   def getAccessor(dt: DataType, nullable: Boolean = true): (SpecializedGetters, Int) => Any = {
     val getValueNullSafe: (SpecializedGetters, Int) => Any = dt match {
       case u: UserDefinedType[_] => getAccessor(u.sqlType, nullable)
-      case _ => PhysicalDataType(dt) match {
-        case PhysicalBooleanType => (input, ordinal) => input.getBoolean(ordinal)
-        case PhysicalByteType => (input, ordinal) => input.getByte(ordinal)
-        case PhysicalShortType => (input, ordinal) => input.getShort(ordinal)
-        case PhysicalIntegerType => (input, ordinal) => input.getInt(ordinal)
-        case PhysicalLongType => (input, ordinal) => input.getLong(ordinal)
-        case PhysicalFloatType => (input, ordinal) => input.getFloat(ordinal)
-        case PhysicalDoubleType => (input, ordinal) => input.getDouble(ordinal)
-        case _: PhysicalStringType => (input, ordinal) => input.getUTF8String(ordinal)
-        case PhysicalBinaryType => (input, ordinal) => input.getBinary(ordinal)
-        case PhysicalCalendarIntervalType => (input, ordinal) => input.getInterval(ordinal)
-        case PhysicalTimestampNTZNanosType => (input, ordinal) =>
-          input.getTimestampNTZNanos(ordinal)
-        case PhysicalTimestampLTZNanosType => (input, ordinal) =>
-          input.getTimestampLTZNanos(ordinal)
-        case t: PhysicalDecimalType => (input, ordinal) =>
-          input.getDecimal(ordinal, t.precision, t.scale)
-        case t: PhysicalStructType => (input, ordinal) => input.getStruct(ordinal, t.fields.length)
-        case _: PhysicalArrayType => (input, ordinal) => input.getArray(ordinal)
-        case _: PhysicalMapType => (input, ordinal) => input.getMap(ordinal)
-        case _ => (input, ordinal) => input.get(ordinal, dt)
-      }
+      case _ =>
+        TypeOps(dt).map(_.getScalaAccessor).getOrElse {
+          PhysicalDataType(dt) match {
+            case PhysicalBooleanType => (input, ordinal) => input.getBoolean(ordinal)
+            case PhysicalByteType => (input, ordinal) => input.getByte(ordinal)
+            case PhysicalShortType => (input, ordinal) => input.getShort(ordinal)
+            case PhysicalIntegerType => (input, ordinal) => input.getInt(ordinal)
+            case PhysicalLongType => (input, ordinal) => input.getLong(ordinal)
+            case PhysicalFloatType => (input, ordinal) => input.getFloat(ordinal)
+            case PhysicalDoubleType => (input, ordinal) => input.getDouble(ordinal)
+            case _: PhysicalStringType => (input, ordinal) => input.getUTF8String(ordinal)
+            case PhysicalBinaryType => (input, ordinal) => input.getBinary(ordinal)
+            case PhysicalCalendarIntervalType => (input, ordinal) => input.getInterval(ordinal)
+            case PhysicalTimestampNTZNanosType => (input, ordinal) =>
+              input.getTimestampNTZNanos(ordinal)
+            case PhysicalTimestampLTZNanosType => (input, ordinal) =>
+              input.getTimestampLTZNanos(ordinal)
+            case t: PhysicalDecimalType => (input, ordinal) =>
+              input.getDecimal(ordinal, t.precision, t.scale)
+            case t: PhysicalStructType =>
+              (input, ordinal) => input.getStruct(ordinal, t.fields.length)
+            case _: PhysicalArrayType => (input, ordinal) => input.getArray(ordinal)
+            case _: PhysicalMapType => (input, ordinal) => input.getMap(ordinal)
+            case _ => (input, ordinal) => input.get(ordinal, dt)
+          }
+        }
     }
 
     if (nullable) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1699,22 +1699,26 @@ object CodeGenerator extends Logging {
     val jt = javaType(dataType)
     dataType match {
       case udt: UserDefinedType[_] => getValue(input, udt.sqlType, ordinal)
-      case _ if isPrimitiveType(jt) => s"$input.get${primitiveTypeName(jt)}($ordinal)"
-      case _ => PhysicalDataType(dataType) match {
-        case _: PhysicalArrayType => s"$input.getArray($ordinal)"
-        case PhysicalBinaryType => s"$input.getBinary($ordinal)"
-        case _: PhysicalBinaryViewType => s"$input.getBinaryView($ordinal)"
-        case PhysicalCalendarIntervalType => s"$input.getInterval($ordinal)"
-        case PhysicalTimestampNTZNanosType => s"$input.getTimestampNTZNanos($ordinal)"
-        case PhysicalTimestampLTZNanosType => s"$input.getTimestampLTZNanos($ordinal)"
-        case t: PhysicalDecimalType => s"$input.getDecimal($ordinal, ${t.precision}, ${t.scale})"
-        case _: PhysicalMapType => s"$input.getMap($ordinal)"
-        case PhysicalNullType => "null"
-        case _: PhysicalStringType => s"$input.getUTF8String($ordinal)"
-        case t: PhysicalStructType => s"$input.getStruct($ordinal, ${t.fields.length})"
-        case PhysicalVariantType => s"$input.getVariant($ordinal)"
-        case _ => s"($jt)$input.get($ordinal, null)"
-      }
+      case _ =>
+        TypeOps(dataType).map(_.getCodegenGetter(input, ordinal)).getOrElse {
+          if (isPrimitiveType(jt)) s"$input.get${primitiveTypeName(jt)}($ordinal)"
+          else PhysicalDataType(dataType) match {
+            case _: PhysicalArrayType => s"$input.getArray($ordinal)"
+            case PhysicalBinaryType => s"$input.getBinary($ordinal)"
+            case _: PhysicalBinaryViewType => s"$input.getBinaryView($ordinal)"
+            case PhysicalCalendarIntervalType => s"$input.getInterval($ordinal)"
+            case PhysicalTimestampNTZNanosType => s"$input.getTimestampNTZNanos($ordinal)"
+            case PhysicalTimestampLTZNanosType => s"$input.getTimestampLTZNanos($ordinal)"
+            case t: PhysicalDecimalType =>
+              s"$input.getDecimal($ordinal, ${t.precision}, ${t.scale})"
+            case _: PhysicalMapType => s"$input.getMap($ordinal)"
+            case PhysicalNullType => "null"
+            case _: PhysicalStringType => s"$input.getUTF8String($ordinal)"
+            case t: PhysicalStructType => s"$input.getStruct($ordinal, ${t.fields.length})"
+            case PhysicalVariantType => s"$input.getVariant($ordinal)"
+            case _ => s"($jt)$input.get($ordinal, null)"
+          }
+        }
     }
   }
 
@@ -1778,20 +1782,28 @@ object CodeGenerator extends Logging {
   def setColumn(row: String, dataType: DataType, ordinal: Int, value: String): String = {
     val jt = javaType(dataType)
     dataType match {
-      case _ if isPrimitiveType(jt) => s"$row.set${primitiveTypeName(jt)}($ordinal, $value)"
-      case CalendarIntervalType => s"$row.setInterval($ordinal, $value)"
-      case _: TimestampNTZNanosType => s"$row.setTimestampNTZNanos($ordinal, $value)"
-      case _: TimestampLTZNanosType => s"$row.setTimestampLTZNanos($ordinal, $value)"
-      case t: DecimalType => s"$row.setDecimal($ordinal, $value, ${t.precision})"
       case udt: UserDefinedType[_] => setColumn(row, udt.sqlType, ordinal, value)
+      case CalendarIntervalType => s"$row.setInterval($ordinal, $value)"
+      case t: DecimalType => s"$row.setDecimal($ordinal, $value, ${t.precision})"
       // The UTF8String, BinaryView, InternalRow, ArrayData and MapData may came from UnsafeRow, we
       // should copy it to avoid keeping a "pointer" to a memory region which may get updated
       // afterwards.
       case _: StringType | _: GeometryType | _: GeographyType |
            _: StructType | _: ArrayType | _: MapType =>
         s"$row.update($ordinal, $value.copy())"
-      case _ => s"$row.update($ordinal, $value)"
+      case _ =>
+        TypeOps(dataType).map(_.getCodegenSetter(row, ordinal, value)).getOrElse {
+          if (isPrimitiveType(jt)) s"$row.set${primitiveTypeName(jt)}($ordinal, $value)"
+          else setColumnDefault(row, dataType, ordinal, value)
+        }
     }
+  }
+
+  private def setColumnDefault(
+      row: String, dataType: DataType, ordinal: Int, value: String): String = dataType match {
+    case _: TimestampNTZNanosType => s"$row.setTimestampNTZNanos($ordinal, $value)"
+    case _: TimestampLTZNanosType => s"$row.setTimestampLTZNanos($ordinal, $value)"
+    case _ => s"$row.update($ordinal, $value)"
   }
 
   /**
@@ -1992,26 +2004,29 @@ object CodeGenerator extends Logging {
     case udt: UserDefinedType[_] => javaType(udt.sqlType)
     case ObjectType(cls) if cls.isArray => s"${javaType(ObjectType(cls.getComponentType))}[]"
     case ObjectType(cls) => cls.getName
-    case _ => PhysicalDataType(dt) match {
-      case _: PhysicalArrayType => "ArrayData"
-      case PhysicalBinaryType => "byte[]"
-      case PhysicalBooleanType => JAVA_BOOLEAN
-      case PhysicalByteType => JAVA_BYTE
-      case PhysicalCalendarIntervalType => "CalendarInterval"
-      case PhysicalTimestampNTZNanosType => "TimestampNanosVal"
-      case PhysicalTimestampLTZNanosType => "TimestampNanosVal"
-      case PhysicalIntegerType => JAVA_INT
-      case _: PhysicalDecimalType => "Decimal"
-      case PhysicalDoubleType => JAVA_DOUBLE
-      case PhysicalFloatType => JAVA_FLOAT
-      case PhysicalLongType => JAVA_LONG
-      case _: PhysicalMapType => "MapData"
-      case PhysicalShortType => JAVA_SHORT
-      case _: PhysicalStringType => "UTF8String"
-      case _: PhysicalStructType => "InternalRow"
-      case _: PhysicalVariantType => "VariantVal"
-      case _ => "Object"
-    }
+    case _ =>
+      TypeOps(dt).map(_.getJavaClass.getSimpleName).getOrElse {
+        PhysicalDataType(dt) match {
+          case _: PhysicalArrayType => "ArrayData"
+          case PhysicalBinaryType => "byte[]"
+          case PhysicalBooleanType => JAVA_BOOLEAN
+          case PhysicalByteType => JAVA_BYTE
+          case PhysicalCalendarIntervalType => "CalendarInterval"
+          case PhysicalTimestampNTZNanosType => "TimestampNanosVal"
+          case PhysicalTimestampLTZNanosType => "TimestampNanosVal"
+          case PhysicalIntegerType => JAVA_INT
+          case _: PhysicalDecimalType => "Decimal"
+          case PhysicalDoubleType => JAVA_DOUBLE
+          case PhysicalFloatType => JAVA_FLOAT
+          case PhysicalLongType => JAVA_LONG
+          case _: PhysicalMapType => "MapData"
+          case PhysicalShortType => JAVA_SHORT
+          case _: PhysicalStringType => "UTF8String"
+          case _: PhysicalStructType => "InternalRow"
+          case _: PhysicalVariantType => "VariantVal"
+          case _ => "Object"
+        }
+      }
   }
 
   def javaClass(dt: DataType): Class[_] =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.expressions.codegen
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.BindReferences.bindReferences
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
+import org.apache.spark.sql.catalyst.types.ops.TypeOps
 import org.apache.spark.sql.types._
 
 /**
@@ -113,9 +114,16 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
             // Can't call setNullAt() for DecimalType with precision larger than 18.
             s"$rowWriter.write($index, (Decimal) null, ${t.precision}, ${t.scale});"
           case CalendarIntervalType => s"$rowWriter.write($index, (CalendarInterval) null);"
-          case _: TimestampNTZNanosType | _: TimestampLTZNanosType =>
-            s"$rowWriter.write($index, (TimestampNanosVal) null);"
-          case _ => s"$rowWriter.setNullAt($index);"
+          case _ =>
+            TypeOps(dt)
+              .flatMap(_.getCodegenNullWrite(rowWriter, index.toString))
+              .getOrElse {
+                dt match {
+                  case _: TimestampNTZNanosType | _: TimestampLTZNanosType =>
+                    s"$rowWriter.write($index, (TimestampNanosVal) null);"
+                  case _ => s"$rowWriter.setNullAt($index);"
+                }
+              }
         }
 
         val writeField = writeElement(ctx, input.value, index.toString, dt, rowWriter)
@@ -191,9 +199,16 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
       case t: DecimalType if t.precision > Decimal.MAX_LONG_DIGITS =>
         s"$arrayWriter.write($index, (Decimal) null, ${t.precision}, ${t.scale});"
       case CalendarIntervalType => s"$arrayWriter.write($index, (CalendarInterval) null);"
-      case _: TimestampNTZNanosType | _: TimestampLTZNanosType =>
-        s"$arrayWriter.write($index, (TimestampNanosVal) null);"
-      case _ => s"$arrayWriter.setNull${elementOrOffsetSize}Bytes($index);"
+      case _ =>
+        TypeOps(et)
+          .flatMap(_.getCodegenNullWrite(arrayWriter, index))
+          .getOrElse {
+            et match {
+              case _: TimestampNTZNanosType | _: TimestampLTZNanosType =>
+                s"$arrayWriter.write($index, (TimestampNanosVal) null);"
+              case _ => s"$arrayWriter.setNull${elementOrOffsetSize}Bytes($index);"
+            }
+          }
     }
 
     val elementAssignment = if (containsNull) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -537,11 +537,21 @@ case class Literal (value: Any, dataType: DataType) extends LeafExpression {
           }
         case ByteType | ShortType =>
           ExprCode.forNonNullValue(JavaCode.expression(s"($javaType)$value", dataType))
-        case TimestampType | TimestampNTZType | LongType | _: DayTimeIntervalType | _: TimeType =>
+        case TimestampType | TimestampNTZType | LongType | _: DayTimeIntervalType =>
           toExprCode(s"${value}L")
         case _ =>
-          val constRef = ctx.addReferenceObj("literal", value, javaType)
-          ExprCode.forNonNullValue(JavaCode.global(constRef, dataType))
+          TypeOps(dataType)
+            .map(ops => toExprCode(ops.getJavaLiteral(value)))
+            .getOrElse {
+              // `references` is an Object[], so casting an element to a primitive type (e.g.
+              // `((long) references[i])`) does not compile. Cast to the boxed type instead and
+              // let Java auto-unbox the value when it is consumed in a primitive context.
+              val refClass =
+                if (CodeGenerator.isPrimitiveType(javaType)) CodeGenerator.boxedType(javaType)
+                else javaType
+              val constRef = ctx.addReferenceObj("literal", value, refClass)
+              ExprCode.forNonNullValue(JavaCode.global(constRef, dataType))
+            }
       }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/ops/TimeTypeOps.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/ops/TimeTypeOps.scala
@@ -22,7 +22,7 @@ import java.time.LocalTime
 import org.apache.arrow.vector.{TimeNanoVector, ValueVector}
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, MutableLong, MutableValue}
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, MutableLong, MutableValue, SpecializedGetters}
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalLongType}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -69,6 +69,9 @@ case class TimeTypeOps(override val t: TimeType) extends TimeTypeApiOps(t) with 
   override def getRowWriter(ordinal: Int): (InternalRow, Any) => Unit =
     (input, v) => input.setLong(ordinal, v.asInstanceOf[Long])
 
+  override def getScalaAccessor: (SpecializedGetters, Int) => Any =
+    (input, ordinal) => input.getLong(ordinal)
+
   // ==================== Literal Creation ====================
 
   override def getDefaultLiteral: Literal = Literal.create(0L, t)
@@ -89,6 +92,14 @@ case class TimeTypeOps(override val t: TimeType) extends TimeTypeApiOps(t) with 
   override def toScalaImpl(row: InternalRow, column: Int): Any = {
     DateTimeUtils.nanosToLocalTime(row.getLong(column))
   }
+
+  // ==================== Code Generation ====================
+
+  override def getCodegenGetter(input: String, ordinal: String): String =
+    s"$input.getLong($ordinal)"
+
+  override def getCodegenSetter(row: String, ordinal: Int, value: String): String =
+    s"$row.setLong($ordinal, $value)"
 
   // ==================== Optional Operations ====================
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/ops/TimestampNanosTypeOps.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/ops/TimestampNanosTypeOps.scala
@@ -21,7 +21,7 @@ import java.time.{Instant, LocalDateTime}
 
 import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, MutableTimestampNanos, MutableValue}
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, MutableTimestampNanos, MutableValue, SpecializedGetters}
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalTimestampLTZNanosType, PhysicalTimestampNTZNanosType}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -66,6 +66,13 @@ trait TimestampNanosTypeOps extends TypeOps {
       s"${tn.epochMicros}L, (short) ${tn.nanosWithinMicro})"
   }
 
+  // ==================== Code Generation ====================
+
+  // Both NTZ and LTZ store a variable-length 16-byte payload in UnsafeRow, so a typed null must
+  // use the write(i, (TimestampNanosVal) null) overload rather than setNullAt.
+  override def getCodegenNullWrite(writer: String, index: String): Option[String] =
+    Some(s"$writer.write($index, (TimestampNanosVal) null);")
+
   // ==================== External Type Conversion ====================
 
   // Raises the same error as the legacy CatalystTypeConverters (SPARK-57033) when an external
@@ -93,6 +100,15 @@ case class TimestampNTZNanosTypeOps(override val t: TimestampNTZNanosType)
 
   override def getRowWriter(ordinal: Int): (InternalRow, Any) => Unit =
     (input, v) => input.setTimestampNTZNanos(ordinal, v.asInstanceOf[TimestampNanosVal])
+
+  override def getScalaAccessor: (SpecializedGetters, Int) => Any =
+    (input, ordinal) => input.getTimestampNTZNanos(ordinal)
+
+  override def getCodegenGetter(input: String, ordinal: String): String =
+    s"$input.getTimestampNTZNanos($ordinal)"
+
+  override def getCodegenSetter(row: String, ordinal: Int, value: String): String =
+    s"$row.setTimestampNTZNanos($ordinal, $value)"
 
   override def toCatalystImpl(scalaValue: Any): Any = scalaValue match {
     case l: LocalDateTime => DateTimeUtils.localDateTimeToTimestampNanos(l, t.precision)
@@ -137,6 +153,15 @@ case class TimestampLTZNanosTypeOps(override val t: TimestampLTZNanosType)
 
   override def getRowWriter(ordinal: Int): (InternalRow, Any) => Unit =
     (input, v) => input.setTimestampLTZNanos(ordinal, v.asInstanceOf[TimestampNanosVal])
+
+  override def getScalaAccessor: (SpecializedGetters, Int) => Any =
+    (input, ordinal) => input.getTimestampLTZNanos(ordinal)
+
+  override def getCodegenGetter(input: String, ordinal: String): String =
+    s"$input.getTimestampLTZNanos($ordinal)"
+
+  override def getCodegenSetter(row: String, ordinal: Int, value: String): String =
+    s"$row.setTimestampLTZNanos($ordinal, $value)"
 
   override def toCatalystImpl(scalaValue: Any): Any = scalaValue match {
     case i: Instant => DateTimeUtils.instantToTimestampNanos(i, t.precision)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/ops/TypeOps.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/ops/TypeOps.scala
@@ -23,7 +23,7 @@ import org.apache.arrow.vector.ValueVector
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.WalkedTypePath
-import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, MutableValue}
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, MutableValue, SpecializedGetters}
 import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.execution.arrow.ArrowFieldWriter
 import org.apache.spark.sql.internal.SQLConf
@@ -112,6 +112,17 @@ trait TypeOps extends Serializable {
    */
   def getRowWriter(ordinal: Int): (InternalRow, Any) => Unit
 
+  /**
+   * Returns an accessor function for reading this type's raw internal value from a row.
+   *
+   * Used by InternalRow.getAccessor. Returns the internal Catalyst representation (e.g., Long for
+   * TimeType, TimestampNanosVal for nanosecond timestamps), not the external Scala type.
+   *
+   * @return
+   *   accessor function (SpecializedGetters, Int) => Any
+   */
+  def getScalaAccessor: (SpecializedGetters, Int) => Any
+
   // ==================== Literal Creation ====================
 
   /**
@@ -192,6 +203,54 @@ trait TypeOps extends Serializable {
   final def toScala(row: InternalRow, column: Int): Any = {
     if (row.isNullAt(column)) null else toScalaImpl(row, column)
   }
+
+  // ==================== Code Generation ====================
+
+  /**
+   * Returns the Java expression string that reads a value of this type from a row in generated
+   * code.
+   *
+   * @param input
+   *   Java variable name of the SpecializedGetters / InternalRow
+   * @param ordinal
+   *   Java expression for the column ordinal
+   * @return
+   *   Java expression string, e.g. "input.getTimestampNTZNanos(ordinal)"
+   */
+  def getCodegenGetter(input: String, ordinal: String): String
+
+  /**
+   * Returns the Java statement string that writes a value of this type into a row in generated
+   * code.
+   *
+   * @param row
+   *   Java variable name of the InternalRow
+   * @param ordinal
+   *   column ordinal
+   * @param value
+   *   Java expression for the value to write
+   * @return
+   *   Java statement string, e.g. "row.setTimestampNTZNanos(ordinal, value)"
+   */
+  def getCodegenSetter(row: String, ordinal: Int, value: String): String
+
+  /**
+   * Returns the Java statement string that writes a typed null into an UnsafeWriter in generated
+   * code, or None to delegate to the caller's default.
+   *
+   * Fixed-size (primitive-backed) types return None: the caller knows the right default for its
+   * context (setNullAt for row writers, setNullXBytes for array writers). Variable-length types
+   * (e.g. nanosecond timestamps) return Some(...) with the typed write(i, (Type) null) overload
+   * that preserves the variable-length offset.
+   *
+   * @param writer
+   *   Java variable name of the UnsafeRowWriter / UnsafeArrayWriter
+   * @param index
+   *   Java expression for the column index
+   * @return
+   *   Some(Java statement string) for variable-length types; None for fixed-size types
+   */
+  def getCodegenNullWrite(writer: String, index: String): Option[String] = None
 
   // ==================== Serialization (optional) ====================
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -552,6 +552,18 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
+  test("SPARK-57101: literal codegen with the Types Framework disabled") {
+    // With the framework off, TypeOps(dt) is empty and Literal.doGenCode falls back to
+    // addReferenceObj. The reference array is Object[], so a primitive-typed value (e.g. TimeType,
+    // backed by long) must be cast via its boxed type or the generated code does not compile.
+    withSQLConf(SQLConf.TYPES_FRAMEWORK_ENABLED.key -> "false") {
+      val time = LocalTime.of(12, 13, 14)
+      DataTypeTestUtils.timeTypes.foreach { tt =>
+        checkEvaluation(Literal.create(time, tt), localTime(12, 13, 14))
+      }
+    }
+  }
+
   test("SPARK-37967: Literal.create support ObjectType") {
     checkEvaluation(
       Literal.create(UTF8String.fromString("Spark SQL"), ObjectType(classOf[UTF8String])),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/types/ops/TimestampNanosTypeOpsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/types/ops/TimestampNanosTypeOpsSuite.scala
@@ -24,7 +24,8 @@ import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.encoders.{AgnosticEncoder, ExpressionEncoder}
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.{InstantNanosEncoder, LocalDateTimeNanosEncoder, OptionEncoder}
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, Literal, MutableTimestampNanos, SpecificInternalRow}
-import org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodeGenerator, CodegenContext}
+import org.apache.spark.sql.catalyst.types.ops.{TimestampLTZNanosTypeOps, TimestampNTZNanosTypeOps}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalTimestampLTZNanosType, PhysicalTimestampNTZNanosType}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -123,6 +124,56 @@ class TimestampNanosTypeOpsSuite extends SparkFunSuite with SQLHelper {
         val e = intercept[org.apache.spark.SparkException](TypeApiOps(dt).get.getEncoder)
         assert(e.getCondition === "FEATURE_NOT_ENABLED")
       }
+    }
+  }
+
+  test("getScalaAccessor reads the correct NTZ/LTZ value via InternalRow.getAccessor") {
+    allCases.foreach { case (dt, _, value) =>
+      val accessor = InternalRow.getAccessor(dt)
+      val row = new GenericInternalRow(Array[Any](value))
+      assert(accessor(row, 0) === value, s"getScalaAccessor roundtrip for $dt")
+      val nullRow = new GenericInternalRow(Array[Any](null))
+      assert(accessor(nullRow, 0) === null, s"getScalaAccessor null for $dt")
+    }
+  }
+
+  test("CodeGenerator.javaType routes through getJavaClass.getSimpleName") {
+    allCases.foreach { case (dt, _, _) =>
+      assert(CodeGenerator.javaType(dt) === "TimestampNanosVal",
+        s"javaType for $dt")
+    }
+  }
+
+  test("getCodegenGetter and getCodegenSetter produce correct method-call strings") {
+    val ntzOps = TimestampNTZNanosTypeOps(TimestampNTZNanosType(9))
+    assert(ntzOps.getCodegenGetter("row", "i") === "row.getTimestampNTZNanos(i)")
+    assert(ntzOps.getCodegenSetter("row", 0, "v") === "row.setTimestampNTZNanos(0, v)")
+
+    val ltzOps = TimestampLTZNanosTypeOps(TimestampLTZNanosType(7))
+    assert(ltzOps.getCodegenGetter("row", "i") === "row.getTimestampLTZNanos(i)")
+    assert(ltzOps.getCodegenSetter("row", 0, "v") === "row.setTimestampLTZNanos(0, v)")
+  }
+
+  test("getCodegenNullWrite returns the typed-null write statement for variable-length nanos") {
+    allCases.foreach { case (dt, _, _) =>
+      val ops = TypeOps(dt).get
+      assert(ops.getCodegenNullWrite("w", "3") ===
+        Some("w.write(3, (TimestampNanosVal) null);"),
+        s"getCodegenNullWrite for $dt")
+    }
+  }
+
+  test("Literal.doGenCode emits getJavaLiteral inline, not a reference object") {
+    allCases.foreach { case (dt, _, value) =>
+      val literal = Literal.create(value, dt)
+      val ctx = new CodegenContext
+      val ev = literal.genCode(ctx)
+      // The generated value expression must contain the inline fromParts(...) call produced
+      // by getJavaLiteral, rather than a global field reference (addReferenceObj path).
+      assert(ev.value.code.contains("fromParts"),
+        s"expected inline fromParts call for $dt, got: ${ev.value.code}")
+      assert(!ctx.references.exists(_.isInstanceOf[TimestampNanosVal]),
+        s"TimestampNanosVal should not be added as a reference object for $dt")
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extends the Types Framework (SPARK-53504) with the codegen and row-accessor operations that were previously hardcoded in `CodeGenerator`, `InternalRow`, `GenerateUnsafeProjection`, and `Literal`, and routes those call sites through `TypeOps` so registered types own their behavior.

New `TypeOps` methods, with `TimeTypeOps` and the nanosecond timestamp Ops as the first implementors:
- `getScalaAccessor` — interpreted row accessor used by `InternalRow.getAccessor`.
- `getCodegenGetter` / `getCodegenSetter` — generated get/set expressions used by `CodeGenerator.getValue` / `setColumn`.
- `getCodegenNullWrite` — typed-null write for variable-length payloads, used by `GenerateUnsafeProjection`.

`Literal.doGenCode` now routes through `TypeOps.getJavaLiteral`, so registered types emit a self-contained inline literal instead of a heap-allocated reference object; the `addReferenceObj` fallback boxes primitive javaTypes so the generated cast compiles when the framework is disabled.

The nanosecond timestamp type registration itself landed separately in SPARK-57207 (#56266); this PR builds on top of it and serves as the example of how a registered type plugs into these framework methods.

### Why are the changes needed?

The Types Framework centralizes type-specific operations in `Ops` classes instead of scattered pattern matching. Codegen value access (`getValue`/`setColumn`), interpreted row access (`getAccessor`), unsafe-projection null writes, and literal codegen were still hardcoded per physical type. Moving them behind `TypeOps` lets registered types (e.g. `TimeType`, the nanosecond timestamp types) supply their own behavior without editing every call site.

### Does this PR introduce _any_ user-facing change?

No. The routing is gated by `spark.sql.types.framework.enabled`; when disabled, the call sites fall back to the existing legacy behavior.

### How was this patch tested?

- `TimestampNanosTypeOpsSuite`: added coverage for `getScalaAccessor` (via `InternalRow.getAccessor`), `CodeGenerator.javaType`, `getCodegenGetter`/`getCodegenSetter`, `getCodegenNullWrite`, and inline `getJavaLiteral` codegen.
- `LiteralExpressionSuite`: regression test that `TimeType` literals codegen correctly through the boxed `addReferenceObj` fallback when the framework is disabled.

```
build/sbt 'catalyst/testOnly *TimestampNanosTypeOpsSuite *LiteralExpressionSuite'
```

All tests pass; `catalyst` scalastyle is clean.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor