### PR TITLE
[SPARK-57149][SQL] Skip statically-dead common sub-expression scaffold in Project and aggregate codegen

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregateCodegenSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregateCodegenSupport.scala
@@ -242,10 +242,18 @@ trait AggregateCodegenSupport
 
     val codeToEvalAggFuncs = generateEvalCodeForAggFuncs(
       ctx, input, inputAttrs, boundUpdateExprs, aggNames, aggCodeBlocks, subExprs)
+    // Only emit the common sub-expression scaffold when subexpression elimination produced code;
+    // otherwise the comment is statically dead text emitted into every generated stage.
+    val commonSubExprs = if (effectiveCodes.nonEmpty) {
+      s"""
+         |// common sub-expressions
+         |$effectiveCodes""".stripMargin
+    } else {
+      ""
+    }
     s"""
        |// do aggregate
-       |// common sub-expressions
-       |$effectiveCodes
+       |$commonSubExprs
        |// evaluate aggregate functions and update aggregation buffers
        |$codeToEvalAggFuncs
      """.stripMargin

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -768,9 +768,16 @@ case class HashAggregateExec(
 
       val codeToEvalAggFuncs = generateEvalCodeForAggFuncs(
         ctx, input, inputAttrs, boundUpdateExprs, aggNames, aggCodeBlocks, subExprs)
+      // Only emit the common sub-expression scaffold when subexpression elimination produced code.
+      val commonSubExprs = if (effectiveCodes.nonEmpty) {
+        s"""
+           |// common sub-expressions
+           |$effectiveCodes""".stripMargin
+      } else {
+        ""
+      }
       s"""
-         |// common sub-expressions
-         |$effectiveCodes
+         |$commonSubExprs
          |// evaluate aggregate functions and update aggregation buffers
          |$codeToEvalAggFuncs
        """.stripMargin
@@ -814,13 +821,21 @@ case class HashAggregateExec(
           val codeToEvalAggFuncs = generateEvalCodeForAggFuncs(
             ctx, input, inputAttrs, boundUpdateExprs, aggNames, aggCodeBlocks, subExprs)
 
+          // Only emit the common sub-expression scaffold when subexpression elimination produced
+          // code.
+          val commonSubExprs = if (effectiveCodes.nonEmpty) {
+            s"""
+               |  // common sub-expressions
+               |  $effectiveCodes""".stripMargin
+          } else {
+            ""
+          }
           // If vectorized fast hash map is on, we first generate code to update row
           // in vectorized fast hash map, if the previous loop up hit vectorized fast hash map.
           // Otherwise, update row in regular hash map.
           s"""
              |if ($fastRowBuffer != null) {
-             |  // common sub-expressions
-             |  $effectiveCodes
+             |  $commonSubExprs
              |  // evaluate aggregate functions and update aggregation buffers
              |  $codeToEvalAggFuncs
              |} else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -82,12 +82,24 @@ case class ProjectExec(projectList: Seq[NamedExpression], child: SparkPlan)
       ("", exprs.map(_.genCode(ctx)), Seq.empty)
     }
 
+    // Only emit the common sub-expression scaffold when subexpression elimination actually
+    // produced code. Otherwise (CSE disabled, or no common subexpressions found) the comment and
+    // empty blocks are statically dead text emitted into every generated stage. Note that
+    // `evaluateVariables` clears the code of the evaluated variables, so it must run regardless.
+    val localVals = evaluateVariables(localValInputs)
+    val commonSubExprs = if (localVals.isEmpty && subExprsCode.isEmpty) {
+      ""
+    } else {
+      s"""
+         |// common sub-expressions
+         |$localVals
+         |$subExprsCode""".stripMargin
+    }
+
     // Evaluation of non-deterministic expressions can't be deferred.
     val nonDeterministicAttrs = projectList.filterNot(_.deterministic).map(_.toAttribute)
     s"""
-       |// common sub-expressions
-       |${evaluateVariables(localValInputs)}
-       |$subExprsCode
+       |$commonSubExprs
        |${evaluateRequiredVariables(output, resultVars, AttributeSet(nonDeterministicAttrs))}
        |${consume(ctx, resultVars)}
      """.stripMargin

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -1186,4 +1186,38 @@ class WholeStageCodegenSuite extends SharedSparkSession
       }
     }
   }
+
+  test("SPARK-57149: omit dead common sub-expression scaffold in Project and aggregate codegen") {
+    def codegen(df: Dataset[Row]): String = {
+      val plan = df.queryExecution.executedPlan
+      assert(plan.exists(_.isInstanceOf[WholeStageCodegenExec]),
+        "query should be in whole-stage codegen")
+      codegenString(plan)
+    }
+
+    withSQLConf(
+      SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "true") {
+      val data = spark.range(10).selectExpr("id as a", "id + 1 as b")
+
+      // Project without common subexpressions: the scaffold is statically dead and must be omitted.
+      val plainProject = data.selectExpr("a", "b")
+      assert(!codegen(plainProject).contains("common sub-expressions"),
+        "Project without common subexpressions should not emit the dead scaffold")
+      checkAnswer(plainProject, (0 until 10).map(i => Row(i, i + 1)))
+
+      // Project with a repeated subexpression: the scaffold must still be emitted.
+      val cseProject = data.selectExpr("(a + b) as x", "(a + b) + 1 as y")
+      assert(codegen(cseProject).contains("common sub-expressions"),
+        "Project with common subexpressions should still emit the scaffold")
+      checkAnswer(cseProject, (0 until 10).map(i => Row(i + (i + 1), i + (i + 1) + 1)))
+
+      // Simple aggregate without common subexpressions: the scaffold must be omitted.
+      val plainAgg = data.groupBy("a").agg(sum("b").as("s"))
+      assert(!codegen(plainAgg).contains("common sub-expressions"),
+        "Aggregate without common subexpressions should not emit the dead scaffold")
+      checkAnswer(plainAgg, (0 until 10).map(i => Row(i, (i + 1).toLong)))
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a sub-task of [SPARK-56908](https://issues.apache.org/jira/browse/SPARK-56908).

`ProjectExec.doConsume` and the three aggregate codegen sites (`AggregateCodegenSupport` and two sites in `HashAggregateExec`) unconditionally emit a `// common sub-expressions` scaffold -- the comment plus the subexpression-elimination (CSE) code blocks -- into the generated Java, even when subexpression elimination is disabled or finds no common subexpressions. In that (overwhelmingly common) case the CSE interpolations are empty strings, so each operator contributes a dead comment line plus blank lines to every generated stage.

This PR gates the scaffold so it is only emitted when CSE actually produced code, mirroring how `FilterExec` already gates its CSE block (SPARK-56032). `ProjectExec` still calls `evaluateVariables` unconditionally for its code-clearing side effect.

### Why are the changes needed?

Reduces the size and Janino parse cost of the Java emitted by whole-stage codegen, per the [SPARK-56908](https://issues.apache.org/jira/browse/SPARK-56908) umbrella, by not emitting text that is statically dead at codegen time.

### Does this PR introduce _any_ user-facing change?

No. Only the generated code's dead comments/blank scaffolding change; behavior and results are identical.

### How was this patch tested?

New test in `WholeStageCodegenSuite` asserting the scaffold is absent for a plain projection and a simple aggregate, present for a projection with a repeated subexpression, with `checkAnswer` for correctness. Also ran `WholeStageCodegenSuite`, `SubexpressionEliminationSuite`, and `DataFrameAggregateSuite` (207 tests passed).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)