### PR TITLE
[SPARK-56305][SQL] Fix collation-aware PIVOT to use collation-sensitive comparison in PivotFirst

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PivotFirst.scala
@@ -23,8 +23,9 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.trees.BinaryLike
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.catalyst.util.{GenericArrayData, TypeUtils}
+import org.apache.spark.sql.catalyst.util.{CollationFactory, GenericArrayData, TypeUtils}
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 
 object PivotFirst {
 
@@ -87,7 +88,16 @@ case class PivotFirst(
   override val dataType: DataType = ArrayType(valueDataType)
 
   val pivotIndex: Map[Any, Int] = if (pivotColumn.dataType.isInstanceOf[AtomicType]) {
-    HashMap(pivotColumnValues.zipWithIndex: _*)
+    val entries = pivotColumn.dataType match {
+      case st: StringType if !st.supportsBinaryEquality =>
+        pivotColumnValues.zipWithIndex.map { case (v, i) =>
+          val key = if (v == null) null
+          else CollationFactory.getCollationKey(v.asInstanceOf[UTF8String], st.collationId)
+          key -> i
+        }
+      case _ => pivotColumnValues.zipWithIndex
+    }
+    HashMap(entries: _*)
   } else {
     TreeMap(pivotColumnValues.zipWithIndex: _*)(
       TypeUtils.getInterpretedOrdering(pivotColumn.dataType))
@@ -100,7 +110,13 @@ case class PivotFirst(
   // never match any pivot value.
   private def findPivotIndex(key: Any): Int = key match {
     case null if !pivotColumn.dataType.isInstanceOf[AtomicType] => -1
-    case _ => pivotIndex.getOrElse(key, -1)
+    case _ =>
+      val lookupKey = pivotColumn.dataType match {
+        case st: StringType if !st.supportsBinaryEquality && key != null =>
+          CollationFactory.getCollationKey(key.asInstanceOf[UTF8String], st.collationId)
+        case _ => key
+      }
+      pivotIndex.getOrElse(lookupKey, -1)
   }
 
   val indexSize = pivotIndex.size

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
@@ -373,6 +373,127 @@ class DataFramePivotSuite extends QueryTest with SharedSparkSession {
     assert(e.getMessage.contains("pivot is not supported on a streaming DataFrames/Datasets"))
   }
 
+  test("SPARK-56305: pivot with UTF8_LCASE collation should match case-insensitively") {
+    withTable("lcase_pivot") {
+      sql(
+        """CREATE TABLE lcase_pivot (
+          |  dept STRING COLLATE UTF8_LCASE,
+          |  amount INT
+          |) USING PARQUET""".stripMargin)
+      sql("INSERT INTO lcase_pivot VALUES ('SALES', 100), ('sales', 50)")
+
+      // With UTF8_LCASE, 'sales' should match both 'SALES' and 'sales' rows
+      checkAnswer(
+        sql(
+          """SELECT * FROM lcase_pivot
+            |PIVOT (SUM(amount) FOR dept IN ('sales' AS sales))""".stripMargin),
+        Row(150))
+    }
+  }
+
+  test("SPARK-56305: pivot with UNICODE_CI collation") {
+    withTable("uci_pivot") {
+      sql(
+        """CREATE TABLE uci_pivot (
+          |  dept STRING COLLATE UNICODE_CI,
+          |  amount INT
+          |) USING PARQUET""".stripMargin)
+      sql("INSERT INTO uci_pivot VALUES ('HR', 10), ('hr', 20), ('Hr', 30)")
+
+      checkAnswer(
+        sql(
+          """SELECT * FROM uci_pivot
+            |PIVOT (SUM(amount) FOR dept IN ('hr' AS hr))""".stripMargin),
+        Row(60))
+    }
+  }
+
+  test("SPARK-56305: pivot with multiple case-insensitive pivot values") {
+    withTable("multi_pivot") {
+      sql(
+        """CREATE TABLE multi_pivot (
+          |  dept STRING COLLATE UTF8_LCASE,
+          |  amount INT
+          |) USING PARQUET""".stripMargin)
+      sql(
+        """INSERT INTO multi_pivot VALUES
+          |('SALES', 100), ('Sales', 50), ('ENG', 200), ('eng', 80)""".stripMargin)
+
+      checkAnswer(
+        sql(
+          """SELECT * FROM multi_pivot
+            |PIVOT (SUM(amount) FOR dept IN ('sales' AS sales, 'eng' AS eng))""".stripMargin),
+        Row(150, 280))
+    }
+  }
+
+  test("SPARK-56305: pivot with binary collation keeps case-sensitive behavior") {
+    withTable("binary_pivot") {
+      sql(
+        """CREATE TABLE binary_pivot (
+          |  dept STRING,
+          |  amount INT
+          |) USING PARQUET""".stripMargin)
+      sql("INSERT INTO binary_pivot VALUES ('SALES', 100), ('sales', 50)")
+
+      // With default binary collation, 'sales' and 'SALES' are different
+      checkAnswer(
+        sql(
+          """SELECT * FROM binary_pivot
+            |PIVOT (SUM(amount) FOR dept IN ('sales' AS sales, 'SALES' AS SALES))""".stripMargin),
+        Row(50, 100))
+    }
+  }
+
+  test("SPARK-56305: pivot with non-string types still works") {
+    withTempView("int_pivot") {
+      sql(
+        """CREATE OR REPLACE TEMP VIEW int_pivot AS
+          |SELECT * FROM VALUES (1, 10), (2, 20), (1, 30) AS t(key, amount)""".stripMargin)
+
+      checkAnswer(
+        sql(
+          """SELECT * FROM int_pivot
+            |PIVOT (SUM(amount) FOR key IN (1 AS one, 2 AS two))""".stripMargin),
+        Row(40, 20))
+    }
+  }
+
+  test("SPARK-56305: pivot with NULL in collated pivot column") {
+    withTable("null_pivot") {
+      sql(
+        """CREATE TABLE null_pivot (
+          |  dept STRING COLLATE UTF8_LCASE,
+          |  amount INT
+          |) USING PARQUET""".stripMargin)
+      sql("INSERT INTO null_pivot VALUES ('sales', 100), (NULL, 50), ('SALES', 75)")
+
+      // NULL rows should be ignored, only 'sales' and 'SALES' match
+      checkAnswer(
+        sql(
+          """SELECT * FROM null_pivot
+            |PIVOT (SUM(amount) FOR dept IN ('sales' AS sales))""".stripMargin),
+        Row(175))
+    }
+  }
+
+  test("SPARK-56305: pivot with empty string pivot values and collation") {
+    withTable("empty_pivot") {
+      sql(
+        """CREATE TABLE empty_pivot (
+          |  dept STRING COLLATE UTF8_LCASE,
+          |  amount INT
+          |) USING PARQUET""".stripMargin)
+      sql("INSERT INTO empty_pivot VALUES ('', 10), ('sales', 90)")
+
+      checkAnswer(
+        sql(
+          """SELECT * FROM empty_pivot
+            |PIVOT (SUM(amount) FOR dept IN ('' AS empty, 'sales' AS sales))""".stripMargin),
+        Row(10, 90))
+    }
+  }
+
   test("SPARK-55483: pivot with null non-atomic pivot column should not throw NPE") {
     // When the pivot column is a non-atomic type (struct, array), PivotFirst uses a TreeMap
     // whose comparison-based lookup throws NPE on null keys. Null pivot column values should


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make `PivotFirst` use collation-aware key comparison when the pivot column has a non-binary collation (e.g., `UTF8_LCASE`, `UNICODE_CI`).

The fix transforms pivot value keys via `CollationFactory.getCollationKey()` before inserting into / looking up from the `pivotIndex` HashMap, so that values equal under the column's collation map to the same index.

### Why are the changes needed?

`PivotFirst` uses a `HashMap` with default (binary) equality for pivot value lookup. When the pivot column has a case-insensitive or accent-insensitive collation, values that should match (e.g., `'SALES'` and `'sales'` under `UTF8_LCASE`) are treated as different keys, producing incorrect NULLs in the pivoted output.

Repro:
```sql
CREATE TABLE t (dept STRING COLLATE UTF8_LCASE, amount INT) USING PARQUET;
INSERT INTO t VALUES ('SALES', 100), ('sales', 50);
SELECT * FROM t PIVOT (SUM(amount) FOR dept IN ('sales' AS sales));
-- Expected: 150
-- Actual (before fix): NULL
```

### Does this PR introduce _any_ user-facing change?

Yes — PIVOT queries on columns with non-binary collations now correctly match values according to the column's collation rules instead of producing incorrect NULLs.

### How was this patch tested?

Added 7 new tests to `DataFramePivotSuite`:
- UTF8_LCASE collation (case-insensitive matching)
- UNICODE_CI collation
- Multiple pivot values with mixed case
- Binary collation preserved (no regression — different cases remain distinct)
- Non-string types (INT) still work
- NULL handling in pivot column
- Empty string pivot values

All 40 existing tests in `DataFramePivotSuite` continue to pass.

### Was this patch authored or co-authored using generative AI tooling?

Yes.