### PR TITLE
[SPARK-34679][SQL][DOCS] Add inferTimestamp option to JSON data source options table

### DIFF
--- a/docs/sql-data-sources-json.md
+++ b/docs/sql-data-sources-json.md
@@ -202,6 +202,12 @@ Data source options of JSON can be set via:
     <td>read/write</td>
   </tr>
   <tr>
+    <td><code>inferTimestamp</code></td>
+    <td><code>false</code></td>
+    <td>Allows inferring of <code>TimestampType</code> and <code>TimestampNTZType</code> from strings that match the timestamp patterns defined by the <code>timestampFormat</code> and <code>timestampNTZFormat</code> options respectively.</td>
+    <td>read</td>
+  </tr>
+  <tr>
     <td><code>enableDateTimeParsingFallback</code></td>
     <td>Enabled if the time parser policy has legacy settings or if no custom date or timestamp pattern was provided.</td>
     <td>Allows falling back to the backward compatible (Spark 1.x and 2.0) behavior of parsing dates and timestamps if values do not match the set patterns.</td>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added the missing `inferTimestamp` option to the Data Source Options table in
`docs/sql-data-sources-json.md`. The option was absent from the table despite
being available since Spark 3.0.1 and referenced in the migration guide.

The new row is placed after `timestampNTZFormat` (the options it relates to)
with the description matching the Scaladoc in `JSONOptions.scala`:

> Allows inferring of `TimestampType` and `TimestampNTZType` from strings that
> match the timestamp patterns defined by the `timestampFormat` and
> `timestampNTZFormat` options respectively.

### Why are the changes needed?

Users have no way to discover `inferTimestamp` from the official options
reference. The option is already mentioned in the migration guide
(`sql-migration-guide.md`) but was never added to the options table.

Fixes https://issues.apache.org/jira/browse/SPARK-34679

### Does this PR introduce _any_ user-facing change?

No. Documentation only.

### How was this patch tested?

No code change — documentation only. Verified the option is defined in
`JSONOptions.scala` with `inferTimestamp` as the key name and `false` as the
default.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude (Anthropic)