### PR TITLE
[SPARK-57200] Fix JVM Codegen Bug - NULL for 3-arg form with column nullReplacement

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2308,9 +2308,16 @@ case class ArrayJoin(
         }
       }
     } else {
+      // When array and delimiter are both non-nullable, neither nullSafeExec wrapper above runs,
+      // so reset ev.isNull here. doGenCode initializes ev.isNull to true whenever the expression
+      // is nullable (e.g. a nullable nullReplacement), and without this reset the computed result
+      // would be discarded as NULL. When the expression is non-nullable, ev.isNull is a literal
+      // false and must not be assigned.
+      val resetIsNull = if (nullable) s"${ev.isNull} = false;" else ""
       s"""
          |${arrayGen.code}
          |${delimiterGen.code}
+         |$resetIsNull
          |$resultCode""".stripMargin
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -962,6 +962,33 @@ class CollectionExpressionsSuite
       Some(Literal.create(null, StringType))), null)
   }
 
+  test("ArrayJoin codegen with non-nullable array/delimiter and nullable " +
+    "nullReplacement") {
+    // When an upstream IsNotNull filter tightens the array and delimiter to
+    // non-nullable but the nullReplacement is a nullable column, ArrayJoin.nullable is true so
+    // doGenCode initializes ev.isNull = true. The non-nullable branch of
+    // genCodeForArrayAndDelimiter must still reset ev.isNull = false, otherwise codegen builds the
+    // joined string but discards it as NULL while interpreted eval() returns the correct result.
+    val arr = BoundReference(0, ArrayType(StringType, containsNull = true), nullable = false)
+    val delimiter = BoundReference(1, StringType, nullable = false)
+    val nullReplacement = BoundReference(2, StringType, nullable = true)
+    val arrayJoin = ArrayJoin(arr, delimiter, Some(nullReplacement))
+    // ArrayJoin is nullable only because nullReplacement is nullable.
+    assert(arrayJoin.nullable)
+
+    // Non-null replacement: NULL array elements are replaced and a joined string is produced.
+    checkEvaluation(
+      arrayJoin,
+      "a,NR,b",
+      create_row(Seq[String]("a", null, "b"), ",", "NR"))
+
+    // Null replacement value: the whole result is NULL, matching eval().
+    checkEvaluation(
+      arrayJoin,
+      null,
+      create_row(Seq[String]("a", null, "b"), ",", null))
+  }
+
   test("ArraysZip") {
     val literals = Seq(
       Literal.create(Seq(9001, 9002, 9003, null), ArrayType(IntegerType)),

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -2009,7 +2009,7 @@ class DataFrameFunctionsSuite extends SharedSparkSession {
       spark.catalog.cacheTable("array_join_codegen")
 
       val query =
-        "SELECT array_join(arr, ',', repl_col) FROM array_join_codegen " +
+        "SELECT array_join(arr, delim_col, repl_col) FROM array_join_codegen " +
           "WHERE arr IS NOT NULL AND delim_col IS NOT NULL"
 
       withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> "CODEGEN_ONLY") {
@@ -2017,13 +2017,13 @@ class DataFrameFunctionsSuite extends SharedSparkSession {
         assert(
           df.queryExecution.executedPlan.exists(_.isInstanceOf[WholeStageCodegenExec]),
           "expected the array_join query to run inside whole-stage codegen")
-        checkAnswer(df, Seq(Row("a,NR,b"), Row(null), Row("x,y")))
+        checkAnswer(df, Seq(Row("a,NR,b"), Row(null), Row("x-y")))
       }
 
       withSQLConf(
           SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
           SQLConf.CODEGEN_FACTORY_MODE.key -> "NO_CODEGEN") {
-        checkAnswer(sql(query), Seq(Row("a,NR,b"), Row(null), Row("x,y")))
+        checkAnswer(sql(query), Seq(Row("a,NR,b"), Row(null), Row("x-y")))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.Cast._
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, UTC}
+import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -1991,6 +1992,40 @@ class DataFrameFunctionsSuite extends SharedSparkSession {
       ),
       queryContext = Array(ExpectedContext("", "", 0, 21, "array_join(x, ', ', 1)"))
     )
+  }
+
+  test("array_join with nullable nullReplacement under whole-stage codegen") {
+    // With a nullable nullReplacement column and an upstream IsNotNull
+    // filter that tightens the array (and delimiter) to non-nullable, whole-stage codegen used to
+    // build the joined string but leave ev.isNull = true, discarding every row as NULL. The result
+    // must match interpreted eval(). The source is materialized via a cached temp view (an
+    // InMemoryRelation), so the plan is not folded to interpreted eval by ConvertToLocalRelation.
+    withTempView("array_join_codegen") {
+      Seq(
+        (Seq[String]("a", null, "b"), ",", "NR"),
+        (Seq[String]("a", null, "b"), ",", null),
+        (Seq[String]("x", "y"), "-", "NR")
+      ).toDF("arr", "delim_col", "repl_col").createOrReplaceTempView("array_join_codegen")
+      spark.catalog.cacheTable("array_join_codegen")
+
+      val query =
+        "SELECT array_join(arr, ',', repl_col) FROM array_join_codegen " +
+          "WHERE arr IS NOT NULL AND delim_col IS NOT NULL"
+
+      withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> "CODEGEN_ONLY") {
+        val df = sql(query)
+        assert(
+          df.queryExecution.executedPlan.exists(_.isInstanceOf[WholeStageCodegenExec]),
+          "expected the array_join query to run inside whole-stage codegen")
+        checkAnswer(df, Seq(Row("a,NR,b"), Row(null), Row("x,y")))
+      }
+
+      withSQLConf(
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
+          SQLConf.CODEGEN_FACTORY_MODE.key -> "NO_CODEGEN") {
+        checkAnswer(sql(query), Seq(Row("a,NR,b"), Row(null), Row("x,y")))
+      }
+    }
   }
 
   test("array_min function") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR fixes a whole-stage codegen (WSCG) correctness bug in ArrayJoin (array_join) where the generated code computes the correct joined string but discards it as NULL.

`ArrayJoin.doGenCode` initializes `ev.isNull = true` whenever the expression is nullable (which is the case when the optional `nullReplacement` argument is a nullable column). The actual join is then produced by `genCodeForArrayAndDelimiter`, which has two branches:

When array or delimiter is nullable, the body is wrapped in `nullSafeExec` and explicitly emits `ev.isNull = false` before building the result. When both array and delimiter are non-nullable, the else branch builds the result but never resets `ev.isNull`, leaving it at its initialized true. 

A minimal reproduction:


      SET spark.sql.codegen.wholeStage = true;
      SET spark.sql.codegen.factoryMode = CODEGEN_ONLY;
      -- Returns NULL for every row (buggy):
      SELECT array_join(
               array('a', 'b'),
               ',',
               CASE WHEN id % 2 = 0 THEN 'NR' ELSE CAST(NULL AS STRING) END
             ) AS r
      FROM range(4);
      SET spark.sql.codegen.wholeStage = false;
      SET spark.sql.codegen.factoryMode = NO_CODEGEN;
      -- Returns ['a,NR,b', NULL, 'a,NR,b', NULL] (correct):
      SELECT array_join(
               array('a', 'b'),
               ',',
               CASE WHEN id % 2 = 0 THEN 'NR' ELSE CAST(NULL AS STRING) END
             ) AS r
      FROM range(4);



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This is a silent correctness bug: `array_join(arr, delimiter, repl)` returns `NULL` for every row instead of the joined string, but only under a specific (and realistic) combination:

- The third argument nullReplacement is a nullable, non-foldable column, so `ArrayJoin.nullable` is true.
- An upstream `Filter` containing `IsNotNull(array)` (and/or `IsNotNull(delimiter)`) tightens those children to non-nullable. `FilterExec.output` marks `IsNotNull`-referenced attributes as non-nullable, and `UpdateAttributeNullability` propagates this downstream, so `genCodeForArrayAndDelimiter` takes the non-nullable else branch.
- The query stays in whole-stage codegen over a materialized source (e.g. `FileScan parquet`, or an `InMemoryRelation` from `CACHE TABLE`). Inline `VALUES / WITH` sources are folded by `ConvertToLocalRelation` to interpreted `eval()` and therefore do not hit the bug.

Interpreted `eval()` returns the correct result, so the same query produces different answers depending on whether codegen kicks in.




### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. It fixes incorrect results. Previously, `array_join(arr, delimiter, nullReplacement)` could return `NULL` for every row under whole-stage codegen when nullReplacement was a nullable column and an upstream `IsNotNull` filter made the array/delimiter non-nullable. After this change, such queries return the correctly joined string, matching interpreted execution. Queries that were already correct (2-arg form, literal non-null `nullReplacement`, no upstream `IsNotNull` filter, or non-codegen execution) are unaffected.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit testing in `CollectionExpressionsSuite` and `DataFrameFunctionsSuite`


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Opus 4.8