### PR TITLE
[SPARK-56561][PYTHON][DOCS] Document order preservation for array_distinct, array_intersect, array_union, array_except

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -19790,7 +19790,8 @@ def array_remove(col: "ColumnOrName", element: Any) -> Column:
 @_try_remote_functions
 def array_distinct(col: "ColumnOrName") -> Column:
     """
-    Array function: removes duplicate values from the array.
+    Array function: removes duplicate values from the array, preserving the order of
+    first occurrence.
 
     .. versionadded:: 2.4.0
 
@@ -19970,7 +19971,7 @@ def array_insert(arr: "ColumnOrName", pos: Union["ColumnOrName", int], value: An
 def array_intersect(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     """
     Array function: returns a new array containing the intersection of elements in col1 and col2,
-    without duplicates.
+    without duplicates, preserving the order of elements from col1.
 
     .. versionadded:: 2.4.0
 
@@ -20063,7 +20064,7 @@ def array_intersect(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
 def array_union(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     """
     Array function: returns a new array containing the union of elements in col1 and col2,
-    without duplicates.
+    without duplicates, preserving the order from col1 followed by elements in col2 not in col1.
 
     .. versionadded:: 2.4.0
 
@@ -20156,7 +20157,7 @@ def array_union(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
 def array_except(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     """
     Array function: returns a new array containing the elements present in col1 but not in col2,
-    without duplicates.
+    without duplicates, preserving the order of elements from col1.
 
     .. versionadded:: 2.4.0
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added explicit order-preservation notes to the docstrings of four array set
functions in PySpark: `array_distinct`, `array_intersect`, `array_union`, and
`array_except`. Previously the docstrings were silent on whether input order is
preserved, leaving users to guess or test empirically.

The additions are:

- `array_distinct`: *preserving the order of first occurrence*
- `array_intersect`: *preserving the order of elements from col1*
- `array_union`: *preserving the order from col1 followed by elements in col2 not in col1*
- `array_except`: *preserving the order of elements from col1*

### Why are the changes needed?

Order-preservation is a useful guarantee for users composing these functions in
pipelines — e.g. knowing that `array_distinct` keeps the first occurrence means
there is no need to sort afterwards to get a stable result. This is useful to
cite in code reviews and helps inform AI coding assistants as noted in
SPARK-56561.

Fixes https://issues.apache.org/jira/browse/SPARK-56561

### Does this PR introduce _any_ user-facing change?

No. Documentation (docstring) only — no logic changes.

### How was this patch tested?

No logic change. Confirmed order-preservation behavior by reading the
`ArraySetLike` trait and `ArrayDistinct`, `ArrayIntersect`, `ArrayUnion`, and
`ArrayExcept` implementations in `collectionOperations.scala`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude (Anthropic)