### PR TITLE
[SPARK-57202][SQL] Skip dead null checks in In expression codegen for non-null list elements

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -557,16 +557,34 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate {
       val valueArg = ctx.freshName("valueArg")
       // All the blocks are meant to be inside a do { ... } while (false); loop.
       // The evaluation of variables can be stopped when we find a matching value.
-      val listCode = listGen.map(x =>
-        s"""
-           |${x.code}
-           |if (${x.isNull}) {
-           |  $tmpResult = $HAS_NULL; // ${ev.isNull} = true;
-           |} else if (${ctx.genEqual(value.dataType, valueArg, x.value)}) {
-           |  $tmpResult = $MATCHED; // ${ev.isNull} = false; ${ev.value} = true;
-           |  continue;
-           |}
-         """.stripMargin)
+      val listCode = listGen.map { x =>
+        if (x.isNull == FalseLiteral) {
+          // The list element is statically non-null, so the HAS_NULL branch is dead code.
+          s"""
+             |${x.code}
+             |if (${ctx.genEqual(value.dataType, valueArg, x.value)}) {
+             |  $tmpResult = $MATCHED; // ${ev.isNull} = false; ${ev.value} = true;
+             |  continue;
+             |}
+           """.stripMargin
+        } else if (x.isNull == TrueLiteral) {
+          // The list element is statically null, so it can only contribute HAS_NULL.
+          s"""
+             |${x.code}
+             |$tmpResult = $HAS_NULL; // ${ev.isNull} = true;
+           """.stripMargin
+        } else {
+          s"""
+             |${x.code}
+             |if (${x.isNull}) {
+             |  $tmpResult = $HAS_NULL; // ${ev.isNull} = true;
+             |} else if (${ctx.genEqual(value.dataType, valueArg, x.value)}) {
+             |  $tmpResult = $MATCHED; // ${ev.isNull} = false; ${ev.value} = true;
+             |  continue;
+             |}
+           """.stripMargin
+        }
+      }
 
       val codes = ctx.splitExpressionsWithCurrentInputs(
         expressions = listCode,


### PR DESCRIPTION
### What changes were proposed in this pull request?

`In`'s whole-stage codegen emits, for each list element `x`:

```java
if (x.isNull) {
  inTmpResult = -1; // HAS_NULL
} else if (value == x) {
  inTmpResult = 1;  // MATCHED
  continue;
}
```

IN lists are usually constant literals, so `x.isNull` is the literal `false` and the `HAS_NULL` branch is dead (`if (false) { inTmpResult = -1; } else if ...`). This PR emits only the equality check when `x.isNull == FalseLiteral`. Symmetrically, when an element is statically null (`x.isNull == TrueLiteral`, e.g. `IN (NULL, ...)`), only the `HAS_NULL` assignment is emitted and the dead equality check is dropped.

### Why are the changes needed?

Sub-task of SPARK-56908 (reduce generated Java size in whole-stage codegen). Dumping the TPC-DS whole-stage codegen shows ~348 dead `if (false) { inTmpResult = -1; } else if (...)` blocks from `In` over literal lists. Emitting only the live branch removes the dead conditional from the generated code.

### Does this PR introduce _any_ user-facing change?

No. The generated code is smaller but evaluates IN with identical (including null) semantics: a statically non-null element can never set `HAS_NULL`, and a statically null element can never match, so dropping those dead branches is equivalent.

### How was this patch tested?

Behavior-preserving change covered by `PredicateSuite` (70 tests, including `In` with null list elements and a null left-hand value), all pass. Additionally verified by re-dumping the TPC-DS whole-stage codegen: the ~348 dead `if (false)` blocks in `In` are gone and every generated subtree still compiles.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
