### PR TITLE
[SPARK-57203][INFRA] Improve dev/merge_spark_pr.py to continue prompting on mistyped branch name

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -542,10 +542,21 @@ def cherry_pick(pr_num, merge_hash, default_branch, branch_names, target_ref, al
     BOTH (the policy-compliant default) or branch-M.N only (treated as a
     maintenance-only bugfix). Returns the list of refs actually picked into, so
     the main loop can advance its remaining-branches list correctly.
+
+    The branch prompt re-prompts on a typo: an entered name that is not one of
+    the known release branches (`branch_names`) is rejected with the list of
+    valid branches, rather than crashing later on a failed `git fetch`.
     """
-    pick_ref = bold_input("Enter a branch name [%s]: " % default_branch)
-    if pick_ref == "":
-        pick_ref = default_branch
+    while True:
+        pick_ref = bold_input("Enter a branch name [%s]: " % default_branch)
+        if pick_ref == "":
+            pick_ref = default_branch
+        if pick_ref in branch_names:
+            break
+        print_error(
+            "'%s' is not a known release branch. Valid branches: %s. Please try again."
+            % (pick_ref, ", ".join(branch_names))
+        )
 
     sibling_x = _upstream_first_sibling(target_ref, pick_ref, branch_names, already_picked)
     if sibling_x is not None:

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -542,20 +542,17 @@ def cherry_pick(pr_num, merge_hash, default_branch, branch_names, target_ref, al
     BOTH (the policy-compliant default) or branch-M.N only (treated as a
     maintenance-only bugfix). Returns the list of refs actually picked into, so
     the main loop can advance its remaining-branches list correctly.
-
-    The branch prompt re-prompts on a typo: an entered name that is not one of
-    the known release branches (`branch_names`) is rejected with the list of
-    valid branches, rather than crashing later on a failed `git fetch`.
     """
     while True:
-        pick_ref = bold_input("Enter a branch name [%s]: " % default_branch)
+        pick_ref = bold_input(f"Enter a branch name [{default_branch}]: ")
         if pick_ref == "":
             pick_ref = default_branch
         if pick_ref in branch_names:
             break
+        valid_branches = ", ".join(branch_names)
         print_error(
-            "'%s' is not a known release branch. Valid branches: %s. Please try again."
-            % (pick_ref, ", ".join(branch_names))
+            f"'{pick_ref}' is not a known release branch. "
+            f"Valid branches: {valid_branches}. Please try again."
         )
 
     sibling_x = _upstream_first_sibling(target_ref, pick_ref, branch_names, already_picked)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes the cherry-pick branch prompt in `dev/merge_spark_pr.py` re-prompt on a typo instead of crashing.

Previously, `cherry_pick` read a branch name and passed it straight to `_do_cherry_pick`, whose first action is `git fetch <PUSH_REMOTE> <pick_ref>:<temp>`. `run_cmd` uses `subprocess.check_output`, which raises `CalledProcessError` on a non-zero exit. The `try/except` in `_do_cherry_pick` only wraps the later `git cherry-pick` call, not this fetch, so a mistyped branch name made the fetch fail and the exception propagated to the top-level handler in `main`, which cleaned up the temp branches and re-raised, aborting the entire merge session with a traceback.

The branch prompt now validates the entered name against `branch_names` (the list of `branch-*` release branches already fetched from the GitHub API) in a loop. On an unrecognized name it prints the list of valid branches and re-prompts; an empty input still accepts the default branch (which is always valid).

### Why are the changes needed?

Mistyping a branch name at the cherry-pick prompt is an easy mistake for a committer to make, and it previously crashed the whole merge tool, forcing the committer to restart the merge/backport flow. Re-prompting lets them simply correct the typo and continue.

### Does this PR introduce _any_ user-facing change?

No. This only affects the committer-facing behavior of the merge tool: the cherry-pick branch prompt now re-prompts on an invalid branch name instead of aborting.

### How was this patch tested?

Ran the module's doctests (`python3 -m doctest dev/merge_spark_pr.py`); all 57 tests pass. Manually verified the validation loop re-prompts on an unknown branch and accepts both a valid branch and the default (empty input).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor (Claude Opus 4.8)