### PR TITLE
[SPARK-57194][SQL] Add preOperatorOptimizationRules extension point to Optimizer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -228,6 +228,8 @@ abstract class Optimizer(catalogManager: CatalogManager)
     Batch("Aggregate", fixedPoint,
       RemoveLiteralFromGroupExpressions,
       RemoveRepetitionFromGroupExpressions),
+    Batch("Early Operator Optimization", Once,
+      earlyOperatorOptimizationRules: _*),
     operatorOptimizationBatch,
     Batch("Clean Up Temporary CTE Info", Once, CleanUpTempCTEInfo),
     // This batch rewrites plans after the operator optimization and
@@ -506,6 +508,13 @@ abstract class Optimizer(catalogManager: CatalogManager)
    * Override to provide additional rules for the operator optimization batch.
    */
   def extendedOperatorOptimizationRules: Seq[Rule[LogicalPlan]] = Nil
+
+  /**
+   * Override to provide additional rules that run in a single pass before the main
+   * operator optimization fixed-point batch. Use this for rules that must observe the
+   * pre-optimization plan shape (e.g., before FoldablePropagation rewrites predicates).
+   */
+  def earlyOperatorOptimizationRules: Seq[Rule[LogicalPlan]] = Nil
 
   /**
    * Override to provide additional rules for early projection and filter pushdown to scans.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -228,8 +228,8 @@ abstract class Optimizer(catalogManager: CatalogManager)
     Batch("Aggregate", fixedPoint,
       RemoveLiteralFromGroupExpressions,
       RemoveRepetitionFromGroupExpressions),
-    Batch("Early Operator Optimization", Once,
-      earlyOperatorOptimizationRules: _*),
+    Batch("Pre Operator Optimization", Once,
+      preOperatorOptimizationRules: _*),
     operatorOptimizationBatch,
     Batch("Clean Up Temporary CTE Info", Once, CleanUpTempCTEInfo),
     // This batch rewrites plans after the operator optimization and
@@ -514,7 +514,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
    * operator optimization fixed-point batch. Use this for rules that must observe the
    * pre-optimization plan shape (e.g., before FoldablePropagation rewrites predicates).
    */
-  def earlyOperatorOptimizationRules: Seq[Rule[LogicalPlan]] = Nil
+  def preOperatorOptimizationRules: Seq[Rule[LogicalPlan]] = Nil
 
   /**
    * Override to provide additional rules for early projection and filter pushdown to scans.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -228,6 +228,8 @@ abstract class Optimizer(catalogManager: CatalogManager)
     Batch("Aggregate", fixedPoint,
       RemoveLiteralFromGroupExpressions,
       RemoveRepetitionFromGroupExpressions),
+    // Injected rules run once here, before the operator-optimization fixed point, so they
+    // can observe the plan before FoldablePropagation/ConstantFolding rewrite it.
     Batch("Pre Operator Optimization", Once,
       preOperatorOptimizationRules: _*),
     operatorOptimizationBatch,
@@ -511,8 +513,9 @@ abstract class Optimizer(catalogManager: CatalogManager)
 
   /**
    * Override to provide additional rules that run in a single pass before the main
-   * operator optimization fixed-point batch. Use this for rules that must observe the
-   * pre-optimization plan shape (e.g., before FoldablePropagation rewrites predicates).
+   * operator optimization fixed-point batch. Use this for rules that need to observe the plan
+   * as it enters the operator-optimization fixed point (e.g., before FoldablePropagation or
+   * ConstantFolding rewrite predicates).
    */
   def preOperatorOptimizationRules: Seq[Rule[LogicalPlan]] = Nil
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensions.scala
@@ -309,6 +309,22 @@ class SparkSessionExtensions {
     optimizerRules += builder
   }
 
+  private[this] val earlyOptimizerRules = mutable.Buffer.empty[RuleBuilder]
+
+  private[sql] def buildEarlyOptimizerRules(session: SparkSession): Seq[Rule[LogicalPlan]] = {
+    earlyOptimizerRules.map(_.apply(session)).toSeq
+  }
+
+  /**
+   * Inject an optimizer `Rule` builder into the [[SparkSession]]. The injected rules will be
+   * executed in a single pass (Once) before the main operator optimization fixed-point batch.
+   * Use this for rules that must observe the pre-optimization plan shape before built-in rules
+   * like FoldablePropagation or ConstantFolding transform it.
+   */
+  def injectEarlyOptimizerRule(builder: RuleBuilder): Unit = {
+    earlyOptimizerRules += builder
+  }
+
   private[this] val preCBORules = mutable.Buffer.empty[RuleBuilder]
 
   private[sql] def buildPreCBORules(session: SparkSession): Seq[Rule[LogicalPlan]] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensions.scala
@@ -319,8 +319,8 @@ class SparkSessionExtensions {
   /**
    * Inject an optimizer `Rule` builder into the [[SparkSession]]. The injected rules will be
    * executed in a single pass (Once) before the main operator optimization fixed-point batch.
-   * Use this for rules that must observe the pre-optimization plan shape before built-in rules
-   * like FoldablePropagation or ConstantFolding transform it.
+   * Use this for rules that need to observe the plan as it enters the operator-optimization
+   * fixed point, before built-in rules like FoldablePropagation or ConstantFolding transform it.
    */
   def injectPreOperatorOptimizationRule(builder: RuleBuilder): Unit = {
     preOperatorOptimizationRuleBuilders += builder

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensions.scala
@@ -309,10 +309,11 @@ class SparkSessionExtensions {
     optimizerRules += builder
   }
 
-  private[this] val earlyOptimizerRules = mutable.Buffer.empty[RuleBuilder]
+  private[this] val preOperatorOptimizationRuleBuilders = mutable.Buffer.empty[RuleBuilder]
 
-  private[sql] def buildEarlyOptimizerRules(session: SparkSession): Seq[Rule[LogicalPlan]] = {
-    earlyOptimizerRules.map(_.apply(session)).toSeq
+  private[sql] def buildPreOperatorOptimizationRules(
+      session: SparkSession): Seq[Rule[LogicalPlan]] = {
+    preOperatorOptimizationRuleBuilders.map(_.apply(session)).toSeq
   }
 
   /**
@@ -321,8 +322,8 @@ class SparkSessionExtensions {
    * Use this for rules that must observe the pre-optimization plan shape before built-in rules
    * like FoldablePropagation or ConstantFolding transform it.
    */
-  def injectEarlyOptimizerRule(builder: RuleBuilder): Unit = {
-    earlyOptimizerRules += builder
+  def injectPreOperatorOptimizationRule(builder: RuleBuilder): Unit = {
+    preOperatorOptimizationRuleBuilders += builder
   }
 
   private[this] val preCBORules = mutable.Buffer.empty[RuleBuilder]

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -332,6 +332,9 @@ abstract class BaseSessionStateBuilder(
 
       override def extendedOperatorOptimizationRules: Seq[Rule[LogicalPlan]] =
         super.extendedOperatorOptimizationRules ++ customOperatorOptimizationRules
+
+      override def earlyOperatorOptimizationRules: Seq[Rule[LogicalPlan]] =
+        super.earlyOperatorOptimizationRules ++ customEarlyOperatorOptimizationRules
     }
   }
 
@@ -343,6 +346,16 @@ abstract class BaseSessionStateBuilder(
    */
   protected def customOperatorOptimizationRules: Seq[Rule[LogicalPlan]] = {
     extensions.buildOptimizerRules(session)
+  }
+
+  /**
+   * Custom rules that run in a single pass before the main operator optimization batch.
+   * Prefer overriding this instead of creating your own Optimizer.
+   *
+   * Note that this may NOT depend on the `optimizer` function.
+   */
+  protected def customEarlyOperatorOptimizationRules: Seq[Rule[LogicalPlan]] = {
+    extensions.buildEarlyOptimizerRules(session)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -333,8 +333,8 @@ abstract class BaseSessionStateBuilder(
       override def extendedOperatorOptimizationRules: Seq[Rule[LogicalPlan]] =
         super.extendedOperatorOptimizationRules ++ customOperatorOptimizationRules
 
-      override def earlyOperatorOptimizationRules: Seq[Rule[LogicalPlan]] =
-        super.earlyOperatorOptimizationRules ++ customEarlyOperatorOptimizationRules
+      override def preOperatorOptimizationRules: Seq[Rule[LogicalPlan]] =
+        super.preOperatorOptimizationRules ++ customPreOperatorOptimizationRules
     }
   }
 
@@ -354,8 +354,8 @@ abstract class BaseSessionStateBuilder(
    *
    * Note that this may NOT depend on the `optimizer` function.
    */
-  protected def customEarlyOperatorOptimizationRules: Seq[Rule[LogicalPlan]] = {
-    extensions.buildEarlyOptimizerRules(session)
+  protected def customPreOperatorOptimizationRules: Seq[Rule[LogicalPlan]] = {
+    extensions.buildPreOperatorOptimizationRules(session)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
@@ -133,7 +133,7 @@ class SparkSessionExtensionSuite extends PlanTest with AdaptiveSparkPlanHelper {
   }
 
   test("SPARK-57194: inject early operator optimization rule") {
-    withSession(Seq(_.injectEarlyOptimizerRule(MyRule))) { session =>
+    withSession(Seq(_.injectPreOperatorOptimizationRule(MyRule))) { session =>
       assert(session.sessionState.optimizer.batches.flatMap(_.rules).contains(MyRule(session)))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
@@ -132,9 +132,9 @@ class SparkSessionExtensionSuite extends PlanTest with AdaptiveSparkPlanHelper {
     }
   }
 
-  test("SPARK-57194: inject early operator optimization rule") {
+  test("SPARK-57194: inject pre operator optimization rule") {
     withSession(Seq(_.injectPreOperatorOptimizationRule(MyRule))) { session =>
-      assert(session.sessionState.optimizer.batches.flatMap(_.rules).contains(MyRule(session)))
+      assert(session.sessionState.optimizer.preOperatorOptimizationRules.contains(MyRule(session)))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
@@ -132,6 +132,12 @@ class SparkSessionExtensionSuite extends PlanTest with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("SPARK-57194: inject early operator optimization rule") {
+    withSession(Seq(_.injectEarlyOptimizerRule(MyRule))) { session =>
+      assert(session.sessionState.optimizer.batches.flatMap(_.rules).contains(MyRule(session)))
+    }
+  }
+
   test("inject spark planner strategy") {
     withSession(Seq(_.injectPlannerStrategy(MySparkStrategy))) { session =>
       assert(session.sessionState.planner.strategies.contains(MySparkStrategy(session)))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `preOperatorOptimizationRules` - a new optimizer extension point that runs in a `Once` batch between "Aggregate" and the main fixed-point "Operator Optimization" batch. Wired through `SparkSessionExtensions.injectPreOperatorOptimizationRule` and `BaseSessionStateBuilder`. The batch is a no-op when no rules are registered.

### Why are the changes needed?
Custom rules injected via `injectOptimizerRule` run inside the fixed-point batch alongside built-in rules (FoldablePropagation, ConstantFolding, PushDownPredicates). A rule that needs to observe the original plan shape (e.g., cross-side join predicates before they are folded into single-side constants) is silently defeated when a built-in rule transforms the plan first within the same fixed-point iteration.

None of the existing extension points cover this:

- `extendedOperatorOptimizationRules` - same fixed-point batch
- `postHocResolutionRules` - analyzer phase, too early
- `earlyScanPushDownRules` - runs after optimization, scoped to scan pushdown
- `preCBORules` - runs after operator optimization, too late


### Does this PR introduce _any_ user-facing change?
Yes. New public API will be available: `SparkSessionExtensions.injectPreOperatorOptimizationRule(builder: RuleBuilder)`.

### How was this patch tested?
- New test in `SparkSessionExtensionSuite` verifying the injected rule is wired into the `preOperatorOptimizationRules` accessor.
- All existing SparkSessionExtensionSuite tests pass.


### Was this patch authored or co-authored using generative AI tooling?
Yes.