### PR TITLE
[SPARK-57218][PYTHON] Fix mypy errors with the latest pandas-stubs

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -7606,7 +7606,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             return DataFrame(internal)
         else:
             psdf = self.copy()
-            psdf.columns = psdf.columns.droplevel(level)
+            psdf.columns = psdf.columns.droplevel(level)  # type: ignore[arg-type]
             return psdf
 
     def drop(

--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -20,7 +20,7 @@ import math
 
 import pandas as pd
 import numpy as np
-from pandas.core.base import PandasObject  # type: ignore[attr-defined]
+from pandas.core.base import PandasObject
 from pandas.core.dtypes.inference import is_integer
 
 from pyspark.sql import functions as F, Column

--- a/python/pyspark/pandas/testing.py
+++ b/python/pyspark/pandas/testing.py
@@ -143,7 +143,7 @@ def assert_frame_equal(
     if isinstance(right, ps.DataFrame):
         right = right.to_pandas()
 
-    pd.testing.assert_frame_equal(
+    pd.testing.assert_frame_equal(  # type: ignore[call-arg]
         left,
         right,
         check_dtype=check_dtype,

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -994,34 +994,34 @@ def _create_converter_to_pandas(
 
             def correct_dtype(pser: pd.Series) -> pd.Series:
                 if pser.isnull().any():
-                    return pser.astype(nullable_type, copy=False)  # type: ignore[arg-type]
+                    return pser.astype(nullable_type, copy=False)  # type: ignore[call-overload]
                 else:
-                    return pser.astype(pandas_type, copy=False)
+                    return pser.astype(pandas_type, copy=False)  # type: ignore[call-overload]
 
         elif isinstance(data_type, BooleanType) and nullable:
 
             def correct_dtype(pser: pd.Series) -> pd.Series:
                 if pser.isnull().any():
-                    return pser.astype(object, copy=False)
+                    return pser.astype(object, copy=False)  # type: ignore[call-overload]
                 else:
-                    return pser.astype(pandas_type, copy=False)
+                    return pser.astype(pandas_type, copy=False)  # type: ignore[call-overload]
 
         elif isinstance(data_type, TimestampType):
             assert timezone is not None
 
             def correct_dtype(pser: pd.Series) -> pd.Series:
                 if not isinstance(pser.dtype, pd.DatetimeTZDtype):
-                    pser = pser.astype(pandas_type, copy=False)
+                    pser = pser.astype(pandas_type, copy=False)  # type: ignore[call-overload]
                 pser = _check_series_convert_timestamps_local_tz(pser, timezone=timezone)
                 if LooseVersion(pd.__version__) < "3.0.0":
                     return pser
                 else:
-                    return pser.astype(pandas_type, copy=False)
+                    return pser.astype(pandas_type, copy=False)  # type: ignore[call-overload]
 
         else:
 
             def correct_dtype(pser: pd.Series) -> pd.Series:
-                return pser.astype(pandas_type, copy=False)
+                return pser.astype(pandas_type, copy=False)  # type: ignore[call-overload]
 
         return correct_dtype
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This fixes the mypy failures that appear once the unpinned `pandas-stubs>=2.2.0` resolves to a recent release (currently 3.0.3.260530). The newer stubs tighten `Series.astype` into strict overloads, so the dynamically-typed `dtype` arguments passed to `astype` in `pyspark.sql.pandas.types` no longer match any overload and are silenced with `# type: ignore[call-overload]`. The stubs also add `PandasObject` to `pandas.core.base`, which makes the existing `# type: ignore[attr-defined]` in `pyspark.pandas.plot.core` unused, so it is removed. `Index.droplevel` is now typed as taking `Sequence[Never]` in `pyspark.pandas.frame`, and `assert_frame_equal` no longer lists the still-supported `check_datetimelike_compat` keyword in `pyspark.pandas.testing`; both are stub inaccuracies and are silenced with the matching ignore code.

### Why are the changes needed?

`pandas-stubs` is unpinned (`>=2.2.0`) and is not a runtime dependency, so the lint image picks up the latest release when rebuilt and breaks the mypy check on master. This restores a green lint without pinning the stubs, consistent with how similar stub drift has been handled before (for example SPARK-55108 and SPARK-56765).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Ran `dev/lint-python --mypy` against `pandas-stubs==3.0.3.260530` (the version the CI image currently resolves) and confirmed the previously-failing checks pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8
