### PR TITLE
[SPARK-57219][INFRA] Pin `pandas-stubs==3.0.0.260204`

### DIFF
--- a/dev/spark-test-image/lint/Dockerfile
+++ b/dev/spark-test-image/lint/Dockerfile
@@ -96,7 +96,7 @@ RUN python3.12 -m pip install \
     'numpy==2.4.1' \
     'numpydoc' \
     'pandas' \
-    'pandas-stubs' \
+    'pandas-stubs==3.0.0.260204' \
     'plotly>=4.8' \
     'pyarrow>=23.0.0' \
     'pytest-mypy-plugins==1.9.3' \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Pin `pandas-stubs` to version `3.0.0.260204` in the lint Docker image.

### Why are the changes needed?
To fix `master` CI failure.
https://github.com/apache/spark/actions/runs/26817624260/job/79067085916

The unpinned `pandas-stubs` dependency caused the lint CI to fail when the Docker image was rebuilt and pulled in `pandas-stubs==3.0.3.260530`. The newer version changed type stubs for `Series.astype()`, `Index.droplevel()`, and `assert_frame_equal()`, causing mypy `call-overload`, `arg-type`, `call-arg`, and `unused-ignore` errors.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified `./dev/lint-python --mypy` passes locally with this pinned version.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude (via Kiro CLI, auto model selection)
