### PR TITLE
[SPARK-57224][INFRA] Add input check for merge script

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -329,7 +329,7 @@ def get_input(prompt, options, bold=True, ignore_case=True):
     Args:
         prompt: The prompt to display to the user.
         options:
-            * A dictionary of option: accepted answer to choose from.
+            * A dictionary of "option: accepted answer" to choose from.
             * A list of options.
             * A regex pattern.
         bold: Whether to use bold formatting for the prompt.
@@ -345,14 +345,12 @@ def get_input(prompt, options, bold=True, ignore_case=True):
 
     # Normalize options
     if isinstance(options, (list, tuple)):
-        options = {option: option for option in options}
+        options = {option: [option] for option in options}
 
     if isinstance(options, dict):
         for option, acceptable_answer in options.items():
-            if isinstance(acceptable_answer, str):
-                options[option] = [acceptable_answer]
             if ignore_case:
-                options[option] = [answer.lower() for answer in options[option]]
+                options[option] = [answer.lower() for answer in acceptable_answer]
 
     while True:
         if bold:

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -322,6 +322,63 @@ def bold_input(prompt) -> str:
     return input("\033[1m%s\033[0m" % prompt)
 
 
+def get_input(prompt, options, bold=True, ignore_case=True):
+    """
+    Get input from the user until a valid answer is provided.
+
+    Args:
+        prompt: The prompt to display to the user.
+        options:
+            * A dictionary of option: accepted answer to choose from.
+            * A list of options.
+            * A regex pattern.
+        bold: Whether to use bold formatting for the prompt.
+        ignore_case: Whether to ignore case when comparing the answer to the options.
+
+    Returns:
+        If options is provided - the valid answer from the user.
+        If regex is provided
+            * If no group is specified - the whole matched string.
+            * If one group is specified - the first group.
+            * If multiple groups are specified - a tuple of the groups.
+    """
+
+    # Normalize options
+    if isinstance(options, (list, tuple)):
+        options = {option: option for option in options}
+
+    if isinstance(options, dict):
+        for option, acceptable_answer in options.items():
+            if isinstance(acceptable_answer, str):
+                options[option] = [acceptable_answer]
+            if ignore_case:
+                options[option] = [answer.lower() for answer in options[option]]
+
+    while True:
+        if bold:
+            answer = bold_input(prompt)
+        else:
+            answer = input(prompt)
+
+        answer = answer.strip()
+        if ignore_case:
+            answer = answer.lower()
+
+        if isinstance(options, str):
+            if (m := re.match(options, answer)) is not None:
+                groups = m.groups()
+                if len(groups) == 0:
+                    return m.group(0)
+                if len(groups) == 1:
+                    return groups[0]
+                else:
+                    return groups
+        else:
+            for option, acceptable_answer in options.items():
+                if answer in acceptable_answer:
+                    return option
+
+
 def get_json(url):
     try:
         request = Request(url)
@@ -376,8 +433,7 @@ def run_cmd(cmd):
 
 
 def continue_maybe(prompt, cherry=False):
-    result = bold_input("%s (y/N): " % prompt)
-    if result.lower() != "y":
+    if get_input(f"{prompt} (y/N): ", {"y": "y", "N": ["N", ""]}) != "y":
         if cherry:
             try:
                 run_cmd("git cherry-pick --abort")
@@ -560,21 +616,17 @@ def cherry_pick(pr_num, merge_hash, default_branch, branch_names, target_ref, al
         )
         print("Otherwise, pick both (%s first, then %s)." % (sibling_x, pick_ref))
         print("=" * 80)
-        choice = (
-            bold_input(
-                "Pick into [b]oth %s + %s / [o]nly %s / [a]bort (default: both): "
-                % (sibling_x, pick_ref, pick_ref)
-            )
-            .strip()
-            .lower()
+        choice = get_input(
+            f"Pick into [b]oth {sibling_x} + {pick_ref} / [o]nly {pick_ref} / [a]bort (default: both): ",
+            {"b": ["b", "both", ""], "o": ["o", "only"], "a": ["a", "abort"]},
         )
-        if choice in ("", "b", "both"):
+        if choice == "b":
             picked_x = _do_cherry_pick(pr_num, merge_hash, sibling_x)
             picked_n = _do_cherry_pick(pr_num, merge_hash, pick_ref)
             return [picked_x, picked_n]
-        elif choice in ("o", "only"):
+        elif choice == "o":
             return [_do_cherry_pick(pr_num, merge_hash, pick_ref)]
-        elif choice in ("a", "abort"):
+        elif choice == "a":
             fail("Aborted by user at Upstream-First policy prompt.")
         else:
             fail("Unrecognized choice %r; aborting." % choice)
@@ -612,7 +664,12 @@ def get_jira_issue(prompt, default_jira_id=""):
         if status == "Resolved" or status == "Closed":
             print("JIRA issue %s already has status '%s'" % (jira_id, status))
             return None
-        if bold_input("Check if the JIRA information is as expected (y/N): ").lower() == "y":
+        if (
+            get_input(
+                "Check if the JIRA information is as expected (y/N): ", {"y": "y", "N": ["N", ""]}
+            )
+            == "y"
+        ):
             return issue
         else:
             return get_jira_issue("Enter the revised JIRA ID again or leave blank to skip")
@@ -1106,7 +1163,7 @@ def main():
     branch_names = sorted(branch_names, key=semver_branch_rank, reverse=True)
 
     if len(sys.argv) == 1:
-        pr_num = bold_input("Which pull request would you like to merge? (e.g. 34): ")
+        pr_num = get_input("Which pull request would you like to merge? (e.g. 34): ", r"^\d+$")
     else:
         pr_num = sys.argv[1]
         print("Start to merge pull request #%s" % (pr_num))
@@ -1180,8 +1237,12 @@ def main():
         print(modified_body)
         print("=" * 80)
         print("I've removed the comments from PR template like the above:")
-        result = bold_input("Would you like to use the modified body? (y/N): ")
-        if result.lower() == "y":
+        if (
+            get_input(
+                "Would you like to use the modified body? (y/N): ", {"y": "y", "N": ["N", ""]}
+            )
+            == "y"
+        ):
             body = modified_body
             print("Using modified body:")
         else:
@@ -1307,7 +1368,7 @@ def main():
     # target_ref (the merge sink, never to be re-picked) and grows with every cherry-pick.
     remaining_branches = [b for b in branch_names if b != target_ref]
     pick_prompt = "Would you like to pick %s into another branch?" % merge_hash
-    while bold_input("\n%s (y/N): " % pick_prompt).lower() == "y":
+    while get_input(f"\n{pick_prompt} (y/N): ", {"y": "y", "N": ["N", ""]}) == "y":
         default = remaining_branches[0] if remaining_branches else branch_names[0]
         picked = cherry_pick(
             pr_num,

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -433,7 +433,7 @@ def run_cmd(cmd):
 
 
 def continue_maybe(prompt, cherry=False):
-    if get_input(f"{prompt} (y/N): ", {"y": "y", "N": ["N", ""]}) != "y":
+    if get_input(f"{prompt} (y/N): ", ["y", "n", ""]) != "y":
         if cherry:
             try:
                 run_cmd("git cherry-pick --abort")
@@ -664,12 +664,7 @@ def get_jira_issue(prompt, default_jira_id=""):
         if status == "Resolved" or status == "Closed":
             print("JIRA issue %s already has status '%s'" % (jira_id, status))
             return None
-        if (
-            get_input(
-                "Check if the JIRA information is as expected (y/N): ", {"y": "y", "N": ["N", ""]}
-            )
-            == "y"
-        ):
+        if get_input("Check if the JIRA information is as expected (y/N): ", ["y", "n", ""]) == "y":
             return issue
         else:
             return get_jira_issue("Enter the revised JIRA ID again or leave blank to skip")
@@ -1237,12 +1232,7 @@ def main():
         print(modified_body)
         print("=" * 80)
         print("I've removed the comments from PR template like the above:")
-        if (
-            get_input(
-                "Would you like to use the modified body? (y/N): ", {"y": "y", "N": ["N", ""]}
-            )
-            == "y"
-        ):
+        if get_input("Would you like to use the modified body? (y/N): ", ["y", "n", ""]) == "y":
             body = modified_body
             print("Using modified body:")
         else:
@@ -1368,7 +1358,7 @@ def main():
     # target_ref (the merge sink, never to be re-picked) and grows with every cherry-pick.
     remaining_branches = [b for b in branch_names if b != target_ref]
     pick_prompt = "Would you like to pick %s into another branch?" % merge_hash
-    while get_input(f"\n{pick_prompt} (y/N): ", {"y": "y", "N": ["N", ""]}) == "y":
+    while get_input(f"\n{pick_prompt} (y/N): ", ["y", "n", ""]) == "y":
         default = remaining_branches[0] if remaining_branches else branch_names[0]
         picked = cherry_pick(
             pr_num,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add a utility function `get_input` for merge script to accept user input with filters - it can be either some acceptable options or a regex.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

If the user is prompt a `y/N` question, but they typed a branch name `branch-4.2`, it's equivalent to type `N`, which is not ideal. The input should only take acceptable answers.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Reviewed by Claude. Did some quick manual test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.