### PR TITLE
[SPARK-57241][SQL] Skip statically-dead null checks in StringLocate codegen for non-nullable children

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -1831,27 +1831,67 @@ case class StringLocate(substr: Expression, str: Expression, start: Expression)
     val substrGen = substr.genCode(ctx)
     val strGen = str.genCode(ctx)
     val startGen = start.genCode(ctx)
-    ev.copy(code = code"""
-      int ${ev.value} = 0;
-      boolean ${ev.isNull} = false;
-      ${startGen.code}
-      if (!${startGen.isNull}) {
-        ${substrGen.code}
-        if (!${substrGen.isNull}) {
-          ${strGen.code}
-          if (!${strGen.isNull}) {
-            if (${startGen.value} > 0) {
-              ${ev.value} = CollationSupport.StringLocate.exec(${strGen.value},
-              ${substrGen.value}, ${startGen.value} - 1, $collationId) + 1;
-            }
-          } else {
-            ${ev.isNull} = true;
-          }
+    // The result is computed only when `start` is non-null; a null `start` returns 0 without
+    // looking at `substr`/`str` (conform to Hive). The `substr`/`str` null checks therefore nest
+    // inside the `start` guard, and the result is null iff a non-null `start` meets a null
+    // `substr` or `str`. Each null check is statically dead when the child is non-nullable, so
+    // emit it only when needed (e.g. the 2-arg form defaults `start` to a non-null literal).
+    val compute =
+      code"""
+        if (${startGen.value} > 0) {
+          ${ev.value} = CollationSupport.StringLocate.exec(${strGen.value},
+            ${substrGen.value}, ${startGen.value} - 1, $collationId) + 1;
+        }
+      """
+    val strBlock = if (str.nullable) {
+      code"""
+        ${strGen.code}
+        if (!${strGen.isNull}) {
+          $compute
         } else {
           ${ev.isNull} = true;
         }
-      }
-     """)
+      """
+    } else {
+      code"""
+        ${strGen.code}
+        $compute
+      """
+    }
+    val substrBlock = if (substr.nullable) {
+      code"""
+        ${substrGen.code}
+        if (!${substrGen.isNull}) {
+          $strBlock
+        } else {
+          ${ev.isNull} = true;
+        }
+      """
+    } else {
+      code"""
+        ${substrGen.code}
+        $strBlock
+      """
+    }
+    val startBlock = if (start.nullable) {
+      code"""
+        ${startGen.code}
+        if (!${startGen.isNull}) {
+          $substrBlock
+        }
+      """
+    } else {
+      code"""
+        ${startGen.code}
+        $substrBlock
+      """
+    }
+    val isNullInit = if (nullable) code"boolean ${ev.isNull} = false;" else EmptyBlock
+    ev.copy(code = code"""
+      int ${ev.value} = 0;
+      $isNullInit
+      $startBlock
+     """, isNull = if (nullable) ev.isNull else FalseLiteral)
   }
 
   override def prettyName: String =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -1009,6 +1009,32 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(new StringLocate(s2, s1), null, row2)
     checkEvaluation(new StringLocate(s2, s1), null, row3)
     checkEvaluation(new StringLocate(s2, s1, Literal.create(null, IntegerType)), 0, row4)
+
+    // Codegen skips the statically-dead null check of any non-nullable child, so cover the
+    // mixed-nullability shapes and the all-non-nullable result (which returns isNull = false).
+    val row5 = create_row("aaads", "aa", "zz", null)
+    // start nullable, substr/str non-nullable: result is non-nullable, but the start guard
+    // stays (a null start returns 0).
+    checkEvaluation(StringLocate(Literal("aa"), Literal("aaads"), s4), 2, row1)
+    checkEvaluation(StringLocate(Literal("aa"), Literal("aaads"), s4), 0, row5)
+    // substr nullable, str non-nullable: only the substr null check is emitted.
+    checkEvaluation(new StringLocate(s2, Literal("aaads")), 1, row1)
+    checkEvaluation(new StringLocate(s2, Literal("aaads")), null, row3)
+    // substr non-nullable, str nullable: only the str null check is emitted.
+    checkEvaluation(new StringLocate(Literal("aa"), s1), 1, row1)
+    checkEvaluation(new StringLocate(Literal("aa"), s1), null, row2)
+    // substr non-nullable, str nullable, start nullable: the str null check nests in the
+    // start guard.
+    checkEvaluation(StringLocate(Literal("aa"), s1, s4), 2, row1)
+    checkEvaluation(StringLocate(Literal("aa"), s1, s4), null, row2)
+    // substr nullable, str non-nullable, start nullable: the substr null check nests in the
+    // start guard.
+    checkEvaluation(StringLocate(s2, Literal("aaads"), s4), 2, row1)
+    checkEvaluation(StringLocate(s2, Literal("aaads"), s4), null, row3)
+    // all nullable with a non-null start: exercise the substr/str null checks nested inside
+    // the start guard (the start-null short-circuit is covered above).
+    checkEvaluation(StringLocate(s2, s1, s4), null, row3)
+    checkEvaluation(StringLocate(s2, s1, s4), null, row2)
   }
 
   test("LPAD/RPAD") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a sub-task of [SPARK-56908](https://issues.apache.org/jira/browse/SPARK-56908) (reduce generated Java size in whole-stage codegen).

`StringLocate.doGenCode` always emitted a null check for each of its three children (`substr`, `str`, `start`), plus a `boolean isNull = false` declaration, regardless of whether a child can actually be null. For a non-nullable child the codegen `isNull` is statically `false`, so these checks are dead code. In particular the 2-arg `locate(substr, str)` / `position(substr IN str)` form defaults `start` to a non-null literal, so the `if (!start.isNull)` guard was an always-true dead branch on every call.

This PR emits each null check only when the corresponding child is nullable, and when the whole expression is non-nullable (i.e. both `substr` and `str` are non-nullable) it drops the `isNull` declaration and returns `isNull = FalseLiteral` so parent expressions can skip their own null check too.

The behavior is unchanged. `eval` and the existing nesting are preserved: a null `start` returns `0` without evaluating `substr`/`str` (to conform with Hive), and the result is null iff a non-null `start` meets a null `substr` or `str`. When all three children are nullable the generated code is identical to before.

For example, `locate(a, b)` on non-nullable columns goes from:

```java
int value = 0;
boolean isNull = false;
/* a.code */
if (!aIsNull) {
  /* b.code */
  if (!bIsNull) {
    /* start.code */    // start = Literal(1), always non-null
    if (!startIsNull) {
      if (start > 0) { value = ...exec(...) + 1; }
    } else { isNull = true; }
  } else { isNull = true; }
}
```

to:

```java
int value = 0;
/* start.code */
/* a.code */
/* b.code */
if (start > 0) { value = ...exec(...) + 1; }
```

This follows the same pattern as the merged sibling sub-tasks (e.g. `If`, `NaNvl`, `AtLeastNNonNulls`, `CreateNamedStruct`).

### Why are the changes needed?

To reduce the size of the generated Java in whole-stage codegen, as tracked by SPARK-56908. The skipped guards are statically dead, and `locate`/`position` are common functions, so eliminating the always-true `start` guard and the dead null checks shrinks generated code on the hot path with no behavior change.

### Does this PR introduce _any_ user-facing change?

No. This is a codegen-only change; `eval`, `nullable`, `dataType`, and results are unchanged, so SQL output and golden files are unaffected.

### How was this patch tested?

Existing `StringExpressionsSuite` "LOCATE" coverage plus new `checkEvaluation` cases covering every combination of nullable/non-nullable `substr`/`str`/`start` (so each generated codegen template is exercised; `checkEvaluation` runs interpreted and codegen, with whole-stage codegen both on and off). Also ran `org.apache.spark.sql.StringFunctionsSuite` (`locate`/`position`).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
