### PR TITLE
[SPARK-57244][SQL] Skip the statically-dead branch in DateAddInterval codegen when the interval is a constant

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1775,22 +1775,44 @@ case class DateAddInterval(
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val dtu = DateTimeUtils.getClass.getName.stripSuffix("$")
+    // In the non-ANSI path the interval's `microseconds` selects a pure date add (when zero) or a
+    // timezone-aware timestamp add. For a constant interval this is known at codegen time, so emit
+    // only the reachable arm and skip the dead one (the timestamp arm also pulls in a zoneId
+    // reference and two temporaries). We match a Literal rather than any foldable child so this
+    // selection never calls `eval` on the interval: ConstantFolding has already reduced a foldable
+    // interval to a Literal, and evaluating a foldable child here could fail in a never-taken
+    // branch.
+    val foldedMicros = interval match {
+      case Literal(itvl: CalendarInterval, _) => Some(itvl.microseconds)
+      case _ => None
+    }
     nullSafeCodeGen(ctx, ev, (sd, i) => if (ansiEnabled) {
       s"""${ev.value} = $dtu.dateAddInterval($sd, $i);"""
     } else {
-      val zid = ctx.addReferenceObj("zoneId", zoneId, classOf[ZoneId].getName)
-      val startTs = ctx.freshName("startTs")
-      val resultTs = ctx.freshName("resultTs")
-      s"""
-         |if ($i.microseconds == 0) {
-         |  ${ev.value} = $dtu.dateAddInterval($sd, $i);
-         |} else {
-         |  long $startTs = $dtu.daysToMicros($sd, $zid);
-         |  long $resultTs =
-         |    $dtu.timestampAddInterval($startTs, $i.months, $i.days, $i.microseconds, $zid);
-         |  ${ev.value} = $dtu.microsToDays($resultTs, $zid);
-         |}
-         |""".stripMargin
+      val dateAddArm = s"""${ev.value} = $dtu.dateAddInterval($sd, $i);"""
+      def timestampAddArm: String = {
+        val zid = ctx.addReferenceObj("zoneId", zoneId, classOf[ZoneId].getName)
+        val startTs = ctx.freshName("startTs")
+        val resultTs = ctx.freshName("resultTs")
+        s"""
+           |long $startTs = $dtu.daysToMicros($sd, $zid);
+           |long $resultTs =
+           |  $dtu.timestampAddInterval($startTs, $i.months, $i.days, $i.microseconds, $zid);
+           |${ev.value} = $dtu.microsToDays($resultTs, $zid);
+           |""".stripMargin
+      }
+      foldedMicros match {
+        case Some(0L) => dateAddArm
+        case Some(_) => timestampAddArm
+        case None =>
+          s"""
+             |if ($i.microseconds == 0) {
+             |  $dateAddArm
+             |} else {
+             |  $timestampAddArm
+             |}
+             |""".stripMargin
+      }
     })
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -448,6 +448,19 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       checkEvaluation(
         DateAddInterval(Literal(d), Literal(new CalendarInterval(1, 1, 25 * MICROS_PER_HOUR))),
         DateTimeUtils.fromJavaDate(Date.valueOf("2016-03-30")))
+
+      // A non-foldable interval keeps the runtime microseconds branch in codegen; exercise
+      // both arms at runtime.
+      val intervalRef =
+        BoundReference(ordinal = 0, dataType = CalendarIntervalType, nullable = true)
+      checkEvaluation(
+        DateAddInterval(Literal(d), intervalRef),
+        DateTimeUtils.fromJavaDate(Date.valueOf("2016-03-29")),
+        InternalRow(new CalendarInterval(1, 1, 0)))
+      checkEvaluation(
+        DateAddInterval(Literal(d), intervalRef),
+        DateTimeUtils.fromJavaDate(Date.valueOf("2016-03-30")),
+        InternalRow(new CalendarInterval(1, 1, 25 * MICROS_PER_HOUR)))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a sub-task of [SPARK-56908](https://issues.apache.org/jira/browse/SPARK-56908) (reduce generated Java size in whole-stage codegen).

In the non-ANSI path, `DateAddInterval.doGenCode` always emitted a runtime branch on the interval's `microseconds`:

```java
if (i.microseconds == 0) {
  ev.value = DateTimeUtils.dateAddInterval(sd, i);
} else {
  long startTs = DateTimeUtils.daysToMicros(sd, zid);
  long resultTs = DateTimeUtils.timestampAddInterval(startTs, i.months, i.days, i.microseconds, zid);
  ev.value = DateTimeUtils.microsToDays(resultTs, zid);
}
```

When the interval is a constant, its `microseconds` is known at codegen time, so only one arm is ever reachable. This PR matches a `Literal(CalendarInterval)` interval and emits only the reachable arm:

- `microseconds == 0` -> only `dateAddInterval(sd, i)`;
- `microseconds != 0` -> only the timezone-aware timestamp-add.

The zero-microseconds case is the common one (e.g. `INTERVAL '1' MONTH`, `INTERVAL '1' DAY`), and dropping the dead timestamp-add arm there also removes the `zoneId` reference object and two temporaries it pulls in. Non-constant intervals keep the original runtime split unchanged.

A `Literal` is matched rather than any foldable child so the interval is never evaluated during codegen: `ConstantFolding` has already reduced a foldable interval to a `Literal` by the time codegen runs, and evaluating a foldable child here could fail in a never-taken branch (e.g. a foldable interval division by zero inside a `CASE` arm that is never executed).

This follows the foldable-literal dead-branch pattern of the sibling sub-task SPARK-57198.

Note: `DateAddInterval` handles the `CalendarInterval` add path, which is reached via legacy interval mode or `make_interval`; default `date + INTERVAL ...` uses ANSI interval types handled by other expressions. The cleanup is therefore narrow in scope but behavior-preserving.

### Why are the changes needed?

To reduce the size of the generated Java in whole-stage codegen, as tracked by SPARK-56908. For a constant interval one of the two arms is statically dead; emitting only the reachable arm removes the dead arm and, in the common zero-microseconds case, also avoids registering a `zoneId` reference object and allocating two temporaries.

### Does this PR introduce _any_ user-facing change?

No. This is a codegen-only change; `eval`, `nullable`, `dataType`, and results are unchanged, so SQL output and golden files are unaffected.

### How was this patch tested?

Existing `DateExpressionsSuite` "date add interval" coverage plus new `checkEvaluation` cases:
- a non-foldable interval (`BoundReference`) exercising both runtime arms of the unchanged split (microseconds zero and non-zero), so the constant-folded fast arms and the runtime split are all covered.

`checkEvaluation` runs interpreted and codegen (whole-stage on and off). Also ran `org.apache.spark.sql.DateFunctionsSuite` and the legacy-interval end-to-end case in `org.apache.spark.sql.DataFrameSuite` (SPARK-44206).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
