### PR TITLE
[SPARK-57246][SQL] Skip the dead result null assignment in MakeDecimal codegen when overflow cannot produce null

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
@@ -85,7 +85,10 @@ case class MakeDecimal(
       } else {
         "set"
       }
-      val setNull = if (nullable) {
+      // Only `setOrNull` (the nullOnOverflow path) can produce a null result; `set` throws on
+      // overflow and never returns null. So the result null check is needed only when
+      // nullOnOverflow is set (a null child is already handled by nullSafeCodeGen).
+      val setNull = if (nullOnOverflow) {
         s"${ev.isNull} = ${ev.value} == null;"
       } else {
         ""

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DecimalExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DecimalExpressionSuite.scala
@@ -46,6 +46,10 @@ class DecimalExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
       checkEvaluation(MakeDecimal(Literal(101L), 3, 1), Decimal("10.1"))
       checkEvaluation(MakeDecimal(Literal.create(null, LongType), 3, 1), null)
+      // A nullable child with a non-null value still yields a non-null result in the non-overflow
+      // (`set`) path, where the result null check is omitted.
+      checkEvaluation(MakeDecimal(BoundReference(0, LongType, nullable = true), 3, 1),
+        Decimal("10.1"), create_row(101L))
       val overflowExpr = MakeDecimal(Literal.create(1000L, LongType), 3, 1)
       intercept[ArithmeticException](checkEvaluationWithMutableProjection(overflowExpr, null))
       intercept[ArithmeticException](evaluateWithoutCodegen(overflowExpr, null))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a sub-task of [SPARK-56908](https://issues.apache.org/jira/browse/SPARK-56908) (reduce generated Java size in whole-stage codegen).

`MakeDecimal.doGenCode` emitted the result null check `ev.isNull = ev.value == null;` whenever the expression is nullable (`nullable = child.nullable || nullOnOverflow`):

```scala
val setNull = if (nullable) {
  s"${ev.isNull} = ${ev.value} == null;"
} else {
  ""
}
```

However, the result can only become null in the `nullOnOverflow` path, which uses `Decimal.setOrNull` (returns null on overflow). The other path uses `Decimal.set`, which throws on overflow and never returns null. A null child is already handled by `nullSafeCodeGen`. So when `nullOnOverflow` is false, `ev.value == null` is always false and the assignment is a dead `ev.isNull = false;` write.

This PR gates the assignment on `nullOnOverflow` instead of `nullable`:

```scala
val setNull = if (nullOnOverflow) {
  s"${ev.isNull} = ${ev.value} == null;"
} else {
  ""
}
```

The new gate is a strict subset of the old one: `nullOnOverflow` implies `nullable`, so the assignment is still only emitted when `ev.isNull` is a declared variable. The only case it drops is `nullOnOverflow == false && child.nullable == true`, where the write was dead.

### Why are the changes needed?

To reduce the size of the generated Java in whole-stage codegen, as tracked by SPARK-56908. `MakeDecimal` is produced by the `DecimalAggregates` rule for decimal `sum`/`avg`/window aggregates (`MakeDecimal(Sum(UnscaledValue(...)), ...)`), whose aggregate child is nullable. Under ANSI mode (the default), `nullOnOverflow` is false, so this dead write was emitted on that common path.

### Does this PR introduce _any_ user-facing change?

No. This is a codegen-only change; `eval`, `nullable`, `dataType`, and results are unchanged, so SQL output and plan/golden files are unaffected.

### How was this patch tested?

Existing `DecimalExpressionSuite` "MakeDecimal" coverage plus a new `checkEvaluation` case for the modified template: a nullable child with a non-null value in the non-overflow (`set`) path, asserting a non-null result. `checkEvaluation` runs interpreted and codegen (whole-stage on and off). Also ran `DecimalAggregatesSuite` (the rule that produces `MakeDecimal`).

Note: `CheckOverflow` and `DecimalDivideWithOverflowCheck` share the same `setOrNull`/`toPrecision(..., nullOnOverflow, ...)` + result-null-check pattern and could get the same treatment as follow-ups; they are intentionally left out of this PR to keep it focused.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
