### PR TITLE
[SPARK-57248][SQL] Skip the dead result null assignment in CheckOverflow codegen when overflow cannot produce null

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
@@ -129,12 +129,16 @@ case class CheckOverflow(
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val errorContextCode = getContextOrNullCode(ctx, !nullOnOverflow)
+    // Only the nullOnOverflow path can produce a null result; otherwise toPrecision throws on
+    // overflow and never returns null. nullSafeCodeGen already initializes ev.isNull from the
+    // child's nullness, so the result null check is only needed when nullOnOverflow is set.
+    val setNull = if (nullOnOverflow) s"${ev.isNull} = ${ev.value} == null;" else ""
     nullSafeCodeGen(ctx, ev, eval => {
       // scalastyle:off line.size.limit
       s"""
          |${ev.value} = $eval.toPrecision(
          |  ${dataType.precision}, ${dataType.scale}, Decimal.ROUND_HALF_UP(), $nullOnOverflow, $errorContextCode);
-         |${ev.isNull} = ${ev.value} == null;
+         |$setNull
        """.stripMargin
       // scalastyle:on line.size.limit
     })

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DecimalExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DecimalExpressionSuite.scala
@@ -62,6 +62,9 @@ class DecimalExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     intercept[ArithmeticException](CheckOverflow(Literal(d1), DecimalType(4, 3), false).eval())
     intercept[ArithmeticException](checkEvaluationWithMutableProjection(
       CheckOverflow(Literal(d1), DecimalType(4, 3), false), null))
+    // nullOnOverflow = false with no overflow returns a non-null value; the result null check is
+    // omitted in this path.
+    checkEvaluation(CheckOverflow(Literal(d1), DecimalType(4, 1), false), d1)
 
     val d2 = Decimal(101, 3, 1)
     checkEvaluation(CheckOverflow(Literal(d2), DecimalType(4, 0), true), Decimal("10"))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a sub-task of [SPARK-56908](https://issues.apache.org/jira/browse/SPARK-56908) (reduce generated Java size in whole-stage codegen).

`CheckOverflow.doGenCode` always emitted the result null check after the `toPrecision` call:

```scala
nullSafeCodeGen(ctx, ev, eval => {
  s"""
     |${ev.value} = $eval.toPrecision(
     |  ${dataType.precision}, ${dataType.scale}, Decimal.ROUND_HALF_UP(), $nullOnOverflow, $errorContextCode);
     |${ev.isNull} = ${ev.value} == null;
   """.stripMargin
})
```

The result can only become null in the `nullOnOverflow` path: `Decimal.toPrecision` returns null only when `nullOnOverflow` is true and overflow occurs; otherwise it throws on overflow and never returns null. A null child is already handled by `nullSafeCodeGen`, which initializes `ev.isNull` from the child's nullness (`CheckOverflow.nullable` is `true`). So when `nullOnOverflow` is false, `ev.value == null` is always false and the assignment is a dead `ev.isNull = false;` write.

This PR gates the assignment on `nullOnOverflow`:

```scala
val setNull = if (nullOnOverflow) s"${ev.isNull} = ${ev.value} == null;" else ""
```

`nullOnOverflow` is the right predicate here: `CheckOverflow.nullable` is hardcoded `true`, so gating on `nullable` would be a no-op. The throw-on-overflow path and the error context are unchanged.

### Why are the changes needed?

To reduce the size of the generated Java in whole-stage codegen, as tracked by SPARK-56908. Under ANSI mode (the default), `nullOnOverflow` is false, so this dead write was emitted on the common path. In current master, decimal arithmetic does its overflow check inline; the standalone `CheckOverflow` node is produced by the decimal encoder/serialization path (e.g. serializing a `BigDecimal` into the internal row at Dataset/case-class/UDF boundaries), which is where this codegen runs.

### Does this PR introduce _any_ user-facing change?

No. This is a codegen-only change; `eval`, `nullable`, `dataType`, `toString`, and results are unchanged, so SQL output and plan/golden files are unaffected.

### How was this patch tested?

Existing `DecimalExpressionSuite` "CheckOverflow" coverage plus a new `checkEvaluation` case for the modified template: `nullOnOverflow = false` with no overflow, asserting a non-null result (the path where the now-removed `setNull` lived). `checkEvaluation` runs interpreted and codegen (mutable and unsafe projections).

Note: `DecimalDivideWithOverflowCheck` shares the same `toPrecision(..., nullOnOverflow, ...)` + result-null-check pattern and could get the same treatment as a follow-up; it is intentionally left out of this PR to keep it focused (its codegen has a different shape — hand-rolled `if/else` and `nullable = nullOnOverflow`).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
