### PR TITLE
[SPARK-57249][SQL] Skip the dead result null assignment in DecimalDivideWithOverflowCheck codegen when overflow cannot produce null

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
@@ -300,6 +300,10 @@ case class DecimalDivideWithOverflowCheck(
     } else {
       s"""throw QueryExecutionErrors.overflowInSumOfDecimalError($errorContextCode, "try_avg");"""
     }
+    // Only the nullOnOverflow path can produce a null result; otherwise toPrecision throws on
+    // overflow and never returns null. ev.isNull is already initialized from eval1.isNull (false
+    // on this branch), so the result null check is dead when nullOnOverflow is false.
+    val setNull = if (nullOnOverflow) s"${ev.isNull} = ${ev.value} == null;" else ""
 
     val eval1 = left.genCode(ctx)
     val eval2 = right.genCode(ctx)
@@ -316,7 +320,7 @@ case class DecimalDivideWithOverflowCheck(
          |} else {
          |  ${ev.value} = ${eval1.value}.$decimalMethod(${eval2.value}).toPrecision(
          |      ${dataType.precision}, ${dataType.scale}, Decimal.ROUND_HALF_UP(), $nullOnOverflow, $errorContextCode);
-         |  ${ev.isNull} = ${ev.value} == null;
+         |  $setNull
          |}
       """.stripMargin
     // scalastyle:on line.size.limit

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DecimalExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DecimalExpressionSuite.scala
@@ -78,6 +78,33 @@ class DecimalExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       Literal.create(null, DecimalType(2, 1)), DecimalType(3, 2), false), null)
   }
 
+  test("DecimalDivideWithOverflowCheck") {
+    val sum = Literal(Decimal(10))
+    val count = Literal(Decimal(2))
+    // nullOnOverflow = false with no overflow returns a non-null value; the result null check is
+    // omitted in this path.
+    checkEvaluation(
+      DecimalDivideWithOverflowCheck(sum, count, DecimalType(10, 1), null, false), Decimal("5.0"))
+    // nullOnOverflow = true keeps the result null check (no overflow here, so the result is
+    // non-null).
+    checkEvaluation(
+      DecimalDivideWithOverflowCheck(sum, count, DecimalType(10, 1), null, true), Decimal("5.0"))
+    // nullOnOverflow = true with an overflowing result returns null (the kept result null check).
+    checkEvaluation(
+      DecimalDivideWithOverflowCheck(Literal(Decimal(100)), Literal(Decimal(1)),
+        DecimalType(2, 0), null, true), null)
+    // nullOnOverflow = false with an overflowing result throws.
+    intercept[ArithmeticException](checkEvaluationWithMutableProjection(
+      DecimalDivideWithOverflowCheck(Literal(Decimal(100)), Literal(Decimal(1)),
+        DecimalType(2, 0), null, false), null))
+    // A null left operand is treated as overflow: null when nullOnOverflow, otherwise an error.
+    val nullSum = Literal.create(null, DecimalType(10, 0))
+    checkEvaluation(
+      DecimalDivideWithOverflowCheck(nullSum, count, DecimalType(10, 1), null, true), null)
+    intercept[ArithmeticException](checkEvaluationWithMutableProjection(
+      DecimalDivideWithOverflowCheck(nullSum, count, DecimalType(10, 1), null, false), null))
+  }
+
   test("SPARK-39208: CheckOverflow & CheckOverflowInSum support query context in runtime errors") {
     val d = Decimal(101, 3, 1)
     val query = "select cast(d as decimal(4, 3)) from t"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a sub-task of [SPARK-56908](https://issues.apache.org/jira/browse/SPARK-56908) (reduce generated Java size in whole-stage codegen).

`DecimalDivideWithOverflowCheck.doGenCode` always emitted the result null check after the `toPrecision` call in the non-null-left branch:

```scala
if (${eval1.isNull}) {
  $nullHandling
} else {
  ${ev.value} = ${eval1.value}.$decimalMethod(${eval2.value}).toPrecision(
      ${dataType.precision}, ${dataType.scale}, Decimal.ROUND_HALF_UP(), $nullOnOverflow, $errorContextCode);
  ${ev.isNull} = ${ev.value} == null;
}
```

The result can only become null in the `nullOnOverflow` path: `Decimal.toPrecision` returns null only when `nullOnOverflow` is true and overflow occurs; otherwise it throws on overflow and never returns null. On this branch `ev.isNull` is already initialized from `eval1.isNull` (which is false here, since the branch runs only when the left operand is non-null). So when `nullOnOverflow` is false, `ev.value == null` is always false and the assignment is a dead `ev.isNull = false;` write.

This PR gates the assignment on `nullOnOverflow`:

```scala
val setNull = if (nullOnOverflow) s"${ev.isNull} = ${ev.value} == null;" else ""
```

`nullOnOverflow` is the right predicate: `nullable = nullOnOverflow`, and on this branch the left operand is non-null, so child nullability is irrelevant. When `nullOnOverflow` is true the assignment is kept (it is what turns a division overflow into a null result). The null-left handling and the throw-on-overflow path are unchanged.

### Why are the changes needed?

To reduce the size of the generated Java in whole-stage codegen, as tracked by SPARK-56908. The expression is produced by decimal `Average` (`DecimalDivideWithOverflowCheck(sum, count, resultType, ctx, evalMode != ANSI)`), so under ANSI mode (the default) `nullOnOverflow` is false and this dead write was emitted on the decimal `avg` codegen path.

This completes the decimal dead-write cleanup that also covers `MakeDecimal` and `CheckOverflow` (the remaining `== null` checks in `decimalExpressions.scala`, e.g. `CheckOverflowInSum`, are live and not removable).

### Does this PR introduce _any_ user-facing change?

No. This is a codegen-only change; `eval`, `nullable`, `dataType`, `toString`, and results are unchanged, so SQL output and plan/golden files are unaffected.

### How was this patch tested?

Adds a direct unit test in `DecimalExpressionSuite` (the expression previously had no direct test), covering `nullOnOverflow` false/true with no overflow, with an overflowing result (null when `nullOnOverflow`, error otherwise), and a null left operand (null vs error). `checkEvaluation` runs interpreted and codegen (mutable and unsafe projections). Also ran the decimal `AVG` aggregate tests in `DataFrameAggregateSuite`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
