### PR TITLE
[SPARK-57073][SS][PYTHON][TESTS] Catch AnalysisException for test_parity_listener

### DIFF
--- a/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
@@ -18,6 +18,7 @@
 import time
 
 import pyspark.cloudpickle
+from pyspark.errors import AnalysisException
 from pyspark.sql.tests.streaming.test_streaming_listener import StreamingListenerTestsMixin
 from pyspark.sql.streaming.listener import StreamingQueryListener
 from pyspark.sql.functions import count, lit
@@ -257,7 +258,13 @@ class StreamingListenerParityTests(StreamingListenerTestsMixin, ReusedConnectTes
 
                 @eventually(timeout=60, catch_assertions=True)
                 def load_event(event_name, table_name):
-                    table = self.spark.read.table(table_name).collect()
+                    try:
+                        table = self.spark.read.table(table_name).collect()
+                    except AnalysisException as e:
+                        # It's possible that the table has not been created yet
+                        if "TABLE_OR_VIEW_NOT_FOUND" in str(e):
+                            return False
+                        raise e
                     if len(table) == 0:
                         return False
                     events[event_name] = pyspark.cloudpickle.loads(table[0][0])

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
@@ -262,7 +262,7 @@ class StreamingListenerParityTests(StreamingListenerTestsMixin, ReusedConnectTes
                         table = self.spark.read.table(table_name).collect()
                     except AnalysisException as e:
                         # It's possible that the table has not been created yet
-                        if "TABLE_OR_VIEW_NOT_FOUND" in str(e):
+                        if e.getCondition() == "TABLE_OR_VIEW_NOT_FOUND":
                             return False
                         raise e
                     if len(table) == 0:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Catch `AnalysisException` for the test and ignore it because it's acceptable (table not created yet).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The test has been flaky on the Build / Python-only (master, Python 3.12, MacOS26) scheduled workflow:

2026-05-23 — https://github.com/apache/spark/actions/runs/26346300968/job/77556662680
2026-05-25 — https://github.com/apache/spark/actions/runs/26423905857/job/77783724134
Both failed with AnalysisException: TABLE_OR_VIEW_NOT_FOUND on listener_terminated_events: the onQueryTerminated callback fires asynchronously after q.stop() returns and writes the table via saveAsTable, but on slower macOS runners the read races the write.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Local test passed. This fails on MacOS more frequently so we need to observe it in scheduled tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.