### PR TITLE
[SPARK-57278][INFRA] Install zstd in CI container images to fix GitHub Actions cache

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -658,6 +658,8 @@ jobs:
       options: >-
         --cap-add=SYS_PTRACE
         --security-opt seccomp=unconfined
+      volumes:
+        - /home/runner/.cache/coursier:/github/home/.cache/coursier
     strategy:
       fail-fast: false
       max-parallel: 20
@@ -898,6 +900,8 @@ jobs:
     timeout-minutes: 120
     container:
       image: ${{ needs.precondition.outputs.image_sparkr_url_link }}
+      volumes:
+        - /home/runner/.cache/coursier:/github/home/.cache/coursier
     env:
       HADOOP_PROFILE: ${{ inputs.hadoop }}
       HIVE_PROFILE: hive2.3
@@ -1058,6 +1062,8 @@ jobs:
       BRANCH: ${{ inputs.branch }}
     container:
       image: ${{ needs.precondition.outputs.image_lint_url_link }}
+      volumes:
+        - /home/runner/.cache/coursier:/github/home/.cache/coursier
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v6
@@ -1257,6 +1263,8 @@ jobs:
       GITHUB_PREV_SHA: ${{ github.event.before }}
     container:
       image: ${{ needs.precondition.outputs.image_docs_url_link }}
+      volumes:
+        - /home/runner/.cache/coursier:/github/home/.cache/coursier
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v6

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -658,8 +658,6 @@ jobs:
       options: >-
         --cap-add=SYS_PTRACE
         --security-opt seccomp=unconfined
-      volumes:
-        - /home/runner/.cache/coursier:/github/home/.cache/coursier
     strategy:
       fail-fast: false
       max-parallel: 20
@@ -900,8 +898,6 @@ jobs:
     timeout-minutes: 120
     container:
       image: ${{ needs.precondition.outputs.image_sparkr_url_link }}
-      volumes:
-        - /home/runner/.cache/coursier:/github/home/.cache/coursier
     env:
       HADOOP_PROFILE: ${{ inputs.hadoop }}
       HIVE_PROFILE: hive2.3
@@ -1062,8 +1058,6 @@ jobs:
       BRANCH: ${{ inputs.branch }}
     container:
       image: ${{ needs.precondition.outputs.image_lint_url_link }}
-      volumes:
-        - /home/runner/.cache/coursier:/github/home/.cache/coursier
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v6
@@ -1263,8 +1257,6 @@ jobs:
       GITHUB_PREV_SHA: ${{ github.event.before }}
     container:
       image: ${{ needs.precondition.outputs.image_docs_url_link }}
-      volumes:
-        - /home/runner/.cache/coursier:/github/home/.cache/coursier
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v6

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -33,12 +33,6 @@ RUN echo 'deb https://mirrors.edge.kernel.org/ubuntu jammy main restricted unive
     echo 'deb https://mirrors.edge.kernel.org/ubuntu jammy-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/mirror.list && \
     echo 'deb https://mirrors.edge.kernel.org/ubuntu jammy-security main restricted universe multiverse' >> /etc/apt/sources.list.d/mirror.list
 
-# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
-# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
-# use it; without zstd the container falls back to gzip, producing a different version
-# hash, so cache entries saved by host jobs are invisible to container jobs even when
-# the key string matches.
-# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -33,6 +33,12 @@ RUN echo 'deb https://mirrors.edge.kernel.org/ubuntu jammy main restricted unive
     echo 'deb https://mirrors.edge.kernel.org/ubuntu jammy-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/mirror.list && \
     echo 'deb https://mirrors.edge.kernel.org/ubuntu jammy-security main restricted universe multiverse' >> /etc/apt/sources.list.d/mirror.list
 
+# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
+# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
+# use it; without zstd the container falls back to gzip, producing a different version
+# hash, so cache entries saved by host jobs are invisible to container jobs even when
+# the key string matches.
+# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update && apt-get install -y \
     software-properties-common \
     wget \
     zlib1g-dev \
+    zstd \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/dev/spark-test-image/docs/Dockerfile
+++ b/dev/spark-test-image/docs/Dockerfile
@@ -31,12 +31,6 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
-# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
-# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
-# use it; without zstd the container falls back to gzip, producing a different version
-# hash, so cache entries saved by host jobs are invisible to container jobs even when
-# the key string matches.
-# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/docs/Dockerfile
+++ b/dev/spark-test-image/docs/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update && apt-get install -y \
     software-properties-common \
     wget \
     zlib1g-dev \
+    zstd \
     && apt-get autoremove --purge -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/dev/spark-test-image/docs/Dockerfile
+++ b/dev/spark-test-image/docs/Dockerfile
@@ -31,6 +31,12 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
+# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
+# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
+# use it; without zstd the container falls back to gzip, producing a different version
+# hash, so cache entries saved by host jobs are invisible to container jobs even when
+# the key string matches.
+# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/lint/Dockerfile
+++ b/dev/spark-test-image/lint/Dockerfile
@@ -31,12 +31,6 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
-# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
-# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
-# use it; without zstd the container falls back to gzip, producing a different version
-# hash, so cache entries saved by host jobs are invisible to container jobs even when
-# the key string matches.
-# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/lint/Dockerfile
+++ b/dev/spark-test-image/lint/Dockerfile
@@ -63,6 +63,7 @@ RUN apt-get update && apt-get install -y \
     software-properties-common \
     wget \
     zlib1g-dev \
+    zstd \
     && apt-get autoremove --purge -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/dev/spark-test-image/lint/Dockerfile
+++ b/dev/spark-test-image/lint/Dockerfile
@@ -31,6 +31,12 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
+# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
+# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
+# use it; without zstd the container falls back to gzip, producing a different version
+# hash, so cache entries saved by host jobs are invisible to container jobs even when
+# the key string matches.
+# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-311/Dockerfile
+++ b/dev/spark-test-image/python-311/Dockerfile
@@ -31,12 +31,6 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
-# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
-# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
-# use it; without zstd the container falls back to gzip, producing a different version
-# hash, so cache entries saved by host jobs are invisible to container jobs even when
-# the key string matches.
-# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-311/Dockerfile
+++ b/dev/spark-test-image/python-311/Dockerfile
@@ -31,6 +31,12 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
+# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
+# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
+# use it; without zstd the container falls back to gzip, producing a different version
+# hash, so cache entries saved by host jobs are invisible to container jobs even when
+# the key string matches.
+# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-311/Dockerfile
+++ b/dev/spark-test-image/python-311/Dockerfile
@@ -46,7 +46,8 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     tzdata \
     software-properties-common \
-    zlib1g-dev
+    zlib1g-dev \
+    zstd
 
 # Install Python 3.11
 RUN add-apt-repository ppa:deadsnakes/ppa

--- a/dev/spark-test-image/python-312-classic-only/Dockerfile
+++ b/dev/spark-test-image/python-312-classic-only/Dockerfile
@@ -31,12 +31,6 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
-# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
-# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
-# use it; without zstd the container falls back to gzip, producing a different version
-# hash, so cache entries saved by host jobs are invisible to container jobs even when
-# the key string matches.
-# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-312-classic-only/Dockerfile
+++ b/dev/spark-test-image/python-312-classic-only/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update && apt-get install -y \
     tzdata \
     software-properties-common \
     zlib1g-dev \
+    zstd \
     && apt-get autoremove --purge -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/dev/spark-test-image/python-312-classic-only/Dockerfile
+++ b/dev/spark-test-image/python-312-classic-only/Dockerfile
@@ -31,6 +31,12 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
+# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
+# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
+# use it; without zstd the container falls back to gzip, producing a different version
+# hash, so cache entries saved by host jobs are invisible to container jobs even when
+# the key string matches.
+# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-312-pandas-3/Dockerfile
+++ b/dev/spark-test-image/python-312-pandas-3/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update && apt-get install -y \
     tzdata \
     software-properties-common \
     zlib1g-dev \
+    zstd \
     && apt-get autoremove --purge -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/dev/spark-test-image/python-312-pandas-3/Dockerfile
+++ b/dev/spark-test-image/python-312-pandas-3/Dockerfile
@@ -34,12 +34,6 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
-# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
-# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
-# use it; without zstd the container falls back to gzip, producing a different version
-# hash, so cache entries saved by host jobs are invisible to container jobs even when
-# the key string matches.
-# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-312-pandas-3/Dockerfile
+++ b/dev/spark-test-image/python-312-pandas-3/Dockerfile
@@ -34,6 +34,12 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
+# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
+# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
+# use it; without zstd the container falls back to gzip, producing a different version
+# hash, so cache entries saved by host jobs are invisible to container jobs even when
+# the key string matches.
+# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-312/Dockerfile
+++ b/dev/spark-test-image/python-312/Dockerfile
@@ -31,12 +31,6 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
-# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
-# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
-# use it; without zstd the container falls back to gzip, producing a different version
-# hash, so cache entries saved by host jobs are invisible to container jobs even when
-# the key string matches.
-# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-312/Dockerfile
+++ b/dev/spark-test-image/python-312/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     tzdata \
     software-properties-common \
+    zstd \
     zlib1g-dev \
     && apt-get autoremove --purge -y \
     && apt-get clean \

--- a/dev/spark-test-image/python-312/Dockerfile
+++ b/dev/spark-test-image/python-312/Dockerfile
@@ -31,6 +31,12 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
+# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
+# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
+# use it; without zstd the container falls back to gzip, producing a different version
+# hash, so cache entries saved by host jobs are invisible to container jobs even when
+# the key string matches.
+# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-313/Dockerfile
+++ b/dev/spark-test-image/python-313/Dockerfile
@@ -31,12 +31,6 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
-# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
-# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
-# use it; without zstd the container falls back to gzip, producing a different version
-# hash, so cache entries saved by host jobs are invisible to container jobs even when
-# the key string matches.
-# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-313/Dockerfile
+++ b/dev/spark-test-image/python-313/Dockerfile
@@ -46,7 +46,8 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     tzdata \
     software-properties-common \
-    zlib1g-dev
+    zlib1g-dev \
+    zstd
 
 # Install Python 3.13
 RUN add-apt-repository ppa:deadsnakes/ppa

--- a/dev/spark-test-image/python-313/Dockerfile
+++ b/dev/spark-test-image/python-313/Dockerfile
@@ -31,6 +31,12 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
+# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
+# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
+# use it; without zstd the container falls back to gzip, producing a different version
+# hash, so cache entries saved by host jobs are invisible to container jobs even when
+# the key string matches.
+# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-314-nogil/Dockerfile
+++ b/dev/spark-test-image/python-314-nogil/Dockerfile
@@ -31,12 +31,6 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
-# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
-# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
-# use it; without zstd the container falls back to gzip, producing a different version
-# hash, so cache entries saved by host jobs are invisible to container jobs even when
-# the key string matches.
-# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-314-nogil/Dockerfile
+++ b/dev/spark-test-image/python-314-nogil/Dockerfile
@@ -46,7 +46,8 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     tzdata \
     software-properties-common \
-    zlib1g-dev
+    zlib1g-dev \
+    zstd
 
 # Install Python 3.14 (no GIL)
 RUN add-apt-repository ppa:deadsnakes/ppa

--- a/dev/spark-test-image/python-314-nogil/Dockerfile
+++ b/dev/spark-test-image/python-314-nogil/Dockerfile
@@ -31,6 +31,12 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
+# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
+# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
+# use it; without zstd the container falls back to gzip, producing a different version
+# hash, so cache entries saved by host jobs are invisible to container jobs even when
+# the key string matches.
+# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-314/Dockerfile
+++ b/dev/spark-test-image/python-314/Dockerfile
@@ -31,12 +31,6 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
-# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
-# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
-# use it; without zstd the container falls back to gzip, producing a different version
-# hash, so cache entries saved by host jobs are invisible to container jobs even when
-# the key string matches.
-# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-314/Dockerfile
+++ b/dev/spark-test-image/python-314/Dockerfile
@@ -46,7 +46,8 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     tzdata \
     software-properties-common \
-    zlib1g-dev
+    zlib1g-dev \
+    zstd
 
 # Install Python 3.14
 RUN add-apt-repository ppa:deadsnakes/ppa

--- a/dev/spark-test-image/python-314/Dockerfile
+++ b/dev/spark-test-image/python-314/Dockerfile
@@ -31,6 +31,12 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
+# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
+# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
+# use it; without zstd the container falls back to gzip, producing a different version
+# hash, so cache entries saved by host jobs are invisible to container jobs even when
+# the key string matches.
+# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-minimum/Dockerfile
+++ b/dev/spark-test-image/python-minimum/Dockerfile
@@ -32,12 +32,6 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
 # Should keep the installation consistent with https://apache.github.io/spark/api/python/getting_started/install.html
-# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
-# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
-# use it; without zstd the container falls back to gzip, producing a different version
-# hash, so cache entries saved by host jobs are invisible to container jobs even when
-# the key string matches.
-# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-minimum/Dockerfile
+++ b/dev/spark-test-image/python-minimum/Dockerfile
@@ -32,6 +32,12 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
 # Should keep the installation consistent with https://apache.github.io/spark/api/python/getting_started/install.html
+# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
+# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
+# use it; without zstd the container falls back to gzip, producing a different version
+# hash, so cache entries saved by host jobs are invisible to container jobs even when
+# the key string matches.
+# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/python-minimum/Dockerfile
+++ b/dev/spark-test-image/python-minimum/Dockerfile
@@ -47,7 +47,8 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     tzdata \
     software-properties-common \
-    zlib1g-dev
+    zlib1g-dev \
+    zstd
 
 # Install Python 3.11
 RUN add-apt-repository ppa:deadsnakes/ppa

--- a/dev/spark-test-image/sparkr/Dockerfile
+++ b/dev/spark-test-image/sparkr/Dockerfile
@@ -31,12 +31,6 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
-# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
-# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
-# use it; without zstd the container falls back to gzip, producing a different version
-# hash, so cache entries saved by host jobs are invisible to container jobs even when
-# the key string matches.
-# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \

--- a/dev/spark-test-image/sparkr/Dockerfile
+++ b/dev/spark-test-image/sparkr/Dockerfile
@@ -62,6 +62,7 @@ RUN apt-get update && apt-get install -y \
     software-properties-common \
     wget \
     zlib1g-dev \
+    zstd \
     && rm -rf /var/lib/apt/lists/*
 
 RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/' >> /etc/apt/sources.list

--- a/dev/spark-test-image/sparkr/Dockerfile
+++ b/dev/spark-test-image/sparkr/Dockerfile
@@ -31,6 +31,12 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN printf 'Types: deb\nURIs: https://mirrors.edge.kernel.org/ubuntu\nSuites: noble noble-updates noble-security\nComponents: main restricted universe multiverse\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' > /etc/apt/sources.list.d/mirror.sources
 
+# zstd is required by @actions/cache (GitHub Actions cache action). The action computes
+# a cache "version" as SHA256(paths + compression_method). Host runners have zstd and
+# use it; without zstd the container falls back to gzip, producing a different version
+# hash, so cache entries saved by host jobs are invisible to container jobs even when
+# the key string matches.
+# See: https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheUtils.ts
 RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Install `zstd` in all CI container image Dockerfiles (`dev/infra/Dockerfile` and the `python-*`, `docs`, `lint`, `sparkr` images under `dev/spark-test-image/`).

### Why are the changes needed?

`actions/cache` has never successfully restored a cache in any container-based CI job — confirmed by `apache/spark`'s cache history, which has no `pyspark-coursier-*` / `sparkr-coursier-*` / `docs-coursier-*` entry. This is a long-standing issue, present since container jobs were introduced.

`actions/cache` computes a cache **version** = `SHA256(paths + compression_method)` and includes it in the lookup URL. Host runners have `zstd` and use it; container images lack `zstd` and fall back to `gzip`. The version then differs, so caches saved by host jobs (e.g. the Coursier cache written by `precompile`) are invisible to container jobs even when the key matches. Installing `zstd` aligns the compression method.

(The `build-` cache happened to work because it is written by both host and container jobs, so a gzip-version entry also existed; host-only caches had no gzip entry.)

### Does this PR introduce _any_ user-facing change?

No. CI-only.

### How was this patch tested?

Before (run [26956300346](https://github.com/zhengruifeng/spark/actions/runs/26956300346)): `precompile` saved `Linux-coursier-<hash>`, but all container jobs reported `Cache not found` for the same key minutes later.

After (run [26996424034](https://github.com/zhengruifeng/spark/actions/runs/26996424034)): `pyspark`, `sparkr`, `lint`, `docs` all `Cache restored from key: Linux-coursier-<hash>`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-sonnet-4-6)