### PR TITLE
[SPARK-56413][UDF][BUILD][FOLLOWUP] Fix parent POM version in udf-worker-grpc module on branch-4.x

### DIFF
--- a/udf/worker/grpc/pom.xml
+++ b/udf/worker/grpc/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.13</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

When the `udf-worker-grpc` module was backported to `branch-4.x` in [SPARK-56413](https://issues.apache.org/jira/browse/SPARK-56413)/SPARK-56661 (commit 7a70689cfc8), its parent POM version in `udf/worker/grpc/pom.xml` was left at `5.0.0-SNAPSHOT` (the `master` version) instead of `4.2.0-SNAPSHOT`. This one-line change corrects it.

### Why are the changes needed?

`branch-4.x` is at `4.2.0-SNAPSHOT`, but `udf/worker/grpc/pom.xml` referenced parent `spark-parent_2.13:5.0.0-SNAPSHOT`, which cannot be resolved. Since the module is registered in the root POM `<modules>`, POM model building fails for every job, breaking the **entire** `branch-4.x` build:

```
[FATAL] Non-resolvable parent POM for org.apache.spark:spark-udf-worker-grpc_2.13:5.0.0-SNAPSHOT:
Could not find artifact org.apache.spark:spark-parent_2.13:pom:5.0.0-SNAPSHOT in central
... and 'parent.relativePath' points at wrong local POM @ line 24, column 11
```

The sibling modules `udf/worker/core` and `udf/worker/proto` already correctly use `4.2.0-SNAPSHOT`.

### Does this PR introduce _any_ user-facing change?

No. Build-only fix on the unreleased `branch-4.x`.

### How was this patch tested?

Existing CI. This unblocks all `branch-4.x` builds, which currently fail at the POM model building step before any compilation/tests run.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)

This pull request and its description were written by Isaac.