### PR TITLE
[SPARK-56721][INFRA][FOLLOWUP] Fix pyspark-connect-old-client CI failure on fork PRs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -832,13 +832,8 @@ jobs:
 
         # Checkout to branch-4.0 to use the tests in branch-4.0.
         cd ..
-        git clone --single-branch --branch branch-4.0 $GITHUB_SERVER_URL/$GITHUB_REPOSITORY spark-4.0
+        git clone --single-branch --branch branch-4.0 https://github.com/apache/spark.git spark-4.0
         cd spark-4.0
-        # Merge in apache/spark's branch-4.0 so CI runs against the latest upstream tests,
-        # while still incorporating any changes the contributor made on their fork's branch-4.0.
-        git fetch https://github.com/apache/spark.git branch-4.0
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' \
-            merge --no-edit FETCH_HEAD
 
         # Several tests related to catalog requires to run them sequencially, e.g., writing a table in a listener.
         # Run branch-4.0 tests


### PR DESCRIPTION
### What changes were proposed in this pull request?
Clone `branch-4.0` directly from `https://github.com/apache/spark.git` instead of `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY` in the `pyspark-connect-old-client` CI job. The subsequent `git fetch` + `merge` of apache/spark's branch-4.0 is also removed since it's no longer needed.
  
### Why are the changes needed?
The `pyspark-connect-old-client` job added in SPARK-56721 (#55677) clones `branch-4.0` from `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY`, which points to the contributor's fork during PR CI. Forks don't necessarily have a `branch-4.0`, causing the job to fail with:
``` 
fatal: Remote branch branch-4.0 not found in upstream origin
```
https://github.com/sarutak/spark/actions/runs/26959847246/job/79550831803
https://github.com/MaxGekk/spark/actions/runs/26946704979/job/79504093998
https://github.com/LuciferYang/spark/actions/runs/26942191431/job/79493901767

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Claude.