### PR TITLE
[SPARK-57270][INFRA][4.0] Fix `spark-rm` Dockerfile to use Python 3.9 specific get-pip.py

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -41,7 +41,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pip for both Python versions
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9 && \
+RUN curl -sS https://bootstrap.pypa.io/pip/3.9/get-pip.py | python3.9 && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 
 # Basic Python packages for Spark 4.0


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR uses the Python 3.9 specific `get-pip.py` URL in `dev/create-release/spark-rm/Dockerfile`.

```diff
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9 && \
+RUN curl -sS https://bootstrap.pypa.io/pip/3.9/get-pip.py | python3.9 && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
```

### Why are the changes needed?

The `Release Apache Spark` workflow for `branch-4.0` fails because the canonical `get-pip.py` dropped Python 3.9 support:
- https://github.com/dongjoon-hyun/spark/actions/runs/26971633560

```
ERROR: This script does not work on Python 3.9. The minimum supported Python
version is 3.10. Please use https://bootstrap.pypa.io/pip/3.9/get-pip.py instead.
```

The version-pinned URL is the documented replacement like other CIs.
- #55722

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test because this is a release script.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)