### PR TITLE
[SPARK-57277][INFRA] Make CI cache keys OS-specific

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -378,9 +378,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          build-
+          ${{ runner.os }}-build-
     - name: Restore Coursier local repository
       uses: actions/cache/restore@v5
       with:
@@ -612,9 +612,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          build-
+          ${{ runner.os }}-build-
     - name: Cache Coursier local repository
       uses: actions/cache@v5
       with:
@@ -741,9 +741,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          build-
+          ${{ runner.os }}-build-
     - name: Restore Coursier local repository
       uses: actions/cache/restore@v5
       with:
@@ -927,9 +927,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          build-
+          ${{ runner.os }}-build-
     - name: Restore Coursier local repository
       uses: actions/cache/restore@v5
       with:
@@ -1078,9 +1078,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          build-
+          ${{ runner.os }}-build-
     - name: Restore Coursier local repository
       uses: actions/cache/restore@v5
       with:
@@ -1092,9 +1092,9 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.m2/repository
-        key: docs-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-docs-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          docs-maven-
+          ${{ runner.os }}-docs-maven-
     - name: Free up disk space
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
@@ -1277,9 +1277,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          build-
+          ${{ runner.os }}-build-
     - name: Restore Coursier local repository
       uses: actions/cache/restore@v5
       with:
@@ -1291,9 +1291,9 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.m2/repository
-        key: docs-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-docs-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          docs-maven-
+          ${{ runner.os }}-docs-maven-
     - name: Free up disk space
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
@@ -1472,9 +1472,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          build-
+          ${{ runner.os }}-build-
     - name: Restore Coursier local repository
       uses: actions/cache/restore@v5
       with:
@@ -1506,7 +1506,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ./tpcds-sf-1
-        key: tpcds-${{ hashFiles('.github/workflows/build_and_test.yml', 'sql/core/src/test/scala/org/apache/spark/sql/TPCDSSchema.scala') }}
+        key: ${{ runner.os }}-tpcds-${{ hashFiles('.github/workflows/build_and_test.yml', 'sql/core/src/test/scala/org/apache/spark/sql/TPCDSSchema.scala') }}
     - name: Checkout tpcds-kit repository
       if: steps.cache-tpcds-sf-1.outputs.cache-hit != 'true'
       uses: actions/checkout@v6
@@ -1604,9 +1604,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          build-
+          ${{ runner.os }}-build-
     - name: Restore Coursier local repository
       uses: actions/cache/restore@v5
       with:
@@ -1690,9 +1690,9 @@ jobs:
             build/apache-maven-*
             build/*.jar
             ~/.sbt
-          key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
           restore-keys: |
-            build-
+            ${{ runner.os }}-build-
       - name: Restore Coursier local repository
         uses: actions/cache/restore@v5
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -378,9 +378,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: build-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          ${{ runner.os }}-build-
+          build-${{ runner.os }}-
     - name: Restore Coursier local repository
       uses: actions/cache/restore@v5
       with:
@@ -612,9 +612,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: build-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          ${{ runner.os }}-build-
+          build-${{ runner.os }}-
     - name: Cache Coursier local repository
       uses: actions/cache@v5
       with:
@@ -741,9 +741,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: build-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          ${{ runner.os }}-build-
+          build-${{ runner.os }}-
     - name: Restore Coursier local repository
       uses: actions/cache/restore@v5
       with:
@@ -927,9 +927,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: build-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          ${{ runner.os }}-build-
+          build-${{ runner.os }}-
     - name: Restore Coursier local repository
       uses: actions/cache/restore@v5
       with:
@@ -1078,9 +1078,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: build-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          ${{ runner.os }}-build-
+          build-${{ runner.os }}-
     - name: Restore Coursier local repository
       uses: actions/cache/restore@v5
       with:
@@ -1092,9 +1092,9 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-docs-maven-${{ hashFiles('**/pom.xml') }}
+        key: docs-maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-docs-maven-
+          docs-maven-${{ runner.os }}-
     - name: Free up disk space
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
@@ -1277,9 +1277,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: build-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          ${{ runner.os }}-build-
+          build-${{ runner.os }}-
     - name: Restore Coursier local repository
       uses: actions/cache/restore@v5
       with:
@@ -1291,9 +1291,9 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-docs-maven-${{ hashFiles('**/pom.xml') }}
+        key: docs-maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-docs-maven-
+          docs-maven-${{ runner.os }}-
     - name: Free up disk space
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
@@ -1472,9 +1472,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: build-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          ${{ runner.os }}-build-
+          build-${{ runner.os }}-
     - name: Restore Coursier local repository
       uses: actions/cache/restore@v5
       with:
@@ -1506,7 +1506,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ./tpcds-sf-1
-        key: ${{ runner.os }}-tpcds-${{ hashFiles('.github/workflows/build_and_test.yml', 'sql/core/src/test/scala/org/apache/spark/sql/TPCDSSchema.scala') }}
+        key: tpcds-${{ runner.os }}-${{ hashFiles('.github/workflows/build_and_test.yml', 'sql/core/src/test/scala/org/apache/spark/sql/TPCDSSchema.scala') }}
     - name: Checkout tpcds-kit repository
       if: steps.cache-tpcds-sf-1.outputs.cache-hit != 'true'
       uses: actions/checkout@v6
@@ -1604,9 +1604,9 @@ jobs:
           build/apache-maven-*
           build/*.jar
           ~/.sbt
-        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        key: build-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
         restore-keys: |
-          ${{ runner.os }}-build-
+          build-${{ runner.os }}-
     - name: Restore Coursier local repository
       uses: actions/cache/restore@v5
       with:
@@ -1690,9 +1690,9 @@ jobs:
             build/apache-maven-*
             build/*.jar
             ~/.sbt
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          key: build-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
           restore-keys: |
-            ${{ runner.os }}-build-
+            build-${{ runner.os }}-
       - name: Restore Coursier local repository
         uses: actions/cache/restore@v5
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -385,10 +385,10 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ~/.cache/coursier
-        key: ${{ runner.os }}-${{ matrix.java }}-${{ matrix.hadoop }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+        key: coursier-${{ runner.os }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.java }}-${{ matrix.hadoop }}-coursier-
-          ${{ runner.os }}-coursier-
+          coursier-${{ runner.os }}-${{ matrix.java }}-${{ matrix.hadoop }}-
+          coursier-${{ runner.os }}-
     - name: Free up disk space
       run: |
         if [ -f ./dev/free_disk_space ]; then
@@ -619,9 +619,9 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.cache/coursier
-        key: ${{ runner.os }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+        key: coursier-${{ runner.os }}-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
-          ${{ runner.os }}-coursier-
+          coursier-${{ runner.os }}-
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v5
       with:
@@ -748,9 +748,9 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ~/.cache/coursier
-        key: ${{ runner.os }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+        key: coursier-${{ runner.os }}-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
-          ${{ runner.os }}-coursier-
+          coursier-${{ runner.os }}-
     - name: Free up disk space
       shell: 'script -q -e -c "bash {0}"'
       run: ./dev/free_disk_space_container
@@ -934,9 +934,9 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ~/.cache/coursier
-        key: ${{ runner.os }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+        key: coursier-${{ runner.os }}-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
-          ${{ runner.os }}-coursier-
+          coursier-${{ runner.os }}-
     - name: Free up disk space
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
@@ -1085,9 +1085,9 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ~/.cache/coursier
-        key: ${{ runner.os }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+        key: coursier-${{ runner.os }}-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
-          ${{ runner.os }}-coursier-
+          coursier-${{ runner.os }}-
     - name: Cache Maven local repository
       uses: actions/cache@v5
       with:
@@ -1284,9 +1284,9 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ~/.cache/coursier
-        key: ${{ runner.os }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+        key: coursier-${{ runner.os }}-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
-          ${{ runner.os }}-coursier-
+          coursier-${{ runner.os }}-
     - name: Cache Maven local repository
       uses: actions/cache@v5
       with:
@@ -1479,9 +1479,9 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ~/.cache/coursier
-        key: ${{ runner.os }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+        key: coursier-${{ runner.os }}-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
-          ${{ runner.os }}-coursier-
+          coursier-${{ runner.os }}-
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v5
       with:
@@ -1611,9 +1611,9 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ~/.cache/coursier
-        key: ${{ runner.os }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+        key: coursier-${{ runner.os }}-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
-          ${{ runner.os }}-coursier-
+          coursier-${{ runner.os }}-
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v5
       with:
@@ -1697,9 +1697,9 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/coursier
-          key: ${{ runner.os }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+          key: coursier-${{ runner.os }}-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
           restore-keys: |
-            ${{ runner.os }}-coursier-
+            coursier-${{ runner.os }}-
       - name: Free up disk space
         run: |
           if [ -f ./dev/free_disk_space ]; then

--- a/.github/workflows/build_python_connect.yml
+++ b/.github/workflows/build_python_connect.yml
@@ -41,16 +41,16 @@ jobs:
             build/apache-maven-*
             build/*.jar
             ~/.sbt
-          key: ${{ runner.os }}-build-spark-connect-python-only-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          key: build-spark-connect-python-only-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
           restore-keys: |
-            ${{ runner.os }}-build-spark-connect-python-only-
+            build-spark-connect-python-only-${{ runner.os }}-
       - name: Cache Coursier local repository
         uses: actions/cache@v5
         with:
           path: ~/.cache/coursier
-          key: ${{ runner.os }}-coursier-build-spark-connect-python-only-${{ hashFiles('**/pom.xml') }}
+          key: coursier-build-spark-connect-python-only-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-coursier-build-spark-connect-python-only-
+            coursier-build-spark-connect-python-only-${{ runner.os }}-
       - name: Install Java 17
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/build_python_connect.yml
+++ b/.github/workflows/build_python_connect.yml
@@ -41,16 +41,16 @@ jobs:
             build/apache-maven-*
             build/*.jar
             ~/.sbt
-          key: build-spark-connect-python-only-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          key: ${{ runner.os }}-build-spark-connect-python-only-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
           restore-keys: |
-            build-spark-connect-python-only-
+            ${{ runner.os }}-build-spark-connect-python-only-
       - name: Cache Coursier local repository
         uses: actions/cache@v5
         with:
           path: ~/.cache/coursier
-          key: coursier-build-spark-connect-python-only-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-coursier-build-spark-connect-python-only-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            coursier-build-spark-connect-python-only-
+            ${{ runner.os }}-coursier-build-spark-connect-python-only-
       - name: Install Java 17
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/build_python_connect40.yml
+++ b/.github/workflows/build_python_connect40.yml
@@ -43,16 +43,16 @@ jobs:
             build/apache-maven-*
             build/*.jar
             ~/.sbt
-          key: ${{ runner.os }}-build-spark-connect-python-only-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          key: build-spark-connect-python-only-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
           restore-keys: |
-            ${{ runner.os }}-build-spark-connect-python-only-
+            build-spark-connect-python-only-${{ runner.os }}-
       - name: Cache Coursier local repository
         uses: actions/cache@v5
         with:
           path: ~/.cache/coursier
-          key: ${{ runner.os }}-coursier-build-spark-connect-python-only-${{ hashFiles('**/pom.xml') }}
+          key: coursier-build-spark-connect-python-only-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-coursier-build-spark-connect-python-only-
+            coursier-build-spark-connect-python-only-${{ runner.os }}-
       - name: Install Java 17
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/build_python_connect40.yml
+++ b/.github/workflows/build_python_connect40.yml
@@ -43,16 +43,16 @@ jobs:
             build/apache-maven-*
             build/*.jar
             ~/.sbt
-          key: build-spark-connect-python-only-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          key: ${{ runner.os }}-build-spark-connect-python-only-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
           restore-keys: |
-            build-spark-connect-python-only-
+            ${{ runner.os }}-build-spark-connect-python-only-
       - name: Cache Coursier local repository
         uses: actions/cache@v5
         with:
           path: ~/.cache/coursier
-          key: coursier-build-spark-connect-python-only-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-coursier-build-spark-connect-python-only-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            coursier-build-spark-connect-python-only-
+            ${{ runner.os }}-coursier-build-spark-connect-python-only-
       - name: Install Java 17
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -43,9 +43,9 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.m2/repository
-        key: build-sparkr-windows-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-build-sparkr-windows-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          build-sparkr-windows-maven-
+          ${{ runner.os }}-build-sparkr-windows-maven-
     - name: Install Java 17
       uses: actions/setup-java@v5
       with:

--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -43,9 +43,9 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-build-sparkr-windows-maven-${{ hashFiles('**/pom.xml') }}
+        key: build-sparkr-windows-maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-build-sparkr-windows-maven-
+          build-sparkr-windows-maven-${{ runner.os }}-
     - name: Install Java 17
       uses: actions/setup-java@v5
       with:

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -89,18 +89,18 @@ jobs:
             build/apache-maven-*
             build/*.jar
             ~/.sbt
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          key: build-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
           restore-keys: |
-            ${{ runner.os }}-build-
+            build-${{ runner.os }}-
       - name: Cache Maven local repository
         # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
         if: ${{ runner.os != 'macOS' }}
         uses: actions/cache@v5
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-java${{ inputs.java }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: maven-${{ runner.os }}-java${{ inputs.java }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-java${{ inputs.java }}-maven-
+            maven-${{ runner.os }}-java${{ inputs.java }}-
       - name: Install Java ${{ inputs.java }}
         uses: actions/setup-java@v5
         with:
@@ -240,18 +240,18 @@ jobs:
             build/apache-maven-*
             build/*.jar
             ~/.sbt
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          key: build-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
           restore-keys: |
-            ${{ runner.os }}-build-
+            build-${{ runner.os }}-
       - name: Cache Maven local repository
         # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
         if: ${{ runner.os != 'macOS' }}
         uses: actions/cache@v5
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-java${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: maven-${{ runner.os }}-java${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-java${{ matrix.java }}-maven-
+            maven-${{ runner.os }}-java${{ matrix.java }}-
       - name: Install Java ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -89,18 +89,18 @@ jobs:
             build/apache-maven-*
             build/*.jar
             ~/.sbt
-          key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
           restore-keys: |
-            build-
+            ${{ runner.os }}-build-
       - name: Cache Maven local repository
         # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
         if: ${{ runner.os != 'macOS' }}
         uses: actions/cache@v5
         with:
           path: ~/.m2/repository
-          key: java${{ inputs.java }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-java${{ inputs.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            java${{ inputs.java }}-maven-
+            ${{ runner.os }}-java${{ inputs.java }}-maven-
       - name: Install Java ${{ inputs.java }}
         uses: actions/setup-java@v5
         with:
@@ -240,18 +240,18 @@ jobs:
             build/apache-maven-*
             build/*.jar
             ~/.sbt
-          key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
           restore-keys: |
-            build-
+            ${{ runner.os }}-build-
       - name: Cache Maven local repository
         # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
         if: ${{ runner.os != 'macOS' }}
         uses: actions/cache@v5
         with:
           path: ~/.m2/repository
-          key: java${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-java${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            java${{ matrix.java }}-maven-
+            ${{ runner.os }}-java${{ matrix.java }}-maven-
       - name: Install Java ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -49,9 +49,9 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.m2/repository
-        key: snapshot-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-snapshot-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          snapshot-maven-
+          ${{ runner.os }}-snapshot-maven-
     - name: Install Java 8 for branch-3.x
       if: matrix.branch == 'branch-3.5'
       uses: actions/setup-java@v5

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -49,9 +49,9 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-snapshot-maven-${{ hashFiles('**/pom.xml') }}
+        key: snapshot-maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-snapshot-maven-
+          snapshot-maven-${{ runner.os }}-
     - name: Install Java 8 for branch-3.x
       if: matrix.branch == 'branch-3.5'
       uses: actions/setup-java@v5

--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -128,9 +128,9 @@ jobs:
             build/apache-maven-*
             build/*.jar
             ~/.sbt
-          key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
           restore-keys: |
-            build-
+            ${{ runner.os }}-build-
       - name: Cache Coursier local repository
         # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
         if: ${{ runner.os != 'macOS' }}

--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -137,9 +137,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/coursier
-          key: ${{ runner.os }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+          key: coursier-${{ runner.os }}-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
           restore-keys: |
-            ${{ runner.os }}-coursier-
+            coursier-${{ runner.os }}-
       - name: Install Java ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -128,9 +128,9 @@ jobs:
             build/apache-maven-*
             build/*.jar
             ~/.sbt
-          key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          key: build-${{ runner.os }}-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
           restore-keys: |
-            ${{ runner.os }}-build-
+            build-${{ runner.os }}-
       - name: Cache Coursier local repository
         # TODO(SPARK-54466): https://github.com/actions/runner-images/issues/13341
         if: ${{ runner.os != 'macOS' }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make every CI cache `key:` and `restore-keys:` value OS-specific and give them a uniform shape: `<prefix>-${{ runner.os }}-<env>-<hash>` — the human-readable prefix leads, `${{ runner.os }}` follows, then any environment-specific component (e.g. the Java version, or Java + Hadoop for Coursier), then the `hashFiles(...)` hash.

- `build_and_test.yml`: `build-`, `docs-maven-`, `tpcds-`, and the Coursier caches (`coursier-${{ runner.os }}-…`, including the matrix variant `coursier-${{ runner.os }}-${{ matrix.java }}-${{ matrix.hadoop }}-…`)
- `build_sparkr_window.yml`: `build-sparkr-windows-maven-`
- `maven_test.yml`: `build-`, and `maven-${{ runner.os }}-java${{ ... }}-` (Java version after the OS)
- `build_python_connect.yml` / `build_python_connect40.yml`: `build-spark-connect-python-only-`, `coursier-build-spark-connect-python-only-`
- `python_hosted_runner_test.yml`: `build-`, `coursier-`
- `publish_snapshot.yml`: `snapshot-maven-`

The Coursier caches already embedded `${{ runner.os }}` (as a leading prefix); they are reordered here so that every cache key in the workflows follows the same `<prefix>-${{ runner.os }}-…` convention.

### Why are the changes needed?

Without an OS component, cache entries from Linux, macOS, and Windows runners share the same key namespace. A cache written by one OS can be restored on another, causing subtle build failures or stale-artifact issues. Embedding `${{ runner.os }}` ensures each OS has its own isolated cache. Keeping the descriptive prefix first preserves readability, groups related caches together, and makes the keys consistent across all workflows.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI workflow change only; no code logic changed. The cache keys are verified by inspection.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8
