### PR TITLE
[SPARK-57275][CONNECT] Validate row count after consuming all arrow batches

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1667,13 +1667,16 @@ class SparkConnectClient(object):
                         for batch in reader:
                             assert isinstance(batch, pa.RecordBatch)
                             num_records_in_batch += batch.num_rows
-                            if num_records_in_batch != b.arrow_batch.row_count:
-                                raise SparkConnectException(
-                                    f"Expected {b.arrow_batch.row_count} rows in arrow batch but "
-                                    + f"got {num_records_in_batch}."
-                                )
-                            num_records += num_records_in_batch
+                            num_records += batch.num_rows
                             yield batch
+                        # An Arrow IPC stream ([Schema][RecordBatch]*[EOS]) may carry
+                        # multiple RecordBatches, so validate row_count only once the
+                        # reader is fully consumed.
+                        if num_records_in_batch != b.arrow_batch.row_count:
+                            raise SparkConnectException(
+                                f"Expected {b.arrow_batch.row_count} rows in arrow batch but "
+                                + f"got {num_records_in_batch}."
+                            )
             if b.HasField("create_resource_profile_command_result"):
                 profile_id = b.create_resource_profile_command_result.profile_id
                 yield {"create_resource_profile_command_result": profile_id}

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -39,7 +39,10 @@ if should_test_connect:
     from pyspark.sql.connect.client.reattach import ExecutePlanResponseReattachableIterator
     from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
     from pyspark.errors import PySparkRuntimeError
-    from pyspark.errors.exceptions.connect import SparkConnectGrpcException
+    from pyspark.errors.exceptions.connect import (
+        SparkConnectException,
+        SparkConnectGrpcException,
+    )
     import pyspark.sql.connect.proto as proto
 
     class TestPolicy(DefaultPolicy):
@@ -277,43 +280,63 @@ class SparkConnectClientTestCase(unittest.TestCase):
             mock.req.client_type, r"^_SPARK_CONNECT_PYTHON spark/[^ ]+ os/[^ ]+ python/[^ ]+$"
         )
 
+    class MultiBatchMockService:
+        """Mock service returning a single arrow batch message whose IPC stream
+        carries multiple RecordBatches. ``declared_row_count`` is the row_count
+        the server claims, allowing tests to exercise both the matching and the
+        mismatching validation paths."""
+
+        def __init__(self, session_id: str, values, declared_row_count: int):
+            self._session_id = session_id
+            self._values = values
+            self._declared_row_count = declared_row_count
+            self.req: Optional[proto.ExecutePlanRequest] = None
+
+        def ExecutePlan(self, req: proto.ExecutePlanRequest, metadata, timeout=None):
+            self.req = req
+            resp = proto.ExecutePlanResponse()
+            resp.session_id = self._session_id
+            resp.operation_id = req.operation_id
+
+            pdf = pd.DataFrame(data={"col1": self._values})
+            schema = pa.Schema.from_pandas(pdf)
+            table = pa.Table.from_pandas(pdf)
+            sink = pa.BufferOutputStream()
+            writer = pa.ipc.new_stream(sink, schema=schema)
+            # Split the data into multiple RecordBatches within one IPC stream.
+            for batch in table.to_batches(max_chunksize=2):
+                writer.write_batch(batch)
+            writer.close()
+
+            resp.arrow_batch.data = sink.getvalue().to_pybytes()
+            resp.arrow_batch.row_count = self._declared_row_count
+            return [resp]
+
     def test_multiple_record_batches_in_single_arrow_batch(self):
         # An Arrow IPC stream may carry multiple RecordBatches; row_count is the total
         # across them and must be validated only after the stream is fully consumed.
         client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
+        values = [1, 2, 3, 4]
+        client._stub = self.MultiBatchMockService(
+            client._session_id, values, declared_row_count=len(values)
+        )
 
-        class MultiBatchMockService:
-            def __init__(self, session_id: str):
-                self._session_id = session_id
-                self.req: Optional[proto.ExecutePlanRequest] = None
+        table, _, _ = client.to_table(proto.Plan(), {})
+        self.assertEqual(table.num_rows, len(values))
+        self.assertEqual(table.column("col1").to_pylist(), values)
 
-            def ExecutePlan(self, req: proto.ExecutePlanRequest, metadata):
-                self.req = req
-                resp = proto.ExecutePlanResponse()
-                resp.session_id = self._session_id
-                resp.operation_id = req.operation_id
+    def test_multiple_record_batches_row_count_mismatch_raises(self):
+        # The validation this fix targets: when the declared row_count does not match
+        # the total rows across all RecordBatches in the stream, it must still raise.
+        client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
+        values = [1, 2, 3, 4]
+        client._stub = self.MultiBatchMockService(
+            client._session_id, values, declared_row_count=len(values) + 1
+        )
 
-                pdf = pd.DataFrame(data={"col1": [1, 2, 3, 4]})
-                schema = pa.Schema.from_pandas(pdf)
-                table = pa.Table.from_pandas(pdf)
-                sink = pa.BufferOutputStream()
-                writer = pa.ipc.new_stream(sink, schema=schema)
-                # Two RecordBatches in one IPC stream.
-                for batch in table.to_batches(max_chunksize=2):
-                    writer.write_batch(batch)
-                writer.close()
-
-                resp.arrow_batch.data = sink.getvalue().to_pybytes()
-                # row_count is the total across all RecordBatches in the message.
-                resp.arrow_batch.row_count = 4
-                return [resp]
-
-        mock = MultiBatchMockService(client._session_id)
-        client._stub = mock
-
-        plan = proto.Plan()
-        table, _, _ = client.to_table(plan, {})
-        self.assertEqual(table.num_rows, 4)
+        with self.assertRaises(SparkConnectException) as ctx:
+            client.to_table(proto.Plan(), {})
+        self.assertIn("Expected 5 rows in arrow batch but got 4", str(ctx.exception))
 
     def test_properties(self):
         client = SparkConnectClient("sc://foo/;token=bar", use_reattachable_execute=False)

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -277,6 +277,44 @@ class SparkConnectClientTestCase(unittest.TestCase):
             mock.req.client_type, r"^_SPARK_CONNECT_PYTHON spark/[^ ]+ os/[^ ]+ python/[^ ]+$"
         )
 
+    def test_multiple_record_batches_in_single_arrow_batch(self):
+        # An Arrow IPC stream may carry multiple RecordBatches; row_count is the total
+        # across them and must be validated only after the stream is fully consumed.
+        client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
+
+        class MultiBatchMockService:
+            def __init__(self, session_id: str):
+                self._session_id = session_id
+                self.req: Optional[proto.ExecutePlanRequest] = None
+
+            def ExecutePlan(self, req: proto.ExecutePlanRequest, metadata):
+                self.req = req
+                resp = proto.ExecutePlanResponse()
+                resp.session_id = self._session_id
+                resp.operation_id = req.operation_id
+
+                pdf = pd.DataFrame(data={"col1": [1, 2, 3, 4]})
+                schema = pa.Schema.from_pandas(pdf)
+                table = pa.Table.from_pandas(pdf)
+                sink = pa.BufferOutputStream()
+                writer = pa.ipc.new_stream(sink, schema=schema)
+                # Two RecordBatches in one IPC stream.
+                for batch in table.to_batches(max_chunksize=2):
+                    writer.write_batch(batch)
+                writer.close()
+
+                resp.arrow_batch.data = sink.getvalue().to_pybytes()
+                # row_count is the total across all RecordBatches in the message.
+                resp.arrow_batch.row_count = 4
+                return [resp]
+
+        mock = MultiBatchMockService(client._session_id)
+        client._stub = mock
+
+        plan = proto.Plan()
+        table, _, _ = client.to_table(plan, {})
+        self.assertEqual(table.num_rows, 4)
+
     def test_properties(self):
         client = SparkConnectClient("sc://foo/;token=bar", use_reattachable_execute=False)
         self.assertEqual(client.token, "bar")

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -312,14 +312,21 @@ class SparkConnectClientTestCase(unittest.TestCase):
             resp.arrow_batch.row_count = self._declared_row_count
             return [resp]
 
+    def _client_with_multi_batch_stub(self, values, declared_row_count):
+        # Build a client whose stub returns ``values`` split across multiple
+        # RecordBatches in a single arrow batch message, declaring
+        # ``declared_row_count`` rows.
+        client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
+        client._stub = self.MultiBatchMockService(
+            client._session_id, values, declared_row_count=declared_row_count
+        )
+        return client
+
     def test_multiple_record_batches_in_single_arrow_batch(self):
         # An Arrow IPC stream may carry multiple RecordBatches; row_count is the total
         # across them and must be validated only after the stream is fully consumed.
-        client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
         values = [1, 2, 3, 4]
-        client._stub = self.MultiBatchMockService(
-            client._session_id, values, declared_row_count=len(values)
-        )
+        client = self._client_with_multi_batch_stub(values, declared_row_count=len(values))
 
         table, _, _ = client.to_table(proto.Plan(), {})
         self.assertEqual(table.num_rows, len(values))
@@ -328,11 +335,8 @@ class SparkConnectClientTestCase(unittest.TestCase):
     def test_multiple_record_batches_row_count_mismatch_raises(self):
         # The validation this fix targets: when the declared row_count does not match
         # the total rows across all RecordBatches in the stream, it must still raise.
-        client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
         values = [1, 2, 3, 4]
-        client._stub = self.MultiBatchMockService(
-            client._session_id, values, declared_row_count=len(values) + 1
-        )
+        client = self._client_with_multi_batch_stub(values, declared_row_count=len(values) + 1)
 
         with self.assertRaises(SparkConnectException) as ctx:
             client.to_table(proto.Plan(), {})


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

When consuming query results on the spark connect client, count each RecordBatch once (num_records += batch.num_rows) and validate row_count only after the IPC stream is fully consumed. The Scala client in SparkResult.scala already validates after the loop and is unaffected.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The Arrow IPC streaming format wraps a result as `[Schema][RecordBatch]*[EOS]` a single message can carry multiple RecordBatches, and `pa.ipc.open_stream(...)` parses all of them. The server's arrow_batch.row_count is the total rows across every RecordBatch in the message and the spark connect client validates the row count inside the per-batch loop:
 
```
  for batch in reader:
      num_records_in_batch += batch.num_rows
      if num_records_in_batch != b.arrow_batch.row_count:   # checked too early
          raise SparkConnectException(...)
      num_records += num_records_in_batch                    # also double-counts
```
When a message contains more than one RecordBatch, the check fires after the first batch, before the stream is fully consumed, and throws:

`SparkConnectException: Expected N rows in arrow batch but got M. (M < N)`

Impact: Any code path that produces multi-RecordBatch IPC streams fails to fetch results, even though the payload is well-formed and parseable by PyArrow.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
Added unit tests for the client,


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by:Claude Opus 4.8
