### PR TITLE
[SPARK-57283][BUILD] Upgrade `wildfly-openssl` to 2.3.0.Final

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -280,7 +280,7 @@ vertx-web-client/4.5.26//vertx-web-client-4.5.26.jar
 vertx-web-common/4.5.26//vertx-web-common-4.5.26.jar
 volcano-client/7.7.0//volcano-client-7.7.0.jar
 volcano-model/7.7.0//volcano-model-7.7.0.jar
-wildfly-openssl/2.2.5.Final//wildfly-openssl-2.2.5.Final.jar
+wildfly-openssl/2.3.0.Final//wildfly-openssl-2.3.0.Final.jar
 xbean-asm9-shaded/4.30//xbean-asm9-shaded-4.30.jar
 xmlschema-core/2.3.1//xmlschema-core-2.3.1.jar
 xz/1.12//xz-1.12.jar

--- a/hadoop-cloud/pom.xml
+++ b/hadoop-cloud/pom.xml
@@ -36,7 +36,7 @@
     <sbt.project.name>hadoop-cloud</sbt.project.name>
     <okhttp.version>3.12.12</okhttp.version>
     <okio.version>1.17.6</okio.version>
-    <wildfly-openssl.version>2.2.5.Final</wildfly-openssl.version>
+    <wildfly-openssl.version>2.3.0.Final</wildfly-openssl.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `wildfly-openssl` to 2.3.0.Final for Apache Spark 5.0.0 (2027)

### Why are the changes needed?

`wildfly-openssl` `2.2.5.Final` was released on 2022-08-03 (about 4 years ago). We had better make it up-to-date for Spark 5.0.0 (2027) in order to bring new improvements and bug fixes:
- https://github.com/wildfly-security/wildfly-openssl/releases/tag/2.3.0.Final (2026-03-12)
  - https://github.com/wildfly-security/wildfly-openssl/pull/151
  - https://github.com/wildfly-security/wildfly-openssl/pull/155

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)