### PR TITLE
[SPARK-57223][SQL] INCOMPATIBLE_DATA_FOR_TABLE errors mis-quote a column/field name that contains a dot

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
@@ -457,7 +457,7 @@ object TableOutputResolver extends SQLConfHelper with Logging {
     val output = if (reordered.length == expectedCols.length) {
       if (matchedCols.size < inputCols.length) {
         val extraCols = inputCols.filterNot(col => matchedCols.contains(col.name))
-          .map(col => s"${toSQLId(col.name)}").mkString(", ")
+          .map(col => s"${toSQLId(Seq(col.name))}").mkString(", ")
         if (colPath.isEmpty) {
           throw QueryCompilationErrors.incompatibleDataToTableExtraColumnsError(tableName,
             extraCols)
@@ -495,7 +495,7 @@ object TableOutputResolver extends SQLConfHelper with Logging {
     }
     if (inputCols.size > actualExpectedCols.size) {
       val extraColsStr = inputCols.takeRight(inputCols.size - actualExpectedCols.size)
-        .map(col => toSQLId(col.name))
+        .map(col => toSQLId(Seq(col.name)))
         .mkString(", ")
       if (colPath.isEmpty) {
         throw QueryCompilationErrors.cannotWriteTooManyColumnsToTableError(tableName,
@@ -508,7 +508,7 @@ object TableOutputResolver extends SQLConfHelper with Logging {
     } else if (inputCols.size < actualExpectedCols.size && !fillDefaultValue) {
       val missingCols = actualExpectedCols.drop(inputCols.size)
       val missingColsStr = missingCols
-        .map(col => toSQLId(col.name))
+        .map(col => toSQLId(Seq(col.name)))
         .mkString(", ")
       if (colPath.isEmpty) {
         throw QueryCompilationErrors.cannotWriteNotEnoughColumnsToTableError(tableName,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
@@ -162,7 +162,7 @@ object TableOutputResolver extends SQLConfHelper with Logging {
 
     if (errors.nonEmpty) {
       throw QueryCompilationErrors.incompatibleDataToTableCannotFindDataError(
-        tableName, expected.map(_.name).map(toSQLId).mkString(", "))
+        tableName, expected.map(col => toSQLId(Seq(col.name))).mkString(", "))
     }
 
     val plan = if (resolved == query.output) {
@@ -457,7 +457,7 @@ object TableOutputResolver extends SQLConfHelper with Logging {
     val output = if (reordered.length == expectedCols.length) {
       if (matchedCols.size < inputCols.length) {
         val extraCols = inputCols.filterNot(col => matchedCols.contains(col.name))
-          .map(col => s"${toSQLId(Seq(col.name))}").mkString(", ")
+          .map(col => toSQLId(Seq(col.name))).mkString(", ")
         if (colPath.isEmpty) {
           throw QueryCompilationErrors.incompatibleDataToTableExtraColumnsError(tableName,
             extraCols)
@@ -471,7 +471,7 @@ object TableOutputResolver extends SQLConfHelper with Logging {
     } else if (enforceFullOutput) {
       val colName =
         if (colPath.nonEmpty) colPath.quoted
-        else expectedCols.map(_.name).map(toSQLId).mkString(", ")
+        else expectedCols.map(col => toSQLId(Seq(col.name))).mkString(", ")
       throw QueryCompilationErrors.incompatibleDataToTableCannotFindDataError(tableName, colName)
     } else {
       Nil
@@ -577,7 +577,7 @@ object TableOutputResolver extends SQLConfHelper with Logging {
     if (result.length != actualExpectedCols.size) {
       val colName =
         if (colPath.nonEmpty) colPath.quoted
-        else actualExpectedCols.map(_.name).map(toSQLId).mkString(", ")
+        else actualExpectedCols.map(col => toSQLId(Seq(col.name))).mkString(", ")
       throw QueryCompilationErrors.incompatibleDataToTableCannotFindDataError(tableName, colName)
     }
     (result, autoFilledGenCols.toSet)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
@@ -155,6 +155,53 @@ class DataFrameWriterV2Suite extends SharedSparkSession with BeforeAndAfter {
       Seq())
   }
 
+  test("SPARK-57223: Append: extra column with special-char name is quoted correctly in error") {
+    spark.sql("CREATE TABLE testcat.table_name (id bigint, data string) USING foo")
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.table("source").withColumnRenamed("data", "b.c")
+          .writeTo("testcat.table_name").append()
+      },
+      condition = "INCOMPATIBLE_DATA_FOR_TABLE.EXTRA_COLUMNS",
+      parameters = Map(
+        "tableName" -> "`testcat`.`table_name`",
+        "extraColumns" -> "`b.c`")
+    )
+  }
+
+  test("SPARK-57223: by-position insert with extra nested struct field with special-char " +
+    "name is quoted correctly in error") {
+    spark.sql("CREATE TABLE testcat.table_name (id bigint, info struct<a: bigint>) USING foo")
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.sql("INSERT INTO testcat.table_name " +
+          "SELECT id, named_struct('a', id, 'b.c', id) AS info FROM range(1)")
+      },
+      condition = "INCOMPATIBLE_DATA_FOR_TABLE.EXTRA_STRUCT_FIELDS",
+      parameters = Map(
+        "tableName" -> "`testcat`.`table_name`",
+        "colName" -> "`info`",
+        "extraFields" -> "`b.c`")
+    )
+  }
+
+  test("SPARK-57223: by-position insert with missing nested struct field with special-char " +
+    "name is quoted correctly in error") {
+    spark.sql("CREATE TABLE testcat.table_name " +
+      "(id bigint, info struct<a: bigint, `b.c`: bigint>) USING foo")
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.sql("INSERT INTO testcat.table_name " +
+          "SELECT id, named_struct('a', id) AS info FROM range(1)")
+      },
+      condition = "INCOMPATIBLE_DATA_FOR_TABLE.STRUCT_MISSING_FIELDS",
+      parameters = Map(
+        "tableName" -> "`testcat`.`table_name`",
+        "colName" -> "`info`",
+        "missingFields" -> "`b.c`")
+    )
+  }
+
   test("Append: fail if table does not exist") {
     val exc = intercept[AnalysisException] {
       spark.table("source").writeTo("testcat.table_name").append()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Quote the verbatim name in the affected renders inside `TableOutputResolver` (the component that resolves a query's output columns against a target schema) by passing it as `toSQLId(Seq(name))`. The shared `toSQLId` helper is intentionally left unchanged: it has ~190 callers, many of which legitimately pass qualified, multi-part names and rely on the split, so changing it would risk wide regressions.

**Note**: 6 `toSQLId` callers are fixed while the other 3 call sites (L548, L590, L657 in TableOutputResolver) are ignored as they seem to be dead code/unreachable branch from what I see.

  ### Why are the changes needed?

When a DataSource V2 write / INSERT fails with an `INCOMPATIBLE_DATA_FOR_TABLE` error, a column or struct-field name that contains a dot is rendered as two back-quoted identifiers instead of one. For a column literally named a.b, the error shows `a`.`b` (which reads as field b nested in struct
a) instead of `a.b`.

Example:
```
spark.table("src").withColumnRenamed("data", "a.b").writeTo("cat.t").append()
// EXTRA_COLUMNS reports extraColumns = `a`.`b` (wrong)
// `a.b` (expected)
```
Affected error classes: `INCOMPATIBLE_DATA_FOR_TABLE`.`EXTRA_COLUMNS`, `EXTRA_STRUCT_FIELDS`, `STRUCT_MISSING_FIELDS`.

**Root Cause:** These messages quote the name via `toSQLId(String)`, which parses it through `AttributeNameParser` and splits on dots – i.e. it treats a stored, verbatim name as SQL text.

**Follow-ups:** The same root cause affects single-name renders in other components / error classes (e.g. `INSERT_COLUMN_ARITY_MISMATCH`, `UNPIVOT`, struct-field / `ALTER COLUMN` errors). Those are distinct user-facing symptoms and will be handled in separate and self-contained follow-up tickets if this solution is accepted.

  ### Does this PR introduce _any_ user-facing change?

  Yes, error-message text only (no behavior change). For a dotted name, e.g. `EXTRA_COLUMNS` now renders `` `b.c` `` instead of `` `b`.`c` ``.

  ### How was this patch tested?

  New tests in `DataFrameWriterV2Suite` covering the three error classes (append and by-position `INSERT`); each fails before the change and passes after.

  ### Was this patch authored or co-authored using generative AI tooling?
Yes. Claude Code