### PR TITLE
[SPARK-57297][SQL][TESTS] Add a test that SQL execution description respects `spark.sql.redaction.string.regex`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLExecutionSuite.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation
 import org.apache.spark.sql.classic
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.util.ThreadUtils
 import org.apache.spark.util.Utils.REDACTION_REPLACEMENT_TEXT
@@ -393,6 +394,30 @@ class SQLExecutionSuite extends SparkFunSuite with SQLConfHelper {
       assert(sqlJobGroupIdOpt.contains(JobGroupId))
     } finally {
       spark.sparkContext.clearJobGroup()
+      spark.stop()
+    }
+  }
+
+  test("SQL execution description should respect spark.sql.redaction.string.regex") {
+    val spark = SparkSession.builder().master("local[*]").appName("test").getOrCreate()
+    try {
+      withSQLConf(SQLConf.SQL_STRING_REDACTION_PATTERN.key -> "password=([^\\s]+)") {
+        var sqlExecutionDescription: String = null
+        spark.sparkContext.addSparkListener(new SparkListener {
+          override def onOtherEvent(event: SparkListenerEvent): Unit = event match {
+            case e: SparkListenerSQLExecutionStart =>
+              sqlExecutionDescription = e.description
+            case _ =>
+          }
+        })
+
+        val sqlStatement = "SELECT 'password=secret123'"
+        spark.sparkContext.setJobDescription(sqlStatement)
+        spark.sql(sqlStatement).collect()
+        spark.sparkContext.listenerBus.waitUntilEmpty()
+        assert(sqlExecutionDescription === s"SELECT '$REDACTION_REPLACEMENT_TEXT")
+      }
+    } finally {
       spark.stop()
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a test to `SQLExecutionSuite` that verifies the SQL execution description (`SparkListenerSQLExecutionStart.description`) is redacted according to `spark.sql.redaction.string.regex`.

### Why are the changes needed?

`SQLExecution` redacts the job description before it is recorded in `SparkListenerSQLExecutionStart`, but there is no test covering this behavior. This test guards the redaction so it is not accidentally dropped.

### Does this PR introduce _any_ user-facing change?

No. This is a test-only change.

### How was this patch tested?

Pass the CI with the newly added test.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)