### PR TITLE
[SPARK-57314][PS][TESTS] Add tests for Index.equals in pandas-on-Spark

### DIFF
--- a/python/pyspark/pandas/tests/indexes/test_basic.py
+++ b/python/pyspark/pandas/tests/indexes/test_basic.py
@@ -22,6 +22,7 @@ import pandas as pd
 
 import pyspark.pandas as ps
 from pyspark.loose_version import LooseVersion
+from pyspark.pandas.config import option_context
 from pyspark.pandas.exceptions import PandasNotImplementedError
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
@@ -192,6 +193,45 @@ class IndexBasicMixin:
         psmidx = ps.from_pandas(pmidx)
 
         self.assertRaises(PandasNotImplementedError, lambda: psmidx.factorize())
+
+    def test_equals(self):
+        # Single Index
+        pidx = pd.Index(["a", "b", "c"])
+        psidx = ps.from_pandas(pidx)
+        self.assert_eq(pidx.equals(pidx), psidx.equals(psidx))
+
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                pidx.equals(pd.Index(["a", "b", "c"])),
+                psidx.equals(ps.Index(["a", "b", "c"])),
+            )
+            self.assert_eq(
+                pidx.equals(pd.Index(["b", "b", "a"])),
+                psidx.equals(ps.Index(["b", "b", "a"])),
+            )
+            # equals ignores the name (unlike identical)
+            self.assert_eq(
+                pd.Index([1, 2, 3], name="x").equals(pd.Index([1, 2, 3], name="y")),
+                ps.Index([1, 2, 3], name="x").equals(ps.Index([1, 2, 3], name="y")),
+            )
+
+        # MultiIndex
+        pmidx = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])
+        psmidx = ps.from_pandas(pmidx)
+        self.assert_eq(pmidx.equals(pmidx), psmidx.equals(psmidx))
+
+        with option_context("compute.ops_on_diff_frames", True):
+            self.assert_eq(
+                pmidx.equals(pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])),
+                psmidx.equals(ps.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")])),
+            )
+            self.assert_eq(
+                pmidx.equals(pd.MultiIndex.from_tuples([("c", "z"), ("b", "y"), ("a", "x")])),
+                psmidx.equals(ps.MultiIndex.from_tuples([("c", "z"), ("b", "y"), ("a", "x")])),
+            )
+
+        # Index vs MultiIndex (different type) -> not equal
+        self.assert_eq(pidx.equals(pmidx), psidx.equals(psmidx))
 
 
 class IndexBasicTests(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds positive parity tests for `Index.equals` in pandas-on-Spark
(`IndexBasicMixin` in `python/pyspark/pandas/tests/indexes/test_basic.py`).
The tests compare the `True`/`False` result of `Index.equals` against pandas
for single `Index` and `MultiIndex`: equal and unequal element sets,
reordered elements, and the fact that `equals` ignores the index name.

### Why are the changes needed?

`Index.equals` currently has no positive test coverage. The only existing
test exercises the error path when `compute.ops_on_diff_frames` is disabled
and never checks the actual `True`/`False` result, so the common behavior is
untested. These tests close that gap.

### Does this PR introduce _any_ user-facing change?

No. This PR only adds tests.

### How was this patch tested?

Ran the new test against a local SparkSession
(`IndexBasicTests.test_equals`); it passes.

### Was this patch authored or co-authored using generative AI tooling?

Yes, this patch was co-authored with generative AI tooling (Claude,
Anthropic Opus 4.8). The contributor selected the under-tested method,
required that the asserted cases first be verified to match pandas on a
real SparkSession (excluding inputs where pandas-on-Spark intentionally
differs, e.g. NaN comparison under Spark equality), and reviewed the result.
