### PR TITLE
[SPARK-57313][SQL] Fix SampleExec numOutputRows metric when whole-stage codegen is disabled

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -492,7 +492,8 @@ case class SampleExec(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
 
   protected override def doExecute(): RDD[InternalRow] = {
-    if (withReplacement) {
+    val numOutputRows = longMetric("numOutputRows")
+    val sampled = if (withReplacement) {
       // Disable gap sampling since the gap sampling method buffers two rows internally,
       // requiring us to copy the row, which is more expensive than the random number generator.
       new PartitionwiseSampledRDD[InternalRow, InternalRow](
@@ -502,6 +503,12 @@ case class SampleExec(
         resolvedSeed)
     } else {
       child.execute().randomSampleWithRange(lowerBound, upperBound, resolvedSeed)
+    }
+    sampled.mapPartitionsInternal { iter =>
+      iter.map { row =>
+        numOutputRows += 1
+        row
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -125,6 +125,22 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
     }
   }
 
+  test("SPARK-57313: Sample numOutputRows metric") {
+    Seq("false", "true").foreach { enableWholeStage =>
+      withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> enableWholeStage) {
+        val df = spark.range(0, 1000, 1, 1)
+          .sample(withReplacement = false, fraction = 0.5, seed = 1)
+        val expectedRows = df.collect().length
+        sparkContext.listenerBus.waitUntilEmpty()
+        val sample = df.queryExecution.executedPlan.collect {
+          case s: SampleExec => s
+        }
+        assert(sample.size == 1)
+        assert(sample.head.metrics("numOutputRows").value == expectedRows)
+      }
+    }
+  }
+
 
   test("Recursive CTEs metrics") {
     withSQLConf(SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> "") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -143,7 +143,6 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
     }
   }
 
-
   test("Recursive CTEs metrics") {
     withSQLConf(SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> "") {
       val df = sql(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -126,17 +126,19 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
   }
 
   test("SPARK-57313: Sample numOutputRows metric") {
-    Seq("false", "true").foreach { enableWholeStage =>
-      withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> enableWholeStage) {
-        val df = spark.range(0, 1000, 1, 1)
-          .sample(withReplacement = false, fraction = 0.5, seed = 1)
-        val expectedRows = df.collect().length
-        sparkContext.listenerBus.waitUntilEmpty()
-        val sample = df.queryExecution.executedPlan.collect {
-          case s: SampleExec => s
+    Seq(false, true).foreach { withReplacement =>
+      Seq("false", "true").foreach { enableWholeStage =>
+        withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> enableWholeStage) {
+          val df = spark.range(0, 1000, 1, 1)
+            .sample(withReplacement = withReplacement, fraction = 0.5, seed = 1)
+          val expectedRows = df.collect().length
+          sparkContext.listenerBus.waitUntilEmpty()
+          val sample = df.queryExecution.executedPlan.collect {
+            case s: SampleExec => s
+          }
+          assert(sample.size == 1)
+          assert(sample.head.metrics("numOutputRows").value == expectedRows)
         }
-        assert(sample.size == 1)
-        assert(sample.head.metrics("numOutputRows").value == expectedRows)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update the metric `number of output rows` for non-WSCG code path

### Why are the changes needed?
`number of output rows` metric is not updated/incremented when WSCG is off - it can be useful to show the numOutputRows and be consistent with the WSCG path.
<img width="370" height="339" alt="image" src="https://github.com/user-attachments/assets/3531d904-16c6-456c-a9a0-6b667b2449f8" />

### Does this PR introduce _any_ user-facing change?
Yes. `number of output rows` metric gets correct value now when WSCG is off


### How was this patch tested?
New test case added.

### Was this patch authored or co-authored using generative AI tooling?
No
