### PR TITLE
[SPARK-57262][SQL][WEBUI][4.0] Job description derived from a query should respect `spark.sql.redaction.string.regex`

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.classic.ClassicConversions._
 import org.apache.spark.sql.execution.{QueryExecution, QueryExecutionException, SQLExecution}
 import org.apache.spark.sql.execution.HiveResult.hiveResultString
 import org.apache.spark.sql.internal.{SQLConf, VariableSubstitution}
+import org.apache.spark.util.Utils
 
 
 private[hive] class SparkSQLDriver(val sparkSession: SparkSession = SparkSQLEnv.sparkSession)
@@ -66,7 +67,9 @@ private[hive] class SparkSQLDriver(val sparkSession: SparkSession = SparkSQLEnv.
       val substitutorCommand = SQLConf.withExistingConf(sparkSession.sessionState.conf) {
         new VariableSubstitution().substitute(command)
       }
-      sparkSession.sparkContext.setJobDescription(substitutorCommand)
+      val redactedCommand =
+        Utils.redact(sparkSession.sessionState.conf.stringRedactionPattern, substitutorCommand)
+      sparkSession.sparkContext.setJobDescription(redactedCommand)
       val execution = sparkSession.sessionState.executePlan(sparkSession.sql(command).logicalPlan)
       // The SQL command has been executed above via `executePlan`, therefore we don't need to
       // wrap it again with a new execution ID when getting Hive result.

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriverSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriverSuite.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.thriftserver
+
+import org.apache.spark.SparkContext
+import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.util.Utils.REDACTION_REPLACEMENT_TEXT
+
+class SparkSQLDriverSuite extends SharedSparkSession {
+
+  test("job description should be redacted by spark.sql.redaction.string.regex") {
+    withSQLConf(SQLConf.SQL_STRING_REDACTION_PATTERN.key -> "password=([^\\s]+)") {
+      var jobDescription: String = null
+      spark.sparkContext.addSparkListener(new SparkListener {
+        override def onJobStart(jobStart: SparkListenerJobStart): Unit = {
+          jobDescription =
+            jobStart.properties.getProperty(SparkContext.SPARK_JOB_DESCRIPTION)
+        }
+      })
+
+      val driver = new SparkSQLDriver(spark)
+      try {
+        driver.run("SELECT 'password=secret123'")
+      } finally {
+        driver.close()
+      }
+
+      spark.sparkContext.listenerBus.waitUntilEmpty()
+      assert(jobDescription != null)
+      assert(!jobDescription.contains("secret123"))
+      assert(jobDescription.contains(REDACTION_REPLACEMENT_TEXT))
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR backports SPARK-57262 (#56361) to `branch-4.0`.
This PR changes `SparkSQLDriver.scala` to redact a query before `setJobDescription`.

### Why are the changes needed?
In the current implementation, when a query is executed through `SparkSQLDriver`, redaction is done in `SQLExecution.scala` so the description in the table on the `/SQL` page is redacted.
<img width="436" height="260" alt="sql-page-4 0" src="https://github.com/user-attachments/assets/81bb3296-67b1-4a03-9c41-e720f767e16e" />

But the description in the table on the `/jobs` page is not redacted.
<img width="511" height="174" alt="jobs-page-before-4 0" src="https://github.com/user-attachments/assets/3107a44e-0e35-4a93-977c-2e764e1c41ae" />

### Does this PR introduce _any_ user-facing change?
Yes.

### How was this patch tested?
Added new test and confirmed the test `SQL execution description should respect spark.sql.redaction.string.regex` added in #56358 passed.
Also confirmed the description is redacted in UI.
```
$ bin/spark-sql --conf spark.sql.redaction.string.regex="secret.*=.*"
spark-sql (default)>  CREATE TABLE test1(secret string);
spark-sql (default)> SELECT * FROM test1 WHERE secret=1;
```
<img width="459" height="171" alt="jobs-page-after-4 0" src="https://github.com/user-attachments/assets/ba24e318-5054-415f-9f96-383f7ed3e99f" />

### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Claude
