### PR TITLE
[WIP][SPARK-57315][SQL] Support HOUR, MINUTE and SECOND functions over nanosecond-precision timestamps

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -561,6 +561,7 @@ class Analyzer(
       ResolveTimeZone ::
       ResolveRandomSeed ::
       ResolveBinaryArithmetic ::
+      ResolveTimestampNanosExpressions ::
       new ResolveIdentifierClause(earlyBatches) ::
       ResolveUnion ::
       ResolveZip ::
@@ -640,6 +641,35 @@ class Analyzer(
       plan.resolveExpressionsUpWithPruning(_.containsPattern(BINARY_ARITHMETIC), ruleId) {
         case expr @ (_: Add | _: Subtract | _: Multiply | _: Divide) if expr.childrenResolved =>
           BinaryArithmeticWithDatetimeResolver.resolve(expr)
+      }
+  }
+
+  /**
+   * Enables expressions that only accept the microsecond timestamp types to operate on the
+   * nanosecond-precision timestamp types (TIMESTAMP_NTZ(p) / TIMESTAMP_LTZ(p)) by casting the
+   * nanosecond child down to the matching microsecond type and reusing the existing expression.
+   *
+   * The cast keeps `epochMicros` and drops the sub-microsecond digits, so it is only applied to
+   * expressions whose result does not depend on those digits. Currently this covers the integer
+   * time-of-day extractors `Hour`, `Minute` and `Second`. `SecondWithFraction` (the
+   * `extract(SECOND)` path returning `DECIMAL(8, 6)`) is intentionally excluded because its result
+   * does depend on the sub-microsecond digits.
+   */
+  object ResolveTimestampNanosExpressions extends Rule[LogicalPlan] {
+    // Maps a nanosecond-precision timestamp type to the matching microsecond timestamp type.
+    private def microTimestampType(dt: DataType): Option[DataType] = dt match {
+      case _: TimestampNTZNanosType => Some(TimestampNTZType)
+      case _: TimestampLTZNanosType => Some(TimestampType)
+      case _ => None
+    }
+
+    override def apply(plan: LogicalPlan): LogicalPlan =
+      plan.resolveExpressionsUpWithPruning(_.containsPattern(GET_TIME_FIELD), ruleId) {
+        case e @ (_: Hour | _: Minute | _: Second) if e.childrenResolved =>
+          val child = e.children.head
+          microTimestampType(child.dataType)
+            .map(t => e.withNewChildren(Seq(Cast(child, t))))
+            .getOrElse(e)
       }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -397,6 +397,8 @@ trait GetTimeField extends UnaryExpression
 
   @transient protected lazy val zoneIdInEval: ZoneId = zoneIdForType(child.dataType)
 
+  override def nodePatternsInternal(): Seq[TreePattern] = Seq(GET_TIME_FIELD)
+
   override def inputTypes: Seq[AbstractDataType] = Seq(AnyTimestampType)
 
   override def dataType: DataType = IntegerType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -71,6 +71,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveSubqueryColumnAliases" ::
       "org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveTables" ::
       "org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveTempViews" ::
+      "org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveTimestampNanosExpressions" ::
       "org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveTranspose" ::
       "org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveUnpivot" ::
       "org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveUpCast" ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -57,6 +57,7 @@ object TreePattern extends Enumeration  {
   val EXTRACT_VALUE: Value = Value
   val FUNCTION_TABLE_RELATION_ARGUMENT_EXPRESSION: Value = Value
   val GENERATOR: Value = Value
+  val GET_TIME_FIELD: Value = Value
   val GROUPING_ANALYTICS: Value = Value
   val HIGH_ORDER_FUNCTION: Value = Value
   val IF: Value = Value

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveTimestampNanosExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveTimestampNanosExpressionsSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.types._
+
+/**
+ * Test suite for
+ * [[org.apache.spark.sql.catalyst.analysis.Analyzer.ResolveTimestampNanosExpressions]].
+ */
+class ResolveTimestampNanosExpressionsSuite extends PlanTest {
+  import org.apache.spark.sql.catalyst.dsl.expressions._
+  import org.apache.spark.sql.catalyst.dsl.plans._
+
+  private object Resolve extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("Resolve", FixedPoint(4), SimpleAnalyzer.ResolveTimestampNanosExpressions) :: Nil
+  }
+
+  private val ntzNanos = AttributeReference("ntz", TimestampNTZNanosType(9))()
+  private val ltzNanos = AttributeReference("ltz", TimestampLTZNanosType(9))()
+  private val microNtz = AttributeReference("mntz", TimestampNTZType)()
+  private val rel = LocalRelation(Seq(ntzNanos, ltzNanos, microNtz))
+
+  // Applies only the rule under test and returns the (possibly) rewritten top expression.
+  private def rewrite(e: Expression): Expression = {
+    val rewritten = Resolve.execute(rel.select(e.as("res")))
+    rewritten.asInstanceOf[Project].projectList.head.asInstanceOf[Alias].child
+  }
+
+  private def checkRewrite(in: Expression, expected: Expression): Unit = {
+    assert(rewrite(in) == expected)
+  }
+
+  test("TIMESTAMP_NTZ nanos child is cast to TIMESTAMP_NTZ") {
+    checkRewrite(Hour(ntzNanos), Hour(Cast(ntzNanos, TimestampNTZType)))
+    checkRewrite(Minute(ntzNanos), Minute(Cast(ntzNanos, TimestampNTZType)))
+    checkRewrite(Second(ntzNanos), Second(Cast(ntzNanos, TimestampNTZType)))
+  }
+
+  test("TIMESTAMP_LTZ nanos child is cast to TIMESTAMP") {
+    checkRewrite(Hour(ltzNanos), Hour(Cast(ltzNanos, TimestampType)))
+    checkRewrite(Minute(ltzNanos), Minute(Cast(ltzNanos, TimestampType)))
+    checkRewrite(Second(ltzNanos), Second(Cast(ltzNanos, TimestampType)))
+  }
+
+  test("microsecond timestamp inputs are left unchanged") {
+    checkRewrite(Hour(microNtz), Hour(microNtz))
+  }
+
+  test("SecondWithFraction is not rewritten because it depends on sub-microsecond digits") {
+    checkRewrite(SecondWithFraction(ntzNanos), SecondWithFraction(ntzNanos))
+    checkRewrite(SecondWithFraction(ltzNanos), SecondWithFraction(ltzNanos))
+  }
+}

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ltz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ltz-nanos.sql.out
@@ -116,3 +116,45 @@ SELECT named_struct('f', CAST(NULL AS timestamp_ltz(9)))
 -- !query analysis
 Project [named_struct(f, cast(null as timestamp_ltz(9))) AS named_struct(f, CAST(NULL AS TIMESTAMP_LTZ(9)))#x]
 +- OneRowRelation
+
+
+-- !query
+SELECT hour(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ltz(9)))
+-- !query analysis
+Project [hour(cast(cast(2020-01-01 13:24:35.123456789 as timestamp_ltz(9)) as timestamp), Some(America/Los_Angeles)) AS hour(CAST(2020-01-01 13:24:35.123456789 AS TIMESTAMP_LTZ(9)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT minute(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ltz(9)))
+-- !query analysis
+Project [minute(cast(cast(2020-01-01 13:24:35.123456789 as timestamp_ltz(9)) as timestamp), Some(America/Los_Angeles)) AS minute(CAST(2020-01-01 13:24:35.123456789 AS TIMESTAMP_LTZ(9)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT second(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ltz(9)))
+-- !query analysis
+Project [second(cast(cast(2020-01-01 13:24:35.123456789 as timestamp_ltz(9)) as timestamp), Some(America/Los_Angeles)) AS second(CAST(2020-01-01 13:24:35.123456789 AS TIMESTAMP_LTZ(9)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT hour(CAST('2020-01-01 13:24:35.999999999' AS timestamp_ltz(7)))
+-- !query analysis
+Project [hour(cast(cast(2020-01-01 13:24:35.999999999 as timestamp_ltz(7)) as timestamp), Some(America/Los_Angeles)) AS hour(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_LTZ(7)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT second(CAST('2020-01-01 13:24:35.999999999' AS timestamp_ltz(8)))
+-- !query analysis
+Project [second(cast(cast(2020-01-01 13:24:35.999999999 as timestamp_ltz(8)) as timestamp), Some(America/Los_Angeles)) AS second(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_LTZ(8)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT hour(CAST(NULL AS timestamp_ltz(9)))
+-- !query analysis
+Project [hour(cast(cast(null as timestamp_ltz(9)) as timestamp), Some(America/Los_Angeles)) AS hour(CAST(NULL AS TIMESTAMP_LTZ(9)))#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz-nanos.sql.out
@@ -116,3 +116,45 @@ SELECT named_struct('f', CAST(NULL AS timestamp_ntz(9)))
 -- !query analysis
 Project [named_struct(f, cast(null as timestamp_ntz(9))) AS named_struct(f, CAST(NULL AS TIMESTAMP_NTZ(9)))#x]
 +- OneRowRelation
+
+
+-- !query
+SELECT hour(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ntz(9)))
+-- !query analysis
+Project [hour(cast(cast(2020-01-01 13:24:35.123456789 as timestamp_ntz(9)) as timestamp_ntz), Some(America/Los_Angeles)) AS hour(CAST(2020-01-01 13:24:35.123456789 AS TIMESTAMP_NTZ(9)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT minute(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ntz(9)))
+-- !query analysis
+Project [minute(cast(cast(2020-01-01 13:24:35.123456789 as timestamp_ntz(9)) as timestamp_ntz), Some(America/Los_Angeles)) AS minute(CAST(2020-01-01 13:24:35.123456789 AS TIMESTAMP_NTZ(9)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT second(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ntz(9)))
+-- !query analysis
+Project [second(cast(cast(2020-01-01 13:24:35.123456789 as timestamp_ntz(9)) as timestamp_ntz), Some(America/Los_Angeles)) AS second(CAST(2020-01-01 13:24:35.123456789 AS TIMESTAMP_NTZ(9)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT hour(CAST('2020-01-01 13:24:35.999999999' AS timestamp_ntz(7)))
+-- !query analysis
+Project [hour(cast(cast(2020-01-01 13:24:35.999999999 as timestamp_ntz(7)) as timestamp_ntz), Some(America/Los_Angeles)) AS hour(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_NTZ(7)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT second(CAST('2020-01-01 13:24:35.999999999' AS timestamp_ntz(8)))
+-- !query analysis
+Project [second(cast(cast(2020-01-01 13:24:35.999999999 as timestamp_ntz(8)) as timestamp_ntz), Some(America/Los_Angeles)) AS second(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_NTZ(8)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT hour(CAST(NULL AS timestamp_ntz(9)))
+-- !query analysis
+Project [hour(cast(cast(null as timestamp_ntz(9)) as timestamp_ntz), Some(America/Los_Angeles)) AS hour(CAST(NULL AS TIMESTAMP_NTZ(9)))#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/inputs/timestamp-ltz-nanos.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/timestamp-ltz-nanos.sql
@@ -30,3 +30,12 @@ SELECT CAST(NULL AS timestamp_ltz(9));
 SELECT array(CAST(NULL AS timestamp_ltz(9)));
 SELECT map('k', CAST(NULL AS timestamp_ltz(9)));
 SELECT named_struct('f', CAST(NULL AS timestamp_ltz(9)));
+
+-- HOUR/MINUTE/SECOND over nanosecond-precision values (SPARK-57315). LTZ extracts in the
+-- session time zone; the sub-microsecond digits never affect the integer field.
+SELECT hour(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ltz(9)));
+SELECT minute(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ltz(9)));
+SELECT second(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ltz(9)));
+SELECT hour(CAST('2020-01-01 13:24:35.999999999' AS timestamp_ltz(7)));
+SELECT second(CAST('2020-01-01 13:24:35.999999999' AS timestamp_ltz(8)));
+SELECT hour(CAST(NULL AS timestamp_ltz(9)));

--- a/sql/core/src/test/resources/sql-tests/inputs/timestamp-ntz-nanos.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/timestamp-ntz-nanos.sql
@@ -30,3 +30,13 @@ SELECT CAST(NULL AS timestamp_ntz(9));
 SELECT array(CAST(NULL AS timestamp_ntz(9)));
 SELECT map('k', CAST(NULL AS timestamp_ntz(9)));
 SELECT named_struct('f', CAST(NULL AS timestamp_ntz(9)));
+
+-- HOUR/MINUTE/SECOND over nanosecond-precision values (SPARK-57315). NTZ extracts the
+-- wall-clock components, so the result is zone-independent and the sub-microsecond digits
+-- never affect the integer field.
+SELECT hour(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ntz(9)));
+SELECT minute(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ntz(9)));
+SELECT second(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ntz(9)));
+SELECT hour(CAST('2020-01-01 13:24:35.999999999' AS timestamp_ntz(7)));
+SELECT second(CAST('2020-01-01 13:24:35.999999999' AS timestamp_ntz(8)));
+SELECT hour(CAST(NULL AS timestamp_ntz(9)));

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ltz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ltz-nanos.sql.out
@@ -133,3 +133,51 @@ SELECT named_struct('f', CAST(NULL AS timestamp_ltz(9)))
 struct<named_struct(f, CAST(NULL AS TIMESTAMP_LTZ(9))):struct<f:timestamp_ltz(9)>>
 -- !query output
 {"f":null}
+
+
+-- !query
+SELECT hour(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ltz(9)))
+-- !query schema
+struct<hour(CAST(2020-01-01 13:24:35.123456789 AS TIMESTAMP_LTZ(9))):int>
+-- !query output
+13
+
+
+-- !query
+SELECT minute(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ltz(9)))
+-- !query schema
+struct<minute(CAST(2020-01-01 13:24:35.123456789 AS TIMESTAMP_LTZ(9))):int>
+-- !query output
+24
+
+
+-- !query
+SELECT second(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ltz(9)))
+-- !query schema
+struct<second(CAST(2020-01-01 13:24:35.123456789 AS TIMESTAMP_LTZ(9))):int>
+-- !query output
+35
+
+
+-- !query
+SELECT hour(CAST('2020-01-01 13:24:35.999999999' AS timestamp_ltz(7)))
+-- !query schema
+struct<hour(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_LTZ(7))):int>
+-- !query output
+13
+
+
+-- !query
+SELECT second(CAST('2020-01-01 13:24:35.999999999' AS timestamp_ltz(8)))
+-- !query schema
+struct<second(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_LTZ(8))):int>
+-- !query output
+35
+
+
+-- !query
+SELECT hour(CAST(NULL AS timestamp_ltz(9)))
+-- !query schema
+struct<hour(CAST(NULL AS TIMESTAMP_LTZ(9))):int>
+-- !query output
+NULL

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ntz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ntz-nanos.sql.out
@@ -133,3 +133,51 @@ SELECT named_struct('f', CAST(NULL AS timestamp_ntz(9)))
 struct<named_struct(f, CAST(NULL AS TIMESTAMP_NTZ(9))):struct<f:timestamp_ntz(9)>>
 -- !query output
 {"f":null}
+
+
+-- !query
+SELECT hour(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ntz(9)))
+-- !query schema
+struct<hour(CAST(2020-01-01 13:24:35.123456789 AS TIMESTAMP_NTZ(9))):int>
+-- !query output
+13
+
+
+-- !query
+SELECT minute(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ntz(9)))
+-- !query schema
+struct<minute(CAST(2020-01-01 13:24:35.123456789 AS TIMESTAMP_NTZ(9))):int>
+-- !query output
+24
+
+
+-- !query
+SELECT second(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ntz(9)))
+-- !query schema
+struct<second(CAST(2020-01-01 13:24:35.123456789 AS TIMESTAMP_NTZ(9))):int>
+-- !query output
+35
+
+
+-- !query
+SELECT hour(CAST('2020-01-01 13:24:35.999999999' AS timestamp_ntz(7)))
+-- !query schema
+struct<hour(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_NTZ(7))):int>
+-- !query output
+13
+
+
+-- !query
+SELECT second(CAST('2020-01-01 13:24:35.999999999' AS timestamp_ntz(8)))
+-- !query schema
+struct<second(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_NTZ(8))):int>
+-- !query output
+35
+
+
+-- !query
+SELECT hour(CAST(NULL AS timestamp_ntz(9)))
+-- !query schema
+struct<hour(CAST(NULL AS TIMESTAMP_NTZ(9))):int>
+-- !query output
+NULL


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes the time-of-day extraction functions `hour()`, `minute()` and `second()` work over the nanosecond-precision timestamp types `TIMESTAMP_NTZ(p)` / `TIMESTAMP_LTZ(p)` (with `p` in `[7, 9]`), whose physical value is `TimestampNanosVal(epochMicros: Long, nanosWithinMicro: Short)`.

These functions are implemented by the `GetTimeField` expressions (`Hour`, `Minute`, `Second`), whose `inputTypes` is `AnyTimestampType`, which only accepts the microsecond `TimestampType` and `TimestampNTZType`. As a result, calling them on a nanosecond timestamp previously failed analysis.

Since the result is an integer field that depends only on `epochMicros` (the sub-microsecond digits never affect hour/minute/second), this PR adds a dedicated analyzer rule `ResolveTimestampNanosExpressions` (modeled on `ResolveBinaryArithmetic`) that casts a resolved `Hour`/`Minute`/`Second` child of a nanosecond type down to the matching microsecond type and reuses the existing expressions and `DateTimeUtils` logic:

- `TimestampNTZNanosType(p)` -> `TimestampNTZType` (UTC / wall-clock extraction)
- `TimestampLTZNanosType(p)` -> `TimestampType` (session-zone extraction)

The cast (already available, SPARK-57293) keeps `epochMicros` and drops `nanosWithinMicro`, which is lossless for these integer results. A rule is preferred over a `TypeCoercion` rule so the behavioral change stays scoped to these functions rather than every `AnyTimestampType` expression. The rule is named generically so future nanos-aware expressions can be added as additional `case` branches.

`SecondWithFraction` (the `extract(SECOND)` path returning `DECIMAL(8, 6)`) is intentionally excluded because its result depends on the sub-microsecond digits.

### Why are the changes needed?

To make the standard datetime extraction functions usable with the new nanosecond-precision timestamp types being added under SPARK-56822 (SPIP: Timestamps with nanosecond precision). Without this, `hour`/`minute`/`second` over `TIMESTAMP_NTZ(p)` / `TIMESTAMP_LTZ(p)` fail analysis.

### Does this PR introduce _any_ user-facing change?

Yes, but only for the in-progress, preview-gated nanosecond timestamp types (guarded by `spark.sql.timestampNanosTypes.enabled`). With the flag enabled, `hour()`, `minute()` and `second()` now accept `TIMESTAMP_NTZ(p)` / `TIMESTAMP_LTZ(p)` values, e.g.:

```
SELECT hour(CAST('2020-01-01 13:24:35.123456789' AS timestamp_ntz(9))); -- 13
```

There is no change for the already-released microsecond timestamp types.

### How was this patch tested?

- New unit suite `ResolveTimestampNanosExpressionsSuite` covering the rewrite for `Hour`/`Minute`/`Second` over NTZ/LTZ nanos inputs, plus negative cases (microsecond inputs and `SecondWithFraction` are left unchanged).
- Added end-to-end golden-file checks to `timestamp-ntz-nanos.sql` and `timestamp-ltz-nanos.sql` (including non-zero sub-microsecond digits and NULL), and regenerated the result/analyzer-result golden files.
- Ran scalafmt and `./dev/scalastyle`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor (Claude Opus 4.8)