### PR TITLE
[SPARK-56661] Addressing review comments from PR #55768

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -159,7 +159,9 @@ class SparkEnv (
         // Get or Else synchronized to protect
         // against concurrent creation requests.
         udfDispatcherManager.getOrElse {
-          createUDFDispatcherManager()
+          val created = createUDFDispatcherManager()
+          udfDispatcherManager = Some(created)
+          created
         }
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/logicalExternalUDFOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/logicalExternalUDFOperators.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.annotation.Experimental
+import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.sql.catalyst.expressions.{Attribute,
   ExternalUserDefinedFunction}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
@@ -46,6 +47,7 @@ trait ExternalUDF extends UnaryNode {
  * @param function         The UDF to invoke. Output attributes are
  *                         derived from `function.dataType`.
  * @param isBarrier        Whether to use barrier execution.
+ * @param profile          Optional resource profile for the UDF execution.
  * @param child            Input relation whose partitions are processed.
  */
 @Experimental
@@ -53,6 +55,7 @@ case class MapPartitionsExternalUDF(
     workerSpec: UDFWorkerSpecification,
     function: ExternalUserDefinedFunction,
     isBarrier: Boolean,
+    profile: Option[ResourceProfile],
     child: LogicalPlan)
   extends ExternalUDF {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -973,10 +973,10 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case logical.MapInArrow(func, output, child, isBarrier, profile) =>
         execution.python.MapInArrowExec(func, output, planLater(child), isBarrier, profile) :: Nil
       case logical.MapPartitionsExternalUDF(
-          workerSpec, functionExpr, isBarrier, child) =>
+          workerSpec, functionExpr, isBarrier, profile, child) =>
         execution.externalUDF.MapPartitionsExternalUDFExec(
           workerSpec, functionExpr,
-          isBarrier, planLater(child)) :: Nil
+          isBarrier, profile, planLater(child)) :: Nil
       case logical.AttachDistributedSequence(attr, child, cache) =>
         execution.python.AttachDistributedSequenceExec(attr, planLater(child), cache) :: Nil
       case logical.PythonWorkerLogs(jsonAttr) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExternalUDFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExternalUDFExec.scala
@@ -62,8 +62,8 @@ trait ExternalUDFExec extends UnaryExecNode {
    * Creates a [[WorkerSession]] via [[SparkEnv#getExternalUDFDispatcher]].
    * Registers session cancellation on task failure and session termination
    * on task completion. The provided function receives the session
-   * and must return the result iterator. The function CAN but MUST NOT
-   * cancel or close the session.
+   * and must return the result iterator. The function may use the
+   * session but MUST NOT cancel or close it.
    */
   protected def withUDFWorkerSession(
       taskContext: TaskContext,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExternalUDFPlanner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/ExternalUDFPlanner.scala
@@ -110,7 +110,7 @@ class UnifiedExternalUDFPlanner(
       children = Seq.empty,
       udfDeterministic = pythonUdf.udfDeterministic,
       udfNullable = true)
-    MapPartitionsExternalUDF(workerSpec, udf, isBarrier, child)
+    MapPartitionsExternalUDF(workerSpec, udf, isBarrier, profile, child)
   }
 
   override def planPythonMapInArrow(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/MapPartitionsExternalUDFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/externalUDF/MapPartitionsExternalUDFExec.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.externalUDF
 import org.apache.spark.TaskContext
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.rdd.RDD
+import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{
   Attribute,
@@ -36,9 +37,9 @@ import org.apache.spark.udf.worker.UDFWorkerSpecification
  * external worker process.
  *
  * @param workerSpec       Specification describing the UDF worker.
- * @param functionExpr     The UDF to invoke.
+ * @param function         The UDF to invoke.
  * @param isBarrier        Whether the UDF should be invoked using barrier execution.
- * @param resultAttributes Output attributes produced by the UDF.
+ * @param profile          Optional resource profile for the UDF execution.
  * @param child            Child plan providing input partitions.
  */
 @Experimental
@@ -46,6 +47,7 @@ case class MapPartitionsExternalUDFExec(
     workerSpec: UDFWorkerSpecification,
     function: ExternalUserDefinedFunction,
     isBarrier: Boolean,
+    profile: Option[ResourceProfile],
     child: SparkPlan)
   extends ExternalUDFExec {
 

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/UDFDispatcherManager.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/UDFDispatcherManager.scala
@@ -30,12 +30,12 @@ import org.apache.spark.udf.worker.UDFWorkerSpecification
  * [[UDFWorkerSpecification]] (protobuf value equality).
  *
  * Callers obtain a dispatcher via [[getDispatcher]] and create
- * sessions on it directly. On [[stop]], all cached dispatchers
+ * sessions on it directly. On [[close]], all cached dispatchers
  * are closed -- dispatchers are responsible for cleaning up
  * their own sessions.
  *
  * Thread safety: a [[ReentrantReadWriteLock]] allows concurrent
- * [[getDispatcher]] calls (read lock) while [[stop]] has
+ * [[getDispatcher]] calls (read lock) while [[close]] has
  * exclusive access (write lock).
  */
 @Experimental
@@ -46,7 +46,7 @@ class UDFDispatcherManager(
 
   // Guarded by `rwLock`. The read lock is used by getDispatcher
   // (with upgrade when a new dispatcher must be added) and the
-  // write lock is used by stop.
+  // write lock is used by close.
   private val rwLock = new ReentrantReadWriteLock()
   private val dispatchers =
     new HashMap[UDFWorkerSpecification, WorkerDispatcher]()
@@ -63,7 +63,6 @@ class UDFDispatcherManager(
     try {
       if (closed) throwClosed()
 
-      // Reading existing dispatcher = quick path
       val dispatcher = dispatchers.get(workerSpec)
       if (dispatcher != null) {
         return dispatcher
@@ -93,7 +92,7 @@ class UDFDispatcherManager(
   }
 
   private def throwClosed(): Nothing =
-    throw new IllegalStateException("UDFDispatcherManager is stopped")
+    throw new IllegalStateException("UDFDispatcherManager is closed")
 
   /**
    * Closes all cached dispatchers and resets internal state.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This change addresses the open review comments from [pull request #55768](https://github.com/apache/spark/pull/55768). In summary, the following changes were made:

  Correctness fixes (2)

  1. SparkEnv.scala:161 — The created UDFDispatcherManager is now stored back into udfDispatcherManager =
  Some(created), so the cache works and stop() properly closes dispatchers.
  2. ExternalUDFPlanner.scala + logical/physical nodes + strategy — profile: Option[ResourceProfile] is now
  threaded through MapPartitionsExternalUDF (logical), MapPartitionsExternalUDFExec (physical),
  SparkStrategies, and UnifiedExternalUDFPlanner, so a ResourceProfile passed to mapInPandas is no longer
  silently dropped.

  Nits (5)

  1. ExternalUDFExec.scala:65 — Reworded "CAN but MUST NOT cancel or close" → "may use the session but MUST
  NOT cancel or close it"
  2. MapPartitionsExternalUDFExec.scala:39-42 — Fixed stale Scaladoc: functionExpr → function, removed
  non-existent resultAttributes
  3. UDFDispatcherManager.scala:33 — [[stop]] → [[close]]
  4. UDFDispatcherManager.scala:49 — "write lock is used by stop" → "close"
  5. UDFDispatcherManager.scala:66 — Removed duplicate "quick path" comment

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
They were requested in a review of the above linked PR.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Linting & re-running existing tests. Mostly nit changes.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes