### PR TITLE
[SPARK-57316][DOCS] Document WITH SCHEMA EVOLUTION and BY NAME for SQL INSERT

### DIFF
--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -334,8 +334,8 @@ SELECT * FROM students;
 +----------+-------------+-------------------------+
 |student_id|         name|                  address|
 +----------+-------------+-------------------------+
-|    444444|    Bob Brown|                     null|
-|    555555|Cathy Johnson|                     null|
+|    444444|    Bob Brown|                     NULL|
+|    555555|Cathy Johnson|                     NULL|
 |    111111|   Ashua Hill|  456 Erica Ct, Cupertino|
 |    222222|Dora Williams|134 Forest Ave, Melo Park|
 +----------+-------------+-------------------------+

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -270,6 +270,51 @@ SELECT * FROM students WHERE student_id = 11215017;
 +------------+----------------------+----------+
 ```
 
+##### Insert By Name Using a SELECT Statement
+
+```sql
+CREATE TABLE target (n INT, text STRING, s STRUCT<a INT, b INT>);
+
+-- BY NAME matches the top-level columns by name, so they may be listed in any order.
+-- Nested struct fields are matched by position, so the struct field order in the query
+-- must match the target schema (STRUCT<a INT, b INT>).
+INSERT INTO target BY NAME
+    SELECT named_struct('a', 1, 'b', 2) AS s, 0 AS n, 'data' AS text;
+
+SELECT * FROM target;
++---+----+------+
+|  n|text|     s|
++---+----+------+
+|  0|data|{1, 2}|
++---+----+------+
+
+CREATE OR REPLACE TABLE target (n INT, arr ARRAY<STRUCT<a INT, b INT>>);
+
+-- A missing top-level column is filled with its default value (NULL here).
+INSERT INTO target BY NAME
+    SELECT array(named_struct('a', 1, 'b', 2)) AS arr, 0 AS n;
+INSERT INTO target BY NAME
+    SELECT array(named_struct('a', 1, 'b', 2)) AS arr;
+
+SELECT * FROM target;
++----+----------+
+|   n|       arr|
++----+----------+
+|   0|[{1, 2}]|
+|NULL|[{1, 2}]|
++----+----------+
+
+-- A source column whose name does not match any target column is an error.
+INSERT INTO target BY NAME
+    SELECT array(named_struct('a', 1, 'b', 2)) AS arr, 0 AS badname;
+Error
+
+-- Duplicate source column names that resolve to the same target column are an error.
+INSERT INTO target BY NAME
+    SELECT array(named_struct('a', 1, 'b', 2)) AS arr, 0 AS n, 1 AS n;
+Error: INSERT_COLUMN_ARITY_MISMATCH.TOO_MANY_DATA_COLUMNS
+```
+
 ##### Insert With Schema Evolution
 
 ```sql

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -37,8 +37,8 @@ INSERT [ WITH SCHEMA EVOLUTION ] INTO [ TABLE ] table_identifier REPLACE WHERE b
 * **WITH SCHEMA EVOLUTION**
 
     An optional clause that enables automatic schema evolution for this `INSERT` operation.
-    When specified, the target data source may evolve the table schema to accommodate columns
-    or widened types present in the input query that differ from the existing table schema.
+    When specified, the target data source may evolve the table schema to accommodate new
+    columns present in the input query that are not in the existing table schema.
     Schema evolution applies only to this single statement and must be supported by the target
     data source; built-in file-based sources do not support it.
 

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -275,11 +275,11 @@ SELECT * FROM students WHERE student_id = 11215017;
 ```sql
 CREATE TABLE target (n INT, text STRING, s STRUCT<a INT, b INT>);
 
--- BY NAME matches the top-level columns by name, so they may be listed in any order.
--- Nested struct fields are matched by position, so the struct field order in the query
--- must match the target schema (STRUCT<a INT, b INT>).
+-- BY NAME matches both top-level columns and nested struct fields by name,
+-- so they may be listed in any order in the source query.
 INSERT INTO target BY NAME
-    SELECT named_struct('a', 1, 'b', 2) AS s, 0 AS n, 'data' AS text;
+    SELECT named_struct('b', 2, 'a', 1) AS s, 0 AS n, 'data' AS text;
+-- s is {1, 2}: nested fields matched by name, not position.
 
 SELECT * FROM target;
 +---+----+------+
@@ -297,12 +297,12 @@ INSERT INTO target BY NAME
     SELECT array(named_struct('a', 1, 'b', 2)) AS arr;
 
 SELECT * FROM target;
-+----+----------+
-|   n|       arr|
-+----+----------+
++----+--------+
+|   n|     arr|
++----+--------+
 |   0|[{1, 2}]|
 |NULL|[{1, 2}]|
-+----+----------+
++----+--------+
 
 -- A source column whose name does not match any target column is an error.
 INSERT INTO target BY NAME
@@ -460,7 +460,7 @@ SELECT * FROM persons2;
 |   Ashua Hill|   456 Erica Ct, Cupertino|432795921|
 +-------------+--------------------------+---------+
 
--- in an atomic operation, 1) delete rows with ssn = 123456789 and 2) insert rows from persons2
+-- in an atomic operation, 1) delete rows with ssn = 123456789 and 2) insert rows from persons2 
 INSERT INTO persons REPLACE WHERE ssn = 123456789 SELECT * FROM persons2;
 
 SELECT * FROM persons;

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -26,13 +26,21 @@ The `INSERT` statement inserts new rows into a table or overwrites the existing 
 ### Syntax
 
 ```sql
-INSERT [ INTO | OVERWRITE ] [ TABLE ] table_identifier [ partition_spec ] [ ( column_list ) | [BY NAME] ]
+INSERT [ WITH SCHEMA EVOLUTION ] [ INTO | OVERWRITE ] [ TABLE ] table_identifier [ partition_spec ] [ ( column_list ) | [BY NAME] ]
     { VALUES ( { value | NULL } [ , ... ] ) [ , ( ... ) ] | query }
 
-INSERT INTO [ TABLE ] table_identifier REPLACE WHERE boolean_expression query
+INSERT [ WITH SCHEMA EVOLUTION ] INTO [ TABLE ] table_identifier REPLACE WHERE boolean_expression query
 ```
 
 ### Parameters
+
+* **WITH SCHEMA EVOLUTION**
+
+    An optional clause that enables automatic schema evolution for this `INSERT` operation.
+    When specified, the target data source may evolve the table schema to accommodate columns
+    or widened types present in the input query that differ from the existing table schema.
+    Schema evolution applies only to this single statement and must be supported by the target
+    data source; built-in file-based sources do not support it.
 
 * **table_identifier**
 

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -322,7 +322,7 @@ INSERT INTO new_students VALUES
     (222222, 'Dora Williams', '134 Forest Ave, Menlo Park');
 
 -- Evolve the students table schema to add the new address column from the query.
-INSERT WITH SCHEMA EVOLUTION INTO TABLE students
+INSERT WITH SCHEMA EVOLUTION INTO students
     SELECT * FROM new_students;
 
 SELECT * FROM students;

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -29,7 +29,7 @@ The `INSERT` statement inserts new rows into a table or overwrites the existing 
 INSERT [ WITH SCHEMA EVOLUTION ] [ INTO | OVERWRITE ] [ TABLE ] table_identifier [ partition_spec ] [ ( column_list ) | [BY NAME] ]
     { VALUES ( { value | NULL } [ , ... ] ) [ , ( ... ) ] | query }
 
-INSERT [ WITH SCHEMA EVOLUTION ] INTO [ TABLE ] table_identifier REPLACE WHERE boolean_expression query
+INSERT [ WITH SCHEMA EVOLUTION ] INTO [ TABLE ] table_identifier [ BY NAME ] REPLACE WHERE boolean_expression query
 ```
 
 ### Parameters
@@ -415,8 +415,43 @@ SELECT * FROM persons2;
 |   Ashua Hill|   456 Erica Ct, Cupertino|432795921|
 +-------------+--------------------------+---------+
 
--- in an atomic operation, 1) delete rows with ssn = 123456789 and 2) insert rows from persons2 
+-- in an atomic operation, 1) delete rows with ssn = 123456789 and 2) insert rows from persons2
 INSERT INTO persons REPLACE WHERE ssn = 123456789 SELECT * FROM persons2;
+
+SELECT * FROM persons;
++-------------+--------------------------+---------+
+|         name|                   address|      ssn|
++-------------+--------------------------+---------+
+|  Eddie Davis|   245 Market St, Milpitas|345678901|
++-------------+--------------------------+---------+
+|   Ashua Hill|   456 Erica Ct, Cupertino|432795921|
++-------------+--------------------------+---------+
+```
+
+##### Insert By Name Using a REPLACE WHERE Statement
+
+```sql
+-- Assuming the persons and persons3 table has already been created and populated.
+SELECT * FROM persons;
++-------------+--------------------------+---------+
+|         name|                   address|      ssn|
++-------------+--------------------------+---------+
+|Dora Williams|134 Forest Ave, Menlo Park|123456789|
++-------------+--------------------------+---------+
+|  Eddie Davis|   245 Market St, Milpitas|345678901|
++-------------+--------------------------+---------+
+
+-- persons3 lists the columns in a different order than the target table.
+SELECT * FROM persons3;
++--------------------------+---------+-----------+
+|                   address|      ssn|       name|
++--------------------------+---------+-----------+
+|   456 Erica Ct, Cupertino|432795921| Ashua Hill|
++--------------------------+---------+-----------+
+
+-- BY NAME matches the query fields to the target columns by name instead of by position,
+-- so the column order mismatch is resolved automatically.
+INSERT INTO persons BY NAME REPLACE WHERE ssn = 123456789 SELECT * FROM persons3;
 
 SELECT * FROM persons;
 +-------------+--------------------------+---------+

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -63,8 +63,8 @@ INSERT [ WITH SCHEMA EVOLUTION ] INTO [ TABLE ] table_identifier [ BY NAME ] REP
 
 * **BY NAME**
 
-    Columns and nested fields are matched by position between the source query and the target
-    table, unless `BY NAME` is specified, in which case columns and fields are matched by name.
+    By default, columns and nested fields are matched by position between the source query and the target
+    table. With `BY NAME`, columns and nested fields are matched by name, allowing them to be ordered differently in the source query and target table.
 
 * **VALUES ( { value `|` NULL } [ , ... ] ) [ , ( ... ) ]**
 

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -40,9 +40,6 @@ INSERT [ WITH SCHEMA EVOLUTION ] INTO [ TABLE ] table_identifier REPLACE WHERE b
     of the target table is automatically evolved to add new columns and widen data types based
     on the source query, subject to the capabilities of the underlying connector.
 
-    Columns and nested fields are matched by position between the source query and the target
-    table, unless `BY NAME` is specified, in which case columns and fields are matched by name.
-
 * **table_identifier**
 
     Specifies a table name, which may be optionally qualified with a database name.
@@ -63,6 +60,11 @@ INSERT [ WITH SCHEMA EVOLUTION ] INTO [ TABLE ] table_identifier REPLACE WHERE b
     **Note:**The current behaviour has some limitations:
     - All specified columns should exist in the table and not be duplicated from each other. It includes all columns except the static partition columns.
     - The size of the column list should be exactly the size of the data from `VALUES` clause or query.
+
+* **BY NAME**
+
+    Columns and nested fields are matched by position between the source query and the target
+    table, unless `BY NAME` is specified, in which case columns and fields are matched by name.
 
 * **VALUES ( { value `|` NULL } [ , ... ] ) [ , ( ... ) ]**
 

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -319,21 +319,21 @@ CREATE TABLE new_students (student_id INT, name STRING, address STRING);
 INSERT INTO students VALUES (444444, 'Bob Brown'), (555555, 'Cathy Johnson');
 INSERT INTO new_students VALUES
     (111111, 'Ashua Hill', '456 Erica Ct, Cupertino'),
-    (222222, 'Dora Williams', '134 Forest Ave, Melo Park');
+    (222222, 'Dora Williams', '134 Forest Ave, Menlo Park');
 
 -- Evolve the students table schema to add the new address column from the query.
 INSERT WITH SCHEMA EVOLUTION INTO TABLE students
     SELECT * FROM new_students;
 
 SELECT * FROM students;
-+----------+-------------+-------------------------+
-|student_id|         name|                  address|
-+----------+-------------+-------------------------+
-|    444444|    Bob Brown|                     NULL|
-|    555555|Cathy Johnson|                     NULL|
-|    111111|   Ashua Hill|  456 Erica Ct, Cupertino|
-|    222222|Dora Williams|134 Forest Ave, Melo Park|
-+----------+-------------+-------------------------+
++----------+-------------+--------------------------+
+|student_id|         name|                   address|
++----------+-------------+--------------------------+
+|    444444|    Bob Brown|                      NULL|
+|    555555|Cathy Johnson|                      NULL|
+|    111111|   Ashua Hill|   456 Erica Ct, Cupertino|
+|    222222|Dora Williams|134 Forest Ave, Menlo Park|
++----------+-------------+--------------------------+
 ```
 
 #### Insert Overwrite

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -36,11 +36,9 @@ INSERT [ WITH SCHEMA EVOLUTION ] INTO [ TABLE ] table_identifier REPLACE WHERE b
 
 * **WITH SCHEMA EVOLUTION**
 
-    An optional clause that enables automatic schema evolution for this `INSERT` operation.
-    When specified, the target data source may evolve the table schema to accommodate new
-    columns present in the input query that are not in the existing table schema.
-    Schema evolution applies only to this single statement and must be supported by the target
-    data source.
+    Enables automatic schema evolution for this `INSERT` operation. When enabled, the schema
+    of the target table is automatically updated to accommodate additional columns of the
+    source query.
 
 * **table_identifier**
 

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -37,8 +37,11 @@ INSERT [ WITH SCHEMA EVOLUTION ] INTO [ TABLE ] table_identifier REPLACE WHERE b
 * **WITH SCHEMA EVOLUTION**
 
     Enables automatic schema evolution for this `INSERT` operation. When enabled, the schema
-    of the target table is automatically updated to accommodate additional columns of the
-    source query.
+    of the target table is automatically evolved to add new columns and widen data types based
+    on the source query, subject to the capabilities of the underlying connector.
+
+    Columns and nested fields are matched by position between the source query and the target
+    table, unless `BY NAME` is specified, in which case columns and fields are matched by name.
 
 * **table_identifier**
 

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -471,7 +471,7 @@ SELECT * FROM persons;
 ##### Insert By Name Using a REPLACE WHERE Statement
 
 ```sql
--- Assuming the persons and persons3 table has already been created and populated.
+-- Assuming the persons and new_persons table has already been created and populated.
 SELECT * FROM persons;
 +-------------+--------------------------+---------+
 |         name|                   address|      ssn|
@@ -480,8 +480,8 @@ SELECT * FROM persons;
 |  Eddie Davis|   245 Market St, Milpitas|345678901|
 +-------------+--------------------------+---------+
 
--- persons3 lists the columns in a different order than the target table.
-SELECT * FROM persons3;
+-- new_persons lists the columns in a different order than the target table.
+SELECT * FROM new_persons;
 +-----------------------+---------+----------+
 |                address|      ssn|      name|
 +-----------------------+---------+----------+
@@ -490,7 +490,7 @@ SELECT * FROM persons3;
 
 -- BY NAME matches the query fields to the target columns by name instead of by position,
 -- so the column order mismatch is resolved automatically.
-INSERT INTO persons BY NAME REPLACE WHERE ssn = 123456789 SELECT * FROM persons3;
+INSERT INTO persons BY NAME REPLACE WHERE ssn = 123456789 SELECT * FROM new_persons;
 
 SELECT * FROM persons;
 +-----------+-----------------------+---------+

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -290,9 +290,9 @@ SELECT * FROM target;
 
 CREATE OR REPLACE TABLE target (n INT, arr ARRAY<STRUCT<a INT, b INT>>);
 
--- A missing top-level column is filled with its default value (NULL here).
 INSERT INTO target BY NAME
     SELECT array(named_struct('a', 1, 'b', 2)) AS arr, 0 AS n;
+-- A missing top-level column is filled with its default value (NULL here).
 INSERT INTO target BY NAME
     SELECT array(named_struct('a', 1, 'b', 2)) AS arr;
 
@@ -308,11 +308,6 @@ SELECT * FROM target;
 INSERT INTO target BY NAME
     SELECT array(named_struct('a', 1, 'b', 2)) AS arr, 0 AS badname;
 Error
-
--- Duplicate source column names that resolve to the same target column are an error.
-INSERT INTO target BY NAME
-    SELECT array(named_struct('a', 1, 'b', 2)) AS arr, 0 AS n, 1 AS n;
-Error: INSERT_COLUMN_ARITY_MISMATCH.TOO_MANY_DATA_COLUMNS
 ```
 
 ##### Insert With Schema Evolution
@@ -488,24 +483,24 @@ SELECT * FROM persons;
 
 -- persons3 lists the columns in a different order than the target table.
 SELECT * FROM persons3;
-+--------------------------+---------+-----------+
-|                   address|      ssn|       name|
-+--------------------------+---------+-----------+
-|   456 Erica Ct, Cupertino|432795921| Ashua Hill|
-+--------------------------+---------+-----------+
++-----------------------+---------+----------+
+|                address|      ssn|      name|
++-----------------------+---------+----------+
+|456 Erica Ct, Cupertino|432795921|Ashua Hill|
++-----------------------+---------+----------+
 
 -- BY NAME matches the query fields to the target columns by name instead of by position,
 -- so the column order mismatch is resolved automatically.
 INSERT INTO persons BY NAME REPLACE WHERE ssn = 123456789 SELECT * FROM persons3;
 
 SELECT * FROM persons;
-+-------------+--------------------------+---------+
-|         name|                   address|      ssn|
-+-------------+--------------------------+---------+
-|  Eddie Davis|   245 Market St, Milpitas|345678901|
-+-------------+--------------------------+---------+
-|   Ashua Hill|   456 Erica Ct, Cupertino|432795921|
-+-------------+--------------------------+---------+
++-----------+-----------------------+---------+
+|       name|                address|      ssn|
++-----------+-----------------------+---------+
+|Eddie Davis|245 Market St, Milpitas|345678901|
++-----------+-----------------------+---------+
+| Ashua Hill|456 Erica Ct, Cupertino|432795921|
++-----------+-----------------------+---------+
 ```
 
 ##### Insert Using a TABLE Statement

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -267,6 +267,32 @@ SELECT * FROM students WHERE student_id = 11215017;
 +------------+----------------------+----------+
 ```
 
+##### Insert With Schema Evolution
+
+```sql
+CREATE TABLE students (student_id INT, name STRING);
+CREATE TABLE new_students (student_id INT, name STRING, address STRING);
+
+INSERT INTO students VALUES (444444, 'Bob Brown'), (555555, 'Cathy Johnson');
+INSERT INTO new_students VALUES
+    (111111, 'Ashua Hill', '456 Erica Ct, Cupertino'),
+    (222222, 'Dora Williams', '134 Forest Ave, Melo Park');
+
+-- Evolve the students table schema to add the new address column from the query.
+INSERT WITH SCHEMA EVOLUTION INTO TABLE students
+    SELECT * FROM new_students;
+
+SELECT * FROM students;
++----------+-------------+-------------------------+
+|student_id|         name|                  address|
++----------+-------------+-------------------------+
+|    444444|    Bob Brown|                     null|
+|    555555|Cathy Johnson|                     null|
+|    111111|   Ashua Hill|  456 Erica Ct, Cupertino|
+|    222222|Dora Williams|134 Forest Ave, Melo Park|
++----------+-------------+-------------------------+
+```
+
 #### Insert Overwrite
 
 ##### Insert Using a VALUES Clause

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -40,7 +40,7 @@ INSERT [ WITH SCHEMA EVOLUTION ] INTO [ TABLE ] table_identifier REPLACE WHERE b
     When specified, the target data source may evolve the table schema to accommodate new
     columns present in the input query that are not in the existing table schema.
     Schema evolution applies only to this single statement and must be supported by the target
-    data source; built-in file-based sources do not support it.
+    data source.
 
 * **table_identifier**
 

--- a/docs/sql-ref-syntax-dml-insert-table.md
+++ b/docs/sql-ref-syntax-dml-insert-table.md
@@ -307,7 +307,7 @@ SELECT * FROM target;
 -- A source column whose name does not match any target column is an error.
 INSERT INTO target BY NAME
     SELECT array(named_struct('a', 1, 'b', 2)) AS arr, 0 AS badname;
-Error
+Error: INCOMPATIBLE_DATA_FOR_TABLE.EXTRA_COLUMNS
 ```
 
 ##### Insert With Schema Evolution
@@ -477,7 +477,6 @@ SELECT * FROM persons;
 |         name|                   address|      ssn|
 +-------------+--------------------------+---------+
 |Dora Williams|134 Forest Ave, Menlo Park|123456789|
-+-------------+--------------------------+---------+
 |  Eddie Davis|   245 Market St, Milpitas|345678901|
 +-------------+--------------------------+---------+
 
@@ -498,7 +497,6 @@ SELECT * FROM persons;
 |       name|                address|      ssn|
 +-----------+-----------------------+---------+
 |Eddie Davis|245 Market St, Milpitas|345678901|
-+-----------+-----------------------+---------+
 | Ashua Hill|456 Erica Ct, Cupertino|432795921|
 +-----------+-----------------------+---------+
 ```


### PR DESCRIPTION
### What changes were proposed in this pull request?

[SPARK-54971](https://issues.apache.org/jira/browse/SPARK-54971) (#53732) added the `WITH SCHEMA EVOLUTION` syntax to the SQL `INSERT` command, but did not add user-facing documentation for it. This PR documents the new clause on the `INSERT TABLE` SQL reference page (`docs/sql-ref-syntax-dml-insert-table.md`):

- Adds the optional `[ WITH SCHEMA EVOLUTION ]` clause to both syntax forms, mirroring the grammar where the clause appears right after `INSERT` and before `INTO` / `OVERWRITE`.
- Adds a `WITH SCHEMA EVOLUTION` entry to the Parameters section describing the behavior.
- Adds a `BY NAME` entry to the Parameters section noting that columns and nested fields are matched by position by default, or by name when `BY NAME` is specified.
- Documents `BY NAME` support for `INSERT INTO ... REPLACE WHERE` (added in #53567): updates the syntax form to `INSERT [ WITH SCHEMA EVOLUTION ] INTO [ TABLE ] table_identifier [ BY NAME ] REPLACE WHERE boolean_expression query` and adds an "Insert By Name Using a REPLACE WHERE Statement" example.

### Why are the changes needed?

The `WITH SCHEMA EVOLUTION` syntax for SQL `INSERT` was introduced without documentation. This page is the reference for the `INSERT` statement, so the new clause should be documented there.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only update.

### How was this patch tested?

Docs-only change. Reviewed the rendered Markdown for correctness.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Anthropic)