### PR TITLE
[SPARK-57317][SQL] Fix Literal.create for external nanosecond timestamp values

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -173,8 +173,31 @@ object Literal {
       case _: ObjectType => Literal(v, dataType)
       case _: CharType | _: VarcharType if SQLConf.get.preserveCharVarcharTypeInfo =>
         Literal(CatalystTypeConverters.createToCatalystConverter(dataType)(v), dataType)
+      case _ if requiresSchemaAwareNanosConversion(dataType, v) =>
+        Literal(CatalystTypeConverters.createToCatalystConverter(dataType)(v), dataType)
       case _ => Literal(CatalystTypeConverters.convertToCatalyst(v), dataType)
     }
+  }
+
+  /**
+   * The schema-less [[CatalystTypeConverters.convertToCatalyst]] keeps bare external nanosecond
+   * timestamp values (`java.time.LocalDateTime` / `java.time.Instant`, and arrays/maps/structs of
+   * them) on the microsecond converters by design (SPARK-57033). When the declared type contains a
+   * nanosecond timestamp type anywhere, route the value through the schema-driven converter so
+   * external values are converted to the internal `TimestampNanosVal` representation. Values
+   * already in Catalyst internal form (`TimestampNanosVal`, `ArrayData`, `MapData`, `InternalRow`)
+   * and nulls keep using the lenient schema-less path, preserving the behavior of callers such as
+   * `Literal.default` that pass internal values.
+   */
+  private def requiresSchemaAwareNanosConversion(dataType: DataType, v: Any): Boolean = {
+    v != null &&
+      !v.isInstanceOf[TimestampNanosVal] &&
+      !v.isInstanceOf[ArrayData] &&
+      !v.isInstanceOf[MapData] &&
+      !v.isInstanceOf[InternalRow] &&
+      dataType.existsRecursively { t =>
+        t.isInstanceOf[TimestampNTZNanosType] || t.isInstanceOf[TimestampLTZNanosType]
+      }
   }
 
   def create[T : TypeTag](v: T): Literal = Try {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -27,8 +27,9 @@ import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.{SparkFunSuite, SparkRuntimeException}
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.catalyst.{CatalystTypeConverters, ScalaReflection}
+import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, ScalaReflection}
 import org.apache.spark.sql.catalyst.encoders.ExamplePointUDT
+import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.localTime
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -132,6 +133,41 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
           }
         }
       }
+    }
+  }
+
+  test("SPARK-57317: create literals from external nanosecond timestamp values") {
+    val instant = Instant.parse("2020-12-31T23:59:59.123456789Z")
+    val ldt = LocalDateTime.parse("2020-12-31T23:59:59.123456789")
+    TimestampNanosTestUtils.foreachNanosPrecision { precision =>
+      val ltzType = TimestampLTZNanosType(precision)
+      val ntzType = TimestampNTZNanosType(precision)
+      val ltzVal = DateTimeUtils.instantToTimestampNanos(instant, precision)
+      val ntzVal = DateTimeUtils.localDateTimeToTimestampNanos(ldt, precision)
+
+      // Scalar external values (java.time.Instant / LocalDateTime) must be converted to the
+      // internal TimestampNanosVal, not kept as epoch micros (a Long) by the schema-less path.
+      val ltzLit = Literal.create(instant, ltzType)
+      assert(ltzLit.dataType === ltzType)
+      assert(ltzLit.value === ltzVal)
+      val ntzLit = Literal.create(ldt, ntzType)
+      assert(ntzLit.dataType === ntzType)
+      assert(ntzLit.value === ntzVal)
+
+      // Arrays of external nanosecond timestamp values are converted element-wise.
+      val arrayLit = Literal.create(Seq(instant), ArrayType(ltzType))
+      val array = arrayLit.value.asInstanceOf[ArrayData]
+      assert(array.numElements() === 1)
+      assert(array.get(0, ltzType) === ltzVal)
+
+      // Structs containing nanosecond timestamp fields are converted field-wise.
+      val structType = new StructType().add("c", ntzType)
+      val structLit = Literal.create(Row(ldt), structType)
+      assert(structLit.value.asInstanceOf[InternalRow].get(0, ntzType) === ntzVal)
+
+      // Values already in Catalyst internal form and nulls keep using the schema-less path.
+      assert(Literal.create(ltzVal, ltzType).value === ltzVal)
+      assert(Literal.create(null, ltzType).value === null)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`Literal.create(value, dataType)` now routes the value through the schema-driven converter (`CatalystTypeConverters.createToCatalystConverter`) when the declared type contains a nanosecond timestamp type (`TimestampLTZNanosType` / `TimestampNTZNanosType`) anywhere, but only for external values. Values already in Catalyst internal form (`TimestampNanosVal`, `ArrayData`, `MapData`, `InternalRow`) and nulls keep using the lenient schema-less path, preserving the behavior of callers such as `Literal.default` that pass internal values.

### Why are the changes needed?

`Literal.create(value, dataType)` produced an invalid literal when the value was an external (high-level) nanosecond timestamp value (`java.time.Instant` / `java.time.LocalDateTime`, and arrays/maps/structs of them) and the declared type was a nanosecond timestamp type, or a complex type containing one.

For these types the method routed the value through the schema-less `CatalystTypeConverters.convertToCatalyst`, which by design (SPARK-57033) keeps bare `java.time.Instant` and `java.time.LocalDateTime` on the microsecond converters. As a result the produced Catalyst value was a `Long` (epoch micros) instead of the internal `TimestampNanosVal` representation expected by the declared type, and `Literal` validation failed, e.g.:

```
java.lang.IllegalArgumentException: requirement failed: Literal must have a corresponding value to timestamp_ltz(7), but class Long found.
```

The same problem affected collections of such values, e.g.:

```
Literal must have a corresponding value to array<timestamp_ntz(9)>, but class GenericArrayData found.
```

This gap was surfaced while adding the nanosecond timestamp types to `DataTypeTestUtils` (SPARK-57259), which drives `PredicateSuite`'s generic "IN with different types" coverage over these types.

### Does this PR introduce _any_ user-facing change?

No. Both nanosecond timestamp types are `@Unstable` and unreleased; previously these `Literal.create` calls threw, so this only enables a path that did not work before.

### How was this patch tested?

Added a unit test in `LiteralExpressionSuite` ("SPARK-57317: create literals from external nanosecond timestamp values") covering scalar, array, and struct nanosecond timestamp values, plus already-internal and null inputs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor (Claude Opus 4.8)