### PR TITLE
[SPARK-57354][SQL] Add ignoredPathSegmentRegex data source option and config

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/HadoopFSUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/HadoopFSUtils.scala
@@ -49,6 +49,8 @@ private[spark] object HadoopFSUtils extends Logging {
    * @param filter Path filter used to exclude leaf files from result
    * @param ignoreMissingFiles Ignore missing files that happen during recursive listing
    *                           (e.g., due to race conditions)
+   * @param listHiddenFiles When true, include files and directories whose names start with '_' or
+   *                        '.' (hidden files), which are skipped by default.
    * @param ignoreLocality Whether to fetch data locality info when listing leaf files. If false,
    *                       this will return `FileStatus` without `BlockLocation` info.
    * @param parallelismThreshold The threshold to enable parallelism. If the number of input paths
@@ -65,11 +67,12 @@ private[spark] object HadoopFSUtils extends Logging {
     hadoopConf: Configuration,
     filter: PathFilter,
     ignoreMissingFiles: Boolean,
+    listHiddenFiles: Boolean,
     ignoreLocality: Boolean,
     parallelismThreshold: Int,
     parallelismMax: Int): Seq[(Path, Seq[FileStatus])] = {
     parallelListLeafFilesInternal(sc, paths, hadoopConf, filter, isRootLevel = true,
-      ignoreMissingFiles, ignoreLocality, parallelismThreshold, parallelismMax)
+      ignoreMissingFiles, listHiddenFiles, ignoreLocality, parallelismThreshold, parallelismMax)
   }
 
   /**
@@ -81,12 +84,15 @@ private[spark] object HadoopFSUtils extends Logging {
    * @param path a path to list
    * @param hadoopConf Hadoop configuration
    * @param filter Path filter used to exclude leaf files from result
+   * @param listHiddenFiles When true, include files and directories whose names start with '_' or
+   *                        '.' (hidden files), which are skipped by default.
    * @return  the set of discovered files for the path
    */
   def listFiles(
       path: Path,
       hadoopConf: Configuration,
-      filter: PathFilter): Seq[(Path, Seq[FileStatus])] = {
+      filter: PathFilter,
+      listHiddenFiles: Boolean): Seq[(Path, Seq[FileStatus])] = {
     logInfo(log"Listing ${MDC(PATH, path)} with listFiles API")
     try {
       val prefixLength = path.toString.length
@@ -94,7 +100,8 @@ private[spark] object HadoopFSUtils extends Logging {
       val statues = new Iterator[LocatedFileStatus]() {
         def next(): LocatedFileStatus = remoteIter.next
         def hasNext: Boolean = remoteIter.hasNext
-      }.filterNot(status => shouldFilterOutPath(status.getPath.toString.substring(prefixLength)))
+      }.filterNot(status =>
+          !listHiddenFiles && shouldFilterOutPath(status.getPath.toString.substring(prefixLength)))
         .filter(f => filter.accept(f.getPath))
         .toArray
       Seq((path, statues.toImmutableArraySeq))
@@ -113,6 +120,7 @@ private[spark] object HadoopFSUtils extends Logging {
       filter: PathFilter,
       isRootLevel: Boolean,
       ignoreMissingFiles: Boolean,
+      listHiddenFiles: Boolean,
       ignoreLocality: Boolean,
       parallelismThreshold: Int,
       parallelismMax: Int): Seq[(Path, Seq[FileStatus])] = {
@@ -126,6 +134,7 @@ private[spark] object HadoopFSUtils extends Logging {
           filter,
           Some(sc),
           ignoreMissingFiles = ignoreMissingFiles,
+          listHiddenFiles = listHiddenFiles,
           ignoreLocality = ignoreLocality,
           isRootPath = isRootLevel,
           parallelismThreshold = parallelismThreshold,
@@ -166,6 +175,7 @@ private[spark] object HadoopFSUtils extends Logging {
               filter = filter,
               contextOpt = None, // Can't execute parallel scans on workers
               ignoreMissingFiles = ignoreMissingFiles,
+              listHiddenFiles = listHiddenFiles,
               ignoreLocality = ignoreLocality,
               isRootPath = isRootLevel,
               parallelismThreshold = Int.MaxValue,
@@ -193,6 +203,7 @@ private[spark] object HadoopFSUtils extends Logging {
       filter: PathFilter,
       contextOpt: Option[SparkContext],
       ignoreMissingFiles: Boolean,
+      listHiddenFiles: Boolean,
       ignoreLocality: Boolean,
       isRootPath: Boolean,
       parallelismThreshold: Int,
@@ -251,7 +262,8 @@ private[spark] object HadoopFSUtils extends Logging {
     }
 
     val filteredStatuses =
-      statuses.filterNot(status => shouldFilterOutPathName(status.getPath.getName))
+      statuses.filterNot(status =>
+        !listHiddenFiles && shouldFilterOutPathName(status.getPath.getName))
 
     val allLeafStatuses = {
       val (dirs, topLevelFiles) = filteredStatuses.partition(_.isDirectory)
@@ -264,6 +276,7 @@ private[spark] object HadoopFSUtils extends Logging {
             filter = filter,
             isRootLevel = false,
             ignoreMissingFiles = ignoreMissingFiles,
+            listHiddenFiles = listHiddenFiles,
             ignoreLocality = ignoreLocality,
             parallelismThreshold = parallelismThreshold,
             parallelismMax = parallelismMax
@@ -276,6 +289,7 @@ private[spark] object HadoopFSUtils extends Logging {
               filter = filter,
               contextOpt = contextOpt,
               ignoreMissingFiles = ignoreMissingFiles,
+              listHiddenFiles = listHiddenFiles,
               ignoreLocality = ignoreLocality,
               isRootPath = false,
               parallelismThreshold = parallelismThreshold,

--- a/core/src/main/scala/org/apache/spark/util/HadoopFSUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/HadoopFSUtils.scala
@@ -101,7 +101,7 @@ private[spark] object HadoopFSUtils extends Logging {
         def next(): LocatedFileStatus = remoteIter.next
         def hasNext: Boolean = remoteIter.hasNext
       }.filterNot(status =>
-          !listHiddenFiles && shouldFilterOutPath(status.getPath.toString.substring(prefixLength)))
+        shouldFilterOutPath(status.getPath.toString.substring(prefixLength), listHiddenFiles))
         .filter(f => filter.accept(f.getPath))
         .toArray
       Seq((path, statues.toImmutableArraySeq))
@@ -263,7 +263,7 @@ private[spark] object HadoopFSUtils extends Logging {
 
     val filteredStatuses =
       statuses.filterNot(status =>
-        !listHiddenFiles && shouldFilterOutPathName(status.getPath.getName))
+        shouldFilterOutPathName(status.getPath.getName, listHiddenFiles))
 
     val allLeafStatuses = {
       val (dirs, topLevelFiles) = filteredStatuses.partition(_.isDirectory)
@@ -356,8 +356,12 @@ private[spark] object HadoopFSUtils extends Logging {
   }
   // scalastyle:on argcount
 
-  /** Checks if we should filter out this path name. */
-  def shouldFilterOutPathName(pathName: String): Boolean = {
+  /**
+   * Checks if we should filter out this path name. When `listHiddenFiles` is true, nothing is
+   * considered hidden and this always returns false.
+   */
+  def shouldFilterOutPathName(pathName: String, listHiddenFiles: Boolean = false): Boolean = {
+    if (listHiddenFiles) return false
     // We filter follow paths:
     // 1. everything that starts with _ and ., except _common_metadata and _metadata
     // because Parquet needs to find those metadata files from leaf files returned by this method.
@@ -373,9 +377,13 @@ private[spark] object HadoopFSUtils extends Logging {
   private val underscore: Regex = "/_[^=/]*/".r
   private val underscoreEnd: Regex = "/_[^=/]*$".r
 
-  /** Checks if we should filter out this path. */
+  /**
+   * Checks if we should filter out this path. When `listHiddenFiles` is true, nothing is
+   * considered hidden and this always returns false.
+   */
   @scala.annotation.tailrec
-  def shouldFilterOutPath(path: String): Boolean = {
+  def shouldFilterOutPath(path: String, listHiddenFiles: Boolean = false): Boolean = {
+    if (listHiddenFiles) return false
     if (path.contains("/.") || path.endsWith("._COPYING_")) return true
     underscoreEnd.findFirstIn(path) match {
       case Some(dir) if dir.equals("/_metadata") || dir.equals("/_common_metadata") => false
@@ -383,9 +391,9 @@ private[spark] object HadoopFSUtils extends Logging {
       case None =>
         underscore.findFirstIn(path) match {
           case Some(dir) if dir.equals("/_metadata/") =>
-            shouldFilterOutPath(path.replaceFirst("/_metadata", ""))
+            shouldFilterOutPath(path.replaceFirst("/_metadata", ""), listHiddenFiles)
           case Some(dir) if dir.equals("/_common_metadata/") =>
-            shouldFilterOutPath(path.replaceFirst("/_common_metadata", ""))
+            shouldFilterOutPath(path.replaceFirst("/_common_metadata", ""), listHiddenFiles)
           case Some(_) => true
           case None => false
         }

--- a/core/src/main/scala/org/apache/spark/util/HadoopFSUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/HadoopFSUtils.scala
@@ -38,15 +38,16 @@ import org.apache.spark.util.ArrayImplicits._
  */
 private[spark] object HadoopFSUtils extends Logging {
   /**
-   * The default value of the `ignoredPathSegmentRegex` option: a regex evaluated with find semantics
-   * against each individual directory and file name during file listing. It hides names that
-   * start with '_' or '.'; see `shouldFilterOutPathName` for the carve-outs that apply
+   * The default value of the `ignoredPathSegmentRegex` option: a regex evaluated with find
+   * semantics against each individual directory and file name during file listing. It hides names
+   * that start with '_' or '.'; see `shouldFilterOutPathName` for the carve-outs that apply
    * regardless of the regex.
    */
   val DEFAULT_IGNORED_PATH_SEGMENT_REGEX = "^[._]"
 
   /** The compiled form of [[DEFAULT_IGNORED_PATH_SEGMENT_REGEX]]. */
-  val defaultIgnoredPathSegmentRegexPattern: Pattern = Pattern.compile(DEFAULT_IGNORED_PATH_SEGMENT_REGEX)
+  val defaultIgnoredPathSegmentRegexPattern: Pattern =
+    Pattern.compile(DEFAULT_IGNORED_PATH_SEGMENT_REGEX)
 
   /**
    * Lists a collection of paths recursively. Picks the listing strategy adaptively depending
@@ -85,7 +86,8 @@ private[spark] object HadoopFSUtils extends Logging {
     parallelismThreshold: Int,
     parallelismMax: Int): Seq[(Path, Seq[FileStatus])] = {
     parallelListLeafFilesInternal(sc, paths, hadoopConf, filter, isRootLevel = true,
-      ignoreMissingFiles, ignoredPathSegmentRegex, ignoreLocality, parallelismThreshold, parallelismMax)
+      ignoreMissingFiles, ignoredPathSegmentRegex, ignoreLocality, parallelismThreshold,
+      parallelismMax)
   }
 
   /**
@@ -116,7 +118,8 @@ private[spark] object HadoopFSUtils extends Logging {
         def next(): LocatedFileStatus = remoteIter.next
         def hasNext: Boolean = remoteIter.hasNext
       }.filterNot(status =>
-        shouldFilterOutPath(status.getPath.toString.substring(prefixLength), ignoredPathSegmentRegex))
+        shouldFilterOutPath(
+          status.getPath.toString.substring(prefixLength), ignoredPathSegmentRegex))
         .filter(f => filter.accept(f.getPath))
         .toArray
       Seq((path, statues.toImmutableArraySeq))

--- a/core/src/main/scala/org/apache/spark/util/HadoopFSUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/HadoopFSUtils.scala
@@ -18,9 +18,9 @@
 package org.apache.spark.util
 
 import java.io.FileNotFoundException
+import java.util.regex.Pattern
 
 import scala.collection.mutable
-import scala.util.matching.Regex
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
@@ -38,6 +38,17 @@ import org.apache.spark.util.ArrayImplicits._
  */
 private[spark] object HadoopFSUtils extends Logging {
   /**
+   * The default value of the `ignoredPathSegmentRegex` option: a regex evaluated with find semantics
+   * against each individual directory and file name during file listing. It hides names that
+   * start with '_' or '.'; see `shouldFilterOutPathName` for the carve-outs that apply
+   * regardless of the regex.
+   */
+  val DEFAULT_IGNORED_PATH_SEGMENT_REGEX = "^[._]"
+
+  /** The compiled form of [[DEFAULT_IGNORED_PATH_SEGMENT_REGEX]]. */
+  val defaultIgnoredPathSegmentRegexPattern: Pattern = Pattern.compile(DEFAULT_IGNORED_PATH_SEGMENT_REGEX)
+
+  /**
    * Lists a collection of paths recursively. Picks the listing strategy adaptively depending
    * on the number of paths to list.
    *
@@ -49,8 +60,10 @@ private[spark] object HadoopFSUtils extends Logging {
    * @param filter Path filter used to exclude leaf files from result
    * @param ignoreMissingFiles Ignore missing files that happen during recursive listing
    *                           (e.g., due to race conditions)
-   * @param listHiddenFiles When true, include files and directories whose names start with '_' or
-   *                        '.' (hidden files), which are skipped by default.
+   * @param ignoredPathSegmentRegex Regex evaluated with find semantics against each directory and
+   *                           file name below the input paths; matching names are skipped and a
+   *                           matching directory name excludes its subtree. See
+   *                           `shouldFilterOutPathName` for the carve-outs that always apply.
    * @param ignoreLocality Whether to fetch data locality info when listing leaf files. If false,
    *                       this will return `FileStatus` without `BlockLocation` info.
    * @param parallelismThreshold The threshold to enable parallelism. If the number of input paths
@@ -67,12 +80,12 @@ private[spark] object HadoopFSUtils extends Logging {
     hadoopConf: Configuration,
     filter: PathFilter,
     ignoreMissingFiles: Boolean,
-    listHiddenFiles: Boolean,
+    ignoredPathSegmentRegex: Pattern,
     ignoreLocality: Boolean,
     parallelismThreshold: Int,
     parallelismMax: Int): Seq[(Path, Seq[FileStatus])] = {
     parallelListLeafFilesInternal(sc, paths, hadoopConf, filter, isRootLevel = true,
-      ignoreMissingFiles, listHiddenFiles, ignoreLocality, parallelismThreshold, parallelismMax)
+      ignoreMissingFiles, ignoredPathSegmentRegex, ignoreLocality, parallelismThreshold, parallelismMax)
   }
 
   /**
@@ -84,15 +97,17 @@ private[spark] object HadoopFSUtils extends Logging {
    * @param path a path to list
    * @param hadoopConf Hadoop configuration
    * @param filter Path filter used to exclude leaf files from result
-   * @param listHiddenFiles When true, include files and directories whose names start with '_' or
-   *                        '.' (hidden files), which are skipped by default.
+   * @param ignoredPathSegmentRegex Regex evaluated with find semantics against each directory and
+   *                           file name below `path`; matching names are skipped. See
+   *                           `shouldFilterOutPathName` for the carve-outs that always apply.
    * @return  the set of discovered files for the path
    */
   def listFiles(
       path: Path,
       hadoopConf: Configuration,
       filter: PathFilter,
-      listHiddenFiles: Boolean): Seq[(Path, Seq[FileStatus])] = {
+      ignoredPathSegmentRegex: Pattern = defaultIgnoredPathSegmentRegexPattern)
+      : Seq[(Path, Seq[FileStatus])] = {
     logInfo(log"Listing ${MDC(PATH, path)} with listFiles API")
     try {
       val prefixLength = path.toString.length
@@ -101,7 +116,7 @@ private[spark] object HadoopFSUtils extends Logging {
         def next(): LocatedFileStatus = remoteIter.next
         def hasNext: Boolean = remoteIter.hasNext
       }.filterNot(status =>
-        shouldFilterOutPath(status.getPath.toString.substring(prefixLength), listHiddenFiles))
+        shouldFilterOutPath(status.getPath.toString.substring(prefixLength), ignoredPathSegmentRegex))
         .filter(f => filter.accept(f.getPath))
         .toArray
       Seq((path, statues.toImmutableArraySeq))
@@ -120,7 +135,7 @@ private[spark] object HadoopFSUtils extends Logging {
       filter: PathFilter,
       isRootLevel: Boolean,
       ignoreMissingFiles: Boolean,
-      listHiddenFiles: Boolean,
+      ignoredPathSegmentRegex: Pattern,
       ignoreLocality: Boolean,
       parallelismThreshold: Int,
       parallelismMax: Int): Seq[(Path, Seq[FileStatus])] = {
@@ -134,7 +149,7 @@ private[spark] object HadoopFSUtils extends Logging {
           filter,
           Some(sc),
           ignoreMissingFiles = ignoreMissingFiles,
-          listHiddenFiles = listHiddenFiles,
+          ignoredPathSegmentRegex = ignoredPathSegmentRegex,
           ignoreLocality = ignoreLocality,
           isRootPath = isRootLevel,
           parallelismThreshold = parallelismThreshold,
@@ -175,7 +190,7 @@ private[spark] object HadoopFSUtils extends Logging {
               filter = filter,
               contextOpt = None, // Can't execute parallel scans on workers
               ignoreMissingFiles = ignoreMissingFiles,
-              listHiddenFiles = listHiddenFiles,
+              ignoredPathSegmentRegex = ignoredPathSegmentRegex,
               ignoreLocality = ignoreLocality,
               isRootPath = isRootLevel,
               parallelismThreshold = Int.MaxValue,
@@ -203,7 +218,7 @@ private[spark] object HadoopFSUtils extends Logging {
       filter: PathFilter,
       contextOpt: Option[SparkContext],
       ignoreMissingFiles: Boolean,
-      listHiddenFiles: Boolean,
+      ignoredPathSegmentRegex: Pattern,
       ignoreLocality: Boolean,
       isRootPath: Boolean,
       parallelismThreshold: Int,
@@ -263,7 +278,7 @@ private[spark] object HadoopFSUtils extends Logging {
 
     val filteredStatuses =
       statuses.filterNot(status =>
-        shouldFilterOutPathName(status.getPath.getName, listHiddenFiles))
+        shouldFilterOutPathName(status.getPath.getName, ignoredPathSegmentRegex))
 
     val allLeafStatuses = {
       val (dirs, topLevelFiles) = filteredStatuses.partition(_.isDirectory)
@@ -276,7 +291,7 @@ private[spark] object HadoopFSUtils extends Logging {
             filter = filter,
             isRootLevel = false,
             ignoreMissingFiles = ignoreMissingFiles,
-            listHiddenFiles = listHiddenFiles,
+            ignoredPathSegmentRegex = ignoredPathSegmentRegex,
             ignoreLocality = ignoreLocality,
             parallelismThreshold = parallelismThreshold,
             parallelismMax = parallelismMax
@@ -289,7 +304,7 @@ private[spark] object HadoopFSUtils extends Logging {
               filter = filter,
               contextOpt = contextOpt,
               ignoreMissingFiles = ignoreMissingFiles,
-              listHiddenFiles = listHiddenFiles,
+              ignoredPathSegmentRegex = ignoredPathSegmentRegex,
               ignoreLocality = ignoreLocality,
               isRootPath = false,
               parallelismThreshold = parallelismThreshold,
@@ -357,46 +372,34 @@ private[spark] object HadoopFSUtils extends Logging {
   // scalastyle:on argcount
 
   /**
-   * Checks if we should filter out this path name. When `listHiddenFiles` is true, nothing is
-   * considered hidden and this always returns false.
+   * Checks if we should filter out this path name, i.e. whether `ignoredPathSegmentRegex` finds a
+   * match in it. Regardless of the regex, names starting with `_common_metadata` or `_metadata`
+   * are never filtered, names ending with `._COPYING_` are always filtered, and '_'-prefixed
+   * names containing '=' (partition directories) are never filtered.
    */
-  def shouldFilterOutPathName(pathName: String, listHiddenFiles: Boolean = false): Boolean = {
-    if (listHiddenFiles) return false
-    // We filter follow paths:
-    // 1. everything that starts with _ and ., except _common_metadata and _metadata
-    // because Parquet needs to find those metadata files from leaf files returned by this method.
+  def shouldFilterOutPathName(
+      pathName: String,
+      ignoredPathSegmentRegex: Pattern = defaultIgnoredPathSegmentRegexPattern): Boolean = {
+    // Parquet summary files must stay visible to listing regardless of the filter, because
+    // Parquet needs to find those metadata files from leaf files returned by this method.
     // We should refactor this logic to not mix metadata files with data files.
-    // 2. everything that ends with `._COPYING_`, because this is a intermediate state of file. we
-    // should skip this file in case of double reading.
-    val exclude = (pathName.startsWith("_") && !pathName.contains("=")) ||
-      pathName.startsWith(".") || pathName.endsWith("._COPYING_")
-    val include = pathName.startsWith("_common_metadata") || pathName.startsWith("_metadata")
-    exclude && !include
+    if (pathName.startsWith("_common_metadata") || pathName.startsWith("_metadata")) return false
+    // In-flight copy files (hadoop fs -put) are always skipped to avoid double reads.
+    if (pathName.endsWith("._COPYING_")) return true
+    // '_'-prefixed names containing '=' are partition directories, never hidden.
+    if (pathName.startsWith("_") && pathName.contains("=")) return false
+    ignoredPathSegmentRegex.matcher(pathName).find()
   }
 
-  private val underscore: Regex = "/_[^=/]*/".r
-  private val underscoreEnd: Regex = "/_[^=/]*$".r
-
   /**
-   * Checks if we should filter out this path. When `listHiddenFiles` is true, nothing is
-   * considered hidden and this always returns false.
+   * Checks if we should filter out this path, i.e. whether any of its individual directory or
+   * file name components below the listed base path is filtered by `ignoredPathSegmentRegex`
+   * according to [[shouldFilterOutPathName]].
    */
-  @scala.annotation.tailrec
-  def shouldFilterOutPath(path: String, listHiddenFiles: Boolean = false): Boolean = {
-    if (listHiddenFiles) return false
-    if (path.contains("/.") || path.endsWith("._COPYING_")) return true
-    underscoreEnd.findFirstIn(path) match {
-      case Some(dir) if dir.equals("/_metadata") || dir.equals("/_common_metadata") => false
-      case Some(_) => true
-      case None =>
-        underscore.findFirstIn(path) match {
-          case Some(dir) if dir.equals("/_metadata/") =>
-            shouldFilterOutPath(path.replaceFirst("/_metadata", ""), listHiddenFiles)
-          case Some(dir) if dir.equals("/_common_metadata/") =>
-            shouldFilterOutPath(path.replaceFirst("/_common_metadata", ""), listHiddenFiles)
-          case Some(_) => true
-          case None => false
-        }
-    }
+  def shouldFilterOutPath(
+      path: String,
+      ignoredPathSegmentRegex: Pattern = defaultIgnoredPathSegmentRegexPattern): Boolean = {
+    path.split("/").exists(name =>
+      name.nonEmpty && shouldFilterOutPathName(name, ignoredPathSegmentRegex))
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/HadoopFSUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/HadoopFSUtilsSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.util
 
 import java.io.File
 import java.nio.file.Files
+import java.util.regex.Pattern
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path, PathFilter}
@@ -28,8 +29,11 @@ import org.apache.spark.LocalSparkContext.withSpark
 
 class HadoopFSUtilsSuite extends SparkFunSuite {
 
-  // Accept everything; hidden-file filtering is exercised via the listHiddenFiles flag.
+  // Accept everything; hidden-file filtering is exercised via the ignoredPathSegmentRegex regex.
   private val acceptAllFilter: PathFilter = AcceptAllPathFilter
+
+  // Never matches any name: disables generic hidden-file filtering, leaving only the carve-outs.
+  private val neverMatch: Pattern = Pattern.compile("(?!)")
 
   /**
    * Builds a tree with one regular file, hidden entries ('_'-, '.'-, '._COPYING_'-named) and a
@@ -68,9 +72,30 @@ class HadoopFSUtilsSuite extends SparkFunSuite {
     assert(HadoopFSUtils.shouldFilterOutPathName("_ab_metadata"))
     assert(HadoopFSUtils.shouldFilterOutPathName("_cd_common_metadata"))
     assert(HadoopFSUtils.shouldFilterOutPathName("a._COPYING_"))
-    // listHiddenFiles short-circuits the predicates: nothing is considered hidden.
-    assert(!HadoopFSUtils.shouldFilterOutPathName(".ab", listHiddenFiles = true))
-    assert(!HadoopFSUtils.shouldFilterOutPath("/.ab", listHiddenFiles = true))
+    // A never-matching regex surfaces generically hidden names...
+    assert(!HadoopFSUtils.shouldFilterOutPathName(".ab", neverMatch))
+    assert(!HadoopFSUtils.shouldFilterOutPathName("_cd", neverMatch))
+    assert(!HadoopFSUtils.shouldFilterOutPath("/.ab", neverMatch))
+    // ... but the hardcoded carve-outs are not overridable: '._COPYING_' files stay hidden and
+    // metadata-prefixed files stay visible regardless of the regex.
+    assert(HadoopFSUtils.shouldFilterOutPathName("a._COPYING_", neverMatch))
+    assert(!HadoopFSUtils.shouldFilterOutPathName("_metadata", neverMatch))
+  }
+
+  test("HadoopFSUtils - file filtering with a custom regex") {
+    val backup = Pattern.compile("^backup")
+    // The custom regex hides matching names.
+    assert(HadoopFSUtils.shouldFilterOutPathName("backup_1", backup))
+    // Names not matching the custom regex are listed, even '_'- or '.'-prefixed ones: the
+    // default '^[._]' regex is replaced, not combined, and no carve-out hides them.
+    assert(!HadoopFSUtils.shouldFilterOutPathName("_hidden", backup))
+    assert(!HadoopFSUtils.shouldFilterOutPathName(".dot", backup))
+    assert(!HadoopFSUtils.shouldFilterOutPathName("abcd", backup))
+    // The carve-outs still apply around the custom regex: '._COPYING_' names stay hidden, and
+    // '_'-prefixed names containing '=' (partition dirs) stay visible even when the regex
+    // finds a match (note find semantics: unanchored "backup" matches inside "_backup=1").
+    assert(HadoopFSUtils.shouldFilterOutPathName("backup_1._COPYING_", backup))
+    assert(!HadoopFSUtils.shouldFilterOutPathName("_backup=1", Pattern.compile("backup")))
   }
 
   test("SPARK-45452: HadoopFSUtils - path filtering") {
@@ -103,51 +128,63 @@ class HadoopFSUtilsSuite extends SparkFunSuite {
     assert(HadoopFSUtils.shouldFilterOutPath("/ab/_cd/part=1"))
     assert(HadoopFSUtils.shouldFilterOutPath("/_ab_metadata"))
     assert(HadoopFSUtils.shouldFilterOutPath("/_cd_common_metadata"))
+    // Case 4: the per-name-component walk unifies this predicate with the recursive-descent
+    // listing path. The verdicts below intentionally differ from the old path-based logic:
+    // a '_metadata' leaf no longer rescues a hidden parent directory...
+    assert(HadoopFSUtils.shouldFilterOutPath("/_foo/_metadata"))
+    // ... the metadata exemption is prefix-based, matching shouldFilterOutPathName...
+    assert(!HadoopFSUtils.shouldFilterOutPath("/x/_metadata.json"))
+    // ... and a '._COPYING_' directory component hides its subtree.
+    assert(HadoopFSUtils.shouldFilterOutPath("/d._COPYING_/x"))
   }
 
-  test("listFiles - listHiddenFiles=false filters hidden files and dirs") {
+  test("listFiles - default ignoredPathSegmentRegex hides hidden files and dirs") {
     withTempDir { root =>
       val (path, regularFile) = createHiddenFileTree(root)
       val hadoopConf = new Configuration()
       val names = leafFileNames(
-        HadoopFSUtils.listFiles(path, hadoopConf, acceptAllFilter, listHiddenFiles = false))
+        HadoopFSUtils.listFiles(path, hadoopConf, acceptAllFilter))
       // Only the regular file survives; every hidden entry is filtered out.
       assert(names === Set(regularFile))
     }
   }
 
-  test("listFiles - listHiddenFiles=true surfaces hidden files and dirs") {
+  test("listFiles - never-matching ignoredPathSegmentRegex surfaces hidden files and dirs") {
     withTempDir { root =>
       val (path, regularFile) = createHiddenFileTree(root)
       val hadoopConf = new Configuration()
       val names = leafFileNames(
-        HadoopFSUtils.listFiles(path, hadoopConf, acceptAllFilter, listHiddenFiles = true))
-      assert(names === Set(regularFile, "_hidden", ".dot", "x._COPYING_", "nested.parquet"))
+        HadoopFSUtils.listFiles(path, hadoopConf, acceptAllFilter, neverMatch))
+      // 'x._COPYING_' stays hidden even with a never-matching regex: the carve-out for
+      // in-flight copy files is not overridable.
+      assert(names === Set(regularFile, "_hidden", ".dot", "nested.parquet"))
     }
   }
 
-  test("parallelListLeafFiles - listHiddenFiles toggles hidden file visibility") {
+  test("parallelListLeafFiles - ignoredPathSegmentRegex toggles hidden file visibility") {
     withTempDir { root =>
       val (path, regularFile) = createHiddenFileTree(root)
       val hadoopConf = new Configuration()
       withSpark(new SparkContext("local", "HadoopFSUtilsSuite")) { sc =>
-        def listNames(listHiddenFiles: Boolean): Set[String] =
+        def listNames(ignoredPathSegmentRegex: Pattern): Set[String] =
           leafFileNames(HadoopFSUtils.parallelListLeafFiles(
             sc,
             Seq(path),
             hadoopConf,
             acceptAllFilter,
             ignoreMissingFiles = false,
-            listHiddenFiles = listHiddenFiles,
+            ignoredPathSegmentRegex = ignoredPathSegmentRegex,
             ignoreLocality = true,
             // Use 0 so the parallel (Spark job) code path is exercised rather than the
             // serial short-circuit.
             parallelismThreshold = 0,
             parallelismMax = 1))
 
-        assert(listNames(listHiddenFiles = false) === Set(regularFile))
-        assert(listNames(listHiddenFiles = true) ===
-          Set(regularFile, "_hidden", ".dot", "x._COPYING_", "nested.parquet"))
+        val defaultFilter = Pattern.compile(HadoopFSUtils.DEFAULT_IGNORED_PATH_SEGMENT_REGEX)
+        assert(listNames(defaultFilter) === Set(regularFile))
+        // 'x._COPYING_' stays hidden even with a never-matching regex (see the listFiles test).
+        assert(listNames(neverMatch) ===
+          Set(regularFile, "_hidden", ".dot", "nested.parquet"))
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/util/HadoopFSUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/HadoopFSUtilsSuite.scala
@@ -31,8 +31,13 @@ class HadoopFSUtilsSuite extends SparkFunSuite {
   // Accept everything; hidden-file filtering is exercised via the listHiddenFiles flag.
   private val acceptAllFilter: PathFilter = AcceptAllPathFilter
 
-  // Builds a tree with one regular file, hidden entries ('_'-, '.'-, '._COPYING_'-named) and a
-  // hidden subdir with its own file. Returns (rootPath, regularFileName).
+  /**
+   * Builds a tree with one regular file, hidden entries ('_'-, '.'-, '._COPYING_'-named) and a
+   * hidden subdir with its own file.
+   *
+   * @return a tuple of (root path to pass to the listing APIs, name of the only non-hidden file
+   *         in the tree).
+   */
   private def createHiddenFileTree(root: File): (Path, String) = {
     def writeFile(parent: File, name: String): Unit = {
       val file = new File(parent, name)
@@ -63,6 +68,9 @@ class HadoopFSUtilsSuite extends SparkFunSuite {
     assert(HadoopFSUtils.shouldFilterOutPathName("_ab_metadata"))
     assert(HadoopFSUtils.shouldFilterOutPathName("_cd_common_metadata"))
     assert(HadoopFSUtils.shouldFilterOutPathName("a._COPYING_"))
+    // listHiddenFiles short-circuits the predicates: nothing is considered hidden.
+    assert(!HadoopFSUtils.shouldFilterOutPathName(".ab", listHiddenFiles = true))
+    assert(!HadoopFSUtils.shouldFilterOutPath("/.ab", listHiddenFiles = true))
   }
 
   test("SPARK-45452: HadoopFSUtils - path filtering") {

--- a/core/src/test/scala/org/apache/spark/util/HadoopFSUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/HadoopFSUtilsSuite.scala
@@ -17,9 +17,43 @@
 
 package org.apache.spark.util
 
-import org.apache.spark.SparkFunSuite
+import java.io.File
+import java.nio.file.Files
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, Path, PathFilter}
+
+import org.apache.spark.{SparkContext, SparkFunSuite}
+import org.apache.spark.LocalSparkContext.withSpark
 
 class HadoopFSUtilsSuite extends SparkFunSuite {
+
+  // Accept everything; hidden-file filtering is exercised via the listHiddenFiles flag.
+  private val acceptAllFilter: PathFilter = AcceptAllPathFilter
+
+  // Builds a tree with one regular file, hidden entries ('_'-, '.'-, '._COPYING_'-named) and a
+  // hidden subdir with its own file. Returns (rootPath, regularFileName).
+  private def createHiddenFileTree(root: File): (Path, String) = {
+    def writeFile(parent: File, name: String): Unit = {
+      val file = new File(parent, name)
+      Files.write(file.toPath, "content".getBytes)
+    }
+    writeFile(root, "data.parquet")
+    writeFile(root, "_hidden")
+    writeFile(root, ".dot")
+    writeFile(root, "x._COPYING_")
+    val hiddenDir = new File(root, "_tmp")
+    assert(hiddenDir.mkdir())
+    writeFile(hiddenDir, "nested.parquet")
+    // Use getCanonicalPath, not toURI: toURI's trailing slash breaks HadoopFSUtils' prefix
+    // stripping and defeats shouldFilterOutPath's leading-'/' match.
+    (new Path(root.getCanonicalPath), "data.parquet")
+  }
+
+  // The set of leaf-file names surfaced for the root path.
+  private def leafFileNames(listing: Seq[(Path, Seq[FileStatus])]): Set[String] =
+    listing.flatMap(_._2).map(_.getPath.getName).toSet
+
   test("HadoopFSUtils - file filtering") {
     assert(!HadoopFSUtils.shouldFilterOutPathName("abcd"))
     assert(HadoopFSUtils.shouldFilterOutPathName(".ab"))
@@ -62,4 +96,55 @@ class HadoopFSUtilsSuite extends SparkFunSuite {
     assert(HadoopFSUtils.shouldFilterOutPath("/_ab_metadata"))
     assert(HadoopFSUtils.shouldFilterOutPath("/_cd_common_metadata"))
   }
+
+  test("listFiles - listHiddenFiles=false filters hidden files and dirs") {
+    withTempDir { root =>
+      val (path, regularFile) = createHiddenFileTree(root)
+      val hadoopConf = new Configuration()
+      val names = leafFileNames(
+        HadoopFSUtils.listFiles(path, hadoopConf, acceptAllFilter, listHiddenFiles = false))
+      // Only the regular file survives; every hidden entry is filtered out.
+      assert(names === Set(regularFile))
+    }
+  }
+
+  test("listFiles - listHiddenFiles=true surfaces hidden files and dirs") {
+    withTempDir { root =>
+      val (path, regularFile) = createHiddenFileTree(root)
+      val hadoopConf = new Configuration()
+      val names = leafFileNames(
+        HadoopFSUtils.listFiles(path, hadoopConf, acceptAllFilter, listHiddenFiles = true))
+      assert(names === Set(regularFile, "_hidden", ".dot", "x._COPYING_", "nested.parquet"))
+    }
+  }
+
+  test("parallelListLeafFiles - listHiddenFiles toggles hidden file visibility") {
+    withTempDir { root =>
+      val (path, regularFile) = createHiddenFileTree(root)
+      val hadoopConf = new Configuration()
+      withSpark(new SparkContext("local", "HadoopFSUtilsSuite")) { sc =>
+        def listNames(listHiddenFiles: Boolean): Set[String] =
+          leafFileNames(HadoopFSUtils.parallelListLeafFiles(
+            sc,
+            Seq(path),
+            hadoopConf,
+            acceptAllFilter,
+            ignoreMissingFiles = false,
+            listHiddenFiles = listHiddenFiles,
+            ignoreLocality = true,
+            // Use 0 so the parallel (Spark job) code path is exercised rather than the
+            // serial short-circuit.
+            parallelismThreshold = 0,
+            parallelismMax = 1))
+
+        assert(listNames(listHiddenFiles = false) === Set(regularFile))
+        assert(listNames(listHiddenFiles = true) ===
+          Set(regularFile, "_hidden", ".dot", "x._COPYING_", "nested.parquet"))
+      }
+    }
+  }
+}
+
+private object AcceptAllPathFilter extends PathFilter with Serializable {
+  override def accept(path: Path): Boolean = true
 }

--- a/docs/sql-data-sources-generic-options.md
+++ b/docs/sql-data-sources-generic-options.md
@@ -108,7 +108,7 @@ takes precedence over the configuration when both are set.
 Regardless of the regex, three rules always apply: names starting with `_metadata` or `_common_metadata` (Parquet summary files) are always listed, names ending in
 `._COPYING_` (in-flight copies) are always skipped, and `_`-prefixed names containing `=` (partition directories) are always kept.
 
-A regex that never matches, such as `(?!)`, disables the generic hidden-file filtering and surfaces hidden files, including Spark-internal marker files such as
+An empty string disables the generic hidden-file filtering (an empty regex matches nothing) and surfaces hidden files, including Spark-internal marker files such as
 `_SUCCESS` and files under `_temporary` directories (the three rules above still apply). Note the difference from `pathGlobFilter`: `pathGlobFilter` is an
 include-style glob applied to leaf file names only, while `ignoredPathSegmentRegex` is an exclude-style regex applied to every directory and file name component; the two
 can be combined, e.g. using `pathGlobFilter` to narrow the results of a relaxed `ignoredPathSegmentRegex`.

--- a/docs/sql-data-sources-generic-options.md
+++ b/docs/sql-data-sources-generic-options.md
@@ -97,6 +97,16 @@ you can use:
 </div>
 </div>
 
+### List Hidden Files
+
+Spark allows you to use the configuration `spark.sql.files.listHiddenFiles` or the data source option `listHiddenFiles` to include hidden files while reading data
+from files. Its default value is `false`, which means files and directories whose names start with `_` or `.` are skipped during
+file listing. When set to true, such hidden files and directories participate in file listing, partition discovery, and reads.
+The data source option takes precedence over the configuration when both are set.
+
+Note that enabling this option also surfaces Spark-internal marker files, such as `_SUCCESS`, `._COPYING_`, and files under
+`_temporary` directories. The `pathGlobFilter` option can be used to narrow the results.
+
 ### Recursive File Lookup
 `recursiveFileLookup` is used to recursively load files and it disables partition inferring. Its default value is `false`.
 If data source explicitly specifies the `partitionSpec` when `recursiveFileLookup` is true, exception will be thrown.

--- a/docs/sql-data-sources-generic-options.md
+++ b/docs/sql-data-sources-generic-options.md
@@ -97,15 +97,45 @@ you can use:
 </div>
 </div>
 
-### List Hidden Files
+### Ignored Path Segment Regex
 
-Spark allows you to use the configuration `spark.sql.files.listHiddenFiles` or the data source option `listHiddenFiles` to include hidden files while reading data
-from files. Its default value is `false`, which means files and directories whose names start with `_` or `.` are skipped during
-file listing. When set to true, such hidden files and directories participate in file listing, partition discovery, and reads.
-The data source option takes precedence over the configuration when both are set.
+Spark allows you to use the configuration `spark.sql.files.ignoredPathSegmentRegex` or the data source option `ignoredPathSegmentRegex` to control which files are treated as
+hidden during file listing. The value is a Java regular expression that is matched (with find semantics, i.e. `java.util.regex.Matcher.find`) against each individual
+directory and file name below the path being read; names in which the regex finds a match are skipped from file listing, partition discovery, and reads, and a matching
+directory name excludes its whole subtree. The default value is `^[._]`, which skips files and directories whose names start with `_` or `.`. The data source option
+takes precedence over the configuration when both are set.
 
-Note that enabling this option also surfaces Spark-internal marker files, such as `_SUCCESS`, `._COPYING_`, and files under
-`_temporary` directories. The `pathGlobFilter` option can be used to narrow the results.
+Regardless of the regex, three rules always apply: names starting with `_metadata` or `_common_metadata` (Parquet summary files) are always listed, names ending in
+`._COPYING_` (in-flight copies) are always skipped, and `_`-prefixed names containing `=` (partition directories) are always kept.
+
+A regex that never matches, such as `(?!)`, disables the generic hidden-file filtering and surfaces hidden files, including Spark-internal marker files such as
+`_SUCCESS` and files under `_temporary` directories (the three rules above still apply). Note the difference from `pathGlobFilter`: `pathGlobFilter` is an
+include-style glob applied to leaf file names only, while `ignoredPathSegmentRegex` is an exclude-style regex applied to every directory and file name component; the two
+can be combined, e.g. using `pathGlobFilter` to narrow the results of a relaxed `ignoredPathSegmentRegex`.
+
+Note that directories surfaced by a relaxed regex also participate in partition discovery, so a hidden directory next to partition directories causes a conflicting
+directory structures error unless `spark.sql.files.ignoreInvalidPartitionPaths` is enabled.
+
+To surface files that are hidden by default, you can use:
+
+<div class="codetabs">
+
+<div data-lang="python"  markdown="1">
+{% include_example ignored_path_segment_regex python/sql/datasource.py %}
+</div>
+
+<div data-lang="scala"  markdown="1">
+{% include_example ignored_path_segment_regex scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala %}
+</div>
+
+<div data-lang="java"  markdown="1">
+{% include_example ignored_path_segment_regex java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java %}
+</div>
+
+<div data-lang="r"  markdown="1">
+{% include_example ignored_path_segment_regex r/RSparkSQLExample.R %}
+</div>
+</div>
 
 ### Recursive File Lookup
 `recursiveFileLookup` is used to recursively load files and it disables partition inferring. Its default value is `false`.

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -22,12 +22,9 @@ license: |
 * Table of contents
 {:toc}
 
-## Upgrading from Spark SQL 4.2 to 5.0
-
-- Since Spark 5.0, zero-length files are skipped during Parquet schema inference instead of failing with a `FAILED_READ_FILE.CANNOT_READ_FILE_FOOTER` error.
-
 ## Upgrading from Spark SQL 4.2 to 4.3
 
+- Since Spark 4.3, zero-length files are skipped during Parquet schema inference instead of failing with a `FAILED_READ_FILE.CANNOT_READ_FILE_FOOTER` error.
 - Since Spark 4.3, the configuration key `spark.sql.sources.v2.bucketing.allowJoinKeysSubsetOfPartitionKeys.enabled` has been renamed to `spark.sql.sources.v2.bucketing.allowKeysSubsetOfPartitionKeys.enabled` to reflect that it now applies to storage-partitioned joins, aggregates, and windows. The old key continues to work as an alias.
 - Since Spark 4.3, the Spark Thrift Server rejects setting JVM system properties through the `set:system:` session configuration overlay (for example, in a JDBC connection string). To restore the previous behavior, set `spark.sql.legacy.hive.thriftServer.allowSettingSystemProperties` to `true`.
 

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -22,6 +22,10 @@ license: |
 * Table of contents
 {:toc}
 
+## Upgrading from Spark SQL 4.2 to 5.0
+
+- Since Spark 5.0, zero-length files are skipped during Parquet schema inference instead of failing with a `FAILED_READ_FILE.CANNOT_READ_FILE_FOOTER` error.
+
 ## Upgrading from Spark SQL 4.2 to 4.3
 
 - Since Spark 4.3, the configuration key `spark.sql.sources.v2.bucketing.allowJoinKeysSubsetOfPartitionKeys.enabled` has been renamed to `spark.sql.sources.v2.bucketing.allowKeysSubsetOfPartitionKeys.enabled` to reflect that it now applies to storage-partitioned joins, aggregates, and windows. The old key continues to work as an alias.

--- a/docs/streaming/apis-on-dataframes-and-datasets.md
+++ b/docs/streaming/apis-on-dataframes-and-datasets.md
@@ -75,6 +75,8 @@ Here are the details of all the sources in Spark.
         "s3n://a/b/dataset.txt"<br/>
         "s3a://a/b/c/dataset.txt"
         <br/>
+        <code>listHiddenFiles</code>: whether to list and read hidden files, i.e. files and directories whose names start with '_' or '.' (default: false)
+        <br/>
         <code>maxFileAge</code>: Maximum age of a file that can be found in this directory, before it is ignored. For the first batch all files will be considered valid. If <code>latestFirst</code> is set to `true` and <code>maxFilesPerTrigger</code> or <code>maxBytesPerTrigger</code> is set, then this parameter will be ignored, because old files that are valid, and should be processed, may be ignored. The max age is specified with respect to the timestamp of the latest file, and not the timestamp of the current system.(default: 1 week)
         <br/>
         <code>maxCachedFiles</code>: maximum number of files to cache to be processed in subsequent batches (default: 10000).  If files are available in the cache, they will be read from first before listing from the input source.

--- a/docs/streaming/apis-on-dataframes-and-datasets.md
+++ b/docs/streaming/apis-on-dataframes-and-datasets.md
@@ -75,7 +75,7 @@ Here are the details of all the sources in Spark.
         "s3n://a/b/dataset.txt"<br/>
         "s3a://a/b/c/dataset.txt"
         <br/>
-        <code>listHiddenFiles</code>: whether to list and read hidden files, i.e. files and directories whose names start with '_' or '.' (default: false)
+        <code>ignoredPathSegmentRegex</code>: a Java regular expression matched against each directory and file name during file listing; matching names are treated as hidden and skipped (default: "^[._]", which skips names starting with '_' or '.')
         <br/>
         <code>maxFileAge</code>: Maximum age of a file that can be found in this directory, before it is ignored. For the first batch all files will be considered valid. If <code>latestFirst</code> is set to `true` and <code>maxFilesPerTrigger</code> or <code>maxBytesPerTrigger</code> is set, then this parameter will be ignored, because old files that are valid, and should be processed, may be ignored. The max age is specified with respect to the timestamp of the latest file, and not the timestamp of the current system.(default: 1 week)
         <br/>

--- a/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
@@ -156,6 +156,13 @@ public class JavaSQLDataSourceExample {
     // |file2.parquet|
     // +-------------+
     // $example off:recursive_file_lookup$
+    // $example on:ignored_path_segment_regex$
+    // "(?!)" surfaces files that are hidden by default (e.g. names starting with "_" or ".")
+    Dataset<Row> surfacedDF = spark.read().format("parquet")
+            .option("ignoredPathSegmentRegex", "(?!)")
+            .load("examples/src/main/resources/dir1");
+    surfacedDF.show();
+    // $example off:ignored_path_segment_regex$
     spark.sql("set spark.sql.files.ignoreCorruptFiles=false");
     // $example on:load_with_path_glob_filter$
     Dataset<Row> testGlobFilterDF = spark.read().format("parquet")

--- a/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
@@ -157,9 +157,9 @@ public class JavaSQLDataSourceExample {
     // +-------------+
     // $example off:recursive_file_lookup$
     // $example on:ignored_path_segment_regex$
-    // "(?!)" surfaces files that are hidden by default (e.g. names starting with "_" or ".")
+    // An empty regex surfaces files hidden by default (e.g. names starting with "_" or ".")
     Dataset<Row> surfacedDF = spark.read().format("parquet")
-            .option("ignoredPathSegmentRegex", "(?!)")
+            .option("ignoredPathSegmentRegex", "")
             .load("examples/src/main/resources/dir1");
     surfacedDF.show();
     // $example off:ignored_path_segment_regex$

--- a/examples/src/main/python/sql/datasource.py
+++ b/examples/src/main/python/sql/datasource.py
@@ -67,6 +67,14 @@ def generic_file_source_options_example(spark: SparkSession) -> None:
     # |file2.parquet|
     # +-------------+
     # $example off:recursive_file_lookup$
+
+    # $example on:ignored_path_segment_regex$
+    # "(?!)" surfaces files that are hidden by default (e.g. names starting with "_" or ".")
+    surfaced_df = spark.read.format("parquet")\
+        .option("ignoredPathSegmentRegex", "(?!)")\
+        .load("examples/src/main/resources/dir1")
+    surfaced_df.show()
+    # $example off:ignored_path_segment_regex$
     spark.sql("set spark.sql.files.ignoreCorruptFiles=false")
 
     # $example on:load_with_path_glob_filter$

--- a/examples/src/main/python/sql/datasource.py
+++ b/examples/src/main/python/sql/datasource.py
@@ -69,9 +69,9 @@ def generic_file_source_options_example(spark: SparkSession) -> None:
     # $example off:recursive_file_lookup$
 
     # $example on:ignored_path_segment_regex$
-    # "(?!)" surfaces files that are hidden by default (e.g. names starting with "_" or ".")
+    # An empty regex surfaces files that are hidden by default (e.g. names starting with "_" or ".")
     surfaced_df = spark.read.format("parquet")\
-        .option("ignoredPathSegmentRegex", "(?!)")\
+        .option("ignoredPathSegmentRegex", "")\
         .load("examples/src/main/resources/dir1")
     surfaced_df.show()
     # $example off:ignored_path_segment_regex$

--- a/examples/src/main/r/RSparkSQLExample.R
+++ b/examples/src/main/r/RSparkSQLExample.R
@@ -128,8 +128,8 @@ head(recursiveLoadedDF)
 # $example off:recursive_file_lookup$
 
 # $example on:ignored_path_segment_regex$
-# "(?!)" surfaces files that are hidden by default (e.g. names starting with "_" or ".")
-surfacedDF <- read.df("examples/src/main/resources/dir1", "parquet", ignoredPathSegmentRegex = "(?!)")
+# An empty regex surfaces files that are hidden by default (e.g. names starting with "_" or ".")
+surfacedDF <- read.df("examples/src/main/resources/dir1", "parquet", ignoredPathSegmentRegex = "")
 head(surfacedDF)
 # $example off:ignored_path_segment_regex$
 sql("set spark.sql.files.ignoreCorruptFiles=false")

--- a/examples/src/main/r/RSparkSQLExample.R
+++ b/examples/src/main/r/RSparkSQLExample.R
@@ -126,6 +126,12 @@ head(recursiveLoadedDF)
 # 1 file1.parquet
 # 2 file2.parquet
 # $example off:recursive_file_lookup$
+
+# $example on:ignored_path_segment_regex$
+# "(?!)" surfaces files that are hidden by default (e.g. names starting with "_" or ".")
+surfacedDF <- read.df("examples/src/main/resources/dir1", "parquet", ignoredPathSegmentRegex = "(?!)")
+head(surfacedDF)
+# $example off:ignored_path_segment_regex$
 sql("set spark.sql.files.ignoreCorruptFiles=false")
 
 # $example on:generic_load_save_functions$

--- a/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
@@ -85,6 +85,13 @@ object SQLDataSourceExample {
     // |file2.parquet|
     // +-------------+
     // $example off:recursive_file_lookup$
+    // $example on:ignored_path_segment_regex$
+    // "(?!)" surfaces files that are hidden by default (e.g. names starting with "_" or ".")
+    val surfacedDF = spark.read.format("parquet")
+      .option("ignoredPathSegmentRegex", "(?!)")
+      .load("examples/src/main/resources/dir1")
+    surfacedDF.show()
+    // $example off:ignored_path_segment_regex$
     spark.sql("set spark.sql.files.ignoreCorruptFiles=false")
     // $example on:load_with_path_glob_filter$
     val testGlobFilterDF = spark.read.format("parquet")

--- a/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
@@ -86,9 +86,9 @@ object SQLDataSourceExample {
     // +-------------+
     // $example off:recursive_file_lookup$
     // $example on:ignored_path_segment_regex$
-    // "(?!)" surfaces files that are hidden by default (e.g. names starting with "_" or ".")
+    // An empty regex surfaces files hidden by default (e.g. names starting with "_" or ".")
     val surfacedDF = spark.read.format("parquet")
-      .option("ignoredPathSegmentRegex", "(?!)")
+      .option("ignoredPathSegmentRegex", "")
       .load("examples/src/main/resources/dir1")
     surfacedDF.show()
     // $example off:ignored_path_segment_regex$

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/FileSourceOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/FileSourceOptions.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.catalyst
 
-import org.apache.spark.sql.catalyst.FileSourceOptions.{IGNORE_CORRUPT_FILES, IGNORE_MISSING_FILES}
+import org.apache.spark.sql.catalyst.FileSourceOptions.{IGNORE_CORRUPT_FILES, IGNORE_MISSING_FILES, LIST_HIDDEN_FILES}
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateFormatter}
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 
@@ -53,9 +53,13 @@ class FileSourceOptions(
    * executors. Only the CSV data source currently honors this.
    */
   val archiveFormatEnabled: Boolean = SQLConf.get.getConf(SQLConf.ARCHIVE_FORMAT_READER_ENABLED)
+
+  val listHiddenFiles: Boolean = parameters.get(LIST_HIDDEN_FILES).map(_.toBoolean)
+    .getOrElse(SQLConf.get.listHiddenFiles)
 }
 
 object FileSourceOptions {
   val IGNORE_CORRUPT_FILES = "ignoreCorruptFiles"
   val IGNORE_MISSING_FILES = "ignoreMissingFiles"
+  val LIST_HIDDEN_FILES = "listHiddenFiles"
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/FileSourceOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/FileSourceOptions.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.catalyst
 
+import java.util.regex.{Pattern, PatternSyntaxException}
+
 import org.apache.spark.sql.catalyst.FileSourceOptions.{IGNORE_CORRUPT_FILES, IGNORE_MISSING_FILES, IGNORED_PATH_SEGMENT_REGEX}
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateFormatter}
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
@@ -56,12 +58,43 @@ class FileSourceOptions(
 
   val ignoredPathSegmentRegex: String =
     parameters.getOrElse(IGNORED_PATH_SEGMENT_REGEX, SQLConf.get.ignoredPathSegmentRegex)
-  require(ignoredPathSegmentRegex.nonEmpty, "The 'ignoredPathSegmentRegex' option must be a non-empty " +
-    "regular expression. Use '(?!)' to disable hidden-file filtering.")
+
+  /**
+   * The effective [[ignoredPathSegmentRegex]] compiled and validated once here, so the ~5 listing
+   * call sites can reuse a single [[Pattern]] instead of re-compiling. An empty value disables the
+   * generic hidden-file filter (see [[FileSourceOptions.compileIgnoredPathSegmentRegex]]).
+   */
+  lazy val ignoredPathSegmentRegexPattern: Pattern =
+    FileSourceOptions.compileIgnoredPathSegmentRegex(ignoredPathSegmentRegex)
 }
 
 object FileSourceOptions {
   val IGNORE_CORRUPT_FILES = "ignoreCorruptFiles"
   val IGNORE_MISSING_FILES = "ignoreMissingFiles"
   val IGNORED_PATH_SEGMENT_REGEX = "ignoredPathSegmentRegex"
+
+  // A regex that never matches any name, used when the filter is disabled by an empty value.
+  private val DISABLED_FILTER_PATTERN = Pattern.compile("(?!)")
+
+  /**
+   * Compiles the effective `ignoredPathSegmentRegex`. An empty string disables the generic
+   * hidden-file filter (logically an "empty" regex matches nothing, so the returned pattern never
+   * matches). A non-empty value must be a valid Java regular expression; an invalid one is reported
+   * as a clear [[IllegalArgumentException]] rather than a raw [[PatternSyntaxException]] surfacing
+   * deep in file listing.
+   */
+  def compileIgnoredPathSegmentRegex(regex: String): Pattern = {
+    if (regex.isEmpty) {
+      DISABLED_FILTER_PATTERN
+    } else {
+      try {
+        Pattern.compile(regex)
+      } catch {
+        case e: PatternSyntaxException =>
+          throw new IllegalArgumentException(
+            s"The '$IGNORED_PATH_SEGMENT_REGEX' value '$regex' is not a valid Java regular " +
+            "expression. Use an empty string to disable hidden-file filtering.", e)
+      }
+    }
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/FileSourceOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/FileSourceOptions.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.catalyst
 
-import org.apache.spark.sql.catalyst.FileSourceOptions.{IGNORE_CORRUPT_FILES, IGNORE_MISSING_FILES, LIST_HIDDEN_FILES}
+import org.apache.spark.sql.catalyst.FileSourceOptions.{IGNORE_CORRUPT_FILES, IGNORE_MISSING_FILES, IGNORED_PATH_SEGMENT_REGEX}
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateFormatter}
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 
@@ -54,12 +54,14 @@ class FileSourceOptions(
    */
   val archiveFormatEnabled: Boolean = SQLConf.get.getConf(SQLConf.ARCHIVE_FORMAT_READER_ENABLED)
 
-  val listHiddenFiles: Boolean = parameters.get(LIST_HIDDEN_FILES).map(_.toBoolean)
-    .getOrElse(SQLConf.get.listHiddenFiles)
+  val ignoredPathSegmentRegex: String =
+    parameters.getOrElse(IGNORED_PATH_SEGMENT_REGEX, SQLConf.get.ignoredPathSegmentRegex)
+  require(ignoredPathSegmentRegex.nonEmpty, "The 'ignoredPathSegmentRegex' option must be a non-empty " +
+    "regular expression. Use '(?!)' to disable hidden-file filtering.")
 }
 
 object FileSourceOptions {
   val IGNORE_CORRUPT_FILES = "ignoreCorruptFiles"
   val IGNORE_MISSING_FILES = "ignoreMissingFiles"
-  val LIST_HIDDEN_FILES = "listHiddenFiles"
+  val IGNORED_PATH_SEGMENT_REGEX = "ignoredPathSegmentRegex"
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2794,17 +2794,17 @@ object SQLConf {
       "are always listed, names ending in '._COPYING_' are always skipped, and '_'-prefixed " +
       "names containing '=' (partition directories) are always kept. This configuration is " +
       "effective only when using file-based sources such as Parquet, JSON and ORC. It can be " +
-      "overridden per read by the 'ignoredPathSegmentRegex' data source option. A regex that never " +
-      "matches (e.g. '(?!)') disables generic hidden-file filtering; note that directories it " +
-      "surfaces also participate in partition discovery, so a hidden directory next to " +
-      "partition directories causes a conflicting directory structures error unless " +
+      "overridden per read by the 'ignoredPathSegmentRegex' data source option. An empty string " +
+      "disables generic hidden-file filtering (an empty regex matches nothing); note that " +
+      "directories it surfaces also participate in partition discovery, so a hidden directory " +
+      "next to partition directories causes a conflicting directory structures error unless " +
       "'spark.sql.files.ignoreInvalidPartitionPaths' is enabled.")
-    .version("5.0.0")
+    .version("4.3.0")
     .withBindingPolicy(ConfigBindingPolicy.SESSION)
     .stringConf
-    .checkValue(v => v.nonEmpty && Try(Pattern.compile(v)).isSuccess,
-      "The value of spark.sql.files.ignoredPathSegmentRegex must be a non-empty valid Java regular " +
-      "expression. Use '(?!)' to disable hidden-file filtering.")
+    .checkValue(v => v.isEmpty || Try(Pattern.compile(v)).isSuccess,
+      "The value of spark.sql.files.ignoredPathSegmentRegex must be empty (to disable " +
+      "hidden-file filtering) or a valid Java regular expression.")
     .createWithDefault(HadoopFSUtils.DEFAULT_IGNORED_PATH_SEGMENT_REGEX)
 
   val IGNORE_INVALID_PARTITION_PATHS = buildConf("spark.sql.files.ignoreInvalidPartitionPaths")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2790,7 +2790,10 @@ object SQLConf {
       "(hidden files), which are skipped by default. When true, such files participate in file " +
       "listing, partition discovery, and reads. This configuration is effective only when using " +
       "file-based sources such as Parquet, JSON and ORC. It can be overridden per read by the " +
-      "'listHiddenFiles' data source option.")
+      "'listHiddenFiles' data source option. Note that hidden directories also participate in " +
+      "partition discovery, so a hidden directory next to partition directories causes a " +
+      "conflicting directory structures error unless " +
+      "'spark.sql.files.ignoreInvalidPartitionPaths' is enabled.")
     .version("5.0.0")
     .withBindingPolicy(ConfigBindingPolicy.SESSION)
     .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -21,6 +21,7 @@ import java.util.{Locale, Properties, TimeZone}
 import java.util
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+import java.util.regex.Pattern
 
 import scala.collection.immutable
 import scala.jdk.CollectionConverters._
@@ -52,7 +53,7 @@ import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors
 import org.apache.spark.sql.types.{AtomicType, TimestampNTZType, TimestampType}
 import org.apache.spark.storage.{StorageLevel, StorageLevelMapper}
 import org.apache.spark.unsafe.array.ByteArrayMethods
-import org.apache.spark.util.{Utils, VersionUtils}
+import org.apache.spark.util.{HadoopFSUtils, Utils, VersionUtils}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This file defines the configuration options for Spark SQL.
@@ -2785,19 +2786,26 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
-  val LIST_HIDDEN_FILES = buildConf("spark.sql.files.listHiddenFiles")
-    .doc("Whether to list and read files and directories whose names start with '_' or '.' " +
-      "(hidden files), which are skipped by default. When true, such files participate in file " +
-      "listing, partition discovery, and reads. This configuration is effective only when using " +
-      "file-based sources such as Parquet, JSON and ORC. It can be overridden per read by the " +
-      "'listHiddenFiles' data source option. Note that hidden directories also participate in " +
-      "partition discovery, so a hidden directory next to partition directories causes a " +
-      "conflicting directory structures error unless " +
+  val IGNORED_PATH_SEGMENT_REGEX = buildConf("spark.sql.files.ignoredPathSegmentRegex")
+    .doc("Java regular expression matched (with find semantics) against each directory and " +
+      "file name during file listing; matching names are skipped from listing, partition " +
+      "discovery, and reads. The default '^[._]' skips names starting with '_' or '.' (hidden " +
+      "files). Regardless of the regex, names starting with '_metadata' or '_common_metadata' " +
+      "are always listed, names ending in '._COPYING_' are always skipped, and '_'-prefixed " +
+      "names containing '=' (partition directories) are always kept. This configuration is " +
+      "effective only when using file-based sources such as Parquet, JSON and ORC. It can be " +
+      "overridden per read by the 'ignoredPathSegmentRegex' data source option. A regex that never " +
+      "matches (e.g. '(?!)') disables generic hidden-file filtering; note that directories it " +
+      "surfaces also participate in partition discovery, so a hidden directory next to " +
+      "partition directories causes a conflicting directory structures error unless " +
       "'spark.sql.files.ignoreInvalidPartitionPaths' is enabled.")
     .version("5.0.0")
     .withBindingPolicy(ConfigBindingPolicy.SESSION)
-    .booleanConf
-    .createWithDefault(false)
+    .stringConf
+    .checkValue(v => v.nonEmpty && Try(Pattern.compile(v)).isSuccess,
+      "The value of spark.sql.files.ignoredPathSegmentRegex must be a non-empty valid Java regular " +
+      "expression. Use '(?!)' to disable hidden-file filtering.")
+    .createWithDefault(HadoopFSUtils.DEFAULT_IGNORED_PATH_SEGMENT_REGEX)
 
   val IGNORE_INVALID_PARTITION_PATHS = buildConf("spark.sql.files.ignoreInvalidPartitionPaths")
     .doc("Whether to ignore invalid partition paths that do not match <column>=<value>. When " +
@@ -7867,7 +7875,7 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def ignoreMissingFiles: Boolean = getConf(IGNORE_MISSING_FILES)
 
-  def listHiddenFiles: Boolean = getConf(LIST_HIDDEN_FILES)
+  def ignoredPathSegmentRegex: String = getConf(IGNORED_PATH_SEGMENT_REGEX)
 
   def ignoreInvalidPartitionPaths: Boolean = getConf(IGNORE_INVALID_PARTITION_PATHS)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2785,6 +2785,17 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val LIST_HIDDEN_FILES = buildConf("spark.sql.files.listHiddenFiles")
+    .doc("Whether to list and read files and directories whose names start with '_' or '.' " +
+      "(hidden files), which are skipped by default. When true, such files participate in file " +
+      "listing, partition discovery, and reads. This configuration is effective only when using " +
+      "file-based sources such as Parquet, JSON and ORC. It can be overridden per read by the " +
+      "'listHiddenFiles' data source option.")
+    .version("5.0.0")
+    .withBindingPolicy(ConfigBindingPolicy.SESSION)
+    .booleanConf
+    .createWithDefault(false)
+
   val IGNORE_INVALID_PARTITION_PATHS = buildConf("spark.sql.files.ignoreInvalidPartitionPaths")
     .doc("Whether to ignore invalid partition paths that do not match <column>=<value>. When " +
       "the option is enabled, table with two partition directories 'table/invalid' and " +
@@ -7852,6 +7863,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def ignoreCorruptFiles: Boolean = getConf(IGNORE_CORRUPT_FILES)
 
   def ignoreMissingFiles: Boolean = getConf(IGNORE_MISSING_FILES)
+
+  def listHiddenFiles: Boolean = getConf(LIST_HIDDEN_FILES)
 
   def ignoreInvalidPartitionPaths: Boolean = getConf(IGNORE_INVALID_PARTITION_PATHS)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -26,7 +26,7 @@ import org.apache.hadoop.fs.{FileStatus, FileSystem, Path, PathFilter}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{COUNT, DATABASE_NAME, ERROR, TABLE_NAME, TIME}
-import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
+import org.apache.spark.sql.catalyst.{FileSourceOptions, InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.analysis.ResolvedIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogStatistics, CatalogTable, CatalogTablePartition, ExternalCatalogUtils}
@@ -197,8 +197,10 @@ object CommandUtils extends Logging {
     val stagingDir = sparkSession.sessionState.conf
       .getConfString("hive.exec.stagingdir", ".hive-staging")
     val filter = new PathFilterIgnoreNonData(stagingDir)
+    // Pin listHiddenFiles off: stats must skip hidden dirs, matching calculateSingleLocationSize.
     val sizes = InMemoryFileIndex.bulkListLeafFiles(paths.flatten,
-      sparkSession.sessionState.newHadoopConf(), filter, sparkSession).map {
+      sparkSession.sessionState.newHadoopConf(), filter, sparkSession,
+      parameters = Map(FileSourceOptions.LIST_HIDDEN_FILES -> "false")).map {
       case (_, files) => files.map(_.getLen).sum
     }
     // the size is 0 where paths(i) is not defined and sizes(i) where it is defined

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -203,7 +203,8 @@ object CommandUtils extends Logging {
     val sizes = InMemoryFileIndex.bulkListLeafFiles(paths.flatten,
       sparkSession.sessionState.newHadoopConf(), filter, sparkSession,
       parameters = Map(
-        FileSourceOptions.IGNORED_PATH_SEGMENT_REGEX -> HadoopFSUtils.DEFAULT_IGNORED_PATH_SEGMENT_REGEX)
+        FileSourceOptions.IGNORED_PATH_SEGMENT_REGEX ->
+          HadoopFSUtils.DEFAULT_IGNORED_PATH_SEGMENT_REGEX)
     ).map {
       case (_, files) => files.map(_.getLen).sum
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -44,6 +44,7 @@ import org.apache.spark.sql.execution.datasources.v2.ExtractV2CatalogAndIdentifi
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.internal.{SessionState, SQLConf}
 import org.apache.spark.sql.types._
+import org.apache.spark.util.HadoopFSUtils
 import org.apache.spark.util.collection.Utils
 
 /**
@@ -197,10 +198,13 @@ object CommandUtils extends Logging {
     val stagingDir = sparkSession.sessionState.conf
       .getConfString("hive.exec.stagingdir", ".hive-staging")
     val filter = new PathFilterIgnoreNonData(stagingDir)
-    // Pin listHiddenFiles off: stats must skip hidden dirs, matching calculateSingleLocationSize.
+    // Pin the default ignoredPathSegmentRegex: stats must always skip hidden dirs (immune to the
+    // session conf), matching calculateSingleLocationSize.
     val sizes = InMemoryFileIndex.bulkListLeafFiles(paths.flatten,
       sparkSession.sessionState.newHadoopConf(), filter, sparkSession,
-      parameters = Map(FileSourceOptions.LIST_HIDDEN_FILES -> "false")).map {
+      parameters = Map(
+        FileSourceOptions.IGNORED_PATH_SEGMENT_REGEX -> HadoopFSUtils.DEFAULT_IGNORED_PATH_SEGMENT_REGEX)
+    ).map {
       case (_, files) => files.map(_.getLen).sum
     }
     // the size is 0 where paths(i) is not defined and sizes(i) where it is defined

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
@@ -61,8 +61,8 @@ abstract class ArchiveReader(path: Path) {
    * one entry's bytes are read at a time. The archive stream is closed when the returned iterator
    * is exhausted, when [[Closeable.close]] is called on it, and (defensively) on task completion.
    * Entry skipping mirrors Spark's file listing: `ignoredPathSegmentRegex` is the effective filter
-   * (the `ignoredPathSegmentRegex` data source option), so callers reading with a custom filter must
-   * pass its compiled form here for archive entries to be filtered like loose files.
+   * (the `ignoredPathSegmentRegex` data source option), so callers reading with a custom filter
+   * must pass its compiled form here for archive entries to be filtered like loose files.
    */
   def readEntries[T](
       conf: Configuration,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.datasources
 
 import java.io.{Closeable, InputStream}
 import java.util.Locale
+import java.util.regex.Pattern
 import java.util.zip.GZIPInputStream
 
 import scala.util.control.NonFatal
@@ -59,9 +60,13 @@ abstract class ArchiveReader(path: Path) {
    * only once the current entry's iterator is exhausted, so nothing is buffered to disk and at most
    * one entry's bytes are read at a time. The archive stream is closed when the returned iterator
    * is exhausted, when [[Closeable.close]] is called on it, and (defensively) on task completion.
+   * Entry skipping mirrors Spark's file listing: `ignoredPathSegmentRegex` is the effective filter
+   * (the `ignoredPathSegmentRegex` data source option), so callers reading with a custom filter must
+   * pass its compiled form here for archive entries to be filtered like loose files.
    */
   def readEntries[T](
-      conf: Configuration)(
+      conf: Configuration,
+      ignoredPathSegmentRegex: Pattern = HadoopFSUtils.defaultIgnoredPathSegmentRegexPattern)(
       parseEntry: (String, InputStream) => Iterator[T]): Iterator[T]
 }
 
@@ -147,16 +152,19 @@ class TarArchiveReader(path: Path) extends ArchiveReader(path) {
   /**
    * Whether an entry is not a real data file and must be skipped: a directory, or a name Spark's
    * own file listing would filter out. Applying [[HadoopFSUtils.shouldFilterOutPathName]] (the
-   * `InMemoryFileIndex` filter) to every path component keeps archive reads in parity with reading
-   * the same entries as loose files: `.`-prefixed sidecars (macOS `._x`, `.DS_Store`), `_`-prefixed
-   * markers (`_SUCCESS`, `_committed_*`), and anything under a `.`/`_`-prefixed directory (e.g. a
-   * leftover `_temporary/` from a failed write) are skipped, while data files are kept. The
-   * per-component check matters because `InMemoryFileIndex` never recurses into such directories,
-   * so a basename-only filter would read `_temporary/part-0.csv` that a loose-file scan drops.
+   * `InMemoryFileIndex` filter) with the same effective `ignoredPathSegmentRegex` to every path
+   * component keeps archive reads in parity with reading the same entries as loose files,
+   * including when the user supplies a custom `ignoredPathSegmentRegex` option: under the default
+   * filter, `.`-prefixed sidecars (macOS `._x`, `.DS_Store`), `_`-prefixed markers (`_SUCCESS`,
+   * `_committed_*`), and anything under a `.`/`_`-prefixed directory (e.g. a leftover
+   * `_temporary/` from a failed write) are skipped, while data files are kept. The per-component
+   * check matters because `InMemoryFileIndex` never recurses into such directories, so a
+   * basename-only filter would read `_temporary/part-0.csv` that a loose-file scan drops.
    */
-  private def shouldSkipEntry(entry: TarArchiveEntry): Boolean = {
+  private def shouldSkipEntry(entry: TarArchiveEntry, ignoredPathSegmentRegex: Pattern): Boolean = {
     if (entry.isDirectory) return true
-    entry.getName.split("/").exists(c => c.nonEmpty && HadoopFSUtils.shouldFilterOutPathName(c))
+    entry.getName.split("/").exists(c =>
+      c.nonEmpty && HadoopFSUtils.shouldFilterOutPathName(c, ignoredPathSegmentRegex))
   }
 
   /** Opens the archive as a tar stream, transparently decompressing `.tar.gz` / `.tgz`. */
@@ -176,7 +184,8 @@ class TarArchiveReader(path: Path) extends ArchiveReader(path) {
     CloseShieldInputStream.wrap(tar)
 
   override def readEntries[T](
-      conf: Configuration)(
+      conf: Configuration,
+      ignoredPathSegmentRegex: Pattern)(
       parseEntry: (String, InputStream) => Iterator[T]): Iterator[T] = {
     val tar = openTarStream(conf)
     var closed = false
@@ -207,7 +216,9 @@ class TarArchiveReader(path: Path) extends ArchiveReader(path) {
             case _ =>
           }
           var entry = tar.getNextEntry
-          while (entry != null && shouldSkipEntry(entry)) entry = tar.getNextEntry
+          while (entry != null && shouldSkipEntry(entry, ignoredPathSegmentRegex)) {
+            entry = tar.getNextEntry
+          }
           if (entry == null) {
             done = true
             cleanup()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -591,7 +591,7 @@ case class DataSource(
       checkFilesExist: Boolean): Seq[Path] = {
     val allPaths = caseInsensitiveOptions.get("path") ++ paths
     val ignoredPathSegmentRegex =
-      Pattern.compile(new FileSourceOptions(caseInsensitiveOptions).ignoredPathSegmentRegex)
+      new FileSourceOptions(caseInsensitiveOptions).ignoredPathSegmentRegexPattern
     DataSource.checkAndGlobPathIfNecessary(allPaths.toSeq, newHadoopConfiguration(),
       checkEmptyGlobPath, checkFilesExist, enableGlobbing = globPaths,
       ignoredPathSegmentRegex = ignoredPathSegmentRegex)
@@ -802,7 +802,8 @@ object DataSource extends Logging {
       checkFilesExist: Boolean,
       numThreads: Integer = 40,
       enableGlobbing: Boolean,
-      ignoredPathSegmentRegex: Pattern = HadoopFSUtils.defaultIgnoredPathSegmentRegexPattern): Seq[Path] = {
+      ignoredPathSegmentRegex: Pattern = HadoopFSUtils.defaultIgnoredPathSegmentRegexPattern)
+      : Seq[Path] = {
     val qualifiedPaths = pathStrings.map { pathString =>
       val path = new Path(pathString)
       val fs = path.getFileSystem(hadoopConf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources
 
 import java.util.{Locale, ServiceConfigurationError, ServiceLoader}
+import java.util.regex.Pattern
 
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
@@ -30,7 +31,7 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{CLASS_NAME, DATA_SOURCE, DATA_SOURCES, PATHS}
 import org.apache.spark.sql.{AnalysisException, SaveMode, SparkSession}
-import org.apache.spark.sql.catalyst.DataSourceOptions
+import org.apache.spark.sql.catalyst.{DataSourceOptions, FileSourceOptions}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat, CatalogTable, CatalogUtils}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -589,8 +590,11 @@ case class DataSource(
       checkEmptyGlobPath: Boolean,
       checkFilesExist: Boolean): Seq[Path] = {
     val allPaths = caseInsensitiveOptions.get("path") ++ paths
+    val ignoredPathSegmentRegex =
+      Pattern.compile(new FileSourceOptions(caseInsensitiveOptions).ignoredPathSegmentRegex)
     DataSource.checkAndGlobPathIfNecessary(allPaths.toSeq, newHadoopConfiguration(),
-      checkEmptyGlobPath, checkFilesExist, enableGlobbing = globPaths)
+      checkEmptyGlobPath, checkFilesExist, enableGlobbing = globPaths,
+      ignoredPathSegmentRegex = ignoredPathSegmentRegex)
   }
 
   private def disallowWritingIntervals(
@@ -797,7 +801,8 @@ object DataSource extends Logging {
       checkEmptyGlobPath: Boolean,
       checkFilesExist: Boolean,
       numThreads: Integer = 40,
-      enableGlobbing: Boolean): Seq[Path] = {
+      enableGlobbing: Boolean,
+      ignoredPathSegmentRegex: Pattern = HadoopFSUtils.defaultIgnoredPathSegmentRegexPattern): Seq[Path] = {
     val qualifiedPaths = pathStrings.map { pathString =>
       val path = new Path(pathString)
       val fs = path.getFileSystem(hadoopConf)
@@ -844,7 +849,7 @@ object DataSource extends Logging {
     val allPaths = globbedPaths ++ nonGlobPaths
     if (checkFilesExist) {
       val (filteredOut, filteredIn) = allPaths.partition { path =>
-        HadoopFSUtils.shouldFilterOutPathName(path.getName)
+        HadoopFSUtils.shouldFilterOutPathName(path.getName, ignoredPathSegmentRegex)
       }
       if (filteredIn.isEmpty) {
         logWarning(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndexOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndexOptions.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 
 object FileIndexOptions extends DataSourceOptions {
   val IGNORE_MISSING_FILES = newOption(FileSourceOptions.IGNORE_MISSING_FILES)
+  val LIST_HIDDEN_FILES = newOption(FileSourceOptions.LIST_HIDDEN_FILES)
   val IGNORE_INVALID_PARTITION_PATHS = newOption("ignoreInvalidPartitionPaths")
   val TIME_ZONE = newOption(DateTimeUtils.TIMEZONE_OPTION)
   val RECURSIVE_FILE_LOOKUP = newOption("recursiveFileLookup")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndexOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndexOptions.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 
 object FileIndexOptions extends DataSourceOptions {
   val IGNORE_MISSING_FILES = newOption(FileSourceOptions.IGNORE_MISSING_FILES)
-  val LIST_HIDDEN_FILES = newOption(FileSourceOptions.LIST_HIDDEN_FILES)
+  val IGNORED_PATH_SEGMENT_REGEX = newOption(FileSourceOptions.IGNORED_PATH_SEGMENT_REGEX)
   val IGNORE_INVALID_PARTITION_PATHS = newOption("ignoreInvalidPartitionPaths")
   val TIME_ZONE = newOption(DateTimeUtils.TIMEZONE_OPTION)
   val RECURSIVE_FILE_LOOKUP = newOption("recursiveFileLookup")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -154,8 +154,9 @@ object InMemoryFileIndex extends Logging {
       parameters: Map[String, String] = Map.empty): Seq[(Path, Seq[FileStatus])] = {
     val fileSystemList =
       sparkSession.sessionState.conf.useListFilesFileSystemList.split(",").map(_.trim)
-    val ignoreMissingFiles =
-      new FileSourceOptions(CaseInsensitiveMap(parameters)).ignoreMissingFiles
+    val fileSourceOptions = new FileSourceOptions(CaseInsensitiveMap(parameters))
+    val ignoreMissingFiles = fileSourceOptions.ignoreMissingFiles
+    val listHiddenFiles = fileSourceOptions.listHiddenFiles
     val useListFiles = try {
       val scheme = paths.head.getFileSystem(hadoopConf).getScheme
       paths.size == 1 && fileSystemList.contains(scheme)
@@ -166,14 +167,16 @@ object InMemoryFileIndex extends Logging {
       HadoopFSUtils.listFiles(
         path = paths.head,
         hadoopConf = hadoopConf,
-        filter = new PathFilterWrapper(filter))
+        filter = new PathFilterWrapper(filter, listHiddenFiles),
+        listHiddenFiles = listHiddenFiles)
     } else {
       HadoopFSUtils.parallelListLeafFiles(
         sc = sparkSession.sparkContext,
         paths = paths,
         hadoopConf = hadoopConf,
-        filter = new PathFilterWrapper(filter),
+        filter = new PathFilterWrapper(filter, listHiddenFiles),
         ignoreMissingFiles = ignoreMissingFiles,
+        listHiddenFiles = listHiddenFiles,
         ignoreLocality = sparkSession.sessionState.conf.ignoreDataLocality,
         parallelismThreshold = sparkSession.sessionState.conf.parallelPartitionDiscoveryThreshold,
         parallelismMax = sparkSession.sessionState.conf.parallelPartitionDiscoveryParallelism)
@@ -182,8 +185,11 @@ object InMemoryFileIndex extends Logging {
 
 }
 
-private class PathFilterWrapper(val filter: PathFilter) extends PathFilter with Serializable {
+private class PathFilterWrapper(
+    val filter: PathFilter,
+    val listHiddenFiles: Boolean) extends PathFilter with Serializable {
   override def accept(path: Path): Boolean = {
-    (filter == null || filter.accept(path)) && !HadoopFSUtils.shouldFilterOutPathName(path.getName)
+    (filter == null || filter.accept(path)) &&
+      (listHiddenFiles || !HadoopFSUtils.shouldFilterOutPathName(path.getName))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -190,6 +190,6 @@ private class PathFilterWrapper(
     val listHiddenFiles: Boolean) extends PathFilter with Serializable {
   override def accept(path: Path): Boolean = {
     (filter == null || filter.accept(path)) &&
-      (listHiddenFiles || !HadoopFSUtils.shouldFilterOutPathName(path.getName))
+      !HadoopFSUtils.shouldFilterOutPathName(path.getName, listHiddenFiles)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import java.util.regex.Pattern
+
 import scala.collection.mutable
 import scala.util.control.NonFatal
 
@@ -121,8 +123,13 @@ class InMemoryFileIndex(
     val startTime = System.nanoTime()
     val output = mutable.LinkedHashSet[FileStatus]()
     val pathsToFetch = mutable.ArrayBuffer[Path]()
+    // The file status cache is keyed by path only, so cached entries must always hold the
+    // default-filtered listing. Bypass the cache when a non-default ignoredPathSegmentRegex is in
+    // effect, to neither serve nor store listings produced with a different filter.
+    val useFileStatusCache = ignoredPathSegmentRegex == HadoopFSUtils.DEFAULT_IGNORED_PATH_SEGMENT_REGEX
     for (path <- paths) {
-      fileStatusCache.getLeafFiles(path) match {
+      val cachedFiles = if (useFileStatusCache) fileStatusCache.getLeafFiles(path) else None
+      cachedFiles match {
         case Some(files) =>
           HiveCatalogMetrics.incrementFileCacheHits(files.length)
           output ++= files
@@ -135,7 +142,9 @@ class InMemoryFileIndex(
       pathsToFetch.toSeq, hadoopConf, filter, sparkSession, parameters)
     discovered.foreach { case (path, leafFiles) =>
       HiveCatalogMetrics.incrementFilesDiscovered(leafFiles.size)
-      fileStatusCache.putLeafFiles(path, leafFiles.toArray)
+      if (useFileStatusCache) {
+        fileStatusCache.putLeafFiles(path, leafFiles.toArray)
+      }
       output ++= leafFiles
     }
     logInfo(log"It took ${MDC(ELAPSED_TIME, (System.nanoTime() - startTime) / (1000 * 1000))} ms" +
@@ -156,7 +165,7 @@ object InMemoryFileIndex extends Logging {
       sparkSession.sessionState.conf.useListFilesFileSystemList.split(",").map(_.trim)
     val fileSourceOptions = new FileSourceOptions(CaseInsensitiveMap(parameters))
     val ignoreMissingFiles = fileSourceOptions.ignoreMissingFiles
-    val listHiddenFiles = fileSourceOptions.listHiddenFiles
+    val ignoredPathSegmentRegex = Pattern.compile(fileSourceOptions.ignoredPathSegmentRegex)
     val useListFiles = try {
       val scheme = paths.head.getFileSystem(hadoopConf).getScheme
       paths.size == 1 && fileSystemList.contains(scheme)
@@ -167,16 +176,16 @@ object InMemoryFileIndex extends Logging {
       HadoopFSUtils.listFiles(
         path = paths.head,
         hadoopConf = hadoopConf,
-        filter = new PathFilterWrapper(filter, listHiddenFiles),
-        listHiddenFiles = listHiddenFiles)
+        filter = new PathFilterWrapper(filter, ignoredPathSegmentRegex),
+        ignoredPathSegmentRegex = ignoredPathSegmentRegex)
     } else {
       HadoopFSUtils.parallelListLeafFiles(
         sc = sparkSession.sparkContext,
         paths = paths,
         hadoopConf = hadoopConf,
-        filter = new PathFilterWrapper(filter, listHiddenFiles),
+        filter = new PathFilterWrapper(filter, ignoredPathSegmentRegex),
         ignoreMissingFiles = ignoreMissingFiles,
-        listHiddenFiles = listHiddenFiles,
+        ignoredPathSegmentRegex = ignoredPathSegmentRegex,
         ignoreLocality = sparkSession.sessionState.conf.ignoreDataLocality,
         parallelismThreshold = sparkSession.sessionState.conf.parallelPartitionDiscoveryThreshold,
         parallelismMax = sparkSession.sessionState.conf.parallelPartitionDiscoveryParallelism)
@@ -187,9 +196,9 @@ object InMemoryFileIndex extends Logging {
 
 private class PathFilterWrapper(
     val filter: PathFilter,
-    val listHiddenFiles: Boolean) extends PathFilter with Serializable {
+    val ignoredPathSegmentRegex: Pattern) extends PathFilter with Serializable {
   override def accept(path: Path): Boolean = {
     (filter == null || filter.accept(path)) &&
-      !HadoopFSUtils.shouldFilterOutPathName(path.getName, listHiddenFiles)
+      !HadoopFSUtils.shouldFilterOutPathName(path.getName, ignoredPathSegmentRegex)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import java.util.regex.Pattern
-
 import scala.collection.mutable
 import scala.util.control.NonFatal
 
@@ -126,7 +124,8 @@ class InMemoryFileIndex(
     // The file status cache is keyed by path only, so cached entries must always hold the
     // default-filtered listing. Bypass the cache when a non-default ignoredPathSegmentRegex is in
     // effect, to neither serve nor store listings produced with a different filter.
-    val useFileStatusCache = ignoredPathSegmentRegex == HadoopFSUtils.DEFAULT_IGNORED_PATH_SEGMENT_REGEX
+    val useFileStatusCache =
+      ignoredPathSegmentRegex == HadoopFSUtils.DEFAULT_IGNORED_PATH_SEGMENT_REGEX
     for (path <- paths) {
       val cachedFiles = if (useFileStatusCache) fileStatusCache.getLeafFiles(path) else None
       cachedFiles match {
@@ -165,7 +164,7 @@ object InMemoryFileIndex extends Logging {
       sparkSession.sessionState.conf.useListFilesFileSystemList.split(",").map(_.trim)
     val fileSourceOptions = new FileSourceOptions(CaseInsensitiveMap(parameters))
     val ignoreMissingFiles = fileSourceOptions.ignoreMissingFiles
-    val ignoredPathSegmentRegex = Pattern.compile(fileSourceOptions.ignoredPathSegmentRegex)
+    val ignoredPathSegmentRegex = fileSourceOptions.ignoredPathSegmentRegexPattern
     val useListFiles = try {
       val scheme = paths.head.getFileSystem(hadoopConf).getScheme
       paths.size == 1 && fileSystemList.contains(scheme)
@@ -176,14 +175,14 @@ object InMemoryFileIndex extends Logging {
       HadoopFSUtils.listFiles(
         path = paths.head,
         hadoopConf = hadoopConf,
-        filter = new PathFilterWrapper(filter, ignoredPathSegmentRegex),
+        filter = new PathFilterWrapper(filter),
         ignoredPathSegmentRegex = ignoredPathSegmentRegex)
     } else {
       HadoopFSUtils.parallelListLeafFiles(
         sc = sparkSession.sparkContext,
         paths = paths,
         hadoopConf = hadoopConf,
-        filter = new PathFilterWrapper(filter, ignoredPathSegmentRegex),
+        filter = new PathFilterWrapper(filter),
         ignoreMissingFiles = ignoreMissingFiles,
         ignoredPathSegmentRegex = ignoredPathSegmentRegex,
         ignoreLocality = sparkSession.sessionState.conf.ignoreDataLocality,
@@ -194,11 +193,10 @@ object InMemoryFileIndex extends Logging {
 
 }
 
-private class PathFilterWrapper(
-    val filter: PathFilter,
-    val ignoredPathSegmentRegex: Pattern) extends PathFilter with Serializable {
-  override def accept(path: Path): Boolean = {
-    (filter == null || filter.accept(path)) &&
-      !HadoopFSUtils.shouldFilterOutPathName(path.getName, ignoredPathSegmentRegex)
-  }
+// Delegates to the input-path filter only (with a null guard). The hidden-file filtering is owned
+// by HadoopFSUtils.listFiles / parallelListLeafFiles via their `ignoredPathSegmentRegex` argument,
+// which already evaluates the regex against every directory and file name, so re-applying it here
+// would be redundant.
+private class PathFilterWrapper(val filter: PathFilter) extends PathFilter with Serializable {
+  override def accept(path: Path): Boolean = filter == null || filter.accept(path)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
@@ -78,6 +78,13 @@ abstract class PartitioningAwareFileIndex(
       .getOrElse(sparkSession.sessionState.conf.ignoreInvalidPartitionPaths)
   }
 
+  protected lazy val listHiddenFiles: Boolean = {
+    caseInsensitiveMap
+      .get(FileIndexOptions.LIST_HIDDEN_FILES)
+      .map(_.toBoolean)
+      .getOrElse(sparkSession.sessionState.conf.listHiddenFiles)
+  }
+
   override def listFiles(
       partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
     def isNonEmptyFile(f: FileStatus): Boolean = {
@@ -264,6 +271,7 @@ abstract class PartitioningAwareFileIndex(
   // SPARK-15895: Metadata files (e.g. Parquet summary files) and temporary files should not be
   // counted as data files, so that they shouldn't participate partition discovery.
   private def isDataPath(path: Path): Boolean = {
+    if (listHiddenFiles) return true
     val name = path.getName
     !((name.startsWith("_") && !name.contains("=")) || name.startsWith("."))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources
 
 import java.io.FileNotFoundException
+import java.util.regex.Pattern
 
 import scala.collection.mutable
 
@@ -78,11 +79,16 @@ abstract class PartitioningAwareFileIndex(
       .getOrElse(sparkSession.sessionState.conf.ignoreInvalidPartitionPaths)
   }
 
-  protected lazy val listHiddenFiles: Boolean = {
+  protected lazy val ignoredPathSegmentRegex: String = {
     caseInsensitiveMap
-      .get(FileIndexOptions.LIST_HIDDEN_FILES)
-      .map(_.toBoolean)
-      .getOrElse(sparkSession.sessionState.conf.listHiddenFiles)
+      .get(FileIndexOptions.IGNORED_PATH_SEGMENT_REGEX)
+      .getOrElse(sparkSession.sessionState.conf.ignoredPathSegmentRegex)
+  }
+
+  private lazy val ignoredPathSegmentRegexPattern: Pattern = {
+    require(ignoredPathSegmentRegex.nonEmpty, "The 'ignoredPathSegmentRegex' option must be a non-empty " +
+      "regular expression. Use '(?!)' to disable hidden-file filtering.")
+    Pattern.compile(ignoredPathSegmentRegex)
   }
 
   override def listFiles(
@@ -271,8 +277,13 @@ abstract class PartitioningAwareFileIndex(
   // SPARK-15895: Metadata files (e.g. Parquet summary files) and temporary files should not be
   // counted as data files, so that they shouldn't participate partition discovery.
   private def isDataPath(path: Path): Boolean = {
-    if (listHiddenFiles) return true
     val name = path.getName
-    !((name.startsWith("_") && !name.contains("=")) || name.startsWith("."))
+    // Partition directories ('_'-prefixed names containing '=') are always data paths.
+    if (name.startsWith("_") && name.contains("=")) return true
+    // Metadata summary files are never data paths, regardless of the ignoredPathSegmentRegex regex
+    // (they always survive listing via the shouldFilterOutPathName carve-out).
+    if (name.startsWith("_common_metadata") || name.startsWith("_metadata")) return false
+    // For all other names the ignoredPathSegmentRegex regex decides.
+    !ignoredPathSegmentRegexPattern.matcher(name).find()
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
@@ -29,7 +29,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{COUNT, PERCENT, TOTAL}
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.{expressions, InternalRow}
+import org.apache.spark.sql.catalyst.{expressions, FileSourceOptions, InternalRow}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -85,11 +85,8 @@ abstract class PartitioningAwareFileIndex(
       .getOrElse(sparkSession.sessionState.conf.ignoredPathSegmentRegex)
   }
 
-  private lazy val ignoredPathSegmentRegexPattern: Pattern = {
-    require(ignoredPathSegmentRegex.nonEmpty, "The 'ignoredPathSegmentRegex' option must be a non-empty " +
-      "regular expression. Use '(?!)' to disable hidden-file filtering.")
-    Pattern.compile(ignoredPathSegmentRegex)
-  }
+  private lazy val ignoredPathSegmentRegexPattern: Pattern =
+    FileSourceOptions.compileIgnoredPathSegmentRegex(ignoredPathSegmentRegex)
 
   override def listFiles(
       partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -120,8 +120,8 @@ abstract class CSVDataSource extends Serializable with Logging {
    *
    * @param getParser builds a fresh [[UnivocityParser]].
    * @param getHeaderChecker builds a fresh [[CSVHeaderChecker]] for `(isStartOfFile, source)`.
-   * @param ignoredPathSegmentRegex the compiled effective `ignoredPathSegmentRegex` option, so hidden
-   *                           entries are skipped exactly like Spark's file listing would.
+   * @param ignoredPathSegmentRegex the compiled effective `ignoredPathSegmentRegex` option, so
+   *                           hidden entries are skipped exactly like Spark's file listing would.
    */
   def readArchive(
       conf: Configuration,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.datasources.csv
 
 import java.io.{FileNotFoundException, InputStream, IOException}
 import java.nio.charset.{Charset, StandardCharsets}
+import java.util.regex.Pattern
 
 import scala.util.control.NonFatal
 
@@ -119,13 +120,16 @@ abstract class CSVDataSource extends Serializable with Logging {
    *
    * @param getParser builds a fresh [[UnivocityParser]].
    * @param getHeaderChecker builds a fresh [[CSVHeaderChecker]] for `(isStartOfFile, source)`.
+   * @param ignoredPathSegmentRegex the compiled effective `ignoredPathSegmentRegex` option, so hidden
+   *                           entries are skipped exactly like Spark's file listing would.
    */
   def readArchive(
       conf: Configuration,
       file: PartitionedFile,
       getParser: () => UnivocityParser,
       getHeaderChecker: (Boolean, String) => CSVHeaderChecker,
-      requiredSchema: StructType): Iterator[InternalRow]
+      requiredSchema: StructType,
+      ignoredPathSegmentRegex: Pattern): Iterator[InternalRow]
 
   /**
    * Shared driver used by the [[readArchive]] implementations: streams each non-skipped entry's
@@ -137,10 +141,11 @@ abstract class CSVDataSource extends Serializable with Logging {
       conf: Configuration,
       file: PartitionedFile,
       getParser: () => UnivocityParser,
-      getHeaderChecker: (Boolean, String) => CSVHeaderChecker)(
+      getHeaderChecker: (Boolean, String) => CSVHeaderChecker,
+      ignoredPathSegmentRegex: Pattern)(
       parseEntry: (UnivocityParser, CSVHeaderChecker, InputStream) => Iterator[InternalRow])
     : Iterator[InternalRow] = {
-    ArchiveReader(file.toPath).readEntries(conf) { (entryName, in) =>
+    ArchiveReader(file.toPath).readEntries(conf, ignoredPathSegmentRegex) { (entryName, in) =>
       val headerChecker =
         getHeaderChecker(true, s"CSV archive entry: ${file.urlEncodedPath}!/$entryName")
       val parser = getParser()
@@ -296,12 +301,14 @@ object TextInputCSVDataSource extends CSVDataSource {
       file: PartitionedFile,
       getParser: () => UnivocityParser,
       getHeaderChecker: (Boolean, String) => CSVHeaderChecker,
-      requiredSchema: StructType): Iterator[InternalRow] =
+      requiredSchema: StructType,
+      ignoredPathSegmentRegex: Pattern): Iterator[InternalRow] =
     // Stream each tar entry through the line-based parser, treating the entry exactly like a
     // standalone CSV file (a fresh parser/header checker is built per entry).
-    streamArchiveEntries(conf, file, getParser, getHeaderChecker) { (parser, headerChecker, in) =>
-      UnivocityParser.parseIterator(
-        entryLines(in, parser.options), parser, headerChecker, requiredSchema)
+    streamArchiveEntries(conf, file, getParser, getHeaderChecker, ignoredPathSegmentRegex) {
+      (parser, headerChecker, in) =>
+        UnivocityParser.parseIterator(
+          entryLines(in, parser.options), parser, headerChecker, requiredSchema)
     }
 
   /**
@@ -425,11 +432,13 @@ object MultiLineCSVDataSource extends CSVDataSource {
       file: PartitionedFile,
       getParser: () => UnivocityParser,
       getHeaderChecker: (Boolean, String) => CSVHeaderChecker,
-      requiredSchema: StructType): Iterator[InternalRow] =
+      requiredSchema: StructType,
+      ignoredPathSegmentRegex: Pattern): Iterator[InternalRow] =
     // Stream each tar entry whole through the multi-line parser (a fresh parser/header checker is
     // built per entry).
-    streamArchiveEntries(conf, file, getParser, getHeaderChecker) { (parser, headerChecker, in) =>
-      UnivocityParser.parseStream(in, parser, headerChecker, requiredSchema)
+    streamArchiveEntries(conf, file, getParser, getHeaderChecker, ignoredPathSegmentRegex) {
+      (parser, headerChecker, in) =>
+        UnivocityParser.parseStream(in, parser, headerChecker, requiredSchema)
     }
 
   override protected def tokenizeForInference(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.datasources.csv
 
+import java.util.regex.Pattern
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.mapreduce._
@@ -107,6 +109,9 @@ case class CSVFileFormat() extends TextBasedFileFormat with DataSourceRegister {
       SerializableConfiguration.broadcast(sparkSession.sparkContext, hadoopConf)
     val parsedOptions = getCsvOptions(sparkSession, options)
     val isColumnPruningEnabled = parsedOptions.isColumnPruningEnabled(requiredSchema)
+    // The effective `ignoredPathSegmentRegex` for skipping hidden archive entries, compiled once here
+    // (Pattern is Serializable) rather than per file or per entry.
+    val ignoredPathSegmentRegex = Pattern.compile(parsedOptions.ignoredPathSegmentRegex)
 
     // Check a field requirement for corrupt records here to throw an exception in a driver side
     ExprUtils.verifyColumnNameOfCorruptRecord(dataSchema, parsedOptions.columnNameOfCorruptRecord)
@@ -141,7 +146,7 @@ case class CSVFileFormat() extends TextBasedFileFormat with DataSourceRegister {
       // archive reads are enabled; otherwise the file is parsed directly.
       if (parsedOptions.archiveFormatEnabled && ArchiveReader.isArchivePath(file.toPath)) {
         CSVDataSource(parsedOptions).readArchive(
-          conf, file, () => newParser(), getHeaderChecker, requiredSchema)
+          conf, file, () => newParser(), getHeaderChecker, requiredSchema, ignoredPathSegmentRegex)
       } else {
         val parser = newParser()
         val headerChecker = getHeaderChecker(file.start == 0, s"CSV file: ${file.urlEncodedPath}")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.execution.datasources.csv
 
-import java.util.regex.Pattern
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.mapreduce._
@@ -109,9 +107,9 @@ case class CSVFileFormat() extends TextBasedFileFormat with DataSourceRegister {
       SerializableConfiguration.broadcast(sparkSession.sparkContext, hadoopConf)
     val parsedOptions = getCsvOptions(sparkSession, options)
     val isColumnPruningEnabled = parsedOptions.isColumnPruningEnabled(requiredSchema)
-    // The effective `ignoredPathSegmentRegex` for skipping hidden archive entries, compiled once here
-    // (Pattern is Serializable) rather than per file or per entry.
-    val ignoredPathSegmentRegex = Pattern.compile(parsedOptions.ignoredPathSegmentRegex)
+    // The effective `ignoredPathSegmentRegex` for skipping hidden archive entries. Reused from the
+    // options' lazily-compiled Pattern (Serializable) instead of re-compiling per file or entry.
+    val ignoredPathSegmentRegex = parsedOptions.ignoredPathSegmentRegexPattern
 
     // Check a field requirement for corrupt records here to throw an exception in a driver side
     ExprUtils.verifyColumnNameOfCorruptRecord(dataSchema, parsedOptions.columnNameOfCorruptRecord)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
@@ -144,7 +144,10 @@ object ParquetUtils extends Logging {
     val leaves = allFiles.toArray.sortBy(_.getPath.toString)
 
     FileTypes(
-      data = leaves.filterNot(f => isSummaryFile(f.getPath)).toImmutableArraySeq,
+      // Zero-length files (e.g. `_SUCCESS` markers surfaced by the `listHiddenFiles` option)
+      // cannot contain a Parquet footer, so exclude them from schema inference candidates.
+      data = leaves.filter(_.getLen > 0).filterNot(f => isSummaryFile(f.getPath))
+        .toImmutableArraySeq,
       metadata =
         leaves.filter(_.getPath.getName == ParquetFileWriter.PARQUET_METADATA_FILE)
           .toImmutableArraySeq,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
@@ -144,7 +144,7 @@ object ParquetUtils extends Logging {
     val leaves = allFiles.toArray.sortBy(_.getPath.toString)
 
     FileTypes(
-      // Zero-length files (e.g. `_SUCCESS` markers surfaced by the `listHiddenFiles` option)
+      // Zero-length files (e.g. `_SUCCESS` markers surfaced by a relaxed `ignoredPathSegmentRegex`)
       // cannot contain a Parquet footer, so exclude them from schema inference candidates.
       data = leaves.filter(_.getLen > 0).filterNot(f => isSummaryFile(f.getPath))
         .toImmutableArraySeq,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.execution.datasources.v2
 
 import java.util
-import java.util.regex.Pattern
 
 import scala.jdk.CollectionConverters._
 
@@ -59,7 +58,7 @@ abstract class FileTable(
     } else {
       // This is a non-streaming file based datasource.
       val ignoredPathSegmentRegex =
-        Pattern.compile(new FileSourceOptions(caseSensitiveMap).ignoredPathSegmentRegex)
+        new FileSourceOptions(caseSensitiveMap).ignoredPathSegmentRegexPattern
       val rootPathsSpecified = DataSource.checkAndGlobPathIfNecessary(paths, hadoopConf,
         checkEmptyGlobPath = true, checkFilesExist = true, enableGlobbing = globPaths,
         ignoredPathSegmentRegex = ignoredPathSegmentRegex)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
@@ -17,12 +17,14 @@
 package org.apache.spark.sql.execution.datasources.v2
 
 import java.util
+import java.util.regex.Pattern
 
 import scala.jdk.CollectionConverters._
 
 import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.FileSourceOptions
 import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.expressions.Transform
@@ -56,8 +58,11 @@ abstract class FileTable(
         options.asScala.toMap, userSpecifiedSchema)
     } else {
       // This is a non-streaming file based datasource.
+      val ignoredPathSegmentRegex =
+        Pattern.compile(new FileSourceOptions(caseSensitiveMap).ignoredPathSegmentRegex)
       val rootPathsSpecified = DataSource.checkAndGlobPathIfNecessary(paths, hadoopConf,
-        checkEmptyGlobPath = true, checkFilesExist = true, enableGlobbing = globPaths)
+        checkEmptyGlobPath = true, checkFilesExist = true, enableGlobbing = globPaths,
+        ignoredPathSegmentRegex = ignoredPathSegmentRegex)
       val fileStatusCache = FileStatusCache.getOrCreate(sparkSession)
       new InMemoryFileIndex(
         sparkSession, rootPathsSpecified, caseSensitiveMap, userSpecifiedSchema, fileStatusCache)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/FileStreamOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/FileStreamOptions.scala
@@ -102,13 +102,6 @@ class FileStreamOptions(parameters: CaseInsensitiveMap[String]) extends Logging 
   val fileNameOnly: Boolean = withBooleanParameter("fileNameOnly", false)
 
   /**
-   * Whether to list and read files and directories whose names start with '_' or '.' (hidden
-   * files), which are skipped by default.
-   */
-  val listHiddenFiles: Boolean =
-    withBooleanParameter(FileIndexOptions.LIST_HIDDEN_FILES, false)
-
-  /**
    * The archive directory to move completed files. The option will be only effective when
    * "cleanSource" is set to "archive".
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/FileStreamOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/FileStreamOptions.scala
@@ -102,6 +102,13 @@ class FileStreamOptions(parameters: CaseInsensitiveMap[String]) extends Logging 
   val fileNameOnly: Boolean = withBooleanParameter("fileNameOnly", false)
 
   /**
+   * Whether to list and read files and directories whose names start with '_' or '.' (hidden
+   * files), which are skipped by default.
+   */
+  val listHiddenFiles: Boolean =
+    withBooleanParameter(FileIndexOptions.LIST_HIDDEN_FILES, false)
+
+  /**
    * The archive directory to move completed files. The option will be only effective when
    * "cleanSource" is set to "archive".
    *

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -1496,6 +1496,22 @@ class FileBasedDataSourceSuite extends SharedSparkSession
       checkListHiddenFilesContract("parquet", basePath)
     }
   }
+
+  test("Option listHiddenFiles: reading an unmodified Spark-written parquet directory works") {
+    withTempDir { dir =>
+      // A normal Spark write leaves a zero-length _SUCCESS marker next to the part files. With
+      // listHiddenFiles enabled, the marker is surfaced by listing but must neither be picked as
+      // a schema inference footer candidate nor scanned as data.
+      val basePath = dir.getCanonicalPath
+      // withTempDir pre-creates the directory, so overwrite to avoid PATH_ALREADY_EXISTS.
+      Seq("a", "b").toDF("col").write.mode("overwrite").parquet(basePath)
+      assert(new File(dir, "_SUCCESS").exists())
+
+      checkAnswer(
+        spark.read.option("listHiddenFiles", "true").parquet(basePath),
+        Seq(Row("a"), Row("b")))
+    }
+  }
 }
 
 object TestingUDT {

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -1429,6 +1429,73 @@ class FileBasedDataSourceSuite extends SharedSparkSession
       }
     }
   }
+
+  // Asserts the listHiddenFiles contract for `format`: default hides the '_'-prefixed file; the
+  // per-read option and the session conf each surface it; the option overrides the conf.
+  private def checkListHiddenFilesContract(format: String, basePath: String): Unit = {
+    // Default: the hidden file is filtered out.
+    checkAnswer(spark.read.format(format).load(basePath), Seq(Row("visible")))
+
+    // Per-read option surfaces the hidden data.
+    checkAnswer(
+      spark.read.option("listHiddenFiles", "true").format(format).load(basePath),
+      Seq(Row("visible"), Row("hidden")))
+
+    // Session conf surfaces the hidden data too.
+    withSQLConf(SQLConf.LIST_HIDDEN_FILES.key -> "true") {
+      checkAnswer(
+        spark.read.format(format).load(basePath),
+        Seq(Row("visible"), Row("hidden")))
+    }
+
+    // Precedence: the per-read option overrides the session conf in both directions.
+    withSQLConf(SQLConf.LIST_HIDDEN_FILES.key -> "false") {
+      checkAnswer(
+        spark.read.option("listHiddenFiles", "true").format(format).load(basePath),
+        Seq(Row("visible"), Row("hidden")))
+    }
+    withSQLConf(SQLConf.LIST_HIDDEN_FILES.key -> "true") {
+      checkAnswer(
+        spark.read.option("listHiddenFiles", "false").format(format).load(basePath),
+        Seq(Row("visible")))
+    }
+  }
+
+  test("Option listHiddenFiles: surfaces hidden files only when enabled - json") {
+    withTempDir { dir =>
+      val basePath = dir.getCanonicalPath
+      // Write JSON files directly: a visible record and a '_'-prefixed hidden record.
+      Files.write(new File(dir, "visible.json").toPath, """{"a":"visible"}""".getBytes)
+      Files.write(new File(dir, "_hidden.json").toPath, """{"a":"hidden"}""".getBytes)
+
+      checkListHiddenFilesContract("json", basePath)
+    }
+  }
+
+  test("Option listHiddenFiles: surfaces hidden files only when enabled - parquet") {
+    withTempDir { dir =>
+      // Copy only the part-*.parquet from a scratch write into basePath -- this drops Spark's own
+      // _SUCCESS / _temporary marker files, so listHiddenFiles surfaces only the intended hidden
+      // file. Flat layout (files directly under basePath) mirrors the JSON test.
+      val basePath = dir.getCanonicalPath
+
+      def copyPartFile(value: String, destName: String): Unit = {
+        withTempDir { scratch =>
+          // withTempDir pre-creates the directory, so overwrite to avoid PATH_ALREADY_EXISTS.
+          Seq(value).toDF("a").write.format("parquet").mode("overwrite")
+            .save(scratch.getCanonicalPath)
+          val partFile = scratch.listFiles()
+            .find(f => f.isFile && f.getName.startsWith("part-") && f.getName.endsWith(".parquet"))
+            .getOrElse(fail(s"no part file produced under ${scratch.getCanonicalPath}"))
+          Files.copy(partFile.toPath, new File(dir, destName).toPath)
+        }
+      }
+      copyPartFile("visible", "visible.parquet")
+      copyPartFile("hidden", "_hidden.parquet")
+
+      checkListHiddenFilesContract("parquet", basePath)
+    }
+  }
 }
 
 object TestingUDT {

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -21,6 +21,7 @@ import java.io.{File, FileNotFoundException}
 import java.net.URI
 import java.nio.file.{Files, StandardOpenOption}
 import java.time.{LocalDateTime, ZoneOffset}
+import java.util.regex.PatternSyntaxException
 
 import scala.collection.mutable
 
@@ -47,6 +48,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.TimestampNanosVal
+import org.apache.spark.util.HadoopFSUtils
 
 class FileBasedDataSourceSuite extends SharedSparkSession
   with AdaptiveSparkPlanHelper {
@@ -1430,53 +1432,56 @@ class FileBasedDataSourceSuite extends SharedSparkSession
     }
   }
 
-  // Asserts the listHiddenFiles contract for `format`: default hides the '_'-prefixed file; the
-  // per-read option and the session conf each surface it; the option overrides the conf.
-  private def checkListHiddenFilesContract(format: String, basePath: String): Unit = {
+  // Asserts the ignoredPathSegmentRegex contract for `format`: the default regex hides the
+  // '_'-prefixed file; a never-matching per-read option or session conf each surface it; the
+  // option overrides the conf.
+  private def checkIgnoredPathSegmentRegexContract(format: String, basePath: String): Unit = {
+    val defaultRegex = HadoopFSUtils.DEFAULT_IGNORED_PATH_SEGMENT_REGEX
+
     // Default: the hidden file is filtered out.
     checkAnswer(spark.read.format(format).load(basePath), Seq(Row("visible")))
 
-    // Per-read option surfaces the hidden data.
+    // A never-matching per-read option surfaces the hidden data.
     checkAnswer(
-      spark.read.option("listHiddenFiles", "true").format(format).load(basePath),
+      spark.read.option("ignoredPathSegmentRegex", "(?!)").format(format).load(basePath),
       Seq(Row("visible"), Row("hidden")))
 
-    // Session conf surfaces the hidden data too.
-    withSQLConf(SQLConf.LIST_HIDDEN_FILES.key -> "true") {
+    // A never-matching session conf surfaces the hidden data too.
+    withSQLConf(SQLConf.IGNORED_PATH_SEGMENT_REGEX.key -> "(?!)") {
       checkAnswer(
         spark.read.format(format).load(basePath),
         Seq(Row("visible"), Row("hidden")))
     }
 
     // Precedence: the per-read option overrides the session conf in both directions.
-    withSQLConf(SQLConf.LIST_HIDDEN_FILES.key -> "false") {
+    withSQLConf(SQLConf.IGNORED_PATH_SEGMENT_REGEX.key -> defaultRegex) {
       checkAnswer(
-        spark.read.option("listHiddenFiles", "true").format(format).load(basePath),
+        spark.read.option("ignoredPathSegmentRegex", "(?!)").format(format).load(basePath),
         Seq(Row("visible"), Row("hidden")))
     }
-    withSQLConf(SQLConf.LIST_HIDDEN_FILES.key -> "true") {
+    withSQLConf(SQLConf.IGNORED_PATH_SEGMENT_REGEX.key -> "(?!)") {
       checkAnswer(
-        spark.read.option("listHiddenFiles", "false").format(format).load(basePath),
+        spark.read.option("ignoredPathSegmentRegex", defaultRegex).format(format).load(basePath),
         Seq(Row("visible")))
     }
   }
 
-  test("Option listHiddenFiles: surfaces hidden files only when enabled - json") {
+  test("Option ignoredPathSegmentRegex: surfaces hidden files only when relaxed - json") {
     withTempDir { dir =>
       val basePath = dir.getCanonicalPath
       // Write JSON files directly: a visible record and a '_'-prefixed hidden record.
       Files.write(new File(dir, "visible.json").toPath, """{"a":"visible"}""".getBytes)
       Files.write(new File(dir, "_hidden.json").toPath, """{"a":"hidden"}""".getBytes)
 
-      checkListHiddenFilesContract("json", basePath)
+      checkIgnoredPathSegmentRegexContract("json", basePath)
     }
   }
 
-  test("Option listHiddenFiles: surfaces hidden files only when enabled - parquet") {
+  test("Option ignoredPathSegmentRegex: surfaces hidden files only when relaxed - parquet") {
     withTempDir { dir =>
       // Copy only the part-*.parquet from a scratch write into basePath -- this drops Spark's own
-      // _SUCCESS / _temporary marker files, so listHiddenFiles surfaces only the intended hidden
-      // file. Flat layout (files directly under basePath) mirrors the JSON test.
+      // _SUCCESS / _temporary marker files, so a relaxed ignoredPathSegmentRegex surfaces only the
+      // intended hidden file. Flat layout (files directly under basePath) mirrors the JSON test.
       val basePath = dir.getCanonicalPath
 
       def copyPartFile(value: String, destName: String): Unit = {
@@ -1493,23 +1498,90 @@ class FileBasedDataSourceSuite extends SharedSparkSession
       copyPartFile("visible", "visible.parquet")
       copyPartFile("hidden", "_hidden.parquet")
 
-      checkListHiddenFilesContract("parquet", basePath)
+      checkIgnoredPathSegmentRegexContract("parquet", basePath)
     }
   }
 
-  test("Option listHiddenFiles: reading an unmodified Spark-written parquet directory works") {
+  test("Option ignoredPathSegmentRegex: reading an unmodified Spark-written parquet directory works") {
     withTempDir { dir =>
       // A normal Spark write leaves a zero-length _SUCCESS marker next to the part files. With
-      // listHiddenFiles enabled, the marker is surfaced by listing but must neither be picked as
-      // a schema inference footer candidate nor scanned as data.
+      // a never-matching ignoredPathSegmentRegex, the marker is surfaced by listing but must neither
+      // be picked as a schema inference footer candidate nor scanned as data.
       val basePath = dir.getCanonicalPath
       // withTempDir pre-creates the directory, so overwrite to avoid PATH_ALREADY_EXISTS.
       Seq("a", "b").toDF("col").write.mode("overwrite").parquet(basePath)
       assert(new File(dir, "_SUCCESS").exists())
 
       checkAnswer(
-        spark.read.option("listHiddenFiles", "true").parquet(basePath),
+        spark.read.option("ignoredPathSegmentRegex", "(?!)").parquet(basePath),
         Seq(Row("a"), Row("b")))
+    }
+  }
+
+  test("Option ignoredPathSegmentRegex: reading a partitioned Spark-written parquet directory works") {
+    withTempDir { dir =>
+      // partitionBy leaves the zero-length _SUCCESS marker at the table root next to the 'p='
+      // partition dirs. Under a never-matching ignoredPathSegmentRegex the marker survives listing,
+      // but partition discovery still works (parsePartition stops at the base path) and the
+      // zero-length marker is neither a schema inference footer candidate nor scanned as data.
+      val basePath = dir.getCanonicalPath
+      // withTempDir pre-creates the directory, so overwrite to avoid PATH_ALREADY_EXISTS.
+      Seq((1, "a"), (2, "b")).toDF("p", "v").write.mode("overwrite").partitionBy("p")
+        .parquet(basePath)
+      assert(new File(dir, "_SUCCESS").exists())
+
+      // The read-back schema appends the discovered partition column after the data column.
+      val expected = Seq(Row("a", 1), Row("b", 2))
+      checkAnswer(spark.read.parquet(basePath), expected)
+      checkAnswer(
+        spark.read.option("ignoredPathSegmentRegex", "(?!)").parquet(basePath),
+        expected)
+    }
+  }
+
+  test("Option ignoredPathSegmentRegex: custom regex replaces the default filter - json") {
+    withTempDir { dir =>
+      val basePath = dir.getCanonicalPath
+      // The default '^[._]' hides both the '_'- and '.'-prefixed files. A custom '^_' regex
+      // replaces it entirely: it keeps hiding the '_'-prefixed file but surfaces the
+      // '.'-prefixed one.
+      Files.write(new File(dir, "visible.json").toPath, """{"a":"visible"}""".getBytes)
+      Files.write(new File(dir, "_under.json").toPath, """{"a":"under"}""".getBytes)
+      Files.write(new File(dir, ".dot.json").toPath, """{"a":"dot"}""".getBytes)
+
+      checkAnswer(spark.read.format("json").load(basePath), Seq(Row("visible")))
+      checkAnswer(
+        spark.read.option("ignoredPathSegmentRegex", "^_").format("json").load(basePath),
+        Seq(Row("visible"), Row("dot")))
+    }
+  }
+
+  test("Option ignoredPathSegmentRegex: invalid or empty regexes are rejected") {
+    withTempDir { dir =>
+      val basePath = dir.getCanonicalPath
+      Files.write(new File(dir, "visible.json").toPath, """{"a":"visible"}""".getBytes)
+
+      // An invalid regex in the per-read option propagates from the Pattern.compile in
+      // InMemoryFileIndex.bulkListLeafFiles when the read resolves the relation.
+      val optionError = intercept[PatternSyntaxException] {
+        spark.read.option("ignoredPathSegmentRegex", "[").format("json").load(basePath)
+      }
+      assert(optionError.getMessage.contains("["))
+
+      // The session conf rejects invalid and empty values eagerly via checkValue.
+      Seq("[", "").foreach { invalid =>
+        val confError = intercept[IllegalArgumentException] {
+          spark.conf.set(SQLConf.IGNORED_PATH_SEGMENT_REGEX.key, invalid)
+        }
+        assert(confError.getMessage.contains(
+          "must be a non-empty valid Java regular expression"))
+      }
+
+      // An empty per-read option is rejected with a pointer to the '(?!)' escape hatch.
+      val emptyOptionError = intercept[IllegalArgumentException] {
+        spark.read.option("ignoredPathSegmentRegex", "").format("json").load(basePath)
+      }
+      assert(emptyOptionError.getMessage.contains("Use '(?!)' to disable hidden-file filtering"))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -21,7 +21,6 @@ import java.io.{File, FileNotFoundException}
 import java.net.URI
 import java.nio.file.{Files, StandardOpenOption}
 import java.time.{LocalDateTime, ZoneOffset}
-import java.util.regex.PatternSyntaxException
 
 import scala.collection.mutable
 
@@ -1502,11 +1501,11 @@ class FileBasedDataSourceSuite extends SharedSparkSession
     }
   }
 
-  test("Option ignoredPathSegmentRegex: reading an unmodified Spark-written parquet directory works") {
+  test("Option ignoredPathSegmentRegex: reads an unmodified Spark-written parquet dir") {
     withTempDir { dir =>
       // A normal Spark write leaves a zero-length _SUCCESS marker next to the part files. With
-      // a never-matching ignoredPathSegmentRegex, the marker is surfaced by listing but must neither
-      // be picked as a schema inference footer candidate nor scanned as data.
+      // a never-matching ignoredPathSegmentRegex, the marker is surfaced by listing but must
+      // neither be picked as a schema inference footer candidate nor scanned as data.
       val basePath = dir.getCanonicalPath
       // withTempDir pre-creates the directory, so overwrite to avoid PATH_ALREADY_EXISTS.
       Seq("a", "b").toDF("col").write.mode("overwrite").parquet(basePath)
@@ -1518,7 +1517,7 @@ class FileBasedDataSourceSuite extends SharedSparkSession
     }
   }
 
-  test("Option ignoredPathSegmentRegex: reading a partitioned Spark-written parquet directory works") {
+  test("Option ignoredPathSegmentRegex: reads a partitioned Spark-written parquet dir") {
     withTempDir { dir =>
       // partitionBy leaves the zero-length _SUCCESS marker at the table root next to the 'p='
       // partition dirs. Under a never-matching ignoredPathSegmentRegex the marker survives listing,
@@ -1556,32 +1555,42 @@ class FileBasedDataSourceSuite extends SharedSparkSession
     }
   }
 
-  test("Option ignoredPathSegmentRegex: invalid or empty regexes are rejected") {
+  test("Option ignoredPathSegmentRegex: invalid regexes are rejected") {
     withTempDir { dir =>
       val basePath = dir.getCanonicalPath
       Files.write(new File(dir, "visible.json").toPath, """{"a":"visible"}""".getBytes)
 
-      // An invalid regex in the per-read option propagates from the Pattern.compile in
-      // InMemoryFileIndex.bulkListLeafFiles when the read resolves the relation.
-      val optionError = intercept[PatternSyntaxException] {
+      // An invalid per-read regex is surfaced as a clear IllegalArgumentException when the read
+      // resolves the relation, instead of a raw PatternSyntaxException deep in file listing.
+      val optionError = intercept[IllegalArgumentException] {
         spark.read.option("ignoredPathSegmentRegex", "[").format("json").load(basePath)
       }
-      assert(optionError.getMessage.contains("["))
+      assert(optionError.getMessage.contains("ignoredPathSegmentRegex"))
 
-      // The session conf rejects invalid and empty values eagerly via checkValue.
-      Seq("[", "").foreach { invalid =>
-        val confError = intercept[IllegalArgumentException] {
-          spark.conf.set(SQLConf.IGNORED_PATH_SEGMENT_REGEX.key, invalid)
-        }
-        assert(confError.getMessage.contains(
-          "must be a non-empty valid Java regular expression"))
+      // The session conf rejects invalid values eagerly via checkValue.
+      val confError = intercept[IllegalArgumentException] {
+        spark.conf.set(SQLConf.IGNORED_PATH_SEGMENT_REGEX.key, "[")
       }
+      assert(confError.getMessage.contains("valid Java regular expression"))
+    }
+  }
 
-      // An empty per-read option is rejected with a pointer to the '(?!)' escape hatch.
-      val emptyOptionError = intercept[IllegalArgumentException] {
-        spark.read.option("ignoredPathSegmentRegex", "").format("json").load(basePath)
+  test("Option ignoredPathSegmentRegex: an empty value disables hidden-file filtering") {
+    withTempDir { dir =>
+      val basePath = dir.getCanonicalPath
+      Files.write(new File(dir, "visible.json").toPath, """{"a":"visible"}""".getBytes)
+      Files.write(new File(dir, "_hidden.json").toPath, """{"a":"hidden"}""".getBytes)
+
+      // The default '^[._]' hides the '_'-prefixed file.
+      checkAnswer(spark.read.format("json").load(basePath), Seq(Row("visible")))
+      // An empty per-read option disables the generic hidden-file filter and surfaces it.
+      checkAnswer(
+        spark.read.option("ignoredPathSegmentRegex", "").format("json").load(basePath),
+        Seq(Row("visible"), Row("hidden")))
+      // An empty session conf does too.
+      withSQLConf(SQLConf.IGNORED_PATH_SEGMENT_REGEX.key -> "") {
+        checkAnswer(spark.read.format("json").load(basePath), Seq(Row("visible"), Row("hidden")))
       }
-      assert(emptyOptionError.getMessage.contains("Use '(?!)' to disable hidden-file filtering"))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ArchiveReaderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ArchiveReaderSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources
 import java.io.{ByteArrayOutputStream, Closeable, File, FileOutputStream, InputStream, OutputStream}
 import java.nio.charset.StandardCharsets
 import java.util.Properties
+import java.util.regex.Pattern
 import java.util.zip.GZIPOutputStream
 
 import scala.collection.mutable.ArrayBuffer
@@ -164,6 +165,21 @@ class ArchiveReaderSuite extends SparkFunSuite {
         textEntry("real.csv", "kept"),
         textEntry("nested/._sidecar", "junk2")))   // dotfile in a subdir
       assert(collect(tar) == Seq("real.csv" -> "kept"))
+    }
+  }
+
+  test("readEntries: a custom ignoredPathSegmentRegex pattern surfaces hidden entries") {
+    withTempDir { dir =>
+      val tar = new File(dir, "custom-filter.tar")
+      writeTar(tar, Seq(textEntry("_SUCCESS", "marker"), textEntry("real.csv", "kept")))
+      // "(?!)" matches nothing, so hidden-name filtering is disabled and only the carve-outs in
+      // HadoopFSUtils.shouldFilterOutPathName still apply -- mirroring a loose-file listing with
+      // the ignoredPathSegmentRegex option set to the same regex.
+      val entries = ArchiveReader(new Path(tar.toURI))
+        .readEntries(new Configuration(), Pattern.compile("(?!)")) { (name, in) =>
+          Iterator.single((name, new String(readAll(in), StandardCharsets.UTF_8)))
+        }.toList
+      assert(entries == Seq("_SUCCESS" -> "marker", "real.csv" -> "kept"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.apache.spark.util.KnownSizeEstimation
+import org.apache.spark.util.{HadoopFSUtils, KnownSizeEstimation}
 
 class FileIndexSuite extends SharedSparkSession {
 
@@ -649,7 +649,7 @@ class FileIndexSuite extends SharedSparkSession {
     assert(FileIndexOptions.getAllOptions.size == 9)
     // Please add validation on any new FileIndex options here
     assert(FileIndexOptions.isValidOption("ignoreMissingFiles"))
-    assert(FileIndexOptions.isValidOption("listHiddenFiles"))
+    assert(FileIndexOptions.isValidOption("ignoredPathSegmentRegex"))
     assert(FileIndexOptions.isValidOption("ignoreInvalidPartitionPaths"))
     assert(FileIndexOptions.isValidOption("timeZone"))
     assert(FileIndexOptions.isValidOption("recursiveFileLookup"))
@@ -705,7 +705,7 @@ class FileIndexSuite extends SharedSparkSession {
     }
   }
 
-  test("InMemoryFileIndex: listHiddenFiles option surfaces hidden files in allFiles()") {
+  test("InMemoryFileIndex: ignoredPathSegmentRegex option surfaces hidden files in allFiles()") {
     withTempDir { dir =>
       stringToFile(new File(dir, "data.txt"), "data")
       stringToFile(new File(dir, "_hidden"), "hidden")
@@ -717,18 +717,21 @@ class FileIndexSuite extends SharedSparkSession {
       val defaultIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, None)
       assert(defaultIndex.allFiles().map(_.getPath.getName).toSet === Set("data.txt"))
 
-      // With the option set, the hidden file, dot file and copying file all surface.
+      // With a never-matching regex, the hidden file and dot file surface, but the copying
+      // file stays hidden: the '._COPYING_' carve-out is not overridable.
       val hiddenIndex = new InMemoryFileIndex(
-        spark, Seq(path), Map("listHiddenFiles" -> "true"), None)
+        spark, Seq(path), Map("ignoredPathSegmentRegex" -> "(?!)"), None)
       assert(hiddenIndex.allFiles().map(_.getPath.getName).toSet ===
-        Set("data.txt", "_hidden", ".dot", "x._COPYING_"))
+        Set("data.txt", "_hidden", ".dot"))
+      assert(!hiddenIndex.allFiles().map(_.getPath.getName).contains("x._COPYING_"))
     }
   }
 
-  test("InMemoryFileIndex: listHiddenFiles option controls partition dirs with hidden data files") {
+  test("InMemoryFileIndex: ignoredPathSegmentRegex option controls partition dirs with hidden " +
+    "data files") {
     withTempDir { dir =>
       // 'part=1' holds a single hidden ('_'-prefixed) file: filtered out by default (so no
-      // partition is discovered), but surfaced and counted as data when listHiddenFiles=true.
+      // partition is discovered), but surfaced and counted as data with a never-matching regex.
       val partitionDir = new File(dir, "part=1")
       assert(partitionDir.mkdir())
       stringToFile(new File(partitionDir, "_data.txt"), "data")
@@ -742,7 +745,7 @@ class FileIndexSuite extends SharedSparkSession {
       // With the option set, '_data.txt' is a data file (covers isDataPath) and 'part=1' is a
       // partition directory.
       val hiddenIndex = new InMemoryFileIndex(
-        spark, Seq(path), Map("listHiddenFiles" -> "true"), None)
+        spark, Seq(path), Map("ignoredPathSegmentRegex" -> "(?!)"), None)
       assert(hiddenIndex.allFiles().map(_.getPath.getName).toSet === Set("_data.txt"))
       val partitionValues = hiddenIndex.partitionSpec().partitions.map(_.values)
       assert(partitionValues.length == 1)
@@ -752,10 +755,10 @@ class FileIndexSuite extends SharedSparkSession {
     }
   }
 
-  test("InMemoryFileIndex: listHiddenFiles with a hidden directory next to partition dirs") {
+  test("InMemoryFileIndex: ignoredPathSegmentRegex with a hidden directory next to partition dirs") {
     withTempDir { dir =>
-      // A hidden directory holding files next to 'part=1' becomes a leaf data dir when
-      // listHiddenFiles=true, so partition discovery sees conflicting base paths.
+      // A hidden directory holding files next to 'part=1' becomes a leaf data dir when the
+      // regex never matches, so partition discovery sees conflicting base paths.
       val partitionDir = new File(dir, "part=1")
       assert(partitionDir.mkdir())
       stringToFile(new File(partitionDir, "data.txt"), "data")
@@ -769,21 +772,21 @@ class FileIndexSuite extends SharedSparkSession {
       assert(defaultIndex.allFiles().map(_.getPath.getName).toSet === Set("data.txt"))
       assert(defaultIndex.partitionSpec().partitionColumns.fieldNames.toSeq === Seq("part"))
 
-      // listHiddenFiles=true: '_stray' is treated as a leaf data dir and discovered as its own
+      // Never-matching regex: '_stray' is treated as a leaf data dir and discovered as its own
       // base path, so partition discovery fails with conflicting directory structures.
       val hiddenIndex = new InMemoryFileIndex(
-        spark, Seq(path), Map("listHiddenFiles" -> "true"), None)
+        spark, Seq(path), Map("ignoredPathSegmentRegex" -> "(?!)"), None)
       val ex = intercept[SparkRuntimeException] {
         hiddenIndex.partitionSpec()
       }
       assert(ex.getMessage.contains("Conflicting directory structures detected"))
 
-      // listHiddenFiles=true + ignoreInvalidPartitionPaths=true: the invalid '_stray' base path
+      // Never-matching regex + ignoreInvalidPartitionPaths=true: the invalid '_stray' base path
       // is ignored, 'part' is still discovered, and both files surface.
       val recoveredIndex = new InMemoryFileIndex(
         spark,
         Seq(path),
-        Map("listHiddenFiles" -> "true", "ignoreInvalidPartitionPaths" -> "true"),
+        Map("ignoredPathSegmentRegex" -> "(?!)", "ignoreInvalidPartitionPaths" -> "true"),
         None)
       assert(recoveredIndex.partitionSpec().partitionColumns.fieldNames.toSeq === Seq("part"))
       assert(recoveredIndex.allFiles().map(_.getPath.getName).toSet ===
@@ -791,27 +794,88 @@ class FileIndexSuite extends SharedSparkSession {
     }
   }
 
-  test("InMemoryFileIndex: listHiddenFiles option overrides the listHiddenFiles SQL conf") {
+  test("InMemoryFileIndex: ignoredPathSegmentRegex with a _SUCCESS marker next to partition dirs") {
+    withTempDir { dir =>
+      // Unlike the hidden directory above, a hidden file at the table root surfaces in the
+      // listing under a never-matching regex but does not break partition discovery:
+      // parsePartition stops at the base path, so 'part' is still inferred.
+      val partitionDir = new File(dir, "part=1")
+      assert(partitionDir.mkdir())
+      stringToFile(new File(partitionDir, "data.txt"), "data")
+      assert(new File(dir, "_SUCCESS").createNewFile())
+      val path = new Path(dir.getCanonicalPath)
+
+      val hiddenIndex = new InMemoryFileIndex(
+        spark, Seq(path), Map("ignoredPathSegmentRegex" -> "(?!)"), None)
+      assert(hiddenIndex.allFiles().map(_.getPath.getName).toSet === Set("data.txt", "_SUCCESS"))
+      assert(hiddenIndex.partitionSpec().partitionColumns.fieldNames.toSeq === Seq("part"))
+    }
+  }
+
+  test("InMemoryFileIndex: ignoredPathSegmentRegex option overrides the ignoredPathSegmentRegex SQL conf") {
     withTempDir { dir =>
       stringToFile(new File(dir, "data.txt"), "data")
       stringToFile(new File(dir, "_hidden"), "hidden")
       val path = new Path(dir.getCanonicalPath)
 
+      val defaultRegex = HadoopFSUtils.DEFAULT_IGNORED_PATH_SEGMENT_REGEX
+
       def hiddenListed(sqlConf: String, options: Map[String, String]): Boolean = {
-        withSQLConf(SQLConf.LIST_HIDDEN_FILES.key -> sqlConf) {
+        withSQLConf(SQLConf.IGNORED_PATH_SEGMENT_REGEX.key -> sqlConf) {
           val index = new InMemoryFileIndex(spark, Seq(path), options, None)
           index.allFiles().map(_.getPath.getName).contains("_hidden")
         }
       }
 
-      // conf=false, option=true -> option wins, hidden file listed.
-      assert(hiddenListed("false", Map("listHiddenFiles" -> "true")))
-      // conf=true, option=false -> option wins, hidden file not listed.
-      assert(!hiddenListed("true", Map("listHiddenFiles" -> "false")))
-      // conf=true, no option -> conf takes effect, hidden file listed.
-      assert(hiddenListed("true", Map.empty))
-      // conf=false, no option -> default, hidden file not listed.
-      assert(!hiddenListed("false", Map.empty))
+      // conf=default, option=never-matching -> option wins, hidden file listed.
+      assert(hiddenListed(defaultRegex, Map("ignoredPathSegmentRegex" -> "(?!)")))
+      // conf=never-matching, option=default -> option wins, hidden file not listed.
+      assert(!hiddenListed("(?!)", Map("ignoredPathSegmentRegex" -> defaultRegex)))
+      // conf=never-matching, no option -> conf takes effect, hidden file listed.
+      assert(hiddenListed("(?!)", Map.empty))
+      // conf=default, no option -> default, hidden file not listed.
+      assert(!hiddenListed(defaultRegex, Map.empty))
+    }
+  }
+
+  test("InMemoryFileIndex: non-default ignoredPathSegmentRegex bypasses the FileStatusCache") {
+    withTempDir { dir =>
+      stringToFile(new File(dir, "data.txt"), "data")
+      stringToFile(new File(dir, "_hidden.txt"), "hidden")
+      val path = new Path(dir.getCanonicalPath)
+      val fileStatusCache = FileStatusCache.getOrCreate(spark)
+
+      // Populate the cache with the default-filtered listing.
+      val defaultIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, None, fileStatusCache)
+      assert(defaultIndex.allFiles().map(_.getPath.getName).toSet === Set("data.txt"))
+
+      // A non-default filter over the same path and cache must not serve the cached
+      // default-filtered listing: the hidden file surfaces.
+      val hiddenIndex = new InMemoryFileIndex(
+        spark, Seq(path), Map("ignoredPathSegmentRegex" -> "(?!)"), None, fileStatusCache)
+      assert(hiddenIndex.allFiles().map(_.getPath.getName).toSet ===
+        Set("data.txt", "_hidden.txt"))
+    }
+  }
+
+  test("InMemoryFileIndex: metadata summary files are never data paths regardless of " +
+    "ignoredPathSegmentRegex") {
+    withTempDir { dir =>
+      stringToFile(new File(dir, "data.txt"), "data")
+      stringToFile(new File(dir, "_metadata"), "metadata")
+      stringToFile(new File(dir, ".dot"), "dot")
+      val path = new Path(dir.getCanonicalPath)
+
+      // Custom regex matching only dot files: '_metadata' still surfaces in the listing (the
+      // shouldFilterOutPathName carve-out is not overridable), while '.dot' stays hidden.
+      val index = new InMemoryFileIndex(
+        spark, Seq(path), Map("ignoredPathSegmentRegex" -> "^[.]"), None)
+      assert(index.allFiles().map(_.getPath.getName).toSet === Set("data.txt", "_metadata"))
+
+      // Although listed, the summary file must never be scanned as data, even when the regex
+      // does not classify it as hidden.
+      val dataFiles = index.listFiles(Nil, Nil).flatMap(_.files).map(_.getPath.getName)
+      assert(dataFiles.toSet === Set("data.txt"))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -646,9 +646,10 @@ class FileIndexSuite extends SharedSparkSession {
   }
 
   test("SPARK-40667: validate FileIndex Options") {
-    assert(FileIndexOptions.getAllOptions.size == 8)
+    assert(FileIndexOptions.getAllOptions.size == 9)
     // Please add validation on any new FileIndex options here
     assert(FileIndexOptions.isValidOption("ignoreMissingFiles"))
+    assert(FileIndexOptions.isValidOption("listHiddenFiles"))
     assert(FileIndexOptions.isValidOption("ignoreInvalidPartitionPaths"))
     assert(FileIndexOptions.isValidOption("timeZone"))
     assert(FileIndexOptions.isValidOption("recursiveFileLookup"))
@@ -701,6 +702,77 @@ class FileIndexSuite extends SharedSparkSession {
       val fileIndex2b = new InMemoryFileIndex(spark, Seq(path1, path1, path1),
         Map.empty, Some(schema))
       assert(fileIndex2a != fileIndex2b)
+    }
+  }
+
+  test("InMemoryFileIndex: listHiddenFiles option surfaces hidden files in allFiles()") {
+    withTempDir { dir =>
+      stringToFile(new File(dir, "data.txt"), "data")
+      stringToFile(new File(dir, "_hidden"), "hidden")
+      stringToFile(new File(dir, ".dot"), "dot")
+      stringToFile(new File(dir, "x._COPYING_"), "copying")
+      val path = new Path(dir.getCanonicalPath)
+
+      // Default: hidden files are filtered out, only the regular file is listed.
+      val defaultIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, None)
+      assert(defaultIndex.allFiles().map(_.getPath.getName).toSet === Set("data.txt"))
+
+      // With the option set, the hidden file, dot file and copying file all surface.
+      val hiddenIndex = new InMemoryFileIndex(
+        spark, Seq(path), Map("listHiddenFiles" -> "true"), None)
+      assert(hiddenIndex.allFiles().map(_.getPath.getName).toSet ===
+        Set("data.txt", "_hidden", ".dot", "x._COPYING_"))
+    }
+  }
+
+  test("InMemoryFileIndex: listHiddenFiles option controls partition dirs with hidden data files") {
+    withTempDir { dir =>
+      // 'part=1' holds a single hidden ('_'-prefixed) file: filtered out by default (so no
+      // partition is discovered), but surfaced and counted as data when listHiddenFiles=true.
+      val partitionDir = new File(dir, "part=1")
+      assert(partitionDir.mkdir())
+      stringToFile(new File(partitionDir, "_data.txt"), "data")
+      val path = new Path(dir.getCanonicalPath)
+
+      // Default: the hidden data file is filtered out, so no files / partitions.
+      val defaultIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, None)
+      assert(defaultIndex.allFiles().isEmpty)
+      assert(defaultIndex.partitionSpec().partitions.isEmpty)
+
+      // With the option set, '_data.txt' is a data file (covers isDataPath) and 'part=1' is a
+      // partition directory.
+      val hiddenIndex = new InMemoryFileIndex(
+        spark, Seq(path), Map("listHiddenFiles" -> "true"), None)
+      assert(hiddenIndex.allFiles().map(_.getPath.getName).toSet === Set("_data.txt"))
+      val partitionValues = hiddenIndex.partitionSpec().partitions.map(_.values)
+      assert(partitionValues.length == 1)
+      assert(partitionValues(0).numFields == 1)
+      assert(partitionValues(0).getInt(0) == 1)
+      assert(hiddenIndex.partitionSpec().partitionColumns.fieldNames.toSeq === Seq("part"))
+    }
+  }
+
+  test("InMemoryFileIndex: listHiddenFiles option overrides the listHiddenFiles SQL conf") {
+    withTempDir { dir =>
+      stringToFile(new File(dir, "data.txt"), "data")
+      stringToFile(new File(dir, "_hidden"), "hidden")
+      val path = new Path(dir.getCanonicalPath)
+
+      def hiddenListed(sqlConf: String, options: Map[String, String]): Boolean = {
+        withSQLConf(SQLConf.LIST_HIDDEN_FILES.key -> sqlConf) {
+          val index = new InMemoryFileIndex(spark, Seq(path), options, None)
+          index.allFiles().map(_.getPath.getName).contains("_hidden")
+        }
+      }
+
+      // conf=false, option=true -> option wins, hidden file listed.
+      assert(hiddenListed("false", Map("listHiddenFiles" -> "true")))
+      // conf=true, option=false -> option wins, hidden file not listed.
+      assert(!hiddenListed("true", Map("listHiddenFiles" -> "false")))
+      // conf=true, no option -> conf takes effect, hidden file listed.
+      assert(hiddenListed("true", Map.empty))
+      // conf=false, no option -> default, hidden file not listed.
+      assert(!hiddenListed("false", Map.empty))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -752,6 +752,45 @@ class FileIndexSuite extends SharedSparkSession {
     }
   }
 
+  test("InMemoryFileIndex: listHiddenFiles with a hidden directory next to partition dirs") {
+    withTempDir { dir =>
+      // A hidden directory holding files next to 'part=1' becomes a leaf data dir when
+      // listHiddenFiles=true, so partition discovery sees conflicting base paths.
+      val partitionDir = new File(dir, "part=1")
+      assert(partitionDir.mkdir())
+      stringToFile(new File(partitionDir, "data.txt"), "data")
+      val strayDir = new File(dir, "_stray")
+      assert(strayDir.mkdir())
+      stringToFile(new File(strayDir, "extra.txt"), "extra")
+      val path = new Path(dir.getCanonicalPath)
+
+      // Default: the hidden directory is filtered out and only the partition data is listed.
+      val defaultIndex = new InMemoryFileIndex(spark, Seq(path), Map.empty, None)
+      assert(defaultIndex.allFiles().map(_.getPath.getName).toSet === Set("data.txt"))
+      assert(defaultIndex.partitionSpec().partitionColumns.fieldNames.toSeq === Seq("part"))
+
+      // listHiddenFiles=true: '_stray' is treated as a leaf data dir and discovered as its own
+      // base path, so partition discovery fails with conflicting directory structures.
+      val hiddenIndex = new InMemoryFileIndex(
+        spark, Seq(path), Map("listHiddenFiles" -> "true"), None)
+      val ex = intercept[SparkRuntimeException] {
+        hiddenIndex.partitionSpec()
+      }
+      assert(ex.getMessage.contains("Conflicting directory structures detected"))
+
+      // listHiddenFiles=true + ignoreInvalidPartitionPaths=true: the invalid '_stray' base path
+      // is ignored, 'part' is still discovered, and both files surface.
+      val recoveredIndex = new InMemoryFileIndex(
+        spark,
+        Seq(path),
+        Map("listHiddenFiles" -> "true", "ignoreInvalidPartitionPaths" -> "true"),
+        None)
+      assert(recoveredIndex.partitionSpec().partitionColumns.fieldNames.toSeq === Seq("part"))
+      assert(recoveredIndex.allFiles().map(_.getPath.getName).toSet ===
+        Set("data.txt", "extra.txt"))
+    }
+  }
+
   test("InMemoryFileIndex: listHiddenFiles option overrides the listHiddenFiles SQL conf") {
     withTempDir { dir =>
       stringToFile(new File(dir, "data.txt"), "data")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -755,7 +755,7 @@ class FileIndexSuite extends SharedSparkSession {
     }
   }
 
-  test("InMemoryFileIndex: ignoredPathSegmentRegex with a hidden directory next to partition dirs") {
+  test("InMemoryFileIndex: ignoredPathSegmentRegex with a hidden dir next to partition dirs") {
     withTempDir { dir =>
       // A hidden directory holding files next to 'part=1' becomes a leaf data dir when the
       // regex never matches, so partition discovery sees conflicting base paths.
@@ -812,7 +812,7 @@ class FileIndexSuite extends SharedSparkSession {
     }
   }
 
-  test("InMemoryFileIndex: ignoredPathSegmentRegex option overrides the ignoredPathSegmentRegex SQL conf") {
+  test("InMemoryFileIndex: ignoredPathSegmentRegex option overrides the SQL conf") {
     withTempDir { dir =>
       stringToFile(new File(dir, "data.txt"), "data")
       stringToFile(new File(dir, "_hidden"), "hidden")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
@@ -64,8 +64,7 @@ abstract class ParquetFileFormatSuite
     HadoopFSUtils.listFiles(
       new Path(basePath),
       hadoopConf,
-      (path: Path) => path.getName != "_SUCCESS",
-      listHiddenFiles = false).flatMap(_._2)
+      (path: Path) => path.getName != "_SUCCESS").flatMap(_._2)
 
   private def deleteFile(hadoopConf: Configuration, status: FileStatus): Unit =
     status.getPath.getFileSystem(hadoopConf).delete(status.getPath, false)
@@ -87,8 +86,7 @@ abstract class ParquetFileFormatSuite
         val fileStatuses = HadoopFSUtils.listFiles(
           new Path(basePath),
           hadoopConf,
-          (path: Path) => path.getName != "_SUCCESS",
-          listHiddenFiles = false).flatMap(_._2)
+          (path: Path) => path.getName != "_SUCCESS").flatMap(_._2)
 
         val footers = ParquetFileFormat.readParquetFootersInParallel(
           hadoopConf, fileStatuses, ignoreCorruptFiles)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
@@ -64,7 +64,8 @@ abstract class ParquetFileFormatSuite
     HadoopFSUtils.listFiles(
       new Path(basePath),
       hadoopConf,
-      (path: Path) => path.getName != "_SUCCESS").flatMap(_._2)
+      (path: Path) => path.getName != "_SUCCESS",
+      listHiddenFiles = false).flatMap(_._2)
 
   private def deleteFile(hadoopConf: Configuration, status: FileStatus): Unit =
     status.getPath.getFileSystem(hadoopConf).delete(status.getPath, false)
@@ -86,7 +87,8 @@ abstract class ParquetFileFormatSuite
         val fileStatuses = HadoopFSUtils.listFiles(
           new Path(basePath),
           hadoopConf,
-          (path: Path) => path.getName != "_SUCCESS").flatMap(_._2)
+          (path: Path) => path.getName != "_SUCCESS",
+          listHiddenFiles = false).flatMap(_._2)
 
         val footers = ParquetFileFormat.readParquetFootersInParallel(
           hadoopConf, fileStatuses, ignoreCorruptFiles)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -2619,6 +2619,65 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
       }
     }
   }
+
+  test("listHiddenFiles option: hidden files are not streamed by default") {
+    withTempDirs { case (src, tmp) =>
+      val textStream = createFileStream("text", src.getCanonicalPath)
+      val filtered = textStream.filter($"value" contains "keep")
+
+      // The '_'-prefixed file is a hidden file and must not be picked up by the stream.
+      testStream(filtered)(
+        AddTextFileData("drop1\nkeep2", src, tmp, tmpFilePrefix = "_hidden"),
+        AddTextFileData("keep3", src, tmp),
+        CheckAnswer("keep3")
+      )
+    }
+  }
+
+  test("listHiddenFiles option: hidden files are streamed when the option is set") {
+    withTempDirs { case (src, tmp) =>
+      val textStream = createFileStream(
+        "text", src.getCanonicalPath, options = Map("listHiddenFiles" -> "true"))
+      val filtered = textStream.filter($"value" contains "keep")
+
+      // With listHiddenFiles=true, the '_'-prefixed file participates in streaming.
+      testStream(filtered)(
+        AddTextFileData("drop1\nkeep2", src, tmp, tmpFilePrefix = "_hidden"),
+        CheckAnswer("keep2"),
+        AddTextFileData("keep3", src, tmp),
+        CheckAnswer("keep2", "keep3")
+      )
+    }
+  }
+
+  test("listHiddenFiles option does not surface another query's _spark_metadata as data") {
+    // Regression: listHiddenFiles must not change _spark_metadata handling -- a reader on a sink's
+    // output dir still consults the metadata log rather than surfacing the log files as data.
+    withSQLConf(SQLConf.FILESTREAM_SINK_METADATA_IGNORED.key -> "false") {
+      withTempDirs { case (outputDir, checkpointDir) =>
+        val source = MemoryStream[String]
+        val writer = source
+          .toDF()
+          .writeStream
+          .option("checkpointLocation", checkpointDir.getCanonicalPath)
+          .format("parquet")
+          .start(outputDir.getCanonicalPath)
+        try {
+          source.addData("keep1", "keep2")
+          writer.processAllAvailable()
+        } finally {
+          writer.stop()
+        }
+
+        // The sink must have created a _spark_metadata directory.
+        assert(new File(outputDir, FileStreamSink.metadataDir).exists())
+
+        // listHiddenFiles=true returns the sink's data, not the _spark_metadata log files.
+        val df = spark.read.option("listHiddenFiles", "true").parquet(outputDir.getCanonicalPath)
+        checkAnswer(df, Seq(Row("keep1"), Row("keep2")))
+      }
+    }
+  }
 }
 
 @SlowSQLTest

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -2620,7 +2620,7 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
     }
   }
 
-  test("listHiddenFiles option: hidden files are not streamed by default") {
+  test("ignoredPathSegmentRegex option: hidden files are not streamed by default") {
     withTempDirs { case (src, tmp) =>
       val textStream = createFileStream("text", src.getCanonicalPath)
       val filtered = textStream.filter($"value" contains "keep")
@@ -2634,13 +2634,13 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
     }
   }
 
-  test("listHiddenFiles option: hidden files are streamed when the option is set") {
+  test("ignoredPathSegmentRegex option: hidden files are streamed with a never-matching regex") {
     withTempDirs { case (src, tmp) =>
       val textStream = createFileStream(
-        "text", src.getCanonicalPath, options = Map("listHiddenFiles" -> "true"))
+        "text", src.getCanonicalPath, options = Map("ignoredPathSegmentRegex" -> "(?!)"))
       val filtered = textStream.filter($"value" contains "keep")
 
-      // With listHiddenFiles=true, the '_'-prefixed file participates in streaming.
+      // With a never-matching regex, the '_'-prefixed file participates in streaming.
       testStream(filtered)(
         AddTextFileData("drop1\nkeep2", src, tmp, tmpFilePrefix = "_hidden"),
         CheckAnswer("keep2"),
@@ -2650,14 +2650,14 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
     }
   }
 
-  test("listHiddenFiles SQL conf: hidden files are streamed when the conf is set") {
-    withSQLConf(SQLConf.LIST_HIDDEN_FILES.key -> "true") {
+  test("ignoredPathSegmentRegex SQL conf: hidden files are streamed with a never-matching regex") {
+    withSQLConf(SQLConf.IGNORED_PATH_SEGMENT_REGEX.key -> "(?!)") {
       withTempDirs { case (src, tmp) =>
         val textStream = createFileStream("text", src.getCanonicalPath)
         val filtered = textStream.filter($"value" contains "keep")
 
         // With the session conf set, the '_'-prefixed file participates in streaming even
-        // though the listHiddenFiles option is not set.
+        // though the ignoredPathSegmentRegex option is not set.
         testStream(filtered)(
           AddTextFileData("drop1\nkeep2", src, tmp, tmpFilePrefix = "_hidden"),
           CheckAnswer("keep2"),
@@ -2668,9 +2668,10 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
     }
   }
 
-  test("listHiddenFiles option does not surface another query's _spark_metadata as data") {
-    // Regression: listHiddenFiles must not change _spark_metadata handling -- a reader on a sink's
-    // output dir still consults the metadata log rather than surfacing the log files as data.
+  test("ignoredPathSegmentRegex option does not surface another query's _spark_metadata as data") {
+    // Regression: ignoredPathSegmentRegex must not change _spark_metadata handling -- a reader on a
+    // sink's output dir still consults the metadata log rather than surfacing the log files as
+    // data.
     withSQLConf(SQLConf.FILESTREAM_SINK_METADATA_IGNORED.key -> "false") {
       withTempDirs { case (outputDir, checkpointDir) =>
         val source = MemoryStream[String]
@@ -2690,8 +2691,9 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
         // The sink must have created a _spark_metadata directory.
         assert(new File(outputDir, FileStreamSink.metadataDir).exists())
 
-        // listHiddenFiles=true returns the sink's data, not the _spark_metadata log files.
-        val df = spark.read.option("listHiddenFiles", "true").parquet(outputDir.getCanonicalPath)
+        // A never-matching regex returns the sink's data, not the _spark_metadata log files.
+        val df = spark.read.option("ignoredPathSegmentRegex", "(?!)")
+          .parquet(outputDir.getCanonicalPath)
         checkAnswer(df, Seq(Row("keep1"), Row("keep2")))
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -2650,6 +2650,24 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
     }
   }
 
+  test("listHiddenFiles SQL conf: hidden files are streamed when the conf is set") {
+    withSQLConf(SQLConf.LIST_HIDDEN_FILES.key -> "true") {
+      withTempDirs { case (src, tmp) =>
+        val textStream = createFileStream("text", src.getCanonicalPath)
+        val filtered = textStream.filter($"value" contains "keep")
+
+        // With the session conf set, the '_'-prefixed file participates in streaming even
+        // though the listHiddenFiles option is not set.
+        testStream(filtered)(
+          AddTextFileData("drop1\nkeep2", src, tmp, tmpFilePrefix = "_hidden"),
+          CheckAnswer("keep2"),
+          AddTextFileData("keep3", src, tmp),
+          CheckAnswer("keep2", "keep3")
+        )
+      }
+    }
+  }
+
   test("listHiddenFiles option does not surface another query's _spark_metadata as data") {
     // Regression: listHiddenFiles must not change _spark_metadata handling -- a reader on a sink's
     // output dir still consults the metadata log rather than surfacing the log files as data.


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add an `ignoredPathSegmentRegex` data source option plus a `spark.sql.files.ignoredPathSegmentRegex` session config (default `^[._]`) for file-based sources. The value is a Java regex matched with find semantics against each individual directory/file name during listing; matching names are skipped from file listing, partition discovery, and reads (a matching directory excludes its whole subtree). The per-read option overrides the session config. Both batch and Structured Streaming reads are covered. 

Regardless of the regex, three rules are hardcoded: 
- `_metadata/_common_metadata` (Parquet summary files) are always listed
- `*._COPYING_` (in-flight Hadoop FS-shell copies) are always skipped
- `_-`prefixed partition dirs containing `=` are always kept. 

A regex that never matches (`(?!)`, or empty string -- pending decision below) disables the generic hidden-file filter.
Two carve-outs: table statistics (CommandUtils) pin the default regex so ANALYZE sizes are unaffected by the session conf; and Parquet schema inference now excludes zero-length files from footer candidates so a directory containing a 0-byte _SUCCESS marker stays readable when hidden files are surfaced.

User documentation is added to `sql-data-sources-generic-options.md` and the Structured Streaming guide.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Hidden files listing is being requested as a feature. We want to enable a user-facing option for this. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. By setting the new option `ignorePathSegmentRegex = ""`, hidden files will now show up inside all file listing operations. Default value preserves current behavior of skipping hidden files. 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit tests covering the data source option and session conf, exercising the file-listing path, partition discovery, batch reads, and structured streaming. Also added tests for the session conf in streaming, partition discovery with a hidden directory next to partition dirs, and reading an unmodified Spark-written parquet directory with the option enabled.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: Claude Opus 4.8
