### PR TITLE
[SPARK-57326][SQL][TESTS] Honor DEFAULT_ARTIFACT_REPOSITORY in IsolatedClientLoaderIvySettingsSuite

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/IsolatedClientLoaderIvySettingsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/IsolatedClientLoaderIvySettingsSuite.scala
@@ -32,6 +32,12 @@ class IsolatedClientLoaderIvySettingsSuite extends SparkFunSuite {
     val ivyPath = Utils.createTempDir(namePrefix = "ivy-settings-test")
     val ivySettingsFile = new File(ivyPath, "ivysettings.xml")
     val writer = new PrintWriter(ivySettingsFile)
+    // Honor the DEFAULT_ARTIFACT_REPOSITORY environment variable so that CI environments which
+    // proxy or mirror Maven Central (and may block direct access to repo1.maven.org) can point
+    // this test at their mirror. This matches how `MavenUtils.createRepoResolvers` picks the
+    // default `central` resolver root. Falls back to Maven Central when the variable is unset.
+    val centralRoot =
+      sys.env.getOrElse("DEFAULT_ARTIFACT_REPOSITORY", "https://repo1.maven.org/maven2/")
     try {
       writer.write(
         s"""<ivysettings>
@@ -39,7 +45,7 @@ class IsolatedClientLoaderIvySettingsSuite extends SparkFunSuite {
            |  <resolvers>
            |    <chain name="main">
            |      <ibiblio name="central" m2compatible="true"
-           |               root="https://repo1.maven.org/maven2/"/>
+           |               root="$centralRoot"/>
            |    </chain>
            |  </resolvers>
            |</ivysettings>""".stripMargin)


### PR DESCRIPTION
### What changes were proposed in this pull request?

`IsolatedClientLoaderIvySettingsSuite` writes an `ivysettings.xml` whose resolver root is hardcoded to `https://repo1.maven.org/maven2/`. This PR reads the root from the `DEFAULT_ARTIFACT_REPOSITORY` environment variable instead, falling back to `https://repo1.maven.org/maven2/` when it is unset — the same way `MavenUtils.createRepoResolvers` already picks the default `central` resolver root.

### Why are the changes needed?

The test downloads the full Hive 2.3 dependency closure over the network and it exercises `MavenUtils`, which already honors `DEFAULT_ARTIFACT_REPOSITORY` to redirect Ivy resolution. By hardcoding Maven Central, the test diverges from the very code path it covers: in an environment that sets `DEFAULT_ARTIFACT_REPOSITORY`, real Hive-jar downloads go through the configured repository, but this test still forces direct Maven Central access.

This is a problem in CI that proxies or mirrors Maven Central and may block or rate-limit direct access to `repo1.maven.org`, where resolution then stalls or times out. Spark already accounts for Maven Central being flaky in CI; see the `gcs-maven-central-mirror` resolver in `project/SparkBuild.scala`, placed first "so that it's used instead of flaky Maven Central." Letting the test honor `DEFAULT_ARTIFACT_REPOSITORY` makes it consistent with that code and lets it run reliably wherever a mirror is configured.

### Does this PR introduce _any_ user-facing change?

No. Test-only change. Default behavior (variable unset) is unchanged.

### How was this patch tested?

Existing test (`IsolatedClientLoaderIvySettingsSuite`). Verified that resolution uses the configured repository when `DEFAULT_ARTIFACT_REPOSITORY` is set, and falls back to Maven Central when it is unset.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
