### PR TITLE
[SPARK-57328][SQL] Add JoinStrategyHint.isJoinStrategyHintName helper

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -52,8 +52,6 @@ object ResolveHints {
    * This rule must happen before common table expressions.
    */
   object ResolveJoinStrategyHints extends Rule[LogicalPlan] {
-    private val STRATEGY_HINT_NAMES = JoinStrategyHint.strategies.flatMap(_.hintAliases)
-
     private def hintErrorHandler = conf.hintErrorHandler
 
     def resolver: Resolver = conf.resolver
@@ -146,7 +144,7 @@ object ResolveHints {
 
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsUpWithPruning(
       _.containsPattern(UNRESOLVED_HINT), ruleId) {
-      case h: UnresolvedHint if STRATEGY_HINT_NAMES.contains(h.name.toUpperCase(Locale.ROOT)) =>
+      case h: UnresolvedHint if JoinStrategyHint.isJoinStrategyHintName(h.name) =>
         if (h.parameters.isEmpty) {
           // If there is no table alias specified, apply the hint on the entire subtree.
           ResolvedHint(h.child, createHintInfo(h.name))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.plans.logical
 
+import java.util.Locale
+
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{TreePattern, UNRESOLVED_HINT}
 
@@ -128,6 +130,13 @@ object JoinStrategyHint {
     SHUFFLE_MERGE,
     SHUFFLE_HASH,
     SHUFFLE_REPLICATE_NL)
+
+  private lazy val allHintAliasesUpperCase: Set[String] =
+    strategies.flatMap(_.hintAliases).map(_.toUpperCase(Locale.ROOT))
+
+  def isJoinStrategyHintName(hintName: String): Boolean = {
+    allHintAliasesUpperCase.contains(hintName.toUpperCase(Locale.ROOT))
+  }
 }
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is a no-behavior-change refactor that centralizes join-strategy hint-name matching into the `JoinStrategyHint` companion object, making it reusable across analyzer rules.
Specifically:
- In `hints.scala`:
  - Added the `import java.util.Locale` import.
  - Added a `private lazy val allHintAliasesUpperCase` to the `JoinStrategyHint` companion object that collects all hint aliases, upper-cased once.
  - Added a `def isJoinStrategyHintName(hintName: String): Boolean` helper that checks whether a given hint name matches a join strategy hint (case-insensitively).
- In `ResolveHints.scala`:
  - Removed the local `STRATEGY_HINT_NAMES` val from `ResolveJoinStrategyHints`.
  - Updated the `apply` match guard to use the new `JoinStrategyHint.isJoinStrategyHintName(h.name)` helper.
This behavior is preserving: `hintAliases` are already upper-case, so folding the upper-casing into `allHintAliasesUpperCase` does not change matching.

## Why are the changes needed?

Centralizing the join-strategy hint-name matching logic removes duplication and makes the check reusable by other components (e.g. a single-pass analyzer), rather than relying on a rule-local val.

## Does this PR introduce _any_ user-facing change?

No. This is a no-behavior-change refactor.

## How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `claude-opus-4-8-thinking-high`