### PR TITLE
[SPARK-57331][SDP] Support native CDC changelog sources as input to AutoCDC flows

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -197,6 +197,24 @@
     ],
     "sqlState" : "42613"
   },
+  "AUTOCDC_CHANGELOG_REQUIRES_CARRYOVER_REMOVAL" : {
+    "message" : [
+      "AutoCDC flow on table <tableName> reads from a native CDC changelog that may surface copy-on-write carry-over rows, but the changelog read uses `deduplicationMode` `none`, which keeps them. A carry-over emits an identical insert and delete for an unchanged row at the same `_commit_version`, and AutoCDC cannot tell the delete apart from a real delete. Read the changelog with `deduplicationMode` set to `dropCarryovers` (the default) or `netChanges` so that carry-over pairs are removed."
+    ],
+    "sqlState" : "22023"
+  },
+  "AUTOCDC_CHANGELOG_REQUIRES_COMMIT_VERSION_SEQUENCING" : {
+    "message" : [
+      "AutoCDC flow on table <tableName> reads from a native CDC changelog but its sequencing expression does not reference `_commit_version`. The native CDC contract only guarantees that `_commit_version` orders changes in commit order; any other column (including `_commit_timestamp`, which is only strictly increasing across micro-batches) may tie or mis-order two changes to the same key and make AutoCDC reconciliation non-deterministic. Sequence the flow by `_commit_version`."
+    ],
+    "sqlState" : "22023"
+  },
+  "AUTOCDC_CHANGELOG_REQUIRES_COMPUTE_UPDATES" : {
+    "message" : [
+      "AutoCDC flow on table <tableName> reads from a native CDC changelog that represents updates as separate delete and insert rows, but the changelog read does not enable `computeUpdates`. AutoCDC cannot unambiguously order the delete and insert halves of an update because they share the same `_commit_version`. Read the changelog with the `computeUpdates` option set to `true` so that updates are materialized as `update_preimage`/`update_postimage` rows."
+    ],
+    "sqlState" : "22023"
+  },
   "AUTOCDC_COLUMNS_NOT_FOUND_IN_SCHEMA" : {
     "message" : [
       "Using <caseSensitivity> column name comparison, the following columns are not present in the <schemaName> schema: <missingColumns>. Available columns: <availableColumns>."

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangelogAutoCdcBridge.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/ChangelogAutoCdcBridge.scala
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.pipelines.autocdc
+
+import org.apache.spark.sql.{functions => F, AnalysisException, Column}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
+import org.apache.spark.sql.catalyst.util.QuotingUtils
+import org.apache.spark.sql.classic.DataFrame
+import org.apache.spark.sql.connector.catalog.{Changelog, ChangelogContext}
+import org.apache.spark.sql.execution.datasources.v2.{ChangelogTable, DataSourceV2Relation}
+import org.apache.spark.sql.types.{LongType, StringType, StructType, TimestampType}
+
+/**
+ * Bridges Spark's native CDC [[Changelog]] connector API into the AutoCDC engine.
+ *
+ * When an AutoCDC flow's source is a native changelog read (e.g. a view defined as
+ * `spark.readStream.changes(table)` or `SELECT * FROM STREAM table CHANGES ...`), its rows carry
+ * the standardized CDC metadata columns `_change_type`, `_commit_version`, and
+ * `_commit_timestamp`. This object detects such sources and derives the AutoCDC
+ * [[ChangeArgs]] (delete detection and metadata-column exclusion) from the changelog contract,
+ * so users do not have to hand-map `_change_type` to `apply_as_deletes` or manually exclude the
+ * metadata columns.
+ *
+ * Detection is decided by locating a [[ChangelogTable]] relation in the resolved source plan and
+ * confirming the output schema still carries the three typed metadata columns. A source fed by a
+ * materialized table (where the [[ChangelogTable]] node no longer appears in the plan) is
+ * intentionally not auto-detected; such users continue to configure the flow manually.
+ */
+private[pipelines] object ChangelogAutoCdcBridge {
+
+  /** The CDC metadata column holding the change kind (insert/delete/update_*). */
+  val ChangeTypeColumn: String = "_change_type"
+
+  /** The CDC metadata column holding the commit version that emitted the change row. */
+  val CommitVersionColumn: String = "_commit_version"
+
+  /** The CDC metadata column holding the commit timestamp of the change row. */
+  val CommitTimestampColumn: String = "_commit_timestamp"
+
+  /** All native CDC metadata column names, in schema order. */
+  val MetadataColumns: Seq[String] = Seq(ChangeTypeColumn, CommitVersionColumn, CommitTimestampColumn)
+
+  /**
+   * A detected native-CDC changelog source, with the bits of the [[Changelog]] contract that
+   * AutoCDC needs to derive its configuration and validate the read.
+   *
+   * @param changeTypeColumn               The actual (case-preserving) name of the `_change_type`
+   *                                       column in the source schema.
+   * @param representsUpdateAsDeleteAndInsert Whether the connector encodes updates as raw
+   *                                       delete+insert pairs rather than pre/post-images.
+   * @param computeUpdates                 Whether the changelog read materializes
+   *                                       `update_preimage`/`update_postimage` rows.
+   * @param containsCarryoverRows          Whether the connector may surface copy-on-write
+   *                                       carry-over insert/delete pairs.
+   * @param removesCarryoverRows           Whether the changelog read removes carry-over pairs
+   *                                       (i.e. `deduplicationMode` is not `none`).
+   */
+  case class ChangelogSource(
+      changeTypeColumn: String,
+      representsUpdateAsDeleteAndInsert: Boolean,
+      computeUpdates: Boolean,
+      containsCarryoverRows: Boolean,
+      removesCarryoverRows: Boolean)
+
+  /**
+   * Detects whether the given resolved source DataFrame reads from a native CDC changelog.
+   * Returns a [[ChangelogSource]] descriptor when so, or `None` otherwise.
+   */
+  def analyzeSource(df: DataFrame, caseSensitive: Boolean): Option[ChangelogSource] = {
+    findChangelogTable(df.queryExecution.analyzed).flatMap { table =>
+      if (hasChangelogMetadataColumns(df.schema, caseSensitive)) {
+        Some(
+          ChangelogSource(
+            changeTypeColumn = resolvedColumnName(df.schema, ChangeTypeColumn, caseSensitive),
+            representsUpdateAsDeleteAndInsert =
+              table.changelog.representsUpdateAsDeleteAndInsert(),
+            computeUpdates = table.changelogContext.computeUpdates(),
+            containsCarryoverRows = table.changelog.containsCarryoverRows(),
+            removesCarryoverRows =
+              table.changelogContext.deduplicationMode() !=
+                ChangelogContext.DeduplicationMode.NONE
+          )
+        )
+      } else {
+        None
+      }
+    }
+  }
+
+  /**
+   * Validates that a detected changelog source is configured such that AutoCDC can unambiguously
+   * classify each row as an upsert or a delete, and order events deterministically. Intended to be
+   * the single entry point for all changelog-source validation; called once at
+   * [[org.apache.spark.sql.pipelines.graph.AutoCdcMergeFlow]] construction.
+   *
+   * AutoCDC sequences events by a single ordering expression and keeps the max-by-sequence event
+   * per key within a microbatch. Its correctness premise is that, after pre-image filtering, no
+   * two surviving rows for the same key share the same sequence value with conflicting
+   * upsert/delete meaning -- otherwise the per-key dedup ties and resolves non-deterministically.
+   * Three changelog configurations break this:
+   *
+   *  - Updates arriving as raw delete+insert pairs (`representsUpdateAsDeleteAndInsert` without
+   *    `computeUpdates`): the delete and insert halves share a `_commit_version`. Requiring
+   *    `computeUpdates = true` materializes them as `update_preimage`/`update_postimage` (the
+   *    pre-image is then filtered out), leaving one surviving upsert per key per commit.
+   *  - Copy-on-write carry-over pairs (`containsCarryoverRows` with `deduplicationMode = none`):
+   *    an unchanged rewritten row is emitted as an identical insert+delete pair at the same
+   *    `_commit_version`, and the delete half would match the derived delete condition. Requiring
+   *    a deduplication mode that removes carry-overs (`dropCarryovers` or `netChanges`) drops
+   *    these pairs before they reach AutoCDC.
+   *  - Sequencing by anything other than `_commit_version`: the [[Changelog]] contract only
+   *    guarantees that `_commit_version`'s natural ordering matches commit order (see the metadata
+   *    column contract on [[Changelog]]). Any other column (including `_commit_timestamp`, which
+   *    is only strictly increasing across micro-batches, not within one) may tie or mis-order two
+   *    changes to the same key, so AutoCDC requires the sequencing expression to reference
+   *    `_commit_version`.
+   *
+   * @param source          The detected changelog source descriptor.
+   * @param df              The resolved source change-data feed.
+   * @param sequencing      The user-provided sequencing expression.
+   * @param destinationName The quoted destination table name, surfaced in error messages.
+   * @param caseSensitive   Whether column-name comparison is case-sensitive.
+   */
+  def validateSource(
+      source: ChangelogSource,
+      df: DataFrame,
+      sequencing: Column,
+      destinationName: String,
+      caseSensitive: Boolean): Unit = {
+    if (source.representsUpdateAsDeleteAndInsert && !source.computeUpdates) {
+      throw new AnalysisException(
+        errorClass = "AUTOCDC_CHANGELOG_REQUIRES_COMPUTE_UPDATES",
+        messageParameters = Map("tableName" -> destinationName)
+      )
+    }
+    if (source.containsCarryoverRows && !source.removesCarryoverRows) {
+      throw new AnalysisException(
+        errorClass = "AUTOCDC_CHANGELOG_REQUIRES_CARRYOVER_REMOVAL",
+        messageParameters = Map("tableName" -> destinationName)
+      )
+    }
+    requireCommitVersionSequencing(df, sequencing, destinationName, caseSensitive)
+  }
+
+  /**
+   * Fails when a changelog source is sequenced by something other than `_commit_version`. The
+   * [[Changelog]] contract only guarantees that `_commit_version` orders rows in commit order, so
+   * it is the only safe choice for AutoCDC's out-of-order event reconciliation. If the sequencing
+   * expression cannot be analyzed (e.g. it references an unresolved column), validation is skipped
+   * rather than failing on an indeterminate result.
+   */
+  private def requireCommitVersionSequencing(
+      df: DataFrame,
+      sequencing: Column,
+      destinationName: String,
+      caseSensitive: Boolean): Unit = {
+    val sequencesByCommitVersion = scala.util.Try {
+      df.select(sequencing).queryExecution.analyzed.references
+        .exists(attr => nameMatches(attr.name, CommitVersionColumn, caseSensitive))
+    }.getOrElse(true)
+    if (!sequencesByCommitVersion) {
+      throw new AnalysisException(
+        errorClass = "AUTOCDC_CHANGELOG_REQUIRES_COMMIT_VERSION_SEQUENCING",
+        messageParameters = Map("tableName" -> destinationName)
+      )
+    }
+  }
+
+  /**
+   * Derives the effective [[ChangeArgs]] for a changelog-backed source: fills in the delete
+   * condition from `_change_type` when the user did not provide one (an explicit user condition
+   * wins), and excludes the native CDC metadata columns from the target output.
+   */
+  def deriveEffectiveChangeArgs(
+      base: ChangeArgs,
+      sourceSchema: StructType,
+      caseSensitive: Boolean): ChangeArgs = {
+    val changeTypeCol = resolvedColumnName(sourceSchema, ChangeTypeColumn, caseSensitive)
+    val derivedDeleteCondition =
+      base.deleteCondition.orElse(Some(deleteCondition(changeTypeCol)))
+    val metadataExclusions = metadataColumnsToExclude(sourceSchema, caseSensitive)
+    val mergedSelection = excludeColumns(base.columnSelection, metadataExclusions, caseSensitive)
+    base.copy(deleteCondition = derivedDeleteCondition, columnSelection = mergedSelection)
+  }
+
+  /**
+   * Filters out `update_preimage` rows from a changelog feed. The pre-image carries the old value
+   * of an updated row; for SCD1 upsert semantics only the post-image (and inserts) matter, and
+   * keeping the pre-image would apply a stale upsert.
+   */
+  def filterOutPreimages(df: DataFrame, changeTypeColumn: String): DataFrame = {
+    df.filter(
+      F.col(QuotingUtils.quoteIdentifier(changeTypeColumn)) =!= Changelog.CHANGE_TYPE_UPDATE_PREIMAGE
+    )
+  }
+
+  /** The delete condition derived from the `_change_type` column for a changelog source. */
+  private def deleteCondition(changeTypeColumn: String): Column = {
+    F.col(QuotingUtils.quoteIdentifier(changeTypeColumn)) === Changelog.CHANGE_TYPE_DELETE
+  }
+
+  /**
+   * Locates a [[ChangelogTable]]-backed relation in a resolved logical plan. The changelog read is
+   * resolved to a [[DataSourceV2Relation]] (batch) or [[StreamingRelationV2]] (streaming) wrapping
+   * a [[ChangelogTable]], possibly under post-processing operators injected by the analyzer.
+   */
+  private def findChangelogTable(plan: LogicalPlan): Option[ChangelogTable] = {
+    plan
+      .collect {
+        case r: DataSourceV2Relation => r.table
+        case r: StreamingRelationV2 => r.table
+      }
+      .collectFirst { case table: ChangelogTable => table }
+  }
+
+  /** Whether the schema carries all three native CDC metadata columns with the expected types. */
+  private def hasChangelogMetadataColumns(schema: StructType, caseSensitive: Boolean): Boolean = {
+    def field(name: String) = findField(schema, name, caseSensitive)
+    field(ChangeTypeColumn).exists(_.dataType == StringType) &&
+    field(CommitVersionColumn).exists(f => f.dataType == LongType || f.dataType == StringType) &&
+    field(CommitTimestampColumn).exists(_.dataType == TimestampType)
+  }
+
+  /** The metadata columns actually present in the schema, as [[UnqualifiedColumnName]]s. */
+  private def metadataColumnsToExclude(
+      schema: StructType,
+      caseSensitive: Boolean): Seq[UnqualifiedColumnName] = {
+    MetadataColumns.flatMap(name => findField(schema, name, caseSensitive)).map { field =>
+      UnqualifiedColumnName(Seq(field.name))
+    }
+  }
+
+  /** Returns the actual (case-preserving) field name matching `name`, or `name` if absent. */
+  private def resolvedColumnName(
+      schema: StructType,
+      name: String,
+      caseSensitive: Boolean): String = {
+    findField(schema, name, caseSensitive).map(_.name).getOrElse(name)
+  }
+
+  private def findField(schema: StructType, name: String, caseSensitive: Boolean) = {
+    schema.fields.find { f =>
+      if (caseSensitive) f.name == name else f.name.equalsIgnoreCase(name)
+    }
+  }
+
+  private def nameMatches(attrName: String, colName: String, caseSensitive: Boolean): Boolean = {
+    if (caseSensitive) attrName == colName else attrName.equalsIgnoreCase(colName)
+  }
+
+  /** Merges the metadata-column exclusions into the user's column selection. */
+  private def excludeColumns(
+      selection: Option[ColumnSelection],
+      toExclude: Seq[UnqualifiedColumnName],
+      caseSensitive: Boolean): Option[ColumnSelection] = {
+    if (toExclude.isEmpty) {
+      selection
+    } else {
+      selection match {
+        case None =>
+          Some(ColumnSelection.ExcludeColumns(toExclude))
+        case Some(ColumnSelection.ExcludeColumns(cols)) =>
+          Some(ColumnSelection.ExcludeColumns((cols ++ toExclude).distinct))
+        case Some(ColumnSelection.IncludeColumns(cols)) =>
+          val excludeNames = toExclude.map(_.name)
+          def matches(a: String, b: String): Boolean =
+            if (caseSensitive) a == b else a.equalsIgnoreCase(b)
+          Some(
+            ColumnSelection.IncludeColumns(
+              cols.filterNot(c => excludeNames.exists(matches(_, c.name)))
+            )
+          )
+      }
+    }
+  }
+}

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/CoreDataflowNodeProcessor.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/CoreDataflowNodeProcessor.scala
@@ -23,6 +23,7 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.pipelines.autocdc.ChangelogAutoCdcBridge
 import org.apache.spark.sql.pipelines.graph.DataflowGraphTransformer.{
   TransformNodeFailedException,
   TransformNodeRetryableException
@@ -203,7 +204,15 @@ private class FlowResolver(rawGraph: DataflowGraph) {
       flow: UnresolvedFlow,
       funcResult: FlowFunctionResult): ResolvedFlow = {
     flow match {
-      case acf: AutoCdcFlow => new AutoCdcMergeFlow(acf, funcResult)
+      case acf: AutoCdcFlow =>
+        val df = funcResult.dataFrame.get
+        val caseSensitive = df.sparkSession.sessionState.conf.caseSensitiveAnalysis
+        ChangelogAutoCdcBridge.analyzeSource(df, caseSensitive) match {
+          case Some(changelogSource) =>
+            new ChangelogAutoCdcMergeFlow(acf, funcResult, changelogSource)
+          case None =>
+            new AutoCdcMergeFlow(acf, funcResult)
+        }
       case utf: UntypedFlow => transformUntypedFlowToResolvedFlow(utf, funcResult)
     }
   }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/Flow.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/Flow.scala
@@ -257,9 +257,8 @@ class AutoCdcMergeFlow(
   protected val caseSensitiveAnalysis: Boolean = spark.sessionState.conf.caseSensitiveAnalysis
 
   /**
-   * The effective CDC configuration for this flow. The base flow uses the user-provided
-   * [[ChangeArgs]] unchanged; [[ChangelogAutoCdcMergeFlow]] augments it with a derived delete
-   * condition and metadata-column exclusions.
+   * The effective CDC configuration for this flow.
+   * Subclasses can override this method to return derived ChangeArgs.
    */
   def changeArgs: ChangeArgs = flow.changeArgs
 

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/Flow.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/Flow.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.pipelines.autocdc.{
   AutoCdcReservedNames,
   CaseSensitivityLabels,
   ChangeArgs,
+  ChangelogAutoCdcBridge,
   ColumnSelection,
   Scd1BatchProcessor,
   ScdType
@@ -253,6 +254,13 @@ class AutoCdcMergeFlow(
 ) extends ResolvedFlow {
   requireReservedPrefixAbsentInSourceColumns()
 
+  protected val caseSensitiveAnalysis: Boolean = spark.sessionState.conf.caseSensitiveAnalysis
+
+  /**
+   * The effective CDC configuration for this flow. The base flow uses the user-provided
+   * [[ChangeArgs]] unchanged; [[ChangelogAutoCdcMergeFlow]] augments it with a derived delete
+   * condition and metadata-column exclusions.
+   */
   def changeArgs: ChangeArgs = flow.changeArgs
 
   /** The user-selected projection of [[df.schema]] (i.e. before the SCD metadata column). */
@@ -395,4 +403,39 @@ class AutoCdcMergeFlow(
         )
       }
   }
+
+}
+
+/**
+ * An [[AutoCdcMergeFlow]] whose source is a native CDC
+ * [[org.apache.spark.sql.connector.catalog.Changelog]] read (e.g. a view defined via
+ * `STREAM ... CHANGES` or `DataStreamReader.changes`). AutoCDC derives its CDC semantics (delete
+ * detection, metadata-column exclusion, and `update_preimage` filtering) from the changelog
+ * contract rather than requiring the user to hand-map them.
+ */
+class ChangelogAutoCdcMergeFlow(
+    flow: AutoCdcFlow,
+    funcResult: FlowFunctionResult,
+    changelogSource: ChangelogAutoCdcBridge.ChangelogSource
+) extends AutoCdcMergeFlow(flow, funcResult) {
+
+  ChangelogAutoCdcBridge.validateSource(
+    source = changelogSource,
+    df = df,
+    sequencing = flow.changeArgs.sequencing,
+    destinationName = destinationIdentifier.quotedString,
+    caseSensitive = caseSensitiveAnalysis
+  )
+
+  /** The `_change_type` column name, used to filter `update_preimage` rows from the live feed. */
+  private[graph] def changeTypeColumn: String = changelogSource.changeTypeColumn
+
+  override def changeArgs: ChangeArgs = effectiveChangeArgs
+
+  private lazy val effectiveChangeArgs: ChangeArgs =
+    ChangelogAutoCdcBridge.deriveEffectiveChangeArgs(
+      base = flow.changeArgs,
+      sourceSchema = df.schema,
+      caseSensitive = caseSensitiveAnalysis
+    )
 }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/FlowExecution.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/FlowExecution.scala
@@ -33,11 +33,12 @@ import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.sql.{AnalysisException, Dataset, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.classic.ClassicConversions._
-import org.apache.spark.sql.classic.SparkSession
+import org.apache.spark.sql.classic.{DataFrame, SparkSession}
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, SupportsRowLevelOperations, Table => CatalogTable, TableCatalog, TableInfo}
 import org.apache.spark.sql.pipelines.autocdc.{
   AutoCdcReservedNames,
   ChangeArgs,
+  ChangelogAutoCdcBridge,
   Scd1BatchProcessor,
   Scd1ForeachBatchHandler
 }
@@ -628,7 +629,7 @@ class Scd1MergeStreamingWrite(
   override protected def changeArgs: ChangeArgs = flow.changeArgs
 
   override def startStream(): StreamingQuery = {
-    val sourceChangeDataFeed = graph.reanalyzeFlow(flow).df
+    val sourceChangeDataFeed = transformSourceFeed(graph.reanalyzeFlow(flow).df)
 
     // The auxiliary table is created here (at flow execution) rather than during flow resolution
     // or dataset materialization for two reasons:
@@ -657,6 +658,12 @@ class Scd1MergeStreamingWrite(
       })
       .start()
   }
+
+  /**
+   * Transforms the reanalyzed live source feed before it is written.
+   * Subclasses can override this method to apply additional transformations to the source feed.
+   */
+  protected def transformSourceFeed(reanalyzedFeed: DataFrame): DataFrame = reanalyzedFeed
 
   override protected lazy val auxiliaryTableSchema: StructType =
     // SCD1's auxiliary table is just keys + the CDC metadata struct; no user data columns. Keys
@@ -696,4 +703,33 @@ class Scd1MergeStreamingWrite(
         )
       )
   }
+}
+
+/**
+ * A [[Scd1MergeStreamingWrite]] whose source is a native CDC changelog read. It drops
+ * `update_preimage` rows from the live source feed so that only inserts and update post-images are
+ * treated as upserts; deletes are detected via the derived delete condition in `changeArgs`.
+ */
+class ChangelogScd1MergeStreamingWrite(
+    identifier: TableIdentifier,
+    flow: AutoCdcMergeFlow,
+    graph: DataflowGraph,
+    updateContext: PipelineUpdateContext,
+    checkpointPath: String,
+    trigger: Trigger,
+    destination: Table,
+    sqlConf: Map[String, String],
+    changeTypeColumn: String
+) extends Scd1MergeStreamingWrite(
+      identifier,
+      flow,
+      graph,
+      updateContext,
+      checkpointPath,
+      trigger,
+      destination,
+      sqlConf) {
+
+  override protected def transformSourceFeed(reanalyzedFeed: DataFrame): DataFrame =
+    ChangelogAutoCdcBridge.filterOutPreimages(reanalyzedFeed, changeTypeColumn)
 }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/FlowPlanner.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/FlowPlanner.scala
@@ -83,16 +83,31 @@ class FlowPlanner(
             val flowMetadata = FlowSystemMetadata(updateContext, acmf, graph)
             output match {
               case o: Table =>
-                new Scd1MergeStreamingWrite(
-                  identifier = acmf.identifier,
-                  flow = acmf,
-                  graph = graph,
-                  updateContext = updateContext,
-                  checkpointPath = flowMetadata.latestCheckpointLocation,
-                  trigger = triggerFor(acmf),
-                  destination = o,
-                  sqlConf = acmf.sqlConf
-                )
+                acmf match {
+                  case changelogFlow: ChangelogAutoCdcMergeFlow =>
+                    new ChangelogScd1MergeStreamingWrite(
+                      identifier = changelogFlow.identifier,
+                      flow = changelogFlow,
+                      graph = graph,
+                      updateContext = updateContext,
+                      checkpointPath = flowMetadata.latestCheckpointLocation,
+                      trigger = triggerFor(changelogFlow),
+                      destination = o,
+                      sqlConf = changelogFlow.sqlConf,
+                      changeTypeColumn = changelogFlow.changeTypeColumn
+                    )
+                  case _ =>
+                    new Scd1MergeStreamingWrite(
+                      identifier = acmf.identifier,
+                      flow = acmf,
+                      graph = graph,
+                      updateContext = updateContext,
+                      checkpointPath = flowMetadata.latestCheckpointLocation,
+                      trigger = triggerFor(acmf),
+                      destination = o,
+                      sqlConf = acmf.sqlConf
+                    )
+                }
               case _ => unsupportedDestinationType(acmf, output)
             }
           case ScdType.Type2 =>

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/AutoCdcFlowSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/autocdc/AutoCdcFlowSuite.scala
@@ -17,18 +17,25 @@
 
 package org.apache.spark.sql.pipelines.autocdc
 
-import java.util.Locale
+import java.util.{HashMap => JHashMap, Locale}
 
 import scala.util.Success
 
 import org.apache.spark.sql.{functions => F, AnalysisException, Column, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.classic.DataFrame
+import org.apache.spark.sql.connector.catalog.{
+  ChangelogProperties,
+  Column => V2Column,
+  Identifier,
+  InMemoryChangelogCatalog
+}
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.pipelines.graph.{
   AutoCdcFlow,
   AutoCdcMergeFlow,
+  ChangelogAutoCdcMergeFlow,
   FlowFunction,
   FlowFunctionResult,
   Input,
@@ -165,16 +172,25 @@ class AutoCdcFlowSuite extends QueryTest with SharedSparkSession {
       keys: Seq[UnqualifiedColumnName] = Seq(UnqualifiedColumnName("id")),
       sequencing: Column = F.col("seq"),
       storedAsScdType: ScdType = ScdType.Type1,
-      columnSelection: Option[ColumnSelection] = None): AutoCdcMergeFlow = {
+      columnSelection: Option[ColumnSelection] = None,
+      deleteCondition: Option[Column] = None): AutoCdcMergeFlow = {
     val flow = newAutoCdcFlow(
       changeArgs = ChangeArgs(
         keys = keys,
         sequencing = sequencing,
         storedAsScdType = storedAsScdType,
-        columnSelection = columnSelection
+        columnSelection = columnSelection,
+        deleteCondition = deleteCondition
       )
     )
-    new AutoCdcMergeFlow(flow, successfulFuncResult(sourceDf))
+    val funcResult = successfulFuncResult(sourceDf)
+    val caseSensitive = sourceDf.sparkSession.sessionState.conf.caseSensitiveAnalysis
+    ChangelogAutoCdcBridge.analyzeSource(sourceDf, caseSensitive) match {
+      case Some(changelogSource) =>
+        new ChangelogAutoCdcMergeFlow(flow, funcResult, changelogSource)
+      case None =>
+        new AutoCdcMergeFlow(flow, funcResult)
+    }
   }
 
   /** A stable 3-column source streaming dataframe used across most schema tests. */
@@ -563,6 +579,255 @@ class AutoCdcFlowSuite extends QueryTest with SharedSparkSession {
         "caseSensitivity" -> CaseSensitivityLabels.CaseInsensitive,
         "keyColumnName" -> "id"
       )
+    )
+  }
+
+  // ===========================================================================================
+  // Native CDC changelog source auto-detection tests (ChangelogAutoCdcBridge wiring)
+  //
+  // These exercise the analysis-time behaviour of [[AutoCdcMergeFlow]] when its source is a
+  // native CDC changelog read (`DataStreamReader.changes`): delete-condition derivation,
+  // metadata-column exclusion, explicit-override precedence, and the computeUpdates validation.
+  // They do not run a pipeline, so no streaming execution is involved.
+  // ===========================================================================================
+
+  private val changelogCatalogName = "cdc_unit"
+  private val changelogNamespace = "cdcns"
+
+  /**
+   * Register an [[InMemoryChangelogCatalog]], create a changelog source table with the given data
+   * columns and properties, and pass a streaming `changes()` DataFrame over it to `f`. The
+   * catalog config and cached catalog instances are cleaned up afterwards.
+   */
+  private def withChangelogSource(
+      tableName: String,
+      dataColumns: Seq[V2Column],
+      properties: ChangelogProperties = ChangelogProperties(),
+      options: Map[String, String] = Map.empty)(f: DataFrame => Unit): Unit = {
+    withSQLConf(
+      s"spark.sql.catalog.$changelogCatalogName" -> classOf[InMemoryChangelogCatalog].getName
+    ) {
+      try {
+        spark.sql(s"CREATE NAMESPACE IF NOT EXISTS $changelogCatalogName.$changelogNamespace")
+        val cat = spark.sessionState.catalogManager
+          .catalog(changelogCatalogName)
+          .asInstanceOf[InMemoryChangelogCatalog]
+        val ident = Identifier.of(Array(changelogNamespace), tableName)
+        cat.createTable(ident, dataColumns.toArray, Array.empty, new JHashMap[String, String]())
+        cat.setChangelogProperties(ident, properties)
+        val reader = (Map("startingVersion" -> "1") ++ options).foldLeft(spark.readStream) {
+          case (r, (k, v)) => r.option(k, v)
+        }
+        f(reader.changes(s"$changelogCatalogName.$changelogNamespace.$tableName"))
+      } finally {
+        spark.sessionState.catalogManager.reset()
+      }
+    }
+  }
+
+  /** Standard `(id BIGINT, name STRING)` changelog data columns. */
+  private def idNameColumns: Seq[V2Column] =
+    Seq(V2Column.create("id", LongType), V2Column.create("name", StringType))
+
+  test("AutoCdcMergeFlow auto-detects a changelog source: derives delete condition and " +
+    "excludes metadata columns") {
+    withChangelogSource("src", idNameColumns) { sourceDf =>
+      val resolvedFlow = newAutoCdcMergeFlow(
+        sourceDf = sourceDf,
+        keys = Seq(UnqualifiedColumnName("id")),
+        sequencing = F.col("_commit_version")
+      )
+
+      // The three native CDC metadata columns are excluded; only user data columns plus the
+      // AutoCDC metadata struct remain.
+      assert(
+        resolvedFlow.schema.fieldNames.toSeq ==
+        Seq("id", "name", AutoCdcReservedNames.cdcMetadataColName)
+      )
+      // A delete condition is derived from `_change_type`.
+      val derived = resolvedFlow.changeArgs.deleteCondition
+      assert(derived.isDefined)
+      assert(derived.get.toString.contains("_change_type"))
+    }
+  }
+
+  test("AutoCdcMergeFlow lets an explicit delete condition override the derived one for a " +
+    "changelog source") {
+    withChangelogSource("src", idNameColumns) { sourceDf =>
+      val explicit = F.lit(false)
+      val resolvedFlow = newAutoCdcMergeFlow(
+        sourceDf = sourceDf,
+        keys = Seq(UnqualifiedColumnName("id")),
+        sequencing = F.col("_commit_version"),
+        deleteCondition = Some(explicit)
+      )
+      // The user-supplied condition is preserved verbatim, not replaced by the derived one.
+      assert(resolvedFlow.changeArgs.deleteCondition.contains(explicit))
+      assert(!resolvedFlow.changeArgs.deleteCondition.get.toString.contains("_change_type"))
+    }
+  }
+
+  test("AutoCdcMergeFlow merges metadata exclusions with a user ExcludeColumns selection") {
+    withChangelogSource(
+      "src",
+      Seq(
+        V2Column.create("id", LongType),
+        V2Column.create("name", StringType),
+        V2Column.create("note", StringType)
+      )
+    ) { sourceDf =>
+      val resolvedFlow = newAutoCdcMergeFlow(
+        sourceDf = sourceDf,
+        keys = Seq(UnqualifiedColumnName("id")),
+        sequencing = F.col("_commit_version"),
+        columnSelection = Some(ColumnSelection.ExcludeColumns(Seq(UnqualifiedColumnName("note"))))
+      )
+      // Both the user-excluded `note` and the derived metadata columns are dropped.
+      assert(
+        resolvedFlow.schema.fieldNames.toSeq ==
+        Seq("id", "name", AutoCdcReservedNames.cdcMetadataColName)
+      )
+    }
+  }
+
+  test("AutoCdcMergeFlow rejects a delete+insert changelog without computeUpdates") {
+    withChangelogSource(
+      "src",
+      Seq(
+        V2Column.create("id", LongType),
+        V2Column.create("name", StringType),
+        V2Column.create("row_version", LongType)
+      ),
+      properties = ChangelogProperties(
+        representsUpdateAsDeleteAndInsert = true,
+        rowIdNames = Seq("id"),
+        rowVersionName = Some("row_version")
+      )
+    ) { sourceDf =>
+      checkError(
+        exception = intercept[AnalysisException] {
+          newAutoCdcMergeFlow(
+            sourceDf = sourceDf,
+            keys = Seq(UnqualifiedColumnName("id")),
+            sequencing = F.col("_commit_version")
+          )
+        },
+        condition = "AUTOCDC_CHANGELOG_REQUIRES_COMPUTE_UPDATES",
+        sqlState = "22023",
+        parameters = Map("tableName" -> testIdentifier.quotedString)
+      )
+    }
+  }
+
+  test("AutoCdcMergeFlow accepts a delete+insert changelog when computeUpdates is enabled") {
+    withChangelogSource(
+      "src",
+      Seq(
+        V2Column.create("id", LongType),
+        V2Column.create("name", StringType),
+        V2Column.create("row_version", LongType)
+      ),
+      properties = ChangelogProperties(
+        representsUpdateAsDeleteAndInsert = true,
+        rowIdNames = Seq("id"),
+        rowVersionName = Some("row_version")
+      ),
+      options = Map("computeUpdates" -> "true")
+    ) { sourceDf =>
+      // No exception: computeUpdates materializes pre/post-images, so the configuration is valid.
+      val resolvedFlow = newAutoCdcMergeFlow(
+        sourceDf = sourceDf,
+        keys = Seq(UnqualifiedColumnName("id")),
+        sequencing = F.col("_commit_version")
+      )
+      assert(resolvedFlow.changeArgs.deleteCondition.isDefined)
+    }
+  }
+
+  test("AutoCdcMergeFlow rejects a carry-over changelog read with deduplicationMode=none") {
+    withChangelogSource(
+      "src",
+      Seq(
+        V2Column.create("id", LongType),
+        V2Column.create("name", StringType),
+        V2Column.create("row_version", LongType)
+      ),
+      properties = ChangelogProperties(
+        containsCarryoverRows = true,
+        rowIdNames = Seq("id"),
+        rowVersionName = Some("row_version")
+      ),
+      options = Map("deduplicationMode" -> "none")
+    ) { sourceDf =>
+      checkError(
+        exception = intercept[AnalysisException] {
+          newAutoCdcMergeFlow(
+            sourceDf = sourceDf,
+            keys = Seq(UnqualifiedColumnName("id")),
+            sequencing = F.col("_commit_version")
+          )
+        },
+        condition = "AUTOCDC_CHANGELOG_REQUIRES_CARRYOVER_REMOVAL",
+        sqlState = "22023",
+        parameters = Map("tableName" -> testIdentifier.quotedString)
+      )
+    }
+  }
+
+  test("AutoCdcMergeFlow accepts a carry-over changelog read with carry-over removal enabled") {
+    withChangelogSource(
+      "src",
+      Seq(
+        V2Column.create("id", LongType),
+        V2Column.create("name", StringType),
+        V2Column.create("row_version", LongType)
+      ),
+      properties = ChangelogProperties(
+        containsCarryoverRows = true,
+        rowIdNames = Seq("id"),
+        rowVersionName = Some("row_version")
+      )
+      // deduplicationMode defaults to dropCarryovers, which removes carry-over pairs.
+    ) { sourceDf =>
+      val resolvedFlow = newAutoCdcMergeFlow(
+        sourceDf = sourceDf,
+        keys = Seq(UnqualifiedColumnName("id")),
+        sequencing = F.col("_commit_version")
+      )
+      assert(resolvedFlow.changeArgs.deleteCondition.isDefined)
+    }
+  }
+
+  test("AutoCdcMergeFlow rejects a changelog source not sequenced by _commit_version") {
+    withChangelogSource("src", idNameColumns) { sourceDf =>
+      // `_commit_timestamp` is only strictly increasing across micro-batches, not within one, so
+      // it is not a safe per-key sequencer and is rejected just like any other non-version column.
+      checkError(
+        exception = intercept[AnalysisException] {
+          newAutoCdcMergeFlow(
+            sourceDf = sourceDf,
+            keys = Seq(UnqualifiedColumnName("id")),
+            sequencing = F.col("_commit_timestamp")
+          )
+        },
+        condition = "AUTOCDC_CHANGELOG_REQUIRES_COMMIT_VERSION_SEQUENCING",
+        sqlState = "22023",
+        parameters = Map("tableName" -> testIdentifier.quotedString)
+      )
+    }
+  }
+
+  test("AutoCdcMergeFlow leaves a non-changelog source unchanged") {
+    // A plain source that happens to carry a `_commit_version` column is not a changelog: no
+    // delete condition is derived and no columns are excluded.
+    val resolvedFlow = newAutoCdcMergeFlow(
+      sourceDf = sourceDfWithExtraColumns("_commit_version" -> LongType),
+      sequencing = F.col("_commit_version")
+    )
+    assert(resolvedFlow.changeArgs.deleteCondition.isEmpty)
+    assert(
+      resolvedFlow.schema.fieldNames.toSeq ==
+      Seq("id", "seq", "_commit_version", AutoCdcReservedNames.cdcMetadataColName)
     )
   }
 }

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcChangelogSourceSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcChangelogSourceSuite.scala
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.pipelines.graph
+
+import org.apache.spark.sql.{functions, Row}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.classic.DataFrame
+import org.apache.spark.sql.connector.catalog.{
+  ChangelogProperties,
+  Column => V2Column,
+  Identifier,
+  InMemoryChangelogCatalog
+}
+import org.apache.spark.sql.connector.catalog.Changelog.{
+  CHANGE_TYPE_DELETE,
+  CHANGE_TYPE_INSERT,
+  CHANGE_TYPE_UPDATE_POSTIMAGE,
+  CHANGE_TYPE_UPDATE_PREIMAGE
+}
+import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
+import org.apache.spark.sql.pipelines.autocdc.AutoCdcReservedNames
+import org.apache.spark.sql.pipelines.utils.ExecutionTest
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{LongType, StringType}
+import org.apache.spark.unsafe.types.UTF8String
+
+/**
+ * End-to-end tests for AutoCDC SCD type 1 flows whose source is a native CDC
+ * [[org.apache.spark.sql.connector.catalog.Changelog]] read (via
+ * `DataStreamReader.changes`). These exercise the [[org.apache.spark.sql.pipelines.autocdc.
+ * ChangelogAutoCdcBridge]] auto-detection: the delete condition and metadata-column exclusion are
+ * derived from the changelog contract rather than supplied by the user, and `update_preimage`
+ * rows are filtered from the feed.
+ */
+class AutoCdcChangelogSourceSuite
+    extends ExecutionTest
+    with SharedSparkSession
+    with AutoCdcGraphExecutionTestMixin {
+
+  /** A second catalog, backed by [[InMemoryChangelogCatalog]], serving the changelog sources. */
+  private val cdcCatalog: String = "cdc"
+  private val cdcNamespace: String = "cdcns"
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    spark.conf.set(
+      s"spark.sql.catalog.$cdcCatalog",
+      classOf[InMemoryChangelogCatalog].getName
+    )
+    spark.sql(s"CREATE NAMESPACE IF NOT EXISTS $cdcCatalog.$cdcNamespace")
+  }
+
+  override protected def afterEach(): Unit = {
+    spark.sessionState.conf.unsetConf(s"spark.sql.catalog.$cdcCatalog")
+    super.afterEach()
+  }
+
+  /** The [[InMemoryChangelogCatalog]] instance backing [[cdcCatalog]]. */
+  private def changelogCatalog: InMemoryChangelogCatalog =
+    spark.sessionState.catalogManager
+      .catalog(cdcCatalog)
+      .asInstanceOf[InMemoryChangelogCatalog]
+
+  /** Identifier of a changelog source table under [[cdcCatalog]].[[cdcNamespace]]. */
+  private def sourceIdent(table: String): Identifier =
+    Identifier.of(Array(cdcNamespace), table)
+
+  /**
+   * Create an `(id BIGINT, name STRING)` changelog source table and add the given change rows.
+   * Each row is `(id, name, _change_type, _commit_version, _commit_timestamp)`.
+   */
+  private def createChangelogSource(
+      table: String,
+      rows: Seq[(Long, String, String, Long)],
+      properties: ChangelogProperties = ChangelogProperties()): Unit = {
+    val cat = changelogCatalog
+    val ident = sourceIdent(table)
+    cat.createTable(
+      ident,
+      Array(V2Column.create("id", LongType), V2Column.create("name", StringType)),
+      Array.empty,
+      new java.util.HashMap[String, String]()
+    )
+    cat.setChangelogProperties(ident, properties)
+    val internalRows = rows.map { case (id, name, changeType, version) =>
+      InternalRow(
+        id,
+        UTF8String.fromString(name),
+        UTF8String.fromString(changeType),
+        version,
+        // _commit_timestamp in micros; unused for raw (non-post-processed) streaming reads.
+        version * 1000000L
+      )
+    }
+    cat.addChangeRows(ident, internalRows)
+  }
+
+  /** A streaming `changes()` DataFrame over a changelog source table. */
+  private def changelogStream(table: String, options: Map[String, String] = Map.empty): DataFrame = {
+    val reader = (Map("startingVersion" -> "1") ++ options).foldLeft(spark.readStream) {
+      case (r, (k, v)) => r.option(k, v)
+    }
+    reader.changes(s"$cdcCatalog.$cdcNamespace.$table")
+  }
+
+  /** Create the standard `(id, name, _cdc_metadata)` SCD1 target table. */
+  private def createTarget(table: String): Unit = {
+    spark.sql(
+      s"CREATE TABLE $catalog.$namespace.$table " +
+      s"(id BIGINT NOT NULL, name STRING, $cdcMetadataDdl)"
+    )
+  }
+
+  test("native CDC changelog source: insert/update/delete propagate to SCD1 target") {
+    createTarget("target")
+    // id=1 is inserted then updated (pre/post-image pair at v2); id=2 is inserted then deleted.
+    createChangelogSource(
+      "src",
+      Seq(
+        (1L, "alice", CHANGE_TYPE_INSERT, 1L),
+        (1L, "alice", CHANGE_TYPE_UPDATE_PREIMAGE, 2L),
+        (1L, "alice2", CHANGE_TYPE_UPDATE_POSTIMAGE, 2L),
+        (2L, "bob", CHANGE_TYPE_INSERT, 1L),
+        (2L, "bob", CHANGE_TYPE_DELETE, 3L)
+      )
+    )
+
+    val ctx = singleAutoCdcFlowPipeline(
+      flowName = "auto_cdc_flow",
+      target = "target",
+      sourceDf = changelogStream("src"),
+      keys = Seq("id"),
+      sequencing = functions.col("_commit_version")
+    )
+    runPipeline(ctx)
+
+    // id=1 converges to the update post-image (the pre-image is filtered out); id=2 is deleted.
+    checkAnswer(
+      spark.table(s"$catalog.$namespace.target"),
+      Seq(Row(1L, "alice2", cdcMeta(None, Some(2L))))
+    )
+  }
+
+  test("native CDC metadata columns are excluded from the target output") {
+    createTarget("target")
+    createChangelogSource(
+      "src",
+      Seq((1L, "alice", CHANGE_TYPE_INSERT, 1L))
+    )
+
+    val ctx = singleAutoCdcFlowPipeline(
+      flowName = "auto_cdc_flow",
+      target = "target",
+      sourceDf = changelogStream("src"),
+      keys = Seq("id"),
+      sequencing = functions.col("_commit_version")
+    )
+    runPipeline(ctx)
+
+    // The target schema must not have gained the native CDC metadata columns: only the user
+    // data columns plus the AutoCDC metadata struct.
+    val targetFields = spark.table(s"$catalog.$namespace.target").schema.fieldNames.toSeq
+    assert(targetFields == Seq("id", "name", AutoCdcReservedNames.cdcMetadataColName))
+    checkAnswer(
+      spark.table(s"$catalog.$namespace.target"),
+      Seq(Row(1L, "alice", cdcMeta(None, Some(1L))))
+    )
+  }
+
+  test("an explicit apply_as_deletes overrides the derived _change_type delete condition") {
+    createTarget("target")
+    // The row is flagged delete via `_change_type`, but the explicit delete condition never
+    // matches, so the event is treated as an upsert and the row survives.
+    createChangelogSource(
+      "src",
+      Seq(
+        (1L, "alice", CHANGE_TYPE_INSERT, 1L),
+        (1L, "alice", CHANGE_TYPE_DELETE, 2L)
+      )
+    )
+
+    val ctx = singleAutoCdcFlowPipeline(
+      flowName = "auto_cdc_flow",
+      target = "target",
+      sourceDf = changelogStream("src"),
+      keys = Seq("id"),
+      sequencing = functions.col("_commit_version"),
+      deleteCondition = Some(functions.lit(false))
+    )
+    runPipeline(ctx)
+
+    // With deletes disabled, the highest-sequenced event (the delete at v2, treated as an
+    // upsert) keeps the row alive.
+    checkAnswer(
+      spark.table(s"$catalog.$namespace.target"),
+      Seq(Row(1L, "alice", cdcMeta(None, Some(2L))))
+    )
+  }
+
+  test("changelog source representing updates as delete+insert without computeUpdates fails") {
+    createTarget("target")
+    val cat = changelogCatalog
+    val ident = sourceIdent("src")
+    cat.createTable(
+      ident,
+      Array(
+        V2Column.create("id", LongType),
+        V2Column.create("name", StringType),
+        V2Column.create("row_version", LongType)
+      ),
+      Array.empty,
+      new java.util.HashMap[String, String]()
+    )
+    cat.setChangelogProperties(
+      ident,
+      ChangelogProperties(
+        representsUpdateAsDeleteAndInsert = true,
+        rowIdNames = Seq("id"),
+        rowVersionName = Some("row_version")
+      )
+    )
+
+    val ctx = singleAutoCdcFlowPipeline(
+      flowName = "auto_cdc_flow",
+      target = "target",
+      // computeUpdates is left at its default of false.
+      sourceDf = changelogStream("src"),
+      keys = Seq("id"),
+      sequencing = functions.col("_commit_version")
+    )
+
+    val ex = intercept[RuntimeException] { runPipeline(ctx) }
+    checkErrorInPipelineFailure(
+      failure = ex,
+      condition = "AUTOCDC_CHANGELOG_REQUIRES_COMPUTE_UPDATES",
+      sqlState = Some("22023"),
+      parameters = Map("tableName" -> s"`$catalog`.`$namespace`.`target`")
+    )
+  }
+
+  test("changelog source surfacing carry-over rows with deduplicationMode=none fails") {
+    createTarget("target")
+    val cat = changelogCatalog
+    val ident = sourceIdent("src")
+    cat.createTable(
+      ident,
+      Array(
+        V2Column.create("id", LongType),
+        V2Column.create("name", StringType),
+        V2Column.create("row_version", LongType)
+      ),
+      Array.empty,
+      new java.util.HashMap[String, String]()
+    )
+    cat.setChangelogProperties(
+      ident,
+      ChangelogProperties(
+        containsCarryoverRows = true,
+        rowIdNames = Seq("id"),
+        rowVersionName = Some("row_version")
+      )
+    )
+
+    val ctx = singleAutoCdcFlowPipeline(
+      flowName = "auto_cdc_flow",
+      target = "target",
+      sourceDf = changelogStream("src", options = Map("deduplicationMode" -> "none")),
+      keys = Seq("id"),
+      sequencing = functions.col("_commit_version")
+    )
+
+    val ex = intercept[RuntimeException] { runPipeline(ctx) }
+    checkErrorInPipelineFailure(
+      failure = ex,
+      condition = "AUTOCDC_CHANGELOG_REQUIRES_CARRYOVER_REMOVAL",
+      sqlState = Some("22023"),
+      parameters = Map("tableName" -> s"`$catalog`.`$namespace`.`target`")
+    )
+  }
+
+  test("a non-changelog source is unaffected by the changelog bridge") {
+    val session = spark
+    import session.implicits._
+
+    // No metadata-column exclusion is derived for a non-changelog source, so the sequencing
+    // column flows through to the target as an ordinary data column.
+    spark.sql(
+      s"CREATE TABLE $catalog.$namespace.target_plain " +
+      s"(id BIGINT NOT NULL, name STRING, version BIGINT NOT NULL, $cdcMetadataDdl)"
+    )
+
+    // A plain streaming source with no native CDC metadata columns: no delete condition is
+    // derived, so every event is an upsert.
+    val stream = MemoryStream[(Long, String, Long)]
+    stream.addData((1L, "alice", 1L), (1L, "alice2", 2L))
+
+    val ctx = singleAutoCdcFlowPipeline(
+      flowName = "auto_cdc_flow",
+      target = "target_plain",
+      sourceDf = stream.toDF().toDF("id", "name", "version"),
+      keys = Seq("id"),
+      sequencing = functions.col("version")
+    )
+    runPipeline(ctx)
+
+    checkAnswer(
+      spark.table(s"$catalog.$namespace.target_plain"),
+      Seq(Row(1L, "alice2", 2L, cdcMeta(None, Some(2L))))
+    )
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR lets AutoCDC (SCD Type 1) flows in Spark Declarative Pipelines consume Spark **native CDC (`Changelog`) sources** directly. When a flow's source is detected as a native changelog read (e.g. a view defined via `STREAM ... CHANGES` or `DataStreamReader.changes`), AutoCDC auto-derives its CDC semantics from the changelog contract instead of requiring the user to hand-map delete conditions, metadata columns, and pre-image filtering.

The scope here is **Scala-first**; Python/Connect API surface is deferred to a follow-up.

Key pieces:

- **`ChangelogAutoCdcBridge`** (new): detects a native changelog source from a resolved source plan, derives the effective `ChangeArgs` (delete detection via `_change_type`, exclusion of `_change_type` / `_commit_version` / `_commit_timestamp` metadata columns), and filters out `update_preimage` rows from the live feed.
- **Subclass isolation**: changelog-specific behavior lives in `ChangelogAutoCdcMergeFlow` (resolution) and `ChangelogScd1MergeStreamingWrite` (execution), keeping the base `AutoCdcMergeFlow` / `Scd1MergeStreamingWrite` untouched for non-changelog sources. Dispatch is done explicitly via pattern matching in `CoreDataflowNodeProcessor.resolveFlow` and `FlowPlanner.plan`.
- **Validation** of changelog configurations that would otherwise make reconciliation ambiguous or non-deterministic, surfaced as dedicated error conditions:
  - `AUTOCDC_CHANGELOG_REQUIRES_COMPUTE_UPDATES` — updates emitted as raw delete+insert pairs share a `_commit_version`; `computeUpdates = true` is required so they materialize as `update_preimage`/`update_postimage`.
  - `AUTOCDC_CHANGELOG_REQUIRES_CARRYOVER_REMOVAL` — copy-on-write carry-over pairs at the same `_commit_version` must be dropped (`deduplicationMode` `dropCarryovers` or `netChanges`).
  - `AUTOCDC_CHANGELOG_REQUIRES_COMMIT_VERSION_SEQUENCING` — the `Changelog` contract only guarantees `_commit_version` orders changes in commit order, so the sequencing expression must reference `_commit_version`.

### Why are the changes needed?

Previously, using Spark native CDC output as input to an AutoCDC flow required the user to manually map the changelog's metadata columns and semantics into `ChangeArgs`, which is error-prone and easy to get subtly wrong (e.g. sequencing by `_commit_timestamp`, which is not strictly ordered within a micro-batch). Auto-detecting and deriving these from the changelog contract makes the integration first-class and protects correctness with explicit validation.

### Does this PR introduce _any_ user-facing change?

Yes. AutoCDC SCD1 flows can now read directly from a native CDC changelog source without manually specifying CDC semantics. Misconfigured changelog reads now fail fast with the new error conditions listed above. No change to existing non-changelog AutoCDC flows.

### How was this patch tested?

- `AutoCdcFlowSuite`: analysis-level unit tests for auto-detection, explicit override, metadata-column exclusion, and rejection/acceptance of the `computeUpdates`, carry-over, and `_commit_version` sequencing checks.
- `AutoCdcChangelogSourceSuite`: end-to-end tests covering insert/update/delete application, metadata-column exclusion, and the validation rejects.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor (Claude Opus 4.8)