### PR TITLE
[SPARK-57148][SQL] Rename splitSemiColonWithIndex to splitSemiColon

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -283,7 +283,7 @@ object StringUtils extends Logging {
   // Handles quoted strings with escapes, line comments (--), and nested block comments (/* */).
   // Semicolons inside strings or comments are not treated as delimiters.
   // Note: [SPARK-31595], [SPARK-33100], [SPARK-54876]
-  def splitSemiColonWithIndex(line: String, enableSqlScripting: Boolean): List[String] = {
+  def splitSemiColon(line: String, enableSqlScripting: Boolean): List[String] = {
     lazy val insideSqlScript: Boolean = isSqlScript(line)
     if (enableSqlScripting && insideSqlScript) return List(line)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -232,7 +232,7 @@ class StringUtilsSuite extends SparkFunSuite with SQLHelper {
   test("SQL string splitter") {
     // semicolon shouldn't delimit if in quotes
     assert(
-      splitSemiColonWithIndex(
+      splitSemiColon(
         """
           |SELECT "string;with;semicolons";
           |USE DATABASE db""".stripMargin,
@@ -244,7 +244,7 @@ class StringUtilsSuite extends SparkFunSuite with SQLHelper {
 
     // semicolon shouldn't delimit if in backticks
     assert(
-      splitSemiColonWithIndex(
+      splitSemiColon(
         """
           |SELECT `escaped;sequence;with;semicolons`;
           |USE DATABASE db""".stripMargin,
@@ -256,7 +256,7 @@ class StringUtilsSuite extends SparkFunSuite with SQLHelper {
 
     // white space around command is included in split string
     assert(
-      splitSemiColonWithIndex(
+      splitSemiColon(
         s"""
           |-- comment 1
           |-- comment 2
@@ -274,7 +274,7 @@ class StringUtilsSuite extends SparkFunSuite with SQLHelper {
 
     // SQL procedures are respected and not split, if configured
     assert(
-      splitSemiColonWithIndex(
+      splitSemiColon(
         """CREATE PROCEDURE p() BEGIN
           | SELECT 1;
           | SELECT 2;
@@ -290,63 +290,63 @@ class StringUtilsSuite extends SparkFunSuite with SQLHelper {
 
     // SPARK-54876: statement after semicolon ending with block comment should not be dropped
     assert(
-      splitSemiColonWithIndex(
+      splitSemiColon(
         "SELECT 1; SELECT 2 /* comment */",
         enableSqlScripting = false) == Seq("SELECT 1", " SELECT 2 /* comment */")
     )
 
     // SPARK-54876: line comment followed by block comment should produce empty result
     assert(
-      splitSemiColonWithIndex(
+      splitSemiColon(
         "-- foo\n/* bar */",
         enableSqlScripting = false) == Seq()
     )
 
     // SPARK-54876: line comment before block comment after semicolon
     assert(
-      splitSemiColonWithIndex(
+      splitSemiColon(
         "SELECT 1; -- foo\n /* bar */",
         enableSqlScripting = false) == Seq("SELECT 1")
     )
 
     // SPARK-54876: nested block comments
     assert(
-      splitSemiColonWithIndex(
+      splitSemiColon(
         "SELECT 1; /* outer /* inner */ */",
         enableSqlScripting = false) == Seq("SELECT 1")
     )
 
     // SPARK-54876: preceding closed block comment + line comment (no SQL statement)
     assert(
-      splitSemiColonWithIndex(
+      splitSemiColon(
         "/* a */ -- foo\n/* b */",
         enableSqlScripting = false) == Seq()
     )
 
     // SPARK-54876: unterminated block comment at EOF
     assert(
-      splitSemiColonWithIndex(
+      splitSemiColon(
         "SELECT 1; /* unterminated",
         enableSqlScripting = false) == Seq("SELECT 1", " /* unterminated")
     )
 
     // SPARK-54876: unterminated string literal (single input, no semicolon)
     assert(
-      splitSemiColonWithIndex(
+      splitSemiColon(
         "'unterminated",
         enableSqlScripting = false) == Seq("'unterminated")
     )
 
     // SPARK-54876: unterminated string literal after semicolon
     assert(
-      splitSemiColonWithIndex(
+      splitSemiColon(
         "SELECT 1; 'unterminated string",
         enableSqlScripting = false) == Seq("SELECT 1", " 'unterminated string")
     )
 
     // SPARK-54876: unterminated block comment (single input, no semicolon)
     assert(
-      splitSemiColonWithIndex(
+      splitSemiColon(
         "/* only a comment that never closes",
         enableSqlScripting = false) == Seq("/* only a comment that never closes")
     )

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -614,8 +614,8 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
   }
 
   // Splits SQL into individual statements by top-level semicolons. See
-  // [[StringUtils.splitSemiColonWithIndex]] for the implementation.
+  // [[StringUtils.splitSemiColon]] for the implementation.
   // Note: [SPARK-31595], [SPARK-33100], [SPARK-54876]
   private[hive] def splitSemiColon(line: String): JList[String] =
-    StringUtils.splitSemiColonWithIndex(line, enableSqlScripting = false).asJava
+    StringUtils.splitSemiColon(line, enableSqlScripting = false).asJava
 }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/SqlGraphRegistrationContext.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/SqlGraphRegistrationContext.scala
@@ -609,7 +609,7 @@ object SqlGraphRegistrationContext {
    * terminated statement is not returned.
    */
   private def splitSqlTextBySemicolon(sqlText: String): List[String] = StringUtils
-    .splitSemiColonWithIndex(line = sqlText, enableSqlScripting = false)
+    .splitSemiColon(line = sqlText, enableSqlScripting = false)
 
   /** Class that holds the logical plan and query origin parsed from a SQL statement. */
   case class SqlQueryPlanWithOrigin(plan: LogicalPlan, queryOrigin: QueryOrigin)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename `splitSemiColonWithIndex` to `splitSemiColon` in `StringUtils`. The method no longer returns indices (it returns `List[String]`), so the name is misleading.

Follow-up to #55466 as suggested by @cloud-fan.

### Why are the changes needed?

The method was originally named `splitSemiColonWithIndex` when it returned index information. After the structural scanner refactor in SPARK-54876, it returns `List[String]` with no index information. The name should match the return type.

### Does this PR introduce _any_ user-facing change?

No. This is an internal API rename (package-private method).

### How was this patch tested?

Existing tests pass. No behavioral change.

### Was this patch authored or co-authored using generative AI tooling?

Yes.