### PR TITLE
[MINOR][PYTHON][DOC] Fix broken See Also links in pyspark.sql.functions

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -4452,7 +4452,7 @@ def var_samp(col: "ColumnOrName") -> Column:
     --------
     :meth:`pyspark.sql.functions.variance`
     :meth:`pyspark.sql.functions.var_pop`
-    :meth:`pyspark.sql.functions.std_samp`
+    :meth:`pyspark.sql.functions.stddev_samp`
 
     Examples
     --------
@@ -4492,7 +4492,7 @@ def var_pop(col: "ColumnOrName") -> Column:
     --------
     :meth:`pyspark.sql.functions.variance`
     :meth:`pyspark.sql.functions.var_samp`
-    :meth:`pyspark.sql.functions.std_pop`
+    :meth:`pyspark.sql.functions.stddev_pop`
 
     Examples
     --------


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix two broken `See Also` cross-references in `pyspark/sql/functions/builtin.py`:

- `var_samp`: `std_samp` → `stddev_samp`
- `var_pop`: `std_pop` → `stddev_pop`

The functions `std_samp` and `std_pop` do not exist in `pyspark.sql.functions`. The correct names are `stddev_samp` and `stddev_pop`, which are the sample and population standard deviation functions respectively.

### Why are the changes needed?

The broken links produce dead references in the generated API documentation. For example, the current published docs for `var_samp` show a broken `See Also` entry:
https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.var_samp.html?highlight=var_samp#pyspark.sql.functions.var_samp


<img width="1089" height="243" alt="image" src="https://github.com/user-attachments/assets/9b9df766-8688-4427-82aa-24b36629069f" />

### Does this PR introduce _any_ user-facing change?

No. Documentation-only fix.

### How was this patch tested?

No tests needed for doc-only fixes. Verified programmatically that `stddev_samp` and `stddev_pop` are valid function names defined in `builtin.py`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 4.6