### PR TITLE
[MINOR][PYTHON][TEST] Use assertEqual instead of assertTrue in PySpark tests

### DIFF
--- a/python/pyspark/ml/tests/test_algorithms.py
+++ b/python/pyspark/ml/tests/test_algorithms.py
@@ -190,9 +190,9 @@ class KMeansTests(SparkSessionTestCase):
         kmeans = KMeans(k=3, seed=1, distanceMeasure="cosine")
         model = kmeans.fit(df)
         result = model.transform(df).collect()
-        self.assertTrue(result[0].prediction == result[1].prediction)
-        self.assertTrue(result[2].prediction == result[3].prediction)
-        self.assertTrue(result[4].prediction == result[5].prediction)
+        self.assertEqual(result[0].prediction, result[1].prediction)
+        self.assertEqual(result[2].prediction, result[3].prediction)
+        self.assertEqual(result[4].prediction, result[5].prediction)
 
 
 class LDATest(SparkSessionTestCase):

--- a/python/pyspark/ml/tests/test_evaluation.py
+++ b/python/pyspark/ml/tests/test_evaluation.py
@@ -289,7 +289,7 @@ class EvaluatorTestsMixin:
             # Load the saved evaluator
             evaluator2 = ClusteringEvaluator.load(tmp_dir)
             self.assertEqual(evaluator2.getPredictionCol(), "prediction")
-            self.assertTrue(str(evaluator) == str(evaluator2))
+            self.assertEqual(str(evaluator), str(evaluator2))
 
     def test_clustering_evaluator_with_cosine_distance(self):
         featureAndPredictions = map(
@@ -339,7 +339,7 @@ class EvaluatorTestsMixin:
             # Load the saved evaluator
             evaluator2 = RegressionEvaluator.load(tmp_dir)
             self.assertEqual(evaluator2.getPredictionCol(), "raw")
-            self.assertTrue(str(evaluator) == str(evaluator2))
+            self.assertEqual(str(evaluator), str(evaluator2))
 
         evaluator_with_weights = RegressionEvaluator(predictionCol="raw", weightCol="weight")
         weighted_rmse = evaluator_with_weights.evaluate(dataset)

--- a/python/pyspark/ml/tests/test_linalg.py
+++ b/python/pyspark/ml/tests/test_linalg.py
@@ -146,10 +146,10 @@ class VectorTests(MLlibTestCase):
         # tests for fix of [SPARK-5089]
         v = array([1, 2, 3, 4], dtype="float64")
         dv = DenseVector(v)
-        self.assertTrue(dv.array.dtype == "float64")
+        self.assertEqual(dv.array.dtype, "float64")
         v = array([1, 2, 3, 4], dtype="float32")
         dv = DenseVector(v)
-        self.assertTrue(dv.array.dtype == "float64")
+        self.assertEqual(dv.array.dtype, "float64")
 
     def test_sparse_vector_indexing(self):
         sv = SparseVector(5, {1: 1, 3: 2})

--- a/python/pyspark/ml/tests/test_model_cache.py
+++ b/python/pyspark/ml/tests/test_model_cache.py
@@ -33,13 +33,13 @@ class ModelCacheTests(SparkSessionTestCase):
         for uuid in uuids:
             ModelCache.add(uuid, predict_fn)
 
-        self.assertTrue(len(ModelCache._models) == 3)
-        self.assertTrue(list(ModelCache._models.keys()) == uuids[7:10])
+        self.assertEqual(len(ModelCache._models), 3)
+        self.assertEqual(list(ModelCache._models.keys()), uuids[7:10])
 
         # get item, expect it to become most recently used
         _ = ModelCache.get(uuids[8])
         expected_uuids = uuids[7:8] + uuids[9:10] + [uuids[8]]
-        self.assertTrue(list(ModelCache._models.keys()) == expected_uuids)
+        self.assertEqual(list(ModelCache._models.keys()), expected_uuids)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/test_param.py
+++ b/python/pyspark/ml/tests/test_param.py
@@ -194,14 +194,14 @@ class ParamTests(SparkSessionTestCase):
         maxIter = testParams.maxIter
         self.assertEqual(maxIter.name, "maxIter")
         self.assertEqual(maxIter.doc, "max number of iterations (>= 0).")
-        self.assertTrue(maxIter.parent == testParams.uid)
+        self.assertEqual(maxIter.parent, testParams.uid)
 
     def test_param(self):
         testParams = TestParams()
         maxIter = testParams.maxIter
         self.assertEqual(maxIter.name, "maxIter")
         self.assertEqual(maxIter.doc, "max number of iterations (>= 0).")
-        self.assertTrue(maxIter.parent == testParams.uid)
+        self.assertEqual(maxIter.parent, testParams.uid)
 
     def test_hasparam(self):
         testParams = TestParams()

--- a/python/pyspark/mllib/tests/test_linalg.py
+++ b/python/pyspark/mllib/tests/test_linalg.py
@@ -152,10 +152,10 @@ class VectorTests(MLlibTestCase):
         # tests for fix of [SPARK-5089]
         v = array([1, 2, 3, 4], dtype="float64")
         dv = DenseVector(v)
-        self.assertTrue(dv.array.dtype == "float64")
+        self.assertEqual(dv.array.dtype, "float64")
         v = array([1, 2, 3, 4], dtype="float32")
         dv = DenseVector(v)
-        self.assertTrue(dv.array.dtype == "float64")
+        self.assertEqual(dv.array.dtype, "float64")
 
     def test_sparse_vector_indexing(self):
         sv = SparseVector(5, {1: 1, 3: 2})

--- a/python/pyspark/pandas/tests/groupby/test_groupby.py
+++ b/python/pyspark/pandas/tests/groupby/test_groupby.py
@@ -407,7 +407,7 @@ class GroupByTestsMixin:
                 expect = pdf.groupby("a")["b"].unique().sort_index()
                 self.assert_eq(len(actual), len(expect))
                 for act, exp in zip(actual, expect):
-                    self.assertTrue(sorted(act) == sorted(exp))
+                    self.assertEqual(sorted(act), sorted(exp))
 
     def test_diff(self):
         pdf = pd.DataFrame(

--- a/python/pyspark/sql/tests/arrow/test_arrow.py
+++ b/python/pyspark/sql/tests/arrow/test_arrow.py
@@ -906,7 +906,7 @@ class ArrowTestsMixin:
         expected = [tuple(list(e) for e in rec) for rec in pdf.to_records(index=False)]
         for r in range(len(expected)):
             for e in range(len(expected[r])):
-                self.assertTrue(expected[r][e] == result[r][e])
+                self.assertEqual(expected[r][e], result[r][e])
 
     def test_createDataFrame_arrow_with_array_type_nulls(self):
         t = pa.table({"a": [[1, 2], None, [3, 4]], "b": [["x", "y"], ["y", "z"], None]})
@@ -918,7 +918,7 @@ class ArrowTestsMixin:
         ]
         for r in range(len(expected)):
             for e in range(len(expected[r])):
-                self.assertTrue(expected[r][e] == result[r][e])
+                self.assertEqual(expected[r][e], result[r][e])
 
     def test_toPandas_with_array_type(self):
         for arrow_enabled in [True, False]:
@@ -935,7 +935,7 @@ class ArrowTestsMixin:
         result = [tuple(list(e) for e in rec) for rec in pdf.to_records(index=False)]
         for r in range(len(expected)):
             for e in range(len(expected[r])):
-                self.assertTrue(expected[r][e] == result[r][e])
+                self.assertEqual(expected[r][e], result[r][e])
 
     def test_toArrow_with_array_type_nulls(self):
         expected = [([1, 2], ["x", "y"]), (None, ["y", "z"]), ([3, 4], None)]
@@ -950,7 +950,7 @@ class ArrowTestsMixin:
         ]
         for r in range(len(expected)):
             for e in range(len(expected[r])):
-                self.assertTrue(expected[r][e] == result[r][e])
+                self.assertEqual(expected[r][e], result[r][e])
 
     def test_createDataFrame_pandas_with_map_type(self):
         with self.quiet():

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1484,7 +1484,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         self.connect.range(1).count()
         default_plan_compression_threshold = self.connect._client._plan_compression_threshold
         self.assertTrue(default_plan_compression_threshold > 0)
-        self.assertTrue(self.connect._client._plan_compression_algorithm == "ZSTD")
+        self.assertEqual(self.connect._client._plan_compression_algorithm, "ZSTD")
         try:
             self.connect._client._plan_compression_threshold = 1000
 
@@ -1492,17 +1492,17 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             cdf1 = self.connect.range(1).select(CF.lit("Apache Spark"))
             plan1 = cdf1._plan.to_proto(self.connect._client)
             self.assertTrue(plan1.root is not None)
-            self.assertTrue(cdf1.count() == 1)
+            self.assertEqual(cdf1.count(), 1)
 
             # Large plan should be compressed
             cdf2 = self.connect.range(1).select(CF.lit("Apache Spark" * 1000))
             plan2 = cdf2._plan.to_proto(self.connect._client)
             self.assertTrue(plan2.compressed_operation is not None)
             # Test compressed relation
-            self.assertTrue(cdf2.count() == 1)
+            self.assertEqual(cdf2.count(), 1)
             # Test compressed command
             cdf2.createOrReplaceTempView("temp_view_cdf2")
-            self.assertTrue(self.connect.sql("SELECT * FROM temp_view_cdf2").count() == 1)
+            self.assertEqual(self.connect.sql("SELECT * FROM temp_view_cdf2").count(), 1)
         finally:
             self.connect._client._plan_compression_threshold = default_plan_compression_threshold
 

--- a/python/pyspark/sql/tests/connect/test_connect_creation.py
+++ b/python/pyspark/sql/tests/connect/test_connect_creation.py
@@ -49,7 +49,7 @@ class SparkConnectCreationTests(ReusedMixedTestCase, PandasOnSparkTestUtils):
         pdf = pd.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
         df = self.connect.createDataFrame(pdf)
         rows = df.filter(df.a == CF.lit(3)).collect()
-        self.assertTrue(len(rows) == 1)
+        self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0][0], 3)
         self.assertEqual(rows[0][1], "c")
 

--- a/python/pyspark/sql/tests/connect/test_connect_plan.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan.py
@@ -246,7 +246,7 @@ class SparkConnectPlanTests(PlanOnlyTestFixture):
             .unpivot(["id"], None, "variable", "value")
             ._plan.to_proto(self.connect)
         )
-        self.assertTrue(len(plan.root.unpivot.ids) == 1)
+        self.assertEqual(len(plan.root.unpivot.ids), 1)
         self.assertTrue(all(isinstance(c, proto.Expression) for c in plan.root.unpivot.ids))
         self.assertEqual(plan.root.unpivot.ids[0].unresolved_attribute.unparsed_identifier, "id")
         self.assertEqual(plan.root.unpivot.HasField("values"), False)
@@ -278,11 +278,11 @@ class SparkConnectPlanTests(PlanOnlyTestFixture):
             .melt(["id"], [], "variable", "value")
             ._plan.to_proto(self.connect)
         )
-        self.assertTrue(len(plan.root.unpivot.ids) == 1)
+        self.assertEqual(len(plan.root.unpivot.ids), 1)
         self.assertTrue(all(isinstance(c, proto.Expression) for c in plan.root.unpivot.ids))
         self.assertEqual(plan.root.unpivot.ids[0].unresolved_attribute.unparsed_identifier, "id")
         self.assertEqual(plan.root.unpivot.HasField("values"), True)
-        self.assertTrue(len(plan.root.unpivot.values.values) == 0)
+        self.assertEqual(len(plan.root.unpivot.values.values), 0)
         self.assertEqual(plan.root.unpivot.variable_column_name, "variable")
         self.assertEqual(plan.root.unpivot.value_column_name, "value")
 
@@ -293,7 +293,7 @@ class SparkConnectPlanTests(PlanOnlyTestFixture):
         df = self.connect.readTable(table_name=self.tbl_name)
 
         def checkRelations(relations: List["DataFrame"]):
-            self.assertTrue(len(relations) == 3)
+            self.assertEqual(len(relations), 3)
 
             plan = relations[0]._plan.to_proto(self.connect)
             self.assertEqual(plan.root.sample.lower_bound, 0.0)

--- a/python/pyspark/sql/tests/connect/test_connect_stat.py
+++ b/python/pyspark/sql/tests/connect/test_connect_stat.py
@@ -149,7 +149,7 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
             self.spark.read.table(self.tbl_name).filter("id > 3").randomSplit([1.0, 2.0, 3.0], 2)
         )
 
-        self.assertTrue(len(relations) == len(datasets))
+        self.assertEqual(len(relations), len(datasets))
         i = 0
         while i < len(relations):
             self.assert_eq(relations[i].toPandas(), datasets[i].toPandas())

--- a/python/pyspark/sql/tests/streaming/test_streaming.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming.py
@@ -382,7 +382,7 @@ class StreamingTestsMixin:
         # SPARK-46873: There should not be a new StreamingQueryManager created every time
         # spark.streams is called.
         for i in range(5):
-            self.assertTrue(self.spark.streams == self.spark.streams)
+            self.assertEqual(self.spark.streams, self.spark.streams)
 
     def test_query_manager_get(self):
         df = self.spark.readStream.format("rate").load()
@@ -391,7 +391,7 @@ class StreamingTestsMixin:
         q = df.writeStream.format("noop").start()
 
         self.assertTrue(q.isActive)
-        self.assertTrue(q.id == self.spark.streams.get(q.id).id)
+        self.assertEqual(q.id, self.spark.streams.get(q.id).id)
 
         q.stop()
 

--- a/python/pyspark/sql/tests/test_catalog.py
+++ b/python/pyspark/sql/tests/test_catalog.py
@@ -283,7 +283,7 @@ class CatalogTestsMixin:
             functionsWithPattern = dict(
                 (f.name, f) for f in spark.catalog.listFunctions(pattern="*not_existing_func*")
             )
-            self.assertTrue(len(functionsWithPattern) == 0)
+            self.assertEqual(len(functionsWithPattern), 0)
 
             with self.function("func1", "some_db.func2"):
                 try:
@@ -335,10 +335,10 @@ class CatalogTestsMixin:
         with self.function("func1"):
             spark.sql("CREATE FUNCTION func1 AS 'org.apache.spark.data.bricks'")
             func1 = spark.catalog.getFunction("spark_catalog.default.func1")
-            self.assertTrue(func1.name == "func1")
-            self.assertTrue(func1.namespace == ["default"])
-            self.assertTrue(func1.catalog == "spark_catalog")
-            self.assertTrue(func1.className == "org.apache.spark.data.bricks")
+            self.assertEqual(func1.name, "func1")
+            self.assertEqual(func1.namespace, ["default"])
+            self.assertEqual(func1.catalog, "spark_catalog")
+            self.assertEqual(func1.className, "org.apache.spark.data.bricks")
             self.assertFalse(func1.isTemporary)
 
     def test_list_columns(self):

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -440,7 +440,7 @@ class ColumnTestsMixin:
             s = str(sf.lit(delta))
 
             # Parse the ISO string representation and compare
-            self.assertTrue(pd.Timedelta(s[8:-2]).to_pytimedelta() == delta)
+            self.assertEqual(pd.Timedelta(s[8:-2]).to_pytimedelta(), delta)
 
     def test_enum_literals(self):
         class IntEnum(Enum):
@@ -528,30 +528,30 @@ class ColumnTestsMixin:
         df1 = self.spark.range(10).withColumn("a", sf.lit(0))
         df2 = df1.withColumnRenamed("a", "b")
         df = df1.join(df2, df1["a"] == df2["b"])
-        self.assertTrue(df.count() == 100)
+        self.assertEqual(df.count(), 100)
         df = df2.join(df1, df2["b"] == df1["a"])
-        self.assertTrue(df.count() == 100)
+        self.assertEqual(df.count(), 100)
 
     def test_self_join_II(self):
         df = self.spark.createDataFrame([(1, 2), (3, 4)], schema=["a", "b"])
         df2 = df.select(df.a.alias("aa"), df.b)
         df3 = df2.join(df, df2.b == df.b)
         self.assertTrue(df3.columns, ["aa", "b", "a", "b"])
-        self.assertTrue(df3.count() == 2)
+        self.assertEqual(df3.count(), 2)
 
     def test_self_join_III(self):
         df1 = self.spark.range(10).withColumn("value", sf.lit(1))
         df2 = df1.union(df1)
         df3 = df1.join(df2, df1.id == df2.id, "left")
         self.assertTrue(df3.columns, ["id", "value", "id", "value"])
-        self.assertTrue(df3.count() == 20)
+        self.assertEqual(df3.count(), 20)
 
     def test_self_join_IV(self):
         df1 = self.spark.range(10).withColumn("value", sf.lit(1))
         df2 = df1.withColumn("value", sf.lit(2)).union(df1.withColumn("value", sf.lit(3)))
         df3 = df1.join(df2, df1.id == df2.id, "right")
         self.assertTrue(df3.columns, ["id", "value", "id", "value"])
-        self.assertTrue(df3.count() == 20)
+        self.assertEqual(df3.count(), 20)
 
     def test_select_join_keys(self):
         df1 = self.spark.range(10).withColumn("v1", sf.lit(1))

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -536,21 +536,21 @@ class ColumnTestsMixin:
         df = self.spark.createDataFrame([(1, 2), (3, 4)], schema=["a", "b"])
         df2 = df.select(df.a.alias("aa"), df.b)
         df3 = df2.join(df, df2.b == df.b)
-        self.assertTrue(df3.columns, ["aa", "b", "a", "b"])
+        self.assertEqual(df3.columns, ["aa", "b", "a", "b"])
         self.assertEqual(df3.count(), 2)
 
     def test_self_join_III(self):
         df1 = self.spark.range(10).withColumn("value", sf.lit(1))
         df2 = df1.union(df1)
         df3 = df1.join(df2, df1.id == df2.id, "left")
-        self.assertTrue(df3.columns, ["id", "value", "id", "value"])
+        self.assertEqual(df3.columns, ["id", "value", "id", "value"])
         self.assertEqual(df3.count(), 20)
 
     def test_self_join_IV(self):
         df1 = self.spark.range(10).withColumn("value", sf.lit(1))
         df2 = df1.withColumn("value", sf.lit(2)).union(df1.withColumn("value", sf.lit(3)))
         df3 = df1.join(df2, df1.id == df2.id, "right")
-        self.assertTrue(df3.columns, ["id", "value", "id", "value"])
+        self.assertEqual(df3.columns, ["id", "value", "id", "value"])
         self.assertEqual(df3.count(), 20)
 
     def test_select_join_keys(self):

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -140,7 +140,7 @@ class DataFrameTestsMixin:
         )
         df2 = self.spark.range(10).select(col("id").alias("x"))
         df3 = df1.join(df2, df1.x == df2.x).select(df1.y)
-        self.assertTrue(df3.columns, ["y"])
+        self.assertEqual(df3.columns, ["y"])
         self.assertEqual(df3.count(), 9)
 
     def test_duplicated_column_names(self):

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -141,7 +141,7 @@ class DataFrameTestsMixin:
         df2 = self.spark.range(10).select(col("id").alias("x"))
         df3 = df1.join(df2, df1.x == df2.x).select(df1.y)
         self.assertTrue(df3.columns, ["y"])
-        self.assertTrue(df3.count() == 9)
+        self.assertEqual(df3.count(), 9)
 
     def test_duplicated_column_names(self):
         df = self.spark.createDataFrame([(1, 2)], ["c", "c"])

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1656,7 +1656,7 @@ class FunctionsTestsMixin:
         non_file_df = self.spark.range(100).select(F.input_file_name())
 
         results = non_file_df.collect()
-        self.assertTrue(len(results) == 100)
+        self.assertEqual(len(results), 100)
 
         # [SPARK-24605]: if everything was properly reset after the last job, this should return
         # empty string rather than the file read in the last job.

--- a/python/pyspark/streaming/tests/test_dstream.py
+++ b/python/pyspark/streaming/tests/test_dstream.py
@@ -642,7 +642,7 @@ class CheckpointTests(unittest.TestCase):
         self.setupCalled = False
         self.ssc = StreamingContext.getOrCreate(self.cpd, setup)
         self.assertFalse(self.setupCalled)
-        self.assertTrue(self.ssc.sparkContext == self.sc)
+        self.assertEqual(self.ssc.sparkContext, self.sc)
 
         # Verify the getActiveOrCreate() recovers from checkpoint files
         self.ssc.stop(True, True)
@@ -665,7 +665,7 @@ class CheckpointTests(unittest.TestCase):
         self.setupCalled = False
         self.ssc = StreamingContext.getActiveOrCreate(self.cpd, setup)
         self.assertFalse(self.setupCalled)
-        self.assertTrue(self.ssc.sparkContext == self.sc)
+        self.assertEqual(self.ssc.sparkContext, self.sc)
 
         # Verify that getActiveOrCreate() calls setup() in absence of checkpoint files
         self.ssc.stop(True, True)

--- a/python/pyspark/tests/test_rdd.py
+++ b/python/pyspark/tests/test_rdd.py
@@ -619,10 +619,10 @@ class RDDTests(ReusedPySparkTestCase):
         a = self.sc.parallelize(range(int(1000)), 2)
         xs = a.repartition(num_partitions).glom().map(len).collect()
         zeros = len([x for x in xs if x == 0])
-        self.assertTrue(zeros == 0)
+        self.assertEqual(zeros, 0)
         xs = a.coalesce(num_partitions, True).glom().map(len).collect()
         zeros = len([x for x in xs if x == 0])
-        self.assertTrue(zeros == 0)
+        self.assertEqual(zeros, 0)
 
     def test_repartition_on_textfile(self):
         path = os.path.join(SPARK_HOME, "python/test_support/hello/hello.txt")

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -169,8 +169,8 @@ class TaskContextTests(PySparkTestCase):
             .map(lambda x: BarrierTaskContext.get().getTaskInfos())
             .collect()
         )
-        self.assertTrue(len(taskInfos) == 4)
-        self.assertTrue(len(taskInfos[0]) == 4)
+        self.assertEqual(len(taskInfos), 4)
+        self.assertEqual(len(taskInfos[0]), 4)
 
     def test_context_get(self):
         """

--- a/python/pyspark/tests/test_util.py
+++ b/python/pyspark/tests/test_util.py
@@ -137,7 +137,7 @@ class UtilTests(PySparkTestCase):
         self.assertEqual(str(v1), "1.2.3")
         self.assertEqual(repr(v1), "LooseVersion ('1.2.3')")
         v2 = "1.2.3"
-        self.assertTrue(v1 == v2)
+        self.assertEqual(v1, v2)
         v3 = 1.1
         with self.assertRaises(TypeError):
             v1 > v3

--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -214,8 +214,8 @@ class WorkerMemoryTest(unittest.TestCase):
             return resource.getrlimit(resource.RLIMIT_AS)
 
         actual = rdd.map(lambda _: getrlimit()).collect()
-        self.assertTrue(len(actual) == 1)
-        self.assertTrue(len(actual[0]) == 2)
+        self.assertEqual(len(actual), 1)
+        self.assertEqual(len(actual[0]), 2)
         [(soft_limit, hard_limit)] = actual
         self.assertEqual(soft_limit, 2 * 1024 * 1024 * 1024)
         self.assertEqual(hard_limit, 2 * 1024 * 1024 * 1024)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR replaces misuses of `assertTrue` with `assertEqual` in PySpark test suites:

1. `self.assertTrue(a == b)` -> `self.assertEqual(a, b)` (53 call sites across 22 files). A mechanical, behavior-preserving change.
2. `self.assertTrue(df.columns, [...])` -> `self.assertEqual(df.columns, [...])` (4 call sites in `test_dataframe.py` and `test_column.py`). These passed the expected column list as the `assertTrue` *message* argument, so they only checked that `df.columns` is truthy and never compared the names. This is a bug fix.

### Why are the changes needed?
- For `assertTrue(a == b)`: when the assertion fails, the message is only `AssertionError: False is not true`, which hides the operands. `assertEqual(a, b)` reports both sides (e.g. `5 != 9`), making failures easier to diagnose.
- For `assertTrue(df.columns, [...])`: a non-empty list is always truthy, so the expected column names were never actually verified. `assertEqual` makes these tests check what they intended to.

### Does this PR introduce _any_ user-facing change?
No. Test-only change.

### How was this patch tested?
Existing tests. The `a == b` rewrites are equivalent to the originals (same `==` comparison). For the column assertions, the expected lists match the actual DataFrame columns, so the now-effective assertions pass.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (model: claude-opus-4-8)
