### PR TITLE
[CORE] Reuse precomputed indices when an ancestor is already zipWithIndex

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/ZippedPartitionsRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ZippedPartitionsRDD.scala
@@ -81,7 +81,8 @@ private[spark] class ZippedPartitionsRDD2[A: ClassTag, B: ClassTag, V: ClassTag]
     var f: (Iterator[A], Iterator[B]) => Iterator[V],
     var rdd1: RDD[A],
     var rdd2: RDD[B],
-    preservesPartitioning: Boolean = false)
+    preservesPartitioning: Boolean = false,
+    val preservesPartitionSizes: Boolean = false)
   extends ZippedPartitionsBaseRDD[V](sc, List(rdd1, rdd2), preservesPartitioning) {
 
   override def compute(s: Partition, context: TaskContext): Iterator[V] = {

--- a/core/src/main/scala/org/apache/spark/rdd/ZippedWithIndexRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ZippedWithIndexRDD.scala
@@ -42,6 +42,10 @@ class ZippedWithIndexRDD[T: ClassTag](prev: RDD[T]) extends RDD[(T, Long)](prev)
 
   private def getAncestorWithSamePartitionSizes(rdd: RDD[_], depth: Int): (RDD[_], Int) = {
     rdd match {
+      // A ZippedWithIndexRDD ancestor that has already computed its startIndices can be reused
+      // directly, so stop here. startIndices is @transient and may be null on a deserialized
+      // ancestor; guard against that so we fall through to running a counting job in that case.
+      case z: ZippedWithIndexRDD[_] if z.startIndices != null => (z, depth)
       case c: RDD[_] if c.getStorageLevel != StorageLevel.NONE => (c, depth)
       case m: MapPartitionsRDD[_, _] if m.preservesPartitionSizes =>
         getAncestorWithSamePartitionSizes(m.prev, depth + 1)
@@ -64,11 +68,18 @@ class ZippedWithIndexRDD[T: ClassTag](prev: RDD[T]) extends RDD[(T, Long)](prev)
       Array(0L)
     } else {
       val (ancestor, _) = getAncestorWithSamePartitionSizes(prev, 0)
-      ancestor.context.runJob(
-        ancestor,
-        Utils.getIteratorSize _,
-        0 until n - 1 // do not need to count the last partition
-      ).scanLeft(0L)(_ + _)
+      ancestor match {
+        // The ancestor is a ZippedWithIndexRDD covering the same partition sizes, so its start
+        // indices are identical to ours; reuse them and skip the counting job. The null guard
+        // mirrors the one above: a non-reusable (null) ancestor falls through to the count.
+        case z: ZippedWithIndexRDD[_] if z.startIndices != null => z.startIndices
+        case _ =>
+          ancestor.context.runJob(
+            ancestor,
+            Utils.getIteratorSize _,
+            0 until n - 1 // do not need to count the last partition
+          ).scanLeft(0L)(_ + _)
+      }
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -974,6 +974,103 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext with Eventually {
     assert(count === 10)
   }
 
+  test("zipWithIndex reuses startIndices from ancestor zipWithIndex through size-preserving maps") {
+    import scala.language.reflectiveCalls
+    val n = 10
+    val numPartitions = 3
+    val data = sc.parallelize(0 until n, numPartitions)
+    val zipped = data.zipWithIndex()
+
+    val jobCountListener = new SparkListener {
+      private val count: AtomicInteger = new AtomicInteger(0)
+      def getCount: Int = count.get
+      override def onJobStart(jobStart: SparkListenerJobStart): Unit = count.incrementAndGet()
+    }
+    sc.addSparkListener(jobCountListener)
+
+    // map is size-preserving, so the second zipWithIndex should reuse startIndices
+    // from the ancestor ZippedWithIndexRDD without an extra counting job
+    val doubleZipped = zipped.map(identity).zipWithIndex()
+    sc.listenerBus.waitUntilEmpty()
+    assert(jobCountListener.getCount === 0,
+      "second zipWithIndex should not trigger a counting job")
+
+    // correctness: the second index must equal the first index
+    doubleZipped.collect().foreach { case ((_, firstIdx), secondIdx) =>
+      assert(firstIdx === secondIdx)
+    }
+  }
+
+  test("zipWithIndex reuses startIndices: direct chaining (no intermediate transform)") {
+    import scala.language.reflectiveCalls
+    val data = sc.parallelize(0 until 10, 3)
+    val zipped = data.zipWithIndex()
+
+    val listener = new SparkListener {
+      private val count: AtomicInteger = new AtomicInteger(0)
+      def getCount: Int = count.get
+      override def onJobStart(jobStart: SparkListenerJobStart): Unit = count.incrementAndGet()
+    }
+    sc.addSparkListener(listener)
+
+    val doubleZipped = zipped.zipWithIndex()
+    sc.listenerBus.waitUntilEmpty()
+    assert(listener.getCount === 0,
+      "direct zipWithIndex.zipWithIndex must not trigger a counting job")
+
+    doubleZipped.collect().foreach { case ((_, firstIdx), secondIdx) =>
+      assert(firstIdx === secondIdx)
+    }
+  }
+
+  test("zipWithIndex reuses startIndices: multiple size-preserving maps in between") {
+    import scala.language.reflectiveCalls
+    val data = sc.parallelize(0 until 10, 3)
+    val zipped = data.zipWithIndex()
+
+    val listener = new SparkListener {
+      private val count: AtomicInteger = new AtomicInteger(0)
+      def getCount: Int = count.get
+      override def onJobStart(jobStart: SparkListenerJobStart): Unit = count.incrementAndGet()
+    }
+    sc.addSparkListener(listener)
+
+    val result = zipped.map(identity).map(identity).map(identity).zipWithIndex()
+    sc.listenerBus.waitUntilEmpty()
+    assert(listener.getCount === 0,
+      "zipWithIndex.map.map.map.zipWithIndex must not trigger a counting job")
+
+    result.collect().foreach { case ((_, firstIdx), secondIdx) =>
+      assert(firstIdx === secondIdx)
+    }
+  }
+
+  test("zipWithIndex recomputes startIndices when chain is broken by non-size-preserving op") {
+    import scala.language.reflectiveCalls
+    // filter removes elements, so partition sizes change — the optimization must NOT apply and
+    // a fresh counting job must be submitted for the second zipWithIndex.
+    val data = sc.parallelize(0 until 10, 3)
+    val zipped = data.zipWithIndex()
+
+    val listener = new SparkListener {
+      private val count: AtomicInteger = new AtomicInteger(0)
+      def getCount: Int = count.get
+      override def onJobStart(jobStart: SparkListenerJobStart): Unit = count.incrementAndGet()
+    }
+    sc.addSparkListener(listener)
+
+    val filtered = zipped.filter(_._1 % 2 == 0)
+    val reindexed = filtered.zipWithIndex()
+    sc.listenerBus.waitUntilEmpty()
+    assert(listener.getCount > 0, "broken chain must trigger a counting job for startIndices")
+
+    // correctness: reindexed produces a fresh 0-based index over the filtered elements
+    val results = reindexed.sortBy(_._2).collect()
+    results.zipWithIndex.foreach { case ((_, idx), pos) =>
+      assert(idx === pos)
+    }
+  }
+
   test("zipWithUniqueId") {
     val n = 10
     val data = sc.parallelize(0 until n, 3)


### PR DESCRIPTION
### What changes were proposed in this pull request?

`zipWithIndex` builds a `ZippedWithIndexRDD`, which precomputes the start index of every partition by launching a small counting job over all but the last partition. This PR makes that step reuse the work an ancestor `ZippedWithIndexRDD` has already done.

`getAncestorWithSamePartitionSizes` walks the lineage across size-preserving operators (`map`, size-preserving `mapPartitions`, size-preserving zips, ...). It now stops at an ancestor `ZippedWithIndexRDD` **as long as that ancestor's `startIndices` is still populated**, and the `startIndices` computation reuses those indices directly instead of running another counting job. Because every operator on the path preserves partition sizes, the ancestor's per-partition start indices are identical to ours.

`startIndices` is `@transient`, so a deserialized/recovered ancestor can have a null `startIndices`. Both the lineage-walk stop and the reuse path guard on `startIndices != null`, so such an ancestor is not reused; the code falls back to a normal counting job instead of propagating a null array.

As a result, a chain such as `rdd.zipWithIndex().map(f).zipWithIndex()` runs the counting job only once.

### Why are the changes needed?

The counting job submitted by `zipWithIndex` is pure overhead when the per-partition indices have already been computed upstream. Pipelines that re-`zipWithIndex` after size-preserving transforms paid for a redundant job every time. Reusing the ancestor's `startIndices` removes that extra job.

### Does this PR introduce any user-facing change?

No. The computed indices are identical; only the redundant counting job is avoided.

### How was this patch tested?

New unit tests in `RDDSuite` that use a `SparkListener` to count submitted jobs:
- reuse through a single size-preserving `map`;
- direct `zipWithIndex().zipWithIndex()` chaining;
- reuse through multiple chained `map`s;
- a negative case where a `filter` breaks the chain, confirming a fresh counting job is still submitted and the indices are recomputed correctly.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (model: claude-opus-4-8)
