### PR TITLE
[SPARK-57344][INFRA] Ensure tests for `pipelines` module triggered when sql-related modules are modified

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -449,7 +449,7 @@ mllib = Module(
 
 pipelines = Module(
     name="pipelines",
-    dependencies=[],
+    dependencies=[sql],
     source_file_regexes=["sql/pipelines"],
     sbt_test_goals=[
         "pipelines/test",

--- a/dev/sparktestsupport/utils.py
+++ b/dev/sparktestsupport/utils.py
@@ -104,8 +104,8 @@ def determine_modules_to_test(changed_modules, deduplicated=True):
     >>> sorted([x.name for x in determine_modules_to_test([modules.sql])])
     ... # doctest: +NORMALIZE_WHITESPACE
     ['avro', 'connect', 'docker-integration-tests', 'examples', 'hive', 'hive-thriftserver',
-     'mllib', 'protobuf', 'pyspark-connect', 'pyspark-ml', 'pyspark-ml-connect', 'pyspark-mllib',
-     'pyspark-pandas', 'pyspark-pandas-connect', 'pyspark-pandas-slow',
+     'mllib', 'pipelines', 'protobuf', 'pyspark-connect', 'pyspark-ml', 'pyspark-ml-connect',
+     'pyspark-mllib', 'pyspark-pandas', 'pyspark-pandas-connect', 'pyspark-pandas-slow',
      'pyspark-pandas-slow-connect', 'pyspark-pipelines', 'pyspark-sql',
      'pyspark-structured-streaming', 'pyspark-structured-streaming-connect',
      'pyspark-testing', 'repl', 'sparkr', 'sql', 'sql-kafka-0-10']
@@ -113,8 +113,8 @@ def determine_modules_to_test(changed_modules, deduplicated=True):
     ...     [modules.sparkr, modules.sql], deduplicated=False)])
     ... # doctest: +NORMALIZE_WHITESPACE
     ['avro', 'connect', 'docker-integration-tests', 'examples', 'hive', 'hive-thriftserver',
-     'mllib', 'protobuf', 'pyspark-connect', 'pyspark-ml', 'pyspark-ml-connect', 'pyspark-mllib',
-     'pyspark-pandas', 'pyspark-pandas-connect', 'pyspark-pandas-slow',
+     'mllib', 'pipelines', 'protobuf', 'pyspark-connect', 'pyspark-ml', 'pyspark-ml-connect',
+     'pyspark-mllib', 'pyspark-pandas', 'pyspark-pandas-connect', 'pyspark-pandas-slow',
      'pyspark-pandas-slow-connect', 'pyspark-pipelines', 'pyspark-sql',
      'pyspark-structured-streaming', 'pyspark-structured-streaming-connect',
      'pyspark-testing', 'repl', 'sparkr', 'sql', 'sql-kafka-0-10']
@@ -122,9 +122,9 @@ def determine_modules_to_test(changed_modules, deduplicated=True):
     ...     [modules.sql, modules.core], deduplicated=False)])
     ... # doctest: +NORMALIZE_WHITESPACE
     ['avro', 'catalyst', 'connect', 'core', 'docker-integration-tests', 'examples', 'graphx',
-     'hive', 'hive-thriftserver', 'mllib', 'mllib-local', 'protobuf', 'pyspark-connect',
-     'pyspark-core', 'pyspark-install', 'pyspark-ml', 'pyspark-ml-connect', 'pyspark-mllib',
-     'pyspark-pandas', 'pyspark-pandas-connect', 'pyspark-pandas-slow',
+     'hive', 'hive-thriftserver', 'mllib', 'mllib-local', 'pipelines', 'protobuf',
+     'pyspark-connect', 'pyspark-core', 'pyspark-install', 'pyspark-ml', 'pyspark-ml-connect',
+     'pyspark-mllib', 'pyspark-pandas', 'pyspark-pandas-connect', 'pyspark-pandas-slow',
      'pyspark-pandas-slow-connect', 'pyspark-pipelines', 'pyspark-resource', 'pyspark-sql',
      'pyspark-streaming', 'pyspark-structured-streaming', 'pyspark-structured-streaming-connect',
      'pyspark-testing', 'repl', 'root', 'sparkr', 'sql', 'sql-kafka-0-10', 'streaming',


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR marks `pipelines` as depending on the `sql` module in Spark's test module graph, and updates the existing doctest expectations for the affected module closure.

### Why are the changes needed?

The `pipelines` project depends on Spark SQL, but the test module graph treated it as independent. As a result, changes in SQL-related modules such as `sql`, `catalyst`, and `sql-api` did not select `pipelines/test` in the affected-module CI path.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```bash
python3 -m py_compile dev/sparktestsupport/modules.py dev/sparktestsupport/utils.py
PYTHONPATH=dev python3 -m doctest dev/sparktestsupport/utils.py
git diff --check
```

Also verified locally that changes in `core`, `sql-api`, `catalyst`, `sql`, and `sql/pipelines` include the `pipelines` module in the affected-module selection.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex
