### PR TITLE
[SPARK-57323][SQL] Support casting between DATE and nanosecond-precision timestamps via an analyzer rule

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -559,6 +559,7 @@ class Analyzer(
       ResolveInlineTables ::
       ResolveLambdaVariables ::
       ResolveTimeZone ::
+      ResolveTimestampNanosCast ::
       ResolveRandomSeed ::
       ResolveBinaryArithmetic ::
       new ResolveIdentifierClause(earlyBatches) ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTimestampNanosCast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTimestampNanosCast.scala
@@ -65,13 +65,15 @@ object ResolveTimestampNanosCast extends Rule[LogicalPlan] {
    */
   def rewriteDateNanosCast(cast: Cast): Option[Cast] = cast match {
     // nanos(p) -> DATE  ==>  nanos(p) -> micros -> DATE
-    case Cast(child, DateType, tz, mode)
-        if child.resolved && microTimestampType(child.dataType).isDefined =>
-      Some(Cast(Cast(child, microTimestampType(child.dataType).get, tz, mode), DateType, tz, mode))
+    case Cast(child, DateType, tz, mode) if child.resolved =>
+      microTimestampType(child.dataType).map { micros =>
+        Cast(Cast(child, micros, tz, mode), DateType, tz, mode)
+      }
     // DATE -> nanos(p)  ==>  DATE -> micros -> nanos(p)
-    case Cast(child, dt, tz, mode)
-        if child.resolved && child.dataType == DateType && microTimestampType(dt).isDefined =>
-      Some(Cast(Cast(child, microTimestampType(dt).get, tz, mode), dt, tz, mode))
+    case Cast(child, dt, tz, mode) if child.resolved && child.dataType == DateType =>
+      microTimestampType(dt).map { micros =>
+        Cast(Cast(child, micros, tz, mode), dt, tz, mode)
+      }
     case _ => None
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTimestampNanosCast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTimestampNanosCast.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.catalyst.expressions.Cast
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.CAST
+import org.apache.spark.sql.types.{DataType, DateType, TimestampLTZNanosType, TimestampNTZNanosType, TimestampNTZType, TimestampType}
+
+/**
+ * Rewrites casts between [[DateType]] and the nanosecond-precision timestamp types
+ * ([[TimestampLTZNanosType]] / [[TimestampNTZNanosType]]) into a two-step cast that goes through
+ * the corresponding microsecond-precision timestamp type:
+ *
+ *   - `nanos(p) -> DATE`  ==>  `nanos(p) -> micros -> DATE`
+ *   - `DATE -> nanos(p)`  ==>  `DATE -> micros -> nanos(p)`
+ *
+ * where the microsecond counterpart is `TIMESTAMP` for `*_LTZ` and `TIMESTAMP_NTZ` for `*_NTZ`.
+ * Both component casts already exist (`nanos(p) <-> micros` and `micros <-> DATE`), so no dedicated
+ * `DATE <-> nanos` conversion is needed in [[Cast]] and the semantics match the microsecond
+ * `DATE <-> TIMESTAMP` casts: the LTZ directions are resolved in the session time zone and the NTZ
+ * directions on the UTC wall-clock grid; sub-microsecond digits and the time-of-day are dropped
+ * when narrowing to `DATE`.
+ *
+ * `Cast.canCast` intentionally does not allow `DATE <-> nanos` directly, so such a cast stays
+ * unresolved until this rule rewrites it into the resolvable nested form. The new casts inherit the
+ * original `timeZoneId` and `evalMode`; the only zone-sensitive part (the `micros <-> DATE` cast)
+ * gets its session time zone from [[ResolveTimeZone]] within the same fixed-point batch.
+ */
+object ResolveTimestampNanosCast extends Rule[LogicalPlan] {
+
+  /** The microsecond-precision timestamp counterpart of a nanosecond-precision timestamp type. */
+  private def microTimestampType(dt: DataType): Option[DataType] = dt match {
+    case _: TimestampLTZNanosType => Some(TimestampType)
+    case _: TimestampNTZNanosType => Some(TimestampNTZType)
+    case _ => None
+  }
+
+  override def apply(plan: LogicalPlan): LogicalPlan =
+    plan.resolveExpressionsWithPruning(_.containsPattern(CAST), ruleId) {
+      // nanos(p) -> DATE  ==>  nanos(p) -> micros -> DATE
+      case Cast(child, DateType, tz, mode)
+          if child.resolved && microTimestampType(child.dataType).isDefined =>
+        Cast(Cast(child, microTimestampType(child.dataType).get, tz, mode), DateType, tz, mode)
+      // DATE -> nanos(p)  ==>  DATE -> micros -> nanos(p)
+      case Cast(child, dt, tz, mode)
+          if child.resolved && child.dataType == DateType && microTimestampType(dt).isDefined =>
+        Cast(Cast(child, microTimestampType(dt).get, tz, mode), dt, tz, mode)
+    }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTimestampNanosCast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTimestampNanosCast.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.CAST
-import org.apache.spark.sql.types.{DataType, DateType, TimestampLTZNanosType, TimestampNTZNanosType, TimestampNTZType, TimestampType}
+import org.apache.spark.sql.types.{ArrayType, DataType, DateType, MapType, StructType, TimestampLTZNanosType, TimestampNTZNanosType, TimestampNTZType, TimestampType}
 
 /**
  * Rewrites casts between [[DateType]] and the nanosecond-precision timestamp types
@@ -38,10 +38,18 @@ import org.apache.spark.sql.types.{DataType, DateType, TimestampLTZNanosType, Ti
  * directions on the UTC wall-clock grid; sub-microsecond digits and the time-of-day are dropped
  * when narrowing to `DATE`.
  *
- * `Cast.canCast` intentionally does not allow `DATE <-> nanos` directly, so such a cast stays
- * unresolved until this rule rewrites it into the resolvable nested form. The new casts inherit the
- * original `timeZoneId` and `evalMode`; the only zone-sensitive part (the `micros <-> DATE` cast)
- * gets its session time zone from [[ResolveTimeZone]] within the same fixed-point batch.
+ * The same rewrite applies when the `DATE <-> nanos` pair is nested inside complex types
+ * ([[ArrayType]] / [[MapType]] / [[StructType]]) at any depth, e.g.
+ * `ARRAY<nanos(p)> -> ARRAY<DATE>` becomes `ARRAY<nanos(p)> -> ARRAY<micros> -> ARRAY<DATE>`. The
+ * intermediate type mirrors the structure (and nullability) of the target type, with every
+ * `DATE <-> nanos` leaf swapped for the corresponding microsecond-precision timestamp type, so that
+ * both component casts pass `Cast.canCast`.
+ *
+ * `Cast.canCast` intentionally does not allow `DATE <-> nanos` directly (it recurses into complex
+ * types, so nested pairs are rejected too), so such a cast stays unresolved until this rule
+ * rewrites it into the resolvable nested form. The new casts inherit the original `timeZoneId` and
+ * `evalMode`; the only zone-sensitive part (the `micros <-> DATE` cast) gets its session time zone
+ * from [[ResolveTimeZone]] within the same fixed-point batch.
  *
  * The per-cast rewrite is exposed via [[rewriteDateNanosCast]] so that the single-pass resolver
  * (see `TimezoneAwareExpressionResolver`) can apply the same transformation and produce an
@@ -58,21 +66,55 @@ object ResolveTimestampNanosCast extends Rule[LogicalPlan] {
   }
 
   /**
-   * If `cast` converts between [[DateType]] and a nanosecond-precision timestamp type, returns the
-   * equivalent two-step cast through the corresponding microsecond-precision timestamp type;
-   * returns `None` for any other cast. The nested casts inherit the original `timeZoneId` and
-   * `evalMode`.
+   * Computes the intermediate ("bridge") type to route a `from -> to` cast through when the
+   * conversion involves a `DATE <-> nanos(p)` pair at any nesting depth. The bridge mirrors the
+   * structure (and nullability) of `to`, with every `DATE <-> nanos` leaf replaced by the
+   * corresponding microsecond-precision timestamp type. Returns `None` when no `DATE <-> nanos`
+   * pair is present, in which case [[Cast]] already handles the conversion directly.
+   */
+  private def bridgeType(from: DataType, to: DataType): Option[DataType] = (from, to) match {
+    // Scalar DATE <-> nanos(p): route through the microsecond counterpart of the nanos side.
+    case (DateType, _) => microTimestampType(to)
+    case (_, DateType) => microTimestampType(from)
+
+    case (ArrayType(fromEl, _), ArrayType(toEl, toContainsNull)) =>
+      bridgeType(fromEl, toEl).map(ArrayType(_, toContainsNull))
+
+    case (MapType(fromKey, fromVal, _), MapType(toKey, toVal, toValContainsNull)) =>
+      val keyBridge = bridgeType(fromKey, toKey)
+      val valBridge = bridgeType(fromVal, toVal)
+      if (keyBridge.isEmpty && valBridge.isEmpty) {
+        None
+      } else {
+        Some(MapType(keyBridge.getOrElse(toKey), valBridge.getOrElse(toVal), toValContainsNull))
+      }
+
+    case (StructType(fromFields), StructType(toFields))
+        if fromFields.length == toFields.length =>
+      val fieldBridges = fromFields.zip(toFields).map {
+        case (fromField, toField) => bridgeType(fromField.dataType, toField.dataType)
+      }
+      if (fieldBridges.forall(_.isEmpty)) {
+        None
+      } else {
+        Some(StructType(toFields.zip(fieldBridges).map {
+          case (toField, bridge) => bridge.map(bt => toField.copy(dataType = bt)).getOrElse(toField)
+        }))
+      }
+
+    case _ => None
+  }
+
+  /**
+   * If `cast` converts (recursively, through complex types) between [[DateType]] and a
+   * nanosecond-precision timestamp type, returns the equivalent two-step cast routed through the
+   * corresponding microsecond-precision timestamp type; returns `None` for any other cast. The
+   * nested casts inherit the original `timeZoneId` and `evalMode`.
    */
   def rewriteDateNanosCast(cast: Cast): Option[Cast] = cast match {
-    // nanos(p) -> DATE  ==>  nanos(p) -> micros -> DATE
-    case Cast(child, DateType, tz, mode) if child.resolved =>
-      microTimestampType(child.dataType).map { micros =>
-        Cast(Cast(child, micros, tz, mode), DateType, tz, mode)
-      }
-    // DATE -> nanos(p)  ==>  DATE -> micros -> nanos(p)
-    case Cast(child, dt, tz, mode) if child.resolved && child.dataType == DateType =>
-      microTimestampType(dt).map { micros =>
-        Cast(Cast(child, micros, tz, mode), dt, tz, mode)
+    case Cast(child, to, tz, mode) if child.resolved =>
+      bridgeType(child.dataType, to).map { micros =>
+        Cast(Cast(child, micros, tz, mode), to, tz, mode)
       }
     case _ => None
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTimestampNanosCast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTimestampNanosCast.scala
@@ -42,6 +42,11 @@ import org.apache.spark.sql.types.{DataType, DateType, TimestampLTZNanosType, Ti
  * unresolved until this rule rewrites it into the resolvable nested form. The new casts inherit the
  * original `timeZoneId` and `evalMode`; the only zone-sensitive part (the `micros <-> DATE` cast)
  * gets its session time zone from [[ResolveTimeZone]] within the same fixed-point batch.
+ *
+ * The per-cast rewrite is exposed via [[rewriteDateNanosCast]] so that the single-pass resolver
+ * (see `TimezoneAwareExpressionResolver`) can apply the same transformation and produce an
+ * identical plan; otherwise single-pass resolution would fail the cast's input type check while
+ * fixed-point succeeds.
  */
 object ResolveTimestampNanosCast extends Rule[LogicalPlan] {
 
@@ -52,15 +57,26 @@ object ResolveTimestampNanosCast extends Rule[LogicalPlan] {
     case _ => None
   }
 
+  /**
+   * If `cast` converts between [[DateType]] and a nanosecond-precision timestamp type, returns the
+   * equivalent two-step cast through the corresponding microsecond-precision timestamp type;
+   * returns `None` for any other cast. The nested casts inherit the original `timeZoneId` and
+   * `evalMode`.
+   */
+  def rewriteDateNanosCast(cast: Cast): Option[Cast] = cast match {
+    // nanos(p) -> DATE  ==>  nanos(p) -> micros -> DATE
+    case Cast(child, DateType, tz, mode)
+        if child.resolved && microTimestampType(child.dataType).isDefined =>
+      Some(Cast(Cast(child, microTimestampType(child.dataType).get, tz, mode), DateType, tz, mode))
+    // DATE -> nanos(p)  ==>  DATE -> micros -> nanos(p)
+    case Cast(child, dt, tz, mode)
+        if child.resolved && child.dataType == DateType && microTimestampType(dt).isDefined =>
+      Some(Cast(Cast(child, microTimestampType(dt).get, tz, mode), dt, tz, mode))
+    case _ => None
+  }
+
   override def apply(plan: LogicalPlan): LogicalPlan =
     plan.resolveExpressionsWithPruning(_.containsPattern(CAST), ruleId) {
-      // nanos(p) -> DATE  ==>  nanos(p) -> micros -> DATE
-      case Cast(child, DateType, tz, mode)
-          if child.resolved && microTimestampType(child.dataType).isDefined =>
-        Cast(Cast(child, microTimestampType(child.dataType).get, tz, mode), DateType, tz, mode)
-      // DATE -> nanos(p)  ==>  DATE -> micros -> nanos(p)
-      case Cast(child, dt, tz, mode)
-          if child.resolved && child.dataType == DateType && microTimestampType(dt).isDefined =>
-        Cast(Cast(child, microTimestampType(dt).get, tz, mode), dt, tz, mode)
+      case cast: Cast => rewriteDateNanosCast(cast).getOrElse(cast)
     }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/TimezoneAwareExpressionResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/TimezoneAwareExpressionResolver.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.analysis.resolver
 
+import org.apache.spark.sql.catalyst.analysis.ResolveTimestampNanosCast
 import org.apache.spark.sql.catalyst.expressions.{
   Cast,
   DefaultStringProducingExpression,
@@ -45,7 +46,9 @@ class TimezoneAwareExpressionResolver(expressionResolver: ExpressionResolver)
   /**
    * Resolves a [[TimeZoneAwareExpression]] by resolving its children, applying a timezone
    * and calling [[coerceExpressionTypes]] on the result. If the expression is a [[Cast]], we apply
-   * [[collapseCast]] to the result.
+   * [[collapseCast]] to the result, and rewrite a `DATE <-> nanos` cast through the microsecond
+   * timestamp type (mirroring the fixed-point [[ResolveTimestampNanosCast]] rule) so single-pass
+   * resolution produces the same plan instead of failing the cast's input type check.
    *
    * @param unresolvedTimezoneExpression The [[TimeZoneAwareExpression]] to resolve.
    * @return A resolved [[Expression]] with the session's local timezone applied, and optionally
@@ -63,9 +66,16 @@ class TimezoneAwareExpressionResolver(expressionResolver: ExpressionResolver)
       expressionTreeTraversal = traversals.current
     )
 
-    coercedTimezoneAwareExpression match {
+    val collapsedExpression = coercedTimezoneAwareExpression match {
       case cast: Cast if traversals.current.defaultCollation.isDefined =>
         tryCollapseCast(cast, traversals.current.defaultCollation.get)
+      case other =>
+        other
+    }
+
+    collapsedExpression match {
+      case cast: Cast =>
+        ResolveTimestampNanosCast.rewriteDateNanosCast(cast).getOrElse(cast)
       case other =>
         other
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/TimezoneAwareExpressionResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/TimezoneAwareExpressionResolver.scala
@@ -66,16 +66,12 @@ class TimezoneAwareExpressionResolver(expressionResolver: ExpressionResolver)
       expressionTreeTraversal = traversals.current
     )
 
-    val collapsedExpression = coercedTimezoneAwareExpression match {
-      case cast: Cast if traversals.current.defaultCollation.isDefined =>
-        tryCollapseCast(cast, traversals.current.defaultCollation.get)
-      case other =>
-        other
-    }
-
-    collapsedExpression match {
+    coercedTimezoneAwareExpression match {
       case cast: Cast =>
-        ResolveTimestampNanosCast.rewriteDateNanosCast(cast).getOrElse(cast)
+        val collapsedCast = traversals.current.defaultCollation
+          .map(tryCollapseCast(cast, _))
+          .getOrElse(cast)
+        ResolveTimestampNanosCast.rewriteDateNanosCast(collapsedCast).getOrElse(collapsedCast)
       case other =>
         other
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -415,6 +415,13 @@ object Cast extends QueryErrorsBase {
     // This conversion stays explicit-only.
     case (_: TimestampNTZNanosType, TimestampNTZType) => false
     case (_: TimestampLTZNanosType, TimestampType) => false
+    // SPARK-57323: casting DATE <-> nanosecond-precision timestamp drops time-of-day and
+    // sub-microsecond digits (or fabricates them), so it requires an explicit CAST and is
+    // not allowed as a (silent) store assignment in either direction.
+    case (DateType, _: TimestampLTZNanosType) => false
+    case (DateType, _: TimestampNTZNanosType) => false
+    case (_: TimestampLTZNanosType, DateType) => false
+    case (_: TimestampNTZNanosType, DateType) => false
     case (_: DatetimeType, _: DatetimeType) => true
 
     case (ArrayType(fromType, fn), ArrayType(toType, tn)) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -103,6 +103,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.analysis.ResolveSetVariable" ::
       "org.apache.spark.sql.catalyst.analysis.ResolveTableConstraints" ::
       "org.apache.spark.sql.catalyst.analysis.ResolveTableSpec" ::
+      "org.apache.spark.sql.catalyst.analysis.ResolveTimestampNanosCast" ::
       "org.apache.spark.sql.catalyst.analysis.ResolveTimeZone" ::
       "org.apache.spark.sql.catalyst.analysis.ResolveUnion" ::
       "org.apache.spark.sql.catalyst.analysis.ResolveUnresolvedHaving" ::

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveTimestampNanosCastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveTimestampNanosCastSuite.scala
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import java.time.{LocalDate, LocalDateTime}
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Cast, EvalMode, Expression, ExpressionEvalHelper, Literal, ScalarSubquery}
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan, OneRowRelation, Project}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
+import org.apache.spark.sql.catalyst.util.DateTimeUtils._
+import org.apache.spark.sql.catalyst.util.TimestampNanosTestUtils._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{DataType, DateType, TimestampLTZNanosType, TimestampNTZNanosType, TimestampNTZType, TimestampType}
+import org.apache.spark.unsafe.types.TimestampNanosVal
+
+/**
+ * Test suite for [[ResolveTimestampNanosCast]], which rewrites `DATE <-> nanos(p)` casts into a
+ * two-step cast through the microsecond timestamp type.
+ */
+class ResolveTimestampNanosCastSuite extends AnalysisTest with ExpressionEvalHelper {
+
+  private val ntzNanos = TimestampNTZNanosType(TimestampNTZNanosType.MAX_PRECISION)
+  private val ltzNanos = TimestampLTZNanosType(TimestampLTZNanosType.MAX_PRECISION)
+
+  private val ntzAttr = AttributeReference("ntz", ntzNanos)()
+  private val ltzAttr = AttributeReference("ltz", ltzNanos)()
+  private val dateAttr = AttributeReference("d", DateType)()
+  private val relation = LocalRelation(ntzAttr, ltzAttr, dateAttr)
+
+  // Rewrite only: keeps the original time zone id so the structure can be compared exactly.
+  private object Rewrite extends RuleExecutor[LogicalPlan] {
+    val batches = Batch("rewrite", FixedPoint(10), ResolveTimestampNanosCast) :: Nil
+  }
+
+  // Rewrite + time zone assignment, used to obtain a fully resolved, evaluable expression.
+  private object Analyze extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("analyze", FixedPoint(10), ResolveTimeZone, ResolveTimestampNanosCast) :: Nil
+  }
+
+  private def micro(dt: DataType): DataType = dt match {
+    case _: TimestampLTZNanosType => TimestampType
+    case _: TimestampNTZNanosType => TimestampNTZType
+  }
+
+  private def checkRewrite(in: Expression, out: Expression): Unit = {
+    comparePlans(Rewrite.execute(relation.select(in.as("c"))), relation.select(out.as("c")))
+  }
+
+  private def analyzeExpr(e: Expression): Expression = {
+    Analyze.execute(OneRowRelation().select(e.as("c")))
+      .asInstanceOf[Project].projectList.head.asInstanceOf[Alias].child
+  }
+
+  test("rewrite nanos(p) -> DATE through the microsecond timestamp type") {
+    Seq(ntzAttr, ltzAttr).foreach { attr =>
+      checkRewrite(
+        Cast(attr, DateType),
+        Cast(Cast(attr, micro(attr.dataType)), DateType))
+    }
+  }
+
+  test("rewrite DATE -> nanos(p) through the microsecond timestamp type") {
+    Seq(ntzNanos, ltzNanos).foreach { nanos =>
+      checkRewrite(
+        Cast(dateAttr, nanos),
+        Cast(Cast(dateAttr, micro(nanos)), nanos))
+    }
+  }
+
+  test("rewrite preserves timeZoneId and evalMode") {
+    val tz = Option(LA.getId)
+    Seq(EvalMode.LEGACY, EvalMode.ANSI, EvalMode.TRY).foreach { mode =>
+      // nanos(p) -> DATE
+      checkRewrite(
+        Cast(ltzAttr, DateType, tz, mode),
+        Cast(Cast(ltzAttr, TimestampType, tz, mode), DateType, tz, mode))
+      // DATE -> nanos(p)
+      checkRewrite(
+        Cast(dateAttr, ltzNanos, tz, mode),
+        Cast(Cast(dateAttr, TimestampType, tz, mode), ltzNanos, tz, mode))
+    }
+  }
+
+  test("rewrite is idempotent") {
+    val in = relation.select(Cast(ntzAttr, DateType).as("c"))
+    val once = Rewrite.execute(in)
+    comparePlans(Rewrite.execute(once), once)
+  }
+
+  test("rewrite reaches casts inside a subquery") {
+    withSQLConf(SQLConf.TIMESTAMP_NANOS_TYPES_ENABLED.key -> "true") {
+      val inner = LocalRelation(ntzAttr).select(Cast(ntzAttr, DateType).as("d"))
+      val outer = OneRowRelation().select(ScalarSubquery(inner).as("s"))
+      assertAnalysisSuccess(outer)
+    }
+  }
+
+  test("DATE <-> TIMESTAMP_NTZ(p): values on the UTC wall-clock grid") {
+    withSQLConf(
+      SQLConf.TIMESTAMP_NANOS_TYPES_ENABLED.key -> "true",
+      SQLConf.SESSION_LOCAL_TIMEZONE.key -> LA.getId) {
+      val date = LocalDate.of(2020, 1, 1)
+      val days = localDateToDays(date)
+      foreachNanosPrecision { p =>
+        // DATE -> TIMESTAMP_NTZ(p): midnight UTC, sub-microsecond part = 0 (zone-independent).
+        checkEvaluation(
+          analyzeExpr(Cast(Literal.create(date, DateType), TimestampNTZNanosType(p))),
+          TimestampNanosVal.fromParts(daysToMicros(days, UTC), 0.toShort))
+        // TIMESTAMP_NTZ(p) -> DATE: drops time-of-day and sub-microsecond digits.
+        val noon = localDateTimeToNanosVal(LocalDateTime.of(2020, 1, 1, 12, 30, 15, 123456789))
+        checkEvaluation(
+          analyzeExpr(Cast(Literal.create(noon, TimestampNTZNanosType(p)), DateType)),
+          days)
+        // Nulls both directions.
+        checkEvaluation(
+          analyzeExpr(Cast(Literal.create(null, DateType), TimestampNTZNanosType(p))), null)
+        checkEvaluation(
+          analyzeExpr(Cast(Literal.create(null, TimestampNTZNanosType(p)), DateType)), null)
+      }
+    }
+  }
+
+  test("DATE <-> TIMESTAMP_LTZ(p): values resolve in the session time zone") {
+    val date = LocalDate.of(2020, 1, 1)
+    val days = localDateToDays(date)
+    foreachNanosPrecision { p =>
+      withSQLConf(
+        SQLConf.TIMESTAMP_NANOS_TYPES_ENABLED.key -> "true",
+        SQLConf.SESSION_LOCAL_TIMEZONE.key -> UTC.getId) {
+        // DATE -> TIMESTAMP_LTZ(p): midnight of the date in the session zone (UTC here).
+        checkEvaluation(
+          analyzeExpr(Cast(Literal.create(date, DateType), TimestampLTZNanosType(p))),
+          TimestampNanosVal.fromParts(daysToMicros(days, UTC), 0.toShort))
+        // TIMESTAMP_LTZ(p) -> DATE: calendar date in the session zone.
+        val noon = instantToNanosVal(timestampLTZ(2020, 1, 1, 12, 30, 15, 123456789))
+        checkEvaluation(
+          analyzeExpr(Cast(Literal.create(noon, TimestampLTZNanosType(p)), DateType)),
+          days)
+        // Nulls both directions.
+        checkEvaluation(
+          analyzeExpr(Cast(Literal.create(null, DateType), TimestampLTZNanosType(p))), null)
+        checkEvaluation(
+          analyzeExpr(Cast(Literal.create(null, TimestampLTZNanosType(p)), DateType)), null)
+      }
+      // Zone sensitivity: a western zone maps the date to a later midnight instant.
+      withSQLConf(
+        SQLConf.TIMESTAMP_NANOS_TYPES_ENABLED.key -> "true",
+        SQLConf.SESSION_LOCAL_TIMEZONE.key -> LA.getId) {
+        assert(daysToMicros(days, LA) != daysToMicros(days, UTC))
+        checkEvaluation(
+          analyzeExpr(Cast(Literal.create(date, DateType), TimestampLTZNanosType(p))),
+          TimestampNanosVal.fromParts(daysToMicros(days, LA), 0.toShort))
+      }
+    }
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveTimestampNanosCastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveTimestampNanosCastSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils._
 import org.apache.spark.sql.catalyst.util.TimestampNanosTestUtils._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{DataType, DateType, TimestampLTZNanosType, TimestampNTZNanosType, TimestampNTZType, TimestampType}
+import org.apache.spark.sql.types.{ArrayType, DataType, DateType, IntegerType, MapType, StringType, StructField, StructType, TimestampLTZNanosType, TimestampNTZNanosType, TimestampNTZType, TimestampType}
 import org.apache.spark.unsafe.types.TimestampNanosVal
 
 /**
@@ -43,7 +43,31 @@ class ResolveTimestampNanosCastSuite extends AnalysisTest with ExpressionEvalHel
   private val ntzAttr = AttributeReference("ntz", ntzNanos)()
   private val ltzAttr = AttributeReference("ltz", ltzNanos)()
   private val dateAttr = AttributeReference("d", DateType)()
-  private val relation = LocalRelation(ntzAttr, ltzAttr, dateAttr)
+
+  // Complex-typed inputs that nest a nanos timestamp at various depths.
+  private val arrNtzAttr = AttributeReference("arr_ntz", ArrayType(ntzNanos, containsNull = true))()
+  private val arrDateAttr = AttributeReference("arr_d", ArrayType(DateType, containsNull = true))()
+  private val mapNtzAttr =
+    AttributeReference("map_ntz", MapType(StringType, ntzNanos, valueContainsNull = true))()
+  private val structNtzAttr =
+    AttributeReference("st_ntz", StructType(Seq(StructField("f", ntzNanos))))()
+  private val structMixedAttr = AttributeReference(
+    "st_mixed",
+    StructType(Seq(StructField("a", ntzNanos), StructField("b", IntegerType))))()
+  private val arrStructNtzAttr = AttributeReference(
+    "arr_st_ntz",
+    ArrayType(StructType(Seq(StructField("f", ntzNanos))), containsNull = true))()
+
+  private val relation = LocalRelation(
+    ntzAttr,
+    ltzAttr,
+    dateAttr,
+    arrNtzAttr,
+    arrDateAttr,
+    mapNtzAttr,
+    structNtzAttr,
+    structMixedAttr,
+    arrStructNtzAttr)
 
   // Rewrite only: keeps the original time zone id so the structure can be compared exactly.
   private object Rewrite extends RuleExecutor[LogicalPlan] {
@@ -102,6 +126,70 @@ class ResolveTimestampNanosCastSuite extends AnalysisTest with ExpressionEvalHel
 
   test("rewrite is idempotent") {
     val in = relation.select(Cast(ntzAttr, DateType).as("c"))
+    val once = Rewrite.execute(in)
+    comparePlans(Rewrite.execute(once), once)
+  }
+
+  test("rewrite nanos(p) <-> DATE nested in an array") {
+    // ARRAY<nanos(p)> -> ARRAY<DATE>
+    checkRewrite(
+      Cast(arrNtzAttr, ArrayType(DateType, containsNull = true)),
+      Cast(
+        Cast(arrNtzAttr, ArrayType(TimestampNTZType, containsNull = true)),
+        ArrayType(DateType, containsNull = true)))
+    // ARRAY<DATE> -> ARRAY<nanos(p)>
+    checkRewrite(
+      Cast(arrDateAttr, ArrayType(ntzNanos, containsNull = true)),
+      Cast(
+        Cast(arrDateAttr, ArrayType(TimestampNTZType, containsNull = true)),
+        ArrayType(ntzNanos, containsNull = true)))
+  }
+
+  test("rewrite nanos(p) -> DATE nested in a map value") {
+    checkRewrite(
+      Cast(mapNtzAttr, MapType(StringType, DateType, valueContainsNull = true)),
+      Cast(
+        Cast(mapNtzAttr, MapType(StringType, TimestampNTZType, valueContainsNull = true)),
+        MapType(StringType, DateType, valueContainsNull = true)))
+  }
+
+  test("rewrite nanos(p) -> DATE nested in a struct field") {
+    checkRewrite(
+      Cast(structNtzAttr, StructType(Seq(StructField("f", DateType)))),
+      Cast(
+        Cast(structNtzAttr, StructType(Seq(StructField("f", TimestampNTZType)))),
+        StructType(Seq(StructField("f", DateType)))))
+  }
+
+  test("rewrite bridges only the nanos field of a mixed struct") {
+    // The non-nanos field (b: INT) is left untouched in the intermediate type.
+    checkRewrite(
+      Cast(structMixedAttr,
+        StructType(Seq(StructField("a", DateType), StructField("b", IntegerType)))),
+      Cast(
+        Cast(structMixedAttr,
+          StructType(Seq(StructField("a", TimestampNTZType), StructField("b", IntegerType)))),
+        StructType(Seq(StructField("a", DateType), StructField("b", IntegerType)))))
+  }
+
+  test("rewrite reaches a nanos(p) -> DATE pair nested two levels deep") {
+    // ARRAY<STRUCT<f: nanos(p)>> -> ARRAY<STRUCT<f: DATE>>
+    val to = ArrayType(StructType(Seq(StructField("f", DateType))), containsNull = true)
+    val mid = ArrayType(StructType(Seq(StructField("f", TimestampNTZType))), containsNull = true)
+    checkRewrite(
+      Cast(arrStructNtzAttr, to),
+      Cast(Cast(arrStructNtzAttr, mid), to))
+  }
+
+  test("no rewrite when a complex cast has no DATE <-> nanos pair") {
+    // ARRAY<nanos(p)> -> ARRAY<nanos(p)> involves no DATE side: left as-is.
+    val same = Cast(arrNtzAttr, ArrayType(ntzNanos, containsNull = true))
+    checkRewrite(same, same)
+  }
+
+  test("complex rewrite is idempotent") {
+    val in = relation.select(
+      Cast(arrNtzAttr, ArrayType(DateType, containsNull = true)).as("c"))
     val once = Rewrite.execute(in)
     comparePlans(Rewrite.execute(once), once)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/resolver/TimezoneAwareExpressionResolverSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/resolver/TimezoneAwareExpressionResolverSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.expressions.{
 }
 import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation
 import org.apache.spark.sql.connector.catalog.CatalogManager
-import org.apache.spark.sql.types.{IntegerType, StringType}
+import org.apache.spark.sql.types.{DataType, DateType, IntegerType, StringType, TimestampLTZNanosType, TimestampNTZNanosType, TimestampNTZType, TimestampType}
 
 class TimezoneAwareExpressionResolverSuite extends SparkFunSuite {
 
@@ -92,5 +92,57 @@ class TimezoneAwareExpressionResolverSuite extends SparkFunSuite {
     assert(
       expressionWithTimezone.asInstanceOf[Cast].child.asInstanceOf[Cast].timeZoneId.get == "UTC"
     )
+  }
+
+  // SPARK-57323: DATE <-> nanos casts are not directly castable, so the single-pass resolver must
+  // apply the same rewrite as the fixed-point `ResolveTimestampNanosCast` rule (cast through the
+  // microsecond timestamp type); otherwise single-pass resolution would fail the cast's input type
+  // check while fixed-point succeeds.
+  private def resolveCast(resolvedChild: Expression, cast: Cast): Cast = {
+    val resolver = new HardCodedExpressionResolver(
+      catalogManager = mock[CatalogManager],
+      resolvedExpression = resolvedChild
+    )
+    val tzResolver = new TimezoneAwareExpressionResolver(resolver)
+    resolver.getExpressionTreeTraversals
+      .withNewTraversal(OneRowRelation()) {
+        tzResolver.resolve(cast)
+      }
+      .asInstanceOf[Cast]
+  }
+
+  private def assertRewrittenThroughMicros(
+      outer: Cast,
+      expectedOuterType: DataType,
+      expectedMicrosType: DataType,
+      expectedInnermost: Expression): Unit = {
+    assert(outer.dataType == expectedOuterType)
+    assert(outer.timeZoneId.nonEmpty)
+    val inner = outer.child.asInstanceOf[Cast]
+    assert(inner.dataType == expectedMicrosType)
+    assert(inner.timeZoneId.nonEmpty)
+    assert(inner.child == expectedInnermost)
+  }
+
+  test("SPARK-57323: single-pass rewrites DATE -> nanos cast through the micros timestamp type") {
+    val dateChild = AttributeReference(name = "d", dataType = DateType)()
+    Seq(
+      TimestampNTZNanosType(TimestampNTZNanosType.MAX_PRECISION) -> TimestampNTZType,
+      TimestampLTZNanosType(TimestampLTZNanosType.MAX_PRECISION) -> TimestampType
+    ).foreach { case (nanos, micros) =>
+      val resolved = resolveCast(dateChild, Cast(child = unresolvedChild, dataType = nanos))
+      assertRewrittenThroughMicros(resolved, nanos, micros, dateChild)
+    }
+  }
+
+  test("SPARK-57323: single-pass rewrites nanos -> DATE cast through the micros timestamp type") {
+    Seq(
+      TimestampNTZNanosType(TimestampNTZNanosType.MAX_PRECISION) -> TimestampNTZType,
+      TimestampLTZNanosType(TimestampLTZNanosType.MAX_PRECISION) -> TimestampType
+    ).foreach { case (nanos, micros) =>
+      val nanosChild = AttributeReference(name = "n", dataType = nanos)()
+      val resolved = resolveCast(nanosChild, Cast(child = unresolvedChild, dataType = DateType))
+      assertRewrittenThroughMicros(resolved, DateType, micros, nanosChild)
+    }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -745,6 +745,14 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       // ... but blocks the lossy narrowing nanos(p) -> micros to avoid silent truncation.
       assert(!Cast.canANSIStoreAssign(TimestampNTZNanosType(p), TimestampNTZType))
       assert(!Cast.canANSIStoreAssign(TimestampLTZNanosType(p), TimestampType))
+
+      // SPARK-57323: DATE <-> nanos requires an explicit CAST in both directions (the explicit
+      // cast is rewritten through the microsecond type by ResolveTimestampNanosCast), so STRICT
+      // store assignment and ANSI store assignment both reject it.
+      assert(!Cast.canANSIStoreAssign(DateType, TimestampNTZNanosType(p)))
+      assert(!Cast.canANSIStoreAssign(TimestampNTZNanosType(p), DateType))
+      assert(!Cast.canANSIStoreAssign(DateType, TimestampLTZNanosType(p)))
+      assert(!Cast.canANSIStoreAssign(TimestampLTZNanosType(p), DateType))
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -749,6 +749,12 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       // SPARK-57323: DATE <-> nanos requires an explicit CAST in both directions (the explicit
       // cast is rewritten through the microsecond type by ResolveTimestampNanosCast), so STRICT
       // store assignment and ANSI store assignment both reject it.
+      // STRICT goes through Cast.canUpCast; assert it directly so a future blanket datetime arm in
+      // UpCastRule cannot silently turn this into a safe (implicit) store assignment.
+      assert(!Cast.canUpCast(DateType, TimestampNTZNanosType(p)))
+      assert(!Cast.canUpCast(TimestampNTZNanosType(p), DateType))
+      assert(!Cast.canUpCast(DateType, TimestampLTZNanosType(p)))
+      assert(!Cast.canUpCast(TimestampLTZNanosType(p), DateType))
       assert(!Cast.canANSIStoreAssign(DateType, TimestampNTZNanosType(p)))
       assert(!Cast.canANSIStoreAssign(TimestampNTZNanosType(p), DateType))
       assert(!Cast.canANSIStoreAssign(DateType, TimestampLTZNanosType(p)))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -759,6 +759,12 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       assert(!Cast.canANSIStoreAssign(TimestampNTZNanosType(p), DateType))
       assert(!Cast.canANSIStoreAssign(DateType, TimestampLTZNanosType(p)))
       assert(!Cast.canANSIStoreAssign(TimestampLTZNanosType(p), DateType))
+      // Cast.canCast also rejects DATE <-> nanos directly: the cast is supported only via the
+      // ResolveTimestampNanosCast analyzer rule (which rewrites through the microsecond type).
+      assert(!Cast.canCast(DateType, TimestampNTZNanosType(p)))
+      assert(!Cast.canCast(TimestampNTZNanosType(p), DateType))
+      assert(!Cast.canCast(DateType, TimestampLTZNanosType(p)))
+      assert(!Cast.canCast(TimestampLTZNanosType(p), DateType))
     }
   }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ltz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ltz-nanos.sql.out
@@ -119,105 +119,46 @@ Project [named_struct(f, cast(null as timestamp_ltz(9))) AS named_struct(f, CAST
 
 
 -- !query
-SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
+SELECT DATE '2020-01-01'::timestamp_ltz(9)
 -- !query analysis
-Project [hour(cast(TimestampNanosVal(1577913875123456, 789) as timestamp), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(1577913875123456, 789))#x]
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+SELECT DATE '2020-01-01'::timestamp_ltz(7)
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+SELECT TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789'::date
+-- !query analysis
+Project [cast(cast(TimestampNanosVal(1577910615123456, 789) as timestamp) as date) AS CAST(TimestampNanosVal(1577910615123456, 789) AS DATE)#x]
 +- OneRowRelation
 
 
 -- !query
-SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
+SELECT TIMESTAMP_LTZ '1960-01-01 00:00:00.000000001'::date
 -- !query analysis
-Project [minute(cast(TimestampNanosVal(1577913875123456, 789) as timestamp), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(1577913875123456, 789))#x]
+Project [cast(cast(TimestampNanosVal(-315590400000000, 1) as timestamp) as date) AS CAST(TimestampNanosVal(-315590400000000, 1) AS DATE)#x]
 +- OneRowRelation
 
 
 -- !query
-SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
+SELECT DATE '2020-01-01'::timestamp_ltz(9)::date
 -- !query analysis
-Project [second(cast(TimestampNanosVal(1577913875123456, 789) as timestamp), Some(America/Los_Angeles)) AS second(TimestampNanosVal(1577913875123456, 789))#x]
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+SELECT (NULL::date)::timestamp_ltz(9)
+-- !query analysis
+Project [cast(cast(cast(null as date) as timestamp) as timestamp_ltz(9)) AS CAST(CAST(NULL AS DATE) AS TIMESTAMP_LTZ(9))#x]
 +- OneRowRelation
 
 
 -- !query
-SELECT hour('2020-01-01 13:24:35.999999999' :: timestamp_ltz(7))
+SELECT (NULL::timestamp_ltz(9))::date
 -- !query analysis
-Project [hour(cast(cast(2020-01-01 13:24:35.999999999 as timestamp_ltz(7)) as timestamp), Some(America/Los_Angeles)) AS hour(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_LTZ(7)))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT second('2020-01-01 13:24:35.999999999' :: timestamp_ltz(8))
--- !query analysis
-Project [second(cast(cast(2020-01-01 13:24:35.999999999 as timestamp_ltz(8)) as timestamp), Some(America/Los_Angeles)) AS second(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_LTZ(8)))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT hour(NULL :: timestamp_ltz(9))
--- !query analysis
-Project [hour(cast(cast(null as timestamp_ltz(9)) as timestamp), Some(America/Los_Angeles)) AS hour(CAST(NULL AS TIMESTAMP_LTZ(9)))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT hour(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
--- !query analysis
-Project [hour(cast(TimestampNanosVal(-315542124876544, 789) as timestamp), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(-315542124876544, 789))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT minute(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
--- !query analysis
-Project [minute(cast(TimestampNanosVal(-315542124876544, 789) as timestamp), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(-315542124876544, 789))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT second(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
--- !query analysis
-Project [second(cast(TimestampNanosVal(-315542124876544, 789) as timestamp), Some(America/Los_Angeles)) AS second(TimestampNanosVal(-315542124876544, 789))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
--- !query analysis
-Project [hour(cast(TimestampNanosVal(1577865275123456, 789) as timestamp), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(1577865275123456, 789))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
--- !query analysis
-Project [minute(cast(TimestampNanosVal(1577865275123456, 789) as timestamp), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(1577865275123456, 789))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
--- !query analysis
-Project [second(cast(TimestampNanosVal(1577865275123456, 789) as timestamp), Some(America/Los_Angeles)) AS second(TimestampNanosVal(1577865275123456, 789))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
--- !query analysis
-Project [hour(cast(TimestampNanosVal(1577885075123456, 789) as timestamp), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(1577885075123456, 789))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
--- !query analysis
-Project [minute(cast(TimestampNanosVal(1577885075123456, 789) as timestamp), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(1577885075123456, 789))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
--- !query analysis
-Project [second(cast(TimestampNanosVal(1577885075123456, 789) as timestamp), Some(America/Los_Angeles)) AS second(TimestampNanosVal(1577885075123456, 789))#x]
+Project [cast(cast(cast(null as timestamp_ltz(9)) as timestamp) as date) AS CAST(CAST(NULL AS TIMESTAMP_LTZ(9)) AS DATE)#x]
 +- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ltz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ltz-nanos.sql.out
@@ -119,6 +119,111 @@ Project [named_struct(f, cast(null as timestamp_ltz(9))) AS named_struct(f, CAST
 
 
 -- !query
+SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
+-- !query analysis
+Project [hour(cast(TimestampNanosVal(1577913875123456, 789) as timestamp), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(1577913875123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
+-- !query analysis
+Project [minute(cast(TimestampNanosVal(1577913875123456, 789) as timestamp), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(1577913875123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
+-- !query analysis
+Project [second(cast(TimestampNanosVal(1577913875123456, 789) as timestamp), Some(America/Los_Angeles)) AS second(TimestampNanosVal(1577913875123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT hour('2020-01-01 13:24:35.999999999' :: timestamp_ltz(7))
+-- !query analysis
+Project [hour(cast(cast(2020-01-01 13:24:35.999999999 as timestamp_ltz(7)) as timestamp), Some(America/Los_Angeles)) AS hour(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_LTZ(7)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT second('2020-01-01 13:24:35.999999999' :: timestamp_ltz(8))
+-- !query analysis
+Project [second(cast(cast(2020-01-01 13:24:35.999999999 as timestamp_ltz(8)) as timestamp), Some(America/Los_Angeles)) AS second(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_LTZ(8)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT hour(NULL :: timestamp_ltz(9))
+-- !query analysis
+Project [hour(cast(cast(null as timestamp_ltz(9)) as timestamp), Some(America/Los_Angeles)) AS hour(CAST(NULL AS TIMESTAMP_LTZ(9)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT hour(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
+-- !query analysis
+Project [hour(cast(TimestampNanosVal(-315542124876544, 789) as timestamp), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(-315542124876544, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT minute(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
+-- !query analysis
+Project [minute(cast(TimestampNanosVal(-315542124876544, 789) as timestamp), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(-315542124876544, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT second(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
+-- !query analysis
+Project [second(cast(TimestampNanosVal(-315542124876544, 789) as timestamp), Some(America/Los_Angeles)) AS second(TimestampNanosVal(-315542124876544, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
+-- !query analysis
+Project [hour(cast(TimestampNanosVal(1577865275123456, 789) as timestamp), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(1577865275123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
+-- !query analysis
+Project [minute(cast(TimestampNanosVal(1577865275123456, 789) as timestamp), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(1577865275123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
+-- !query analysis
+Project [second(cast(TimestampNanosVal(1577865275123456, 789) as timestamp), Some(America/Los_Angeles)) AS second(TimestampNanosVal(1577865275123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
+-- !query analysis
+Project [hour(cast(TimestampNanosVal(1577885075123456, 789) as timestamp), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(1577885075123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
+-- !query analysis
+Project [minute(cast(TimestampNanosVal(1577885075123456, 789) as timestamp), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(1577885075123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
+-- !query analysis
+Project [second(cast(TimestampNanosVal(1577885075123456, 789) as timestamp), Some(America/Los_Angeles)) AS second(TimestampNanosVal(1577885075123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
 SELECT DATE '2020-01-01'::timestamp_ltz(9)
 -- !query analysis
 [Analyzer test output redacted due to nondeterminism]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ltz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ltz-nanos.sql.out
@@ -267,3 +267,43 @@ SELECT (NULL::timestamp_ltz(9))::date
 -- !query analysis
 Project [cast(cast(cast(null as timestamp_ltz(9)) as timestamp) as date) AS CAST(CAST(NULL AS TIMESTAMP_LTZ(9)) AS DATE)#x]
 +- OneRowRelation
+
+
+-- !query
+SELECT array(TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789', NULL)::array<date>
+-- !query analysis
+Project [cast(cast(array(TimestampNanosVal(1577910615123456, 789), cast(null as timestamp_ltz(9))) as array<timestamp>) as array<date>) AS array(TimestampNanosVal(1577910615123456, 789), NULL)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT map('k', TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789')::map<string, date>
+-- !query analysis
+Project [cast(cast(map(k, TimestampNanosVal(1577910615123456, 789)) as map<string,timestamp>) as map<string,date>) AS map(k, TimestampNanosVal(1577910615123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT named_struct('f', TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789')::struct<f: date>
+-- !query analysis
+Project [cast(cast(named_struct(f, TimestampNanosVal(1577910615123456, 789)) as struct<f:timestamp>) as struct<f:date>) AS named_struct(f, TimestampNanosVal(1577910615123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT array(DATE '2020-01-01', NULL)::array<timestamp_ltz(9)>::string
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+SELECT named_struct('f', DATE '2020-01-01')::struct<f: timestamp_ltz(9)>::string
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+SELECT array(named_struct('f', TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789'))::array<struct<f: date>>
+-- !query analysis
+Project [cast(cast(array(named_struct(f, TimestampNanosVal(1577910615123456, 789))) as array<struct<f:timestamp>>) as array<struct<f:date>>) AS array(named_struct(f, TimestampNanosVal(1577910615123456, 789)))#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz-nanos.sql.out
@@ -119,6 +119,69 @@ Project [named_struct(f, cast(null as timestamp_ntz(9))) AS named_struct(f, CAST
 
 
 -- !query
+SELECT hour(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
+-- !query analysis
+Project [hour(cast(TimestampNanosVal(1577885075123456, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(1577885075123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT minute(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
+-- !query analysis
+Project [minute(cast(TimestampNanosVal(1577885075123456, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(1577885075123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT second(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
+-- !query analysis
+Project [second(cast(TimestampNanosVal(1577885075123456, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS second(TimestampNanosVal(1577885075123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT hour('2020-01-01 13:24:35.999999999' :: timestamp_ntz(7))
+-- !query analysis
+Project [hour(cast(cast(2020-01-01 13:24:35.999999999 as timestamp_ntz(7)) as timestamp_ntz), Some(America/Los_Angeles)) AS hour(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_NTZ(7)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT second('2020-01-01 13:24:35.999999999' :: timestamp_ntz(8))
+-- !query analysis
+Project [second(cast(cast(2020-01-01 13:24:35.999999999 as timestamp_ntz(8)) as timestamp_ntz), Some(America/Los_Angeles)) AS second(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_NTZ(8)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT hour(NULL :: timestamp_ntz(9))
+-- !query analysis
+Project [hour(cast(cast(null as timestamp_ntz(9)) as timestamp_ntz), Some(America/Los_Angeles)) AS hour(CAST(NULL AS TIMESTAMP_NTZ(9)))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT hour(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
+-- !query analysis
+Project [hour(cast(TimestampNanosVal(-315570924876544, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(-315570924876544, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT minute(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
+-- !query analysis
+Project [minute(cast(TimestampNanosVal(-315570924876544, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(-315570924876544, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT second(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
+-- !query analysis
+Project [second(cast(TimestampNanosVal(-315570924876544, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS second(TimestampNanosVal(-315570924876544, 789))#x]
++- OneRowRelation
+
+
+-- !query
 SELECT DATE '2020-01-01'::timestamp_ntz(9)
 -- !query analysis
 [Analyzer test output redacted due to nondeterminism]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz-nanos.sql.out
@@ -225,3 +225,43 @@ SELECT (NULL::timestamp_ntz(9))::date
 -- !query analysis
 Project [cast(cast(cast(null as timestamp_ntz(9)) as timestamp_ntz) as date) AS CAST(CAST(NULL AS TIMESTAMP_NTZ(9)) AS DATE)#x]
 +- OneRowRelation
+
+
+-- !query
+SELECT array(TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789', NULL)::array<date>
+-- !query analysis
+Project [cast(cast(array(TimestampNanosVal(1577881815123456, 789), cast(null as timestamp_ntz(9))) as array<timestamp_ntz>) as array<date>) AS array(TimestampNanosVal(1577881815123456, 789), NULL)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT map('k', TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789')::map<string, date>
+-- !query analysis
+Project [cast(cast(map(k, TimestampNanosVal(1577881815123456, 789)) as map<string,timestamp_ntz>) as map<string,date>) AS map(k, TimestampNanosVal(1577881815123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT named_struct('f', TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789')::struct<f: date>
+-- !query analysis
+Project [cast(cast(named_struct(f, TimestampNanosVal(1577881815123456, 789)) as struct<f:timestamp_ntz>) as struct<f:date>) AS named_struct(f, TimestampNanosVal(1577881815123456, 789))#x]
++- OneRowRelation
+
+
+-- !query
+SELECT array(DATE '2020-01-01', NULL)::array<timestamp_ntz(9)>::string
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+SELECT named_struct('f', DATE '2020-01-01')::struct<f: timestamp_ntz(9)>::string
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+SELECT array(named_struct('f', TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789'))::array<struct<f: date>>
+-- !query analysis
+Project [cast(cast(array(named_struct(f, TimestampNanosVal(1577881815123456, 789))) as array<struct<f:timestamp_ntz>>) as array<struct<f:date>>) AS array(named_struct(f, TimestampNanosVal(1577881815123456, 789)))#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz-nanos.sql.out
@@ -119,63 +119,46 @@ Project [named_struct(f, cast(null as timestamp_ntz(9))) AS named_struct(f, CAST
 
 
 -- !query
-SELECT hour(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
+SELECT DATE '2020-01-01'::timestamp_ntz(9)
 -- !query analysis
-Project [hour(cast(TimestampNanosVal(1577885075123456, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(1577885075123456, 789))#x]
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+SELECT DATE '2020-01-01'::timestamp_ntz(7)
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+SELECT TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789'::date
+-- !query analysis
+Project [cast(cast(TimestampNanosVal(1577881815123456, 789) as timestamp_ntz) as date) AS CAST(TimestampNanosVal(1577881815123456, 789) AS DATE)#x]
 +- OneRowRelation
 
 
 -- !query
-SELECT minute(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
+SELECT TIMESTAMP_NTZ '1960-01-01 00:00:00.000000001'::date
 -- !query analysis
-Project [minute(cast(TimestampNanosVal(1577885075123456, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(1577885075123456, 789))#x]
+Project [cast(cast(TimestampNanosVal(-315619200000000, 1) as timestamp_ntz) as date) AS CAST(TimestampNanosVal(-315619200000000, 1) AS DATE)#x]
 +- OneRowRelation
 
 
 -- !query
-SELECT second(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
+SELECT DATE '2020-01-01'::timestamp_ntz(9)::date
 -- !query analysis
-Project [second(cast(TimestampNanosVal(1577885075123456, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS second(TimestampNanosVal(1577885075123456, 789))#x]
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+SELECT (NULL::date)::timestamp_ntz(9)
+-- !query analysis
+Project [cast(cast(cast(null as date) as timestamp_ntz) as timestamp_ntz(9)) AS CAST(CAST(NULL AS DATE) AS TIMESTAMP_NTZ(9))#x]
 +- OneRowRelation
 
 
 -- !query
-SELECT hour('2020-01-01 13:24:35.999999999' :: timestamp_ntz(7))
+SELECT (NULL::timestamp_ntz(9))::date
 -- !query analysis
-Project [hour(cast(cast(2020-01-01 13:24:35.999999999 as timestamp_ntz(7)) as timestamp_ntz), Some(America/Los_Angeles)) AS hour(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_NTZ(7)))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT second('2020-01-01 13:24:35.999999999' :: timestamp_ntz(8))
--- !query analysis
-Project [second(cast(cast(2020-01-01 13:24:35.999999999 as timestamp_ntz(8)) as timestamp_ntz), Some(America/Los_Angeles)) AS second(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_NTZ(8)))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT hour(NULL :: timestamp_ntz(9))
--- !query analysis
-Project [hour(cast(cast(null as timestamp_ntz(9)) as timestamp_ntz), Some(America/Los_Angeles)) AS hour(CAST(NULL AS TIMESTAMP_NTZ(9)))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT hour(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
--- !query analysis
-Project [hour(cast(TimestampNanosVal(-315570924876544, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(-315570924876544, 789))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT minute(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
--- !query analysis
-Project [minute(cast(TimestampNanosVal(-315570924876544, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(-315570924876544, 789))#x]
-+- OneRowRelation
-
-
--- !query
-SELECT second(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
--- !query analysis
-Project [second(cast(TimestampNanosVal(-315570924876544, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS second(TimestampNanosVal(-315570924876544, 789))#x]
+Project [cast(cast(cast(null as timestamp_ntz(9)) as timestamp_ntz) as date) AS CAST(CAST(NULL AS TIMESTAMP_NTZ(9)) AS DATE)#x]
 +- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/inputs/timestamp-ltz-nanos.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/timestamp-ltz-nanos.sql
@@ -67,3 +67,14 @@ SELECT DATE '2020-01-01'::timestamp_ltz(9)::date;
 -- NULLs in both directions.
 SELECT (NULL::date)::timestamp_ltz(9);
 SELECT (NULL::timestamp_ltz(9))::date;
+
+-- DATE <-> TIMESTAMP_LTZ(p) casts nested in complex types (SPARK-57323): the rewrite reaches the
+-- DATE <-> nanos pair at any depth. nanos -> DATE outputs display directly; DATE -> nanos outputs
+-- are rendered via ::string so they materialize independently of the nanos type's collection support.
+SELECT array(TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789', NULL)::array<date>;
+SELECT map('k', TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789')::map<string, date>;
+SELECT named_struct('f', TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789')::struct<f: date>;
+SELECT array(DATE '2020-01-01', NULL)::array<timestamp_ltz(9)>::string;
+SELECT named_struct('f', DATE '2020-01-01')::struct<f: timestamp_ltz(9)>::string;
+-- Two levels deep: ARRAY<STRUCT<f: nanos>> -> ARRAY<STRUCT<f: DATE>>.
+SELECT array(named_struct('f', TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789'))::array<struct<f: date>>;

--- a/sql/core/src/test/resources/sql-tests/inputs/timestamp-ltz-nanos.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/timestamp-ltz-nanos.sql
@@ -55,3 +55,15 @@ SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata');
 SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC');
 SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC');
 SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC');
+
+-- DATE <-> TIMESTAMP_LTZ(p) casts (SPARK-57323): midnight in the session zone / date extraction.
+-- Nanosecond typed literals derive precision from the fractional digits (SPARK-57250).
+SELECT DATE '2020-01-01'::timestamp_ltz(9);
+SELECT DATE '2020-01-01'::timestamp_ltz(7);
+SELECT TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789'::date;
+SELECT TIMESTAMP_LTZ '1960-01-01 00:00:00.000000001'::date;
+-- Round trip date -> ltz(p) -> date.
+SELECT DATE '2020-01-01'::timestamp_ltz(9)::date;
+-- NULLs in both directions.
+SELECT (NULL::date)::timestamp_ltz(9);
+SELECT (NULL::timestamp_ltz(9))::date;

--- a/sql/core/src/test/resources/sql-tests/inputs/timestamp-ntz-nanos.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/timestamp-ntz-nanos.sql
@@ -46,3 +46,15 @@ SELECT hour(NULL :: timestamp_ntz(9));
 SELECT hour(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789');
 SELECT minute(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789');
 SELECT second(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789');
+
+-- DATE <-> TIMESTAMP_NTZ(p) casts (SPARK-57323): midnight UTC / date extraction (zone-independent).
+-- Nanosecond typed literals derive precision from the fractional digits (SPARK-57250).
+SELECT DATE '2020-01-01'::timestamp_ntz(9);
+SELECT DATE '2020-01-01'::timestamp_ntz(7);
+SELECT TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789'::date;
+SELECT TIMESTAMP_NTZ '1960-01-01 00:00:00.000000001'::date;
+-- Round trip date -> ntz(p) -> date.
+SELECT DATE '2020-01-01'::timestamp_ntz(9)::date;
+-- NULLs in both directions.
+SELECT (NULL::date)::timestamp_ntz(9);
+SELECT (NULL::timestamp_ntz(9))::date;

--- a/sql/core/src/test/resources/sql-tests/inputs/timestamp-ntz-nanos.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/timestamp-ntz-nanos.sql
@@ -58,3 +58,14 @@ SELECT DATE '2020-01-01'::timestamp_ntz(9)::date;
 -- NULLs in both directions.
 SELECT (NULL::date)::timestamp_ntz(9);
 SELECT (NULL::timestamp_ntz(9))::date;
+
+-- DATE <-> TIMESTAMP_NTZ(p) casts nested in complex types (SPARK-57323): the rewrite reaches the
+-- DATE <-> nanos pair at any depth. nanos -> DATE outputs display directly; DATE -> nanos outputs
+-- are rendered via ::string so they materialize independently of the nanos type's collection support.
+SELECT array(TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789', NULL)::array<date>;
+SELECT map('k', TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789')::map<string, date>;
+SELECT named_struct('f', TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789')::struct<f: date>;
+SELECT array(DATE '2020-01-01', NULL)::array<timestamp_ntz(9)>::string;
+SELECT named_struct('f', DATE '2020-01-01')::struct<f: timestamp_ntz(9)>::string;
+-- Two levels deep: ARRAY<STRUCT<f: nanos>> -> ARRAY<STRUCT<f: DATE>>.
+SELECT array(named_struct('f', TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789'))::array<struct<f: date>>;

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ltz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ltz-nanos.sql.out
@@ -136,6 +136,126 @@ struct<named_struct(f, CAST(NULL AS TIMESTAMP_LTZ(9))):struct<f:timestamp_ltz(9)
 
 
 -- !query
+SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
+-- !query schema
+struct<hour(TimestampNanosVal(1577913875123456, 789)):int>
+-- !query output
+13
+
+
+-- !query
+SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
+-- !query schema
+struct<minute(TimestampNanosVal(1577913875123456, 789)):int>
+-- !query output
+24
+
+
+-- !query
+SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
+-- !query schema
+struct<second(TimestampNanosVal(1577913875123456, 789)):int>
+-- !query output
+35
+
+
+-- !query
+SELECT hour('2020-01-01 13:24:35.999999999' :: timestamp_ltz(7))
+-- !query schema
+struct<hour(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_LTZ(7))):int>
+-- !query output
+13
+
+
+-- !query
+SELECT second('2020-01-01 13:24:35.999999999' :: timestamp_ltz(8))
+-- !query schema
+struct<second(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_LTZ(8))):int>
+-- !query output
+35
+
+
+-- !query
+SELECT hour(NULL :: timestamp_ltz(9))
+-- !query schema
+struct<hour(CAST(NULL AS TIMESTAMP_LTZ(9))):int>
+-- !query output
+NULL
+
+
+-- !query
+SELECT hour(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
+-- !query schema
+struct<hour(TimestampNanosVal(-315542124876544, 789)):int>
+-- !query output
+13
+
+
+-- !query
+SELECT minute(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
+-- !query schema
+struct<minute(TimestampNanosVal(-315542124876544, 789)):int>
+-- !query output
+24
+
+
+-- !query
+SELECT second(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
+-- !query schema
+struct<second(TimestampNanosVal(-315542124876544, 789)):int>
+-- !query output
+35
+
+
+-- !query
+SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
+-- !query schema
+struct<hour(TimestampNanosVal(1577865275123456, 789)):int>
+-- !query output
+23
+
+
+-- !query
+SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
+-- !query schema
+struct<minute(TimestampNanosVal(1577865275123456, 789)):int>
+-- !query output
+54
+
+
+-- !query
+SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
+-- !query schema
+struct<second(TimestampNanosVal(1577865275123456, 789)):int>
+-- !query output
+35
+
+
+-- !query
+SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
+-- !query schema
+struct<hour(TimestampNanosVal(1577885075123456, 789)):int>
+-- !query output
+5
+
+
+-- !query
+SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
+-- !query schema
+struct<minute(TimestampNanosVal(1577885075123456, 789)):int>
+-- !query output
+24
+
+
+-- !query
+SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
+-- !query schema
+struct<second(TimestampNanosVal(1577885075123456, 789)):int>
+-- !query output
+35
+
+
+-- !query
 SELECT DATE '2020-01-01'::timestamp_ltz(9)
 -- !query schema
 struct<CAST(DATE '2020-01-01' AS TIMESTAMP_LTZ(9)):timestamp_ltz(9)>

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ltz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ltz-nanos.sql.out
@@ -136,120 +136,56 @@ struct<named_struct(f, CAST(NULL AS TIMESTAMP_LTZ(9))):struct<f:timestamp_ltz(9)
 
 
 -- !query
-SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
+SELECT DATE '2020-01-01'::timestamp_ltz(9)
 -- !query schema
-struct<hour(TimestampNanosVal(1577913875123456, 789)):int>
+struct<CAST(DATE '2020-01-01' AS TIMESTAMP_LTZ(9)):timestamp_ltz(9)>
 -- !query output
-13
+2020-01-01 00:00:00
 
 
 -- !query
-SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
+SELECT DATE '2020-01-01'::timestamp_ltz(7)
 -- !query schema
-struct<minute(TimestampNanosVal(1577913875123456, 789)):int>
+struct<CAST(DATE '2020-01-01' AS TIMESTAMP_LTZ(7)):timestamp_ltz(7)>
 -- !query output
-24
+2020-01-01 00:00:00
 
 
 -- !query
-SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
+SELECT TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789'::date
 -- !query schema
-struct<second(TimestampNanosVal(1577913875123456, 789)):int>
+struct<CAST(TimestampNanosVal(1577910615123456, 789) AS DATE):date>
 -- !query output
-35
+2020-01-01
 
 
 -- !query
-SELECT hour('2020-01-01 13:24:35.999999999' :: timestamp_ltz(7))
+SELECT TIMESTAMP_LTZ '1960-01-01 00:00:00.000000001'::date
 -- !query schema
-struct<hour(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_LTZ(7))):int>
+struct<CAST(TimestampNanosVal(-315590400000000, 1) AS DATE):date>
 -- !query output
-13
+1960-01-01
 
 
 -- !query
-SELECT second('2020-01-01 13:24:35.999999999' :: timestamp_ltz(8))
+SELECT DATE '2020-01-01'::timestamp_ltz(9)::date
 -- !query schema
-struct<second(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_LTZ(8))):int>
+struct<CAST(CAST(DATE '2020-01-01' AS TIMESTAMP_LTZ(9)) AS DATE):date>
 -- !query output
-35
+2020-01-01
 
 
 -- !query
-SELECT hour(NULL :: timestamp_ltz(9))
+SELECT (NULL::date)::timestamp_ltz(9)
 -- !query schema
-struct<hour(CAST(NULL AS TIMESTAMP_LTZ(9))):int>
+struct<CAST(CAST(NULL AS DATE) AS TIMESTAMP_LTZ(9)):timestamp_ltz(9)>
 -- !query output
 NULL
 
 
 -- !query
-SELECT hour(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
+SELECT (NULL::timestamp_ltz(9))::date
 -- !query schema
-struct<hour(TimestampNanosVal(-315542124876544, 789)):int>
+struct<CAST(CAST(NULL AS TIMESTAMP_LTZ(9)) AS DATE):date>
 -- !query output
-13
-
-
--- !query
-SELECT minute(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
--- !query schema
-struct<minute(TimestampNanosVal(-315542124876544, 789)):int>
--- !query output
-24
-
-
--- !query
-SELECT second(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
--- !query schema
-struct<second(TimestampNanosVal(-315542124876544, 789)):int>
--- !query output
-35
-
-
--- !query
-SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
--- !query schema
-struct<hour(TimestampNanosVal(1577865275123456, 789)):int>
--- !query output
-23
-
-
--- !query
-SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
--- !query schema
-struct<minute(TimestampNanosVal(1577865275123456, 789)):int>
--- !query output
-54
-
-
--- !query
-SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
--- !query schema
-struct<second(TimestampNanosVal(1577865275123456, 789)):int>
--- !query output
-35
-
-
--- !query
-SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
--- !query schema
-struct<hour(TimestampNanosVal(1577885075123456, 789)):int>
--- !query output
-5
-
-
--- !query
-SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
--- !query schema
-struct<minute(TimestampNanosVal(1577885075123456, 789)):int>
--- !query output
-24
-
-
--- !query
-SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
--- !query schema
-struct<second(TimestampNanosVal(1577885075123456, 789)):int>
--- !query output
-35
+NULL

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ltz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ltz-nanos.sql.out
@@ -309,3 +309,51 @@ SELECT (NULL::timestamp_ltz(9))::date
 struct<CAST(CAST(NULL AS TIMESTAMP_LTZ(9)) AS DATE):date>
 -- !query output
 NULL
+
+
+-- !query
+SELECT array(TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789', NULL)::array<date>
+-- !query schema
+struct<array(TimestampNanosVal(1577910615123456, 789), NULL):array<date>>
+-- !query output
+[2020-01-01,null]
+
+
+-- !query
+SELECT map('k', TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789')::map<string, date>
+-- !query schema
+struct<map(k, TimestampNanosVal(1577910615123456, 789)):map<string,date>>
+-- !query output
+{"k":2020-01-01}
+
+
+-- !query
+SELECT named_struct('f', TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789')::struct<f: date>
+-- !query schema
+struct<named_struct(f, TimestampNanosVal(1577910615123456, 789)):struct<f:date>>
+-- !query output
+{"f":2020-01-01}
+
+
+-- !query
+SELECT array(DATE '2020-01-01', NULL)::array<timestamp_ltz(9)>::string
+-- !query schema
+struct<CAST(array(DATE '2020-01-01', NULL) AS STRING):string>
+-- !query output
+[2020-01-01 00:00:00, null]
+
+
+-- !query
+SELECT named_struct('f', DATE '2020-01-01')::struct<f: timestamp_ltz(9)>::string
+-- !query schema
+struct<CAST(named_struct(f, DATE '2020-01-01') AS STRING):string>
+-- !query output
+{2020-01-01 00:00:00}
+
+
+-- !query
+SELECT array(named_struct('f', TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789'))::array<struct<f: date>>
+-- !query schema
+struct<array(named_struct(f, TimestampNanosVal(1577910615123456, 789))):array<struct<f:date>>>
+-- !query output
+[{"f":2020-01-01}]

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ntz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ntz-nanos.sql.out
@@ -136,6 +136,78 @@ struct<named_struct(f, CAST(NULL AS TIMESTAMP_NTZ(9))):struct<f:timestamp_ntz(9)
 
 
 -- !query
+SELECT hour(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
+-- !query schema
+struct<hour(TimestampNanosVal(1577885075123456, 789)):int>
+-- !query output
+13
+
+
+-- !query
+SELECT minute(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
+-- !query schema
+struct<minute(TimestampNanosVal(1577885075123456, 789)):int>
+-- !query output
+24
+
+
+-- !query
+SELECT second(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
+-- !query schema
+struct<second(TimestampNanosVal(1577885075123456, 789)):int>
+-- !query output
+35
+
+
+-- !query
+SELECT hour('2020-01-01 13:24:35.999999999' :: timestamp_ntz(7))
+-- !query schema
+struct<hour(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_NTZ(7))):int>
+-- !query output
+13
+
+
+-- !query
+SELECT second('2020-01-01 13:24:35.999999999' :: timestamp_ntz(8))
+-- !query schema
+struct<second(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_NTZ(8))):int>
+-- !query output
+35
+
+
+-- !query
+SELECT hour(NULL :: timestamp_ntz(9))
+-- !query schema
+struct<hour(CAST(NULL AS TIMESTAMP_NTZ(9))):int>
+-- !query output
+NULL
+
+
+-- !query
+SELECT hour(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
+-- !query schema
+struct<hour(TimestampNanosVal(-315570924876544, 789)):int>
+-- !query output
+13
+
+
+-- !query
+SELECT minute(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
+-- !query schema
+struct<minute(TimestampNanosVal(-315570924876544, 789)):int>
+-- !query output
+24
+
+
+-- !query
+SELECT second(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
+-- !query schema
+struct<second(TimestampNanosVal(-315570924876544, 789)):int>
+-- !query output
+35
+
+
+-- !query
 SELECT DATE '2020-01-01'::timestamp_ntz(9)
 -- !query schema
 struct<CAST(DATE '2020-01-01' AS TIMESTAMP_NTZ(9)):timestamp_ntz(9)>

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ntz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ntz-nanos.sql.out
@@ -261,3 +261,51 @@ SELECT (NULL::timestamp_ntz(9))::date
 struct<CAST(CAST(NULL AS TIMESTAMP_NTZ(9)) AS DATE):date>
 -- !query output
 NULL
+
+
+-- !query
+SELECT array(TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789', NULL)::array<date>
+-- !query schema
+struct<array(TimestampNanosVal(1577881815123456, 789), NULL):array<date>>
+-- !query output
+[2020-01-01,null]
+
+
+-- !query
+SELECT map('k', TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789')::map<string, date>
+-- !query schema
+struct<map(k, TimestampNanosVal(1577881815123456, 789)):map<string,date>>
+-- !query output
+{"k":2020-01-01}
+
+
+-- !query
+SELECT named_struct('f', TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789')::struct<f: date>
+-- !query schema
+struct<named_struct(f, TimestampNanosVal(1577881815123456, 789)):struct<f:date>>
+-- !query output
+{"f":2020-01-01}
+
+
+-- !query
+SELECT array(DATE '2020-01-01', NULL)::array<timestamp_ntz(9)>::string
+-- !query schema
+struct<CAST(array(DATE '2020-01-01', NULL) AS STRING):string>
+-- !query output
+[2020-01-01 00:00:00, null]
+
+
+-- !query
+SELECT named_struct('f', DATE '2020-01-01')::struct<f: timestamp_ntz(9)>::string
+-- !query schema
+struct<CAST(named_struct(f, DATE '2020-01-01') AS STRING):string>
+-- !query output
+{2020-01-01 00:00:00}
+
+
+-- !query
+SELECT array(named_struct('f', TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789'))::array<struct<f: date>>
+-- !query schema
+struct<array(named_struct(f, TimestampNanosVal(1577881815123456, 789))):array<struct<f:date>>>
+-- !query output
+[{"f":2020-01-01}]

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ntz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ntz-nanos.sql.out
@@ -136,72 +136,56 @@ struct<named_struct(f, CAST(NULL AS TIMESTAMP_NTZ(9))):struct<f:timestamp_ntz(9)
 
 
 -- !query
-SELECT hour(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
+SELECT DATE '2020-01-01'::timestamp_ntz(9)
 -- !query schema
-struct<hour(TimestampNanosVal(1577885075123456, 789)):int>
+struct<CAST(DATE '2020-01-01' AS TIMESTAMP_NTZ(9)):timestamp_ntz(9)>
 -- !query output
-13
+2020-01-01 00:00:00
 
 
 -- !query
-SELECT minute(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
+SELECT DATE '2020-01-01'::timestamp_ntz(7)
 -- !query schema
-struct<minute(TimestampNanosVal(1577885075123456, 789)):int>
+struct<CAST(DATE '2020-01-01' AS TIMESTAMP_NTZ(7)):timestamp_ntz(7)>
 -- !query output
-24
+2020-01-01 00:00:00
 
 
 -- !query
-SELECT second(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
+SELECT TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789'::date
 -- !query schema
-struct<second(TimestampNanosVal(1577885075123456, 789)):int>
+struct<CAST(TimestampNanosVal(1577881815123456, 789) AS DATE):date>
 -- !query output
-35
+2020-01-01
 
 
 -- !query
-SELECT hour('2020-01-01 13:24:35.999999999' :: timestamp_ntz(7))
+SELECT TIMESTAMP_NTZ '1960-01-01 00:00:00.000000001'::date
 -- !query schema
-struct<hour(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_NTZ(7))):int>
+struct<CAST(TimestampNanosVal(-315619200000000, 1) AS DATE):date>
 -- !query output
-13
+1960-01-01
 
 
 -- !query
-SELECT second('2020-01-01 13:24:35.999999999' :: timestamp_ntz(8))
+SELECT DATE '2020-01-01'::timestamp_ntz(9)::date
 -- !query schema
-struct<second(CAST(2020-01-01 13:24:35.999999999 AS TIMESTAMP_NTZ(8))):int>
+struct<CAST(CAST(DATE '2020-01-01' AS TIMESTAMP_NTZ(9)) AS DATE):date>
 -- !query output
-35
+2020-01-01
 
 
 -- !query
-SELECT hour(NULL :: timestamp_ntz(9))
+SELECT (NULL::date)::timestamp_ntz(9)
 -- !query schema
-struct<hour(CAST(NULL AS TIMESTAMP_NTZ(9))):int>
+struct<CAST(CAST(NULL AS DATE) AS TIMESTAMP_NTZ(9)):timestamp_ntz(9)>
 -- !query output
 NULL
 
 
 -- !query
-SELECT hour(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
+SELECT (NULL::timestamp_ntz(9))::date
 -- !query schema
-struct<hour(TimestampNanosVal(-315570924876544, 789)):int>
+struct<CAST(CAST(NULL AS TIMESTAMP_NTZ(9)) AS DATE):date>
 -- !query output
-13
-
-
--- !query
-SELECT minute(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
--- !query schema
-struct<minute(TimestampNanosVal(-315570924876544, 789)):int>
--- !query output
-24
-
-
--- !query
-SELECT second(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
--- !query schema
-struct<second(TimestampNanosVal(-315570924876544, 789)):int>
--- !query output
-35
+NULL

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ResolveTimestampNanosCastHybridAnalyzerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ResolveTimestampNanosCastHybridAnalyzerSuite.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.analysis.resolver
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * End-to-end checks that `DATE <-> nanos(p)` casts resolve under the single-pass analyzer the same
+ * way they do under the fixed-point analyzer.
+ *
+ * `DATE <-> nanos(p)` is not directly castable, so the fixed-point `ResolveTimestampNanosCast` rule
+ * rewrites it through the microsecond timestamp type. Without an equivalent rewrite in the
+ * single-pass resolver, the cast fails its input type check and dual-run mode throws
+ * `HYBRID_ANALYZER_EXCEPTION.SINGLE_PASS_FAILED_FIXED_POINT_SUCCEEDED`. Each query below is
+ * analyzed under dual-run mode (which compares the single-pass and fixed-point plans and fails on
+ * any divergence) and its result is compared against the fixed-point-only result.
+ */
+class ResolveTimestampNanosCastHybridAnalyzerSuite extends QueryTest with SharedSparkSession {
+
+  private def checkDualRunMatchesFixedPoint(query: String): Unit = {
+    val expected = withSQLConf(
+      SQLConf.TIMESTAMP_NANOS_TYPES_ENABLED.key -> "true",
+      SQLConf.ANALYZER_DUAL_RUN_LEGACY_AND_SINGLE_PASS_RESOLVER.key -> "false",
+      SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_ENABLED.key -> "false",
+      SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_ENABLED_TENTATIVELY.key -> "false"
+    ) {
+      sql(query).collect().toIndexedSeq
+    }
+
+    withSQLConf(
+      SQLConf.TIMESTAMP_NANOS_TYPES_ENABLED.key -> "true",
+      SQLConf.ANALYZER_DUAL_RUN_LEGACY_AND_SINGLE_PASS_RESOLVER.key -> "true",
+      SQLConf.ANALYZER_DUAL_RUN_SAMPLE_RATE.key -> "1.0",
+      SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_ENABLED_TENTATIVELY.key -> "false",
+      SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_EXPOSE_RESOLVER_GUARD_FAILURE.key -> "true"
+    ) {
+      // sql() analyzes eagerly, so the dual-run comparison happens here.
+      checkAnswer(sql(query), expected)
+    }
+  }
+
+  test("SPARK-57323: DATE <-> TIMESTAMP_NTZ(p) casts resolve under the single-pass analyzer") {
+    Seq(
+      // Nanos-typed outputs are rendered via ::string so they materialize independently of the
+      // nanosecond type's collection support; the DATE -> nanos cast still drives the rewrite.
+      "SELECT (DATE '2020-01-01'::timestamp_ntz(9))::string",
+      "SELECT (DATE '2020-01-01'::timestamp_ntz(7))::string",
+      "SELECT TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789'::date",
+      "SELECT TIMESTAMP_NTZ '1960-01-01 00:00:00.000000001'::date",
+      "SELECT DATE '2020-01-01'::timestamp_ntz(9)::date",
+      "SELECT ((NULL::date)::timestamp_ntz(9))::string",
+      "SELECT (NULL::timestamp_ntz(9))::date"
+    ).foreach(checkDualRunMatchesFixedPoint)
+  }
+
+  test("SPARK-57323: DATE <-> TIMESTAMP_LTZ(p) casts resolve under the single-pass analyzer") {
+    Seq(
+      "SELECT (DATE '2020-01-01'::timestamp_ltz(9))::string",
+      "SELECT (DATE '2020-01-01'::timestamp_ltz(7))::string",
+      "SELECT TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789'::date",
+      "SELECT TIMESTAMP_LTZ '1960-01-01 00:00:00.000000001'::date",
+      "SELECT DATE '2020-01-01'::timestamp_ltz(9)::date",
+      "SELECT ((NULL::date)::timestamp_ltz(9))::string",
+      "SELECT (NULL::timestamp_ltz(9))::date"
+    ).foreach(checkDualRunMatchesFixedPoint)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ResolveTimestampNanosCastHybridAnalyzerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/analysis/resolver/ResolveTimestampNanosCastHybridAnalyzerSuite.scala
@@ -66,7 +66,15 @@ class ResolveTimestampNanosCastHybridAnalyzerSuite extends QueryTest with Shared
       "SELECT TIMESTAMP_NTZ '1960-01-01 00:00:00.000000001'::date",
       "SELECT DATE '2020-01-01'::timestamp_ntz(9)::date",
       "SELECT ((NULL::date)::timestamp_ntz(9))::string",
-      "SELECT (NULL::timestamp_ntz(9))::date"
+      "SELECT (NULL::timestamp_ntz(9))::date",
+      // DATE <-> nanos nested in complex types: the rewrite must reach the pair at any depth.
+      "SELECT array(TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789', NULL)::array<date>",
+      "SELECT map('k', TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789')::map<string, date>",
+      "SELECT named_struct('f', TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789')::struct<f: date>",
+      "SELECT (array(DATE '2020-01-01', NULL)::array<timestamp_ntz(9)>)::string",
+      "SELECT (named_struct('f', DATE '2020-01-01')::struct<f: timestamp_ntz(9)>)::string",
+      "SELECT array(named_struct('f', TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789'))" +
+        "::array<struct<f: date>>"
     ).foreach(checkDualRunMatchesFixedPoint)
   }
 
@@ -78,7 +86,15 @@ class ResolveTimestampNanosCastHybridAnalyzerSuite extends QueryTest with Shared
       "SELECT TIMESTAMP_LTZ '1960-01-01 00:00:00.000000001'::date",
       "SELECT DATE '2020-01-01'::timestamp_ltz(9)::date",
       "SELECT ((NULL::date)::timestamp_ltz(9))::string",
-      "SELECT (NULL::timestamp_ltz(9))::date"
+      "SELECT (NULL::timestamp_ltz(9))::date",
+      // DATE <-> nanos nested in complex types: the rewrite must reach the pair at any depth.
+      "SELECT array(TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789', NULL)::array<date>",
+      "SELECT map('k', TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789')::map<string, date>",
+      "SELECT named_struct('f', TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789')::struct<f: date>",
+      "SELECT (array(DATE '2020-01-01', NULL)::array<timestamp_ltz(9)>)::string",
+      "SELECT (named_struct('f', DATE '2020-01-01')::struct<f: timestamp_ltz(9)>)::string",
+      "SELECT array(named_struct('f', TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789'))" +
+        "::array<struct<f: date>>"
     ).foreach(checkDualRunMatchesFixedPoint)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds support for casting between `DATE` and the nanosecond-precision timestamp types (`TIMESTAMP_NTZ(p)` and `TIMESTAMP_LTZ(p)`).

Instead of teaching `Cast` to convert these types directly, it introduces a new analyzer rule `ResolveTimestampNanosCast` that rewrites such casts through the corresponding microsecond-precision timestamp type:

- `DATE -> TIMESTAMP_NTZ/LTZ(p)`  ==>  `DATE -> TIMESTAMP_NTZ/TIMESTAMP -> TIMESTAMP_NTZ/LTZ(p)`
- `TIMESTAMP_NTZ/LTZ(p) -> DATE`  ==>  `TIMESTAMP_NTZ/LTZ(p) -> TIMESTAMP_NTZ/TIMESTAMP -> DATE`

Details:

- `ResolveTimestampNanosCast` runs in the `Resolution` fixed-point batch right after `ResolveTimeZone`, and preserves the original cast's `timeZoneId` and `evalMode` on the rewritten nested casts. The micro-precision intermediate (`TIMESTAMP` for LTZ, `TIMESTAMP_NTZ` for NTZ) already supports casting to/from `DATE`, so the resulting expression resolves normally.
- The rewrite also reaches `DATE <-> nanos(p)` pairs nested inside complex types (`ARRAY`/`MAP`/`STRUCT`) at any depth. `Cast.canCast` recurses into element types, so a nested `DATE <-> nanos` pair is rejected just like a top-level one. The rule recurses in parallel over the source and target types and builds a bridge type that mirrors the target's structure and nullability, with every `DATE <-> nanos` leaf swapped for its microsecond counterpart, e.g. `ARRAY<nanos(p)> -> ARRAY<micros> -> ARRAY<DATE>` and `STRUCT<a: nanos(p), b: INT> -> STRUCT<a: micros, b: INT> -> STRUCT<a: DATE, b: INT>`. When no `DATE <-> nanos` pair is present, the rule returns the cast unchanged so plain casts are still handled directly by `Cast`. The rewrite is idempotent.
- The rule is registered in `RuleIdCollection` so it participates in tree-pattern based pruning.
- The single-pass analyzer applies the same rewrite. The per-cast logic is extracted into `ResolveTimestampNanosCast.rewriteDateNanosCast`, which `TimezoneAwareExpressionResolver` invokes after resolving a `Cast`. Without this, single-pass resolution would fail the cast's input type check (`DATATYPE_MISMATCH` in pure single-pass mode, `HYBRID_ANALYZER_EXCEPTION.SINGLE_PASS_FAILED_FIXED_POINT_SUCCEEDED` in dual-run mode). Because both paths share the helper, the complex-type support applies to single-pass resolution as well.
- `Cast` is left mostly untouched: the only change is in `canANSIStoreAssign`, which now rejects `DATE <-> nanos` in both directions. STRICT store assignment goes through `Cast.canUpCast`, which already rejects `DATE <-> nanos` (`UpCastRule` has no nanos arms). Casting between `DATE` and a nanosecond timestamp drops the time-of-day (or fabricates it) and sub-microsecond digits, so it must be an explicit `CAST` rather than a silent store assignment.

### Why are the changes needed?

`DATE` could not be cast to or from the nanosecond-precision timestamp types (`TIMESTAMP_NTZ(p)`/`TIMESTAMP_LTZ(p)`), so common date/time conversions failed for these new types, including conversions nested inside `ARRAY`/`MAP`/`STRUCT` values.

### Does this PR introduce _any_ user-facing change?

Yes. Users can now cast between `DATE` and `TIMESTAMP_NTZ(p)` / `TIMESTAMP_LTZ(p)`, both at the top level and nested in complex types, e.g.:

```sql
SELECT DATE '2020-01-01'::timestamp_ntz(9);
SELECT TIMESTAMP_LTZ '2020-01-01 12:30:15.123456789'::date;
SELECT array(TIMESTAMP_NTZ '2020-01-01 12:30:15.123456789')::array<date>;
SELECT named_struct('f', DATE '2020-01-01')::struct<f: timestamp_ntz(9)>;
```

These casts previously failed; store assignment between the two types is still disallowed and requires an explicit `CAST`.

### How was this patch tested?

- New `ResolveTimestampNanosCastSuite` covering the structural rewrite for all four `DATE <-> nanos` directions, `timeZoneId`/`evalMode` propagation, idempotence, rewrite inside a subquery, end-to-end value/zone semantics, and the complex-type rewrite (array both directions, map value, struct field, mixed struct where only the nanos field is bridged, two-levels-deep `ARRAY<STRUCT<nanos>>`, the no-rewrite case with no `DATE <-> nanos` pair, and complex idempotence).
- New `TimezoneAwareExpressionResolverSuite` tests that the single-pass resolver rewrites `DATE <-> nanos` casts through the microsecond timestamp type in both directions for NTZ and LTZ.
- New `ResolveTimestampNanosCastHybridAnalyzerSuite` end-to-end dual-run tests asserting that `DATE <-> nanos` casts (top-level and nested in array/map/struct) resolve consistently between the single-pass and fixed-point analyzers.
- New assertions in `CastSuiteBase` that `canUpCast` (STRICT), `canANSIStoreAssign`, and `canCast` all reject `DATE <-> nanos` in both directions, guarding the invariant that makes `ResolveTimestampNanosCast` necessary.
- New golden-file queries in `timestamp-ltz-nanos.sql` and `timestamp-ntz-nanos.sql`, including complex-type casts, with regenerated `analyzer-results` and `results` outputs.
- `catalyst/scalastyle` and `catalyst/Test/scalastyle` pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor (Claude Opus 4.8)
