### PR TITLE
[DO-NOT-MERGE][POC] In-browser PySpark shell in PySpark documentation

### DIFF
--- a/python/docs/source/_static/pyspark-live/bootstrap.py
+++ b/python/docs/source/_static/pyspark-live/bootstrap.py
@@ -1,0 +1,278 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+In-browser bootstrap for the "Try PySpark in your browser" documentation
+feature. This runs *inside* Pyodide (CPython on WebAssembly), after pyspark-live.js
+has installed PySpark.
+
+It lives entirely under python/docs and is never imported by the PySpark package.
+It exposes two synchronous helpers that pyspark-live.js drives:
+
+    pyspark_live_plan_b64(code)   -> JSON: build a DataFrame from the user's code
+                                     and return its serialized Spark Connect plan
+                                     (base64). No RPC, no execution.
+    pyspark_live_render_b64(b64)  -> JSON: decode Arrow IPC stream bytes (the result
+                                     of running the plan) and render them as a table.
+
+Execution happens in JavaScript, which calls the sail-wasm ``execute_plan(planBytes)``
+between these two steps. Splitting the work this way keeps every Python step
+synchronous (Pyodide cannot block on a JS Promise on the main thread) while the
+asynchronous wasm call stays in JS.
+
+PySpark normally imports ``grpc`` at module load, but grpcio is a C-extension and
+is unavailable in Pyodide. We register permissive stand-ins for ``grpc`` and
+``grpc_status`` in ``sys.modules`` before importing the Connect client. They are
+never actually used: building a DataFrame and serializing its plan is entirely
+client-side, and execution goes through sail-wasm, not gRPC.
+"""
+
+import sys
+import types
+from importlib.machinery import ModuleSpec
+
+
+# ---------------------------------------------------------------------------
+# 1. Satisfy "import grpc" / "from grpc_status import rpc_status" without grpcio.
+#
+# The stock Connect client hard-imports grpcio at module load
+# (pyspark/sql/connect/client/core.py, retries.py, reattach.py, artifact.py and
+# the generated base_pb2_grpc.py), and references grpc symbols such as
+# ``grpc.Channel`` inside type annotations evaluated at import time (those
+# modules do not use ``from __future__ import annotations``).
+#
+# Rather than enumerate every symbol, register permissive stand-in modules. Any
+# attribute access resolves to an inert placeholder; ``grpc.RpcError`` is a real
+# exception class so ``except grpc.RpcError`` stays valid. The placeholders are
+# never invoked -- no RPC is ever made. Documentation-only; nothing ships in the
+# PySpark package.
+# ---------------------------------------------------------------------------
+class _Placeholder:
+    """Inert stand-in for any unused gRPC symbol (callable and attributable)."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return _Placeholder()
+
+    def __getattr__(self, name):
+        return _Placeholder()
+
+
+class _FakeRpcError(Exception):
+    pass
+
+
+def _install_fake_module(name, attrs):
+    if name in sys.modules:
+        return sys.modules[name]
+    module = types.ModuleType(name)
+    # A non-None __spec__ keeps importlib.util.find_spec(name) working, which
+    # PySpark uses to probe for optional packages.
+    module.__spec__ = ModuleSpec(name, loader=None)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    # PEP 562: resolve any other attribute access to a placeholder so import-time
+    # annotations like ``grpc.Channel`` evaluate without error.
+    module.__getattr__ = lambda attr: _Placeholder()  # type: ignore[attr-defined]
+    sys.modules[name] = module
+    return module
+
+
+def _install_fake_grpc():
+    # PySpark's connect dependency check requires grpcio >= 1.48.1, grpcio-status
+    # and zstandard. None can run in Pyodide, so present satisfying stand-ins; the
+    # actual RPC/compression paths are never exercised when only building plans.
+    _install_fake_module("grpc", {"RpcError": _FakeRpcError, "__version__": "1.99.0"})
+    rpc_status = _install_fake_module(
+        "grpc_status.rpc_status", {"from_call": lambda *a, **k: None}
+    )
+    _install_fake_module("grpc_status", {"rpc_status": rpc_status, "__version__": "1.99.0"})
+    _install_fake_module("zstandard", {"__version__": "0.99.0"})
+
+
+def _install_google_rpc_shim():
+    # The Connect client imports ``google.rpc.error_details_pb2`` (from the
+    # googleapis-common-protos package) at module load, only for error-detail
+    # decoding. The protobuf runtime provides ``google`` and ``google.protobuf``
+    # but not ``google.rpc``. If the real package is present (a normal install),
+    # leave it alone; otherwise register an inert stand-in so the import succeeds.
+    try:
+        import google.rpc.error_details_pb2  # noqa: F401
+
+        return
+    except Exception:
+        pass
+    import google  # provided by the protobuf runtime
+
+    errmod = _install_fake_module("google.rpc.error_details_pb2", {})
+    rpcpkg = _install_fake_module("google.rpc", {"error_details_pb2": errmod})
+    google.rpc = rpcpkg  # type: ignore[attr-defined]
+
+
+_install_fake_grpc()
+_install_google_rpc_shim()
+
+# PySpark's check_dependencies() treats "no __main__.__file__ and no spec and no
+# sys.ps1" as "running doctests" and imports the heavy pyspark.testing module
+# (and may sys.exit). Give __main__ a file so that branch is skipped.
+import __main__ as _main_module
+
+if not hasattr(_main_module, "__file__"):
+    _main_module.__file__ = "<pyspark-live>"
+
+# The generated *_pb2 modules may be built with a newer protobuf "gencode" than
+# the protobuf runtime bundled with Pyodide. That major-version guard is advisory
+# for the simple Spark Connect message types built here, so relax it.
+try:
+    from google.protobuf import runtime_version as _pb_runtime_version
+
+    _pb_runtime_version.ValidateProtobufRuntimeVersion = lambda *a, **k: None
+except Exception:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# 2. An inert channel + a session that never talks to a server.
+#
+# Building a DataFrame and serializing its plan does not require any RPC, so the
+# channel only needs to satisfy the generated stub's constructor (which calls
+# channel.unary_unary(...) / unary_stream(...) at client init). The returned
+# multicallables raise if ever invoked -- they should not be, because execution
+# is handled by sail-wasm in JS, not through this channel.
+# ---------------------------------------------------------------------------
+from pyspark.sql.connect.client.core import ChannelBuilder
+
+
+class _InertMultiCallable:
+    def __call__(self, *args, **kwargs):
+        raise RuntimeError(
+            "Spark Connect RPCs are not available in the in-browser docs shell; "
+            "execution is performed locally by sail-wasm."
+        )
+
+
+class _InertChannel:
+    def unary_unary(self, *args, **kwargs):
+        return _InertMultiCallable()
+
+    def unary_stream(self, *args, **kwargs):
+        return _InertMultiCallable()
+
+    def stream_unary(self, *args, **kwargs):
+        return _InertMultiCallable()
+
+    def close(self):
+        pass
+
+
+class WasmChannelBuilder(ChannelBuilder):
+    """A ``ChannelBuilder`` for the in-browser shell. Builds plans only."""
+
+    def __init__(self):
+        super().__init__()
+
+    def toChannel(self):
+        return _InertChannel()
+
+    @property
+    def host(self):
+        return "in-browser"
+
+
+from pyspark.sql.connect.session import SparkSession
+
+spark = SparkSession.builder.channelBuilder(WasmChannelBuilder()).getOrCreate()
+
+
+# ---------------------------------------------------------------------------
+# 3. Helpers driven by pyspark-live.js.
+# ---------------------------------------------------------------------------
+import ast
+import base64
+import io
+import json
+import traceback
+from contextlib import redirect_stdout
+
+from pyspark.sql.connect.dataframe import DataFrame as _ConnectDataFrame
+
+# Namespace shared across cells on the page. ``spark`` is always available; cells
+# import whatever else they need (the same code they would write locally).
+_CELL_GLOBALS = {"__name__": "__pyspark_live__", "spark": spark}
+
+
+def _run_cell(code):
+    """Execute a cell. If its last statement is an expression, return its value."""
+    tree = ast.parse(code, filename="<cell>", mode="exec")
+    last_expr = None
+    if tree.body and isinstance(tree.body[-1], ast.Expr):
+        last_expr = tree.body.pop().value
+    exec(compile(tree, "<cell>", "exec"), _CELL_GLOBALS)
+    if last_expr is not None:
+        return eval(compile(ast.Expression(last_expr), "<cell>", "eval"), _CELL_GLOBALS)
+    return None
+
+
+def _format_error(exc):
+    return "".join(traceback.format_exception_only(type(exc), exc)).strip()
+
+
+def pyspark_live_plan_b64(code):
+    """Run the user's code and, if it yields a DataFrame, return its plan (base64).
+
+    Returns a JSON string: {"ok", "stdout", "plan"} or {"ok": false, "error"}.
+    """
+    out = io.StringIO()
+    try:
+        with redirect_stdout(out):
+            result = _run_cell(code)
+        plan_b64 = None
+        if isinstance(result, _ConnectDataFrame):
+            plan_bytes = result._plan.to_proto(spark._client).SerializeToString()
+            plan_b64 = base64.b64encode(plan_bytes).decode("ascii")
+        return json.dumps({"ok": True, "stdout": out.getvalue(), "plan": plan_b64})
+    except Exception as exc:  # noqa: BLE001 - surfaced to the reader as cell output
+        return json.dumps(
+            {"ok": False, "error": _format_error(exc), "stdout": out.getvalue()}
+        )
+
+
+def pyspark_live_render_b64(arrow_b64):
+    """Decode Arrow IPC stream bytes and render them as a text table.
+
+    Returns a JSON string: {"ok", "text"} or {"ok": false, "error"}.
+    """
+    try:
+        import pyarrow as pa
+
+        table = pa.ipc.open_stream(base64.b64decode(arrow_b64)).read_all()
+        if table.num_columns == 0:
+            text = "(no columns)"
+        else:
+            pdf = table.to_pandas()
+            text = pdf.to_string(index=False)
+            text += "\n\n[%d row%s]" % (
+                table.num_rows,
+                "" if table.num_rows == 1 else "s",
+            )
+        return json.dumps({"ok": True, "text": text})
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps({"ok": False, "error": _format_error(exc)})
+
+
+print("PySpark is ready. A SparkSession is available as `spark`.")

--- a/python/docs/source/_static/pyspark-live/pyspark-live.css
+++ b/python/docs/source/_static/pyspark-live/pyspark-live.css
@@ -1,0 +1,90 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * Styling for the experimental "Try PySpark in your browser" feature.
+ * Loaded only when the documentation is built with PYSPARK_DOCS_LIVE set;
+ * see python/docs/source/conf.py.
+ */
+
+.pyspark-live-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0.25rem 0 0 0;
+}
+
+.pyspark-live-run {
+    cursor: pointer;
+    border: none;
+    border-radius: 0.2rem;
+    padding: 0.2rem 0.8rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #ffffff;
+    background-color: #17A2B8;
+}
+
+.pyspark-live-run:hover {
+    background-color: #1B5162;
+}
+
+.pyspark-live-run:disabled {
+    cursor: default;
+    opacity: 0.6;
+}
+
+.pyspark-live-status {
+    font-size: 0.8rem;
+    color: #6c757d;
+    font-style: italic;
+}
+
+.pyspark-live-output {
+    display: none;
+    margin: 0.25rem 0 1rem 0;
+    padding: 0.6rem 0.8rem;
+    border-left: 3px solid #17A2B8;
+    background-color: #f6f8fa;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.82rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-x: auto;
+}
+
+.pyspark-live-output.pyspark-live-error {
+    border-left-color: #d9534f;
+    background-color: #fdf2f2;
+    color: #a94442;
+}
+
+.pyspark-live-output.pyspark-live-visible {
+    display: block;
+}
+
+/* Dark theme support (pydata-sphinx-theme sets data-theme="dark"). */
+html[data-theme="dark"] .pyspark-live-output {
+    background-color: #1f2937;
+    color: #e5e7eb;
+}
+
+html[data-theme="dark"] .pyspark-live-output.pyspark-live-error {
+    background-color: #3b1f22;
+    color: #f5b7b1;
+}

--- a/python/docs/source/_static/pyspark-live/pyspark-live.js
+++ b/python/docs/source/_static/pyspark-live/pyspark-live.js
@@ -1,0 +1,300 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * "Try PySpark in your browser" - progressive enhancement for the PySpark
+ * documentation. It turns code blocks marked with the "pyspark-live" CSS class
+ * into runnable cells backed by Pyodide (CPython on WebAssembly) and an
+ * in-browser, JVM-free Spark engine (sail-wasm).
+ *
+ * Lives entirely under python/docs and is loaded only when the docs are built
+ * with PYSPARK_DOCS_LIVE set (see conf.py). It ships nothing into the PySpark
+ * package and runs only in the reader's browser.
+ *
+ * How a cell runs:
+ *   1. Python (sync): build the DataFrame from the cell's code and serialize its
+ *      Spark Connect plan. No RPC -- plan building is entirely client-side.
+ *   2. JS (async):    await sailWasm.execute_plan(planBytes) -> Arrow IPC bytes.
+ *   3. Python (sync): decode the Arrow stream and render it as a table.
+ * Splitting it this way keeps each Python step synchronous (Pyodide cannot block
+ * on a JS Promise on the main thread) while the async wasm call stays in JS.
+ *
+ * Nothing heavy downloads until the reader clicks "Run".
+ */
+
+(function () {
+  "use strict";
+
+  var DEFAULTS = {
+    // Pyodide distribution. 0.27.x is the series that ships pyarrow (which the
+    // Spark Connect client imports); pandas, numpy and protobuf come with it too.
+    pyodideIndexUrl: "https://cdn.jsdelivr.net/pyodide/v0.27.7/full/",
+    // The sail-wasm loader (ES module) published as a GitHub Release asset of
+    // https://github.com/HyukjinKwon/sail-wasm . Overridable via conf.py env vars.
+    engineUrl:
+      "https://github.com/HyukjinKwon/sail-wasm/releases/latest/download/sail_wasm.js",
+    // The wasm binary. Defaults to sail_wasm_bg.wasm next to engineUrl.
+    engineWasmUrl: null,
+    // Packages preloaded from the Pyodide distribution before installing PySpark.
+    prebuiltPackages: ["micropip", "numpy", "pandas", "pyarrow", "protobuf"],
+    // Installed via micropip from PyPI. grpcio is shimmed away (not installed).
+    pipPackages: ["pyspark"],
+    // Optional archives unpacked into the Pyodide filesystem before bootstrap,
+    // each {url, format, extractDir}. Lets a deployment provide PySpark (and
+    // friends) as hosted archives instead of, or in addition to, PyPI. extractDir
+    // is added to sys.path. Empty by default.
+    setupArchives: []
+  };
+
+  var CONFIG = Object.assign({}, DEFAULTS, window.PYSPARK_LIVE_CONFIG || {});
+  if (!CONFIG.engineWasmUrl) {
+    CONFIG.engineWasmUrl = CONFIG.engineUrl.replace(
+      /sail_wasm\.js(\?.*)?$/,
+      "sail_wasm_bg.wasm"
+    );
+  }
+
+  function assetBaseUrl() {
+    var current =
+      document.currentScript ||
+      document.querySelector('script[src*="pyspark-live/pyspark-live.js"]');
+    if (current && current.src) {
+      return current.src.replace(/pyspark-live\.js(\?.*)?$/, "");
+    }
+    return "";
+  }
+
+  var ASSET_BASE = assetBaseUrl();
+
+  // Lazily-created runtime: a ready Pyodide with PySpark installed and the
+  // bootstrap helpers defined, plus the sail-wasm execute_plan function.
+  var runtimeReady = null;
+
+  function loadScript(src) {
+    return new Promise(function (resolve, reject) {
+      var s = document.createElement("script");
+      s.src = src;
+      s.onload = resolve;
+      s.onerror = function () {
+        reject(new Error("Failed to load " + src));
+      };
+      document.head.appendChild(s);
+    });
+  }
+
+  // Import the sail-wasm ES module without depending on the server's MIME type
+  // (GitHub Releases serve assets as octet-stream, which blocks a direct
+  // import()). We fetch the source, import it from a blob URL, and point the
+  // initializer at the wasm binary explicitly.
+  async function loadEngine() {
+    var source = await fetch(CONFIG.engineUrl).then(function (r) {
+      if (!r.ok) throw new Error("Could not fetch sail-wasm (" + r.status + ")");
+      return r.text();
+    });
+    var blobUrl = URL.createObjectURL(
+      new Blob([source], { type: "text/javascript" })
+    );
+    var engine = await import(/* webpackIgnore: true */ blobUrl);
+    await engine.default({ module_or_path: CONFIG.engineWasmUrl });
+    if (typeof engine.start === "function") {
+      try {
+        engine.start();
+      } catch (e) {
+        /* start() may already have run during init */
+      }
+    }
+    return engine.execute_plan;
+  }
+
+  function bootstrapRuntime(onStatus) {
+    if (runtimeReady) {
+      return runtimeReady;
+    }
+    runtimeReady = (async function () {
+      onStatus("Downloading the Python runtime (one-time, ~10s)...");
+      await loadScript(CONFIG.pyodideIndexUrl + "pyodide.js");
+      var pyodide = await loadPyodide({ indexURL: CONFIG.pyodideIndexUrl });
+
+      onStatus("Installing PySpark and its dependencies...");
+      await pyodide.loadPackage(CONFIG.prebuiltPackages);
+
+      if (CONFIG.setupArchives && CONFIG.setupArchives.length) {
+        for (var a = 0; a < CONFIG.setupArchives.length; a++) {
+          var archive = CONFIG.setupArchives[a];
+          var buffer = await fetch(archive.url).then(function (r) {
+            if (!r.ok) throw new Error("Could not fetch " + archive.url);
+            return r.arrayBuffer();
+          });
+          var options = archive.extractDir ? { extractDir: archive.extractDir } : undefined;
+          pyodide.unpackArchive(buffer, archive.format || "zip", options);
+          if (archive.extractDir) {
+            pyodide.runPython(
+              "import sys; sys.path.insert(0, " + JSON.stringify(archive.extractDir) + ")"
+            );
+          }
+        }
+      }
+
+      if (CONFIG.pipPackages && CONFIG.pipPackages.length) {
+        var micropip = pyodide.pyimport("micropip");
+        await micropip.install(CONFIG.pipPackages);
+      }
+
+      onStatus("Starting the in-browser Spark engine...");
+      var executePlan = await loadEngine();
+
+      onStatus("Wiring up PySpark...");
+      var bootstrap = await fetch(ASSET_BASE + "bootstrap.py").then(function (r) {
+        if (!r.ok) throw new Error("Could not fetch bootstrap.py (" + r.status + ")");
+        return r.text();
+      });
+      await pyodide.runPythonAsync(bootstrap);
+
+      return { pyodide: pyodide, executePlan: executePlan };
+    })().catch(function (err) {
+      runtimeReady = null; // allow retry after a transient failure
+      throw err;
+    });
+    return runtimeReady;
+  }
+
+  function bytesToBase64(bytes) {
+    var binary = "";
+    var chunk = 0x8000;
+    for (var i = 0; i < bytes.length; i += chunk) {
+      binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+    }
+    return btoa(binary);
+  }
+
+  function base64ToBytes(b64) {
+    var binary = atob(b64);
+    var bytes = new Uint8Array(binary.length);
+    for (var i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+
+  function cellSource(container) {
+    var pre = container.querySelector("pre");
+    if (!pre) return "";
+    var clone = pre.cloneNode(true);
+    clone.querySelectorAll(".linenos, .gp, button").forEach(function (el) {
+      el.remove();
+    });
+    return clone.textContent.replace(/\n+$/, "");
+  }
+
+  function showOutput(elements, text, isError) {
+    elements.output.textContent = text;
+    elements.output.classList.add("pyspark-live-visible");
+    elements.output.classList.toggle("pyspark-live-error", !!isError);
+  }
+
+  async function runCell(elements) {
+    elements.button.disabled = true;
+    elements.output.classList.remove("pyspark-live-visible");
+    var setStatus = function (msg) {
+      elements.status.textContent = msg;
+    };
+
+    try {
+      var rt = await bootstrapRuntime(setStatus);
+      var pyodide = rt.pyodide;
+
+      setStatus("Building the query plan...");
+      pyodide.globals.set("_pyspark_live_src", cellSource(elements.container));
+      var planResult = JSON.parse(
+        pyodide.runPython("pyspark_live_plan_b64(_pyspark_live_src)")
+      );
+      if (!planResult.ok) {
+        setStatus("");
+        showOutput(elements, planResult.error, true);
+        return;
+      }
+
+      var text = planResult.stdout || "";
+      if (planResult.plan) {
+        setStatus("Executing in sail-wasm...");
+        var arrow = await rt.executePlan(base64ToBytes(planResult.plan));
+        pyodide.globals.set("_pyspark_live_arrow", bytesToBase64(arrow));
+        var rendered = JSON.parse(
+          pyodide.runPython("pyspark_live_render_b64(_pyspark_live_arrow)")
+        );
+        if (!rendered.ok) {
+          setStatus("");
+          showOutput(elements, (text ? text + "\n" : "") + rendered.error, true);
+          return;
+        }
+        text += (text && rendered.text ? "\n" : "") + rendered.text;
+      }
+
+      setStatus("");
+      showOutput(elements, text.length ? text : "(no output)", false);
+    } catch (err) {
+      setStatus("");
+      showOutput(elements, String(err && err.message ? err.message : err), true);
+    } finally {
+      elements.button.disabled = false;
+    }
+  }
+
+  function enhance(container) {
+    if (container.dataset.pysparkLiveReady) return;
+    container.dataset.pysparkLiveReady = "1";
+
+    var toolbar = document.createElement("div");
+    toolbar.className = "pyspark-live-toolbar";
+
+    var button = document.createElement("button");
+    button.className = "pyspark-live-run";
+    button.type = "button";
+    button.textContent = "Run";
+
+    var status = document.createElement("span");
+    status.className = "pyspark-live-status";
+
+    var output = document.createElement("div");
+    output.className = "pyspark-live-output";
+
+    toolbar.appendChild(button);
+    toolbar.appendChild(status);
+    container.parentNode.insertBefore(toolbar, container.nextSibling);
+    toolbar.parentNode.insertBefore(output, toolbar.nextSibling);
+
+    var elements = {
+      container: container,
+      button: button,
+      status: status,
+      output: output
+    };
+    button.addEventListener("click", function () {
+      runCell(elements);
+    });
+  }
+
+  function init() {
+    document.querySelectorAll(".pyspark-live").forEach(enhance);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -151,6 +151,28 @@ release = os.environ.get('RELEASE_VERSION', version)
 # directories to ignore when looking for source files.
 exclude_patterns = ['_build', '.DS_Store', '**.ipynb_checkpoints']
 
+# -- "Try PySpark in your browser" (experimental, documentation-only) ------
+#
+# Opt-in feature that turns code blocks marked with the "pyspark-live" class
+# into runnable cells backed by Pyodide and an in-browser, JVM-free Spark
+# engine (sail-wasm). It is enabled only when PYSPARK_DOCS_LIVE is set at
+# doc-build time, so the default build (for example the one published to
+# spark.apache.org) is completely unaffected. None of the supporting code ships
+# in the PySpark package; it all lives under python/docs/source/_static.
+pyspark_live_enabled = os.environ.get("PYSPARK_DOCS_LIVE", "").lower() in (
+    "1", "true", "yes", "on")
+
+if pyspark_live_enabled:
+    # Reveal ".. only:: pyspark_live" blocks (e.g. the toctree entry).
+    tags.add("pyspark_live")  # noqa: F821  (``tags`` is injected by Sphinx)
+else:
+    # Keep the experimental page out of the default build entirely. It is still
+    # referenced by a ".. only:: pyspark_live" toctree in getting_started; that
+    # reference to an excluded document would warn (and "-W" would fail the
+    # default build), so suppress only that specific warning.
+    exclude_patterns.append("getting_started/live_shell.rst")
+    suppress_warnings = ["toc.excluded"]
+
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
 #default_role = None
@@ -452,3 +474,34 @@ epub_exclude_files = ['search.html']
 
 # Skip sample endpoint link (not expected to resolve)
 linkcheck_ignore = [r'https://kinesis.us-east-1.amazonaws.com']
+
+
+def setup(app):
+    # Register the experimental "Try PySpark in your browser" assets. This is a
+    # no-op unless PYSPARK_DOCS_LIVE is set (see above), so the default build is
+    # untouched. The engine and runtime URLs can be overridden via environment
+    # variables (e.g. to point at a specific sail-wasm release), and are passed
+    # to the browser through a small inline config object.
+    if not pyspark_live_enabled:
+        return
+
+    import json
+
+    live_config = {
+        "pyodideIndexUrl": os.environ.get(
+            "PYSPARK_DOCS_LIVE_PYODIDE_URL",
+            "https://cdn.jsdelivr.net/pyodide/v0.27.7/full/"),
+        "engineUrl": os.environ.get(
+            "PYSPARK_DOCS_LIVE_ENGINE_URL",
+            "https://github.com/HyukjinKwon/sail-wasm/releases/latest/"
+            "download/sail_wasm.js"),
+    }
+    # Optional explicit wasm binary URL (defaults to sail_wasm_bg.wasm next to
+    # engineUrl when unset).
+    engine_wasm_url = os.environ.get("PYSPARK_DOCS_LIVE_ENGINE_WASM_URL")
+    if engine_wasm_url:
+        live_config["engineWasmUrl"] = engine_wasm_url
+
+    app.add_css_file("pyspark-live/pyspark-live.css")
+    app.add_js_file(None, body="window.PYSPARK_LIVE_CONFIG = %s;" % json.dumps(live_config))
+    app.add_js_file("pyspark-live/pyspark-live.js", loading_method="defer")

--- a/python/docs/source/getting_started/index.rst
+++ b/python/docs/source/getting_started/index.rst
@@ -41,3 +41,10 @@ The list below is the contents of this quickstart page:
    quickstart_connect
    quickstart_ps
    testing_pyspark
+
+.. only:: pyspark_live
+
+   .. toctree::
+      :maxdepth: 2
+
+      live_shell

--- a/python/docs/source/getting_started/live_shell.rst
+++ b/python/docs/source/getting_started/live_shell.rst
@@ -1,0 +1,83 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+==============================
+Try PySpark in Your Browser
+==============================
+
+.. warning::
+   This page is **experimental**. It runs a JVM-free Spark engine entirely in
+   your browser through `Pyodide <https://pyodide.org>`_ (CPython on
+   WebAssembly) and `sail-wasm <https://github.com/HyukjinKwon/sail-wasm>`_, a
+   WebAssembly build of `Sail <https://github.com/lakehq/sail>`_ (a Rust,
+   DataFusion-based engine that implements the Spark Connect protocol). It is
+   meant for learning and quickstart exploration, not for production or full
+   semantic fidelity. Nothing is sent to a server; all computation happens
+   locally in this tab.
+
+The cells below are runnable. Press **Run** on the first cell to start the
+in-browser engine (a one-time download of a few seconds), then run the others.
+A single ``SparkSession`` named ``spark`` is shared across every cell. When a
+cell ends with a DataFrame, it is executed in the browser and its result is
+shown.
+
+.. note::
+   This proof of concept supports **lazy DataFrame transformations** (such as
+   ``range``, ``filter``, ``select``, and ``selectExpr``). Operations that
+   eagerly contact a server in Spark Connect -- for example ``spark.sql(...)``
+   and ``spark.createDataFrame(...)`` -- are not wired up in the browser yet.
+
+A range of numbers
+------------------
+
+.. code-block:: python
+   :class: pyspark-live
+
+   spark.range(10)
+
+Filter and project
+------------------
+
+.. code-block:: python
+   :class: pyspark-live
+
+   spark.range(10).filter("id > 3").selectExpr("id", "id * id AS squared")
+
+A derived column
+----------------
+
+.. code-block:: python
+   :class: pyspark-live
+
+   spark.range(1, 11).selectExpr(
+       "id",
+       "CASE WHEN id % 2 = 0 THEN 'even' ELSE 'odd' END AS parity",
+   )
+
+How it works
+------------
+
+These cells use the **stock** PySpark Spark Connect client. The client builds a
+Spark Connect plan for the DataFrame entirely on the client side (no server, no
+gRPC). The serialized plan is handed to ``sail-wasm``, which decodes, resolves,
+and executes it with DataFusion and returns the result as Arrow IPC bytes; the
+page then renders those with pandas.
+
+None of this code ships in the PySpark package -- it lives under
+``python/docs/source/_static/pyspark-live/`` -- and this page is only built when
+the documentation is generated with ``PYSPARK_DOCS_LIVE`` set.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds an experimental, documentation-only "Try PySpark in your browser" feature. Code blocks marked with the `pyspark-live` class get a **Run** button and execute real PySpark right in the page, with no server or install. It runs entirely in the
browser using Pyodide (Python on WebAssembly) and a JVM-free Spark engine ([sail-wasm](https://github.com/HyukjinKwon/sail-wasm)). It is off by default and only turns on when the docs are built with `PYSPARK_DOCS_LIVE` set, so the normal docs and the PySpark package are untouched.

This is similar to the in-browser console on the NumPy homepage (https://numpy.org/ - see the "Try NumPy" live shell).

<img width="960" height="571" alt="pyspark-in-browser" src="https://github.com/user-attachments/assets/bb767e07-8841-4b9a-b6e1-553e45efe693" />

[sail-wasm](https://github.com/HyukjinKwon/sail-wasm) is a WebAssembly build of [Sail](https://github.com/lakehq/sail) (a Rust, DataFusion-based engine that implements the Spark Connect protocol). It runs the serialized Spark Connect plans
the PySpark client produces and returns Arrow results - all in the browser tab, no JVM and no backend. The compiled wasm artifact is **not** part of Apache Spark; it is hosted separately by me via GitHub Releases, and the docs only load it at runtime when the feature is enabled.

### Why are the changes needed?

- The current way is too slow and Binder is broken so long time.
- So readers can try PySpark instantly from the docs to learn, without setting up a
cluster, installing anything, or waiting for a remote notebook to start.

### Does this PR introduce _any_ user-facing change?

No. Docs-only, and disabled unless the docs are built with `PYSPARK_DOCS_LIVE`.

### How was this patch tested?

Built the docs both with and without `PYSPARK_DOCS_LIVE`: the default build is
unchanged, and the enabled build shows working "Run" cells.

### Was this patch authored or co-authored using generative AI tooling?

No.