### PR TITLE
[SPARK-57363][PS][TESTS] Add tests for Index.identical in pandas-on-Spark

### DIFF
--- a/python/pyspark/pandas/tests/indexes/test_basic.py
+++ b/python/pyspark/pandas/tests/indexes/test_basic.py
@@ -233,6 +233,65 @@ class IndexBasicMixin:
         # Index vs MultiIndex (different type) -> not equal
         self.assert_eq(pidx.equals(pmidx), psidx.equals(psmidx))
 
+    def test_identical(self):
+        # Single Index
+        pidx = pd.Index(["a", "b", "c"], name="x")
+        psidx = ps.from_pandas(pidx)
+        self.assert_eq(pidx.identical(pidx), psidx.identical(psidx))
+
+        with option_context("compute.ops_on_diff_frames", True):
+            # same elements and same name -> True
+            self.assert_eq(
+                pidx.identical(pd.Index(["a", "b", "c"], name="x")),
+                psidx.identical(ps.Index(["a", "b", "c"], name="x")),
+            )
+            # same elements but different name -> False (unlike equals)
+            self.assert_eq(
+                pidx.identical(pd.Index(["a", "b", "c"], name="y")),
+                psidx.identical(ps.Index(["a", "b", "c"], name="y")),
+            )
+            # different elements -> False
+            self.assert_eq(
+                pidx.identical(pd.Index(["b", "b", "a"], name="x")),
+                psidx.identical(ps.Index(["b", "b", "a"], name="x")),
+            )
+
+        # MultiIndex
+        pmidx = pd.MultiIndex.from_tuples([("a", "x"), ("b", "y"), ("c", "z")], names=["n1", "n2"])
+        psmidx = ps.from_pandas(pmidx)
+        self.assert_eq(pmidx.identical(pmidx), psmidx.identical(psmidx))
+
+        with option_context("compute.ops_on_diff_frames", True):
+            # same tuples and same names -> True
+            self.assert_eq(
+                pmidx.identical(
+                    pd.MultiIndex.from_tuples(
+                        [("a", "x"), ("b", "y"), ("c", "z")], names=["n1", "n2"]
+                    )
+                ),
+                psmidx.identical(
+                    ps.MultiIndex.from_tuples(
+                        [("a", "x"), ("b", "y"), ("c", "z")], names=["n1", "n2"]
+                    )
+                ),
+            )
+            # same tuples but different names -> False
+            self.assert_eq(
+                pmidx.identical(
+                    pd.MultiIndex.from_tuples(
+                        [("a", "x"), ("b", "y"), ("c", "z")], names=["m1", "m2"]
+                    )
+                ),
+                psmidx.identical(
+                    ps.MultiIndex.from_tuples(
+                        [("a", "x"), ("b", "y"), ("c", "z")], names=["m1", "m2"]
+                    )
+                ),
+            )
+
+        # Index vs MultiIndex (different type) -> not identical
+        self.assert_eq(pidx.identical(pmidx), psidx.identical(psmidx))
+
 
 class IndexBasicTests(
     IndexBasicMixin,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds positive parity tests for `Index.identical` in pandas-on-Spark
(`IndexBasicMixin` in `python/pyspark/pandas/tests/indexes/test_basic.py`).
The tests compare the `True`/`False` result of `Index.identical` against
pandas for single `Index` and `MultiIndex`: equal elements with the same
name, equal elements with a different name (the case that distinguishes
`identical` from `equals`), unequal elements, and comparing an `Index`
against a `MultiIndex`.

### Why are the changes needed?

`Index.identical` currently has no positive test coverage. The only mention
of it in the test suite is a comment in `test_equals` noting that `equals`
ignores the index name unlike `identical`; the method itself is never
exercised. These tests close that gap and lock in that `identical` returns
`True` only when both the elements and the name match.

### Does this PR introduce _any_ user-facing change?

No. This PR only adds tests.

### How was this patch tested?

Ran the new test against a local SparkSession
(`IndexBasicTests.test_identical`); it passes.

### Was this patch authored or co-authored using generative AI tooling?

Yes, this patch was co-authored with generative AI tooling (Claude,
Anthropic Opus 4.8). The contributor selected the under-tested method,
required that the asserted cases first be verified to match pandas on a
real SparkSession (excluding inputs where pandas-on-Spark intentionally
differs, e.g. NaN comparison under Spark equality), and reviewed the result.
