### PR TITLE
[SPARK-57362][DOCS] Prevent content from overlapping left navigation

### DIFF
--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -3,10 +3,6 @@
 {% for i in (1..current_page_segments.size) %}
   {% assign rel_path_to_root = rel_path_to_root | append: "../" %}
 {% endfor %}
-{% assign has_left_nav = false %}
-{% if page.url contains "/ml" or page.url contains "/sql" or page.url contains "/streaming/" or page.url contains "migration-guide.html" %}
-  {% assign has_left_nav = true %}
-{% endif %}
 
 <!DOCTYPE html>
 <html class="no-js">
@@ -57,7 +53,7 @@
         {% endproduction %}
 
     </head>
-    <body class="global{% if has_left_nav %} has-left-nav{% endif %}">
+    <body class="global">
         <!-- This code is taken from http://twitter.github.com/bootstrap/examples/hero.html -->
         <nav class="navbar navbar-expand-lg navbar-dark p-0 px-4 fixed-top" style="background: #1d6890;" id="topbar">
             <div class="navbar-brand"><a href="{{ rel_path_to_root }}index.html">
@@ -160,7 +156,7 @@
         {% endif %}
 
         <div class="container">
-            {% if has_left_nav %}
+            {% if page.url contains "/ml" or page.url contains "/sql" or page.url contains "/streaming/" or page.url contains "migration-guide.html" %}
                 {% if page.url contains "migration-guide.html" %}
                     {% include nav-left-wrapper-migration.html nav-migration=site.data.menu-migration %}
                 {% elsif page.url contains "/ml" %}

--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -3,6 +3,10 @@
 {% for i in (1..current_page_segments.size) %}
   {% assign rel_path_to_root = rel_path_to_root | append: "../" %}
 {% endfor %}
+{% assign has_left_nav = false %}
+{% if page.url contains "/ml" or page.url contains "/sql" or page.url contains "/streaming/" or page.url contains "migration-guide.html" %}
+  {% assign has_left_nav = true %}
+{% endif %}
 
 <!DOCTYPE html>
 <html class="no-js">
@@ -53,7 +57,7 @@
         {% endproduction %}
 
     </head>
-    <body class="global">
+    <body class="global{% if has_left_nav %} has-left-nav{% endif %}">
         <!-- This code is taken from http://twitter.github.com/bootstrap/examples/hero.html -->
         <nav class="navbar navbar-expand-lg navbar-dark p-0 px-4 fixed-top" style="background: #1d6890;" id="topbar">
             <div class="navbar-brand"><a href="{{ rel_path_to_root }}index.html">
@@ -156,7 +160,7 @@
         {% endif %}
 
         <div class="container">
-            {% if page.url contains "/ml" or page.url contains "/sql" or page.url contains "/streaming/" or page.url contains "migration-guide.html" %}
+            {% if has_left_nav %}
                 {% if page.url contains "migration-guide.html" %}
                     {% include nav-left-wrapper-migration.html nav-migration=site.data.menu-migration %}
                 {% elsif page.url contains "/ml" %}

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -13,10 +13,6 @@ body {
   padding-top: var(--navbar-height);
 }
 
-body.has-left-nav {
-  overflow-x: hidden;
-}
-
 a {
   background: transparent;
   color: #2fa4e7;

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -13,6 +13,10 @@ body {
   padding-top: var(--navbar-height);
 }
 
+body.has-left-nav {
+  overflow-x: hidden;
+}
+
 a {
   background: transparent;
   color: #2fa4e7;
@@ -834,6 +838,7 @@ blockquote {
   line-height: 1.6;
   padding-left: 30px;
   min-height: 100vh;
+  overflow-x: auto;
 }
 
 .left-menu-wrapper {
@@ -850,6 +855,8 @@ blockquote {
   overflow-y: scroll;
   padding-right: 20px;
   font-size: 0.9em !important;
+  z-index: 2;
+  background-color: #FFF;
 }
 
 .left-menu h3 {


### PR DESCRIPTION
### What changes were proposed in this pull request?

  On documentation pages with a left navigation sidebar, wide content (long inline code, wide tables, etc.) could push the page wider than the viewport. Because the sidebar is position: fixed, horizontal page
  scrolling then caused the main content to slide over / under the navigation and visually overlap it.

  This PR fixes that with two small CSS rules in docs/css/custom.css:

  - .content-with-sidebar gets overflow-x: auto, so wide content scrolls inside the content column instead of widening the whole page.
  - .left-menu-wrapper gets an explicit z-index and an opaque background, so the fixed navigation is never visually overlapped by content.

jira [SPARK-57362](https://issues.apache.org/jira/browse/SPARK-57362)

### Why are the changes needed?

On pages with long inline code or other wide content, horizontal page scrolling can cause the main content to overlap the fixed left navigation sidebar.

For example, this can be reproduced on the GROUP BY documentation page:
https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-groupby.html
<img width="2186" height="2074" alt="image" src="https://github.com/user-attachments/assets/cbf67725-3186-4028-9766-21f1657cc0e0" />
<img width="2512" height="2388" alt="image" src="https://github.com/user-attachments/assets/cb22cbb3-b6b6-4e14-baed-00c4c78b4f44" />


The left navigation should remain visible while wide content is scrolled.

### Does this PR introduce _any_ user-facing change?

Yes. This changes the documentation website layout behavior for pages with a left navigation sidebar. Wide content is now horizontally scrolled within the main content area instead of overlapping the left navigation.

### How was this patch tested?

Manually tested by serving the documentation locally:

```bash
SKIP_ERRORDOC=1 SKIP_API=1 bundle exec jekyll serve --host 127.0.0.1 --port 4000