### PR TITLE
[CONNECT][SDP][SPARK-57375] Fix flaky AutoCdcScd1SchemaEvolutionSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/txns.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/txns.scala
@@ -251,4 +251,9 @@ object SharedTablesInMemoryRowLevelOperationTableCatalog {
     new ConcurrentHashMap[Identifier, Table]()
 
   def reset(): Unit = sharedTables.clear()
+
+  /** Remove only entries whose namespace contains the given name. */
+  def clearNamespace(ns: String): Unit = {
+    sharedTables.keySet().removeIf(id => java.util.Arrays.asList(id.namespace(): _*).contains(ns))
+  }
 }

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcGraphExecutionTestMixin.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcGraphExecutionTestMixin.scala
@@ -46,8 +46,14 @@ trait AutoCdcGraphExecutionTestMixin extends BeforeAndAfterEach {
   /** v2 catalog name registered for AutoCDC E2E tests. Tests qualify tables as `cat.ns1.t`. */
   protected val catalog: String = "cat"
 
-  /** Namespace under [[catalog]] used by AutoCDC E2E tests. */
-  protected val namespace: String = "ns1"
+  /**
+   * Namespace under [[catalog]] used by AutoCDC E2E tests. Each concrete suite gets a unique
+   * namespace derived from its class name so that suites running in parallel in the same JVM
+   * do not collide on the shared static table map used by
+   * [[SharedTablesInMemoryRowLevelOperationTableCatalog]].
+   */
+  protected val namespace: String =
+    "ns_" + getClass.getSimpleName.toLowerCase(java.util.Locale.ROOT)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -64,7 +70,9 @@ trait AutoCdcGraphExecutionTestMixin extends BeforeAndAfterEach {
   }
 
   override protected def afterEach(): Unit = {
-    SharedTablesInMemoryRowLevelOperationTableCatalog.reset()
+    // Remove only this suite's tables from the shared static map. A global reset() would
+    // destroy tables belonging to other suites that run in parallel in the same JVM.
+    SharedTablesInMemoryRowLevelOperationTableCatalog.clearNamespace(namespace)
     spark.sessionState.catalogManager.reset()
     spark.sessionState.conf.unsetConf(s"spark.sql.catalog.$catalog")
     spark.sessionState.conf.unsetConf(SQLConf.PIPELINES_MAX_FLOW_RETRY_ATTEMPTS.key)

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd1SchemaEvolutionSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd1SchemaEvolutionSuite.scala
@@ -579,7 +579,7 @@ class AutoCdcScd1SchemaEvolutionSuite
           ExpectedContext(
             fragment = s"`$catalog`.`$namespace`.`target`.`Value`",
             start = 0,
-            stop = 27
+            stop = s"`$catalog`.`$namespace`.`target`.`Value`".length - 1
           )
         )
       )


### PR DESCRIPTION
### What changes were proposed in this pull request?

All AutoCDC E2E test suites share a single static
SharedTablesInMemoryRowLevelOperationTableCatalog.sharedTables map and previously used the same namespace "ns1". When SBT runs suites in parallel within the same JVM (parallelExecution = true), one suite's afterEach calling reset() (which clears the entire map) destroys tables that another concurrent suite is actively using, causing flaky failures where stale data survives full refreshes or auxiliary state persists.

Fix:
- Give each suite a unique namespace derived from its class name so table Identifier keys never collide across suites.
- Replace the global reset() in afterEach with a targeted clearNamespace() that removes only this suite's entries from the shared map.
- Compute the ExpectedContext stop position dynamically in AutoCdcScd1SchemaEvolutionSuite so it adapts to the longer namespace.

### Why are the changes needed?
To fix a flaky test that often fails the CI

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
It fixes a test

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Opus 4.6