### PR TITLE
[SPARK-57377][INFRA] Add CI check to prevent new entries in the config binding policy exceptions file

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1077,13 +1077,12 @@ jobs:
           echo "ERROR: This PR adds the following entries to $EXCEPTIONS_FILE:"
           echo "$ADDED_ENTRIES"
           echo ""
-          echo "This file is a frozen list of pre-existing configs that lack a binding policy,"
-          echo "and new entries must not be added to it. Instead, declare a binding policy when"
-          echo "building the config entry, e.g."
+          echo "This file is a frozen list of configs that predate the binding policy, and new"
+          echo "entries must not be added to it. Instead, declare a binding policy when building"
+          echo "the config entry, e.g."
           echo "  .withBindingPolicy(ConfigBindingPolicy.SESSION/PERSISTED/NOT_APPLICABLE)"
-          echo "See org.apache.spark.internal.config.ConfigBindingPolicy for the semantics of"
-          echo "each policy. Use NOT_APPLICABLE if the config does not affect the behavior of"
-          echo "SQL views/UDFs/procedures."
+          echo "See the scaladoc of org.apache.spark.internal.config.ConfigBindingPolicy for the"
+          echo "semantics of each policy and how to choose one."
           exit 1
         fi
         echo "No new entries added to the binding policy exceptions file."

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1038,6 +1038,56 @@ jobs:
       if: inputs.branch != 'branch-3.5'
       run: ./dev/check-protos.py
 
+  # The config binding policy exceptions file lists pre-existing configs that were created before
+  # the binding policy was introduced. It must never grow: new configs must declare a binding
+  # policy via .withBindingPolicy() instead of being added to the exceptions file. This job fails
+  # if a PR adds entries to the file. It only runs on forks because PR builds run there, and the
+  # diff against apache/spark master is exactly the PR's change.
+  binding-policy:
+    needs: [precondition]
+    if: >-
+      (!cancelled()) &&
+      github.repository != 'apache/spark' &&
+      fromJson(needs.precondition.outputs.required).lint == 'true'
+    name: Config binding policy exceptions check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Checkout Spark repository
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        repository: apache/spark
+        ref: ${{ needs.precondition.outputs.head_sha }}
+    - name: Sync the current branch with the latest in Apache Spark
+      run: |
+        echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
+        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
+        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+    - name: Check no new entries in the binding policy exceptions file
+      run: |
+        EXCEPTIONS_FILE="sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions"
+        if [ ! -f "$EXCEPTIONS_FILE" ]; then
+          echo "$EXCEPTIONS_FILE does not exist on this branch, skipping."
+          exit 0
+        fi
+        ADDED_ENTRIES=$(git diff "$APACHE_SPARK_REF" HEAD -- "$EXCEPTIONS_FILE" | grep '^+' | grep -v '^+++' || true)
+        if [ -n "$ADDED_ENTRIES" ]; then
+          echo "ERROR: This PR adds the following entries to $EXCEPTIONS_FILE:"
+          echo "$ADDED_ENTRIES"
+          echo ""
+          echo "This file is a frozen list of pre-existing configs that lack a binding policy,"
+          echo "and new entries must not be added to it. Instead, declare a binding policy when"
+          echo "building the config entry, e.g."
+          echo "  .withBindingPolicy(ConfigBindingPolicy.SESSION/PERSISTED/NOT_APPLICABLE)"
+          echo "See org.apache.spark.internal.config.ConfigBindingPolicy for the semantics of"
+          echo "each policy. Use NOT_APPLICABLE if the config does not affect the behavior of"
+          echo "SQL views/UDFs/procedures."
+          exit 1
+        fi
+        echo "No new entries added to the binding policy exceptions file."
+
   # Static analysis
   lint:
     needs: [precondition, infra-image]

--- a/common/utils/src/main/scala/org/apache/spark/internal/config/ConfigBindingPolicy.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/config/ConfigBindingPolicy.scala
@@ -32,21 +32,16 @@ package org.apache.spark.internal.config
  *
  * How to choose a policy for a new config:
  *
- *  - NOT_APPLICABLE: the config is never consulted when resolving the body of a view/UDF/
- *    procedure, e.g. physical planning, scheduling, runtime, or transport toggles. This is
- *    the right choice for most configs. At runtime it behaves the same as SESSION.
- *
- *  - SESSION: the config is consulted during view/UDF/procedure resolution and the caller's
- *    session value should apply. This is the default choice for configs that affect query
- *    behavior: it keeps behavior uniform across the entire query, and lets behavior changes
- *    such as bug-fix flags reach existing views/UDFs/procedures.
- *
- *  - PERSISTED: the view/UDF/procedure should use the create-time value of the config, e.g.
- *    ANSI mode or the session timezone. These are configs that change query behavior, where a
- *    persisted object should keep computing the same result as it did at creation, no matter
- *    who calls it later. Note that changing query behavior alone does not justify PERSISTED:
- *    a bug-fix flag also changes query behavior, but views should not freeze the buggy
- *    behavior, so it should use SESSION.
+ *  1. Is the config consulted when resolving the body of a view/UDF/procedure? If not (e.g.
+ *     physical planning, scheduling, runtime, or transport toggles), use NOT_APPLICABLE. This
+ *     covers most configs.
+ *  2. If it is consulted, should the persisted object use the create-time value of the config,
+ *     so that it keeps computing the same result as it did at creation no matter who calls it
+ *     later (e.g. ANSI mode, session timezone)? If so, use PERSISTED. Note that changing query
+ *     behavior alone does not justify PERSISTED: a bug-fix flag also changes query behavior,
+ *     but views should not freeze the buggy behavior.
+ *  3. Otherwise, use SESSION: the caller's session value applies, keeping behavior uniform
+ *     across the entire query.
  */
 object ConfigBindingPolicy extends Enumeration {
   type ConfigBindingPolicy = Value

--- a/common/utils/src/main/scala/org/apache/spark/internal/config/ConfigBindingPolicy.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/config/ConfigBindingPolicy.scala
@@ -32,10 +32,13 @@ package org.apache.spark.internal.config
  *
  * How to choose a policy for a new config:
  *
- *  1. Is the config consulted when resolving the body of a view/UDF/procedure? If not (e.g.
- *     physical planning, scheduling, runtime, or transport toggles), use NOT_APPLICABLE. This
- *     covers most configs.
- *  2. If it is consulted, should the persisted object use the create-time value of the config,
+ *  1. Can the config change the result of resolving the body of a view/UDF/procedure, i.e. the
+ *     resolved plan? If not, use NOT_APPLICABLE. This covers most configs. Note that the test
+ *     is whether the config changes the resolution result, not whether it is read during
+ *     resolution: view analysis can itself trigger query execution (e.g. a schema inference
+ *     job), so even physical planning or runtime configs may be read while resolving a view,
+ *     but they do not change what the body resolves to.
+ *  2. If it can, should the persisted object use the create-time value of the config,
  *     so that it keeps computing the same result as it did at creation no matter who calls it
  *     later (e.g. ANSI mode, session timezone)? If so, use PERSISTED. Note that changing query
  *     behavior alone does not justify PERSISTED: a bug-fix flag also changes query behavior,

--- a/common/utils/src/main/scala/org/apache/spark/internal/config/ConfigBindingPolicy.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/config/ConfigBindingPolicy.scala
@@ -29,6 +29,24 @@ package org.apache.spark.internal.config
  * is PERSISTED, session-level config changes will not apply to views/UDFs/procedures but only
  * to outer queries. In order for session-level changes to propagate correctly, this value must
  * be explicitly set to SESSION.
+ *
+ * How to choose a policy for a new config:
+ *
+ *  - NOT_APPLICABLE: the config is never consulted when resolving the body of a view/UDF/
+ *    procedure, e.g. physical planning, scheduling, runtime, or transport toggles. This is
+ *    the right choice for most configs. At runtime it behaves the same as SESSION.
+ *
+ *  - SESSION: the config is consulted during view/UDF/procedure resolution and the caller's
+ *    session value should apply. This is the default choice for configs that affect query
+ *    behavior: it keeps behavior uniform across the entire query, and lets behavior changes
+ *    such as bug-fix flags reach existing views/UDFs/procedures.
+ *
+ *  - PERSISTED: the view/UDF/procedure should use the create-time value of the config, e.g.
+ *    ANSI mode or the session timezone. These are configs that change query behavior, where a
+ *    persisted object should keep computing the same result as it did at creation, no matter
+ *    who calls it later. Note that changing query behavior alone does not justify PERSISTED:
+ *    a bug-fix flag also changes query behavior, but views should not freeze the buggy
+ *    behavior, so it should use SESSION.
  */
 object ConfigBindingPolicy extends Enumeration {
   type ConfigBindingPolicy = Value

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -76,6 +76,7 @@ private[spark] object History {
         "(e.g., S3 Lifecycle Policies) for those. " +
         "Example: \"s3a://.*,gs://.*\" disables scanning for all S3 and GCS directories.")
       .version("4.2.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .stringConf
       .toSequence
       .createWithDefault(Nil)

--- a/core/src/main/scala/org/apache/spark/internal/config/Tests.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Tests.scala
@@ -43,6 +43,7 @@ private[spark] object Tests {
     ConfigBuilder("spark.testing.injectShuffleFetchFailures")
       .doc("Injecting fetch failures for shuffle stages by providing an invalid BlockManager " +
         "location for the first stage attempt. Testing only flag!")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(false)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -149,6 +149,7 @@ private[spark] object UI {
       "backward compatibility with standalone deployments. Set to true to enforce " +
       "SNI host checking for stricter security.")
     .version("4.2.0")
+    .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
     .booleanConf
     .createWithDefault(false)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2393,6 +2393,7 @@ package object config {
       .doc("When true, scheduler log messages for streaming tasks include " +
         "the structured streaming query ID and batch ID.")
       .version("4.2.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(true)
 
@@ -2401,6 +2402,7 @@ package object config {
       .doc("Maximum number of characters of the streaming query ID to include " +
         "in scheduler log messages. Set to -1 to include the full query ID.")
       .version("4.2.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .intConf
       .createWithDefault(5)
 
@@ -2971,6 +2973,7 @@ package object config {
         "Application Master JVM options in client mode. In cluster mode, use " +
         "`spark.driver.limitActiveProcessorCount.enabled` instead.")
       .version("4.2.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(false)
 
@@ -2979,6 +2982,7 @@ package object config {
       .doc("Whether to add -XX:ActiveProcessorCount=<spark.driver.cores> to the driver JVM " +
         "options. Currently, this only takes effect in YARN cluster mode.")
       .version("4.2.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(false)
 
@@ -2987,6 +2991,7 @@ package object config {
       .doc("Whether to add -XX:ActiveProcessorCount=<spark.executor.cores> to executor JVM " +
         "options. Currently, this only takes effect in YARN mode.")
       .version("4.2.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(false)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4230,7 +4230,7 @@ object SQLConf {
 
   val WINDOW_SEGMENT_TREE_ENABLED =
     buildConf("spark.sql.window.segmentTree.enabled")
-      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .doc("Use block-chunked segment tree for moving aggregate window frames " +
         "whose functions are all DeclarativeAggregate without FILTER/DISTINCT.")
       .version("4.2.0")
@@ -4239,7 +4239,7 @@ object SQLConf {
 
   val WINDOW_SEGMENT_TREE_MIN_PARTITION_ROWS =
     buildConf("spark.sql.window.segmentTree.minPartitionRows")
-      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .doc("Minimum partition row count to activate the segment-tree moving frame. " +
         "Partitions smaller than this fall back to the default sliding implementation.")
       .version("4.2.0")
@@ -4250,7 +4250,7 @@ object SQLConf {
 
   val WINDOW_SEGMENT_TREE_BLOCK_SIZE =
     buildConf("spark.sql.window.segmentTree.blockSize")
-      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .doc("Block size, in rows, for the block-chunked segment tree used by moving " +
         "window frames. Each leaf of the tree aggregates this many consecutive rows. " +
         "Smaller values reduce per-partition memory and speed up tree build for small " +
@@ -4265,7 +4265,7 @@ object SQLConf {
 
   val WINDOW_SEGMENT_TREE_FANOUT =
     buildConf("spark.sql.window.segmentTree.fanout")
-      .withBindingPolicy(ConfigBindingPolicy.SESSION)
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .doc("Fanout of internal nodes for the block-chunked segment tree.")
       .version("4.2.0")
       .internal()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3812,6 +3812,7 @@ object SQLConf {
     .doc("Decides if we use HashAggregateExec when possible, the rule takes precedence " +
       s"over ${USE_OBJECT_HASH_AGG.key}.")
     .version("4.3.0")
+    .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
     .booleanConf
     .createWithDefault(true)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3250,6 +3250,7 @@ object SQLConf {
         "This enables sink evolution capability where sinks can be changed while maintaining " +
         "a historical record of all sinks used in the checkpoint.")
       .version("4.1.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(false)
 
@@ -7436,6 +7437,7 @@ object SQLConf {
         "top-level columns are filled with their default value (or null). This is " +
         "experimental and the semantics may change.")
       .version("4.2.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3249,7 +3249,7 @@ object SQLConf {
       .doc("When true, streaming sinks can be named using the name() API on DataStreamWriter. " +
         "This enables sink evolution capability where sinks can be changed while maintaining " +
         "a historical record of all sinks used in the checkpoint.")
-      .version("4.1.0")
+      .version("4.3.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(false)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.internal
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
+import org.apache.spark.internal.config.ConfigBindingPolicy
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.util.Utils
 
@@ -128,6 +129,7 @@ object StaticSQLConf {
       .doc("Whether to enable Jetty's SNI host check on the ThriftHttpCLIService HTTPS " +
         "connector. Set to false to restore the behavior prior to SPARK-45522 (Jetty 10+).")
       .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(true)
 

--- a/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
+++ b/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
@@ -603,7 +603,6 @@ spark.sql.execution.replaceHashWithSortAgg
 spark.sql.execution.reuseSubquery
 spark.sql.execution.sortBeforeRepartition
 spark.sql.execution.topKSortFallbackThreshold
-spark.sql.execution.useHashAggregateExec
 spark.sql.execution.useObjectHashAggregateExec
 spark.sql.execution.usePartitionEvaluator
 spark.sql.extendedExplainProviders

--- a/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
+++ b/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
@@ -648,7 +648,6 @@ spark.sql.hive.metastorePartitionPruningFastFallback
 spark.sql.hive.metastorePartitionPruningInSetThreshold
 spark.sql.hive.tablePropertyLengthThreshold
 spark.sql.hive.thriftServer.async
-spark.sql.hive.thriftServer.http.sniHostCheckEnabled
 spark.sql.hive.thriftServer.singleSession
 spark.sql.hive.useDelegateForSymlinkTextInputFormat
 spark.sql.hive.version

--- a/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
+++ b/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
@@ -43,7 +43,6 @@ spark.driver.extraClassPath
 spark.driver.extraJavaOptions
 spark.driver.extraLibraryPath
 spark.driver.host
-spark.driver.limitActiveProcessorCount.enabled
 spark.driver.log.allowErasureCoding
 spark.driver.log.dfsDir
 spark.driver.log.layout
@@ -120,7 +119,6 @@ spark.executor.id
 spark.executor.instances
 spark.executor.isolatedSessionCache.size
 spark.executor.killOnFatalError.depth
-spark.executor.limitActiveProcessorCount.enabled
 spark.executor.logs.redirectConsoleOutputs
 spark.executor.logs.rolling.enableCompression
 spark.executor.logs.rolling.maxRetainedFiles
@@ -169,7 +167,6 @@ spark.history.fs.numReplayThreads
 spark.history.fs.safemodeCheck.interval
 spark.history.fs.update.batchSize
 spark.history.fs.update.interval
-spark.history.fs.update.scanDisabledPathPatterns
 spark.history.kerberos.enabled
 spark.history.kerberos.keytab
 spark.history.kerberos.principal
@@ -319,8 +316,6 @@ spark.scheduler.numCancelledJobGroupsToTrack
 spark.scheduler.resource.profileMergeConflicts
 spark.scheduler.revive.interval
 spark.scheduler.stage.legacyAbortAfterKillTasks
-spark.scheduler.streaming.idAwareLogging.enabled
-spark.scheduler.streaming.idAwareLogging.queryIdLength
 spark.security.credentials.renewalRatio
 spark.security.credentials.retryWait
 spark.serializer
@@ -659,7 +654,6 @@ spark.sql.inMemoryColumnarStorage.hugeVectorReserveRatio
 spark.sql.inMemoryColumnarStorage.hugeVectorThreshold
 spark.sql.inMemoryColumnarStorage.partitionPruning
 spark.sql.inMemoryTableScanStatistics.enable
-spark.sql.insertNestedTypeCoercion.enabled
 spark.sql.join.preferSortMergeJoin
 spark.sql.json.enableExactStringParsing
 spark.sql.json.enablePartialResults
@@ -1036,7 +1030,6 @@ spark.sql.streaming.numRecentProgressUpdates
 spark.sql.streaming.offsetLog.formatVersion
 spark.sql.streaming.optimizeOneRowPlan.enabled
 spark.sql.streaming.pollingDelay
-spark.sql.streaming.queryEvolution.enableSinkEvolution
 spark.sql.streaming.queryEvolution.enableSourceEvolution
 spark.sql.streaming.ratioExtraSpaceAllowedInCheckpoint
 spark.sql.streaming.realTimeMode.allowlistCheck
@@ -1175,7 +1168,6 @@ spark.taskMetrics.trackUpdatedBlockStatuses
 spark.test.noStageRetry
 spark.testing
 spark.testing.dynamicAllocation.schedule.enabled
-spark.testing.injectShuffleFetchFailures
 spark.testing.memory
 spark.testing.nCoresPerExecutor
 spark.testing.nExecutorsPerHost
@@ -1192,7 +1184,6 @@ spark.ui.enabled
 spark.ui.filters
 spark.ui.groupSQLSubExecutionEnabled
 spark.ui.heapHistogramEnabled
-spark.ui.jetty.sniHostCheckEnabled
 spark.ui.jetty.stopTimeout
 spark.ui.killEnabled
 spark.ui.liveUpdate.minFlushPeriod
@@ -1227,7 +1218,6 @@ spark.unsafe.sorter.spill.read.ahead.enabled
 spark.unsafe.sorter.spill.reader.buffer.size
 spark.user.groups.mapping
 spark.worker.executorStateSync.maxAttempts
-spark.yarn.am.limitActiveProcessorCount.enabled
 spark.yarn.dist.forceDownloadSchemes
 spark.yarn.dist.pyFiles
 spark.yarn.isPython

--- a/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
+++ b/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
@@ -1097,6 +1097,7 @@ spark.sql.subexpressionElimination.cache.maxEntries
 spark.sql.subexpressionElimination.enabled
 spark.sql.subexpressionElimination.skipForShortcutExpr
 spark.sql.subquery.maxThreadThreshold
+spark.sql.test.tempEntryToVerifyBindingPolicyCiCheck
 spark.sql.thriftServer.incrementalCollect
 spark.sql.thriftServer.interruptOnCancel
 spark.sql.thriftServer.queryTimeout

--- a/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
+++ b/sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions
@@ -1097,7 +1097,6 @@ spark.sql.subexpressionElimination.cache.maxEntries
 spark.sql.subexpressionElimination.enabled
 spark.sql.subexpressionElimination.skipForShortcutExpr
 spark.sql.subquery.maxThreadThreshold
-spark.sql.test.tempEntryToVerifyBindingPolicyCiCheck
 spark.sql.thriftServer.incrementalCollect
 spark.sql.thriftServer.interruptOnCancel
 spark.sql.thriftServer.queryTimeout

--- a/sql/hive/src/test/scala/org/apache/spark/sql/configaudit/SparkConfigBindingPolicySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/configaudit/SparkConfigBindingPolicySuite.scala
@@ -29,9 +29,9 @@ import org.apache.spark.sql.internal.SQLConf
  * Enforces that every Spark config declares a `ConfigBindingPolicy`. The exceptions file
  * `conf/binding-policy-exceptions/configs-without-binding-policy-exceptions` is a frozen list
  * of configs that predate the binding policy and must only ever shrink: new configs must
- * declare a policy via `.withBindingPolicy()` when building the config entry, using
- * `NOT_APPLICABLE` if the config does not affect the behavior of SQL views/UDFs/procedures.
- * The `binding-policy` CI job rejects any PR that adds entries to the exceptions file.
+ * declare a policy via `.withBindingPolicy()` when building the config entry (see the
+ * [[ConfigBindingPolicy]] scaladoc for how to choose a policy). The `binding-policy` CI job
+ * rejects any PR that adds entries to the exceptions file.
  */
 class SparkConfigBindingPolicySuite extends SparkFunSuite {
 
@@ -66,10 +66,10 @@ class SparkConfigBindingPolicySuite extends SparkFunSuite {
       fail(
         s"The following configs do not have bindingPolicy field set. You need to define it " +
         "by using .withBindingPolicy(ConfigBindingPolicy.SESSION/PERSISTED/NOT_APPLICABLE) " +
-        "when you build the config entry. Use NOT_APPLICABLE if the config does not affect " +
-        "the behavior of SQL views/UDFs/procedures. DO NOT add new entries to the " +
-        "exceptions file: it is a frozen list of configs that predate the binding policy " +
-        "and must only ever shrink (the binding-policy CI job rejects any addition).\n" +
+        "when you build the config entry. See the ConfigBindingPolicy scaladoc for how to " +
+        "choose a policy. DO NOT add new entries to the exceptions file: it is a frozen " +
+        "list of configs that predate the binding policy and must only ever shrink (the " +
+        "binding-policy CI job rejects any addition).\n" +
         missingBindingPolicyConfigs.mkString("\n")
       )
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/configaudit/SparkConfigBindingPolicySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/configaudit/SparkConfigBindingPolicySuite.scala
@@ -25,6 +25,14 @@ import org.apache.spark.internal.config.{ConfigBindingPolicy, ConfigEntry}
 import org.apache.spark.sql.hive.HiveUtils
 import org.apache.spark.sql.internal.SQLConf
 
+/**
+ * Enforces that every Spark config declares a `ConfigBindingPolicy`. The exceptions file
+ * `conf/binding-policy-exceptions/configs-without-binding-policy-exceptions` is a frozen list
+ * of configs that predate the binding policy and must only ever shrink: new configs must
+ * declare a policy via `.withBindingPolicy()` when building the config entry, using
+ * `NOT_APPLICABLE` if the config does not affect the behavior of SQL views/UDFs/procedures.
+ * The `binding-policy` CI job rejects any PR that adds entries to the exceptions file.
+ */
 class SparkConfigBindingPolicySuite extends SparkFunSuite {
 
   override def beforeAll(): Unit = {
@@ -57,8 +65,11 @@ class SparkConfigBindingPolicySuite extends SparkFunSuite {
     if (missingBindingPolicyConfigs.nonEmpty) {
       fail(
         s"The following configs do not have bindingPolicy field set. You need to define it " +
-        "by using .withBindingPolicy(ConfigBindingPolicy.SESSION/PERSISTED) when you build " +
-        "the config entry.\n" +
+        "by using .withBindingPolicy(ConfigBindingPolicy.SESSION/PERSISTED/NOT_APPLICABLE) " +
+        "when you build the config entry. Use NOT_APPLICABLE if the config does not affect " +
+        "the behavior of SQL views/UDFs/procedures. DO NOT add new entries to the " +
+        "exceptions file: it is a frozen list of configs that predate the binding policy " +
+        "and must only ever shrink (the binding-policy CI job rejects any addition).\n" +
         missingBindingPolicyConfigs.mkString("\n")
       )
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a new lightweight CI job `binding-policy` ("Config binding policy exceptions check") to `build_and_test.yml`. The job diffs `sql/hive/src/test/resources/conf/binding-policy-exceptions/configs-without-binding-policy-exceptions` against the latest apache/spark base (using the same fork-sync mechanism as the existing `buf` job) and fails if the PR adds any entries to the file, with an error message pointing the author to `.withBindingPolicy()` and the `ConfigBindingPolicy` scaladoc. Removing entries from the file is still allowed (and encouraged).

The job runs on a bare runner in well under a minute, is gated on the existing `lint` flag from the `precondition` job, only runs on forks (where PR builds run, so the diff against apache/spark master is exactly the PR's change; on apache/spark itself the job is skipped at the scheduler level and consumes no runner), and skips cleanly on branches where the exceptions file does not exist.

On top of the CI check, this PR also:

- Documents how to choose a binding policy: the `ConfigBindingPolicy` scaladoc now has a 3-step decision flow (does the config change the result of resolving a view/UDF/procedure body? should persisted objects freeze the create-time value, like ANSI mode or session timezone? otherwise SESSION). `SparkConfigBindingPolicySuite` and the CI job's error message point to that scaladoc as the single source of truth, and the suite's failure message now explicitly says not to grow the exceptions file.
- Fixes the 12 recently-added configs that were put in the exceptions file instead of declaring a policy, all with `NOT_APPLICABLE` (none of them can change the result of resolving a view/UDF/procedure body): `spark.sql.execution.useHashAggregateExec`, `spark.sql.hive.thriftServer.http.sniHostCheckEnabled`, `spark.sql.streaming.queryEvolution.enableSinkEvolution`, `spark.sql.insertNestedTypeCoercion.enabled`, `spark.testing.injectShuffleFetchFailures`, `spark.ui.jetty.sniHostCheckEnabled`, `spark.scheduler.streaming.idAwareLogging.enabled`, `spark.scheduler.streaming.idAwareLogging.queryIdLength`, `spark.driver.limitActiveProcessorCount.enabled`, `spark.executor.limitActiveProcessorCount.enabled`, `spark.yarn.am.limitActiveProcessorCount.enabled`, `spark.history.fs.update.scanDisabledPathPatterns`. The exceptions file shrinks by 12 entries.
- Relabels the four `spark.sql.window.segmentTree.*` configs from `SESSION` to `NOT_APPLICABLE` per the review discussion (runtime-identical, but `NOT_APPLICABLE` is the accurate label for physical-execution toggles).
- Fixes the `version()` of `spark.sql.streaming.queryEvolution.enableSinkEvolution` from 4.1.0 to 4.3.0 (it was added after the branch-4.2 cut).

### Why are the changes needed?

The exceptions file is a frozen list of pre-existing configs that were created before the binding policy was introduced, and it should only ever shrink. `SparkConfigBindingPolicySuite` forces every config to either declare a binding policy or be listed in this file, so PR authors who add a new config without a binding policy see a test failure and "fix" it by adding the config to the exceptions file, which defeats the purpose of the enforcement (see https://github.com/apache/spark/pull/56323#discussion_r3389669681 for a recent example). A new config always has a valid policy choice, including `NOT_APPLICABLE` for configs that cannot change the result of resolving SQL views/UDFs/procedures, so additions to the exceptions file are never justified. Only a diff-based CI check can catch this, since to a regular test the grown file looks consistent.

### Does this PR introduce _any_ user-facing change?

No. `SESSION` and `NOT_APPLICABLE` behave identically at runtime, and declaring either for a config that previously had no policy only affects view/UDF resolution for configs that are actually consulted there, which none of the touched configs are.

### How was this patch tested?

The CI job was verified end to end on this PR itself: a temporary commit adding an entry to the exceptions file made the job fail with the guidance message in ~10 seconds (https://github.com/cloud-fan/spark/actions/runs/27302316185), and the commits that shrink the file pass the check. The config changes are covered by the existing `SparkConfigBindingPolicySuite`, which verifies that every config either declares a policy or is listed in the exceptions file, and that no config does both.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code

This pull request and its description were written by Isaac.