### PR TITLE
[SPARK-57332][SQL][FOLLOWUP] Fix line length exceeding 100 characters in JDBCSuite and V2ExpressionSQLBuilder

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -55,9 +55,10 @@ public class V2ExpressionSQLBuilder {
 
   /**
    * Escape the LIKE pattern special chars, using {@code \} as the escape character. The LIKE
-   * patterns produced by {@link #visitStartsWith}, {@link #visitEndsWith} and {@link #visitContains}
-   * declare {@code ESCAPE '\'}, so the wildcards {@code _} and {@code %} and the escape character
-   * {@code \} itself must each be prefixed with {@code \} to be matched literally.
+   * patterns produced by {@link #visitStartsWith}, {@link #visitEndsWith} and
+   * {@link #visitContains} declare {@code ESCAPE '\'}, so the wildcards {@code _} and {@code %}
+   * and the escape character {@code \} itself must each be prefixed with {@code \} to be matched
+   * literally.
    *
    * Note: This method adopts the escape representation within Spark and is not bound to any JDBC
    * dialect. A JDBC dialect should overwrite this API if the underlying database has more LIKE
@@ -237,9 +238,10 @@ public class V2ExpressionSQLBuilder {
 
   /**
    * Build a {@code <left> LIKE '<pattern>' ESCAPE '\'} predicate. The pattern already has its LIKE
-   * special chars escaped (via {@link #escapeSpecialCharsForLikePattern}); both the pattern and the
-   * {@code \} escape character are then passed through {@link #escapeStringLiteralForLikePattern} so
-   * a dialect can add any string-literal escaping its SQL syntax requires.
+   * special chars escaped (via {@link #escapeSpecialCharsForLikePattern}); both the pattern and
+   * the {@code \} escape character are then passed through
+   * {@link #escapeStringLiteralForLikePattern} so a dialect can add any string-literal escaping
+   * its SQL syntax requires.
    */
   private String likeWithEscape(String l, String pattern) {
     return l + " LIKE '" + escapeStringLiteralForLikePattern(pattern)

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -925,8 +925,9 @@ class JDBCSuite extends SharedSparkSession {
 
     // MySQL treats backslash as an escape character inside string literals, so every backslash is
     // doubled again: the ESCAPE clause uses `\\` and a literal backslash in the value becomes four
-    // backslashes (escapeSpecialCharsForLikePattern doubles it, then escapeStringLiteralForLikePattern
-    // doubles each of those). The wildcard escaping for `%`/`_` is unchanged from the default.
+    // backslashes (escapeSpecialCharsForLikePattern doubles it, then
+    // escapeStringLiteralForLikePattern doubles each of those). The wildcard escaping for
+    // `%`/`_` is unchanged from the default.
     val mySQLDialect = JdbcDialects.get("jdbc:mysql://127.0.0.1/db")
     def mySQLSQL(f: Filter): String = mySQLDialect.compileExpression(f.toV2).getOrElse("")
     // `c` LIKE 'ab\\\\%' ESCAPE '\\'


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes a style issue introduced by #56384.
There are some lines in `JDBCSuite.scala` and `V2ExpressionSQLBuilder.java`‎ whose length exceed 100 characters.

### Why are the changes needed?
To recover CI.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Claude
