### PR TITLE
[SPARK-57382][INFRA] Default merge script JIRA assignee prompt to reporter

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -764,9 +764,11 @@ def choose_jira_assignee(issue):
         try:
             reporter = issue.fields.reporter
             commentators = list(map(lambda x: x.author, issue.fields.comment.comments))
-            candidates = set(commentators)
-            candidates.add(reporter)
-            candidates = list(candidates)
+            # Put the reporter first so that [0] is a sensible default assignee.
+            candidates = []
+            if reporter is not None:
+                candidates.append(reporter)
+            candidates += [c for c in set(commentators) if c != reporter]
             print("JIRA is unassigned, choose assignee")
             for idx, author in enumerate(candidates):
                 if author.key == "apachespark":
@@ -775,35 +777,39 @@ def choose_jira_assignee(issue):
                 if author in commentators:
                     annotations.append("Commentator")
                 print("[%d] %s (%s)" % (idx, author.displayName, ",".join(annotations)))
-            raw_assignee = bold_input(
-                "Enter number of user, or userid, to assign to (blank to leave unassigned): "
-            )
-            if raw_assignee == "":
-                return None
+            base_prompt = "Enter number of user, or userid, to assign to"
+            if reporter is not None:
+                prompt = "%s [%s]: " % (base_prompt, reporter.displayName)
             else:
-                try:
-                    id = int(raw_assignee)
-                    assignee = candidates[id]
-                except BaseException:
-                    # assume it's a user id, and try to assign (might fail, we just prompt again)
-                    assignee = asf_jira.user(raw_assignee)
-                try:
+                prompt = "%s (blank to leave unassigned): " % base_prompt
+            raw_assignee = bold_input(prompt)
+            if raw_assignee == "":
+                if reporter is None:
+                    return None
+                raw_assignee = "0"
+            try:
+                id = int(raw_assignee)
+                assignee = candidates[id]
+            except BaseException:
+                # assume it's a user id, and try to assign (might fail, we just prompt again)
+                assignee = asf_jira.user(raw_assignee)
+            try:
+                assign_issue(issue.key, assignee.name)
+            except Exception as e:
+                if (
+                    e.__class__.__name__ == "JIRAError"
+                    and ("'%s' cannot be assigned" % assignee.name)
+                    in getattr(e, "response").text
+                ):
+                    continue_maybe(
+                        "User '%s' cannot be assigned, add to contributors role and try again?"
+                        % assignee.name
+                    )
+                    grant_contributor_role(assignee.name)
                     assign_issue(issue.key, assignee.name)
-                except Exception as e:
-                    if (
-                        e.__class__.__name__ == "JIRAError"
-                        and ("'%s' cannot be assigned" % assignee.name)
-                        in getattr(e, "response").text
-                    ):
-                        continue_maybe(
-                            "User '%s' cannot be assigned, add to contributors role and try again?"
-                            % assignee.name
-                        )
-                        grant_contributor_role(assignee.name)
-                        assign_issue(issue.key, assignee.name)
-                    else:
-                        raise e
-                return assignee
+                else:
+                    raise e
+            return assignee
         except KeyboardInterrupt:
             raise
         except BaseException:


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `dev/merge_spark_pr.py`, the `choose_jira_assignee` prompt now defaults to the JIRA reporter when one exists. The reporter is placed at index `[0]` in the candidate list, and the prompt uses the standard `[default]` convention used by the other prompts in the script, e.g.:

```
Enter number of user, or userid, to assign to [Reporter Name]:
```

Pressing enter (blank) assigns the reporter. When there is no reporter, the prompt keeps the previous wording and a blank entry still leaves the issue unassigned:

```
Enter number of user, or userid, to assign to (blank to leave unassigned):
```

### Why are the changes needed?
Previously a blank entry left the issue unassigned, with no default offered. The reporter is by far the most common assignee, so defaulting to it on blank input saves a step and makes the prompt consistent with the other `[default]`-style prompts in the script (e.g. branch name and fix versions).

### Does this PR introduce _any_ user-facing change?
No. This only affects the committer-facing merge tooling (`dev/merge_spark_pr.py`).

### How was this patch tested?
Exercised `choose_jira_assignee` directly with a stubbed input function and a fake issue object (no real merge or JIRA connection), covering three cases:
- reporter present + blank input -> assigns the reporter (index `[0]`)
- reporter present + numeric pick -> assigns the selected commentator
- no reporter + blank input -> returns unassigned, no assign call

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Cursor