### PR TITLE
[SPARK-37856][K8S] Clean up terminal executor pods on driver restart

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -446,16 +446,6 @@ private[spark] object Config extends Logging {
           "/names/#dns-subdomain-names and the value length <= 237")
       .createOptional
 
-  val KUBERNETES_CLEAN_FAILED_PODS_ON_START =
-    ConfigBuilder("spark.kubernetes.executor.cleanFailedPodsOnStart")
-      .doc("If set to true and spark.kubernetes.executor.podNamePrefix is configured, " +
-        "the driver will delete executor pods in Failed or Completed state matching the same " +
-        "podNamePrefix and the same spark-app-name at startup. This cleans up " +
-        "orphaned executor pods left by a previously force-killed driver.")
-      .version("4.1.0")
-      .booleanConf
-      .createWithDefault(false)
-
   val KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP =
     ConfigBuilder("spark.kubernetes.executor.disableConfigMap")
       .doc("If true, disable ConfigMap creation for executors.")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -446,6 +446,16 @@ private[spark] object Config extends Logging {
           "/names/#dns-subdomain-names and the value length <= 237")
       .createOptional
 
+  val KUBERNETES_CLEAN_FAILED_PODS_ON_START =
+    ConfigBuilder("spark.kubernetes.executor.cleanFailedPodsOnStart")
+      .doc("If set to true and spark.kubernetes.executor.podNamePrefix is configured, " +
+        "the driver will delete executor pods in Failed or Completed state matching the same " +
+        "podNamePrefix and the same spark-app-name at startup. This cleans up " +
+        "orphaned executor pods left by a previously force-killed driver.")
+      .version("4.1.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP =
     ConfigBuilder("spark.kubernetes.executor.disableConfigMap")
       .doc("If true, disable ConfigMap creation for executors.")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable.HashMap
 import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
 
 import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.api.model.PodBuilder
@@ -98,6 +99,35 @@ private[spark] class KubernetesClusterSchedulerBackend(
     kubernetesClient.configMaps().inNamespace(namespace).resource(configMap).create()
   }
 
+  private def cleanTerminalExecutorPodsOnStart(): Unit = {
+    val appNameLabel = KubernetesConf.getAppNameLabel(sc.appName)
+    logInfo(s"Checking for orphaned Failed/Completed executor pods " +
+      s"with app name '$appNameLabel'")
+    try {
+      val terminalPhases = Set("Failed", "Completed")
+      val terminalPods = kubernetesClient
+        .pods()
+        .inNamespace(namespace)
+        .withLabel(SPARK_ROLE_LABEL, SPARK_POD_EXECUTOR_ROLE)
+        .withLabel(SPARK_APP_NAME_LABEL, appNameLabel)
+        .list()
+        .getItems
+        .asScala
+        .filter(pod => terminalPhases.contains(pod.getStatus.getPhase))
+      if (terminalPods.nonEmpty) {
+        logInfo(s"Deleting ${terminalPods.size} orphaned Failed/Completed executor pods " +
+          s"with app name '$appNameLabel'")
+        kubernetesClient.resourceList(terminalPods.asJava).inNamespace(namespace).delete()
+      } else {
+        logInfo(s"No orphaned Failed/Completed executor pods found with app name '$appNameLabel'")
+      }
+    } catch {
+      case e: Exception =>
+        logWarning(s"Failed to clean orphaned Failed/Completed executor pods " +
+          s"with app name '$appNameLabel'", e)
+    }
+  }
+
   /**
    * Get an application ID associated with the job.
    * This returns the string value of spark.app.id if set, otherwise
@@ -109,6 +139,9 @@ private[spark] class KubernetesClusterSchedulerBackend(
 
   override def start(): Unit = {
     super.start()
+    if (conf.get(KUBERNETES_CLEAN_FAILED_PODS_ON_START)) {
+      cleanTerminalExecutorPodsOnStart()
+    }
     // Must be called before setting the executors
     podAllocator.start(applicationId(), this)
     val defaultProfile = scheduler.sc.resourceProfileManager.defaultResourceProfile

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -139,10 +139,9 @@ private[spark] class KubernetesClusterSchedulerBackend(
 
   override def start(): Unit = {
     super.start()
-    if (conf.get(KUBERNETES_CLEAN_FAILED_PODS_ON_START)) {
-      cleanTerminalExecutorPodsOnStart()
-    }
+
     // Must be called before setting the executors
+    cleanTerminalExecutorPodsOnStart()
     podAllocator.start(applicationId(), this)
     val defaultProfile = scheduler.sc.resourceProfileManager.defaultResourceProfile
     val initExecs = Map(defaultProfile -> initialExecutors)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackendSuite.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
 
 import scala.jdk.CollectionConverters._
 
-import io.fabric8.kubernetes.api.model.{ConfigMap, Pod, PodBuilder, PodList}
+import io.fabric8.kubernetes.api.model.{ConfigMap, HasMetadata, Pod, PodBuilder, PodList}
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.dsl.PodResource
 import io.fabric8.kubernetes.client.dsl.base.PatchContext
@@ -35,6 +35,7 @@ import org.apache.spark.{SparkConf, SparkContext, SparkEnv, SparkFunSuite}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.k8s.Fabric8Aliases._
+import org.apache.spark.deploy.k8s.KubernetesConf
 import org.apache.spark.resource.{ResourceProfile, ResourceProfileManager}
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpoint, RpcEndpointRef, RpcEnv}
 import org.apache.spark.scheduler.{ExecutorKilled, ExecutorLossReason, LiveListenerBus, TaskSchedulerImpl}
@@ -104,6 +105,9 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
 
   @Mock
   private var pollEvents: ExecutorPodsPollingSnapshotSource = _
+
+  @Mock
+  private var resourceListOperation: RESOURCE_LIST = _
 
   @Mock
   private var context: RpcCallContext = _
@@ -349,5 +353,45 @@ class KubernetesClusterSchedulerBackendSuite extends SparkFunSuite with BeforeAn
     val id2 = backendWithoutAppId.applicationId()
     assert(id1 === id2, "applicationId() must return the same value on repeated calls")
     assert(id1.startsWith("spark-"), "generated app ID should have the spark- prefix")
+  }
+
+  test("SPARK-37856: cleanTerminalExecutorPodsOnStart deletes Failed and Completed executor pods") {
+    val appName = "test-spark-app"
+    val appNameLabel = KubernetesConf.getAppNameLabel(appName)
+    when(sc.appName).thenReturn(appName)
+
+    val failedPod = new PodBuilder()
+      .withNewMetadata().withName("exec-failed").endMetadata()
+      .withNewStatus().withPhase("Failed").endStatus()
+      .build()
+    val completedPod = new PodBuilder()
+      .withNewMetadata().withName("exec-completed").endMetadata()
+      .withNewStatus().withPhase("Completed").endStatus()
+      .build()
+    val runningPod = new PodBuilder()
+      .withNewMetadata().withName("exec-running").endMetadata()
+      .withNewStatus().withPhase("Running").endStatus()
+      .build()
+
+    val podList = mock(classOf[PodList])
+    when(podsWithNamespace.withLabel(SPARK_ROLE_LABEL, SPARK_POD_EXECUTOR_ROLE))
+      .thenReturn(labeledPods)
+    when(labeledPods.withLabel(SPARK_APP_NAME_LABEL, appNameLabel))
+      .thenReturn(labeledPods)
+    when(labeledPods.list()).thenReturn(podList)
+    when(podList.getItems)
+      .thenReturn(java.util.Arrays.asList(failedPod, completedPod, runningPod))
+    var capturedPods: Seq[Pod] = Seq.empty
+    when(kubernetesClient.resourceList(any[java.util.Collection[HasMetadata]]()))
+      .thenAnswer { invocation =>
+        capturedPods = invocation.getArgument[java.util.Collection[Pod]](0).asScala.toSeq
+        resourceListOperation
+      }
+    when(resourceListOperation.inNamespace("default")).thenReturn(resourceListOperation)
+
+    schedulerBackendUnderTest.start()
+
+    assert(capturedPods.map(_.getMetadata.getName).toSet === Set("exec-failed", "exec-completed"))
+    verify(resourceListOperation).delete()
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
  When a Spark driver container running on Kubernetes restarts (e.g., due to OOM) without the driver pod being deleted, executor pods from the previous driver lifetime are left in a terminal state (Failed or Completed). These orphaned pods are not cleaned up by Kubernetes garbage collection because they still hold an ownerReference to the original driver pod (which still exists), and the restarted driver no longer tracks them.                                                                                                                                                                                                                                                                                                                                                                          
  This PR adds a cleanTerminalExecutorPodsOnStart() method in KubernetesClusterSchedulerBackend that runs at driver startup — before the pod allocator is started — to detect and delete any executor pods in Failed or Completed phase that share the same app name label as the current application.

  The cleanup logic:
  1. Lists executor pods filtered by spark-role=executor and the app name label
  2. Filters for pods in terminal phases (Failed or Completed)
  3. Deletes them via the Kubernetes client
  4. Logs a warning and continues if the cleanup fails (non-fatal)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
  When the driver container is restarted by Kubernetes (e.g., due to OOM kill), the driver pod itself is not recreated — only the container inside it restarts. As a result:
  - The old executor pods remain with ownerReference pointing to the still-existing driver pod, so Kubernetes garbage collection does not remove them.
  - The restarted driver has no knowledge of those old executors and will spawn new ones, leaving the old ones as zombie pods in Failed/Completed state.
  This causes resource leakage and, in long-running applications like Spark Thrift Server, accumulates stale pods over time.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
  Yes. On driver restart, Spark will now automatically delete orphaned executor pods in Failed or Completed state (matched by app name label) before starting pod allocation. Users running Spark on Kubernetes — especially long-lived services like Thrift Server — will see stale executor pods cleaned up on each driver restart instead of accumulating indefinitely.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
  A unit test SPARK-37856: cleanTerminalExecutorPodsOnStart deletes Failed and Completed executor pods was added to KubernetesClusterSchedulerBackendSuite. The test sets up mocks for executor pods in Failed, Completed, and Running phases, calls start(), and asserts that only the terminal pods are passed to kubernetesClient.resourceList(...).delete() — the running pod is not included.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes