### PR TITLE
[MINOR][HOTFIX] Wrap overlong comment line in JDBCSuite to fix scalastyle

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -925,8 +925,9 @@ class JDBCSuite extends SharedSparkSession {
 
     // MySQL treats backslash as an escape character inside string literals, so every backslash is
     // doubled again: the ESCAPE clause uses `\\` and a literal backslash in the value becomes four
-    // backslashes (escapeSpecialCharsForLikePattern doubles it, then escapeStringLiteralForLikePattern
-    // doubles each of those). The wildcard escaping for `%`/`_` is unchanged from the default.
+    // backslashes (escapeSpecialCharsForLikePattern doubles it, then
+    // escapeStringLiteralForLikePattern doubles each of those). The wildcard escaping for
+    // `%`/`_` is unchanged from the default.
     val mySQLDialect = JdbcDialects.get("jdbc:mysql://127.0.0.1/db")
     def mySQLSQL(f: Filter): String = mySQLDialect.compileExpression(f.toV2).getOrElse("")
     // `c` LIKE 'ab\\\\%' ESCAPE '\\'


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rewraps a 103-character comment line in `JDBCSuite.scala` introduced by SPARK-57332 (f5eabcbd170) so it fits the 100-character scalastyle limit. Comment-only change.

### Why are the changes needed?

The overlong line fails `dev/scalastyle`, so the "Linters, licenses, and dependencies" job is currently red on master and on every open PR (PR CI merges with the latest master before running).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Verified no non-import line in the file exceeds 100 characters.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code
