### PR TITLE
[SPARK-57387][YARN] Make executor JVM options `-XX:OnOutOfMemoryError` configurable on YARN

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -540,6 +540,15 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>1.4.0</td>
 </tr>
 <tr>
+  <td><code>spark.yarn.executor.oomKill.enabled</code></td>
+  <td>true</td>
+  <td>
+  Whether to add `-XX:OnOutOfMemoryError='kill %p'` (or its counterpart on Windows) to executor
+  JVM options.
+  </td>
+  <td>4.3.0</td>
+</tr>
+<tr>
   <td><code>spark.yarn.tags</code></td>
   <td>(none)</td>
   <td>

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -38,6 +38,7 @@ import org.apache.hadoop.yarn.ipc.YarnRPC
 import org.apache.hadoop.yarn.util.Records
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkException}
+import org.apache.spark.deploy.yarn.config.YARN_EXECUTOR_OOM_KILL_ENABLED
 import org.apache.spark.internal.{Logging, MessageWithContext}
 import org.apache.spark.internal.LogKeys.{EXECUTOR_ENVS, EXECUTOR_LAUNCH_COMMANDS, EXECUTOR_RESOURCES}
 import org.apache.spark.internal.config._
@@ -190,7 +191,9 @@ private[yarn] class ExecutorRunnable(
     // For log4j configuration to reference
     javaOpts += ("-Dspark.yarn.app.container.log.dir=" + ApplicationConstants.LOG_DIR_EXPANSION_VAR)
 
-    YarnSparkHadoopUtil.addOutOfMemoryErrorArgument(javaOpts)
+    if (sparkConf.get(YARN_EXECUTOR_OOM_KILL_ENABLED)) {
+      YarnSparkHadoopUtil.addOutOfMemoryErrorArgument(javaOpts)
+    }
     val commands = prefixEnv ++
       Seq(Environment.JAVA_HOME.$$() + "/bin/java", "-server") ++
       javaOpts ++

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config/package.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config/package.scala
@@ -21,7 +21,7 @@ import java.util.Properties
 import java.util.concurrent.TimeUnit
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.ConfigBuilder
+import org.apache.spark.internal.config.{ConfigBindingPolicy, ConfigBuilder}
 import org.apache.spark.network.util.ByteUnit
 
 package object config extends Logging {
@@ -347,6 +347,15 @@ package object config extends Logging {
       .version("1.4.0")
       .stringConf
       .createOptional
+
+  private[spark] val YARN_EXECUTOR_OOM_KILL_ENABLED =
+    ConfigBuilder("spark.yarn.executor.OOMKill.enabled")
+      .doc("Whether to add `-XX:OnOutOfMemoryError='kill %p'`(or its counterpart on Windows) " +
+        "to executor JVM options.")
+      .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .booleanConf
+      .createWithDefault(true)
 
   /* Unmanaged AM configuration. */
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config/package.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config/package.scala
@@ -349,8 +349,8 @@ package object config extends Logging {
       .createOptional
 
   private[spark] val YARN_EXECUTOR_OOM_KILL_ENABLED =
-    ConfigBuilder("spark.yarn.executor.OOMKill.enabled")
-      .doc("Whether to add `-XX:OnOutOfMemoryError='kill %p'`(or its counterpart on Windows) " +
+    ConfigBuilder("spark.yarn.executor.oomKill.enabled")
+      .doc("Whether to add `-XX:OnOutOfMemoryError='kill %p'` (or its counterpart on Windows) " +
         "to executor JVM options.")
       .version("4.3.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ExecutorRunnableSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ExecutorRunnableSuite.scala
@@ -141,13 +141,13 @@ class ExecutorRunnableSuite extends SparkFunSuite with PrivateMethodTester {
   }
 
   test("test executor OnOutOfMemoryError JVM options") {
-    Seq(true, false).foreach { OOMKill =>
+    Seq(true, false).foreach { oomKill =>
       val sparkConf = new SparkConf()
-        .set(YARN_EXECUTOR_OOM_KILL_ENABLED, OOMKill)
+        .set(YARN_EXECUTOR_OOM_KILL_ENABLED, oomKill)
       val execRunnable = createExecutorRunnable(sparkConf)
 
       val commands = execRunnable invokePrivate _prepareCommand()
-      if (OOMKill) {
+      if (oomKill) {
         assert(commands.exists(_.contains("-XX:OnOutOfMemoryError")))
       } else {
         assert(!commands.exists(_.contains("-XX:OnOutOfMemoryError")))

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ExecutorRunnableSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ExecutorRunnableSuite.scala
@@ -140,14 +140,6 @@ class ExecutorRunnableSuite extends SparkFunSuite with PrivateMethodTester {
     commands should contain inOrderElementsOf List("--cores", "7")
   }
 
-  test("OnOutOfMemoryError argument is added by default") {
-    val sparkConf = new SparkConf()
-    val execRunnable = createExecutorRunnable(sparkConf)
-
-    val commands = execRunnable invokePrivate _prepareCommand()
-    assert(commands.exists(_.contains("-XX:OnOutOfMemoryError")))
-  }
-
   test("test executor OnOutOfMemoryError JVM options") {
     Seq(true, false).foreach { OOMKill =>
       val sparkConf = new SparkConf()

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ExecutorRunnableSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ExecutorRunnableSuite.scala
@@ -30,6 +30,7 @@ import org.scalatest.matchers.must.Matchers.{contain, not}
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
+import org.apache.spark.deploy.yarn.config.YARN_EXECUTOR_OOM_KILL_ENABLED
 import org.apache.spark.internal.config._
 import org.apache.spark.network.util.JavaUtils
 
@@ -137,5 +138,39 @@ class ExecutorRunnableSuite extends SparkFunSuite with PrivateMethodTester {
     val commands = execRunnable invokePrivate _prepareCommand()
     commands should contain ("-XX:ActiveProcessorCount=7")
     commands should contain inOrderElementsOf List("--cores", "7")
+  }
+
+  test("OnOutOfMemoryError argument is added by default") {
+    val sparkConf = new SparkConf()
+    val execRunnable = createExecutorRunnable(sparkConf)
+
+    val commands = execRunnable invokePrivate _prepareCommand()
+    assert(commands.exists(_.contains("-XX:OnOutOfMemoryError")))
+  }
+
+  test("test executor OnOutOfMemoryError JVM options") {
+    Seq(true, false).foreach { OOMKill =>
+      val sparkConf = new SparkConf()
+        .set(YARN_EXECUTOR_OOM_KILL_ENABLED, OOMKill)
+      val execRunnable = createExecutorRunnable(sparkConf)
+
+      val commands = execRunnable invokePrivate _prepareCommand()
+      if (OOMKill) {
+        assert(commands.exists(_.contains("-XX:OnOutOfMemoryError")))
+      } else {
+        assert(!commands.exists(_.contains("-XX:OnOutOfMemoryError")))
+      }
+    }
+  }
+
+  test("user provided OnOutOfMemoryError option takes precedence over default") {
+    val sparkConf = new SparkConf()
+      .set(YARN_EXECUTOR_OOM_KILL_ENABLED, true)
+      .set(EXECUTOR_JAVA_OPTIONS, "-XX:OnOutOfMemoryError='kill -9 %p'")
+    val execRunnable = createExecutorRunnable(sparkConf)
+
+    val commands = execRunnable invokePrivate _prepareCommand()
+    assert(commands.count(_.contains("-XX:OnOutOfMemoryError")) === 1)
+    assert(commands.exists(_.contains("-XX:OnOutOfMemoryError=kill -9 %p")))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently, Spark always adds `-XX:OnOutOfMemoryError='kill %p'` to executor JVM options when running on YARN. This PR makes the behavior configurable.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
There are many places where Spark's internal memory management handles `OutOfMemoryError` and intends to recover from that, with `-XX:OnOutOfMemoryError='kill %p'`, the recovery code does not work, and the executor always gets killed when hit `OutOfMemoryError`.

Note: when `-XX:OnOutOfMemoryError='kill %p'` is configured, `kill %p` will be performed no matter whether the code catches the `OutOfMemoryError` when it is thrown by JVM.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UTs are added.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Opus 4.8.