### PR TITLE
[SPARK-57388][INFRA] Pin actions/checkout to resolved SHA in maven_test.yml and python_hosted_runner_test.yml

### DIFF
--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -68,7 +68,7 @@ jobs:
       GITHUB_PREV_SHA: ${{ github.event.before }}
     steps:
       - name: Checkout Spark repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
           repository: apache/spark
@@ -217,7 +217,7 @@ jobs:
       GITHUB_PREV_SHA: ${{ github.event.before }}
     steps:
       - name: Checkout Spark repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         # In order to fetch changed files
         with:
           fetch-depth: 0

--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -72,7 +72,7 @@ jobs:
       GITHUB_PREV_SHA: ${{ github.event.before }}
     steps:
       - name: Checkout Spark repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
           repository: apache/spark
@@ -180,7 +180,7 @@ jobs:
       PYSPARK_TEST_TIMEOUT: 450
     steps:
       - name: Checkout Spark repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         # In order to fetch changed files
         with:
           fetch-depth: 0


### PR DESCRIPTION
### What changes were proposed in this pull request?

this PR pins the `actions/checkout` GitHub Action in `.github/workflows/maven_test.yml` and `.github/workflows/python_hosted_runner_test.yml` to the specific resolved commit SHA for version `v6.0.3` (`df4cb1c069e1874edd31b4311f1884172cec0e10`).

### Why are the changes needed?

pinning actions to a specific, immutable commit SHA is a security best practice, because it protects the repository's CI/CD workflows from untrusted tag updates and ensures build reproducibility.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

verified by checking that the commit SHA resolves directly to `v6.0.3` on `actions/checkout`.

### Was this patch authored or co-authored using generative AI tooling?
yes.
Generated-by: codex (partially co-authored)
