### PR TITLE
[SPARK-56903][SQL][FOLLOWUP] Fix null join key shuffle config version

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1007,7 +1007,7 @@ object SQLConf {
         "equi-joins may require an extra shuffle. If one input is already hash partitioned, " +
         "only the other input may be reshuffled into the null-aware layout, so the pre-shuffled " +
         "input can keep its NULL skew.")
-      .version("4.1.0")
+      .version("4.3.0")
       .withBindingPolicy(ConfigBindingPolicy.SESSION)
       .booleanConf
       .createWithDefault(false)


### PR DESCRIPTION
## Why are the changes needed?

`spark.sql.shuffle.spreadNullJoinKeys.enabled` was introduced on the Spark 4.3 development line, but its configuration metadata incorrectly says that it was introduced in Spark 4.1.0.

This follow-up addresses the review comment on apache/spark#55927 so the documented version matches the first Spark release that contains the configuration.

## What changes were proposed in this PR?

Update the configuration's `version` metadata from `4.1.0` to `4.3.0`.

## How was this PR tested?

- Ran `git diff --check`.
- No runtime tests were added because this change only corrects configuration metadata and does not affect behavior.
