### PR TITLE
[SPARK-57781][INFRA] Add backport confirmation and show push target branch in merge_spark_pr.py

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -514,7 +514,8 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc, pr_author, co_author
     run_cmd(["git", "commit", '--author="%s"' % primary_author] + merge_message_flags)
 
     continue_maybe(
-        "Merge complete (local ref %s). Push to %s?" % (target_branch_name, PUSH_REMOTE_NAME)
+        "Merge complete (local ref %s). Push to %s/%s?"
+        % (target_branch_name, PUSH_REMOTE_NAME, target_ref)
     )
 
     try:
@@ -546,7 +547,8 @@ def _do_cherry_pick(pr_num, merge_hash, pick_ref):
         continue_maybe(msg, True)
 
     continue_maybe(
-        "Pick complete (local ref %s). Push to %s?" % (pick_branch_name, PUSH_REMOTE_NAME)
+        "Pick complete (local ref %s). Push to %s/%s?"
+        % (pick_branch_name, PUSH_REMOTE_NAME, pick_ref)
     )
 
     try:
@@ -1445,7 +1447,7 @@ def main():
         merge_hash = merge_commits[-1]["commit_id"]
         message = get_json("%s/commits/%s" % (GITHUB_API_BASE, merge_hash))["commit"]["message"]
 
-        print("Pull request %s has already been merged, assuming you want to backport" % pr_num)
+        print("Pull request %s has already been merged" % pr_num)
         commit_is_downloaded = (
             run_cmd(["git", "rev-parse", "--quiet", "--verify", "%s^{commit}" % merge_hash]).strip()
             != ""
@@ -1454,6 +1456,7 @@ def main():
             fail("Couldn't find any merge commit for #%s, you may need to update HEAD." % pr_num)
 
         print("Found commit %s:\n%s" % (merge_hash, message))
+        continue_maybe("Proceed with backporting pull request #%s?" % pr_num)
         default = branch_names[0]
         cherry_pick(pr_num, merge_hash, default, branch_names, target_ref, already_picked=())
         sys.exit(0)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Two prompt improvements in `dev/merge_spark_pr.py`:

1. The backport path (re-running the script on an already-merged, closed PR) now asks for an explicit confirmation before doing any git work, and the "assuming you want to backport" wording is dropped since the script now asks instead of assumes:

   ```
   Pull request 12345 has already been merged
   Found commit abcdef01234:
   [SPARK-XXXXX][SQL] Some change
   Proceed with backporting pull request #12345? (y/N):
   ```

   Pressing Enter defaults to No and aborts.

2. The push confirmations in `merge_pr` and `_do_cherry_pick` now name the destination branch:

   ```
   Merge complete (local ref PR_TOOL_MERGE_PR_12345_MASTER). Push to apache/master? (y/N):
   Pick complete (local ref PR_TOOL_PICK_PR_12345_BRANCH-4.2). Push to apache/branch-4.2? (y/N):
   ```

   instead of just `Push to apache? (y/N)`.

### Why are the changes needed?

The normal merge flow shows a PR summary and asks `Proceed with merging pull request #N? (y/N)` before doing anything. The backport flow has no such gate: it jumps straight from "Pull request N has already been merged, assuming you want to backport" to the `Enter a branch name` prompt, and the only y/N confirmation before pushing is `Pick complete (local ref ...). Push to apache? (y/N)`, which never names the target branch in plain text (it is only embedded in the local ref name, e.g. `PR_TOOL_PICK_PR_12345_BRANCH-4.2`). This makes it easy to back-port to a maintenance branch without ever explicitly confirming what is being merged where.

### Does this PR introduce _any_ user-facing change?

No. This only affects the committer-facing merge tooling.

### How was this patch tested?

- Manually traced the prompt flow for both the normal merge path and the already-merged backport path.
- Module doctests pass (57 passed).
- `ruff format --check dev/merge_spark_pr.py` reports the file as already formatted.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-fable-5)
