### PR TITLE
[SPARK-57418][DOCS] Add singleVariantColumn option to CSV, JSON, and XML data source options tables

### DIFF
--- a/docs/sql-data-sources-csv.md
+++ b/docs/sql-data-sources-csv.md
@@ -217,6 +217,12 @@ Data source options of CSV can be set via:
     <td>read</td>
   </tr>
   <tr>
+    <td><code>singleVariantColumn</code></td>
+    <td>(none)</td>
+    <td>If specified, the entire CSV record is parsed and stored as a single column of <code>VariantType</code> with the given column name, instead of being split into individual fields.</td>
+    <td>read</td>
+  </tr>
+  <tr>
     <td><code>multiLine</code></td>
     <td>false</td>
     <td>Allows a row to span multiple lines, by parsing line breaks within quoted values as part of the value itself. CSV built-in functions ignore this option.</td>

--- a/docs/sql-data-sources-json.md
+++ b/docs/sql-data-sources-json.md
@@ -208,6 +208,12 @@ Data source options of JSON can be set via:
     <td>read</td>
   </tr>
   <tr>
+    <td><code>singleVariantColumn</code></td>
+    <td>(none)</td>
+    <td>If specified, the entire JSON record is parsed and stored as a single column of <code>VariantType</code> with the given column name, instead of being split into individual fields.</td>
+    <td>read</td>
+  </tr>
+  <tr>
     <td><code>enableDateTimeParsingFallback</code></td>
     <td>Enabled if the time parser policy has legacy settings or if no custom date or timestamp pattern was provided.</td>
     <td>Allows falling back to the backward compatible (Spark 1.x and 2.0) behavior of parsing dates and timestamps if values do not match the set patterns.</td>

--- a/docs/sql-data-sources-xml.md
+++ b/docs/sql-data-sources-xml.md
@@ -106,6 +106,13 @@ Data source options of XML can be set via:
   </tr>
 
   <tr>
+      <td><code>singleVariantColumn</code></td>
+      <td>(none)</td>
+      <td>If specified, the entire XML record is parsed and stored as a single column of <code>VariantType</code> with the given column name, instead of being split into individual fields. When writing, if the schema consists solely of this column, the Variant value is written directly under the row tag.</td>
+      <td>read/write</td>
+  </tr>
+
+  <tr>
     <td><code>attributePrefix</code></td>
     <td><code>_</code></td>
     <td>The prefix for attributes to differentiate attributes from elements. This will be the prefix for field names. Can be empty for reading XML, but not for writing.</td>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added the missing `singleVariantColumn` option to the Data Source Options tables in:
- `docs/sql-data-sources-csv.md`
- `docs/sql-data-sources-json.md`
- `docs/sql-data-sources-xml.md`

The option was introduced in Spark 4.1.0 (SPARK-51298 for CSV, also supported for JSON and XML) but was never documented in the reference tables. It is defined as a shared constant in `DataSourceOptions.scala` and consumed by `CSVOptions`, `JSONOptions`, and `XmlOptions`.

### Why are the changes needed?

Users have no way to discover `singleVariantColumn` from the official data source options reference. The option allows ingesting an entire CSV/JSON/XML record as a single `VariantType` column instead of parsing it into individual fields — a key use case for the Variant type introduced in Spark 4.0.

### Does this PR introduce _any_ user-facing change?

No. Documentation only.

### How was this patch tested?

No code change — documentation only. Verified the option is defined in `DataSourceOptions.scala` (line 78), `CSVOptions.scala` (line 338), `JSONOptions.scala` (line 215), and `XmlOptions.scala` (line 194).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude (Anthropic)