### PR TITLE
[SPARK-57379][SQL] Block temporary variables in CHECK constraint expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -949,18 +949,7 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
 
           // Reject session/temp variables in persisted CHECK constraints.
           case a: AddCheckConstraint =>
-            a.checkConstraint.child.collectFirst {
-              case v: VariableReference => v
-            }.foreach { v =>
-              v.failAnalysis(
-                errorClass = "INVALID_TEMP_OBJ_REFERENCE",
-                messageParameters = Map(
-                  "obj" -> "CHECK CONSTRAINT",
-                  "objName" -> toSQLId(
-                    Option(a.checkConstraint.userProvidedName).getOrElse("")),
-                  "tempObj" -> "VARIABLE",
-                  "tempObjName" -> toSQLId(v.originalNameParts)))
-            }
+            CheckConstraint.rejectTempVariables(a.checkConstraint)
 
           case alter: AlterTableCommand =>
             checkAlterTableCommand(alter)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -947,6 +947,21 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
               messageParameters = Map("checkCondition" -> a.checkConstraint.condition)
             )
 
+          // Reject session/temp variables in persisted CHECK constraints.
+          case a: AddCheckConstraint =>
+            a.checkConstraint.child.collectFirst {
+              case v: VariableReference => v
+            }.foreach { v =>
+              v.failAnalysis(
+                errorClass = "INVALID_TEMP_OBJ_REFERENCE",
+                messageParameters = Map(
+                  "obj" -> "CHECK CONSTRAINT",
+                  "objName" -> toSQLId(
+                    Option(a.checkConstraint.userProvidedName).getOrElse("")),
+                  "tempObj" -> "VARIABLE",
+                  "tempObjName" -> toSQLId(v.originalNameParts)))
+            }
+
           case alter: AlterTableCommand =>
             checkAlterTableCommand(alter)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTableSpec.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTableSpec.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.optimizer.ComputeCurrentTime
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.COMMAND
-import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryErrorsBase}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ArrayType, MapType, StructType}
 
@@ -34,7 +34,7 @@ import org.apache.spark.sql.types.{ArrayType, MapType, StructType}
  * table specifications wherein these OPTIONS list values are represented as strings instead, for
  * convenience.
  */
-object ResolveTableSpec extends Rule[LogicalPlan] {
+object ResolveTableSpec extends Rule[LogicalPlan] with QueryErrorsBase {
   override def apply(plan: LogicalPlan): LogicalPlan = {
     val preparedPlan = if (SQLConf.get.legacyEvalCurrentTime && plan.containsPattern(COMMAND)) {
       AnalysisHelper.allowInvokingTransformsInAnalyzer {
@@ -94,6 +94,21 @@ object ResolveTableSpec extends Rule[LogicalPlan] {
               errorClass = "NON_DETERMINISTIC_CHECK_CONSTRAINT",
               messageParameters = Map("checkCondition" -> check.condition)
             )
+          }
+          // Reject session/temp variables in persisted CHECK constraints.
+          check.child.collectFirst {
+            case v: VariableReference => v
+          }.foreach { v =>
+            // For an inline (unnamed) constraint the name is not yet available here
+            // (it is synthesized later from the table name), so the empty name is intentional.
+            v.failAnalysis(
+              errorClass = "INVALID_TEMP_OBJ_REFERENCE",
+              messageParameters = Map(
+                "obj" -> "CHECK CONSTRAINT",
+                "objName" -> toSQLId(
+                  Option(check.userProvidedName).getOrElse("")),
+                "tempObj" -> "VARIABLE",
+                "tempObjName" -> toSQLId(v.originalNameParts)))
           }
         case _ =>
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTableSpec.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTableSpec.scala
@@ -96,20 +96,7 @@ object ResolveTableSpec extends Rule[LogicalPlan] with QueryErrorsBase {
             )
           }
           // Reject session/temp variables in persisted CHECK constraints.
-          check.child.collectFirst {
-            case v: VariableReference => v
-          }.foreach { v =>
-            // For an inline (unnamed) constraint the name is not yet available here
-            // (it is synthesized later from the table name), so the empty name is intentional.
-            v.failAnalysis(
-              errorClass = "INVALID_TEMP_OBJ_REFERENCE",
-              messageParameters = Map(
-                "obj" -> "CHECK CONSTRAINT",
-                "objName" -> toSQLId(
-                  Option(check.userProvidedName).getOrElse("")),
-                "tempObj" -> "VARIABLE",
-                "tempObjName" -> toSQLId(v.originalNameParts)))
-          }
+          CheckConstraint.rejectTempVariables(check)
         case _ =>
       }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/constraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/constraints.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.expressions
 import java.util.UUID
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, UnresolvedException}
+import org.apache.spark.sql.catalyst.analysis.{AnalysisErrorAt, TypeCheckResult, UnresolvedException}
 import org.apache.spark.sql.catalyst.expressions.codegen.{Block, CodegenContext, ExprCode, FalseLiteral, TrueLiteral}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block.BlockHelper
 import org.apache.spark.sql.catalyst.parser.ParseException
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.trees.CurrentOrigin
 import org.apache.spark.sql.catalyst.util.V2ExpressionBuilder
 import org.apache.spark.sql.connector.catalog.constraints.Constraint
 import org.apache.spark.sql.connector.expressions.FieldReference
-import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.errors.{QueryErrorsBase, QueryExecutionErrors}
 import org.apache.spark.sql.types.{AbstractDataType, BooleanType, DataType}
 
 trait TableConstraint extends Expression with Unevaluable {
@@ -168,6 +168,29 @@ case class CheckConstraint(
       )
     }
     copy(userProvidedCharacteristic = c)
+  }
+}
+
+object CheckConstraint extends QueryErrorsBase {
+  /**
+   * Rejects session/temp variables in persisted CHECK constraints by detecting the first
+   * [[VariableReference]] in the constraint expression and raising INVALID_TEMP_OBJ_REFERENCE.
+   */
+  def rejectTempVariables(check: CheckConstraint): Unit = {
+    check.child.collectFirst {
+      case v: VariableReference => v
+    }.foreach { v =>
+      v.failAnalysis(
+        errorClass = "INVALID_TEMP_OBJ_REFERENCE",
+        messageParameters = Map(
+          "obj" -> "CHECK CONSTRAINT",
+          // Inline (unnamed) constraints have no name yet (it is synthesized later from the
+          // table name), so the empty string here is intentional.
+          "objName" -> toSQLId(
+            Option(check.userProvidedName).getOrElse("")),
+          "tempObj" -> "VARIABLE",
+          "tempObjName" -> toSQLId(v.originalNameParts)))
+    }
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CheckConstraintSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CheckConstraintSuite.scala
@@ -78,6 +78,94 @@ class CheckConstraintSuite extends QueryTest with CommandSuiteBase with DDLComma
     }
   }
 
+  test("SPARK-57379: Temporary variable in check constraint -- alter table") {
+    withNamespaceAndTable("ns", "tbl", nonPartitionCatalog) { t =>
+      sql(s"CREATE TABLE $t (i INT) $defaultUsing")
+      withSessionVariable("my_var") {
+        sql("DECLARE OR REPLACE VARIABLE my_var INT DEFAULT 1")
+        Seq(
+          s"ALTER TABLE $t ADD CONSTRAINT c1 CHECK (i > my_var)",
+          s"ALTER TABLE $t ADD CONSTRAINT c1 CHECK (i > CAST(my_var AS BIGINT))"
+        ).foreach { query =>
+          val error = intercept[AnalysisException] {
+            sql(query)
+          }
+          checkError(
+            exception = error,
+            condition = "INVALID_TEMP_OBJ_REFERENCE",
+            sqlState = "42K0F",
+            parameters = Map(
+              "obj" -> "CHECK CONSTRAINT",
+              "objName" -> "`c1`",
+              "tempObj" -> "VARIABLE",
+              "tempObjName" -> "`my_var`"),
+            context = ExpectedContext(fragment = "my_var")
+          )
+        }
+      }
+    }
+  }
+
+  test("SPARK-57379: Temporary variable in check constraint -- create table") {
+    withSessionVariable("my_var") {
+      sql("DECLARE OR REPLACE VARIABLE my_var INT DEFAULT 1")
+      Seq(
+        ("CREATE TABLE t(i INT CHECK (i > my_var))", "``"),
+        ("CREATE TABLE t(i INT, CONSTRAINT c1 CHECK (i > my_var))", "`c1`"),
+        ("REPLACE TABLE t(i INT CHECK (i > my_var))", "``"),
+        ("REPLACE TABLE t(i INT, CONSTRAINT c1 CHECK (i > my_var))", "`c1`"),
+        ("CREATE TABLE t(i INT CHECK (i > CAST(my_var AS BIGINT)))", "``")
+      ).foreach { case (query, expectedObjName) =>
+        withTable("t") {
+          val error = intercept[AnalysisException] {
+            sql(query)
+          }
+          checkError(
+            exception = error,
+            condition = "INVALID_TEMP_OBJ_REFERENCE",
+            sqlState = "42K0F",
+            parameters = Map(
+              "obj" -> "CHECK CONSTRAINT",
+              "objName" -> expectedObjName,
+              "tempObj" -> "VARIABLE",
+              "tempObjName" -> "`my_var`"),
+            context = ExpectedContext(fragment = "my_var")
+          )
+        }
+      }
+    }
+  }
+
+  test("SPARK-57379: Temporary variable in check constraint -- qualified variable name") {
+    withNamespaceAndTable("ns", "tbl", nonPartitionCatalog) { t =>
+      sql(s"CREATE TABLE $t (i INT) $defaultUsing")
+      withSessionVariable("my_var") {
+        sql("DECLARE OR REPLACE VARIABLE my_var INT DEFAULT 1")
+        val error = intercept[AnalysisException] {
+          sql(s"ALTER TABLE $t ADD CONSTRAINT c1 CHECK (i > session.my_var)")
+        }
+        checkError(
+          exception = error,
+          condition = "INVALID_TEMP_OBJ_REFERENCE",
+          sqlState = "42K0F",
+          parameters = Map(
+            "obj" -> "CHECK CONSTRAINT",
+            "objName" -> "`c1`",
+            "tempObj" -> "VARIABLE",
+            "tempObjName" -> "`session`.`my_var`"),
+          context = ExpectedContext(fragment = "session.my_var")
+        )
+      }
+    }
+  }
+
+  test("SPARK-57379: Temporary variable in check constraint -- happy path without variable") {
+    withNamespaceAndTable("ns", "tbl", nonPartitionCatalog) { t =>
+      sql(s"CREATE TABLE $t (i INT, CONSTRAINT c1 CHECK (i > 0)) $defaultUsing")
+      sql(s"ALTER TABLE $t ADD CONSTRAINT c2 CHECK (i > -1)")
+    }
+  }
+
   test("Expression referring a column of another table -- alter table") {
     withNamespaceAndTable("ns", "tbl_1", nonPartitionCatalog) { t1 =>
       withNamespaceAndTable("ns", "tbl_2", nonPartitionCatalog) { t2 =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Block references to temporary (session) variables in CHECK constraint expressions, on both the `CREATE`/`REPLACE TABLE` path and the `ALTER TABLE ... ADD CONSTRAINT` path. A CHECK constraint that references a session variable is now rejected at analysis time with `INVALID_TEMP_OBJ_REFERENCE`.

The check mirrors the structural placement of the existing non-deterministic-constraint validation in both the `CREATE`/`REPLACE TABLE` (`ResolveTableSpec`) and `ALTER TABLE ... ADD CONSTRAINT` (`CheckAnalysis`) paths. It uses `INVALID_TEMP_OBJ_REFERENCE` — the canonical error class already raised when a persistent view references a temporary variable — rather than the generated-column-specific error used by SPARK-57360. Detection scans the constraint expression for any `VariableReference` node, so nested references (e.g. inside a `CAST`) are caught.

### Why are the changes needed?

A CHECK constraint is persisted with the table, but a temporary/session variable is session-scoped and will not exist in other sessions, making the persisted constraint invalid. Today both paths silently accept it:

```sql
DECLARE OR REPLACE VARIABLE my_var INT DEFAULT 5;

-- Both currently succeed and persist CHECK (val > my_var):
CREATE TABLE t (id INT, val INT, CONSTRAINT c1 CHECK (val > my_var)) USING parquet;

CREATE TABLE t2 (id INT, val INT) USING parquet;
ALTER TABLE t2 ADD CONSTRAINT c2 CHECK (val > my_var);
```

Spark already blocks the analogous case for persistent views via `INVALID_TEMP_OBJ_REFERENCE`; this extends the same protection to CHECK constraints.

### Does this PR introduce _any_ user-facing change?

Yes. Creating or altering a table with a CHECK constraint that references a temporary variable now fails with `INVALID_TEMP_OBJ_REFERENCE` instead of silently persisting an invalid constraint. No previously-valid constraint is affected.

### How was this patch tested?

New tests in `CheckConstraintSuite` covering `CREATE TABLE`, `REPLACE TABLE`, and `ALTER TABLE ADD CONSTRAINT`, including a nested reference (`CHECK (i > CAST(my_var AS BIGINT))`) to confirm detection is recursive, a qualified variable name (`session.my_var`), and a happy-path guard (a non-variable constraint still succeeds). CTAS/RTAS cannot carry CHECK constraints (the parser rejects them), so they need no coverage. Verified the tests fail without the fix.

### Was this patch authored or co-authored using generative AI tooling?

Tests and PR description generated by Claude Opus 4.8