### PR TITLE
[SPARK-57397][PYTHON][3.5] Raise an exception when parsed UDT is the wrong type

### DIFF
--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -231,6 +231,11 @@ ERROR_CLASSES_JSON = """
       "Duplicated field names in Arrow Struct are not allowed, got <field_names>"
     ]
   },
+  "FIELD_TYPE_MISMATCH": {
+    "message": [
+      "<obj> is not an instance of type <data_type>."
+    ]
+  },
   "HIGHER_ORDER_FUNCTION_SHOULD_RETURN_COLUMN" : {
     "message" : [
       "Function `<func_name>` should return Column, got <return_type>."

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -49,6 +49,7 @@ from pyspark.sql.types import (
     BinaryType,
     BooleanType,
     NullType,
+    UserDefinedType,
 )
 from pyspark.sql.types import (
     _array_signed_int_typecode_ctype_mappings,
@@ -540,6 +541,16 @@ class TypesTestsMixin:
         self.assertEqual(_infer_type(p), PythonOnlyUDT())
         _make_type_verifier(PythonOnlyUDT())(PythonOnlyPoint(1.0, 2.0))
         self.assertRaises(ValueError, lambda: _make_type_verifier(PythonOnlyUDT())([1.0, 2.0]))
+
+    def test_udt_from_json_import_type_mismatch(self):
+        json = {
+            "type": "udt",
+            "pyClass": "random.random",
+            "serializedClass": "",
+            "sqlType": StringType().jsonValue(),
+        }
+        with self.assertRaises(PySparkTypeError):
+            UserDefinedType.fromJson(json)
 
     def test_simple_udt_in_df(self):
         schema = StructType().add("key", LongType()).add("val", PythonOnlyUDT())

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1212,8 +1212,8 @@ class UserDefinedType(DataType):
             UDT = getattr(m, pyClass)
             if not (isinstance(UDT, type) and issubclass(UDT, UserDefinedType)):
                 raise PySparkTypeError(
-                    errorClass="FIELD_TYPE_MISMATCH",
-                    messageParameters={"obj": str(UDT), "data_type": "UserDefinedType"},
+                    error_class="FIELD_TYPE_MISMATCH",
+                    message_parameters={"obj": str(UDT), "data_type": "UserDefinedType"},
                 )
         return UDT()
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1210,6 +1210,11 @@ class UserDefinedType(DataType):
             )
         else:
             UDT = getattr(m, pyClass)
+            if not (isinstance(UDT, type) and issubclass(UDT, UserDefinedType)):
+                raise PySparkTypeError(
+                    errorClass="FIELD_TYPE_MISMATCH",
+                    messageParameters={"obj": str(UDT), "data_type": "UserDefinedType"},
+                )
         return UDT()
 
     def __eq__(self, other: Any) -> bool:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Check whether the imported class is a real UserDefinedType before calling it.

### Why are the changes needed?

If it's not a UDT, it could run wrong code.

### Does this PR introduce _any_ user-facing change?

Not for normal use.

### How was this patch tested?

Regression test added.

### Was this patch authored or co-authored using generative AI tooling?

No.