### PR TITLE
[SPARK-57420][INFRA] Add generate-tpcds input and early CPU check to benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,6 +56,11 @@ on:
         description: 'Commit the benchmark results to the current branch'
         required: true
         default: false
+      generate-tpcds:
+        type: boolean
+        description: 'Generate TPC-DS data (required for TPC-DS benchmarks and all-benchmark runs)'
+        required: true
+        default: true
       expected-cpu:
         type: string
         description: 'Expected CPU model (e.g. "AMD EPYC 7763"). If set, the job fails early when the runner CPU does not match.'
@@ -78,11 +83,7 @@ jobs:
   # Any TPC-DS related updates on this job need to be applied to tpcds-1g job of build_and_test.yml as well
   tpcds-1g-gen:
     name: "Generate an TPC-DS dataset with SF=1"
-    # Only generate TPC-DS data when running TPC-DS benchmarks or all benchmarks (class == '*').
-    # Use contains(inputs.class, 'TPCDS') to catch both exact class names and globs like '*TPCDS*'.
-    # Use exact equality for '*' to avoid matching wildcard patterns like
-    # '*VectorizedDeltaReaderBenchmark' that don't need TPC-DS data.
-    if: contains(inputs.class, 'TPCDS') || inputs.class == '*'
+    if: inputs.generate-tpcds
     runs-on: ubuntu-latest
     env:
       SPARK_LOCAL_IP: localhost
@@ -203,7 +204,7 @@ jobs:
         distribution: zulu
         java-version: ${{ inputs.jdk }}
     - name: Cache TPC-DS generated data
-      if: contains(inputs.class, 'TPCDS') || inputs.class == '*'
+      if: inputs.generate-tpcds
       id: cache-tpcds-sf-1
       uses: actions/cache@v5
       with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,6 +56,11 @@ on:
         description: 'Commit the benchmark results to the current branch'
         required: true
         default: false
+      expected-cpu:
+        type: string
+        description: 'Expected CPU model (e.g. "AMD EPYC 7763"). If set, the job fails early when the runner CPU does not match.'
+        required: false
+        default: ''
 
 jobs:
   matrix-gen:
@@ -73,7 +78,11 @@ jobs:
   # Any TPC-DS related updates on this job need to be applied to tpcds-1g job of build_and_test.yml as well
   tpcds-1g-gen:
     name: "Generate an TPC-DS dataset with SF=1"
-    if: contains(inputs.class, 'TPCDSQueryBenchmark') || contains(inputs.class, 'LZ4TPCDSDataBenchmark') || contains(inputs.class, 'ZStandardTPCDSDataBenchmark') || contains(inputs.class, '*')
+    # Only generate TPC-DS data when running TPC-DS benchmarks or all benchmarks (class == '*').
+    # Use contains(inputs.class, 'TPCDS') to catch both exact class names and globs like '*TPCDS*'.
+    # Use exact equality for '*' to avoid matching wildcard patterns like
+    # '*VectorizedDeltaReaderBenchmark' that don't need TPC-DS data.
+    if: contains(inputs.class, 'TPCDS') || inputs.class == '*'
     runs-on: ubuntu-latest
     env:
       SPARK_LOCAL_IP: localhost
@@ -156,6 +165,21 @@ jobs:
       # In order to get diff files
       with:
         fetch-depth: 0
+    - name: Check CPU model
+      env:
+        EXPECTED_CPU: ${{ inputs.expected-cpu }}
+      run: |
+        CPU_MODEL=$(grep "model name" /proc/cpuinfo | head -1 | sed 's/model name\s*:\s*//')
+        echo "Runner CPU: $CPU_MODEL"
+        echo "::notice::Runner CPU: $CPU_MODEL"
+        if [ -n "$EXPECTED_CPU" ]; then
+          if echo "$CPU_MODEL" | grep -qF "$EXPECTED_CPU"; then
+            echo "CPU matches expected: $EXPECTED_CPU"
+          else
+            echo "::error::CPU mismatch! Expected '$EXPECTED_CPU' but got '$CPU_MODEL'"
+            exit 1
+          fi
+        fi
     - name: Cache SBT and Maven
       uses: actions/cache@v5
       with:
@@ -179,7 +203,7 @@ jobs:
         distribution: zulu
         java-version: ${{ inputs.jdk }}
     - name: Cache TPC-DS generated data
-      if: contains(inputs.class, 'TPCDSQueryBenchmark') || contains(inputs.class, 'LZ4TPCDSDataBenchmark') || contains(inputs.class, 'ZStandardTPCDSDataBenchmark') || contains(inputs.class, '*')
+      if: contains(inputs.class, 'TPCDS') || inputs.class == '*'
       id: cache-tpcds-sf-1
       uses: actions/cache@v5
       with:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Two improvements to the benchmark workflow:

1. **Add explicit `generate-tpcds` boolean input** (default: `true`) to control TPC-DS data generation. Users running non-TPC-DS benchmarks can set it to `false` to skip the expensive generation step (~5-10 min saved per run). This replaces the previous `contains(inputs.class, '*')` heuristic which incorrectly triggered TPC-DS generation for wildcard patterns like `*VectorizedDeltaReaderBenchmark`.

2. **Add early CPU model check step** that runs immediately after checkout, before compilation. Prints the CPU as a `::notice::` annotation for live visibility in the Actions UI, and optionally fails fast if the runner CPU does not match the `expected-cpu` input parameter.

### Why are the changes needed?

The benchmark workflow previously used heuristic pattern matching (`contains(inputs.class, '*')`, later `contains(inputs.class, 'TPCDS')`) to decide whether to generate TPC-DS data. This approach had edge cases -- wildcard patterns that don't need TPC-DS data would trigger generation, and generic package-level globs like `org.apache.spark.sql.execution.benchmark.*` that do include TPC-DS benchmarks would miss it. An explicit boolean input eliminates all ambiguity and is future-proof against new class names.

Additionally, when benchmark results need to match a specific CPU (e.g., AMD EPYC 7763 for consistent comparisons against upstream baselines), there is no way to detect a CPU mismatch until the full benchmark completes (~20-30 min). The early CPU check allows the job to fail within seconds of starting if the runner does not match, saving significant time and compute.

### Does this PR introduce _any_ user-facing change?

No. This only affects the GHA benchmark workflow. Existing behavior is preserved: `generate-tpcds` defaults to `true` (matching the default `class: '*'`), and `expected-cpu` defaults to empty (no check).

### How was this patch tested?

The workflow changes are self-contained in `.github/workflows/benchmark.yml`. Tested by inspection. Both new parameters are optional with backward-compatible defaults.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenCode (Claude claude-opus-4.6)