### PR TITLE
[SPARK-57421][SQL] Support @-syntax version time travel on table names

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5062,12 +5062,6 @@
     },
     "sqlState" : "42K0E"
   },
-  "INVALID_TIME_TRAVEL_TIMESTAMP_FORMAT" : {
-    "message" : [
-      "The provided timestamp <timestamp> doesn't match the expected syntax <format>."
-    ],
-    "sqlState" : "22000"
-  },
   "INVALID_TYPED_LITERAL" : {
     "message" : [
       "The value of the typed literal <valueType> is invalid: <value>."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5010,12 +5010,6 @@
     ],
     "sqlState" : "42K0F"
   },
-  "INVALID_TIMESTAMP_FORMAT" : {
-    "message" : [
-      "The provided timestamp <timestamp> doesn't match the expected syntax <format>."
-    ],
-    "sqlState" : "22000"
-  },
   "INVALID_TIMESTAMP_LITERAL_PRECISION" : {
     "message" : [
       "The timestamp literal <value> has more than 9 fractional-second digits. The maximum supported fractional-second precision of a timestamp literal is 9 (nanoseconds)."
@@ -5067,6 +5061,12 @@
       }
     },
     "sqlState" : "42K0E"
+  },
+  "INVALID_TIME_TRAVEL_TIMESTAMP_FORMAT" : {
+    "message" : [
+      "The provided timestamp <timestamp> doesn't match the expected syntax <format>."
+    ],
+    "sqlState" : "22000"
   },
   "INVALID_TYPED_LITERAL" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5010,6 +5010,12 @@
     ],
     "sqlState" : "42K0F"
   },
+  "INVALID_TIMESTAMP_FORMAT" : {
+    "message" : [
+      "The provided timestamp <timestamp> doesn't match the expected syntax <format>."
+    ],
+    "sqlState" : "22000"
+  },
   "INVALID_TIMESTAMP_LITERAL_PRECISION" : {
     "message" : [
       "The timestamp literal <value> has more than 9 fractional-second digits. The maximum supported fractional-second precision of a timestamp literal is 9 (nanoseconds)."
@@ -5579,7 +5585,7 @@
   },
   "MULTIPLE_TIME_TRAVEL_SPEC" : {
     "message" : [
-      "Cannot specify time travel in both the time travel clause and options."
+      "Cannot specify time travel in more than one of: the '@' suffix in the table name, the time travel clause, and the read options."
     ],
     "sqlState" : "42K0E"
   },
@@ -8467,6 +8473,11 @@
       "TIME_TRAVEL" : {
         "message" : [
           "Time travel on the relation: <relationId>."
+        ]
+      },
+      "TIME_TRAVEL_AT_SYNTAX" : {
+        "message" : [
+          "Time travel using the '@' suffix in table names. Set <config> to true to enable it."
         ]
       },
       "TOO_MANY_TYPE_ARGUMENTS_FOR_UDF_CLASS" : {

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseLexer.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseLexer.g4
@@ -590,7 +590,6 @@ OPERATOR_PIPE: '|>';
 HAT: '^';
 COLON: ':';
 DOUBLE_COLON: '::';
-AT_SIGN: '@';
 AT_VERSION: '@V';
 ARROW: '->';
 FAT_ARROW : '=>';

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseLexer.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseLexer.g4
@@ -590,6 +590,8 @@ OPERATOR_PIPE: '|>';
 HAT: '^';
 COLON: ':';
 DOUBLE_COLON: '::';
+AT_SIGN: '@';
+AT_VERSION: '@V';
 ARROW: '->';
 FAT_ARROW : '=>';
 HENT_START: '/*+';

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -201,6 +201,10 @@ singleTableIdentifier
     : tableIdentifier EOF
     ;
 
+singleTemporalTableIdentifier
+    : temporalTableIdentifier EOF
+    ;
+
 singleMultipartIdentifier
     : multipartIdentifier EOF
     ;
@@ -1133,7 +1137,7 @@ relationPrimary
     : streamRelationPrimary                                 #streamRelation
     | identifierReference changesClause
       optionsClause? tableAlias                             #changelogTableName
-    | identifierReference temporalClause?
+    | temporalTableIdentifierReference temporalClause?
       optionsClause? sample? watermarkClause? tableAlias    #tableName
     | LEFT_PAREN query RIGHT_PAREN sample? watermarkClause?
       tableAlias                                            #aliasedQuery
@@ -1237,6 +1241,18 @@ multipartIdentifierProperty
 
 tableIdentifier
     : (db=errorCapturingIdentifier DOT)? table=errorCapturingIdentifier
+    ;
+
+temporalTableIdentifier
+    : id=multipartIdentifier AT_SIGN timestamp=INTEGER_VALUE
+    | id=multipartIdentifier AT_VERSION version
+    | id=multipartIdentifier
+    ;
+
+temporalTableIdentifierReference
+    : identifierReference AT_SIGN timestamp=INTEGER_VALUE
+    | identifierReference AT_VERSION version
+    | identifierReference
     ;
 
 functionIdentifier

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -1244,14 +1244,12 @@ tableIdentifier
     ;
 
 temporalTableIdentifier
-    : id=multipartIdentifier AT_SIGN timestamp=INTEGER_VALUE
-    | id=multipartIdentifier AT_VERSION version
+    : id=multipartIdentifier AT_VERSION version
     | id=multipartIdentifier
     ;
 
 temporalTableIdentifierReference
-    : identifierReference AT_SIGN timestamp=INTEGER_VALUE
-    | identifierReference AT_VERSION version
+    : identifierReference AT_VERSION version
     | identifierReference
     ;
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -872,7 +872,7 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
   def invalidAtSyntaxTimestamp(
       timestamp: String, format: String, ctx: ParserRuleContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_TIMESTAMP_FORMAT",
+      errorClass = "INVALID_TIME_TRAVEL_TIMESTAMP_FORMAT",
       messageParameters = Map("timestamp" -> timestamp, "format" -> format),
       ctx)
   }

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -869,6 +869,28 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
       ctx)
   }
 
+  def invalidAtSyntaxTimestamp(
+      timestamp: String, format: String, ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      errorClass = "INVALID_TIMESTAMP_FORMAT",
+      messageParameters = Map("timestamp" -> timestamp, "format" -> format),
+      ctx)
+  }
+
+  def multipleTimeTravelSpec(ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      errorClass = "MULTIPLE_TIME_TRAVEL_SPEC",
+      messageParameters = Map.empty,
+      ctx)
+  }
+
+  def timeTravelAtSyntaxDisabled(configKey: String, ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      errorClass = "UNSUPPORTED_FEATURE.TIME_TRAVEL_AT_SYNTAX",
+      messageParameters = Map("config" -> toSQLConf(configKey)),
+      ctx)
+  }
+
   def invalidNameForDropTempFunc(name: Seq[String], ctx: ParserRuleContext): Throwable = {
     new ParseException(
       errorClass = "INVALID_SQL_SYNTAX.MULTI_PART_NAME",

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -869,14 +869,6 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
       ctx)
   }
 
-  def invalidAtSyntaxTimestamp(
-      timestamp: String, format: String, ctx: ParserRuleContext): Throwable = {
-    new ParseException(
-      errorClass = "INVALID_TIME_TRAVEL_TIMESTAMP_FORMAT",
-      messageParameters = Map("timestamp" -> timestamp, "format" -> format),
-      ctx)
-  }
-
   def multipleTimeTravelSpec(ctx: ParserRuleContext): Throwable = {
     new ParseException(
       errorClass = "MULTIPLE_TIME_TRAVEL_SPEC",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AbstractSqlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AbstractSqlParser.scala
@@ -72,6 +72,16 @@ abstract class AbstractSqlParser extends AbstractParser with ParserInterface {
     }
   }
 
+  /** Creates a TemporalIdentifier for a given SQL string */
+  override def parseTemporalTableIdentifier(sqlText: String): TemporalIdentifier = {
+    parse(sqlText) { parser =>
+      val ctx = parser.singleTemporalTableIdentifier()
+      withErrorHandling(ctx, Some(sqlText)) {
+        astBuilder.visitSingleTemporalTableIdentifier(ctx)
+      }
+    }
+  }
+
   /** Creates LogicalPlan for a given SQL string of query. */
   override def parseQuery(sqlText: String): LogicalPlan =
     parse(sqlText) { parser =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2641,23 +2641,30 @@ class AstBuilder extends DataTypeAstBuilder
    */
   override def visitTableName(ctx: TableNameContext): LogicalPlan = withOrigin(ctx) {
     val ttCtx = ctx.temporalTableIdentifierReference
-    val (atTimestamp, atVersion) = temporalSpec(ttCtx, ttCtx.timestamp, ttCtx.version)
-    val hasAtSpec = atTimestamp.isDefined || atVersion.isDefined
-    if (hasAtSpec && ctx.temporalClause != null) {
-      withOrigin(ctx.temporalClause) {
-        throw QueryParsingErrors.multipleTimeTravelSpec(ctx.temporalClause)
-      }
-    }
     val relation = createUnresolvedRelation(ttCtx.identifierReference, Option(ctx.optionsClause))
-    val withAtSpec = if (hasAtSpec) {
-      RelationTimeTravel(relation, atTimestamp, atVersion)
-    } else {
-      relation
-    }
-    val table = mayApplyAliasPlan(
-      ctx.tableAlias, withAtSpec.optionalMap(ctx.temporalClause)(withTimeTravel))
+    val withTimeTravelSpec = withTableTimeTravel(relation, ttCtx, ctx.temporalClause)
+    val table = mayApplyAliasPlan(ctx.tableAlias, withTimeTravelSpec)
     val sample = table.optionalMap(ctx.sample)(withSample)
     sample.optionalMap(ctx.watermarkClause)(withWatermark)
+  }
+
+  /**
+   * Applies the table-name '@' time travel suffix and/or the `AS OF` clause to `relation`.
+   */
+  private def withTableTimeTravel(
+      relation: LogicalPlan,
+      ttCtx: TemporalTableIdentifierReferenceContext,
+      clause: TemporalClauseContext): LogicalPlan = {
+    val (atTimestamp, atVersion) = temporalSpec(ttCtx, ttCtx.timestamp, ttCtx.version)
+    val hasAtSpec = atTimestamp.isDefined || atVersion.isDefined
+    if (hasAtSpec && clause != null) {
+      withOrigin(clause) {
+        throw QueryParsingErrors.multipleTimeTravelSpec(clause)
+      }
+    }
+    val withAtSpec =
+      if (hasAtSpec) RelationTimeTravel(relation, atTimestamp, atVersion) else relation
+    withAtSpec.optionalMap(clause)(withTimeTravel)
   }
 
   override def visitTemporalTableIdentifier(
@@ -2666,15 +2673,14 @@ class AstBuilder extends DataTypeAstBuilder
     TemporalIdentifier(visitMultipartIdentifier(ctx.id), timestamp, version)
   }
 
-  private val atSyntaxTimestampFormat = "yyyyMMddHHmmssSSS"
-
   /**
    * Parse the digits of an '@' time travel timestamp (format yyyyMMddHHmmssSSS) to
    * microseconds since epoch in the session time zone.
    */
   private def parseAtSyntaxTimestamp(text: String, ctx: ParserRuleContext): Long = {
-    if (text.length != atSyntaxTimestampFormat.length) {
-      throw QueryParsingErrors.invalidAtSyntaxTimestamp(text, atSyntaxTimestampFormat, ctx)
+    val format = TemporalIdentifier.TimestampFormat
+    if (text.length != format.length) {
+      throw QueryParsingErrors.invalidAtSyntaxTimestamp(text, format, ctx)
     }
     try {
       val localDateTime = LocalDateTime.of(
@@ -2689,7 +2695,7 @@ class AstBuilder extends DataTypeAstBuilder
         localDateTime.atZone(getZoneId(conf.sessionLocalTimeZone)).toInstant)
     } catch {
       case _: DateTimeException =>
-        throw QueryParsingErrors.invalidAtSyntaxTimestamp(text, atSyntaxTimestampFormat, ctx)
+        throw QueryParsingErrors.invalidAtSyntaxTimestamp(text, format, ctx)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.parser
 
+import java.time.{DateTimeException, LocalDateTime}
 import java.util.{List, Locale}
 import java.util.concurrent.TimeUnit
 
@@ -45,7 +46,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
 import org.apache.spark.sql.catalyst.trees.TreePattern.PARAMETER
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, CollationFactory, DateTimeUtils, EvaluateUnresolvedInlineTable, IntervalUtils}
+import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, CollationFactory, DateTimeConstants, DateTimeUtils, EvaluateUnresolvedInlineTable, IntervalUtils}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{convertSpecialDate, convertSpecialTimestamp, convertSpecialTimestampNTZ, fractionalSecondsDigits, getZoneId, stringToDate, stringToTime, stringToTimestamp, stringToTimestampLTZNanos, stringToTimestampNTZNanos, stringToTimestampWithoutTimeZone}
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, ChangelogContext, PathElement, SupportsNamespaces, TableCatalog, TableWritePrivilege}
 import org.apache.spark.sql.connector.catalog.ChangelogRange.{TimestampRange, UnboundedRange, VersionRange}
@@ -706,6 +707,11 @@ class AstBuilder extends DataTypeAstBuilder
   override def visitSingleMultipartIdentifier(
       ctx: SingleMultipartIdentifierContext): Seq[String] = withOrigin(ctx) {
     visitMultipartIdentifier(ctx.multipartIdentifier)
+  }
+
+  override def visitSingleTemporalTableIdentifier(
+      ctx: SingleTemporalTableIdentifierContext): TemporalIdentifier = withOrigin(ctx) {
+    visitTemporalTableIdentifier(ctx.temporalTableIdentifier)
   }
 
   override def visitSinglePathElementList(
@@ -2634,11 +2640,81 @@ class AstBuilder extends DataTypeAstBuilder
    * Create an aliased table reference. This is typically used in FROM clauses.
    */
   override def visitTableName(ctx: TableNameContext): LogicalPlan = withOrigin(ctx) {
-    val relation = createUnresolvedRelation(ctx.identifierReference, Option(ctx.optionsClause))
+    val ttCtx = ctx.temporalTableIdentifierReference
+    val (atTimestamp, atVersion) = temporalSpec(ttCtx, ttCtx.timestamp, ttCtx.version)
+    val hasAtSpec = atTimestamp.isDefined || atVersion.isDefined
+    if (hasAtSpec && ctx.temporalClause != null) {
+      withOrigin(ctx.temporalClause) {
+        throw QueryParsingErrors.multipleTimeTravelSpec(ctx.temporalClause)
+      }
+    }
+    val relation = createUnresolvedRelation(ttCtx.identifierReference, Option(ctx.optionsClause))
+    val withAtSpec = if (hasAtSpec) {
+      RelationTimeTravel(relation, atTimestamp, atVersion)
+    } else {
+      relation
+    }
     val table = mayApplyAliasPlan(
-      ctx.tableAlias, relation.optionalMap(ctx.temporalClause)(withTimeTravel))
+      ctx.tableAlias, withAtSpec.optionalMap(ctx.temporalClause)(withTimeTravel))
     val sample = table.optionalMap(ctx.sample)(withSample)
     sample.optionalMap(ctx.watermarkClause)(withWatermark)
+  }
+
+  override def visitTemporalTableIdentifier(
+      ctx: TemporalTableIdentifierContext): TemporalIdentifier = withOrigin(ctx) {
+    val (timestamp, version) = temporalSpec(ctx, ctx.timestamp, ctx.version)
+    TemporalIdentifier(visitMultipartIdentifier(ctx.id), timestamp, version)
+  }
+
+  private val atSyntaxTimestampFormat = "yyyyMMddHHmmssSSS"
+
+  /**
+   * Parse the digits of an '@' time travel timestamp (format yyyyMMddHHmmssSSS) to
+   * microseconds since epoch in the session time zone.
+   */
+  private def parseAtSyntaxTimestamp(text: String, ctx: ParserRuleContext): Long = {
+    if (text.length != atSyntaxTimestampFormat.length) {
+      throw QueryParsingErrors.invalidAtSyntaxTimestamp(text, atSyntaxTimestampFormat, ctx)
+    }
+    try {
+      val localDateTime = LocalDateTime.of(
+        text.substring(0, 4).toInt,
+        text.substring(4, 6).toInt,
+        text.substring(6, 8).toInt,
+        text.substring(8, 10).toInt,
+        text.substring(10, 12).toInt,
+        text.substring(12, 14).toInt,
+        text.substring(14, 17).toInt * DateTimeConstants.NANOS_PER_MILLIS.toInt)
+      DateTimeUtils.instantToMicros(
+        localDateTime.atZone(getZoneId(conf.sessionLocalTimeZone)).toInstant)
+    } catch {
+      case _: DateTimeException =>
+        throw QueryParsingErrors.invalidAtSyntaxTimestamp(text, atSyntaxTimestampFormat, ctx)
+    }
+  }
+
+  /**
+   * Extract the optional '@' time travel suffix of a table identifier: '@<timestamp>'
+   * (format yyyyMMddHHmmssSSS) or '@v<version>'.
+   */
+  private def temporalSpec(
+      ctx: ParserRuleContext,
+      timestampToken: Token,
+      versionCtx: VersionContext): (Option[Expression], Option[String]) = {
+    if (timestampToken == null && versionCtx == null) {
+      (None, None)
+    } else {
+      if (!conf.getConf(SQLConf.TIME_TRAVEL_AT_SYNTAX_ENABLED)) {
+        throw QueryParsingErrors.timeTravelAtSyntaxDisabled(
+          SQLConf.TIME_TRAVEL_AT_SYNTAX_ENABLED.key, ctx)
+      }
+      if (timestampToken != null) {
+        val micros = parseAtSyntaxTimestamp(timestampToken.getText, ctx)
+        (Some(Literal(micros, TimestampType)), None)
+      } else {
+        (None, visitVersion(versionCtx))
+      }
+    }
   }
 
   override def visitVersion(ctx: VersionContext): Option[String] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.catalyst.parser
 
-import java.time.{DateTimeException, LocalDateTime}
 import java.util.{List, Locale}
 import java.util.concurrent.TimeUnit
 
@@ -46,7 +45,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
 import org.apache.spark.sql.catalyst.trees.TreePattern.PARAMETER
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, CollationFactory, DateTimeConstants, DateTimeUtils, EvaluateUnresolvedInlineTable, IntervalUtils}
+import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, CollationFactory, DateTimeUtils, EvaluateUnresolvedInlineTable, IntervalUtils}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{convertSpecialDate, convertSpecialTimestamp, convertSpecialTimestampNTZ, fractionalSecondsDigits, getZoneId, stringToDate, stringToTime, stringToTimestamp, stringToTimestampLTZNanos, stringToTimestampNTZNanos, stringToTimestampWithoutTimeZone}
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, ChangelogContext, PathElement, SupportsNamespaces, TableCatalog, TableWritePrivilege}
 import org.apache.spark.sql.connector.catalog.ChangelogRange.{TimestampRange, UnboundedRange, VersionRange}
@@ -2655,7 +2654,7 @@ class AstBuilder extends DataTypeAstBuilder
       relation: LogicalPlan,
       ttCtx: TemporalTableIdentifierReferenceContext,
       clause: TemporalClauseContext): LogicalPlan = {
-    val (atTimestamp, atVersion) = temporalSpec(ttCtx, ttCtx.timestamp, ttCtx.version)
+    val (atTimestamp, atVersion) = temporalSpec(ttCtx, ttCtx.version)
     val hasAtSpec = atTimestamp.isDefined || atVersion.isDefined
     if (hasAtSpec && clause != null) {
       withOrigin(clause) {
@@ -2669,57 +2668,24 @@ class AstBuilder extends DataTypeAstBuilder
 
   override def visitTemporalTableIdentifier(
       ctx: TemporalTableIdentifierContext): TemporalIdentifier = withOrigin(ctx) {
-    val (timestamp, version) = temporalSpec(ctx, ctx.timestamp, ctx.version)
-    TemporalIdentifier(visitMultipartIdentifier(ctx.id), timestamp, version)
+    val (_, version) = temporalSpec(ctx, ctx.version)
+    TemporalIdentifier(visitMultipartIdentifier(ctx.id), version)
   }
 
   /**
-   * Parse the digits of an '@' time travel timestamp (format yyyyMMddHHmmssSSS) to
-   * microseconds since epoch in the session time zone.
-   */
-  private def parseAtSyntaxTimestamp(text: String, ctx: ParserRuleContext): Long = {
-    val format = TemporalIdentifier.TimestampFormat
-    if (text.length != format.length) {
-      throw QueryParsingErrors.invalidAtSyntaxTimestamp(text, format, ctx)
-    }
-    try {
-      val localDateTime = LocalDateTime.of(
-        text.substring(0, 4).toInt,
-        text.substring(4, 6).toInt,
-        text.substring(6, 8).toInt,
-        text.substring(8, 10).toInt,
-        text.substring(10, 12).toInt,
-        text.substring(12, 14).toInt,
-        text.substring(14, 17).toInt * DateTimeConstants.NANOS_PER_MILLIS.toInt)
-      DateTimeUtils.instantToMicros(
-        localDateTime.atZone(getZoneId(conf.sessionLocalTimeZone)).toInstant)
-    } catch {
-      case _: DateTimeException =>
-        throw QueryParsingErrors.invalidAtSyntaxTimestamp(text, format, ctx)
-    }
-  }
-
-  /**
-   * Extract the optional '@' time travel suffix of a table identifier: '@<timestamp>'
-   * (format yyyyMMddHHmmssSSS) or '@v<version>'.
+   * Extract the optional '@v<version>' time travel suffix of a table identifier.
    */
   private def temporalSpec(
       ctx: ParserRuleContext,
-      timestampToken: Token,
       versionCtx: VersionContext): (Option[Expression], Option[String]) = {
-    if (timestampToken == null && versionCtx == null) {
+    if (versionCtx == null) {
       (None, None)
     } else {
       if (!conf.getConf(SQLConf.TIME_TRAVEL_AT_SYNTAX_ENABLED)) {
         throw QueryParsingErrors.timeTravelAtSyntaxDisabled(
           SQLConf.TIME_TRAVEL_AT_SYNTAX_ENABLED.key, ctx)
       }
-      if (timestampToken != null) {
-        val micros = parseAtSyntaxTimestamp(timestampToken.getText, ctx)
-        (Some(Literal(micros, TimestampType)), None)
-      } else {
-        (None, visitVersion(versionCtx))
-      }
+      (None, visitVersion(versionCtx))
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserInterface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserInterface.scala
@@ -70,6 +70,16 @@ trait ParserInterface extends DataTypeParserInterface {
   def parseMultipartIdentifier(sqlText: String): Seq[String]
 
   /**
+   * Parse a string to a [[TemporalIdentifier]].
+   */
+  @throws[ParseException]("Text cannot be parsed to a temporal table identifier")
+  def parseTemporalTableIdentifier(sqlText: String): TemporalIdentifier = {
+    // Default implementation does not recognize the time travel suffix. Concrete
+    // implementations can override this to support it.
+    TemporalIdentifier(parseMultipartIdentifier(sqlText), None, None)
+  }
+
+  /**
    * Parse a query string to a [[LogicalPlan]].
    */
   @throws[ParseException]("Text cannot be parsed to a LogicalPlan")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserInterface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserInterface.scala
@@ -76,7 +76,7 @@ trait ParserInterface extends DataTypeParserInterface {
   def parseTemporalTableIdentifier(sqlText: String): TemporalIdentifier = {
     // Default implementation does not recognize the time travel suffix. Concrete
     // implementations can override this to support it.
-    TemporalIdentifier(parseMultipartIdentifier(sqlText), None, None)
+    TemporalIdentifier(parseMultipartIdentifier(sqlText), None)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/TemporalIdentifier.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/TemporalIdentifier.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.parser
+
+import org.apache.spark.sql.catalyst.analysis.RelationTimeTravel
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+/**
+ * Result of parsing a table name that may carry an '@' time travel suffix:
+ * `name@v<version>` reads a specific version of the table, and `name@<yyyyMMddHHmmssSSS>`
+ * reads the table as of a timestamp. `timestamp` is an already-converted TimestampType
+ * literal (the digits are interpreted in the session time zone at parse time). At most one
+ * of `timestamp` and `version` is set.
+ */
+case class TemporalIdentifier(
+    nameParts: Seq[String],
+    timestamp: Option[Expression],
+    version: Option[String]) {
+
+  def isTemporal: Boolean = timestamp.isDefined || version.isDefined
+
+  /** Wraps `plan` in a [[RelationTimeTravel]] if a time travel suffix was specified. */
+  def wrapTimeTravel(plan: LogicalPlan): LogicalPlan = {
+    if (isTemporal) RelationTimeTravel(plan, timestamp, version) else plan
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/TemporalIdentifier.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/TemporalIdentifier.scala
@@ -18,27 +18,19 @@
 package org.apache.spark.sql.catalyst.parser
 
 import org.apache.spark.sql.catalyst.analysis.RelationTimeTravel
-import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
 /**
- * Result of parsing a table name that may carry an '@' time travel suffix: `name@v<version>`
- * or `name@<yyyyMMddHHmmssSSS>`. At most one of `timestamp` and `version` is set.
+ * Result of parsing a table name that may carry an '@v<version>' time travel suffix.
  */
 case class TemporalIdentifier(
     nameParts: Seq[String],
-    timestamp: Option[Expression],
     version: Option[String]) {
 
-  def isTemporal: Boolean = timestamp.isDefined || version.isDefined
+  def isTemporal: Boolean = version.isDefined
 
   /** Wraps `plan` in a [[RelationTimeTravel]] if a time travel suffix was specified. */
   def wrapTimeTravel(plan: LogicalPlan): LogicalPlan = {
-    if (isTemporal) RelationTimeTravel(plan, timestamp, version) else plan
+    if (isTemporal) RelationTimeTravel(plan, None, version) else plan
   }
-}
-
-object TemporalIdentifier {
-  /** The fixed timestamp format accepted in the suffix. */
-  val TimestampFormat: String = "yyyyMMddHHmmssSSS"
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/TemporalIdentifier.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/TemporalIdentifier.scala
@@ -22,11 +22,8 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
 /**
- * Result of parsing a table name that may carry an '@' time travel suffix:
- * `name@v<version>` reads a specific version of the table, and `name@<yyyyMMddHHmmssSSS>`
- * reads the table as of a timestamp. `timestamp` is an already-converted TimestampType
- * literal (the digits are interpreted in the session time zone at parse time). At most one
- * of `timestamp` and `version` is set.
+ * Result of parsing a table name that may carry an '@' time travel suffix: `name@v<version>`
+ * or `name@<yyyyMMddHHmmssSSS>`. At most one of `timestamp` and `version` is set.
  */
 case class TemporalIdentifier(
     nameParts: Seq[String],
@@ -39,4 +36,9 @@ case class TemporalIdentifier(
   def wrapTimeTravel(plan: LogicalPlan): LogicalPlan = {
     if (isTemporal) RelationTimeTravel(plan, timestamp, version) else plan
   }
+}
+
+object TemporalIdentifier {
+  /** The fixed timestamp format accepted in the suffix. */
+  val TimestampFormat: String = "yyyyMMddHHmmssSSS"
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6999,7 +6999,7 @@ object SQLConf {
       .doc("When true, a table name in a query or in table-reading APIs can carry a time " +
         "travel suffix: 'name@v123' reads version 123 of the table. When false, '@' in " +
         "table names fails at parse time.")
-      .version("5.0.0")
+      .version("4.3.0")
       .booleanConf
       .createWithDefault(true)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -7000,6 +7000,7 @@ object SQLConf {
         "travel suffix: 'name@v123' reads version 123 of the table. When false, '@' in " +
         "table names fails at parse time.")
       .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(true)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6994,6 +6994,17 @@ object SQLConf {
       .stringConf
       .createWithDefault("versionAsOf")
 
+  val TIME_TRAVEL_AT_SYNTAX_ENABLED =
+    buildConf("spark.sql.timeTravel.atSyntax.enabled")
+      .doc("When true, a table name in a query or in table-reading APIs can carry a time " +
+        "travel suffix: 'name@v123' reads version 123 of the table, and " +
+        "'name@20240101000000000' (format yyyyMMddHHmmssSSS, interpreted in the session " +
+        "time zone) reads the table as of that timestamp. When false, '@' in table names " +
+        "fails at parse time.")
+      .version("5.0.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val OPERATOR_PIPE_SYNTAX_ENABLED =
     buildConf("spark.sql.operatorPipeSyntaxEnabled")
       .doc("If true, enable operator pipe syntax for Apache Spark SQL. This uses the operator " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -6997,10 +6997,8 @@ object SQLConf {
   val TIME_TRAVEL_AT_SYNTAX_ENABLED =
     buildConf("spark.sql.timeTravel.atSyntax.enabled")
       .doc("When true, a table name in a query or in table-reading APIs can carry a time " +
-        "travel suffix: 'name@v123' reads version 123 of the table, and " +
-        "'name@20240101000000000' (format yyyyMMddHHmmssSSS, interpreted in the session " +
-        "time zone) reads the table as of that timestamp. When false, '@' in table names " +
-        "fails at parse time.")
+        "travel suffix: 'name@v123' reads version 123 of the table. When false, '@' in " +
+        "table names fails at parse time.")
       .version("5.0.0")
       .booleanConf
       .createWithDefault(true)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -26,11 +26,12 @@ import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, RelationChanges, Re
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.util.{EvaluateUnresolvedInlineTable, IntervalUtils}
+import org.apache.spark.sql.catalyst.util.{DateTimeUtils, EvaluateUnresolvedInlineTable, IntervalUtils}
 import org.apache.spark.sql.connector.catalog.{ChangelogContext, ChangelogRange}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{Decimal, DecimalType, IntegerType, LongType, StringType}
+import org.apache.spark.sql.types.{Decimal, DecimalType, IntegerType, LongType, StringType, TimestampType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * Parser test cases for rules defined in [[CatalystSqlParser]] / [[AstBuilder]].
@@ -2191,6 +2192,69 @@ class PlanParserSuite extends AnalysisTest {
         fragment = fragment,
         start = 20,
         stop = 38))
+  }
+
+  test("at syntax time travel") {
+    def versionPlan(version: String): LogicalPlan = {
+      Project(Seq(UnresolvedStar(None)),
+        RelationTimeTravel(UnresolvedRelation(Seq("a", "b", "c")), None, Some(version)))
+    }
+    assertEqual("SELECT * FROM a.b.c@v123456789", versionPlan("123456789"))
+    assertEqual("SELECT * FROM a.b.c@V123456789", versionPlan("123456789"))
+    assertEqual("SELECT * FROM a.b.c @v123456789", versionPlan("123456789"))
+    assertEqual("SELECT * FROM a.b.c@v'Snapshot123456789'", versionPlan("Snapshot123456789"))
+
+    val micros = DateTimeUtils.stringToTimestampAnsi(
+      UTF8String.fromString("2019-01-29 00:37:58"),
+      DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
+    assertEqual("SELECT * FROM a.b.c@20190129003758000",
+      Project(Seq(UnresolvedStar(None)),
+        RelationTimeTravel(
+          UnresolvedRelation(Seq("a", "b", "c")),
+          Some(Literal(micros, TimestampType)),
+          None)))
+
+    assertEqual("SELECT * FROM `t@v1`",
+      Project(Seq(UnresolvedStar(None)), UnresolvedRelation(Seq("t@v1"))))
+
+    checkError(
+      exception = parseException("SELECT * FROM t@v1 VERSION AS OF 2"),
+      condition = "MULTIPLE_TIME_TRAVEL_SPEC",
+      parameters = Map.empty,
+      context = ExpectedContext(fragment = "VERSION AS OF 2", start = 19, stop = 33))
+
+    checkError(
+      exception = parseException("SELECT * FROM t@123"),
+      condition = "INVALID_TIMESTAMP_FORMAT",
+      parameters = Map("timestamp" -> "123", "format" -> "yyyyMMddHHmmssSSS"),
+      context = ExpectedContext(fragment = "t@123", start = 14, stop = 18))
+
+    assert(intercept[ParseException] {
+      parsePlan("INSERT INTO t@v1 VALUES (1)")
+    }.getCondition == "PARSE_SYNTAX_ERROR")
+
+    withSQLConf(SQLConf.TIME_TRAVEL_AT_SYNTAX_ENABLED.key -> "false") {
+      checkError(
+        exception = parseException("SELECT * FROM t@v1"),
+        condition = "UNSUPPORTED_FEATURE.TIME_TRAVEL_AT_SYNTAX",
+        parameters = Map("config" -> "\"spark.sql.timeTravel.atSyntax.enabled\""),
+        context = ExpectedContext(fragment = "t@v1", start = 14, stop = 17))
+    }
+  }
+
+  test("parseTemporalTableIdentifier") {
+    assert(parseTemporalTableIdentifier("a.b") ===
+      TemporalIdentifier(Seq("a", "b"), None, None))
+    assert(parseTemporalTableIdentifier("a.b@v5") ===
+      TemporalIdentifier(Seq("a", "b"), None, Some("5")))
+    assert(parseTemporalTableIdentifier("`t@v1`") ===
+      TemporalIdentifier(Seq("t@v1"), None, None))
+    val micros = DateTimeUtils.stringToTimestampAnsi(
+      UTF8String.fromString("2019-01-29 00:37:58"),
+      DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
+    assert(parseTemporalTableIdentifier("t@20190129003758000") ===
+      TemporalIdentifier(Seq("t"), Some(Literal(micros, TimestampType)), None))
+    intercept[ParseException](parseTemporalTableIdentifier("a.b@x"))
   }
 
   test("CHANGES clause - version range") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -26,12 +26,11 @@ import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, RelationChanges, Re
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.util.{DateTimeUtils, EvaluateUnresolvedInlineTable, IntervalUtils}
+import org.apache.spark.sql.catalyst.util.{EvaluateUnresolvedInlineTable, IntervalUtils}
 import org.apache.spark.sql.connector.catalog.{ChangelogContext, ChangelogRange}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{Decimal, DecimalType, IntegerType, LongType, StringType, TimestampType}
+import org.apache.spark.sql.types.{Decimal, DecimalType, IntegerType, LongType, StringType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * Parser test cases for rules defined in [[CatalystSqlParser]] / [[AstBuilder]].
@@ -2204,16 +2203,6 @@ class PlanParserSuite extends AnalysisTest {
     assertEqual("SELECT * FROM a.b.c @v123456789", versionPlan("123456789"))
     assertEqual("SELECT * FROM a.b.c@v'Snapshot123456789'", versionPlan("Snapshot123456789"))
 
-    val micros = DateTimeUtils.stringToTimestampAnsi(
-      UTF8String.fromString("2019-01-29 00:37:58"),
-      DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
-    assertEqual("SELECT * FROM a.b.c@20190129003758000",
-      Project(Seq(UnresolvedStar(None)),
-        RelationTimeTravel(
-          UnresolvedRelation(Seq("a", "b", "c")),
-          Some(Literal(micros, TimestampType)),
-          None)))
-
     assertEqual("SELECT * FROM `t@v1`",
       Project(Seq(UnresolvedStar(None)), UnresolvedRelation(Seq("t@v1"))))
 
@@ -2228,18 +2217,6 @@ class PlanParserSuite extends AnalysisTest {
       condition = "MULTIPLE_TIME_TRAVEL_SPEC",
       parameters = Map.empty,
       context = ExpectedContext(fragment = "VERSION AS OF 2", start = 19, stop = 33))
-
-    checkError(
-      exception = parseException("SELECT * FROM t@123"),
-      condition = "INVALID_TIME_TRAVEL_TIMESTAMP_FORMAT",
-      parameters = Map("timestamp" -> "123", "format" -> "yyyyMMddHHmmssSSS"),
-      context = ExpectedContext(fragment = "t@123", start = 14, stop = 18))
-
-    checkError(
-      exception = parseException("SELECT * FROM t@20191301000000000"),
-      condition = "INVALID_TIME_TRAVEL_TIMESTAMP_FORMAT",
-      parameters = Map("timestamp" -> "20191301000000000", "format" -> "yyyyMMddHHmmssSSS"),
-      context = ExpectedContext(fragment = "t@20191301000000000", start = 14, stop = 32))
 
     assert(intercept[ParseException] {
       parsePlan("INSERT INTO t@v1 VALUES (1)")
@@ -2256,16 +2233,11 @@ class PlanParserSuite extends AnalysisTest {
 
   test("parseTemporalTableIdentifier") {
     assert(parseTemporalTableIdentifier("a.b") ===
-      TemporalIdentifier(Seq("a", "b"), None, None))
+      TemporalIdentifier(Seq("a", "b"), None))
     assert(parseTemporalTableIdentifier("a.b@v5") ===
-      TemporalIdentifier(Seq("a", "b"), None, Some("5")))
+      TemporalIdentifier(Seq("a", "b"), Some("5")))
     assert(parseTemporalTableIdentifier("`t@v1`") ===
-      TemporalIdentifier(Seq("t@v1"), None, None))
-    val micros = DateTimeUtils.stringToTimestampAnsi(
-      UTF8String.fromString("2019-01-29 00:37:58"),
-      DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
-    assert(parseTemporalTableIdentifier("t@20190129003758000") ===
-      TemporalIdentifier(Seq("t"), Some(Literal(micros, TimestampType)), None))
+      TemporalIdentifier(Seq("t@v1"), None))
     Seq("a.b@x", "a@foo", "a@", "a@v").foreach { s =>
       intercept[ParseException](parseTemporalTableIdentifier(s))
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -2212,11 +2212,17 @@ class PlanParserSuite extends AnalysisTest {
         s"expected PARSE_SYNTAX_ERROR for: $q")
     }
 
+    // The '@' suffix conflicts with an AS OF clause.
     checkError(
       exception = parseException("SELECT * FROM t@v1 VERSION AS OF 2"),
       condition = "MULTIPLE_TIME_TRAVEL_SPEC",
       parameters = Map.empty,
       context = ExpectedContext(fragment = "VERSION AS OF 2", start = 19, stop = 33))
+    checkError(
+      exception = parseException("SELECT * FROM t@v1 TIMESTAMP AS OF '2019-01-29'"),
+      condition = "MULTIPLE_TIME_TRAVEL_SPEC",
+      parameters = Map.empty,
+      context = ExpectedContext(fragment = "TIMESTAMP AS OF '2019-01-29'", start = 19, stop = 46))
 
     assert(intercept[ParseException] {
       parsePlan("INSERT INTO t@v1 VALUES (1)")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -2217,6 +2217,12 @@ class PlanParserSuite extends AnalysisTest {
     assertEqual("SELECT * FROM `t@v1`",
       Project(Seq(UnresolvedStar(None)), UnresolvedRelation(Seq("t@v1"))))
 
+    // A non-time-travel '@' suffix is always a parse error.
+    Seq("SELECT * FROM a@foo", "SELECT * FROM a@", "SELECT * FROM a@v").foreach { q =>
+      assert(intercept[ParseException](parsePlan(q)).getCondition == "PARSE_SYNTAX_ERROR",
+        s"expected PARSE_SYNTAX_ERROR for: $q")
+    }
+
     checkError(
       exception = parseException("SELECT * FROM t@v1 VERSION AS OF 2"),
       condition = "MULTIPLE_TIME_TRAVEL_SPEC",
@@ -2225,9 +2231,15 @@ class PlanParserSuite extends AnalysisTest {
 
     checkError(
       exception = parseException("SELECT * FROM t@123"),
-      condition = "INVALID_TIMESTAMP_FORMAT",
+      condition = "INVALID_TIME_TRAVEL_TIMESTAMP_FORMAT",
       parameters = Map("timestamp" -> "123", "format" -> "yyyyMMddHHmmssSSS"),
       context = ExpectedContext(fragment = "t@123", start = 14, stop = 18))
+
+    checkError(
+      exception = parseException("SELECT * FROM t@20191301000000000"),
+      condition = "INVALID_TIME_TRAVEL_TIMESTAMP_FORMAT",
+      parameters = Map("timestamp" -> "20191301000000000", "format" -> "yyyyMMddHHmmssSSS"),
+      context = ExpectedContext(fragment = "t@20191301000000000", start = 14, stop = 32))
 
     assert(intercept[ParseException] {
       parsePlan("INSERT INTO t@v1 VALUES (1)")
@@ -2254,7 +2266,9 @@ class PlanParserSuite extends AnalysisTest {
       DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
     assert(parseTemporalTableIdentifier("t@20190129003758000") ===
       TemporalIdentifier(Seq("t"), Some(Literal(micros, TimestampType)), None))
-    intercept[ParseException](parseTemporalTableIdentifier("a.b@x"))
+    Seq("a.b@x", "a@foo", "a@", "a@v").foreach { s =>
+      intercept[ParseException](parseTemporalTableIdentifier(s))
+    }
   }
 
   test("CHANGES clause - version range") {

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -55,7 +55,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{AppendColumns, Assignment, C
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin, TreePattern}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, CharVarcharUtils, QuotingUtils}
+import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, CharVarcharUtils}
 import org.apache.spark.sql.classic.{Catalog, DataFrameWriter, Dataset, MergeIntoWriter, RelationalGroupedDataset, SparkSession, TypedAggUtils, UserDefinedFunctionUtils}
 import org.apache.spark.sql.classic.ClassicConversions._
 import org.apache.spark.sql.connect.client.arrow.ArrowSerializer
@@ -1675,7 +1675,7 @@ class SparkConnectPlanner(
           parser.parseTemporalTableIdentifier(rel.getNamedTable.getUnparsedIdentifier)
         if (temporalIdent.isTemporal && rel.getIsStreaming) {
           throw QueryCompilationErrors.timeTravelUnsupportedError(
-            QuotingUtils.quoteNameParts(temporalIdent.nameParts))
+            QueryCompilationErrors.toSQLId(temporalIdent.nameParts))
         }
         val relation = UnresolvedRelation(
           temporalIdent.nameParts,

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -55,7 +55,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{AppendColumns, Assignment, C
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin, TreePattern}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, CharVarcharUtils}
+import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, CharVarcharUtils, QuotingUtils}
 import org.apache.spark.sql.classic.{Catalog, DataFrameWriter, Dataset, MergeIntoWriter, RelationalGroupedDataset, SparkSession, TypedAggUtils, UserDefinedFunctionUtils}
 import org.apache.spark.sql.classic.ClassicConversions._
 import org.apache.spark.sql.connect.client.arrow.ArrowSerializer
@@ -1671,10 +1671,17 @@ class SparkConnectPlanner(
 
     rel.getReadTypeCase match {
       case proto.Read.ReadTypeCase.NAMED_TABLE =>
-        UnresolvedRelation(
-          parser.parseMultipartIdentifier(rel.getNamedTable.getUnparsedIdentifier),
+        val temporalIdent =
+          parser.parseTemporalTableIdentifier(rel.getNamedTable.getUnparsedIdentifier)
+        if (temporalIdent.isTemporal && rel.getIsStreaming) {
+          throw QueryCompilationErrors.timeTravelUnsupportedError(
+            QuotingUtils.quoteNameParts(temporalIdent.nameParts))
+        }
+        val relation = UnresolvedRelation(
+          temporalIdent.nameParts,
           new CaseInsensitiveStringMap(rel.getNamedTable.getOptionsMap),
           isStreaming = rel.getIsStreaming)
+        temporalIdent.wrapTimeTravel(relation)
 
       case proto.Read.ReadTypeCase.DATA_SOURCE if !rel.getIsStreaming =>
         val reader = session.read

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
@@ -179,6 +179,24 @@ class SparkConnectPlannerSuite extends SparkFunSuite with SparkConnectPlanTest {
       transform(proto.Relation.newBuilder.setRead(streamingRead).build())
     }
     assert(e.getCondition === "UNSUPPORTED_FEATURE.TIME_TRAVEL")
+
+    // A non-time-travel '@' suffix is a parse error.
+    val badRead = read.toBuilder
+      .setNamedTable(proto.Read.NamedTable.newBuilder.setUnparsedIdentifier("name@foo").build())
+      .build()
+    val pe = intercept[AnalysisException] {
+      transform(proto.Relation.newBuilder.setRead(badRead).build())
+    }
+    assert(pe.getCondition === "PARSE_SYNTAX_ERROR")
+
+    // A backticked '@' name stays a literal table name.
+    val quotedRead = read.toBuilder
+      .setNamedTable(proto.Read.NamedTable.newBuilder.setUnparsedIdentifier("`name@v1`").build())
+      .build()
+    transform(proto.Relation.newBuilder.setRead(quotedRead).build()) match {
+      case u: UnresolvedRelation => assert(u.multipartIdentifier === Seq("name@v1"))
+      case other => fail(s"Expected a literal UnresolvedRelation but got: $other")
+    }
   }
 
   test("Simple Table with options") {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.Expression.{Alias, ExpressionString, UnresolvedStar}
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.analysis.{UnresolvedAlias, UnresolvedFunction, UnresolvedRelation}
+import org.apache.spark.sql.catalyst.analysis.{RelationTimeTravel, UnresolvedAlias, UnresolvedFunction, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, UnsafeProjection}
 import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
@@ -157,6 +157,28 @@ class SparkConnectPlannerSuite extends SparkFunSuite with SparkConnectPlanTest {
     val res = transform(proto.Relation.newBuilder.setRead(readWithTable).build())
     assert(res !== null)
     assert(res.nodeName == "UnresolvedRelation")
+  }
+
+  test("Read with at syntax time travel") {
+    val read = proto.Read
+      .newBuilder()
+      .setNamedTable(proto.Read.NamedTable.newBuilder.setUnparsedIdentifier("name@v1").build())
+      .build()
+    val res = transform(proto.Relation.newBuilder.setRead(read).build())
+    res match {
+      case RelationTimeTravel(relation: UnresolvedRelation, timestamp, version) =>
+        assert(relation.multipartIdentifier === Seq("name"))
+        assert(timestamp.isEmpty)
+        assert(version === Some("1"))
+      case other => fail(s"Expected RelationTimeTravel but got: $other")
+    }
+
+    // Streaming reads do not support time travel.
+    val streamingRead = read.toBuilder.setIsStreaming(true).build()
+    val e = intercept[AnalysisException] {
+      transform(proto.Relation.newBuilder.setRead(streamingRead).build())
+    }
+    assert(e.getCondition === "UNSUPPORTED_FEATURE.TIME_TRAVEL")
   }
 
   test("Simple Table with options") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameReader.scala
@@ -315,10 +315,11 @@ class DataFrameReader private[sql](sparkSession: SparkSession)
   /** @inheritdoc */
   def table(tableName: String): DataFrame = {
     assertNoSpecifiedSchema("table")
-    val multipartIdentifier =
-      sparkSession.sessionState.sqlParser.parseMultipartIdentifier(tableName)
-    Dataset.ofRows(sparkSession, UnresolvedRelation(multipartIdentifier,
-      new CaseInsensitiveStringMap(extraOptions.toMap.asJava)))
+    val temporalIdent =
+      sparkSession.sessionState.sqlParser.parseTemporalTableIdentifier(tableName)
+    val relation = UnresolvedRelation(temporalIdent.nameParts,
+      new CaseInsensitiveStringMap(extraOptions.toMap.asJava))
+    Dataset.ofRows(sparkSession, temporalIdent.wrapTimeTravel(relation))
   }
 
   /** @inheritdoc */

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/DataStreamReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/DataStreamReader.scala
@@ -102,9 +102,14 @@ final class DataStreamReader private[sql](sparkSession: SparkSession)
   /** @inheritdoc */
   def table(tableName: String): DataFrame = {
     require(tableName != null, "The table name can't be null")
-    val identifier = sparkSession.sessionState.sqlParser.parseMultipartIdentifier(tableName)
+    val temporalIdent =
+      sparkSession.sessionState.sqlParser.parseTemporalTableIdentifier(tableName)
+    if (temporalIdent.isTemporal) {
+      throw QueryCompilationErrors.timeTravelUnsupportedError(
+        QueryCompilationErrors.toSQLId(temporalIdent.nameParts))
+    }
     val unresolved = UnresolvedRelation(
-      identifier,
+      temporalIdent.nameParts,
       new CaseInsensitiveStringMap(extraOptions.toMap.asJava),
       isStreaming = true)
     val plan = NamedStreamingRelation.withUserProvidedName(unresolved, userProvidedSourceName)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pipe-operators.sql.out
@@ -1346,8 +1346,8 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "errorClass" : "PARSE_SYNTAX_ERROR",
   "sqlState" : "42601",
   "messageParameters" : {
-    "error" : "'@'",
-    "hint" : ""
+    "error" : "'@v'",
+    "hint" : ": extra input '@v'"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pipe-operators.sql.out
@@ -1279,8 +1279,8 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "errorClass" : "PARSE_SYNTAX_ERROR",
   "sqlState" : "42601",
   "messageParameters" : {
-    "error" : "'@'",
-    "hint" : ""
+    "error" : "'@v'",
+    "hint" : ": extra input '@v'"
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3865,6 +3865,75 @@ class DataSourceV2SQLSuiteV1Filter
     }
   }
 
+  test("time travel with at syntax") {
+    sql("use testcat")
+    val t1 = "testcat.tSnapshot123456789"
+    val t2 = "testcat.t2345678910"
+    withTable(t1, t2) {
+      sql(s"CREATE TABLE $t1 (id int) USING foo")
+      sql(s"CREATE TABLE $t2 (id int) USING foo")
+      sql(s"INSERT INTO $t1 VALUES (1), (2)")
+      sql(s"INSERT INTO $t2 VALUES (3), (4)")
+
+      checkAnswer(sql("SELECT * FROM t@v2345678910"), Seq(Row(3), Row(4)))
+      checkAnswer(sql("SELECT * FROM t@V2345678910"), Seq(Row(3), Row(4)))
+      checkAnswer(sql("SELECT * FROM t@v'Snapshot123456789'"), Seq(Row(1), Row(2)))
+      checkAnswer(spark.read.table("t@v2345678910"), Seq(Row(3), Row(4)))
+      checkAnswer(spark.table("t@v2345678910"), Seq(Row(3), Row(4)))
+
+      checkError(
+        exception = intercept[ParseException] {
+          sql("SELECT * FROM t@v2345678910 VERSION AS OF 1")
+        },
+        condition = "MULTIPLE_TIME_TRAVEL_SPEC",
+        parameters = Map.empty,
+        context = ExpectedContext(fragment = "VERSION AS OF 1", start = 28, stop = 42))
+      checkError(
+        exception = intercept[AnalysisException] {
+          spark.read.option("versionAsOf", "2345678910").table("t@v2345678910").collect()
+        },
+        condition = "MULTIPLE_TIME_TRAVEL_SPEC",
+        parameters = Map.empty)
+
+      withSQLConf(SQLConf.TIME_TRAVEL_AT_SYNTAX_ENABLED.key -> "false") {
+        checkError(
+          exception = intercept[ParseException] {
+            sql("SELECT * FROM t@v2345678910")
+          },
+          condition = "UNSUPPORTED_FEATURE.TIME_TRAVEL_AT_SYNTAX",
+          parameters = Map("config" -> "\"spark.sql.timeTravel.atSyntax.enabled\""),
+          context = ExpectedContext(fragment = "t@v2345678910", start = 14, stop = 26))
+        intercept[ParseException](spark.read.table("t@v2345678910"))
+      }
+    }
+
+    val ts1 = DateTimeUtils.stringToTimestampAnsi(
+      UTF8String.fromString("2019-01-29 00:37:58"),
+      DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
+    val t3 = s"testcat.t$ts1"
+    withTable(t3) {
+      sql(s"CREATE TABLE $t3 (id int) USING foo")
+      sql(s"INSERT INTO $t3 VALUES (5), (6)")
+
+      checkAnswer(sql("SELECT * FROM t@20190129003758000"), Seq(Row(5), Row(6)))
+      checkAnswer(spark.read.table("t@20190129003758000"), Seq(Row(5), Row(6)))
+    }
+
+    withTempView("v") {
+      spark.range(1).createOrReplaceTempView("v")
+      checkError(
+        exception = analysisException("SELECT * FROM v@v1"),
+        condition = "UNSUPPORTED_FEATURE.TIME_TRAVEL",
+        sqlState = None,
+        parameters = Map("relationId" -> "`v`"))
+    }
+    checkError(
+      exception = analysisException("WITH x AS (SELECT 1) SELECT * FROM x@v1"),
+      condition = "UNSUPPORTED_FEATURE.TIME_TRAVEL",
+      sqlState = None,
+      parameters = Map("relationId" -> "`x`"))
+  }
+
   test("SPARK-37827: put build-in properties into V1Table.properties to adapt v2 command") {
     val t = "tbl"
     withTable(t) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3889,8 +3889,28 @@ class DataSourceV2SQLSuiteV1Filter
         parameters = Map.empty,
         context = ExpectedContext(fragment = "VERSION AS OF 1", start = 28, stop = 42))
       checkError(
+        exception = intercept[ParseException] {
+          sql("SELECT * FROM t@v2345678910 TIMESTAMP AS OF '2019-01-29'")
+        },
+        condition = "MULTIPLE_TIME_TRAVEL_SPEC",
+        parameters = Map.empty,
+        context = ExpectedContext(
+          fragment = "TIMESTAMP AS OF '2019-01-29'", start = 28, stop = 55))
+      checkError(
         exception = intercept[AnalysisException] {
           spark.read.option("versionAsOf", "2345678910").table("t@v2345678910").collect()
+        },
+        condition = "MULTIPLE_TIME_TRAVEL_SPEC",
+        parameters = Map.empty)
+      checkError(
+        exception = intercept[AnalysisException] {
+          spark.read.option("timestampAsOf", "2019-01-29").table("t@v2345678910").collect()
+        },
+        condition = "MULTIPLE_TIME_TRAVEL_SPEC",
+        parameters = Map.empty)
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("SELECT * FROM t@v2345678910 WITH ('timestampAsOf' = '2019-01-29')")
         },
         condition = "MULTIPLE_TIME_TRAVEL_SPEC",
         parameters = Map.empty)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3907,18 +3907,6 @@ class DataSourceV2SQLSuiteV1Filter
       }
     }
 
-    val ts1 = DateTimeUtils.stringToTimestampAnsi(
-      UTF8String.fromString("2019-01-29 00:37:58"),
-      DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
-    val t3 = s"testcat.t$ts1"
-    withTable(t3) {
-      sql(s"CREATE TABLE $t3 (id int) USING foo")
-      sql(s"INSERT INTO $t3 VALUES (5), (6)")
-
-      checkAnswer(sql("SELECT * FROM t@20190129003758000"), Seq(Row(5), Row(6)))
-      checkAnswer(spark.read.table("t@20190129003758000"), Seq(Row(5), Row(6)))
-    }
-
     intercept[ParseException](sql("SELECT * FROM t@foo"))
     intercept[ParseException](spark.read.table("t@foo"))
     withTable("testcat.`weird@v1`") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3919,6 +3919,15 @@ class DataSourceV2SQLSuiteV1Filter
       checkAnswer(spark.read.table("t@20190129003758000"), Seq(Row(5), Row(6)))
     }
 
+    intercept[ParseException](sql("SELECT * FROM t@foo"))
+    intercept[ParseException](spark.read.table("t@foo"))
+    withTable("testcat.`weird@v1`") {
+      sql("CREATE TABLE testcat.`weird@v1` (id int) USING foo")
+      sql("INSERT INTO testcat.`weird@v1` VALUES (42)")
+      checkAnswer(sql("SELECT * FROM `weird@v1`"), Row(42))
+      checkAnswer(spark.read.table("`weird@v1`"), Row(42))
+    }
+
     withTempView("v") {
       spark.range(1).createOrReplaceTempView("v")
       checkError(

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
@@ -84,6 +84,15 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
     checkErrorTableNotFound(e, "`non_exist_table`")
   }
 
+  test("read: time travel @-syntax is unsupported for streaming") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.readStream.table("t@v1")
+      },
+      condition = "UNSUPPORTED_FEATURE.TIME_TRAVEL",
+      parameters = Map("relationId" -> "`t`"))
+  }
+
   test("read: stream table API with temp view") {
     val tblName = "my_table"
     val stream = MemoryStream[Int]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add the `@` version time travel shorthand on table names so that
```
SELECT * FROM name@vN
```
and
```
spark.read.format("format").table("name@vN")
```
parse into the same plan as the existing `VERSION AS OF` and `option("versionAsOf")` clauses. Support for SQL, the DataFrame reader, and Spark Connect.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Spark has SQL `VERSION AS OF` and the `versionAsOf` reader option, but not the compact `@` suffix. Resolving it at parse time also simplifies the time travel entry points pipeline.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, new syntax on table names gated by a `conf` (`spark.sql.timeTravel.atSyntax.enabled`, default **true**) which allows version time travel. No longer gives a parse error when enabled and the syntax is used.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New tests in `PlanParserSuite`, `SparkConnectPlannerSuite`, `DataSourceV2SQLSuite`, and `DataStreamTableAPISuite`.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
With help from Claude :)