### PR TITLE
[SPARK-56504][SQL] Extend join pushdown to accept pushed samples

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.connector.read;
 
+import javax.annotation.Nullable;
+
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.sql.connector.join.JoinType;
@@ -62,6 +64,61 @@ public interface SupportsPushDownJoin extends ScanBuilder {
       ColumnWithAlias[] rightSideRequiredColumnsWithAliases,
       Predicate condition
   );
+
+  /**
+   * Pushes down the join of the current {@code SupportsPushDownJoin} and the other side of join
+   * {@code SupportsPushDownJoin}, with pushed samples from either side.
+   *
+   * @param other {@code SupportsPushDownJoin} that this {@code SupportsPushDownJoin}
+   * gets joined with.
+   * @param joinType the type of join.
+   * @param leftSideRequiredColumnsWithAliases required output of the
+   *                                           left side {@code SupportsPushDownJoin}
+   * @param rightSideRequiredColumnsWithAliases required output of the
+   *                                            right side {@code SupportsPushDownJoin}
+   * @param condition join condition. Columns are named after the specified aliases in
+   * {@code leftSideRequiredColumnWithAliases} and {@code rightSideRequiredColumnWithAliases}
+   * @param leftSample pushed sample from the left side, or null if there is no pushed sample.
+   * @param rightSample pushed sample from the right side, or null if there is no pushed sample.
+   * @return True if join has been successfully pushed down.
+   *
+   * @since 4.2.0
+   */
+  default boolean pushDownJoin(
+      SupportsPushDownJoin other,
+      JoinType joinType,
+      ColumnWithAlias[] leftSideRequiredColumnsWithAliases,
+      ColumnWithAlias[] rightSideRequiredColumnsWithAliases,
+      Predicate condition,
+      @Nullable TableSample leftSample,
+      @Nullable TableSample rightSample) {
+    if ((leftSample == null || leftSample.isNoOp()) &&
+        (rightSample == null || rightSample.isNoOp())) {
+      return pushDownJoin(
+          other,
+          joinType,
+          leftSideRequiredColumnsWithAliases,
+          rightSideRequiredColumnsWithAliases,
+          condition);
+    }
+    return false;
+  }
+
+  /**
+   * A pushed table sample from one side of the join.
+   *
+   * @since 4.2.0
+   */
+  record TableSample(
+      double lowerBound,
+      double upperBound,
+      boolean withReplacement,
+      long seed,
+      SampleMethod sampleMethod) {
+    private boolean isNoOp() {
+      return !withReplacement && upperBound - lowerBound >= 1.0;
+    }
+  }
 
   /**
    *  A helper class used when there are duplicated names coming from 2 sides of the join

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
@@ -79,7 +79,7 @@ public interface SupportsPushDownJoin extends ScanBuilder {
    * @since 4.3.0
    */
   default Set<PushedOperator> supportedPushedOperatorsForJoin() {
-    return Collections.emptySet();
+    return Set.of();
   }
 
   /**
@@ -200,7 +200,7 @@ public interface SupportsPushDownJoin extends ScanBuilder {
       if (sample != null && !sample.isNoOp()) {
         return Collections.unmodifiableSet(EnumSet.of(PushedOperator.TABLE_SAMPLE));
       }
-      return Collections.emptySet();
+      return Set.of();
     }
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
@@ -82,7 +82,7 @@ public interface SupportsPushDownJoin extends ScanBuilder {
    * @param rightSample pushed sample from the right side, or null if there is no pushed sample.
    * @return True if join has been successfully pushed down.
    *
-   * @since 4.2.0
+   * @since 4.3.0
    */
   default boolean pushDownJoin(
       SupportsPushDownJoin other,

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
@@ -17,6 +17,10 @@
 
 package org.apache.spark.sql.connector.read;
 
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
 import javax.annotation.Nullable;
 
 import org.apache.spark.annotation.Evolving;
@@ -54,7 +58,7 @@ public interface SupportsPushDownJoin extends ScanBuilder {
    * @param rightSideRequiredColumnsWithAliases required output of the
    *                                            right side {@code SupportsPushDownJoin}
    * @param condition join condition. Columns are named after the specified aliases in
-   * {@code leftSideRequiredColumnWithAliases} and {@code rightSideRequiredColumnWithAliases}
+   * {@code leftSideRequiredColumnsWithAliases} and {@code rightSideRequiredColumnsWithAliases}
    * @return True if join has been successfully pushed down.
    */
   boolean pushDownJoin(
@@ -66,8 +70,21 @@ public interface SupportsPushDownJoin extends ScanBuilder {
   );
 
   /**
+   * Returns pushed operators this data source can preserve when pushing down a join.
+   * <p>
+   * Spark uses this as a safety check before attempting join push down. If the join input
+   * already contains pushed operators not listed here, Spark will not push down the join.
+   * This prevents a data source from silently dropping pushed state it does not understand.
+   *
+   * @since 4.3.0
+   */
+  default Set<PushedOperator> supportedPushedOperatorsForJoin() {
+    return Collections.emptySet();
+  }
+
+  /**
    * Pushes down the join of the current {@code SupportsPushDownJoin} and the other side of join
-   * {@code SupportsPushDownJoin}, with pushed samples from either side.
+   * {@code SupportsPushDownJoin}, with information about pushed operators from each side.
    *
    * @param other {@code SupportsPushDownJoin} that this {@code SupportsPushDownJoin}
    * gets joined with.
@@ -77,9 +94,8 @@ public interface SupportsPushDownJoin extends ScanBuilder {
    * @param rightSideRequiredColumnsWithAliases required output of the
    *                                            right side {@code SupportsPushDownJoin}
    * @param condition join condition. Columns are named after the specified aliases in
-   * {@code leftSideRequiredColumnWithAliases} and {@code rightSideRequiredColumnWithAliases}
-   * @param leftSample pushed sample from the left side, or null if there is no pushed sample.
-   * @param rightSample pushed sample from the right side, or null if there is no pushed sample.
+   * {@code leftSideRequiredColumnsWithAliases} and {@code rightSideRequiredColumnsWithAliases}
+   * @param joinPushDownInfo information about pushed operators from each side of the join.
    * @return True if join has been successfully pushed down.
    *
    * @since 4.3.0
@@ -90,10 +106,10 @@ public interface SupportsPushDownJoin extends ScanBuilder {
       ColumnWithAlias[] leftSideRequiredColumnsWithAliases,
       ColumnWithAlias[] rightSideRequiredColumnsWithAliases,
       Predicate condition,
-      @Nullable TableSample leftSample,
-      @Nullable TableSample rightSample) {
-    if ((leftSample == null || leftSample.isNoOp()) &&
-        (rightSample == null || rightSample.isNoOp())) {
+      JoinPushDownInfo joinPushDownInfo) {
+    JoinPushDownInfo info =
+        joinPushDownInfo == null ? JoinPushDownInfo.empty() : joinPushDownInfo;
+    if (info.requiredPushedOperators().isEmpty()) {
       return pushDownJoin(
           other,
           joinType,
@@ -102,6 +118,90 @@ public interface SupportsPushDownJoin extends ScanBuilder {
           condition);
     }
     return false;
+  }
+
+  /**
+   * Pushed operators that may need to be preserved when pushing down a join.
+   *
+   * @since 4.3.0
+   */
+  enum PushedOperator {
+    TABLE_SAMPLE
+  }
+
+  /**
+   * Information about pushed operators from each side of the join.
+   *
+   * @since 4.3.0
+   */
+  final class JoinPushDownInfo {
+    private static final JoinPushDownInfo EMPTY =
+        new JoinPushDownInfo(JoinSideInfo.empty(), JoinSideInfo.empty());
+
+    private final JoinSideInfo leftSideInfo;
+    private final JoinSideInfo rightSideInfo;
+
+    public JoinPushDownInfo(JoinSideInfo leftSideInfo, JoinSideInfo rightSideInfo) {
+      this.leftSideInfo = leftSideInfo == null ? JoinSideInfo.empty() : leftSideInfo;
+      this.rightSideInfo = rightSideInfo == null ? JoinSideInfo.empty() : rightSideInfo;
+    }
+
+    public static JoinPushDownInfo empty() {
+      return EMPTY;
+    }
+
+    public JoinSideInfo leftSideInfo() {
+      return leftSideInfo;
+    }
+
+    public JoinSideInfo rightSideInfo() {
+      return rightSideInfo;
+    }
+
+    /**
+     * Returns result-affecting pushed operators that must be preserved by join push down.
+     */
+    public Set<PushedOperator> requiredPushedOperators() {
+      EnumSet<PushedOperator> operators = EnumSet.noneOf(PushedOperator.class);
+      operators.addAll(leftSideInfo.requiredPushedOperators());
+      operators.addAll(rightSideInfo.requiredPushedOperators());
+      return Collections.unmodifiableSet(operators);
+    }
+  }
+
+  /**
+   * Information about pushed operators from one side of the join.
+   *
+   * @since 4.3.0
+   */
+  final class JoinSideInfo {
+    private static final JoinSideInfo EMPTY = new JoinSideInfo(null);
+
+    @Nullable
+    private final TableSample sample;
+
+    public JoinSideInfo(@Nullable TableSample sample) {
+      this.sample = sample;
+    }
+
+    public static JoinSideInfo empty() {
+      return EMPTY;
+    }
+
+    @Nullable
+    public TableSample sample() {
+      return sample;
+    }
+
+    /**
+     * Returns result-affecting pushed operators from this side of the join.
+     */
+    public Set<PushedOperator> requiredPushedOperators() {
+      if (sample != null && !sample.isNoOp()) {
+        return Collections.unmodifiableSet(EnumSet.of(PushedOperator.TABLE_SAMPLE));
+      }
+      return Collections.emptySet();
+    }
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
@@ -43,6 +43,9 @@ public interface SupportsPushDownJoin extends ScanBuilder {
   /**
    * Pushes down the join of the current {@code SupportsPushDownJoin} and the other side of join
    * {@code SupportsPushDownJoin}.
+   * <p>
+   * If this scan builder holds previously pushed state, such as a pushed table sample, and cannot
+   * preserve it when pushing down the join, this method must return false.
    *
    * @param other {@code SupportsPushDownJoin} that this {@code SupportsPushDownJoin}
    * gets joined with.
@@ -53,9 +56,6 @@ public interface SupportsPushDownJoin extends ScanBuilder {
    *                                            right side {@code SupportsPushDownJoin}
    * @param condition join condition. Columns are named after the specified aliases in
    * {@code leftSideRequiredColumnsWithAliases} and {@code rightSideRequiredColumnsWithAliases}
-   * <p>
-   * If this scan builder holds previously pushed state, such as a pushed table sample, and cannot
-   * preserve it when pushing down the join, this method must return false.
    *
    * @return True if join has been successfully pushed down.
    */

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
@@ -107,7 +107,7 @@ public interface SupportsPushDownJoin extends ScanBuilder {
   /**
    * A pushed table sample from one side of the join.
    *
-   * @since 4.2.0
+   * @since 4.3.0
    */
   record TableSample(
       double lowerBound,

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownJoin.java
@@ -17,12 +17,6 @@
 
 package org.apache.spark.sql.connector.read;
 
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.Set;
-
-import javax.annotation.Nullable;
-
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.sql.connector.join.JoinType;
@@ -59,6 +53,10 @@ public interface SupportsPushDownJoin extends ScanBuilder {
    *                                            right side {@code SupportsPushDownJoin}
    * @param condition join condition. Columns are named after the specified aliases in
    * {@code leftSideRequiredColumnsWithAliases} and {@code rightSideRequiredColumnsWithAliases}
+   * <p>
+   * If this scan builder holds previously pushed state, such as a pushed table sample, and cannot
+   * preserve it when pushing down the join, this method must return false.
+   *
    * @return True if join has been successfully pushed down.
    */
   boolean pushDownJoin(
@@ -68,157 +66,6 @@ public interface SupportsPushDownJoin extends ScanBuilder {
       ColumnWithAlias[] rightSideRequiredColumnsWithAliases,
       Predicate condition
   );
-
-  /**
-   * Returns pushed operators this data source can preserve when pushing down a join.
-   * <p>
-   * Spark uses this as a safety check before attempting join push down. If the join input
-   * already contains pushed operators not listed here, Spark will not push down the join.
-   * This prevents a data source from silently dropping pushed state it does not understand.
-   *
-   * @since 4.3.0
-   */
-  default Set<PushedOperator> supportedPushedOperatorsForJoin() {
-    return Set.of();
-  }
-
-  /**
-   * Pushes down the join of the current {@code SupportsPushDownJoin} and the other side of join
-   * {@code SupportsPushDownJoin}, with information about pushed operators from each side.
-   *
-   * @param other {@code SupportsPushDownJoin} that this {@code SupportsPushDownJoin}
-   * gets joined with.
-   * @param joinType the type of join.
-   * @param leftSideRequiredColumnsWithAliases required output of the
-   *                                           left side {@code SupportsPushDownJoin}
-   * @param rightSideRequiredColumnsWithAliases required output of the
-   *                                            right side {@code SupportsPushDownJoin}
-   * @param condition join condition. Columns are named after the specified aliases in
-   * {@code leftSideRequiredColumnsWithAliases} and {@code rightSideRequiredColumnsWithAliases}
-   * @param joinPushDownInfo information about pushed operators from each side of the join.
-   * @return True if join has been successfully pushed down.
-   *
-   * @since 4.3.0
-   */
-  default boolean pushDownJoin(
-      SupportsPushDownJoin other,
-      JoinType joinType,
-      ColumnWithAlias[] leftSideRequiredColumnsWithAliases,
-      ColumnWithAlias[] rightSideRequiredColumnsWithAliases,
-      Predicate condition,
-      JoinPushDownInfo joinPushDownInfo) {
-    JoinPushDownInfo info =
-        joinPushDownInfo == null ? JoinPushDownInfo.empty() : joinPushDownInfo;
-    if (info.requiredPushedOperators().isEmpty()) {
-      return pushDownJoin(
-          other,
-          joinType,
-          leftSideRequiredColumnsWithAliases,
-          rightSideRequiredColumnsWithAliases,
-          condition);
-    }
-    return false;
-  }
-
-  /**
-   * Pushed operators that may need to be preserved when pushing down a join.
-   *
-   * @since 4.3.0
-   */
-  enum PushedOperator {
-    TABLE_SAMPLE
-  }
-
-  /**
-   * Information about pushed operators from each side of the join.
-   *
-   * @since 4.3.0
-   */
-  final class JoinPushDownInfo {
-    private static final JoinPushDownInfo EMPTY =
-        new JoinPushDownInfo(JoinSideInfo.empty(), JoinSideInfo.empty());
-
-    private final JoinSideInfo leftSideInfo;
-    private final JoinSideInfo rightSideInfo;
-
-    public JoinPushDownInfo(JoinSideInfo leftSideInfo, JoinSideInfo rightSideInfo) {
-      this.leftSideInfo = leftSideInfo == null ? JoinSideInfo.empty() : leftSideInfo;
-      this.rightSideInfo = rightSideInfo == null ? JoinSideInfo.empty() : rightSideInfo;
-    }
-
-    public static JoinPushDownInfo empty() {
-      return EMPTY;
-    }
-
-    public JoinSideInfo leftSideInfo() {
-      return leftSideInfo;
-    }
-
-    public JoinSideInfo rightSideInfo() {
-      return rightSideInfo;
-    }
-
-    /**
-     * Returns result-affecting pushed operators that must be preserved by join push down.
-     */
-    public Set<PushedOperator> requiredPushedOperators() {
-      EnumSet<PushedOperator> operators = EnumSet.noneOf(PushedOperator.class);
-      operators.addAll(leftSideInfo.requiredPushedOperators());
-      operators.addAll(rightSideInfo.requiredPushedOperators());
-      return Collections.unmodifiableSet(operators);
-    }
-  }
-
-  /**
-   * Information about pushed operators from one side of the join.
-   *
-   * @since 4.3.0
-   */
-  final class JoinSideInfo {
-    private static final JoinSideInfo EMPTY = new JoinSideInfo(null);
-
-    @Nullable
-    private final TableSample sample;
-
-    public JoinSideInfo(@Nullable TableSample sample) {
-      this.sample = sample;
-    }
-
-    public static JoinSideInfo empty() {
-      return EMPTY;
-    }
-
-    @Nullable
-    public TableSample sample() {
-      return sample;
-    }
-
-    /**
-     * Returns result-affecting pushed operators from this side of the join.
-     */
-    public Set<PushedOperator> requiredPushedOperators() {
-      if (sample != null && !sample.isNoOp()) {
-        return Collections.unmodifiableSet(EnumSet.of(PushedOperator.TABLE_SAMPLE));
-      }
-      return Set.of();
-    }
-  }
-
-  /**
-   * A pushed table sample from one side of the join.
-   *
-   * @since 4.3.0
-   */
-  record TableSample(
-      double lowerBound,
-      double upperBound,
-      boolean withReplacement,
-      long seed,
-      SampleMethod sampleMethod) {
-    private boolean isNoOp() {
-      return !withReplacement && upperBound - lowerBound >= 1.0;
-    }
-  }
 
   /**
    *  A helper class used when there are duplicated names coming from 2 sides of the join

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithTableSample.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithTableSample.scala
@@ -196,8 +196,12 @@ class InMemoryTableWithJoinAndSample(
         leftSideRequiredColumnsWithAliases,
         rightSideRequiredColumnsWithAliases,
         condition,
-        null,
-        null)
+        SupportsPushDownJoin.JoinPushDownInfo.empty())
+    }
+
+    override def supportedPushedOperatorsForJoin(): java.util.Set[
+        SupportsPushDownJoin.PushedOperator] = {
+      util.Collections.singleton(SupportsPushDownJoin.PushedOperator.TABLE_SAMPLE)
     }
 
     override def pushDownJoin(
@@ -206,8 +210,10 @@ class InMemoryTableWithJoinAndSample(
         leftSideRequiredColumnsWithAliases: Array[ColumnWithAlias],
         rightSideRequiredColumnsWithAliases: Array[ColumnWithAlias],
         condition: Predicate,
-        leftSample: SupportsPushDownJoin.TableSample,
-        rightSample: SupportsPushDownJoin.TableSample): Boolean = {
+        joinPushDownInfo: SupportsPushDownJoin.JoinPushDownInfo): Boolean = {
+      val leftSample = joinPushDownInfo.leftSideInfo().sample()
+      val rightSample = joinPushDownInfo.rightSideInfo().sample()
+
       if (Option(leftSample).exists(_.withReplacement()) ||
           Option(rightSample).exists(_.withReplacement())) {
         return false
@@ -261,6 +267,33 @@ class InMemoryTableWithJoinAndSample(
       override def description(): String = {
         Seq(super.description(), sampleDescription).filter(_.nonEmpty).mkString(" ")
       }
+    }
+  }
+}
+
+/**
+ * An in-memory table that supports TABLESAMPLE pushdown and the sample-aware JOIN pushdown API,
+ * but does not acknowledge preserving pushed samples during JOIN pushdown.
+ */
+class InMemoryTableWithUnacknowledgedJoinAndSample(
+    name: String,
+    columns: Array[Column],
+    partitioning: Array[Transform],
+    properties: util.Map[String, String])
+  extends InMemoryTableWithJoinAndSample(name, columns, partitioning, properties) {
+
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+    new InMemoryUnacknowledgedJoinAndSampleScanBuilder(schema, options)
+  }
+
+  class InMemoryUnacknowledgedJoinAndSampleScanBuilder(
+      tableSchema: StructType,
+      options: CaseInsensitiveStringMap)
+    extends InMemoryJoinAndSampleScanBuilder(tableSchema, options) {
+
+    override def supportedPushedOperatorsForJoin(): java.util.Set[
+        SupportsPushDownJoin.PushedOperator] = {
+      util.Collections.emptySet()
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithTableSample.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithTableSample.scala
@@ -293,7 +293,7 @@ class InMemoryTableWithUnacknowledgedJoinAndSample(
 
     override def supportedPushedOperatorsForJoin(): java.util.Set[
         SupportsPushDownJoin.PushedOperator] = {
-      util.Collections.emptySet()
+      util.Set.of()
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithTableSample.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithTableSample.scala
@@ -66,11 +66,11 @@ class InMemoryTableWithTableSample(
       options: CaseInsensitiveStringMap)
     extends InMemoryScanBuilder(tableSchema, options) with SupportsPushDownTableSample {
 
-    private var sampleFraction: Double = 1.0
-    private var sampleSeed: Long = 0L
-    private var sampleMethod: SampleMethod = SampleMethod.BERNOULLI
-    private var sampleWithReplacement: Boolean = false
-    private var samplePushed: Boolean = false
+    protected var sampleFraction: Double = 1.0
+    protected var sampleSeed: Long = 0L
+    protected var sampleMethod: SampleMethod = SampleMethod.BERNOULLI
+    protected var sampleWithReplacement: Boolean = false
+    protected var samplePushed: Boolean = false
 
     override def pushTableSample(
         lowerBound: Double,
@@ -116,6 +116,20 @@ class InMemoryTableWithTableSample(
           sampleFraction, sampleSeed, sampleMethod, sampleWithReplacement)
       } else {
         InMemoryBatchScan(filteredPartitions, schema, tableSchema, options)
+      }
+    }
+
+    protected def hasResultAffectingSample: Boolean = {
+      samplePushed && (sampleWithReplacement || sampleFraction < 1.0)
+    }
+
+    protected def sampleDescription(side: String): Option[String] = {
+      if (samplePushed) {
+        val pct = sampleFraction * 100
+        val method = sampleMethod.toString.toUpperCase(Locale.ROOT)
+        Some(s"$side SAMPLE: $method SAMPLE ($pct)")
+      } else {
+        None
       }
     }
   }
@@ -190,36 +204,12 @@ class InMemoryTableWithJoinAndSample(
         leftSideRequiredColumnsWithAliases: Array[ColumnWithAlias],
         rightSideRequiredColumnsWithAliases: Array[ColumnWithAlias],
         condition: Predicate): Boolean = {
-      pushDownJoin(
-        other,
-        joinType,
-        leftSideRequiredColumnsWithAliases,
-        rightSideRequiredColumnsWithAliases,
-        condition,
-        SupportsPushDownJoin.JoinPushDownInfo.empty())
-    }
-
-    override def supportedPushedOperatorsForJoin(): java.util.Set[
-        SupportsPushDownJoin.PushedOperator] = {
-      util.Collections.singleton(SupportsPushDownJoin.PushedOperator.TABLE_SAMPLE)
-    }
-
-    override def pushDownJoin(
-        other: SupportsPushDownJoin,
-        joinType: JoinType,
-        leftSideRequiredColumnsWithAliases: Array[ColumnWithAlias],
-        rightSideRequiredColumnsWithAliases: Array[ColumnWithAlias],
-        condition: Predicate,
-        joinPushDownInfo: SupportsPushDownJoin.JoinPushDownInfo): Boolean = {
-      val leftSample = joinPushDownInfo.leftSideInfo().sample()
-      val rightSample = joinPushDownInfo.rightSideInfo().sample()
-
-      if (Option(leftSample).exists(_.withReplacement()) ||
-          Option(rightSample).exists(_.withReplacement())) {
+      val otherScanBuilder = other.asInstanceOf[InMemoryJoinAndSampleScanBuilder]
+      if (sampleWithReplacement || otherScanBuilder.sampleWithReplacement) {
         return false
       }
 
-      val otherSchema = other.asInstanceOf[InMemoryJoinAndSampleScanBuilder].ownSchema
+      val otherSchema = otherScanBuilder.ownSchema
       val leftFields = leftSideRequiredColumnsWithAliases.map { col =>
         val name = if (col.alias() != null) col.alias() else col.colName()
         tableSchema(col.colName()).copy(name = name)
@@ -230,7 +220,7 @@ class InMemoryTableWithJoinAndSample(
       }
       joinedSchema = Some(StructType(leftFields ++ rightFields))
       joinedSampleDescription = Some(
-        Seq(sampleDescription("LEFT", leftSample), sampleDescription("RIGHT", rightSample))
+        Seq(sampleDescription("LEFT"), otherScanBuilder.sampleDescription("RIGHT"))
           .flatten
           .mkString(" "))
       true
@@ -243,16 +233,6 @@ class InMemoryTableWithJoinAndSample(
             data.map(_.asInstanceOf[InputPartition]).toImmutableArraySeq,
             js, tableSchema, options, joinedSampleDescription.getOrElse(""))
         case None => super.build
-      }
-    }
-
-    private def sampleDescription(
-        side: String,
-        sample: SupportsPushDownJoin.TableSample): Option[String] = {
-      Option(sample).map { s =>
-        val pct = (s.upperBound() - s.lowerBound()) * 100
-        val method = s.sampleMethod().toString.toUpperCase(Locale.ROOT)
-        s"$side SAMPLE: $method SAMPLE ($pct)"
       }
     }
 
@@ -272,35 +252,8 @@ class InMemoryTableWithJoinAndSample(
 }
 
 /**
- * An in-memory table that supports TABLESAMPLE pushdown and the sample-aware JOIN pushdown API,
- * but does not acknowledge preserving pushed samples during JOIN pushdown.
- */
-class InMemoryTableWithUnacknowledgedJoinAndSample(
-    name: String,
-    columns: Array[Column],
-    partitioning: Array[Transform],
-    properties: util.Map[String, String])
-  extends InMemoryTableWithJoinAndSample(name, columns, partitioning, properties) {
-
-  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
-    new InMemoryUnacknowledgedJoinAndSampleScanBuilder(schema, options)
-  }
-
-  class InMemoryUnacknowledgedJoinAndSampleScanBuilder(
-      tableSchema: StructType,
-      options: CaseInsensitiveStringMap)
-    extends InMemoryJoinAndSampleScanBuilder(tableSchema, options) {
-
-    override def supportedPushedOperatorsForJoin(): java.util.Set[
-        SupportsPushDownJoin.PushedOperator] = {
-      util.Set.of()
-    }
-  }
-}
-
-/**
  * An in-memory table that supports TABLESAMPLE pushdown and only the original
- * JOIN pushdown API. Used to test the default sample-aware JOIN pushdown behavior.
+ * JOIN pushdown API. Used to test a connector rejecting pushed samples from pushDownJoin.
  */
 class InMemoryTableWithLegacyJoinAndSample(
     name: String,
@@ -342,7 +295,12 @@ class InMemoryTableWithLegacyJoinAndSample(
         leftSideRequiredColumnsWithAliases: Array[ColumnWithAlias],
         rightSideRequiredColumnsWithAliases: Array[ColumnWithAlias],
         condition: Predicate): Boolean = {
-      val otherSchema = other.asInstanceOf[InMemoryLegacyJoinAndSampleScanBuilder].ownSchema
+      val otherScanBuilder = other.asInstanceOf[InMemoryLegacyJoinAndSampleScanBuilder]
+      if (hasResultAffectingSample || otherScanBuilder.hasResultAffectingSample) {
+        return false
+      }
+
+      val otherSchema = otherScanBuilder.ownSchema
       val leftFields = leftSideRequiredColumnsWithAliases.map { col =>
         val name = if (col.alias() != null) col.alias() else col.colName()
         tableSchema(col.colName()).copy(name = name)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithTableSample.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithTableSample.scala
@@ -141,7 +141,7 @@ class InMemoryTableWithTableSample(
 
 /**
  * An in-memory table that supports both TABLESAMPLE pushdown and JOIN pushdown.
- * Used to test the guard that prevents join pushdown when a side has a pushed sample.
+ * Used to test join pushdown when a side has a pushed sample.
  */
 class InMemoryTableWithJoinAndSample(
     name: String,
@@ -163,6 +163,7 @@ class InMemoryTableWithJoinAndSample(
     private[catalog] val ownSchema: StructType = tableSchema
     private var pushed: Array[Predicate] = Array.empty
     private var joinedSchema: Option[StructType] = None
+    private var joinedSampleDescription: Option[String] = None
 
     override def pushPredicates(predicates: Array[Predicate]): Array[Predicate] = {
       pushed = predicates
@@ -189,7 +190,126 @@ class InMemoryTableWithJoinAndSample(
         leftSideRequiredColumnsWithAliases: Array[ColumnWithAlias],
         rightSideRequiredColumnsWithAliases: Array[ColumnWithAlias],
         condition: Predicate): Boolean = {
+      pushDownJoin(
+        other,
+        joinType,
+        leftSideRequiredColumnsWithAliases,
+        rightSideRequiredColumnsWithAliases,
+        condition,
+        null,
+        null)
+    }
+
+    override def pushDownJoin(
+        other: SupportsPushDownJoin,
+        joinType: JoinType,
+        leftSideRequiredColumnsWithAliases: Array[ColumnWithAlias],
+        rightSideRequiredColumnsWithAliases: Array[ColumnWithAlias],
+        condition: Predicate,
+        leftSample: SupportsPushDownJoin.TableSample,
+        rightSample: SupportsPushDownJoin.TableSample): Boolean = {
+      if (Option(leftSample).exists(_.withReplacement()) ||
+          Option(rightSample).exists(_.withReplacement())) {
+        return false
+      }
+
       val otherSchema = other.asInstanceOf[InMemoryJoinAndSampleScanBuilder].ownSchema
+      val leftFields = leftSideRequiredColumnsWithAliases.map { col =>
+        val name = if (col.alias() != null) col.alias() else col.colName()
+        tableSchema(col.colName()).copy(name = name)
+      }
+      val rightFields = rightSideRequiredColumnsWithAliases.map { col =>
+        val name = if (col.alias() != null) col.alias() else col.colName()
+        otherSchema(col.colName()).copy(name = name)
+      }
+      joinedSchema = Some(StructType(leftFields ++ rightFields))
+      joinedSampleDescription = Some(
+        Seq(sampleDescription("LEFT", leftSample), sampleDescription("RIGHT", rightSample))
+          .flatten
+          .mkString(" "))
+      true
+    }
+
+    override def build: Scan = {
+      joinedSchema match {
+        case Some(js) =>
+          new InMemoryBatchScanWithJoinSample(
+            data.map(_.asInstanceOf[InputPartition]).toImmutableArraySeq,
+            js, tableSchema, options, joinedSampleDescription.getOrElse(""))
+        case None => super.build
+      }
+    }
+
+    private def sampleDescription(
+        side: String,
+        sample: SupportsPushDownJoin.TableSample): Option[String] = {
+      Option(sample).map { s =>
+        val pct = (s.upperBound() - s.lowerBound()) * 100
+        val method = s.sampleMethod().toString.toUpperCase(Locale.ROOT)
+        s"$side SAMPLE: $method SAMPLE ($pct)"
+      }
+    }
+
+    private class InMemoryBatchScanWithJoinSample(
+        data: Seq[InputPartition],
+        readSchema: StructType,
+        tableSchema: StructType,
+        options: CaseInsensitiveStringMap,
+        sampleDescription: String)
+      extends InMemoryBatchScan(data, readSchema, tableSchema, options) {
+
+      override def description(): String = {
+        Seq(super.description(), sampleDescription).filter(_.nonEmpty).mkString(" ")
+      }
+    }
+  }
+}
+
+/**
+ * An in-memory table that supports TABLESAMPLE pushdown and only the original
+ * JOIN pushdown API. Used to test the default sample-aware JOIN pushdown behavior.
+ */
+class InMemoryTableWithLegacyJoinAndSample(
+    name: String,
+    columns: Array[Column],
+    partitioning: Array[Transform],
+    properties: util.Map[String, String])
+  extends InMemoryTableWithTableSample(name, columns, partitioning, properties) {
+
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+    new InMemoryLegacyJoinAndSampleScanBuilder(schema, options)
+  }
+
+  class InMemoryLegacyJoinAndSampleScanBuilder(
+      tableSchema: StructType,
+      options: CaseInsensitiveStringMap)
+    extends InMemoryTableSampleScanBuilder(tableSchema, options)
+      with SupportsPushDownJoin with SupportsPushDownV2Filters {
+
+    private[catalog] val ownSchema: StructType = tableSchema
+    private var pushed: Array[Predicate] = Array.empty
+    private var joinedSchema: Option[StructType] = None
+
+    override def pushPredicates(predicates: Array[Predicate]): Array[Predicate] = {
+      pushed = predicates
+      Array.empty
+    }
+
+    override def pushFilters(filters: Array[Filter]): Array[Filter] = {
+      Array.empty
+    }
+
+    override def pushedPredicates(): Array[Predicate] = pushed
+
+    override def isOtherSideCompatibleForJoin(other: SupportsPushDownJoin): Boolean = true
+
+    override def pushDownJoin(
+        other: SupportsPushDownJoin,
+        joinType: JoinType,
+        leftSideRequiredColumnsWithAliases: Array[ColumnWithAlias],
+        rightSideRequiredColumnsWithAliases: Array[ColumnWithAlias],
+        condition: Predicate): Boolean = {
+      val otherSchema = other.asInstanceOf[InMemoryLegacyJoinAndSampleScanBuilder].ownSchema
       val leftFields = leftSideRequiredColumnsWithAliases.map { col =>
         val name = if (col.alias() != null) col.alias() else col.colName()
         tableSchema(col.colName()).copy(name = name)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithTableSampleCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithTableSampleCatalog.scala
@@ -101,6 +101,33 @@ class InMemoryTableWithLegacyJoinAndSampleCatalog extends InMemoryTableCatalog {
   }
 }
 
+class InMemoryTableWithUnacknowledgedJoinAndSampleCatalog extends InMemoryTableCatalog {
+  import CatalogV2Implicits._
+
+  override def createTable(
+      ident: Identifier,
+      columns: Array[Column],
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): Table = {
+    if (tables.containsKey(ident)) {
+      throw new TableAlreadyExistsException(ident.asMultipartIdentifier)
+    }
+
+    InMemoryTableCatalog.maybeSimulateFailedTableCreation(properties)
+
+    val tableName = s"$name.${ident.quoted}"
+    val table = new InMemoryTableWithUnacknowledgedJoinAndSample(
+      tableName, columns, partitions, properties)
+    tables.put(ident, table)
+    namespaces.putIfAbsent(ident.namespace.toList, Map())
+    table
+  }
+
+  override def createTable(ident: Identifier, tableInfo: TableInfo): Table = {
+    createTable(ident, tableInfo.columns(), tableInfo.partitions(), tableInfo.properties)
+  }
+}
+
 class InMemoryTableWithLegacyTableSampleCatalog extends InMemoryTableCatalog {
   import CatalogV2Implicits._
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithTableSampleCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithTableSampleCatalog.scala
@@ -101,33 +101,6 @@ class InMemoryTableWithLegacyJoinAndSampleCatalog extends InMemoryTableCatalog {
   }
 }
 
-class InMemoryTableWithUnacknowledgedJoinAndSampleCatalog extends InMemoryTableCatalog {
-  import CatalogV2Implicits._
-
-  override def createTable(
-      ident: Identifier,
-      columns: Array[Column],
-      partitions: Array[Transform],
-      properties: util.Map[String, String]): Table = {
-    if (tables.containsKey(ident)) {
-      throw new TableAlreadyExistsException(ident.asMultipartIdentifier)
-    }
-
-    InMemoryTableCatalog.maybeSimulateFailedTableCreation(properties)
-
-    val tableName = s"$name.${ident.quoted}"
-    val table = new InMemoryTableWithUnacknowledgedJoinAndSample(
-      tableName, columns, partitions, properties)
-    tables.put(ident, table)
-    namespaces.putIfAbsent(ident.namespace.toList, Map())
-    table
-  }
-
-  override def createTable(ident: Identifier, tableInfo: TableInfo): Table = {
-    createTable(ident, tableInfo.columns(), tableInfo.partitions(), tableInfo.properties)
-  }
-}
-
 class InMemoryTableWithLegacyTableSampleCatalog extends InMemoryTableCatalog {
   import CatalogV2Implicits._
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithTableSampleCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableWithTableSampleCatalog.scala
@@ -74,6 +74,33 @@ class InMemoryTableWithJoinAndSampleCatalog extends InMemoryTableCatalog {
   }
 }
 
+class InMemoryTableWithLegacyJoinAndSampleCatalog extends InMemoryTableCatalog {
+  import CatalogV2Implicits._
+
+  override def createTable(
+      ident: Identifier,
+      columns: Array[Column],
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): Table = {
+    if (tables.containsKey(ident)) {
+      throw new TableAlreadyExistsException(ident.asMultipartIdentifier)
+    }
+
+    InMemoryTableCatalog.maybeSimulateFailedTableCreation(properties)
+
+    val tableName = s"$name.${ident.quoted}"
+    val table = new InMemoryTableWithLegacyJoinAndSample(
+      tableName, columns, partitions, properties)
+    tables.put(ident, table)
+    namespaces.putIfAbsent(ident.namespace.toList, Map())
+    table
+  }
+
+  override def createTable(ident: Identifier, tableInfo: TableInfo): Table = {
+    createTable(ident, tableInfo.columns(), tableInfo.partitions(), tableInfo.properties)
+  }
+}
+
 class InMemoryTableWithLegacyTableSampleCatalog extends InMemoryTableCatalog {
   import CatalogV2Implicits._
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.connector.expressions.{SortOrder => V2SortOrder}
 import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Avg, Count, CountStar, Max, Min, Sum}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
-import org.apache.spark.sql.connector.read.{SampleMethod => SampleMethodV2, Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, SupportsPushDownJoin, SupportsPushDownRequiredColumns, SupportsPushDownVariantExtractions, V1Scan, VariantExtraction}
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, SupportsPushDownJoin, SupportsPushDownRequiredColumns, SupportsPushDownVariantExtractions, V1Scan, VariantExtraction}
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, VariantInRelation, VariantMetadata}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.connector.VariantExtractionImpl
@@ -218,21 +218,14 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
           rightSideRequiredColumnsWithAliases.map(_.prettyString()).mkString(", ")
         )}")
 
-      val joinPushDownInfo = toJoinPushDownInfo(
-        leftHolder.pushedSample, rightHolder.pushedSample)
-      val pushedOperatorsSupported = lBuilder.supportedPushedOperatorsForJoin()
-        .containsAll(joinPushDownInfo.requiredPushedOperators())
-
       if (translatedJoinType.isDefined &&
         translatedCondition.isDefined &&
-        pushedOperatorsSupported &&
         lBuilder.pushDownJoin(
           rBuilder,
           translatedJoinType.get,
           leftSideRequiredColumnsWithAliases,
           rightSideRequiredColumnsWithAliases,
-          translatedCondition.get,
-          joinPushDownInfo)
+          translatedCondition.get)
       ) {
         val leftSidePushedDownOperators = getPushedDownOperators(leftHolder)
         val rightSidePushedDownOperators = getPushedDownOperators(rightHolder)
@@ -1168,28 +1161,6 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
       sHolder.joinedRelationsPushedDownOperators, optRelationName)
   }
 
-  private def toJoinPushDownInfo(
-      leftSample: Option[TableSampleInfo],
-      rightSample: Option[TableSampleInfo]): SupportsPushDownJoin.JoinPushDownInfo = {
-    new SupportsPushDownJoin.JoinPushDownInfo(
-      new SupportsPushDownJoin.JoinSideInfo(toJoinTableSample(leftSample)),
-      new SupportsPushDownJoin.JoinSideInfo(toJoinTableSample(rightSample)))
-  }
-
-  private def toJoinTableSample(
-      sample: Option[TableSampleInfo]): SupportsPushDownJoin.TableSample = {
-    sample.map { s =>
-      new SupportsPushDownJoin.TableSample(
-        s.lowerBound,
-        s.upperBound,
-        s.withReplacement,
-        s.seed,
-        s.sampleMethod match {
-          case SampleMethod.Bernoulli => SampleMethodV2.BERNOULLI
-          case SampleMethod.System => SampleMethodV2.SYSTEM
-        })
-    }.orNull
-  }
 }
 
 case class ScanBuilderHolder(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.connector.expressions.{SortOrder => V2SortOrder}
 import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Avg, Count, CountStar, Max, Min, Sum}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
-import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, SupportsPushDownJoin, SupportsPushDownRequiredColumns, SupportsPushDownVariantExtractions, V1Scan, VariantExtraction}
+import org.apache.spark.sql.connector.read.{SampleMethod => SampleMethodV2, Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, SupportsPushDownJoin, SupportsPushDownRequiredColumns, SupportsPushDownVariantExtractions, V1Scan, VariantExtraction}
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, VariantInRelation, VariantMetadata}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.connector.VariantExtractionImpl
@@ -165,18 +165,6 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
         rightProjections.forall(_.isInstanceOf[AttributeReference]) &&
         // Cross joins are not supported because they increase the amount of data.
         condition.isDefined &&
-        // Do not push down join if either side has a pushed sample with
-        // fraction < 1, because the merged scan builder would silently
-        // discard it and change the result. At fraction = 1 without
-        // replacement the sample is a no-op on the result set, so dropping
-        // it is safe. With replacement (Poisson sampling), even fraction 1
-        // can emit each row 0, 1, 2, ... times, so it is not a no-op.
-        // TODO(SPARK-56504): Extend SupportsPushDownJoin to accept pushed
-        //   samples so sources supporting both can handle the composition.
-        leftHolder.pushedSample.forall(s =>
-          !s.withReplacement && s.upperBound - s.lowerBound >= 1.0) &&
-        rightHolder.pushedSample.forall(s =>
-          !s.withReplacement && s.upperBound - s.lowerBound >= 1.0) &&
         lBuilder.isOtherSideCompatibleForJoin(rBuilder) =>
       // Process left and right columns in original order
       val (leftSideRequiredColumnsWithAliases, rightSideRequiredColumnsWithAliases) =
@@ -237,7 +225,9 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
           translatedJoinType.get,
           leftSideRequiredColumnsWithAliases,
           rightSideRequiredColumnsWithAliases,
-          translatedCondition.get)
+          translatedCondition.get,
+          toJoinTableSample(leftHolder.pushedSample),
+          toJoinTableSample(rightHolder.pushedSample))
       ) {
         val leftSidePushedDownOperators = getPushedDownOperators(leftHolder)
         val rightSidePushedDownOperators = getPushedDownOperators(rightHolder)
@@ -1171,6 +1161,21 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
     PushedDownOperators(sHolder.pushedAggregate, sHolder.pushedSample,
       sHolder.pushedLimit, sHolder.pushedOffset, sHolder.sortOrders, sHolder.pushedPredicates,
       sHolder.joinedRelationsPushedDownOperators, optRelationName)
+  }
+
+  private def toJoinTableSample(
+      sample: Option[TableSampleInfo]): SupportsPushDownJoin.TableSample = {
+    sample.map { s =>
+      new SupportsPushDownJoin.TableSample(
+        s.lowerBound,
+        s.upperBound,
+        s.withReplacement,
+        s.seed,
+        s.sampleMethod match {
+          case SampleMethod.Bernoulli => SampleMethodV2.BERNOULLI
+          case SampleMethod.System => SampleMethodV2.SYSTEM
+        })
+    }.orNull
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -218,16 +218,21 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
           rightSideRequiredColumnsWithAliases.map(_.prettyString()).mkString(", ")
         )}")
 
+      val joinPushDownInfo = toJoinPushDownInfo(
+        leftHolder.pushedSample, rightHolder.pushedSample)
+      val pushedOperatorsSupported = lBuilder.supportedPushedOperatorsForJoin()
+        .containsAll(joinPushDownInfo.requiredPushedOperators())
+
       if (translatedJoinType.isDefined &&
         translatedCondition.isDefined &&
+        pushedOperatorsSupported &&
         lBuilder.pushDownJoin(
           rBuilder,
           translatedJoinType.get,
           leftSideRequiredColumnsWithAliases,
           rightSideRequiredColumnsWithAliases,
           translatedCondition.get,
-          toJoinTableSample(leftHolder.pushedSample),
-          toJoinTableSample(rightHolder.pushedSample))
+          joinPushDownInfo)
       ) {
         val leftSidePushedDownOperators = getPushedDownOperators(leftHolder)
         val rightSidePushedDownOperators = getPushedDownOperators(rightHolder)
@@ -1161,6 +1166,14 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
     PushedDownOperators(sHolder.pushedAggregate, sHolder.pushedSample,
       sHolder.pushedLimit, sHolder.pushedOffset, sHolder.sortOrders, sHolder.pushedPredicates,
       sHolder.joinedRelationsPushedDownOperators, optRelationName)
+  }
+
+  private def toJoinPushDownInfo(
+      leftSample: Option[TableSampleInfo],
+      rightSample: Option[TableSampleInfo]): SupportsPushDownJoin.JoinPushDownInfo = {
+    new SupportsPushDownJoin.JoinPushDownInfo(
+      new SupportsPushDownJoin.JoinSideInfo(toJoinTableSample(leftSample)),
+      new SupportsPushDownJoin.JoinSideInfo(toJoinTableSample(rightSample)))
   }
 
   private def toJoinTableSample(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -16,8 +16,6 @@
  */
 package org.apache.spark.sql.execution.datasources.v2.jdbc
 
-import java.util.Collections
-
 import scala.util.control.NonFatal
 
 import org.apache.spark.internal.Logging
@@ -184,27 +182,6 @@ case class JDBCScanBuilder(
       leftSideRequiredColumnsWithAliases: Array[SupportsPushDownJoin.ColumnWithAlias],
       rightSideRequiredColumnsWithAliases: Array[SupportsPushDownJoin.ColumnWithAlias],
       condition: Predicate ): Boolean = {
-    pushDownJoin(
-      other,
-      joinType,
-      leftSideRequiredColumnsWithAliases,
-      rightSideRequiredColumnsWithAliases,
-      condition,
-      SupportsPushDownJoin.JoinPushDownInfo.empty())
-  }
-
-  override def supportedPushedOperatorsForJoin(): java.util.Set[
-      SupportsPushDownJoin.PushedOperator] = {
-    Collections.singleton(SupportsPushDownJoin.PushedOperator.TABLE_SAMPLE)
-  }
-
-  override def pushDownJoin(
-      other: SupportsPushDownJoin,
-      joinType: JoinType,
-      leftSideRequiredColumnsWithAliases: Array[SupportsPushDownJoin.ColumnWithAlias],
-      rightSideRequiredColumnsWithAliases: Array[SupportsPushDownJoin.ColumnWithAlias],
-      condition: Predicate,
-      joinPushDownInfo: SupportsPushDownJoin.JoinPushDownInfo): Boolean = {
     if (!jdbcOptions.pushDownJoin || !dialect.supportsJoin) {
       return false
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.execution.datasources.v2.jdbc
 
+import java.util.Collections
+
 import scala.util.control.NonFatal
 
 import org.apache.spark.internal.Logging
@@ -188,8 +190,12 @@ case class JDBCScanBuilder(
       leftSideRequiredColumnsWithAliases,
       rightSideRequiredColumnsWithAliases,
       condition,
-      null,
-      null)
+      SupportsPushDownJoin.JoinPushDownInfo.empty())
+  }
+
+  override def supportedPushedOperatorsForJoin(): java.util.Set[
+      SupportsPushDownJoin.PushedOperator] = {
+    Collections.singleton(SupportsPushDownJoin.PushedOperator.TABLE_SAMPLE)
   }
 
   override def pushDownJoin(
@@ -198,8 +204,7 @@ case class JDBCScanBuilder(
       leftSideRequiredColumnsWithAliases: Array[SupportsPushDownJoin.ColumnWithAlias],
       rightSideRequiredColumnsWithAliases: Array[SupportsPushDownJoin.ColumnWithAlias],
       condition: Predicate,
-      leftSample: SupportsPushDownJoin.TableSample,
-      rightSample: SupportsPushDownJoin.TableSample): Boolean = {
+      joinPushDownInfo: SupportsPushDownJoin.JoinPushDownInfo): Boolean = {
     if (!jdbcOptions.pushDownJoin || !dialect.supportsJoin) {
       return false
     }
@@ -224,12 +229,6 @@ case class JDBCScanBuilder(
     }
 
     val otherJdbcScanBuilder = other.asInstanceOf[JDBCScanBuilder]
-    if ((leftSample != null && tableSampleClause.isEmpty) ||
-        (rightSample != null && otherJdbcScanBuilder.tableSampleClause.isEmpty)) {
-      logError(log"Failed to push down join to JDBC because a pushed table sample " +
-        log"could not be represented in the join query")
-      return false
-    }
 
     // requiredSchema will become the finalSchema of this JDBCScanBuilder
     var requiredSchema = StructType(Seq())

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -182,6 +182,24 @@ case class JDBCScanBuilder(
       leftSideRequiredColumnsWithAliases: Array[SupportsPushDownJoin.ColumnWithAlias],
       rightSideRequiredColumnsWithAliases: Array[SupportsPushDownJoin.ColumnWithAlias],
       condition: Predicate ): Boolean = {
+    pushDownJoin(
+      other,
+      joinType,
+      leftSideRequiredColumnsWithAliases,
+      rightSideRequiredColumnsWithAliases,
+      condition,
+      null,
+      null)
+  }
+
+  override def pushDownJoin(
+      other: SupportsPushDownJoin,
+      joinType: JoinType,
+      leftSideRequiredColumnsWithAliases: Array[SupportsPushDownJoin.ColumnWithAlias],
+      rightSideRequiredColumnsWithAliases: Array[SupportsPushDownJoin.ColumnWithAlias],
+      condition: Predicate,
+      leftSample: SupportsPushDownJoin.TableSample,
+      rightSample: SupportsPushDownJoin.TableSample): Boolean = {
     if (!jdbcOptions.pushDownJoin || !dialect.supportsJoin) {
       return false
     }
@@ -206,6 +224,12 @@ case class JDBCScanBuilder(
     }
 
     val otherJdbcScanBuilder = other.asInstanceOf[JDBCScanBuilder]
+    if ((leftSample != null && tableSampleClause.isEmpty) ||
+        (rightSample != null && otherJdbcScanBuilder.tableSampleClause.isEmpty)) {
+      logError(log"Failed to push down join to JDBC because a pushed table sample " +
+        log"could not be represented in the join query")
+      return false
+    }
 
     // requiredSchema will become the finalSchema of this JDBCScanBuilder
     var requiredSchema = StructType(Seq())
@@ -263,13 +287,13 @@ case class JDBCScanBuilder(
     val quotedAliases = columnsWithAliases
       .map(col => Option(col.alias()).map(dialect.quoteIdentifier))
 
-    // Only filters can be pushed down before join pushdown, so we need to craft SQL query
-    // that contains filters as well.
-    // Joins on top of samples are not supported so we don't need to provide tableSample here.
-    dialect
+    val builder = dialect
       .getJdbcSQLQueryBuilder(jdbcOptions)
       .withPredicates(pushedPredicate, JDBCPartition(whereClause = null, idx = 1))
       .withAliasedColumns(quotedColumns, quotedAliases)
+
+    tableSampleClause.foreach(builder.withTableSampleClause)
+    builder
   }
 
   override def pushTableSample(

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2TableSampleSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2TableSampleSuite.scala
@@ -18,7 +18,11 @@
 package org.apache.spark.sql.connector
 
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.connector.catalog.{InMemoryTableWithJoinAndSampleCatalog, InMemoryTableWithLegacyTableSampleCatalog, InMemoryTableWithTableSampleCatalog}
+import org.apache.spark.sql.connector.catalog.{
+  InMemoryTableWithJoinAndSampleCatalog,
+  InMemoryTableWithLegacyJoinAndSampleCatalog,
+  InMemoryTableWithLegacyTableSampleCatalog,
+  InMemoryTableWithTableSampleCatalog}
 import org.apache.spark.sql.internal.SQLConf
 
 class DataSourceV2TableSampleSuite extends DatasourceV2SQLBase
@@ -156,7 +160,7 @@ class DataSourceV2TableSampleSuite extends DatasourceV2SQLBase
     }
   }
 
-  test("SPARK-55978: join pushdown is skipped when a side has a pushed sample") {
+  test("SPARK-56504: join pushdown includes left side pushed sample") {
     val joinSampleCatalog = "testjoinsample"
     registerCatalog(joinSampleCatalog, classOf[InMemoryTableWithJoinAndSampleCatalog])
     val t1 = s"$joinSampleCatalog.ns.t1"
@@ -171,15 +175,48 @@ class DataSourceV2TableSampleSuite extends DatasourceV2SQLBase
         val dfNoSample = sql(s"SELECT * FROM $t1 JOIN $t2 ON $t1.id = $t2.id")
         checkJoinPushed(dfNoSample)
 
-        // With a SYSTEM sample (fraction < 1) on one side: join pushdown
-        // should be skipped because the merged scan builder would silently
-        // discard the sample.
+        // With the sample-aware join pushdown API, the pushed sample remains
+        // attached to the left side of the pushed join.
         val dfWithSample = sql(
           s"SELECT * FROM $t1 TABLESAMPLE SYSTEM (50 PERCENT) " +
           s"JOIN $t2 ON $t1.id = $t2.id")
-        checkJoinNotPushed(dfWithSample)
-        // The sample should still be pushed down though
+        checkJoinPushed(dfWithSample)
         checkSamplePushed(dfWithSample, pushed = true)
+        checkPushedInfo(dfWithSample, "LEFT SAMPLE: SYSTEM SAMPLE (50.0)")
+      }
+    } finally {
+      sql(s"DROP TABLE IF EXISTS $t1")
+      sql(s"DROP TABLE IF EXISTS $t2")
+    }
+  }
+
+  test("SPARK-56504: join pushdown includes right and both side pushed samples") {
+    val joinSampleCatalog = "testjoinsampleboth"
+    registerCatalog(joinSampleCatalog, classOf[InMemoryTableWithJoinAndSampleCatalog])
+    val t1 = s"$joinSampleCatalog.ns.t1"
+    val t2 = s"$joinSampleCatalog.ns.t2"
+    sql(s"CREATE TABLE $t1 (id bigint, data string) USING _")
+    sql(s"CREATE TABLE $t2 (id bigint, data string) USING _")
+    try {
+      sql(s"INSERT INTO $t1 VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+      sql(s"INSERT INTO $t2 VALUES (2, 'x'), (3, 'y'), (4, 'z')")
+      withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
+        val rightSample = sql(
+          s"SELECT * FROM $t1 JOIN $t2 TABLESAMPLE BERNOULLI (50 PERCENT) " +
+          s"ON $t1.id = $t2.id")
+        checkJoinPushed(rightSample)
+        checkSamplePushed(rightSample, pushed = true)
+        checkPushedInfo(rightSample, "RIGHT SAMPLE: BERNOULLI SAMPLE (50.0)")
+
+        val bothSamples = sql(
+          s"SELECT * FROM $t1 TABLESAMPLE SYSTEM (50 PERCENT) " +
+          s"JOIN $t2 TABLESAMPLE BERNOULLI (50 PERCENT) ON $t1.id = $t2.id")
+        checkJoinPushed(bothSamples)
+        checkSamplePushed(bothSamples, pushed = true)
+        checkPushedInfo(
+          bothSamples,
+          "LEFT SAMPLE: SYSTEM SAMPLE (50.0)",
+          "RIGHT SAMPLE: BERNOULLI SAMPLE (50.0)")
       }
     } finally {
       sql(s"DROP TABLE IF EXISTS $t1")
@@ -198,14 +235,44 @@ class DataSourceV2TableSampleSuite extends DatasourceV2SQLBase
       sql(s"INSERT INTO $t1 VALUES (1, 'a'), (2, 'b'), (3, 'c')")
       sql(s"INSERT INTO $t2 VALUES (2, 'x'), (3, 'y'), (4, 'z')")
       withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
-        // At fraction = 1 the sample is a no-op on the result set, so
-        // dropping it inside the merged scan builder is safe. The guard
-        // in V2ScanRelationPushDown short-circuits and join pushdown
-        // proceeds.
+        // At fraction = 1 the sample is a no-op on the result set, so join
+        // pushdown can proceed even for connectors that treat it as ordinary
+        // sample-aware join pushdown input.
         val dfWithSample = sql(
           s"SELECT * FROM $t1 TABLESAMPLE SYSTEM (100 PERCENT) " +
           s"JOIN $t2 ON $t1.id = $t2.id")
         checkJoinPushed(dfWithSample)
+      }
+    } finally {
+      sql(s"DROP TABLE IF EXISTS $t1")
+      sql(s"DROP TABLE IF EXISTS $t2")
+    }
+  }
+
+  test("SPARK-56504: old join pushdown API rejects real pushed samples by default") {
+    val joinSampleCatalog = "testlegjoinandsample"
+    registerCatalog(joinSampleCatalog, classOf[InMemoryTableWithLegacyJoinAndSampleCatalog])
+    val t1 = s"$joinSampleCatalog.ns.t1"
+    val t2 = s"$joinSampleCatalog.ns.t2"
+    sql(s"CREATE TABLE $t1 (id bigint, data string) USING _")
+    sql(s"CREATE TABLE $t2 (id bigint, data string) USING _")
+    try {
+      sql(s"INSERT INTO $t1 VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+      sql(s"INSERT INTO $t2 VALUES (2, 'x'), (3, 'y'), (4, 'z')")
+      withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
+        val noSample = sql(s"SELECT * FROM $t1 JOIN $t2 ON $t1.id = $t2.id")
+        checkJoinPushed(noSample)
+
+        val noOpSample = sql(
+          s"SELECT * FROM $t1 TABLESAMPLE SYSTEM (100 PERCENT) " +
+          s"JOIN $t2 ON $t1.id = $t2.id")
+        checkJoinPushed(noOpSample)
+
+        val realSample = sql(
+          s"SELECT * FROM $t1 TABLESAMPLE SYSTEM (50 PERCENT) " +
+          s"JOIN $t2 ON $t1.id = $t2.id")
+        checkJoinNotPushed(realSample)
+        checkSamplePushed(realSample, pushed = true)
       }
     } finally {
       sql(s"DROP TABLE IF EXISTS $t1")

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2TableSampleSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2TableSampleSuite.scala
@@ -22,7 +22,8 @@ import org.apache.spark.sql.connector.catalog.{
   InMemoryTableWithJoinAndSampleCatalog,
   InMemoryTableWithLegacyJoinAndSampleCatalog,
   InMemoryTableWithLegacyTableSampleCatalog,
-  InMemoryTableWithTableSampleCatalog}
+  InMemoryTableWithTableSampleCatalog,
+  InMemoryTableWithUnacknowledgedJoinAndSampleCatalog}
 import org.apache.spark.sql.internal.SQLConf
 
 class DataSourceV2TableSampleSuite extends DatasourceV2SQLBase
@@ -267,6 +268,32 @@ class DataSourceV2TableSampleSuite extends DatasourceV2SQLBase
           s"SELECT * FROM $t1 TABLESAMPLE SYSTEM (100 PERCENT) " +
           s"JOIN $t2 ON $t1.id = $t2.id")
         checkJoinPushed(noOpSample)
+
+        val realSample = sql(
+          s"SELECT * FROM $t1 TABLESAMPLE SYSTEM (50 PERCENT) " +
+          s"JOIN $t2 ON $t1.id = $t2.id")
+        checkJoinNotPushed(realSample)
+        checkSamplePushed(realSample, pushed = true)
+      }
+    } finally {
+      sql(s"DROP TABLE IF EXISTS $t1")
+      sql(s"DROP TABLE IF EXISTS $t2")
+    }
+  }
+
+  test("SPARK-56504: join pushdown requires acknowledging pushed samples") {
+    val joinSampleCatalog = "testunackjoinandsample"
+    registerCatalog(joinSampleCatalog, classOf[InMemoryTableWithUnacknowledgedJoinAndSampleCatalog])
+    val t1 = s"$joinSampleCatalog.ns.t1"
+    val t2 = s"$joinSampleCatalog.ns.t2"
+    sql(s"CREATE TABLE $t1 (id bigint, data string) USING _")
+    sql(s"CREATE TABLE $t2 (id bigint, data string) USING _")
+    try {
+      sql(s"INSERT INTO $t1 VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+      sql(s"INSERT INTO $t2 VALUES (2, 'x'), (3, 'y'), (4, 'z')")
+      withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
+        val noSample = sql(s"SELECT * FROM $t1 JOIN $t2 ON $t1.id = $t2.id")
+        checkJoinPushed(noSample)
 
         val realSample = sql(
           s"SELECT * FROM $t1 TABLESAMPLE SYSTEM (50 PERCENT) " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2TableSampleSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2TableSampleSuite.scala
@@ -22,8 +22,7 @@ import org.apache.spark.sql.connector.catalog.{
   InMemoryTableWithJoinAndSampleCatalog,
   InMemoryTableWithLegacyJoinAndSampleCatalog,
   InMemoryTableWithLegacyTableSampleCatalog,
-  InMemoryTableWithTableSampleCatalog,
-  InMemoryTableWithUnacknowledgedJoinAndSampleCatalog}
+  InMemoryTableWithTableSampleCatalog}
 import org.apache.spark.sql.internal.SQLConf
 
 class DataSourceV2TableSampleSuite extends DatasourceV2SQLBase
@@ -176,8 +175,7 @@ class DataSourceV2TableSampleSuite extends DatasourceV2SQLBase
         val dfNoSample = sql(s"SELECT * FROM $t1 JOIN $t2 ON $t1.id = $t2.id")
         checkJoinPushed(dfNoSample)
 
-        // With the sample-aware join pushdown API, the pushed sample remains
-        // attached to the left side of the pushed join.
+        // The connector preserves its previously pushed sample when pushing down the join.
         val dfWithSample = sql(
           s"SELECT * FROM $t1 TABLESAMPLE SYSTEM (50 PERCENT) " +
           s"JOIN $t2 ON $t1.id = $t2.id")
@@ -236,9 +234,8 @@ class DataSourceV2TableSampleSuite extends DatasourceV2SQLBase
       sql(s"INSERT INTO $t1 VALUES (1, 'a'), (2, 'b'), (3, 'c')")
       sql(s"INSERT INTO $t2 VALUES (2, 'x'), (3, 'y'), (4, 'z')")
       withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
-        // At fraction = 1 the sample is a no-op on the result set, so join
-        // pushdown can proceed even for connectors that treat it as ordinary
-        // sample-aware join pushdown input.
+        // At fraction = 1 the sample is a no-op on the result set, so this connector
+        // can safely preserve it while pushing down the join.
         val dfWithSample = sql(
           s"SELECT * FROM $t1 TABLESAMPLE SYSTEM (100 PERCENT) " +
           s"JOIN $t2 ON $t1.id = $t2.id")
@@ -250,7 +247,7 @@ class DataSourceV2TableSampleSuite extends DatasourceV2SQLBase
     }
   }
 
-  test("SPARK-56504: old join pushdown API rejects real pushed samples by default") {
+  test("SPARK-56504: connector rejects join pushdown when it cannot preserve pushed samples") {
     val joinSampleCatalog = "testlegjoinandsample"
     registerCatalog(joinSampleCatalog, classOf[InMemoryTableWithLegacyJoinAndSampleCatalog])
     val t1 = s"$joinSampleCatalog.ns.t1"
@@ -268,32 +265,6 @@ class DataSourceV2TableSampleSuite extends DatasourceV2SQLBase
           s"SELECT * FROM $t1 TABLESAMPLE SYSTEM (100 PERCENT) " +
           s"JOIN $t2 ON $t1.id = $t2.id")
         checkJoinPushed(noOpSample)
-
-        val realSample = sql(
-          s"SELECT * FROM $t1 TABLESAMPLE SYSTEM (50 PERCENT) " +
-          s"JOIN $t2 ON $t1.id = $t2.id")
-        checkJoinNotPushed(realSample)
-        checkSamplePushed(realSample, pushed = true)
-      }
-    } finally {
-      sql(s"DROP TABLE IF EXISTS $t1")
-      sql(s"DROP TABLE IF EXISTS $t2")
-    }
-  }
-
-  test("SPARK-56504: join pushdown requires acknowledging pushed samples") {
-    val joinSampleCatalog = "testunackjoinandsample"
-    registerCatalog(joinSampleCatalog, classOf[InMemoryTableWithUnacknowledgedJoinAndSampleCatalog])
-    val t1 = s"$joinSampleCatalog.ns.t1"
-    val t2 = s"$joinSampleCatalog.ns.t2"
-    sql(s"CREATE TABLE $t1 (id bigint, data string) USING _")
-    sql(s"CREATE TABLE $t2 (id bigint, data string) USING _")
-    try {
-      sql(s"INSERT INTO $t1 VALUES (1, 'a'), (2, 'b'), (3, 'c')")
-      sql(s"INSERT INTO $t2 VALUES (2, 'x'), (3, 'y'), (4, 'z')")
-      withSQLConf(SQLConf.DATA_SOURCE_V2_JOIN_PUSHDOWN.key -> "true") {
-        val noSample = sql(s"SELECT * FROM $t1 JOIN $t2 ON $t1.id = $t2.id")
-        checkJoinPushed(noSample)
 
         val realSample = sql(
           s"SELECT * FROM $t1 TABLESAMPLE SYSTEM (50 PERCENT) " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1289,6 +1289,31 @@ class JDBCSuite extends SharedSparkSession {
       "SELECT tab.* FROM (SELECT a,b FROM test    ) tab WHERE rownum <= 123")
   }
 
+  test("SPARK-56504: JdbcSQLQueryBuilder preserves table sample in pushed join sides") {
+    // JDBC url is a required option but is not used in this test.
+    val options = new JDBCOptions(Map("url" -> "jdbc:h2://host:port", "dbtable" -> "test"))
+    val dialect = JdbcDialects.get("jdbc:h2://host:port")
+    val left = dialect
+      .getJdbcSQLQueryBuilder(options)
+      .withColumns(Array("a"))
+      .withTableSampleClause("TABLESAMPLE SYSTEM (50)")
+    val right = dialect
+      .getJdbcSQLQueryBuilder(options)
+      .withColumns(Array("b"))
+      .withTableSampleClause("TABLESAMPLE BERNOULLI (25)")
+
+    val query = dialect
+      .getJdbcSQLQueryBuilder(options)
+      .withJoin(left, right, "L", "R", Array("a", "b"), "INNER JOIN", "L.a = R.b")
+      .build()
+      .replaceAll("\\s+", " ")
+
+    assert(query.contains("SELECT a FROM test TABLESAMPLE SYSTEM (50)"))
+    assert(query.contains("SELECT b FROM test TABLESAMPLE BERNOULLI (25)"))
+    assert(query.contains("INNER JOIN"))
+    assert(query.contains("ON L.a = R.b"))
+  }
+
   test("MsSqlServerDialect jdbc type mapping") {
     val msSqlServerDialect = JdbcDialects.get("jdbc:sqlserver")
     assert(msSqlServerDialect.getJDBCType(TimestampType).map(_.databaseTypeDefinition).get ==


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->


### What changes were proposed in this pull request?

This PR allows DataSource V2 join pushdown to compose with pushed table samples when the connector can preserve the previously pushed sample state ([SPARK-56504](https://issues.apache.org/jira/browse/SPARK-56504)).

Before this change, Spark blocked join pushdown when either side of the join had a real pushed table sample. That guard prevented incorrect results, because a connector that pushed the join without preserving the already-pushed sample could silently drop the sample.

This PR now removes that hard Spark-side block and relies on the existing stateful `ScanBuilder` model:

1. Table sample pushdown is attempted before join pushdown.
2. If a connector accepts table sample pushdown, its scan builder already stores that pushed sample state.
3. When `pushDownJoin(...)` is called later, the connector can decide from its own stored state whether it can preserve the sample.
4. If it cannot preserve previously pushed state such as a table sample, it must return `false`.

The PR updates the existing `SupportsPushDownJoin.pushDownJoin(...)` documentation to make that contract explicit.

For JDBC, this PR preserves pushed table sample clauses when building the left and right subqueries used for join pushdown. After the joined SQL query is built, JDBC clears the stored table sample clause so it is not applied again.

This PR does not add a new public join pushdown API.

### Why are the changes needed?

SPARK-55978 added table sample pushdown and intentionally blocked composing pushed table samples with join pushdown. That was safe, but too restrictive for connectors that can correctly preserve both operations.

JDBC is one such connector. It already stores accepted table sample pushdown state internally as a table sample clause. During join pushdown, JDBC can include that clause in each pushed join-side subquery, preserving the correct semantics.

This change allows Spark to push down joins on top of pushed table samples when the connector accepts the composition through the existing `pushDownJoin(...)` contract.

If a connector cannot preserve previously pushed state, it must reject join pushdown by returning `false`.

### Does this PR introduce _any_ user-facing change?

Yes, for DataSource V2 JDBC queries with both table sample pushdown and join pushdown enabled.

Previously, Spark did not push down joins when either side had a real pushed table sample. After this change, JDBC can push down such joins while preserving the table sample clause in the generated SQL.

There is no new public API. The existing `SupportsPushDownJoin` contract is clarified for connectors that hold previously pushed state.

### How was this patch tested?

Added and updated tests in:

- `DataSourceV2TableSampleSuite`
- `JDBCSuite`
- in-memory test connector/catalog fixtures for sample and join pushdown behavior

Ran:

```bash
build/sbt 'sql/Test/compile'
build/sbt 'sql/testOnly *DataSourceV2TableSampleSuite -- -z SPARK-56504' 'sql/testOnly org.apache.spark.sql.jdbc.JDBCSuite -- -z SPARK-56504'
```
### Was this patch authored or co-authored using generative AI tooling?
Generated-by: OpenAI Codex GPT 5.5