### PR TITLE
[SPARK-57339][SQL] Format nanosecond-precision timestamp literals in Literal.toString and Literal.sql

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -570,10 +570,6 @@ case class Literal (value: Any, dataType: DataType) extends LeafExpression {
           ExprCode.forNonNullValue(JavaCode.expression(s"($javaType)$value", dataType))
         case TimestampType | TimestampNTZType | LongType | _: DayTimeIntervalType | _: TimeType =>
           toExprCode(s"${value}L")
-        case (_: TimestampNTZNanosType | _: TimestampLTZNanosType)
-            if TypeOps(dataType).isDefined =>
-          ExprCode.forNonNullValue(
-            JavaCode.expression(TypeOps(dataType).get.getJavaLiteral(value), dataType))
         case _ =>
           val constRef = ctx.addReferenceObj("literal", value, javaType)
           ExprCode.forNonNullValue(JavaCode.global(constRef, dataType))
@@ -589,7 +585,7 @@ case class Literal (value: Any, dataType: DataType) extends LeafExpression {
       val fracLen = ts.length - dotIdx - 1
       // fracLen can never exceed precision: formatNanos/formatWithoutTimeZoneNanos truncate
       // the value to `precision` digits before formatting, and the fractionFormatter only
-      // strips trailing zeros (never adds digits). The else branch is a defensive fallback.
+      // strips trailing zeros (never adds digits); the else branch handles fracLen == precision.
       if (fracLen < precision) ts + "0" * (precision - fracLen) else ts
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -475,6 +475,12 @@ case class Literal (value: Any, dataType: DataType) extends LeafExpression {
           TimestampFormatter.getFractionFormatter(timeZoneId).format(value.asInstanceOf[Long])
         case TimestampNTZType =>
           TimestampFormatter.getFractionFormatter(ZoneOffset.UTC).format(value.asInstanceOf[Long])
+        case t: TimestampNTZNanosType =>
+          TimestampFormatter.getFractionFormatter(ZoneOffset.UTC)
+            .formatWithoutTimeZoneNanos(value.asInstanceOf[TimestampNanosVal], t.precision)
+        case t: TimestampLTZNanosType =>
+          TimestampFormatter.getFractionFormatter(timeZoneId)
+            .formatNanos(value.asInstanceOf[TimestampNanosVal], t.precision)
         case DayTimeIntervalType(startField, endField) =>
           toDayTimeIntervalString(value.asInstanceOf[Long], ANSI_STYLE, startField, endField)
         case YearMonthIntervalType(startField, endField) =>
@@ -518,6 +524,8 @@ case class Literal (value: Any, dataType: DataType) extends LeafExpression {
       case (null, _) => JNull
       case (i: Int, DateType) => JString(toString)
       case (l: Long, TimestampType | _: TimeType) => JString(toString)
+      case (_: TimestampNanosVal, _: TimestampNTZNanosType | _: TimestampLTZNanosType) =>
+        JString(toString)
       case (other, _) => JString(other.toString)
     }
     ("value" -> jsonValue) :: ("dataType" -> dataType.jsonValue) :: Nil
@@ -562,10 +570,27 @@ case class Literal (value: Any, dataType: DataType) extends LeafExpression {
           ExprCode.forNonNullValue(JavaCode.expression(s"($javaType)$value", dataType))
         case TimestampType | TimestampNTZType | LongType | _: DayTimeIntervalType | _: TimeType =>
           toExprCode(s"${value}L")
+        case (_: TimestampNTZNanosType | _: TimestampLTZNanosType)
+            if TypeOps(dataType).isDefined =>
+          ExprCode.forNonNullValue(
+            JavaCode.expression(TypeOps(dataType).get.getJavaLiteral(value), dataType))
         case _ =>
           val constRef = ctx.addReferenceObj("literal", value, javaType)
           ExprCode.forNonNullValue(JavaCode.global(constRef, dataType))
       }
+    }
+  }
+
+  private def padToNanosPrecision(ts: String, precision: Int): String = {
+    val dotIdx = ts.indexOf('.')
+    if (dotIdx < 0) {
+      ts + "." + "0" * precision
+    } else {
+      val fracLen = ts.length - dotIdx - 1
+      // fracLen can never exceed precision: formatNanos/formatWithoutTimeZoneNanos truncate
+      // the value to `precision` digits before formatting, and the fractionFormatter only
+      // strips trailing zeros (never adds digits). The else branch is a defensive fallback.
+      if (fracLen < precision) ts + "0" * (precision - fracLen) else ts
     }
   }
 
@@ -607,6 +632,12 @@ case class Literal (value: Any, dataType: DataType) extends LeafExpression {
       s"TIMESTAMP '$toString'"
     case (v: Long, TimestampNTZType) =>
       s"TIMESTAMP_NTZ '$toString'"
+    // toString strips trailing zeros (display-only); pad back to exactly `precision` digits
+    // here so the SQL literal round-trips correctly through the parser.
+    case (_: TimestampNanosVal, t: TimestampNTZNanosType) =>
+      s"TIMESTAMP_NTZ '${padToNanosPrecision(toString, t.precision)}'"
+    case (_: TimestampNanosVal, t: TimestampLTZNanosType) =>
+      s"TIMESTAMP_LTZ '${padToNanosPrecision(toString, t.precision)}'"
     case (i: CalendarInterval, CalendarIntervalType) =>
       s"INTERVAL '${i.toString}'"
     case (v: Array[Byte], BinaryType) => s"X'${HexFormat.of().withUpperCase().formatHex(v)}'"

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -171,6 +171,89 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
+  test("SPARK-57339: format nanosecond-precision timestamp literals in toString and sql") {
+    // UTC session timezone keeps LTZ and NTZ formatted strings identical for the same wall-clock.
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      val ldt = LocalDateTime.of(2020, 1, 1, 13, 24, 35, 123456789)
+      val instant = ldt.toInstant(ZoneOffset.UTC)
+
+      TimestampNanosTestUtils.foreachNanosPrecision { precision =>
+        val ltzType = TimestampLTZNanosType(precision)
+        val ntzType = TimestampNTZNanosType(precision)
+        val ltzVal = DateTimeUtils.instantToTimestampNanos(instant, precision)
+        val ntzVal = DateTimeUtils.localDateTimeToTimestampNanos(ldt, precision)
+        val ltzLit = Literal(ltzVal, ltzType)
+        val ntzLit = Literal(ntzVal, ntzType)
+
+        // ".123456789" truncated to `precision` fractional digits (trailing zeros stripped by
+        // the FractionTimestampFormatter, but "123456789" has none for p in [7,9]).
+        val frac = ".123456789".substring(0, 1 + precision)
+        val expected = s"2020-01-01 13:24:35$frac"
+
+        assert(ltzLit.toString === expected, s"LTZ toString at precision $precision")
+        assert(ntzLit.toString === expected, s"NTZ toString at precision $precision")
+        assert(ltzLit.sql === s"TIMESTAMP_LTZ '$expected'",
+          s"LTZ sql at precision $precision")
+        assert(ntzLit.sql === s"TIMESTAMP_NTZ '$expected'",
+          s"NTZ sql at precision $precision")
+
+        // Round-trip: parsing the sql output must reproduce the same literal value.
+        checkEvaluation(Literal.fromSQL(ltzLit.sql), ltzVal)
+        checkEvaluation(Literal.fromSQL(ntzLit.sql), ntzVal)
+
+        // Trailing-zero edge: nanosWithinMicro=0 means the formatter strips sub-micro digits.
+        // sql must still emit exactly `precision` fractional digits so the round-trip is correct.
+        val zeroNanosLdt = LocalDateTime.of(2020, 1, 1, 13, 24, 35, 123456000)
+        val zeroNanosInstant = zeroNanosLdt.toInstant(ZoneOffset.UTC)
+        val zeroNtzVal = DateTimeUtils.localDateTimeToTimestampNanos(zeroNanosLdt, precision)
+        val zeroLtzVal = DateTimeUtils.instantToTimestampNanos(zeroNanosInstant, precision)
+        val zeroNtzLit = Literal(zeroNtzVal, ntzType)
+        val zeroLtzLit = Literal(zeroLtzVal, ltzType)
+
+        assert(zeroNtzLit.sql.startsWith("TIMESTAMP_NTZ '"),
+          s"NTZ zero-nanos sql prefix at precision $precision")
+        assert(zeroLtzLit.sql.startsWith("TIMESTAMP_LTZ '"),
+          s"LTZ zero-nanos sql prefix at precision $precision")
+
+        val ntzFrac = zeroNtzLit.sql.dropWhile(_ != '.').takeWhile(_ != '\'')
+        val ltzFrac = zeroLtzLit.sql.dropWhile(_ != '.').takeWhile(_ != '\'')
+        assert(ntzFrac.length == precision + 1,
+          s"NTZ zero-nanos sql must have exactly $precision fractional digits, got: $ntzFrac")
+        assert(ltzFrac.length == precision + 1,
+          s"LTZ zero-nanos sql must have exactly $precision fractional digits, got: $ltzFrac")
+
+        // toString strips trailing zeros (display-only, no padding) - same for all precisions.
+        assert(zeroNtzLit.toString === "2020-01-01 13:24:35.123456",
+          s"NTZ zero-nanos toString at precision $precision (display strips trailing zeros)")
+        assert(zeroLtzLit.toString === "2020-01-01 13:24:35.123456",
+          s"LTZ zero-nanos toString at precision $precision (display strips trailing zeros)")
+
+        checkEvaluation(Literal.fromSQL(zeroNtzLit.sql), zeroNtzVal)
+        checkEvaluation(Literal.fromSQL(zeroLtzLit.sql), zeroLtzVal)
+
+        // Whole-second edge: no fractional part at all. padToNanosPrecision must insert
+        // "." + zeros so the SQL literal carries exactly `precision` fractional digits.
+        val wholeLdt = LocalDateTime.of(2020, 1, 1, 13, 24, 35, 0)
+        val wholeInstant = wholeLdt.toInstant(ZoneOffset.UTC)
+        val wholeNtzVal = DateTimeUtils.localDateTimeToTimestampNanos(wholeLdt, precision)
+        val wholeLtzVal = DateTimeUtils.instantToTimestampNanos(wholeInstant, precision)
+        val wholeNtzLit = Literal(wholeNtzVal, ntzType)
+        val wholeLtzLit = Literal(wholeLtzVal, ltzType)
+
+        assert(wholeNtzLit.toString === "2020-01-01 13:24:35",
+          s"NTZ whole-second toString at precision $precision")
+        assert(wholeLtzLit.toString === "2020-01-01 13:24:35",
+          s"LTZ whole-second toString at precision $precision")
+        assert(wholeNtzLit.sql === s"TIMESTAMP_NTZ '2020-01-01 13:24:35.${"0" * precision}'",
+          s"NTZ whole-second sql at precision $precision")
+        assert(wholeLtzLit.sql === s"TIMESTAMP_LTZ '2020-01-01 13:24:35.${"0" * precision}'",
+          s"LTZ whole-second sql at precision $precision")
+        checkEvaluation(Literal.fromSQL(wholeNtzLit.sql), wholeNtzVal)
+        checkEvaluation(Literal.fromSQL(wholeLtzLit.sql), wholeLtzVal)
+      }
+    }
+  }
+
   test("boolean literals") {
     checkEvaluation(Literal(true), true)
     checkEvaluation(Literal(false), false)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ltz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ltz-nanos.sql.out
@@ -121,21 +121,21 @@ Project [named_struct(f, cast(null as timestamp_ltz(9))) AS named_struct(f, CAST
 -- !query
 SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [hour(cast(TimestampNanosVal(1577913875123456, 789) as timestamp), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(1577913875123456, 789))#x]
+Project [hour(cast(2020-01-01 13:24:35.123456789 as timestamp), Some(America/Los_Angeles)) AS hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [minute(cast(TimestampNanosVal(1577913875123456, 789) as timestamp), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(1577913875123456, 789))#x]
+Project [minute(cast(2020-01-01 13:24:35.123456789 as timestamp), Some(America/Los_Angeles)) AS minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [second(cast(TimestampNanosVal(1577913875123456, 789) as timestamp), Some(America/Los_Angeles)) AS second(TimestampNanosVal(1577913875123456, 789))#x]
+Project [second(cast(2020-01-01 13:24:35.123456789 as timestamp), Some(America/Los_Angeles)) AS second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
@@ -163,63 +163,63 @@ Project [hour(cast(cast(null as timestamp_ltz(9)) as timestamp), Some(America/Lo
 -- !query
 SELECT hour(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
 -- !query analysis
-Project [hour(cast(TimestampNanosVal(-315542124876544, 789) as timestamp), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(-315542124876544, 789))#x]
+Project [hour(cast(1960-01-01 13:24:35.123456789 as timestamp), Some(America/Los_Angeles)) AS hour(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT minute(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
 -- !query analysis
-Project [minute(cast(TimestampNanosVal(-315542124876544, 789) as timestamp), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(-315542124876544, 789))#x]
+Project [minute(cast(1960-01-01 13:24:35.123456789 as timestamp), Some(America/Los_Angeles)) AS minute(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT second(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
 -- !query analysis
-Project [second(cast(TimestampNanosVal(-315542124876544, 789) as timestamp), Some(America/Los_Angeles)) AS second(TimestampNanosVal(-315542124876544, 789))#x]
+Project [second(cast(1960-01-01 13:24:35.123456789 as timestamp), Some(America/Los_Angeles)) AS second(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
 -- !query analysis
-Project [hour(cast(TimestampNanosVal(1577865275123456, 789) as timestamp), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(1577865275123456, 789))#x]
+Project [hour(cast(2019-12-31 23:54:35.123456789 as timestamp), Some(America/Los_Angeles)) AS hour(TIMESTAMP_LTZ '2019-12-31 23:54:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
 -- !query analysis
-Project [minute(cast(TimestampNanosVal(1577865275123456, 789) as timestamp), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(1577865275123456, 789))#x]
+Project [minute(cast(2019-12-31 23:54:35.123456789 as timestamp), Some(America/Los_Angeles)) AS minute(TIMESTAMP_LTZ '2019-12-31 23:54:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
 -- !query analysis
-Project [second(cast(TimestampNanosVal(1577865275123456, 789) as timestamp), Some(America/Los_Angeles)) AS second(TimestampNanosVal(1577865275123456, 789))#x]
+Project [second(cast(2019-12-31 23:54:35.123456789 as timestamp), Some(America/Los_Angeles)) AS second(TIMESTAMP_LTZ '2019-12-31 23:54:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
 -- !query analysis
-Project [hour(cast(TimestampNanosVal(1577885075123456, 789) as timestamp), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(1577885075123456, 789))#x]
+Project [hour(cast(2020-01-01 05:24:35.123456789 as timestamp), Some(America/Los_Angeles)) AS hour(TIMESTAMP_LTZ '2020-01-01 05:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
 -- !query analysis
-Project [minute(cast(TimestampNanosVal(1577885075123456, 789) as timestamp), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(1577885075123456, 789))#x]
+Project [minute(cast(2020-01-01 05:24:35.123456789 as timestamp), Some(America/Los_Angeles)) AS minute(TIMESTAMP_LTZ '2020-01-01 05:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
 -- !query analysis
-Project [second(cast(TimestampNanosVal(1577885075123456, 789) as timestamp), Some(America/Los_Angeles)) AS second(TimestampNanosVal(1577885075123456, 789))#x]
+Project [second(cast(2020-01-01 05:24:35.123456789 as timestamp), Some(America/Los_Angeles)) AS second(TIMESTAMP_LTZ '2020-01-01 05:24:35.123456789')#x]
 +- OneRowRelation
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ltz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ltz-nanos.sql.out
@@ -226,42 +226,42 @@ Project [second(cast(2020-01-01 05:24:35.123456789 as timestamp), Some(America/L
 -- !query
 SELECT extract(HOUR FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [extract(HOUR, TimestampNanosVal(1577913875123456, 789)) AS extract(HOUR FROM TimestampNanosVal(1577913875123456, 789))#x]
+Project [extract(HOUR, 2020-01-01 13:24:35.123456789) AS extract(HOUR FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT extract(MINUTE FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [extract(MINUTE, TimestampNanosVal(1577913875123456, 789)) AS extract(MINUTE FROM TimestampNanosVal(1577913875123456, 789))#x]
+Project [extract(MINUTE, 2020-01-01 13:24:35.123456789) AS extract(MINUTE FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT extract(SECOND FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [extract(SECOND, TimestampNanosVal(1577913875123456, 789)) AS extract(SECOND FROM TimestampNanosVal(1577913875123456, 789))#x]
+Project [extract(SECOND, 2020-01-01 13:24:35.123456789) AS extract(SECOND FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT date_part('HOUR', TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [date_part(HOUR, TimestampNanosVal(1577913875123456, 789)) AS date_part(HOUR, TimestampNanosVal(1577913875123456, 789))#x]
+Project [date_part(HOUR, 2020-01-01 13:24:35.123456789) AS date_part(HOUR, TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT date_part('MINUTE', TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [date_part(MINUTE, TimestampNanosVal(1577913875123456, 789)) AS date_part(MINUTE, TimestampNanosVal(1577913875123456, 789))#x]
+Project [date_part(MINUTE, 2020-01-01 13:24:35.123456789) AS date_part(MINUTE, TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT date_part('SECOND', TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [date_part(SECOND, TimestampNanosVal(1577913875123456, 789)) AS date_part(SECOND, TimestampNanosVal(1577913875123456, 789))#x]
+Project [date_part(SECOND, 2020-01-01 13:24:35.123456789) AS date_part(SECOND, TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
@@ -289,19 +289,19 @@ Project [extract(SECOND, cast(null as timestamp_ltz(9))) AS extract(SECOND FROM 
 -- !query
 SELECT extract(SECOND FROM TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
 -- !query analysis
-Project [extract(SECOND, TimestampNanosVal(-315542124876544, 789)) AS extract(SECOND FROM TimestampNanosVal(-315542124876544, 789))#x]
+Project [extract(SECOND, 1960-01-01 13:24:35.123456789) AS extract(SECOND FROM TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT extract(MINUTE FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
 -- !query analysis
-Project [extract(MINUTE, TimestampNanosVal(1577865275123456, 789)) AS extract(MINUTE FROM TimestampNanosVal(1577865275123456, 789))#x]
+Project [extract(MINUTE, 2019-12-31 23:54:35.123456789) AS extract(MINUTE FROM TIMESTAMP_LTZ '2019-12-31 23:54:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT extract(SECOND FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
 -- !query analysis
-Project [extract(SECOND, TimestampNanosVal(1577865275123456, 789)) AS extract(SECOND FROM TimestampNanosVal(1577865275123456, 789))#x]
+Project [extract(SECOND, 2019-12-31 23:54:35.123456789) AS extract(SECOND FROM TIMESTAMP_LTZ '2019-12-31 23:54:35.123456789')#x]
 +- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz-nanos.sql.out
@@ -121,21 +121,21 @@ Project [named_struct(f, cast(null as timestamp_ntz(9))) AS named_struct(f, CAST
 -- !query
 SELECT hour(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [hour(cast(TimestampNanosVal(1577885075123456, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(1577885075123456, 789))#x]
+Project [hour(cast(2020-01-01 13:24:35.123456789 as timestamp_ntz), Some(America/Los_Angeles)) AS hour(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT minute(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [minute(cast(TimestampNanosVal(1577885075123456, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(1577885075123456, 789))#x]
+Project [minute(cast(2020-01-01 13:24:35.123456789 as timestamp_ntz), Some(America/Los_Angeles)) AS minute(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT second(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [second(cast(TimestampNanosVal(1577885075123456, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS second(TimestampNanosVal(1577885075123456, 789))#x]
+Project [second(cast(2020-01-01 13:24:35.123456789 as timestamp_ntz), Some(America/Los_Angeles)) AS second(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
@@ -163,21 +163,21 @@ Project [hour(cast(cast(null as timestamp_ntz(9)) as timestamp_ntz), Some(Americ
 -- !query
 SELECT hour(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
 -- !query analysis
-Project [hour(cast(TimestampNanosVal(-315570924876544, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS hour(TimestampNanosVal(-315570924876544, 789))#x]
+Project [hour(cast(1960-01-01 13:24:35.123456789 as timestamp_ntz), Some(America/Los_Angeles)) AS hour(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT minute(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
 -- !query analysis
-Project [minute(cast(TimestampNanosVal(-315570924876544, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS minute(TimestampNanosVal(-315570924876544, 789))#x]
+Project [minute(cast(1960-01-01 13:24:35.123456789 as timestamp_ntz), Some(America/Los_Angeles)) AS minute(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT second(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
 -- !query analysis
-Project [second(cast(TimestampNanosVal(-315570924876544, 789) as timestamp_ntz), Some(America/Los_Angeles)) AS second(TimestampNanosVal(-315570924876544, 789))#x]
+Project [second(cast(1960-01-01 13:24:35.123456789 as timestamp_ntz), Some(America/Los_Angeles)) AS second(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz-nanos.sql.out
@@ -184,42 +184,42 @@ Project [second(cast(1960-01-01 13:24:35.123456789 as timestamp_ntz), Some(Ameri
 -- !query
 SELECT extract(HOUR FROM TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [extract(HOUR, TimestampNanosVal(1577885075123456, 789)) AS extract(HOUR FROM TimestampNanosVal(1577885075123456, 789))#x]
+Project [extract(HOUR, 2020-01-01 13:24:35.123456789) AS extract(HOUR FROM TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT extract(MINUTE FROM TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [extract(MINUTE, TimestampNanosVal(1577885075123456, 789)) AS extract(MINUTE FROM TimestampNanosVal(1577885075123456, 789))#x]
+Project [extract(MINUTE, 2020-01-01 13:24:35.123456789) AS extract(MINUTE FROM TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT extract(SECOND FROM TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [extract(SECOND, TimestampNanosVal(1577885075123456, 789)) AS extract(SECOND FROM TimestampNanosVal(1577885075123456, 789))#x]
+Project [extract(SECOND, 2020-01-01 13:24:35.123456789) AS extract(SECOND FROM TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT date_part('HOUR', TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [date_part(HOUR, TimestampNanosVal(1577885075123456, 789)) AS date_part(HOUR, TimestampNanosVal(1577885075123456, 789))#x]
+Project [date_part(HOUR, 2020-01-01 13:24:35.123456789) AS date_part(HOUR, TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT date_part('MINUTE', TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [date_part(MINUTE, TimestampNanosVal(1577885075123456, 789)) AS date_part(MINUTE, TimestampNanosVal(1577885075123456, 789))#x]
+Project [date_part(MINUTE, 2020-01-01 13:24:35.123456789) AS date_part(MINUTE, TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
 -- !query
 SELECT date_part('SECOND', TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query analysis
-Project [date_part(SECOND, TimestampNanosVal(1577885075123456, 789)) AS date_part(SECOND, TimestampNanosVal(1577885075123456, 789))#x]
+Project [date_part(SECOND, 2020-01-01 13:24:35.123456789) AS date_part(SECOND, TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')#x]
 +- OneRowRelation
 
 
@@ -247,5 +247,5 @@ Project [extract(SECOND, cast(null as timestamp_ntz(9))) AS extract(SECOND FROM 
 -- !query
 SELECT extract(SECOND FROM TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
 -- !query analysis
-Project [extract(SECOND, TimestampNanosVal(-315570924876544, 789)) AS extract(SECOND FROM TimestampNanosVal(-315570924876544, 789))#x]
+Project [extract(SECOND, 1960-01-01 13:24:35.123456789) AS extract(SECOND FROM TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')#x]
 +- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ltz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ltz-nanos.sql.out
@@ -258,7 +258,7 @@ struct<second(TIMESTAMP_LTZ '2020-01-01 05:24:35.123456789'):int>
 -- !query
 SELECT extract(HOUR FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<extract(HOUR FROM TimestampNanosVal(1577913875123456, 789)):int>
+struct<extract(HOUR FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789'):int>
 -- !query output
 13
 
@@ -266,7 +266,7 @@ struct<extract(HOUR FROM TimestampNanosVal(1577913875123456, 789)):int>
 -- !query
 SELECT extract(MINUTE FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<extract(MINUTE FROM TimestampNanosVal(1577913875123456, 789)):int>
+struct<extract(MINUTE FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789'):int>
 -- !query output
 24
 
@@ -274,7 +274,7 @@ struct<extract(MINUTE FROM TimestampNanosVal(1577913875123456, 789)):int>
 -- !query
 SELECT extract(SECOND FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<extract(SECOND FROM TimestampNanosVal(1577913875123456, 789)):decimal(11,9)>
+struct<extract(SECOND FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789'):decimal(11,9)>
 -- !query output
 35.123456789
 
@@ -282,7 +282,7 @@ struct<extract(SECOND FROM TimestampNanosVal(1577913875123456, 789)):decimal(11,
 -- !query
 SELECT date_part('HOUR', TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<date_part(HOUR, TimestampNanosVal(1577913875123456, 789)):int>
+struct<date_part(HOUR, TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789'):int>
 -- !query output
 13
 
@@ -290,7 +290,7 @@ struct<date_part(HOUR, TimestampNanosVal(1577913875123456, 789)):int>
 -- !query
 SELECT date_part('MINUTE', TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<date_part(MINUTE, TimestampNanosVal(1577913875123456, 789)):int>
+struct<date_part(MINUTE, TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789'):int>
 -- !query output
 24
 
@@ -298,7 +298,7 @@ struct<date_part(MINUTE, TimestampNanosVal(1577913875123456, 789)):int>
 -- !query
 SELECT date_part('SECOND', TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<date_part(SECOND, TimestampNanosVal(1577913875123456, 789)):decimal(11,9)>
+struct<date_part(SECOND, TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789'):decimal(11,9)>
 -- !query output
 35.123456789
 
@@ -330,7 +330,7 @@ NULL
 -- !query
 SELECT extract(SECOND FROM TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
 -- !query schema
-struct<extract(SECOND FROM TimestampNanosVal(-315542124876544, 789)):decimal(11,9)>
+struct<extract(SECOND FROM TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789'):decimal(11,9)>
 -- !query output
 35.123456789
 
@@ -338,7 +338,7 @@ struct<extract(SECOND FROM TimestampNanosVal(-315542124876544, 789)):decimal(11,
 -- !query
 SELECT extract(MINUTE FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
 -- !query schema
-struct<extract(MINUTE FROM TimestampNanosVal(1577865275123456, 789)):int>
+struct<extract(MINUTE FROM TIMESTAMP_LTZ '2019-12-31 23:54:35.123456789'):int>
 -- !query output
 54
 
@@ -346,6 +346,6 @@ struct<extract(MINUTE FROM TimestampNanosVal(1577865275123456, 789)):int>
 -- !query
 SELECT extract(SECOND FROM TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
 -- !query schema
-struct<extract(SECOND FROM TimestampNanosVal(1577865275123456, 789)):decimal(11,9)>
+struct<extract(SECOND FROM TIMESTAMP_LTZ '2019-12-31 23:54:35.123456789'):decimal(11,9)>
 -- !query output
 35.123456789

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ltz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ltz-nanos.sql.out
@@ -138,7 +138,7 @@ struct<named_struct(f, CAST(NULL AS TIMESTAMP_LTZ(9))):struct<f:timestamp_ltz(9)
 -- !query
 SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<hour(TimestampNanosVal(1577913875123456, 789)):int>
+struct<hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789'):int>
 -- !query output
 13
 
@@ -146,7 +146,7 @@ struct<hour(TimestampNanosVal(1577913875123456, 789)):int>
 -- !query
 SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<minute(TimestampNanosVal(1577913875123456, 789)):int>
+struct<minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789'):int>
 -- !query output
 24
 
@@ -154,7 +154,7 @@ struct<minute(TimestampNanosVal(1577913875123456, 789)):int>
 -- !query
 SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<second(TimestampNanosVal(1577913875123456, 789)):int>
+struct<second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789'):int>
 -- !query output
 35
 
@@ -186,7 +186,7 @@ NULL
 -- !query
 SELECT hour(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
 -- !query schema
-struct<hour(TimestampNanosVal(-315542124876544, 789)):int>
+struct<hour(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789'):int>
 -- !query output
 13
 
@@ -194,7 +194,7 @@ struct<hour(TimestampNanosVal(-315542124876544, 789)):int>
 -- !query
 SELECT minute(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
 -- !query schema
-struct<minute(TimestampNanosVal(-315542124876544, 789)):int>
+struct<minute(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789'):int>
 -- !query output
 24
 
@@ -202,7 +202,7 @@ struct<minute(TimestampNanosVal(-315542124876544, 789)):int>
 -- !query
 SELECT second(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789')
 -- !query schema
-struct<second(TimestampNanosVal(-315542124876544, 789)):int>
+struct<second(TIMESTAMP_LTZ '1960-01-01 13:24:35.123456789'):int>
 -- !query output
 35
 
@@ -210,7 +210,7 @@ struct<second(TimestampNanosVal(-315542124876544, 789)):int>
 -- !query
 SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
 -- !query schema
-struct<hour(TimestampNanosVal(1577865275123456, 789)):int>
+struct<hour(TIMESTAMP_LTZ '2019-12-31 23:54:35.123456789'):int>
 -- !query output
 23
 
@@ -218,7 +218,7 @@ struct<hour(TimestampNanosVal(1577865275123456, 789)):int>
 -- !query
 SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
 -- !query schema
-struct<minute(TimestampNanosVal(1577865275123456, 789)):int>
+struct<minute(TIMESTAMP_LTZ '2019-12-31 23:54:35.123456789'):int>
 -- !query output
 54
 
@@ -226,7 +226,7 @@ struct<minute(TimestampNanosVal(1577865275123456, 789)):int>
 -- !query
 SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 Asia/Kolkata')
 -- !query schema
-struct<second(TimestampNanosVal(1577865275123456, 789)):int>
+struct<second(TIMESTAMP_LTZ '2019-12-31 23:54:35.123456789'):int>
 -- !query output
 35
 
@@ -234,7 +234,7 @@ struct<second(TimestampNanosVal(1577865275123456, 789)):int>
 -- !query
 SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
 -- !query schema
-struct<hour(TimestampNanosVal(1577885075123456, 789)):int>
+struct<hour(TIMESTAMP_LTZ '2020-01-01 05:24:35.123456789'):int>
 -- !query output
 5
 
@@ -242,7 +242,7 @@ struct<hour(TimestampNanosVal(1577885075123456, 789)):int>
 -- !query
 SELECT minute(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
 -- !query schema
-struct<minute(TimestampNanosVal(1577885075123456, 789)):int>
+struct<minute(TIMESTAMP_LTZ '2020-01-01 05:24:35.123456789'):int>
 -- !query output
 24
 
@@ -250,7 +250,7 @@ struct<minute(TimestampNanosVal(1577885075123456, 789)):int>
 -- !query
 SELECT second(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789 UTC')
 -- !query schema
-struct<second(TimestampNanosVal(1577885075123456, 789)):int>
+struct<second(TIMESTAMP_LTZ '2020-01-01 05:24:35.123456789'):int>
 -- !query output
 35
 

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ntz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ntz-nanos.sql.out
@@ -138,7 +138,7 @@ struct<named_struct(f, CAST(NULL AS TIMESTAMP_NTZ(9))):struct<f:timestamp_ntz(9)
 -- !query
 SELECT hour(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<hour(TimestampNanosVal(1577885075123456, 789)):int>
+struct<hour(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789'):int>
 -- !query output
 13
 
@@ -146,7 +146,7 @@ struct<hour(TimestampNanosVal(1577885075123456, 789)):int>
 -- !query
 SELECT minute(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<minute(TimestampNanosVal(1577885075123456, 789)):int>
+struct<minute(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789'):int>
 -- !query output
 24
 
@@ -154,7 +154,7 @@ struct<minute(TimestampNanosVal(1577885075123456, 789)):int>
 -- !query
 SELECT second(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<second(TimestampNanosVal(1577885075123456, 789)):int>
+struct<second(TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789'):int>
 -- !query output
 35
 
@@ -186,7 +186,7 @@ NULL
 -- !query
 SELECT hour(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
 -- !query schema
-struct<hour(TimestampNanosVal(-315570924876544, 789)):int>
+struct<hour(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789'):int>
 -- !query output
 13
 
@@ -194,7 +194,7 @@ struct<hour(TimestampNanosVal(-315570924876544, 789)):int>
 -- !query
 SELECT minute(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
 -- !query schema
-struct<minute(TimestampNanosVal(-315570924876544, 789)):int>
+struct<minute(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789'):int>
 -- !query output
 24
 
@@ -202,7 +202,7 @@ struct<minute(TimestampNanosVal(-315570924876544, 789)):int>
 -- !query
 SELECT second(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
 -- !query schema
-struct<second(TimestampNanosVal(-315570924876544, 789)):int>
+struct<second(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789'):int>
 -- !query output
 35
 

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ntz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ntz-nanos.sql.out
@@ -210,7 +210,7 @@ struct<second(TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789'):int>
 -- !query
 SELECT extract(HOUR FROM TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<extract(HOUR FROM TimestampNanosVal(1577885075123456, 789)):int>
+struct<extract(HOUR FROM TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789'):int>
 -- !query output
 13
 
@@ -218,7 +218,7 @@ struct<extract(HOUR FROM TimestampNanosVal(1577885075123456, 789)):int>
 -- !query
 SELECT extract(MINUTE FROM TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<extract(MINUTE FROM TimestampNanosVal(1577885075123456, 789)):int>
+struct<extract(MINUTE FROM TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789'):int>
 -- !query output
 24
 
@@ -226,7 +226,7 @@ struct<extract(MINUTE FROM TimestampNanosVal(1577885075123456, 789)):int>
 -- !query
 SELECT extract(SECOND FROM TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<extract(SECOND FROM TimestampNanosVal(1577885075123456, 789)):decimal(11,9)>
+struct<extract(SECOND FROM TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789'):decimal(11,9)>
 -- !query output
 35.123456789
 
@@ -234,7 +234,7 @@ struct<extract(SECOND FROM TimestampNanosVal(1577885075123456, 789)):decimal(11,
 -- !query
 SELECT date_part('HOUR', TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<date_part(HOUR, TimestampNanosVal(1577885075123456, 789)):int>
+struct<date_part(HOUR, TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789'):int>
 -- !query output
 13
 
@@ -242,7 +242,7 @@ struct<date_part(HOUR, TimestampNanosVal(1577885075123456, 789)):int>
 -- !query
 SELECT date_part('MINUTE', TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<date_part(MINUTE, TimestampNanosVal(1577885075123456, 789)):int>
+struct<date_part(MINUTE, TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789'):int>
 -- !query output
 24
 
@@ -250,7 +250,7 @@ struct<date_part(MINUTE, TimestampNanosVal(1577885075123456, 789)):int>
 -- !query
 SELECT date_part('SECOND', TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789')
 -- !query schema
-struct<date_part(SECOND, TimestampNanosVal(1577885075123456, 789)):decimal(11,9)>
+struct<date_part(SECOND, TIMESTAMP_NTZ '2020-01-01 13:24:35.123456789'):decimal(11,9)>
 -- !query output
 35.123456789
 
@@ -282,6 +282,6 @@ NULL
 -- !query
 SELECT extract(SECOND FROM TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789')
 -- !query schema
-struct<extract(SECOND FROM TimestampNanosVal(-315570924876544, 789)):decimal(11,9)>
+struct<extract(SECOND FROM TIMESTAMP_NTZ '1960-01-01 13:24:35.123456789'):decimal(11,9)>
 -- !query output
 35.123456789


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
As part of the nanosecond timestamp preview (SPARK-56822), `TIMESTAMP_NTZ(p)` and `TIMESTAMP_LTZ(p)` (with p in [7, 9]) are represented internally by `TimestampNanosVal`. However, `Literal.toString` and `Literal.sql` had no dedicated cases for these types and fell through to generic defaults.

This PR adds explicit cases for both nanosecond timestamp types in `Literal.toString` and `Literal.sql`, consistent with how the microsecond types (`TimestampType`, `TimestampNTZType`) are handled. It also fixes the jsonFields match site in Literal that had the same missing nanos case. The doGenCode path intentionally relies on the existing default addReferenceObj object path — no nanos-specific codegen case is needed.

This PR [56455](https://github.com/apache/spark/pull/56455) was reverted due to a recent Golden file conflict on the main branch. So, raising a new PR with the latest master branch changes 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The raw `TimestampNanosVal` representation was leaking into user-facing output such as analyzed plans, schemas, and generated SQL. For example, the analyzer result of:
```
SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
```
produced:
```
Project [hour(cast(TimestampNanosVal(1577913875123456, 789) as timestamp), ...) AS hour(TimestampNanosVal(1577913875123456, 789))#x]
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, within the unreleased nanosecond timestamp preview on master.

Before:
```
SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
-- schema: struct<hour(TimestampNanosVal(1577913875123456, 789)):int>
```

After:
```
SELECT hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789')
-- schema: struct<hour(TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789'):int>
```

`Literal.toString` now renders a formatted timestamp string with up to 9 fractional digits, and `Literal.sql` emits typed literals such as `TIMESTAMP_NTZ '2018-02-14 12:58:59.123456789'` / `TIMESTAMP_LTZ '2020-01-01 13:24:35.123456789'`.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
A new unit test was added to LiteralExpressionSuite, covering:

- toString and .sql output correctness for TIMESTAMP_NTZ(p) and TIMESTAMP_LTZ(p) at each precision p in [7, 9]
- Round-trip correctness: Literal.fromSQL(lit.sql) must evaluate back to the original stored value
- Trailing-zero edge case: timestamps where sub-microsecond digits are zero (e.g. nanosWithinMicro = 0) must still emit exactly precision fractional digits in SQL output and round-trip correctly

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Sonnet 4.6