### PR TITLE
[SPARK-57435][CORE][SQL][K8S] Avoid fully-qualified `o.a.s.internal.config` reference repetition

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonUtils.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonUtils.scala
@@ -30,6 +30,7 @@ import org.apache.spark.{SparkContext, SparkEnv}
 import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{PATH, PYTHON_PACKAGES, PYTHON_VERSION}
+import org.apache.spark.internal.config._
 import org.apache.spark.util.ArrayImplicits.SparkArrayOps
 import org.apache.spark.util.Utils
 
@@ -86,23 +87,23 @@ private[spark] object PythonUtils extends Logging {
   }
 
   def isEncryptionEnabled(sc: JavaSparkContext): Boolean = {
-    sc.conf.get(org.apache.spark.internal.config.IO_ENCRYPTION_ENABLED)
+    sc.conf.get(IO_ENCRYPTION_ENABLED)
   }
 
   def getBroadcastThreshold(sc: JavaSparkContext): Long = {
-    sc.conf.get(org.apache.spark.internal.config.BROADCAST_FOR_UDF_COMPRESSION_THRESHOLD)
+    sc.conf.get(BROADCAST_FOR_UDF_COMPRESSION_THRESHOLD)
   }
 
   def getPythonAuthSocketTimeout(sc: JavaSparkContext): Long = {
-    sc.conf.get(org.apache.spark.internal.config.Python.PYTHON_AUTH_SOCKET_TIMEOUT)
+    sc.conf.get(Python.PYTHON_AUTH_SOCKET_TIMEOUT)
   }
 
   def getSparkBufferSize(sc: JavaSparkContext): Int = {
-    sc.conf.get(org.apache.spark.internal.config.BUFFER_SIZE)
+    sc.conf.get(BUFFER_SIZE)
   }
 
   def logPythonInfo(pythonExec: String): Unit = {
-    if (SparkEnv.get.conf.get(org.apache.spark.internal.config.Python.PYTHON_LOG_INFO)) {
+    if (SparkEnv.get.conf.get(Python.PYTHON_LOG_INFO)) {
       import scala.sys.process._
       def runCommand(process: ProcessBuilder): Option[String] = {
         try {

--- a/core/src/main/scala/org/apache/spark/api/r/RUtils.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RUtils.scala
@@ -108,7 +108,7 @@ private[spark] object RUtils {
   }
 
   def isEncryptionEnabled(sc: JavaSparkContext): Boolean = {
-    sc.conf.get(org.apache.spark.internal.config.IO_ENCRYPTION_ENABLED)
+    sc.conf.get(IO_ENCRYPTION_ENABLED)
   }
 
   def getJobTags(sc: JavaSparkContext): Array[String] = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStep.scala
@@ -51,8 +51,8 @@ import org.apache.spark.util.Utils
 private[spark] class KerberosConfDriverFeatureStep(kubernetesConf: KubernetesDriverConf)
   extends KubernetesFeatureConfigStep with Logging {
 
-  private val principal = kubernetesConf.get(org.apache.spark.internal.config.PRINCIPAL)
-  private val keytab = kubernetesConf.get(org.apache.spark.internal.config.KEYTAB)
+  private val principal = kubernetesConf.get(PRINCIPAL)
+  private val keytab = kubernetesConf.get(KEYTAB)
   private val existingSecretName = kubernetesConf.get(KUBERNETES_KERBEROS_DT_SECRET_NAME)
   private val existingSecretItemKey = kubernetesConf.get(KUBERNETES_KERBEROS_DT_SECRET_ITEM_KEY)
   private val krb5File = kubernetesConf.get(KUBERNETES_KERBEROS_KRB5_FILE)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4991,7 +4991,7 @@ object SQLConf {
         "dummy value. This is currently used to redact the output of SQL explain commands. " +
         "When this conf is not set, the value from `spark.redaction.string.regex` is used.")
       .version("2.3.0")
-      .fallbackConf(org.apache.spark.internal.config.STRING_REDACTION_PATTERN)
+      .fallbackConf(STRING_REDACTION_PATTERN)
 
   val SQL_SCRIPTING_ENABLED =
     buildConf("spark.sql.scripting.enabled")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces redundant fully-qualified `org.apache.spark.internal.config.*` references with the short names available through the package wildcard import.

- `KerberosConfDriverFeatureStep`, `RUtils`, and `SQLConf` already wildcard-import `org.apache.spark.internal.config._`, so the redundant prefix is simply dropped.
- `PythonUtils` adds the wildcard import and then drops the prefix in 5 references (including the `Python.*` members).

### Why are the changes needed?

The fully-qualified references are redundant and inconsistent with the surrounding code, which already uses the imported short names. This is a code cleanup with no functional change.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)