### PR TITLE
[SPARK-57425][CONNECT] Fix reattach iterator to recover from expired credentials mid-stream

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -1202,6 +1202,7 @@ pyspark_connect = Module(
         "pyspark.sql.tests.connect.client.test_client_call_stack_trace",
         "pyspark.sql.tests.connect.client.test_client_retries",
         "pyspark.sql.tests.connect.client.test_reattach",
+        "pyspark.sql.tests.connect.client.test_reattach_credential_refresh",
         "pyspark.sql.tests.connect.test_parity_resources",
         "pyspark.sql.tests.connect.shell.test_progress",
         "pyspark.sql.tests.connect.test_df_debug",

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1566,7 +1566,7 @@ class SparkConnectClient(object):
                     req,
                     self._stub,
                     self._retrying,
-                    self._builder.metadata(),
+                    self._builder.metadata,
                     reattachable_execute_plan_timeout=self._rpc_deadlines.reattachable_execute_plan,
                     reattach_execute_timeout=self._rpc_deadlines.reattach_execute,
                 )
@@ -1781,7 +1781,7 @@ class SparkConnectClient(object):
                     req,
                     self._stub,
                     self._retrying,
-                    self._builder.metadata(),
+                    self._builder.metadata,
                     reattachable_execute_plan_timeout=self._rpc_deadlines.reattachable_execute_plan,
                     reattach_execute_timeout=self._rpc_deadlines.reattach_execute,
                 )

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -19,7 +19,7 @@ from pyspark.sql.connect.client.retries import Retrying, RetryException
 from threading import RLock
 import uuid
 from collections.abc import Generator
-from typing import Optional, Any, Iterator, Iterable, Tuple, Callable, cast, ClassVar
+from typing import Optional, Any, Iterator, Iterable, Tuple, Callable, Union, cast, ClassVar
 from concurrent.futures import Future, ThreadPoolExecutor
 import os
 import weakref
@@ -71,7 +71,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
         request: pb2.ExecutePlanRequest,
         stub: grpc_lib.SparkConnectServiceStub,
         retrying: Callable[[], Retrying],
-        metadata: Iterable[Tuple[str, str]],
+        metadata: "Union[Iterable[Tuple[str, str]], Callable[[], Iterable[Tuple[str, str]]]]",
         reattachable_execute_plan_timeout: Optional[float] = None,
         reattach_execute_timeout: Optional[float] = None,
     ):
@@ -109,12 +109,16 @@ class ExecutePlanResponseReattachableIterator(Generator):
         # Initial iterator comes from ExecutePlan request.
         # Note: This is not retried, because no error would ever be thrown here, and GRPC will only
         # throw error on first self._has_next().
-        self._metadata = metadata
+        # Store metadata as a callable so credentials can be refreshed on reattach.
+        if callable(metadata):
+            self._metadata_callable = metadata
+        else:
+            self._metadata_callable = lambda: metadata
         with disable_gc():
             self._iterator: Optional[Iterator[pb2.ExecutePlanResponse]] = iter(
                 self._stub.ExecutePlan(
                     self._initial_request,
-                    metadata=metadata,
+                    metadata=self._metadata_callable(),
                     timeout=self._reattachable_execute_plan_timeout,
                 )
             )
@@ -222,7 +226,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
             try:
                 for attempt in self._retrying():
                     with attempt:
-                        self._stub.ReleaseExecute(request, metadata=self._metadata)
+                        self._stub.ReleaseExecute(request, metadata=self._metadata_callable())
             except Exception as e:
                 logger.warning(f"ReleaseExecute failed with exception: {e}.")
 
@@ -245,7 +249,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
             try:
                 for attempt in self._retrying():
                     with attempt:
-                        self._stub.ReleaseExecute(request, metadata=self._metadata)
+                        self._stub.ReleaseExecute(request, metadata=self._metadata_callable())
             except Exception as e:
                 logger.warning(f"ReleaseExecute failed with exception: {e}.")
 
@@ -265,7 +269,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
             self._iterator = iter(
                 self._stub.ReattachExecute(
                     self._create_reattach_execute_request(),
-                    metadata=self._metadata,
+                    metadata=self._metadata_callable(),
                     timeout=self._reattach_execute_timeout,
                 )
             )
@@ -295,7 +299,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
                 self._iterator = iter(
                     self._stub.ExecutePlan(
                         self._initial_request,
-                        metadata=self._metadata,
+                        metadata=self._metadata_callable(),
                         timeout=self._reattachable_execute_plan_timeout,
                     )
                 )

--- a/python/pyspark/sql/connect/client/retries.py
+++ b/python/pyspark/sql/connect/client/retries.py
@@ -364,6 +364,9 @@ class DefaultPolicy(RetryPolicy):
         if e.code() == grpc.StatusCode.UNAVAILABLE:
             return True
 
+        if e.code() in [grpc.StatusCode.UNAUTHENTICATED, grpc.StatusCode.PERMISSION_DENIED]:
+            return True
+
         if extract_retry_info(e) is not None:
             # All errors messages containing `RetryInfo` should be retried.
             return True

--- a/python/pyspark/sql/tests/connect/client/test_reattach_credential_refresh.py
+++ b/python/pyspark/sql/tests/connect/client/test_reattach_credential_refresh.py
@@ -1,0 +1,225 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Tests for SPARK-57425: Reattach iterator recovers when short-TTL
+credentials expire mid-stream.
+"""
+
+import unittest
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+
+if should_test_connect:
+    import grpc
+    import pyspark.sql.connect.proto as proto
+    from pyspark.sql.connect.client.reattach import ExecutePlanResponseReattachableIterator
+    from pyspark.sql.connect.client.retries import Retrying, DefaultPolicy
+
+
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
+class TestSPARK57425(unittest.TestCase):
+    """Tests for SPARK-57425 fix."""
+
+    def test_permission_denied_is_retryable(self):
+        """PERMISSION_DENIED should be retryable after the fix."""
+        policy = DefaultPolicy()
+
+        class PermDeniedError(grpc.RpcError, grpc.Call):
+            def code(self):
+                return grpc.StatusCode.PERMISSION_DENIED
+
+            def details(self):
+                return "Token expired"
+
+            def trailing_metadata(self):
+                return None
+
+        self.assertTrue(policy.can_retry(PermDeniedError()))
+
+    def test_unauthenticated_is_retryable(self):
+        """UNAUTHENTICATED should be retryable after the fix."""
+        policy = DefaultPolicy()
+
+        class UnauthError(grpc.RpcError, grpc.Call):
+            def code(self):
+                return grpc.StatusCode.UNAUTHENTICATED
+
+            def details(self):
+                return "Token expired"
+
+            def trailing_metadata(self):
+                return None
+
+        self.assertTrue(policy.can_retry(UnauthError()))
+
+    def test_metadata_refreshed_on_reattach(self):
+        """Metadata callable is invoked on each RPC so credentials are fresh."""
+        call_count = {"n": 0}
+
+        def refreshing_metadata():
+            call_count["n"] += 1
+            return [("authorization", f"Bearer token-v{call_count['n']}")]
+
+        metadata_log = []
+
+        class TrackingStub:
+            def ExecutePlan(self, request, metadata=None, timeout=None):
+                metadata_log.append(("execute", list(metadata) if metadata else []))
+                resp = proto.ExecutePlanResponse()
+                resp.session_id = "s"
+                resp.operation_id = request.operation_id
+                resp.response_id = "r1"
+                return iter([resp])  # no result_complete -> triggers reattach
+
+            def ReattachExecute(self, request, metadata=None, timeout=None):
+                metadata_log.append(("reattach", list(metadata) if metadata else []))
+                resp = proto.ExecutePlanResponse()
+                resp.session_id = "s"
+                resp.operation_id = request.operation_id
+                resp.response_id = "r2"
+                resp.result_complete.CopyFrom(proto.ExecutePlanResponse.ResultComplete())
+                return iter([resp])
+
+            def ReleaseExecute(self, request, metadata=None, timeout=None):
+                pass
+
+        req = proto.ExecutePlanRequest()
+        req.session_id = "s"
+        req.user_context.user_id = "u"
+
+        it = ExecutePlanResponseReattachableIterator(
+            request=req,
+            stub=TrackingStub(),
+            retrying=lambda: Retrying(DefaultPolicy()),
+            metadata=refreshing_metadata,  # callable!
+        )
+        list(it)
+
+        exec_md = [m for rpc, m in metadata_log if rpc == "execute"]
+        reattach_md = [m for rpc, m in metadata_log if rpc == "reattach"]
+
+        # Metadata should be DIFFERENT between execute and reattach (refreshed)
+        self.assertNotEqual(exec_md[0], reattach_md[0],
+                            "Reattach should use fresh metadata from callable")
+        self.assertIn("token-v1", exec_md[0][0][1])
+        # Reattach token version > 1 (exact number depends on interleaved ReleaseExecute calls)
+        self.assertNotIn("token-v1", reattach_md[0][0][1])
+
+    def test_static_metadata_still_works(self):
+        """Backwards compat: plain iterable metadata still works."""
+
+        class SimpleStub:
+            def ExecutePlan(self, request, metadata=None, timeout=None):
+                resp = proto.ExecutePlanResponse()
+                resp.session_id = "s"
+                resp.operation_id = request.operation_id
+                resp.response_id = "r1"
+                resp.result_complete.CopyFrom(proto.ExecutePlanResponse.ResultComplete())
+                return iter([resp])
+
+            def ReleaseExecute(self, request, metadata=None, timeout=None):
+                pass
+
+        req = proto.ExecutePlanRequest()
+        req.session_id = "s"
+        req.user_context.user_id = "u"
+
+        # Pass static metadata (old style) -- should still work
+        it = ExecutePlanResponseReattachableIterator(
+            request=req,
+            stub=SimpleStub(),
+            retrying=lambda: Retrying(DefaultPolicy()),
+            metadata=[("authorization", "Bearer static-token")],
+        )
+        responses = list(it)
+        self.assertEqual(len(responses), 1)
+
+    def test_permission_denied_triggers_reattach(self):
+        """After fix: PERMISSION_DENIED mid-stream triggers retry with fresh creds."""
+        call_count = {"n": 0}
+
+        def refreshing_metadata():
+            call_count["n"] += 1
+            return [("authorization", f"Bearer token-v{call_count['n']}")]
+
+        class RecoveringStub:
+            def __init__(self):
+                self.execute_count = 0
+
+            def ExecutePlan(self, request, metadata=None, timeout=None):
+                self.execute_count += 1
+
+                class Iter:
+                    def __init__(self, op_id, fail):
+                        self._op_id = op_id
+                        self._done = False
+                        self._fail = fail
+
+                    def __iter__(self):
+                        return self
+
+                    def __next__(self):
+                        if not self._done:
+                            self._done = True
+                            if self._fail:
+                                e = grpc.RpcError()
+                                e.code = lambda: grpc.StatusCode.PERMISSION_DENIED
+                                e.details = lambda: "Token expired"
+                                e.trailing_metadata = lambda: None
+                                raise e
+                            resp = proto.ExecutePlanResponse()
+                            resp.session_id = "s"
+                            resp.operation_id = self._op_id
+                            resp.response_id = "r1"
+                            resp.result_complete.CopyFrom(
+                                proto.ExecutePlanResponse.ResultComplete())
+                            return resp
+                        raise StopIteration()
+
+                # First call fails with PERMISSION_DENIED, second succeeds
+                return Iter(request.operation_id, fail=(self.execute_count == 1))
+
+            def ReattachExecute(self, request, metadata=None, timeout=None):
+                resp = proto.ExecutePlanResponse()
+                resp.session_id = "s"
+                resp.operation_id = request.operation_id
+                resp.response_id = "r2"
+                resp.result_complete.CopyFrom(proto.ExecutePlanResponse.ResultComplete())
+                return iter([resp])
+
+            def ReleaseExecute(self, request, metadata=None, timeout=None):
+                pass
+
+        stub = RecoveringStub()
+        req = proto.ExecutePlanRequest()
+        req.session_id = "s"
+        req.user_context.user_id = "u"
+
+        it = ExecutePlanResponseReattachableIterator(
+            request=req,
+            stub=stub,
+            retrying=lambda: Retrying(DefaultPolicy()),
+            metadata=refreshing_metadata,
+        )
+
+        # Should NOT raise -- PERMISSION_DENIED is now retried with fresh creds
+        responses = list(it)
+        self.assertEqual(len(responses), 1)
+
+
+if __name__ == "__main__":
+    from pyspark.testing import main
+    main()


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fix the reattachable execute iterator to recover when credentials expire mid-stream. Added two changes:
1. Add `UNAUTHENTICATED` and `PERMISSION_DENIED` as retryable gRPC status codes in `DefaultPolicy`.
2. Change `ExecutePlanResponseReattachableIterator` to accept `metadata` as a callable (in addition to a static iterable), invoking it fresh on every RPC so that retries use refreshed credentials instead of the stale token captured at construction time.

### Why are the changes needed?
`ExecutePlanResponseReattachableIterator` cannot recover when the server enforces a short auth-token TTL (e.g., 30 minutes). Two bugs prevent recovery:
1. `PERMISSION_DENIED` is not treated as retryable, so the retry loop never fires.
2. `self._metadata` is captured once at `__init__` and reused for all subsequent RPCs (ReattachExecute, ReleaseExecute). Even if retry were attempted, the stale token would fail again immediately.

This affects managed environments that combine short-lived tokens with long-running streams (e.g., AWS Athena Spark Connect with 30-min auth tokens).


### Does this PR introduce _any_ user-facing change?
Yes. Spark Connect Python client streams that previously died with `PERMISSION_DENIED` when credentials expired mid-stream now transparently retry with refreshed credentials and continue producing results.

### How was this patch tested?
New unit tests in `test_reattach_credential_refresh.py` covering:
1. `PERMISSION_DENIED` and `UNAUTHENTICATED` are retryable
2. Metadata callable is invoked fresh on each RPC (not reusing stale token)
3. Static metadata (backwards compat) still works
4. End-to-end: `PERMISSION_DENIED` mid-stream triggers retry with fresh credentials and recovers

All existing retry tests (`test_client_retries.py`, 14 tests) pass without modification.

### Was this patch authored or co-authored using generative AI tooling?
Yes. Authored using Claude Opus 4.6