### PR TITLE
[SPARK-57425][CONNECT][PYTHON] Make reattach iterator recover from short-TTL credential expiry

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1566,7 +1566,7 @@ class SparkConnectClient(object):
                     req,
                     self._stub,
                     self._retrying,
-                    self._builder.metadata(),
+                    self._builder.metadata,
                     reattachable_execute_plan_timeout=self._rpc_deadlines.reattachable_execute_plan,
                     reattach_execute_timeout=self._rpc_deadlines.reattach_execute,
                 )
@@ -1781,7 +1781,7 @@ class SparkConnectClient(object):
                     req,
                     self._stub,
                     self._retrying,
-                    self._builder.metadata(),
+                    self._builder.metadata,
                     reattachable_execute_plan_timeout=self._rpc_deadlines.reattachable_execute_plan,
                     reattach_execute_timeout=self._rpc_deadlines.reattach_execute,
                 )

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -19,7 +19,7 @@ from pyspark.sql.connect.client.retries import Retrying, RetryException
 from threading import RLock
 import uuid
 from collections.abc import Generator
-from typing import Optional, Any, Iterator, Iterable, Tuple, Callable, cast, ClassVar
+from typing import Optional, Any, Iterator, Iterable, Tuple, Callable, Union, cast, ClassVar
 from concurrent.futures import Future, ThreadPoolExecutor
 import os
 import weakref
@@ -53,6 +53,12 @@ class ExecutePlanResponseReattachableIterator(Generator):
     In reattachable execute the server does buffer some responses in case the client needs to
     backtrack. To let server release this buffer sooner, this iterator asynchronously sends
     ReleaseExecute RPCs that instruct the server to release responses that it already processed.
+
+    ``metadata`` may be a static iterable or a zero-arg callable; the callable is invoked
+    before every RPC (so short-TTL credentials refresh across reattach) and must be thread-safe
+    because ``ReleaseExecute`` runs in a background thread pool. A ``PERMISSION_DENIED`` mid-
+    stream is retried once per iterator so the next ``ReattachExecute`` can use a refreshed
+    credential; a second one propagates as a genuine auth failure.
     """
 
     _lock: ClassVar[RLock] = RLock()
@@ -71,7 +77,10 @@ class ExecutePlanResponseReattachableIterator(Generator):
         request: pb2.ExecutePlanRequest,
         stub: grpc_lib.SparkConnectServiceStub,
         retrying: Callable[[], Retrying],
-        metadata: Iterable[Tuple[str, str]],
+        metadata: Union[
+            Iterable[Tuple[str, str]],
+            Callable[[], Iterable[Tuple[str, str]]],
+        ],
         reattachable_execute_plan_timeout: Optional[float] = None,
         reattach_execute_timeout: Optional[float] = None,
     ):
@@ -106,15 +115,23 @@ class ExecutePlanResponseReattachableIterator(Generator):
         # finishes without producing one, another iterator needs to be reattached.
         self._result_complete = False
 
-        # Initial iterator comes from ExecutePlan request.
-        # Note: This is not retried, because no error would ever be thrown here, and GRPC will only
-        # throw error on first self._has_next().
-        self._metadata = metadata
+        # PERMISSION_DENIED budget: one reattach between successful responses.
+        self._permission_denied_retried = False
+
+        self._metadata_provider: Callable[[], Iterable[Tuple[str, str]]]
+        if callable(metadata):
+            self._metadata_provider = metadata
+        else:
+            # one-shot iterators would be exhausted after the first RPC.
+            _cached_metadata = list(metadata)
+            self._metadata_provider = lambda: _cached_metadata
+
+        # ``_metadata_provider()`` runs eagerly here and may raise (e.g. credential refresh).
         with disable_gc():
             self._iterator: Optional[Iterator[pb2.ExecutePlanResponse]] = iter(
                 self._stub.ExecutePlan(
                     self._initial_request,
-                    metadata=metadata,
+                    metadata=self._metadata_provider(),
                     timeout=self._reattachable_execute_plan_timeout,
                 )
             )
@@ -220,9 +237,15 @@ class ExecutePlanResponseReattachableIterator(Generator):
 
         def target() -> None:
             try:
+                metadata = self._metadata_provider()
+            except Exception as e:
+                # Don't let provider errors masquerade as server-side release failures.
+                logger.warning(f"metadata provider failed before ReleaseExecute: {e}.")
+                return
+            try:
                 for attempt in self._retrying():
                     with attempt:
-                        self._stub.ReleaseExecute(request, metadata=self._metadata)
+                        self._stub.ReleaseExecute(request, metadata=metadata)
             except Exception as e:
                 logger.warning(f"ReleaseExecute failed with exception: {e}.")
 
@@ -243,9 +266,14 @@ class ExecutePlanResponseReattachableIterator(Generator):
 
         def target() -> None:
             try:
+                metadata = self._metadata_provider()
+            except Exception as e:
+                logger.warning(f"metadata provider failed before ReleaseExecute: {e}.")
+                return
+            try:
                 for attempt in self._retrying():
                     with attempt:
-                        self._stub.ReleaseExecute(request, metadata=self._metadata)
+                        self._stub.ReleaseExecute(request, metadata=metadata)
             except Exception as e:
                 logger.warning(f"ReleaseExecute failed with exception: {e}.")
 
@@ -265,13 +293,13 @@ class ExecutePlanResponseReattachableIterator(Generator):
             self._iterator = iter(
                 self._stub.ReattachExecute(
                     self._create_reattach_execute_request(),
-                    metadata=self._metadata,
+                    metadata=self._metadata_provider(),
                     timeout=self._reattach_execute_timeout,
                 )
             )
 
         try:
-            return iter_fun()
+            result = iter_fun()
         except grpc.RpcError as e:
             status = rpc_status.from_call(cast(grpc.Call, e))
             unexpected_error = next(
@@ -295,7 +323,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
                 self._iterator = iter(
                     self._stub.ExecutePlan(
                         self._initial_request,
-                        metadata=self._metadata,
+                        metadata=self._metadata_provider(),
                         timeout=self._reattachable_execute_plan_timeout,
                     )
                 )
@@ -310,6 +338,19 @@ class ExecutePlanResponseReattachableIterator(Generator):
                 )
                 self._iterator = None
                 raise RetryException() from e
+            elif (
+                e.code() == grpc.StatusCode.PERMISSION_DENIED
+                and not self._permission_denied_retried
+            ):
+                # Treat the first mid-stream PERMISSION_DENIED as a token-expiry signal; reattach
+                # once so the metadata provider can produce a fresh credential.
+                logger.debug(
+                    f"PERMISSION_DENIED on stream for operation {self._operation_id}; "
+                    f"allowing one reattach with refreshed metadata."
+                )
+                self._permission_denied_retried = True
+                self._iterator = None
+                raise RetryException() from e
             else:
                 # Remove the iterator, so that a new one will be created after retry.
                 self._iterator = None
@@ -318,6 +359,8 @@ class ExecutePlanResponseReattachableIterator(Generator):
             # Remove the iterator, so that a new one will be created after retry.
             self._iterator = None
             raise e
+        self._permission_denied_retried = False
+        return result
 
     def _create_reattach_execute_request(self) -> pb2.ReattachExecuteRequest:
         server_side_session_id = (

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -57,10 +57,9 @@ class ExecutePlanResponseReattachableIterator(Generator):
     ``metadata`` may be a static iterable or a zero-arg callable; the callable is invoked
     before every RPC (so short-TTL credentials refresh across reattach) and must be thread-safe
     because ``ReleaseExecute`` runs in a background thread pool. A ``PERMISSION_DENIED`` mid-
-    stream is retried so the next ``ReattachExecute`` can use a refreshed credential. The retry
-    counter resets only on forward progress (a returned response), so a token that never refreshes
-    to a valid one fails fast after ``_MAX_PERMISSION_DENIED_RETRIES`` consecutive denials instead
-    of spinning, while a long-lived stream can recover from token expiry any number of times.
+    stream is retried so the next ``ReattachExecute`` can use a refreshed credential, capped at
+    ``_MAX_PERMISSION_DENIED_RETRIES`` consecutive denials (reset on forward progress) so an
+    unrefreshable token fails fast instead of spinning.
     """
 
     _lock: ClassVar[RLock] = RLock()
@@ -119,8 +118,6 @@ class ExecutePlanResponseReattachableIterator(Generator):
         # finishes without producing one, another iterator needs to be reattached.
         self._result_complete = False
 
-        # Consecutive PERMISSION_DENIED reattaches since the last returned response; capped so a
-        # token that never refreshes to a valid one fails fast instead of spinning forever.
         self._permission_denied_retries = 0
 
         self._metadata_provider: Callable[[], Iterable[Tuple[str, str]]]
@@ -347,8 +344,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
                 e.code() == grpc.StatusCode.PERMISSION_DENIED
                 and self._permission_denied_retries < self._MAX_PERMISSION_DENIED_RETRIES
             ):
-                # Treat mid-stream PERMISSION_DENIED as a token-expiry signal; reattach so the
-                # metadata provider can produce a fresh credential.
+                # Mid-stream PERMISSION_DENIED signals token expiry; reattach with fresh metadata.
                 logger.debug(
                     f"PERMISSION_DENIED on stream for operation {self._operation_id}; "
                     f"reattaching with refreshed metadata "

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -327,6 +327,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
                         timeout=self._reattachable_execute_plan_timeout,
                     )
                 )
+                self._permission_denied_retried = False
                 raise RetryException()
             elif e.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
                 # The per-RPC deadline fired. The server-side operation is still alive; clear

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -57,11 +57,15 @@ class ExecutePlanResponseReattachableIterator(Generator):
     ``metadata`` may be a static iterable or a zero-arg callable; the callable is invoked
     before every RPC (so short-TTL credentials refresh across reattach) and must be thread-safe
     because ``ReleaseExecute`` runs in a background thread pool. A ``PERMISSION_DENIED`` mid-
-    stream is retried once per iterator so the next ``ReattachExecute`` can use a refreshed
-    credential; a second one propagates as a genuine auth failure.
+    stream is retried so the next ``ReattachExecute`` can use a refreshed credential. The retry
+    counter resets only on forward progress (a returned response), so a token that never refreshes
+    to a valid one fails fast after ``_MAX_PERMISSION_DENIED_RETRIES`` consecutive denials instead
+    of spinning, while a long-lived stream can recover from token expiry any number of times.
     """
 
     _lock: ClassVar[RLock] = RLock()
+
+    _MAX_PERMISSION_DENIED_RETRIES: ClassVar[int] = 3
     _release_thread_pool_instance: Optional[ThreadPoolExecutor] = None
     _instances: ClassVar[weakref.WeakSet["ExecutePlanResponseReattachableIterator"]] = (
         weakref.WeakSet()
@@ -115,8 +119,9 @@ class ExecutePlanResponseReattachableIterator(Generator):
         # finishes without producing one, another iterator needs to be reattached.
         self._result_complete = False
 
-        # PERMISSION_DENIED budget: one reattach between successful responses.
-        self._permission_denied_retried = False
+        # Consecutive PERMISSION_DENIED reattaches since the last returned response; capped so a
+        # token that never refreshes to a valid one fails fast instead of spinning forever.
+        self._permission_denied_retries = 0
 
         self._metadata_provider: Callable[[], Iterable[Tuple[str, str]]]
         if callable(metadata):
@@ -327,7 +332,6 @@ class ExecutePlanResponseReattachableIterator(Generator):
                         timeout=self._reattachable_execute_plan_timeout,
                     )
                 )
-                self._permission_denied_retried = False
                 raise RetryException()
             elif e.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
                 # The per-RPC deadline fired. The server-side operation is still alive; clear
@@ -341,15 +345,17 @@ class ExecutePlanResponseReattachableIterator(Generator):
                 raise RetryException() from e
             elif (
                 e.code() == grpc.StatusCode.PERMISSION_DENIED
-                and not self._permission_denied_retried
+                and self._permission_denied_retries < self._MAX_PERMISSION_DENIED_RETRIES
             ):
-                # Treat the first mid-stream PERMISSION_DENIED as a token-expiry signal; reattach
-                # once so the metadata provider can produce a fresh credential.
+                # Treat mid-stream PERMISSION_DENIED as a token-expiry signal; reattach so the
+                # metadata provider can produce a fresh credential.
                 logger.debug(
                     f"PERMISSION_DENIED on stream for operation {self._operation_id}; "
-                    f"allowing one reattach with refreshed metadata."
+                    f"reattaching with refreshed metadata "
+                    f"({self._permission_denied_retries + 1}/"
+                    f"{self._MAX_PERMISSION_DENIED_RETRIES})."
                 )
-                self._permission_denied_retried = True
+                self._permission_denied_retries += 1
                 self._iterator = None
                 raise RetryException() from e
             else:
@@ -360,7 +366,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
             # Remove the iterator, so that a new one will be created after retry.
             self._iterator = None
             raise e
-        self._permission_denied_retried = False
+        self._permission_denied_retries = 0
         return result
 
     def _create_reattach_execute_request(self) -> pb2.ReattachExecuteRequest:

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -1283,7 +1283,7 @@ class SparkConnectClientReattachTestCase(unittest.TestCase):
 
         eventually(timeout=1, catch_assertions=True)(check)()
 
-    def test_permission_denied_budget_replenishes_after_successful_response(self):
+    def test_permission_denied_counter_resets_after_successful_response(self):
         counter = itertools.count(1)
 
         def provider():
@@ -1314,7 +1314,7 @@ class SparkConnectClientReattachTestCase(unittest.TestCase):
 
         eventually(timeout=1, catch_assertions=True)(check)()
 
-    def test_permission_denied_budget_resets_after_operation_not_found(self):
+    def test_permission_denied_recovers_across_operation_not_found(self):
         def permission_denied():
             raise TestException("PERMISSION_DENIED", grpc.StatusCode.PERMISSION_DENIED)
 
@@ -1329,9 +1329,10 @@ class SparkConnectClientReattachTestCase(unittest.TestCase):
                 ),
             )
 
-        # ExecutePlan #1 hits PERMISSION_DENIED before any response, the reattach attempt
-        # observes OPERATION_NOT_FOUND so a fresh ExecutePlan is started. The fresh stream
-        # is logically new, so a second PERMISSION_DENIED on it must be retried again.
+        # ExecutePlan #1 hits PERMISSION_DENIED before any response, the reattach attempt observes
+        # OPERATION_NOT_FOUND so a fresh ExecutePlan starts. The retry counter carries over (no
+        # reset on OPERATION_NOT_FOUND) but stays under the cap, so a second PERMISSION_DENIED is
+        # still retried and the stream then recovers.
         stub = self._stub_with(
             [permission_denied, permission_denied],
             [not_found, self.response, self.finished],
@@ -1346,7 +1347,7 @@ class SparkConnectClientReattachTestCase(unittest.TestCase):
 
         eventually(timeout=1, catch_assertions=True)(check)()
 
-    def test_permission_denied_propagates_after_single_retry(self):
+    def test_permission_denied_propagates_after_max_retries(self):
         provider_calls = itertools.count(1)
 
         def provider():
@@ -1355,9 +1356,11 @@ class SparkConnectClientReattachTestCase(unittest.TestCase):
         def permission_denied():
             raise TestException("PERMISSION_DENIED", grpc.StatusCode.PERMISSION_DENIED)
 
+        # One response makes forward progress (resetting the counter), then PERMISSION_DENIED
+        # repeats with no further progress until the per-iterator cap is exhausted and propagates.
         stub = self._stub_with(
             [self.response, permission_denied],
-            [permission_denied],
+            [permission_denied, permission_denied, permission_denied],
         )
         with self.assertRaises(TestException) as cm:
             ite = ExecutePlanResponseReattachableIterator(
@@ -1366,6 +1369,43 @@ class SparkConnectClientReattachTestCase(unittest.TestCase):
             for _ in ite:
                 pass
         self.assertEqual(cm.exception.code(), grpc.StatusCode.PERMISSION_DENIED)
+        self.assertEqual(
+            stub.attach_calls,
+            ExecutePlanResponseReattachableIterator._MAX_PERMISSION_DENIED_RETRIES,
+        )
+
+    def test_permission_denied_spin_fails_fast_across_operation_not_found(self):
+        """SPARK-57425: a token that never refreshes to a valid one must fail fast instead of
+        spinning forever through PERMISSION_DENIED -> OPERATION_NOT_FOUND -> fresh ExecutePlan.
+        The counter is not reset on OPERATION_NOT_FOUND, so the cap stops the loop."""
+
+        def permission_denied():
+            raise TestException("PERMISSION_DENIED", grpc.StatusCode.PERMISSION_DENIED)
+
+        def not_found():
+            raise TestException(
+                "INVALID_HANDLE.OPERATION_NOT_FOUND",
+                grpc.StatusCode.UNAVAILABLE,
+                trailing_status=status_pb2.Status(
+                    code=14,
+                    message="INVALID_HANDLE.OPERATION_NOT_FOUND",
+                    details="",
+                ),
+            )
+
+        stub = self._stub_with(
+            [permission_denied, permission_denied, permission_denied, permission_denied],
+            [not_found, not_found, not_found],
+        )
+        with self.assertRaises(TestException) as cm:
+            ite = ExecutePlanResponseReattachableIterator(self.request, stub, self.retrying, [])
+            for _ in ite:
+                pass
+        self.assertEqual(cm.exception.code(), grpc.StatusCode.PERMISSION_DENIED)
+        self.assertEqual(
+            stub.attach_calls,
+            ExecutePlanResponseReattachableIterator._MAX_PERMISSION_DENIED_RETRIES,
+        )
 
     def test_metadata_callable_failure_in_release_does_not_break_iteration(self):
         calls = itertools.count(1)
@@ -1521,12 +1561,13 @@ class SparkConnectClientReattachGrpcEndToEndTestCase(unittest.TestCase):
 
         eventually(timeout=2, catch_assertions=True)(check)()
 
-    def test_permission_denied_propagates_after_one_retry_over_grpc(self):
+    def test_permission_denied_propagates_after_max_retries_over_grpc(self):
         def provider():
             return [("authorization", "bearer static")]
 
+        cap = ExecutePlanResponseReattachableIterator._MAX_PERMISSION_DENIED_RETRIES
         self.servicer.execute_plans = [[self.response, grpc.StatusCode.PERMISSION_DENIED]]
-        self.servicer.reattach_plans = [[grpc.StatusCode.PERMISSION_DENIED]]
+        self.servicer.reattach_plans = [[grpc.StatusCode.PERMISSION_DENIED]] * cap
 
         with self.assertRaises(grpc.RpcError) as cm:
             ite = ExecutePlanResponseReattachableIterator(
@@ -1535,6 +1576,7 @@ class SparkConnectClientReattachGrpcEndToEndTestCase(unittest.TestCase):
             for _ in ite:
                 pass
         self.assertEqual(cm.exception.code(), grpc.StatusCode.PERMISSION_DENIED)
+        self.assertEqual(len(self.servicer.metadata_seen["ReattachExecute"]), cap)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -1329,10 +1329,8 @@ class SparkConnectClientReattachTestCase(unittest.TestCase):
                 ),
             )
 
-        # ExecutePlan #1 hits PERMISSION_DENIED before any response, the reattach attempt observes
-        # OPERATION_NOT_FOUND so a fresh ExecutePlan starts. The retry counter carries over (no
-        # reset on OPERATION_NOT_FOUND) but stays under the cap, so a second PERMISSION_DENIED is
-        # still retried and the stream then recovers.
+        # The counter is not reset on OPERATION_NOT_FOUND, but stays under the cap, so the second
+        # PERMISSION_DENIED on the fresh ExecutePlan is still retried and the stream recovers.
         stub = self._stub_with(
             [permission_denied, permission_denied],
             [not_found, self.response, self.finished],
@@ -1356,8 +1354,8 @@ class SparkConnectClientReattachTestCase(unittest.TestCase):
         def permission_denied():
             raise TestException("PERMISSION_DENIED", grpc.StatusCode.PERMISSION_DENIED)
 
-        # One response makes forward progress (resetting the counter), then PERMISSION_DENIED
-        # repeats with no further progress until the per-iterator cap is exhausted and propagates.
+        # After one response resets the counter, PERMISSION_DENIED repeats with no further progress
+        # until the cap is exhausted and it propagates.
         stub = self._stub_with(
             [self.response, permission_denied],
             [permission_denied, permission_denied, permission_denied],
@@ -1375,9 +1373,8 @@ class SparkConnectClientReattachTestCase(unittest.TestCase):
         )
 
     def test_permission_denied_spin_fails_fast_across_operation_not_found(self):
-        """SPARK-57425: a token that never refreshes to a valid one must fail fast instead of
-        spinning forever through PERMISSION_DENIED -> OPERATION_NOT_FOUND -> fresh ExecutePlan.
-        The counter is not reset on OPERATION_NOT_FOUND, so the cap stops the loop."""
+        """SPARK-57425: an unrefreshable token must fail fast instead of spinning forever through
+        PERMISSION_DENIED -> OPERATION_NOT_FOUND -> fresh ExecutePlan."""
 
         def permission_denied():
             raise TestException("PERMISSION_DENIED", grpc.StatusCode.PERMISSION_DENIED)

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import itertools
 import unittest
 import uuid
 from collections.abc import Generator
@@ -113,20 +114,34 @@ if should_test_connect:
             self.release_calls = 0
             self.release_until_calls = 0
             self.attach_calls = 0
+            self.captured_metadata = {
+                "ExecutePlan": [],
+                "ReattachExecute": [],
+                "ReleaseExecuteAll": [],
+                "ReleaseExecuteUntil": [],
+            }
+
+        def _capture_metadata(self, rpc, kwargs):
+            assert "metadata" in kwargs, f"{rpc} called without keyword metadata"
+            self.captured_metadata[rpc].append(list(kwargs["metadata"]))
 
         def ExecutePlan(self, *args, **kwargs):
             self.execute_calls += 1
+            self._capture_metadata("ExecutePlan", kwargs)
             return self._execute_ops
 
         def ReattachExecute(self, *args, **kwargs):
             self.attach_calls += 1
+            self._capture_metadata("ReattachExecute", kwargs)
             return self._attach_ops
 
         def ReleaseExecute(self, req: proto.ReleaseExecuteRequest, *args, **kwargs):
             if req.HasField("release_all"):
                 self.release_calls += 1
+                self._capture_metadata("ReleaseExecuteAll", kwargs)
             elif req.HasField("release_until"):
                 self.release_until_calls += 1
+                self._capture_metadata("ReleaseExecuteUntil", kwargs)
 
     class MockService:
         # Simplest mock of the SparkConnectService.
@@ -1126,6 +1141,368 @@ class SparkConnectClientReattachTestCase(unittest.TestCase):
             self.assertEqual(err.getGrpcStatusCode(), expected_status_code)
             self.assertEqual(err.getErrorClass(), expected_error_class)
             self.assertEqual(err.getSqlState(), expected_sql_state)
+
+    @staticmethod
+    def _all_captured(stub):
+        return (
+            stub.captured_metadata["ExecutePlan"]
+            + stub.captured_metadata["ReattachExecute"]
+            + stub.captured_metadata["ReleaseExecuteAll"]
+            + stub.captured_metadata["ReleaseExecuteUntil"]
+        )
+
+    def test_metadata_callable_invoked_per_rpc(self):
+        counter = itertools.count(1)
+
+        def provider():
+            return [("authorization", f"Bearer token-{next(counter)}")]
+
+        def non_fatal():
+            raise TestException("Non Fatal", grpc.StatusCode.UNAVAILABLE)
+
+        stub = self._stub_with(
+            [self.response, non_fatal],
+            [self.response, self.response, self.finished],
+        )
+        ite = ExecutePlanResponseReattachableIterator(self.request, stub, self.retrying, provider)
+        for _ in ite:
+            pass
+
+        def check():
+            captured = stub.captured_metadata
+            self.assertGreaterEqual(len(captured["ExecutePlan"]), 1)
+            self.assertGreaterEqual(len(captured["ReattachExecute"]), 1)
+            self.assertGreaterEqual(
+                len(captured["ReleaseExecuteAll"]) + len(captured["ReleaseExecuteUntil"]), 1
+            )
+            tokens = [md[0][1] for md in self._all_captured(stub)]
+            self.assertTrue(all(t.startswith("Bearer token-") for t in tokens))
+            self.assertEqual(len(set(tokens)), len(tokens))
+
+        eventually(timeout=1, catch_assertions=True)(check)()
+
+    def test_metadata_callable_refreshed_on_operation_not_found(self):
+        counter = itertools.count(1)
+
+        def provider():
+            return [("authorization", f"Bearer token-{next(counter)}")]
+
+        def not_found():
+            raise TestException(
+                "INVALID_HANDLE.OPERATION_NOT_FOUND",
+                grpc.StatusCode.UNAVAILABLE,
+                trailing_status=status_pb2.Status(
+                    code=14,
+                    message="INVALID_HANDLE.OPERATION_NOT_FOUND",
+                    details="",
+                ),
+            )
+
+        stub = self._stub_with([not_found, self.finished])
+        ite = ExecutePlanResponseReattachableIterator(self.request, stub, self.retrying, provider)
+        for _ in ite:
+            pass
+
+        def check():
+            exec_tokens = [md[0][1] for md in stub.captured_metadata["ExecutePlan"]]
+            self.assertEqual(len(exec_tokens), 2)
+            self.assertNotEqual(exec_tokens[0], exec_tokens[1])
+
+        eventually(timeout=1, catch_assertions=True)(check)()
+
+    def test_metadata_iterable_is_cached(self):
+        static_md = [("authorization", "Bearer static")]
+
+        def non_fatal():
+            raise TestException("Non Fatal", grpc.StatusCode.UNAVAILABLE)
+
+        stub = self._stub_with(
+            [self.response, non_fatal],
+            [self.response, self.response, self.finished],
+        )
+        ite = ExecutePlanResponseReattachableIterator(self.request, stub, self.retrying, static_md)
+        for _ in ite:
+            pass
+
+        def check():
+            all_captured = self._all_captured(stub)
+            self.assertGreater(len(all_captured), 0)
+            for md in all_captured:
+                self.assertEqual(md, static_md)
+
+        eventually(timeout=1, catch_assertions=True)(check)()
+
+    def test_metadata_one_shot_iterator_is_materialized(self):
+        one_shot = iter([("authorization", "Bearer once")])
+
+        def non_fatal():
+            raise TestException("Non Fatal", grpc.StatusCode.UNAVAILABLE)
+
+        # Force reattach so the cached list must survive multiple RPCs.
+        stub = self._stub_with(
+            [self.response, non_fatal],
+            [self.response, self.response, self.finished],
+        )
+        ite = ExecutePlanResponseReattachableIterator(self.request, stub, self.retrying, one_shot)
+        for _ in ite:
+            pass
+
+        expected = [("authorization", "Bearer once")]
+
+        def check():
+            all_captured = self._all_captured(stub)
+            self.assertGreaterEqual(len(stub.captured_metadata["ExecutePlan"]), 1)
+            self.assertGreaterEqual(len(stub.captured_metadata["ReattachExecute"]), 1)
+            for md in all_captured:
+                self.assertEqual(md, expected)
+
+        eventually(timeout=1, catch_assertions=True)(check)()
+
+    def test_permission_denied_retries_once_with_refreshed_metadata(self):
+        counter = itertools.count(1)
+
+        def provider():
+            return [("authorization", f"Bearer token-{next(counter)}")]
+
+        def permission_denied():
+            raise TestException("PERMISSION_DENIED", grpc.StatusCode.PERMISSION_DENIED)
+
+        stub = self._stub_with(
+            [self.response, permission_denied],
+            [self.response, self.finished],
+        )
+        ite = ExecutePlanResponseReattachableIterator(self.request, stub, self.retrying, provider)
+        for _ in ite:
+            pass
+
+        def check():
+            self.assertGreaterEqual(stub.attach_calls, 1)
+            exec_tokens = [md[0][1] for md in stub.captured_metadata["ExecutePlan"]]
+            reattach_tokens = [md[0][1] for md in stub.captured_metadata["ReattachExecute"]]
+            self.assertNotEqual(exec_tokens[0], reattach_tokens[0])
+
+        eventually(timeout=1, catch_assertions=True)(check)()
+
+    def test_permission_denied_budget_replenishes_after_successful_response(self):
+        counter = itertools.count(1)
+
+        def provider():
+            return [("authorization", f"Bearer token-{next(counter)}")]
+
+        def permission_denied():
+            raise TestException("PERMISSION_DENIED", grpc.StatusCode.PERMISSION_DENIED)
+
+        finished = proto.ExecutePlanResponse(
+            result_complete=proto.ExecutePlanResponse.ResultComplete(),
+            response_id="4",
+        )
+        stub = self._stub_with(
+            [self.response, permission_denied],
+            [
+                proto.ExecutePlanResponse(response_id="2"),
+                permission_denied,
+                proto.ExecutePlanResponse(response_id="3"),
+                finished,
+            ],
+        )
+        ite = ExecutePlanResponseReattachableIterator(self.request, stub, self.retrying, provider)
+        for _ in ite:
+            pass
+
+        def check():
+            self.assertEqual(stub.attach_calls, 2)
+
+        eventually(timeout=1, catch_assertions=True)(check)()
+
+    def test_permission_denied_propagates_after_single_retry(self):
+        provider_calls = itertools.count(1)
+
+        def provider():
+            return [("authorization", f"Bearer token-{next(provider_calls)}")]
+
+        def permission_denied():
+            raise TestException("PERMISSION_DENIED", grpc.StatusCode.PERMISSION_DENIED)
+
+        stub = self._stub_with(
+            [self.response, permission_denied],
+            [permission_denied],
+        )
+        with self.assertRaises(TestException) as cm:
+            ite = ExecutePlanResponseReattachableIterator(
+                self.request, stub, self.retrying, provider
+            )
+            for _ in ite:
+                pass
+        self.assertEqual(cm.exception.code(), grpc.StatusCode.PERMISSION_DENIED)
+
+    def test_metadata_callable_failure_in_release_does_not_break_iteration(self):
+        calls = itertools.count(1)
+
+        def provider():
+            n = next(calls)
+            if n > 1:
+                raise RuntimeError("token refresh failed")
+            return [("authorization", "Bearer initial")]
+
+        stub = self._stub_with([self.response, self.finished])
+        ite = ExecutePlanResponseReattachableIterator(self.request, stub, self.retrying, provider)
+        for _ in ite:
+            pass
+
+        def check():
+            self.assertEqual(
+                stub.captured_metadata["ExecutePlan"][0],
+                [("authorization", "Bearer initial")],
+            )
+
+        eventually(timeout=1, catch_assertions=True)(check)()
+
+
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
+class SparkConnectClientReattachGrpcEndToEndTestCase(unittest.TestCase):
+    """Drives the reattach iterator over a real in-process gRPC channel so the
+    metadata callable and PERMISSION_DENIED recovery are exercised at the wire level."""
+
+    @staticmethod
+    def _make_servicer():
+        from pyspark.sql.connect.proto.base_pb2_grpc import SparkConnectServiceServicer
+
+        class _ScriptedServicer(SparkConnectServiceServicer):
+            def __init__(self) -> None:
+                self.metadata_seen: dict[str, list[dict[str, str]]] = {
+                    "ExecutePlan": [],
+                    "ReattachExecute": [],
+                    "ReleaseExecute": [],
+                }
+                self.execute_plans: list[list] = []
+                self.reattach_plans: list[list] = []
+
+            def _record(self, rpc, context) -> None:
+                self.metadata_seen[rpc].append(dict(context.invocation_metadata()))
+
+            def ExecutePlan(self, request, context):
+                self._record("ExecutePlan", context)
+                actions = self.execute_plans.pop(0) if self.execute_plans else []
+                for action in actions:
+                    if isinstance(action, grpc.StatusCode):
+                        context.abort(action, "scripted PERMISSION_DENIED")
+                    yield action
+
+            def ReattachExecute(self, request, context):
+                self._record("ReattachExecute", context)
+                actions = self.reattach_plans.pop(0) if self.reattach_plans else []
+                for action in actions:
+                    if isinstance(action, grpc.StatusCode):
+                        context.abort(action, "scripted PERMISSION_DENIED")
+                    yield action
+
+            def ReleaseExecute(self, request, context):
+                self._record("ReleaseExecute", context)
+                return proto.ReleaseExecuteResponse(session_id=request.session_id)
+
+        return _ScriptedServicer()
+
+    def setUp(self) -> None:
+        from concurrent.futures import ThreadPoolExecutor
+
+        from pyspark.sql.connect.proto.base_pb2_grpc import (
+            SparkConnectServiceStub,
+            add_SparkConnectServiceServicer_to_server,
+        )
+
+        self.servicer = self._make_servicer()
+        self.server = grpc.server(ThreadPoolExecutor(max_workers=4))
+        add_SparkConnectServiceServicer_to_server(self.servicer, self.server)
+        self.port = self.server.add_insecure_port("localhost:0")
+        self.server.start()
+
+        self.channel = grpc.insecure_channel(f"localhost:{self.port}")
+        self.stub = SparkConnectServiceStub(self.channel)
+        self.request = proto.ExecutePlanRequest()
+        self.retrying = lambda: Retrying(TestPolicy())
+        self.response = proto.ExecutePlanResponse(response_id="1")
+        self.finished = proto.ExecutePlanResponse(
+            result_complete=proto.ExecutePlanResponse.ResultComplete(),
+            response_id="2",
+        )
+
+    def tearDown(self) -> None:
+        self.channel.close()
+        self.server.stop(grace=None)
+
+    def test_callable_metadata_invoked_per_rpc_over_grpc(self):
+        counter = itertools.count(1)
+
+        def provider():
+            return [("authorization", f"bearer token-{next(counter)}")]
+
+        self.servicer.execute_plans = [[self.response, self.finished]]
+
+        ite = ExecutePlanResponseReattachableIterator(
+            self.request, self.stub, self.retrying, provider
+        )
+        for _ in ite:
+            pass
+
+        def check():
+            execute_tokens = [
+                m.get("authorization") for m in self.servicer.metadata_seen["ExecutePlan"]
+            ]
+            release_tokens = [
+                m.get("authorization") for m in self.servicer.metadata_seen["ReleaseExecute"]
+            ]
+            tokens = execute_tokens + release_tokens
+            self.assertTrue(all(t and t.startswith("bearer token-") for t in tokens))
+            self.assertEqual(len(set(tokens)), len(tokens))
+
+        eventually(timeout=2, catch_assertions=True)(check)()
+
+    def test_permission_denied_mid_stream_recovers_over_grpc(self):
+        counter = itertools.count(1)
+
+        def provider():
+            return [("authorization", f"bearer token-{next(counter)}")]
+
+        self.servicer.execute_plans = [[self.response, grpc.StatusCode.PERMISSION_DENIED]]
+        self.servicer.reattach_plans = [
+            [
+                proto.ExecutePlanResponse(response_id="2"),
+                proto.ExecutePlanResponse(
+                    result_complete=proto.ExecutePlanResponse.ResultComplete(),
+                    response_id="3",
+                ),
+            ]
+        ]
+
+        ite = ExecutePlanResponseReattachableIterator(
+            self.request, self.stub, self.retrying, provider
+        )
+        for _ in ite:
+            pass
+
+        def check():
+            self.assertEqual(len(self.servicer.metadata_seen["ExecutePlan"]), 1)
+            self.assertEqual(len(self.servicer.metadata_seen["ReattachExecute"]), 1)
+            exec_token = self.servicer.metadata_seen["ExecutePlan"][0]["authorization"]
+            reattach_token = self.servicer.metadata_seen["ReattachExecute"][0]["authorization"]
+            self.assertNotEqual(exec_token, reattach_token)
+
+        eventually(timeout=2, catch_assertions=True)(check)()
+
+    def test_permission_denied_propagates_after_one_retry_over_grpc(self):
+        def provider():
+            return [("authorization", "bearer static")]
+
+        self.servicer.execute_plans = [[self.response, grpc.StatusCode.PERMISSION_DENIED]]
+        self.servicer.reattach_plans = [[grpc.StatusCode.PERMISSION_DENIED]]
+
+        with self.assertRaises(grpc.RpcError) as cm:
+            ite = ExecutePlanResponseReattachableIterator(
+                self.request, self.stub, self.retrying, provider
+            )
+            for _ in ite:
+                pass
+        self.assertEqual(cm.exception.code(), grpc.StatusCode.PERMISSION_DENIED)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -1314,6 +1314,38 @@ class SparkConnectClientReattachTestCase(unittest.TestCase):
 
         eventually(timeout=1, catch_assertions=True)(check)()
 
+    def test_permission_denied_budget_resets_after_operation_not_found(self):
+        def permission_denied():
+            raise TestException("PERMISSION_DENIED", grpc.StatusCode.PERMISSION_DENIED)
+
+        def not_found():
+            raise TestException(
+                "INVALID_HANDLE.OPERATION_NOT_FOUND",
+                grpc.StatusCode.UNAVAILABLE,
+                trailing_status=status_pb2.Status(
+                    code=14,
+                    message="INVALID_HANDLE.OPERATION_NOT_FOUND",
+                    details="",
+                ),
+            )
+
+        # ExecutePlan #1 hits PERMISSION_DENIED before any response, the reattach attempt
+        # observes OPERATION_NOT_FOUND so a fresh ExecutePlan is started. The fresh stream
+        # is logically new, so a second PERMISSION_DENIED on it must be retried again.
+        stub = self._stub_with(
+            [permission_denied, permission_denied],
+            [not_found, self.response, self.finished],
+        )
+        ite = ExecutePlanResponseReattachableIterator(self.request, stub, self.retrying, [])
+        for _ in ite:
+            pass
+
+        def check():
+            self.assertEqual(stub.execute_calls, 2)
+            self.assertEqual(stub.attach_calls, 2)
+
+        eventually(timeout=1, catch_assertions=True)(check)()
+
     def test_permission_denied_propagates_after_single_retry(self):
         provider_calls = itertools.count(1)
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SPARK-57425

### What changes were proposed in this pull request?

Two changes in `python/pyspark/sql/connect/client/reattach.py` so the
reattach iterator survives short-TTL credential expiry:

**1. Per-RPC metadata refresh.** `metadata` now accepts a zero-arg
`Callable` in addition to an `Iterable`. A callable is invoked before
every RPC (initial `ExecutePlan`, retry `ExecutePlan` after
`INVALID_HANDLE.OPERATION_NOT_FOUND`, `ReattachExecute`, and both flavors
of `ReleaseExecute`). `SparkConnectClient` passes the bound method
`self._builder.metadata` rather than calling it once at construction, so
a custom `ChannelBuilder` that refreshes its parameters takes effect
across reattach. Static iterables are materialized once. Provider
failures inside `_release_*` log a distinct message to avoid being
mistaken for server-side release errors.

**2. `PERMISSION_DENIED` retry budget.** A mid-stream `PERMISSION_DENIED`
is treated as a candidate token-expiry signal: the iterator clears its
underlying stream and raises `RetryException`, mirroring the existing
`DEADLINE_EXCEEDED` branch. The retry attempt issues `ReattachExecute`
with the metadata provider re-evaluated. Each successful response
replenishes the budget, so a query that spans multiple TTL boundaries
recovers at each one. Back-to-back `PERMISSION_DENIED`s without a
successful response between them propagate.

### Why are the changes needed?

The reattach mechanism is designed to recover from a broken gRPC stream,
but recovery is structurally impossible today when the server enforces a
short auth-token TTL (e.g. AWS Athena Spark, ~30 min observed in practice;
the value is not formally documented) and a query outlives
it: the default retry policy doesn't treat `PERMISSION_DENIED` as
retryable, and even if reattach fired it would carry the expired token
captured at `__init__`. Both gaps must change for this scenario.

`ChannelBuilder.metadata()` is already rebuilt per call, so non-reattach
RPCs (`AnalyzePlan`, `Config`, ...) already pick up refreshed credentials
when a user supplies a custom `ChannelBuilder` — only the reattach
iterator was stuck. Downstream adapters working around this currently have
to patch `pyspark` at runtime to make long-running jobs usable (see
[dbt-labs/dbt-adapters#1874](https://github.com/dbt-labs/dbt-adapters/pull/1874)).

**Backport requested to branch-4.0, branch-4.1, branch-4.2.** The touched
code is structurally identical across 4.x and master, so the backport is
near-mechanical.

### Does this PR introduce _any_ user-facing change?

No. `ExecutePlanResponseReattachableIterator` is internal. Existing
callers passing an iterable see no behavior change, and back-to-back
`PERMISSION_DENIED`s without a successful response between them still
propagate.

### How was this patch tested?

`python/pyspark/sql/tests/connect/client/test_client.py`:

- `SparkConnectClientReattachTestCase` — eight mock-stub cases covering
  per-RPC callable invocation, refresh on
  `INVALID_HANDLE.OPERATION_NOT_FOUND`, static-iterable caching, one-shot
  iterator materialization, isolation of provider errors in `_release_*`,
  `PERMISSION_DENIED` retry, budget replenishment across multiple TTL
  boundaries, and propagation after back-to-back `PERMISSION_DENIED`s.
- `SparkConnectClientReattachGrpcEndToEndTestCase` — three cases driving
  the iterator through an in-process `grpc.server()` so the metadata
  callable and `PERMISSION_DENIED` recovery are exercised at the wire
  level.

Existing tests in the same file and `test_client_retries.py` continue
to pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Anthropic), Opus 4.7 (1M context)
