### PR TITLE
[SPARK-57441][SQL] Disallow setting JVM system properties in `Spark Thrift Server` sessions

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -25,6 +25,7 @@ license: |
 ## Upgrading from Spark SQL 4.2 to 4.3
 
 - Since Spark 4.3, the configuration key `spark.sql.sources.v2.bucketing.allowJoinKeysSubsetOfPartitionKeys.enabled` has been renamed to `spark.sql.sources.v2.bucketing.allowKeysSubsetOfPartitionKeys.enabled` to reflect that it now applies to storage-partitioned joins, aggregates, and windows. The old key continues to work as an alias.
+- Since Spark 4.3, the Spark Thrift Server rejects setting JVM system properties through the `set:system:` session configuration overlay (for example, in a JDBC connection string). To restore the previous behavior, set `spark.sql.legacy.hive.thriftServer.allowSettingSystemProperties` to `true`.
 
 ## Upgrading from Spark SQL 4.1 to 4.2
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -125,6 +125,7 @@ object StaticSQLConf {
 
   val LEGACY_HIVE_THRIFT_SERVER_ALLOW_SETTING_SYSTEM_PROPERTIES =
     buildStaticConf("spark.sql.legacy.hive.thriftServer.allowSettingSystemProperties")
+      .internal()
       .doc("When set to true, the Hive Thrift Server allows setting JVM system properties " +
         "through the 'set:system:' session configuration overlay (for example, in a JDBC " +
         "connection string). By default, such system property assignments are rejected.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -129,6 +129,7 @@ object StaticSQLConf {
         "through the 'set:system:' session configuration overlay (for example, in a JDBC " +
         "connection string). By default, such system property assignments are rejected.")
       .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -123,6 +123,15 @@ object StaticSQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val LEGACY_HIVE_THRIFT_SERVER_ALLOW_SETTING_SYSTEM_PROPERTIES =
+    buildStaticConf("spark.sql.legacy.hive.thriftServer.allowSettingSystemProperties")
+      .doc("When set to true, the Hive Thrift Server allows setting JVM system properties " +
+        "through the 'set:system:' session configuration overlay (for example, in a JDBC " +
+        "connection string). By default, such system property assignments are rejected.")
+      .version("4.3.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val HIVE_THRIFT_SERVER_HTTP_SNI_HOST_CHECK_ENABLED =
     buildStaticConf("spark.sql.hive.thriftServer.http.sniHostCheckEnabled")
       .internal()

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
@@ -234,8 +234,10 @@ public class HiveSessionImpl implements HiveSession {
     }
   }
 
-  // Copy from org.apache.hadoop.hive.ql.processors.SetProcessor, only change:
-  // setConf(varname, propName, varvalue, true) when varname.startsWith(HIVECONF_PREFIX)
+  // Copy from org.apache.hadoop.hive.ql.processors.SetProcessor, only changes:
+  // 1. setConf(varname, propName, varvalue, true) when varname.startsWith(HIVECONF_PREFIX)
+  // 2. system:* variables can not be set unless the legacy configuration
+  //    spark.sql.legacy.hive.thriftServer.allowSettingSystemProperties is enabled
   public static int setVariable(String varname, String varvalue) throws Exception {
     SessionState ss = SessionState.get();
     VariableSubstitution substitution = new VariableSubstitution(() -> ss.getHiveVariables());
@@ -247,8 +249,16 @@ public class HiveSessionImpl implements HiveSession {
       ss.err.println("env:* variables can not be set.");
       return 1;
     } else if (varname.startsWith(SYSTEM_PREFIX)){
-      String propName = varname.substring(SYSTEM_PREFIX.length());
-      System.getProperties().setProperty(propName, substitution.substitute(ss.getConf(),varvalue));
+      // Setting JVM system properties is allowed only when the legacy configuration
+      // spark.sql.legacy.hive.thriftServer.allowSettingSystemProperties is enabled.
+      if (ss.getConf().getBoolean(
+          "spark.sql.legacy.hive.thriftServer.allowSettingSystemProperties", false)) {
+        String propName = varname.substring(SYSTEM_PREFIX.length());
+        System.getProperties().setProperty(propName, substitution.substitute(ss.getConf(),varvalue));
+      } else {
+        ss.err.println("system:* variables can not be set.");
+        return 1;
+      }
     } else if (varname.startsWith(HIVECONF_PREFIX)){
       String propName = varname.substring(HIVECONF_PREFIX.length());
       setConf(varname, propName, varvalue, true);

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
@@ -29,7 +29,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.hive.thriftserver.ReflectionUtils._
 import org.apache.spark.sql.hive.thriftserver.server.SparkSQLOperationManager
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 
 
 private[hive] class SparkSQLSessionManager(hiveServer: HiveServer2, sparkSession: SparkSession)
@@ -40,6 +40,12 @@ private[hive] class SparkSQLSessionManager(hiveServer: HiveServer2, sparkSession
 
   override def init(hiveConf: HiveConf): Unit = {
     setSuperField(this, "operationManager", sparkSqlOperationManager)
+    // Propagate the legacy toggle into HiveConf so that HiveSessionImpl.setVariable,
+    // which runs during session open before the SparkSession is attached, can read it.
+    hiveConf.setBoolean(
+      StaticSQLConf.LEGACY_HIVE_THRIFT_SERVER_ALLOW_SETTING_SYSTEM_PROPERTIES.key,
+      sparkSession.sessionState.conf.getConf(
+        StaticSQLConf.LEGACY_HIVE_THRIFT_SERVER_ALLOW_SETTING_SYSTEM_PROPERTIES))
     super.init(hiveConf)
   }
 

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveSessionImplSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveSessionImplSuite.scala
@@ -16,18 +16,21 @@
  */
 package org.apache.spark.sql.hive.thriftserver
 
+import java.io.{ByteArrayOutputStream, PrintStream}
 import java.lang.reflect.InvocationTargetException
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hive.service.cli.OperationHandle
 import org.apache.hive.service.cli.operation.{GetCatalogsOperation, Operation, OperationManager}
 import org.apache.hive.service.cli.session.{HiveSession, HiveSessionImpl, SessionManager}
 import org.apache.hive.service.rpc.thrift.TProtocolVersion
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.internal.StaticSQLConf
 
 class HiveSessionImplSuite extends SparkFunSuite {
   private var session: HiveSessionImpl = _
@@ -60,6 +63,47 @@ class HiveSessionImplSuite extends SparkFunSuite {
 
     assert(operationManager.getCalledHandles.contains(operationHandle1))
     assert(operationManager.getCalledHandles.contains(operationHandle2))
+  }
+
+  private def withSystemPropSession[T](allowSettingSystemProperties: Boolean)(f: => T): T = {
+    val conf = new HiveConf()
+    conf.setBoolean(
+      StaticSQLConf.LEGACY_HIVE_THRIFT_SERVER_ALLOW_SETTING_SYSTEM_PROPERTIES.key,
+      allowSettingSystemProperties)
+    val sessionImpl = new HiveSessionImpl(
+      TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V1, "", "", conf, "")
+    sessionImpl.setSessionManager(new SessionManager(null))
+    sessionImpl.setOperationManager(new OperationManagerMock())
+    sessionImpl.open(Map.empty[String, String].asJava)
+    // open() does not call SessionState.start(), so err is not initialized in this unit test.
+    SessionState.get().err = new PrintStream(new ByteArrayOutputStream())
+    try f finally sessionImpl.close()
+  }
+
+  test("SPARK-57441: system:* variables can not be set by default") {
+    val key = "spark.test.HiveSessionImplSuite.systemPrefixDefault"
+    try {
+      val rc = withSystemPropSession(allowSettingSystemProperties = false) {
+        HiveSessionImpl.setVariable("system:" + key, "value")
+      }
+      assert(rc == 1)
+      assert(System.getProperty(key) == null)
+    } finally {
+      System.clearProperty(key)
+    }
+  }
+
+  test("SPARK-57441: system:* variables can be set when the legacy conf is enabled") {
+    val key = "spark.test.HiveSessionImplSuite.systemPrefixLegacy"
+    try {
+      val rc = withSystemPropSession(allowSettingSystemProperties = true) {
+        HiveSessionImpl.setVariable("system:" + key, "value")
+      }
+      assert(rc == 0)
+      assert(System.getProperty(key) == "value")
+    } finally {
+      System.clearProperty(key)
+    }
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make Spark Thrift Server rejects setting JVM system properties via the `set:system:` session config overlay (e.g. `set:system:foo=bar` in a JDBC URL), matching how the `env:*` prefix is already handled in `HiveSessionImpl.setVariable` for Apache Spark 4.3.0.

A new static config `spark.sql.legacy.hive.thriftServer.allowSettingSystemProperties` (default `false`) restores the old behavior when set to `true`. It is propagated into the session `HiveConf` in `SparkSQLSessionManager.init` so that `setVariable` can read it during session open.

### Why are the changes needed?

The `set:system:` overlay lets an untrusted per-connection client mutate the shared Thrift Server's process-wide JVM state. The `env:*` prefix is already rejected for the same reason; `system:*` should be too.

### Does this PR introduce _any_ user-facing change?

Yes. `set:system:` overlays (e.g. `jdbc:hive2://host:port/db?set:system:foo=bar`) are now rejected by default instead of applied. Set `spark.sql.legacy.hive.thriftServer.allowSettingSystemProperties` to `true` to restore the old behavior. Documented in `docs/sql-migration-guide.md`.

### How was this patch tested?

New `HiveSessionImplSuite` tests covering both the default (rejected) and legacy-enabled (applied) cases.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)