### PR TITLE
[SPARK-56740][BUILD][FOLLOWUP] Add 4.3 MiMa excludes section to master

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -33,8 +33,11 @@ import com.typesafe.tools.mima.core.*
  */
 object MimaExcludes {
 
-  // Exclude rules for 5.0.x from 4.2.0 (add 5.0-specific filters below as needed).
-  lazy val v50excludes: Seq[Problem => Boolean] = v42excludes
+  // Exclude rules for 5.0.x from 4.3.0 (add 5.0-specific filters below as needed).
+  lazy val v50excludes: Seq[Problem => Boolean] = v43excludes
+
+  // Exclude rules for 4.3.x from 4.2.0 (add 4.3-specific filters below as needed).
+  lazy val v43excludes: Seq[Problem => Boolean] = v42excludes
 
   // Exclude rules for 4.2.x from 4.1.0
   lazy val v42excludes = v41excludes ++ Seq(
@@ -168,6 +171,7 @@ object MimaExcludes {
 
   def excludes(version: String): Seq[Problem => Boolean] = version match {
     case v if v.startsWith("5.0") => v50excludes
+    case v if v.startsWith("4.3") => v43excludes
     case v if v.startsWith("4.2") => v42excludes
     case v if v.startsWith("4.1") => v41excludes
     case _ => Seq()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Followup to #55703 ([SPARK-56740], which bumped `master` to `5.0.0-SNAPSHOT` and added the MiMa section as `v50excludes = v42excludes`). At that time `4.3.0` did not yet exist; now that `branch-4.x` is `4.3.0-SNAPSHOT`, `master`'s `MimaExcludes` needs the intervening `4.3` section:

- add `v43excludes` (built from `v42excludes`);
- re-point `v50excludes` to build on `v43excludes` instead of `v42excludes`, so the exclude chain is `... -> v42excludes -> v43excludes -> v50excludes`;
- add the `case v if v.startsWith("4.3") => v43excludes` arm to `excludes(version)`.

### Why are the changes needed?

`master`'s exclude chain skipped `4.3` (`v50excludes` built directly on `v42excludes`), and `excludes(version)` did not resolve `4.3.x`. Now that `4.3.0` is a live version, the chain should be complete (5.0 builds on 4.3) and `4.3.x` should resolve. This also keeps `master` consistent with `branch-4.x`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A (build / MiMa configuration only).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)

This pull request and its description were written by Isaac.
