### PR TITLE
[SPARK-57472][SQL] Make FileTable.mergedOptions merge table and relation options case-insensitively

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
@@ -157,9 +157,9 @@ abstract class FileTable(
    * @return
    */
   protected def mergedOptions(options: CaseInsensitiveStringMap): CaseInsensitiveStringMap = {
-    val finalOptions = this.options.asCaseSensitiveMap().asScala ++
-      options.asCaseSensitiveMap().asScala
-    new CaseInsensitiveStringMap(finalOptions.asJava)
+    val tableOnly = this.options.asCaseSensitiveMap().asScala
+      .filter { case (key, _) => !options.containsKey(key) }
+    new CaseInsensitiveStringMap((tableOnly ++ options.asCaseSensitiveMap().asScala).asJava)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/FileTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/FileTableSuite.scala
@@ -156,4 +156,44 @@ class FileTableSuite extends SharedSparkSession {
       }
     }
   }
+
+  allFileBasedDataSources.foreach { format =>
+    test("SPARK-49519, SPARK-50287: relation options override table options case-insensitively " +
+      s"when merging table and relation options - $format") {
+      withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
+        val userSpecifiedSchema = StructType(Seq(StructField("c1", StringType)))
+
+        DataSource.lookupDataSourceV2(format, spark.sessionState.conf) match {
+          case Some(provider) =>
+            val dsOptions = new CaseInsensitiveStringMap(Map("lineSep" -> "table_val").asJava)
+            val table = provider.getTable(
+              userSpecifiedSchema,
+              Array.empty,
+              dsOptions.asCaseSensitiveMap()).asInstanceOf[FileTable]
+            val relationOptions = new CaseInsensitiveStringMap(
+              Map("linesep" -> "relation_val").asJava)
+
+            val mergedReadOptions = table.newScanBuilder(relationOptions) match {
+              case csv: CSVScanBuilder => csv.options
+              case json: JsonScanBuilder => json.options
+              case orc: OrcScanBuilder => orc.options
+              case parquet: ParquetScanBuilder => parquet.options
+              case text: TextScanBuilder => text.options
+            }
+            assert(mergedReadOptions.size === 1)
+            assert(mergedReadOptions.get("lineSep") === "relation_val")
+            assert(mergedReadOptions.get("linesep") === "relation_val")
+
+            val writeInfo = LogicalWriteInfoImpl("query-id", userSpecifiedSchema, relationOptions)
+            val mergedWriteOptions = table.newWriteBuilder(writeInfo).build()
+              .asInstanceOf[FileWrite].options
+            assert(mergedWriteOptions.size === 1)
+            assert(mergedWriteOptions.get("lineSep") === "relation_val")
+            assert(mergedWriteOptions.get("linesep") === "relation_val")
+          case _ =>
+            throw new IllegalArgumentException(s"Failed to get table provider for $format")
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`FileTable.mergedOptions` merges a `FileTable`'s own options with the options carried by the table operation (the relation), with the operation's options taking precedence. This PR makes that merge **case-insensitive** so the operation value deterministically wins on a key that differs only in case.

Previously the merge used a case-sensitive `++`:
```scala
val finalOptions = this.options.asCaseSensitiveMap().asScala ++ options.asCaseSensitiveMap().asScala
new CaseInsensitiveStringMap(finalOptions.asJava)
```
If the table and the operation set the same option with different key casing (e.g. `lineSep` vs `linesep`), both entries survive the `++`, and `CaseInsensitiveStringMap`'s constructor then collapses them by `HashMap` iteration order — picking an arbitrary winner and silently dropping the other (logging `"Converting duplicated key ... into CaseInsensitiveStringMap"`).

The fix drops any table option the operation already sets (case-insensitively, via `CaseInsensitiveStringMap.containsKey`) before merging:
```scala
val tableOnly = this.options.asCaseSensitiveMap().asScala
  .filter { case (key, _) => !options.containsKey(key) }
new CaseInsensitiveStringMap((tableOnly ++ options.asCaseSensitiveMap().asScala).asJava)
```

### Why are the changes needed?

The documented "operation options take precedence" behavior (asserted by the existing `FileTableSuite` test added in SPARK-49519 / SPARK-50287) is not honored when the two option maps use different casing for the same key. The winner is determined by `HashMap` iteration order rather than precedence, which is non-deterministic and can silently drop the intended value.

### Does this PR introduce _any_ user-facing change?

No behavior is intended to change for correctly-cased options. For options that differ only in case between the table and the operation, the operation value now deterministically wins (previously the winner was arbitrary). This only affects unreleased `master`.

### How was this patch tested?

Extended the existing SPARK-49519 / SPARK-50287 `FileTableSuite` test with a case-variant case (table `lineSep` vs operation `linesep`) across all file-based data sources, asserting the operation value wins for both read (`newScanBuilder`) and write (`newWriteBuilder`) and that the colliding table key does not survive as a separate entry.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
