### PR TITLE
[SPARK-57482][CORE][TESTS] Fix flaky SparkLauncherSuite.testInProcessLauncher under CI load

### DIFF
--- a/core/src/test/java/org/apache/spark/launcher/SparkLauncherSuite.java
+++ b/core/src/test/java/org/apache/spark/launcher/SparkLauncherSuite.java
@@ -152,8 +152,10 @@ public class SparkLauncherSuite extends BaseSuite {
         // SPARK-23020: see doc for InProcessTestApp.LOCK for a description of the race. Here
         // we wait until we know that the connection between the app and the launcher has been
         // established before allowing the app to finish.
+        // Use a generous timeout because, under heavy CI load, establishing the connection
+        // between the in-process app and the launcher can take longer than a few seconds.
         final SparkAppHandle _handle = handle;
-        eventually(Duration.ofSeconds(5), Duration.ofMillis(10), () -> {
+        eventually(Duration.ofSeconds(30), Duration.ofMillis(100), () -> {
           assertNotEquals(SparkAppHandle.State.UNKNOWN, _handle.getState());
         });
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`SparkLauncherSuite.testInProcessLauncher` waits for the connection between the in-process app and the launcher to be established by polling the app handle state with `eventually(Duration.ofSeconds(5), Duration.ofMillis(10))`. Under heavy CI load this 5-second window is too short: the handle can remain in `UNKNOWN` for longer, causing the test to fail with:

```
java.lang.IllegalStateException: Failed check after 476 tries: expected: not equal but was: <UNKNOWN>.
  at org.apache.spark.launcher.BaseSuite.eventually(BaseSuite.java:88)
  at org.apache.spark.launcher.SparkLauncherSuite.inProcessLauncherTestImpl(SparkLauncherSuite.java:162)
  at org.apache.spark.launcher.SparkLauncherSuite.testInProcessLauncher(SparkLauncherSuite.java:130)
```

This change increases the timeout to 30 seconds with a 100ms poll interval, consistent with `waitForSparkContextShutdown` (30s/100ms) and the other `eventually` calls in this suite (60s/1000ms).

### Why are the changes needed?

`SparkLauncherSuite.testInProcessLauncher` is flaky under CI load. The change only relaxes a test timeout; it does not change production behavior.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing test `SparkLauncherSuite.testInProcessLauncher`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8
