### PR TITLE
[SPARK-42751][PS] Support str.findall with capture groups

### DIFF
--- a/python/pyspark/pandas/strings.py
+++ b/python/pyspark/pandas/strings.py
@@ -1184,9 +1184,7 @@ class StringMethods:
         num_groups = re.compile(pat, flags=flags).groups
         str_dtype = is_str_dtype(self._data.dtype)
         if num_groups > 1:
-            return_type = ArrayType(
-                ArrayType(StringType(), containsNull=True), containsNull=True
-            )
+            return_type = ArrayType(ArrayType(StringType(), containsNull=True), containsNull=True)
         else:
             return_type = ArrayType(StringType(), containsNull=True)
 

--- a/python/pyspark/pandas/strings.py
+++ b/python/pyspark/pandas/strings.py
@@ -1117,6 +1117,12 @@ class StringMethods:
             All non-overlapping matches of pattern or regular expression in
             each string of this Series.
 
+        Notes
+        -----
+        For regular expressions with more than one capture group, pandas-on-Spark
+        returns nested lists instead of pandas' tuple matches because Spark SQL
+        does not have a tuple type.
+
         Examples
         --------
         >>> s = ps.Series(['Lion', 'Monkey', 'Rabbit'])

--- a/python/pyspark/pandas/strings.py
+++ b/python/pyspark/pandas/strings.py
@@ -19,6 +19,7 @@
 String functions on pandas-on-Spark Series
 """
 
+import re
 from functools import wraps
 from typing import (
     Any,
@@ -1174,14 +1175,25 @@ class StringMethods:
         2    [b, b]
         dtype: object
         """
+        num_groups = re.compile(pat, flags=flags).groups
         str_dtype = is_str_dtype(self._data.dtype)
+        if num_groups > 1:
+            return_type = ArrayType(
+                ArrayType(StringType(), containsNull=True), containsNull=True
+            )
+        else:
+            return_type = ArrayType(StringType(), containsNull=True)
 
         # type hint does not support to specify array type yet.
-        @pandas_udf(  # type: ignore[call-overload]
-            returnType=ArrayType(StringType(), containsNull=True)
-        )
+        @pandas_udf(returnType=return_type)  # type: ignore[call-overload]
         def pudf(s: pd.Series) -> pd.Series:
             ret = s.str.findall(pat, flags)
+            if num_groups > 1:
+                ret = ret.map(
+                    lambda matches: [list(match) for match in matches]
+                    if isinstance(matches, list)
+                    else matches
+                )
             if str_dtype:
                 # ArrayType does not support NaN, so replace with None
                 ret = ret.replace(np.nan, None)

--- a/python/pyspark/pandas/tests/series/test_string_ops_adv.py
+++ b/python/pyspark/pandas/tests/series/test_string_ops_adv.py
@@ -86,6 +86,15 @@ class SeriesStringOpsAdvMixin:
                 lambda x: x.str.findall("wh.*", flags=re.IGNORECASE), self.pser, ignore_null=True
             )
 
+        pser = pd.Series(["abc-123 def-456", "no match"])
+        expected = pser.str.findall("([a-z]+)-([0-9]+)").map(
+            lambda matches: [list(match) for match in matches]
+        )
+        self.assert_eq(
+            ps.from_pandas(pser).str.findall("([a-z]+)-([0-9]+)"),
+            expected,
+        )
+
     def test_string_index(self):
         pser = pd.Series(["tea", "eat"])
         self.check_func_on_series(lambda x: x.str.index("ea"), pser)

--- a/python/pyspark/pandas/tests/series/test_string_ops_adv.py
+++ b/python/pyspark/pandas/tests/series/test_string_ops_adv.py
@@ -86,15 +86,14 @@ class SeriesStringOpsAdvMixin:
                 lambda x: x.str.findall("wh.*", flags=re.IGNORECASE), self.pser, ignore_null=True
             )
 
-        pser = pd.Series(["abc-123 def-456", "no match"])
+        pser = pd.Series(["abc-123 def-456", "no match", None])
         pattern = "([a-z]+)-([0-9]+)"
-        expected = pser.str.findall(pattern).map(lambda matches: [list(match) for match in matches])
-        actual = (
-            ps.from_pandas(pser)
-            .str.findall(pattern)
-            .to_pandas()
-            .map(lambda matches: [list(match) for match in matches])
-        )
+
+        def normalize_matches(matches):  # type: ignore[no-untyped-def]
+            return [list(match) for match in matches] if isinstance(matches, list) else matches
+
+        expected = pser.str.findall(pattern).map(normalize_matches)
+        actual = ps.from_pandas(pser).str.findall(pattern).to_pandas().map(normalize_matches)
         self.assert_eq(actual, expected)
 
     def test_string_index(self):

--- a/python/pyspark/pandas/tests/series/test_string_ops_adv.py
+++ b/python/pyspark/pandas/tests/series/test_string_ops_adv.py
@@ -87,13 +87,15 @@ class SeriesStringOpsAdvMixin:
             )
 
         pser = pd.Series(["abc-123 def-456", "no match"])
-        expected = pser.str.findall("([a-z]+)-([0-9]+)").map(
-            lambda matches: [list(match) for match in matches]
+        pattern = "([a-z]+)-([0-9]+)"
+        expected = pser.str.findall(pattern).map(lambda matches: [list(match) for match in matches])
+        actual = (
+            ps.from_pandas(pser)
+            .str.findall(pattern)
+            .to_pandas()
+            .map(lambda matches: [list(match) for match in matches])
         )
-        self.assert_eq(
-            ps.from_pandas(pser).str.findall("([a-z]+)-([0-9]+)").apply(str),
-            expected.apply(str),
-        )
+        self.assert_eq(actual, expected)
 
     def test_string_index(self):
         pser = pd.Series(["tea", "eat"])

--- a/python/pyspark/pandas/tests/series/test_string_ops_adv.py
+++ b/python/pyspark/pandas/tests/series/test_string_ops_adv.py
@@ -91,8 +91,8 @@ class SeriesStringOpsAdvMixin:
             lambda matches: [list(match) for match in matches]
         )
         self.assert_eq(
-            ps.from_pandas(pser).str.findall("([a-z]+)-([0-9]+)"),
-            expected,
+            ps.from_pandas(pser).str.findall("([a-z]+)-([0-9]+)").apply(str),
+            expected.apply(str),
         )
 
     def test_string_index(self):

--- a/python/pyspark/pandas/tests/series/test_string_ops_adv.py
+++ b/python/pyspark/pandas/tests/series/test_string_ops_adv.py
@@ -90,10 +90,14 @@ class SeriesStringOpsAdvMixin:
         pattern = "([a-z]+)-([0-9]+)"
 
         def normalize_matches(matches):  # type: ignore[no-untyped-def]
-            return [list(match) for match in matches] if isinstance(matches, list) else matches
+            if isinstance(matches, (list, np.ndarray)):
+                return [list(match) for match in matches]
+            return matches
 
         expected = pser.str.findall(pattern).map(normalize_matches)
-        actual = ps.from_pandas(pser).str.findall(pattern).to_pandas().map(normalize_matches)
+        actual = ps.from_pandas(pser).str.findall(pattern).to_pandas()
+        self.assertIsNone(actual.iloc[-1])
+        actual = actual.map(normalize_matches)
         self.assert_eq(actual, expected)
 
     def test_string_index(self):


### PR DESCRIPTION


### What changes were proposed in this pull request?


This PR updates pandas-on-Spark `Series.str.findall` to support regex patterns with multiple capture groups.

When the regex pattern has more than one capture group, pandas returns a list of tuples. The existing pandas UDF return type expects an array of strings, which can fail during Arrow conversion. This PR returns an array of arrays of strings for this case and converts each tuple match into a list.

This PR also adds regression test coverage for `Series.str.findall` with multiple capture groups.


### Why are the changes needed?

`Series.str.findall` currently cannot handle regex patterns that return tuples, for example:

```python
ps.Series(["abc-123 def-456"]).str.findall("([a-z]+)-([0-9]+)")
```

This should return the captured groups instead of failing during conversion.


### Does this PR introduce _any_ user-facing change?

Yes.

Previously, `Series.str.findall` could fail for regex patterns with multiple capture groups. With this change, it returns nested arrays representing the captured groups.


### How was this patch tested?


Added a regression test in `SeriesStringOpsAdvTests.test_string_findall`.

Also ran:

```bash
python -m py_compile python/pyspark/pandas/strings.py python/pyspark/pandas/tests/series/test_string_ops_adv.py
git diff --check
PYTHON_EXECUTABLE=python ./dev/lint-python --ruff
```

Note: the local `lint-python --ruff` wrapper skipped ruff because the `ruff` command was not installed. The focused PySpark unittest could not start locally because Spark jars have not been built in this checkout.


### Was this patch authored or co-authored using generative AI tooling?

No.