### PR TITLE
[SPARK-55707][SQL][TESTS] Re-enable DB2 JDBC tests by upgrading jcc to 12.1.4.0

### DIFF
--- a/connector/docker-integration-tests/pom.xml
+++ b/connector/docker-integration-tests/pom.xml
@@ -100,12 +100,11 @@
       <artifactId>ojdbc17</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- TODO(SPARK-55707: Re-enable DB2 JDBC Driver tests) -->
-    <!--dependency>
+    <dependency>
       <groupId>com.ibm.db2</groupId>
       <artifactId>jcc</artifactId>
       <scope>test</scope>
-    </dependency-->
+    </dependency>
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2IntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2IntegrationSuite.scala
@@ -21,13 +21,12 @@ import java.math.BigDecimal
 import java.sql.{Connection, Date, Timestamp}
 import java.util.Properties
 
-import org.scalatest.Ignore
-
 import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ByteType, ShortType, StructType}
+import org.apache.spark.tags.DockerTest
 
 /**
  * To run this test suite for a specific version (e.g., icr.io/db2_community/db2:11.5.9.0):
@@ -37,7 +36,7 @@ import org.apache.spark.sql.types.{ByteType, ShortType, StructType}
  *     "docker-integration-tests/testOnly org.apache.spark.sql.jdbc.DB2IntegrationSuite"
  * }}}
  */
-@Ignore // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
+@DockerTest
 class DB2IntegrationSuite extends SharedJDBCIntegrationSuite {
   override val db = new DB2DatabaseOnDocker
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2KrbIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DB2KrbIntegrationSuite.scala
@@ -24,7 +24,6 @@ import javax.security.auth.login.Configuration
 import com.github.dockerjava.api.model.{AccessMode, Bind, ContainerConfig, HostConfig, Volume}
 import org.apache.hadoop.security.{SecurityUtil, UserGroupInformation}
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS
-import org.scalatest.Ignore
 
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.execution.datasources.jdbc.connection.{DB2ConnectionProvider, SecureConnectionProvider}
@@ -38,7 +37,6 @@ import org.apache.spark.tags.DockerTest
  *     "docker-integration-tests/testOnly *DB2KrbIntegrationSuite"
  * }}}
  */
-@Ignore // TODO(SPARK-55707: Re-enable DB2 JDBC Driver tests)
 @DockerTest
 class DB2KrbIntegrationSuite extends DockerKrbJDBCIntegrationSuite {
   override protected val userName = s"db2/$dockerIp"

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
@@ -20,13 +20,12 @@ package org.apache.spark.sql.jdbc.v2
 import java.sql.Connection
 import java.util.Locale
 
-import org.scalatest.Ignore
-
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.apache.spark.sql.jdbc.DB2DatabaseOnDocker
 import org.apache.spark.sql.types._
+import org.apache.spark.tags.DockerTest
 
 /**
  * To run this test suite for a specific version (e.g., icr.io/db2_community/db2:11.5.9.0):
@@ -35,7 +34,7 @@ import org.apache.spark.sql.types._
  *     ./build/sbt -Pdocker-integration-tests "testOnly *v2.DB2IntegrationSuite"
  * }}}
  */
-@Ignore // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
+@DockerTest
 class DB2IntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest {
 
   // Following tests are disabled for both single and multiple partition read

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2NamespaceSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2NamespaceSuite.scala
@@ -21,8 +21,6 @@ import java.sql.Connection
 
 import scala.jdk.CollectionConverters._
 
-import org.scalatest.Ignore
-
 import org.apache.spark.sql.jdbc.{DB2DatabaseOnDocker, DockerJDBCIntegrationSuite}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.tags.DockerTest
@@ -34,7 +32,6 @@ import org.apache.spark.tags.DockerTest
  *     ./build/sbt -Pdocker-integration-tests "testOnly *v2.DB2NamespaceSuite"
  * }}}
  */
-@Ignore // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
 @DockerTest
 class DB2NamespaceSuite extends DockerJDBCIntegrationSuite with V2JDBCNamespaceTest {
   override val db = new DB2DatabaseOnDocker
@@ -42,8 +39,7 @@ class DB2NamespaceSuite extends DockerJDBCIntegrationSuite with V2JDBCNamespaceT
     Map("url" -> db.getJdbcUrl(dockerIp, externalPort),
       "driver" -> "com.ibm.db2.jcc.DB2Driver").asJava)
 
-  // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
-  // catalog.initialize("db2", map)
+  catalog.initialize("db2", map)
 
   override def dataPreparation(conn: Connection): Unit = {}
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2NamespaceSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2NamespaceSuite.scala
@@ -39,7 +39,10 @@ class DB2NamespaceSuite extends DockerJDBCIntegrationSuite with V2JDBCNamespaceT
     Map("url" -> db.getJdbcUrl(dockerIp, externalPort),
       "driver" -> "com.ibm.db2.jcc.DB2Driver").asJava)
 
-  catalog.initialize("db2", map)
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    catalog.initialize("db2", map)
+  }
 
   override def dataPreparation(conn: Connection): Unit = {}
 

--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
     <mariadb.java.client.version>3.5.7</mariadb.java.client.version>
     <mysql.connector.version>9.6.0</mysql.connector.version>
     <postgresql.version>42.7.11</postgresql.version>
-    <db2.jcc.version>11.5.9.0</db2.jcc.version>
+    <db2.jcc.version>12.1.4.0</db2.jcc.version>
     <mssql.jdbc.version>13.2.1.jre11</mssql.jdbc.version>
     <ojdbc17.version>23.26.1.0.0</ojdbc17.version>
     <databricks.jdbc.version>3.3.1</databricks.jdbc.version>
@@ -1382,13 +1382,12 @@
         <version>${postgresql.version}</version>
         <scope>test</scope>
       </dependency>
-      <!-- TODO(SPARK-55707: Re-enable DB2 JDBC Driver tests) -->
-      <!--dependency>
+      <dependency>
         <groupId>com.ibm.db2</groupId>
         <artifactId>jcc</artifactId>
         <version>${db2.jcc.version}</version>
         <scope>test</scope>
-      </dependency-->
+      </dependency>
       <dependency>
         <groupId>com.microsoft.sqlserver</groupId>
         <artifactId>mssql-jdbc</artifactId>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -211,12 +211,11 @@
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- TODO(SPARK-55707: Re-enable DB2 JDBC Driver tests) -->
-    <!--dependency>
+    <dependency>
       <groupId>com.ibm.db2</groupId>
       <artifactId>jcc</artifactId>
       <scope>test</scope>
-    </dependency-->
+    </dependency>
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/ConnectionProviderSuite.scala
@@ -185,28 +185,28 @@ class ConnectionProviderSuite
     val postgresDriver = registerDriver(postgresProvider.driverClass)
     val postgresOptions = options("jdbc:postgresql://localhost/postgres")
     val postgresAppEntry = postgresProvider.appEntry(postgresDriver, postgresOptions)
-    val mysqlProvider = new MariaDBConnectionProvider()
-    val mysqlDriver = registerDriver(mysqlProvider.driverClass)
-    val mysqlOptions = options("jdbc:mysql://localhost/db")
-    val mysqlAppEntry = mysqlProvider.appEntry(mysqlDriver, mysqlOptions)
+    val db2Provider = new DB2ConnectionProvider()
+    val db2Driver = registerDriver(db2Provider.driverClass)
+    val db2Options = options("jdbc:db2://localhost/db2")
+    val db2AppEntry = db2Provider.appEntry(db2Driver, db2Options)
 
     // Make sure no authentication for the databases are set
     val rootConfig = Configuration.getConfiguration
     assert(rootConfig.getAppConfigurationEntry(postgresAppEntry) == null)
-    assert(rootConfig.getAppConfigurationEntry(mysqlAppEntry) == null)
+    assert(rootConfig.getAppConfigurationEntry(db2AppEntry) == null)
 
     postgresProvider.setAuthenticationConfig(postgresDriver, postgresOptions)
     val postgresConfig = Configuration.getConfiguration
 
-    mysqlProvider.setAuthenticationConfig(mysqlDriver, mysqlOptions)
-    val mysqlConfig = Configuration.getConfiguration
+    db2Provider.setAuthenticationConfig(db2Driver, db2Options)
+    val db2Config = Configuration.getConfiguration
 
     // Make sure authentication for the databases are set
     assert(rootConfig != postgresConfig)
-    assert(rootConfig != mysqlConfig)
+    assert(rootConfig != db2Config)
     // The topmost config in the chain is linked with all the subsequent entries
-    assert(mysqlConfig.getAppConfigurationEntry(postgresAppEntry) != null)
-    assert(mysqlConfig.getAppConfigurationEntry(mysqlAppEntry) != null)
+    assert(db2Config.getAppConfigurationEntry(postgresAppEntry) != null)
+    assert(db2Config.getAppConfigurationEntry(db2AppEntry) != null)
 
     Configuration.setConfiguration(null)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/DB2ConnectionProviderSuite.scala
@@ -17,9 +17,6 @@
 
 package org.apache.spark.sql.execution.datasources.jdbc.connection
 
-import org.scalatest.Ignore
-
-@Ignore // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
 class DB2ConnectionProviderSuite extends ConnectionProviderSuiteBase {
   test("setAuthenticationConfig must set authentication all the time") {
     val provider = new DB2ConnectionProvider()

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1265,8 +1265,7 @@ class JDBCSuite extends SharedSparkSession {
       "SELECT TOP (123) a,b FROM test")
   }
 
-  // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
-  ignore("SPARK-42534: DB2Dialect Limit query test") {
+  test("SPARK-42534: DB2Dialect Limit query test") {
     // JDBC url is a required option but is not used in this test.
     val options = new JDBCOptions(Map("url" -> "jdbc:db2://host:port", "dbtable" -> "test"))
     assert(
@@ -2439,9 +2438,7 @@ class JDBCSuite extends SharedSparkSession {
     }
     // not supported
     Seq(
-      // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
-      // "jdbc:db2://host:port",
-      "jdbc:derby:memory", "jdbc:h2://host:port",
+      "jdbc:db2://host:port", "jdbc:derby:memory", "jdbc:h2://host:port",
       "jdbc:sqlserver://host:port", "jdbc:postgresql://host:5432/postgres",
       "jdbc:snowflake://host:443?account=test", "jdbc:teradata://host:port").foreach { url =>
       val options = new JDBCOptions(baseParameters + ("url" -> url))
@@ -2462,8 +2459,7 @@ class JDBCSuite extends SharedSparkSession {
       "jdbc:mysql",
       "jdbc:postgresql",
       "jdbc:sqlserver",
-      // TODO(SPARK-55707): Re-enable DB2 JDBC Driver tests
-      // "jdbc:db2",
+      "jdbc:db2",
       "jdbc:h2",
       "jdbc:teradata",
       "jdbc:databricks"


### PR DESCRIPTION
### What changes were proposed in this pull request?

SPARK-55706 disabled the DB2 JDBC driver tests because `com.ibm.db2:jcc` 11.5.x
bundles an old, unshaded copy of lz4-java (`net.jpountz.*`) that predates
`LZ4BlockInputStream.newBuilder()`. On the shared test classpath it shadows the
lz4-java Spark ships and breaks the builder API adopted in SPARK-54571.

The jcc 12.1.x driver bundles a newer lz4-java that already provides the full
`newBuilder()` builder API (including the `LZ4SafeDecompressor` overload), so the
conflict no longer occurs. This:
- bumps `db2.jcc.version` 11.5.9.0 -> 12.1.4.0, and
- reverts the test-disabling changes from SPARK-55706.

### Why are the changes needed?

To restore the DB2 JDBC test coverage disabled in SPARK-55706.

### Does this PR introduce _any_ user-facing change?

No. `com.ibm.db2:jcc` is a test-only dependency.

### How was this patch tested?

The DB2 integration / connection-provider suites disabled by SPARK-55706 are
re-enabled. The 12.1.x driver is backward-compatible with the DB2 11 test
container.


This pull request and its description were written by Isaac.
