### PR TITLE
[SPARK-57484][SQL] Preserve row nullability after ColumnarToRowExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -20,7 +20,8 @@ package org.apache.spark.sql.execution
 import org.apache.spark.broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder, SpecializedGetters}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, Expression, SortOrder,
+  SpecializedGetters}
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
@@ -55,6 +56,23 @@ class ColumnarRule {
  * that walk a spark plan looking for this type of transition properly match it.
  */
 trait ColumnarToRowTransition extends UnaryExecNode
+
+private[execution] object RowBoundaryOutput {
+  def withPhysicalInputAttributes[E <: Expression](
+      expression: E,
+      inputAttributes: Seq[Attribute]): E = {
+    val inputAttrMap = AttributeMap(inputAttributes.map(attr => attr -> attr))
+    expression.transformUp {
+      case attr: Attribute => inputAttrMap.getOrElse(attr, attr)
+    }.asInstanceOf[E]
+  }
+
+  def withPhysicalInputAttributes[E <: Expression](
+      expressions: Seq[E],
+      inputAttributes: Seq[Attribute]): Seq[E] = {
+    expressions.map(withPhysicalInputAttributes(_, inputAttributes))
+  }
+}
 
 /**
  * Provides a common executor to translate an [[RDD]] of [[ColumnarBatch]] into an [[RDD]] of

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -66,7 +66,9 @@ trait ColumnarToRowTransition extends UnaryExecNode
  */
 case class ColumnarToRowExec(child: SparkPlan)
     extends ColumnarToRowTransition with CodegenSupport with SafeForKWayMerge {
-  override def output: Seq[Attribute] = child.output
+  // Columnar batches carry their own null bitmap. Keep row consumers from assuming a value is
+  // non-null solely because the logical schema said so when materializing batch rows.
+  override def output: Seq[Attribute] = child.output.map(_.withNullability(true))
 
   override def outputPartitioning: Partitioning = child.outputPartitioning
 
@@ -83,7 +85,7 @@ case class ColumnarToRowExec(child: SparkPlan)
 
   override def doExecute(): RDD[InternalRow] = {
     val evaluatorFactory = new ColumnarToRowEvaluatorFactory(
-      child.output,
+      output,
       longMetric("numOutputRows"),
       longMetric("numInputBatches"))
     if (conf.usePartitionEvaluator) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
@@ -50,6 +50,16 @@ case class ExpandExec(
   override lazy val references: AttributeSet =
     AttributeSet(projections.flatten.flatMap(_.references))
 
+  private def outputForChild(childOutput: Seq[Attribute]): Seq[Attribute] = {
+    val inputAttributes = AttributeSeq(childOutput)
+    output.zip(projections.transpose).map { case (attr, projectionExprs) =>
+      val nullable = projectionExprs.exists { expr =>
+        BindReferences.bindReference(expr, inputAttributes).nullable
+      }
+      attr.withNullability(nullable)
+    }
+  }
+
   private[this] val projection =
     (exprs: Seq[Expression]) => UnsafeProjection.create(exprs, child.output)
 
@@ -229,5 +239,5 @@ case class ExpandExec(
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): ExpandExec =
-    copy(child = newChild)
+    copy(output = outputForChild(newChild.output), child = newChild)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
@@ -50,12 +50,13 @@ case class ExpandExec(
   override lazy val references: AttributeSet =
     AttributeSet(projections.flatten.flatMap(_.references))
 
-  private def outputForChild(childOutput: Seq[Attribute]): Seq[Attribute] = {
-    val inputAttributes = AttributeSeq(childOutput)
+  private def projectionsForChild(childOutput: Seq[Attribute]): Seq[Seq[Expression]] = {
+    projections.map(RowBoundaryOutput.withPhysicalInputAttributes(_, childOutput))
+  }
+
+  private def outputForProjections(projections: Seq[Seq[Expression]]): Seq[Attribute] = {
     output.zip(projections.transpose).map { case (attr, projectionExprs) =>
-      val nullable = projectionExprs.exists { expr =>
-        BindReferences.bindReference(expr, inputAttributes).nullable
-      }
+      val nullable = projectionExprs.exists(_.nullable)
       attr.withNullability(nullable)
     }
   }
@@ -238,6 +239,15 @@ case class ExpandExec(
      """.stripMargin
   }
 
-  override protected def withNewChildInternal(newChild: SparkPlan): ExpandExec =
-    copy(output = outputForChild(newChild.output), child = newChild)
+  override protected def withNewChildInternal(newChild: SparkPlan): ExpandExec = {
+    if (isCanonicalizedPlan) {
+      copy(child = newChild)
+    } else {
+      val newProjections = projectionsForChild(newChild.output)
+      copy(
+        projections = newProjections,
+        output = outputForProjections(newProjections),
+        child = newChild)
+    }
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
@@ -64,7 +64,15 @@ case class GenerateExec(
     child: SparkPlan)
   extends UnaryExecNode with CodegenSupport {
 
-  override def output: Seq[Attribute] = requiredChildOutput ++ generatorOutput
+  // ColumnarToRowExec can make required child attributes physically nullable after GenerateExec
+  // was planned. Keep the passthrough side of GenerateExec aligned with the actual child output so
+  // its own unsafe-row materialization does not revive stale non-nullable metadata.
+  private lazy val requiredChildOutputForExecution: Seq[Attribute] = {
+    val childOutput = AttributeMap(child.output.map(attr => attr -> attr))
+    requiredChildOutput.map(attr => childOutput.getOrElse(attr, attr))
+  }
+
+  override def output: Seq[Attribute] = requiredChildOutputForExecution ++ generatorOutput
 
   override lazy val metrics = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
@@ -84,16 +92,16 @@ case class GenerateExec(
         case _ =>
       }
       val generatorNullRow = new GenericInternalRow(generator.elementSchema.length)
-      val rows = if (requiredChildOutput.nonEmpty) {
+      val rows = if (requiredChildOutputForExecution.nonEmpty) {
 
         val pruneChildForResult: InternalRow => InternalRow = {
           // The declared output of this operator is `requiredChildOutput ++ generatorOutput`.
           // If `child.output` is different from `requiredChildOutput`, we must do an projection
           // to adjust the child output and make sure the final result matches the declared output.
-          if (child.output == requiredChildOutput) {
+          if (child.output == requiredChildOutputForExecution) {
             identity
           } else {
-            UnsafeProjection.create(requiredChildOutput, child.output)
+            UnsafeProjection.create(requiredChildOutputForExecution, child.output)
           }
         }
 
@@ -147,7 +155,7 @@ case class GenerateExec(
 
   override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
     val attrToInputCode = AttributeMap(child.output.zip(input))
-    val requiredInput = requiredChildOutput.map(attrToInputCode)
+    val requiredInput = requiredChildOutputForExecution.map(attrToInputCode)
     boundGenerator match {
       case e: CollectionGenerator => codeGenCollection(ctx, e, requiredInput)
       case g => codeGenIterableOnce(ctx, g, requiredInput)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/GenerateExec.scala
@@ -68,8 +68,12 @@ case class GenerateExec(
   // was planned. Keep the passthrough side of GenerateExec aligned with the actual child output so
   // its own unsafe-row materialization does not revive stale non-nullable metadata.
   private lazy val requiredChildOutputForExecution: Seq[Attribute] = {
-    val childOutput = AttributeMap(child.output.map(attr => attr -> attr))
-    requiredChildOutput.map(attr => childOutput.getOrElse(attr, attr))
+    if (isCanonicalizedPlan) {
+      requiredChildOutput
+    } else {
+      val childOutput = AttributeMap(child.output.map(attr => attr -> attr))
+      requiredChildOutput.map(attr => childOutput.getOrElse(attr, attr))
+    }
   }
 
   override def output: Seq[Attribute] = requiredChildOutputForExecution ++ generatorOutput
@@ -98,7 +102,7 @@ case class GenerateExec(
           // The declared output of this operator is `requiredChildOutput ++ generatorOutput`.
           // If `child.output` is different from `requiredChildOutput`, we must do an projection
           // to adjust the child output and make sure the final result matches the declared output.
-          if (child.output == requiredChildOutputForExecution) {
+          if (child.outputSet == AttributeSet(requiredChildOutputForExecution)) {
             identity
           } else {
             UnsafeProjection.create(requiredChildOutputForExecution, child.output)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregateCodegenSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregateCodegenSupport.scala
@@ -65,7 +65,7 @@ trait AggregateCodegenSupport
   protected def doConsumeWithKeys(ctx: CodegenContext, input: Seq[ExprCode]): String
 
   protected override def doProduce(ctx: CodegenContext): String = {
-    if (groupingExpressions.isEmpty) {
+    if (groupingExpressionsForExecution.isEmpty) {
       doProduceWithoutKeys(ctx)
     } else {
       doProduceWithKeys(ctx)
@@ -73,7 +73,7 @@ trait AggregateCodegenSupport
   }
 
   override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
-    if (groupingExpressions.isEmpty) {
+    if (groupingExpressionsForExecution.isEmpty) {
       doConsumeWithoutKeys(ctx, input)
     } else {
       doConsumeWithKeys(ctx, input)
@@ -134,7 +134,8 @@ trait AggregateCodegenSupport
       val evaluateAggResults = evaluateVariables(aggResults)
       // evaluate result expressions
       ctx.currentVars = aggResults
-      val resultVars = bindReferences(resultExpressions, aggregateAttributes).map(_.genCode(ctx))
+      val resultVars =
+        bindReferences(resultExpressionsForExecution, aggregateAttributes).map(_.genCode(ctx))
       (resultVars,
         s"""
            |$evaluateAggResults
@@ -145,7 +146,7 @@ trait AggregateCodegenSupport
       (flatBufVars, "")
     } else {
       // no aggregate function, the result should be literals
-      val resultVars = resultExpressions.map(_.genCode(ctx))
+      val resultVars = resultExpressionsForExecution.map(_.genCode(ctx))
       (resultVars, evaluateVariables(resultVars))
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/BaseAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/BaseAggregateExec.scala
@@ -18,7 +18,8 @@
 package org.apache.spark.sql.execution.aggregate
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference,
+  AttributeSet, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Final, PartialMerge}
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, UnspecifiedDistribution}
 import org.apache.spark.sql.execution.{ExplainUtils, PartitioningPreservingUnaryExecNode, UnaryExecNode}
@@ -80,18 +81,42 @@ trait BaseAggregateExec extends UnaryExecNode with PartitioningPreservingUnaryEx
     aggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes)
   }
 
+  // ColumnarToRowExec can make child attributes physically nullable after aggregate planning.
+  // Rebind by exprId so aggregate projections read the actual execution-time nullability instead
+  // of reviving stale non-nullable attributes captured before the row transition was inserted.
+  private def withPhysicalInputAttributes(
+      expressions: Seq[NamedExpression],
+      inputAttributes: Seq[Attribute]): Seq[NamedExpression] = {
+    val inputAttrMap = AttributeMap(inputAttributes.map(attr => attr -> attr))
+    expressions.map(_.transformUp {
+      case attr: Attribute => inputAttrMap.getOrElse(attr, attr)
+    }.asInstanceOf[NamedExpression])
+  }
+
+  protected lazy val groupingExpressionsForExecution: Seq[NamedExpression] =
+    withPhysicalInputAttributes(groupingExpressions, child.output)
+
+  protected lazy val groupingAttributesForExecution: Seq[Attribute] =
+    groupingExpressionsForExecution.map(_.toAttribute)
+
+  protected lazy val resultExpressionsForExecution: Seq[NamedExpression] =
+    withPhysicalInputAttributes(
+      resultExpressions,
+      groupingAttributesForExecution ++ aggregateAttributes)
+
   override def producedAttributes: AttributeSet =
     AttributeSet(aggregateAttributes) ++
-    AttributeSet(resultExpressions.diff(groupingExpressions).map(_.toAttribute)) ++
+    AttributeSet(resultExpressionsForExecution.diff(groupingExpressionsForExecution)
+      .map(_.toAttribute)) ++
     AttributeSet(aggregateBufferAttributes) ++
     // it's not empty when the inputAggBufferAttributes is not equal to the aggregate buffer
     // attributes of the child Aggregate, when the child Aggregate contains the subquery in
     // AggregateFunction. See SPARK-31620 for more details.
     AttributeSet(inputAggBufferAttributes) -- child.outputSet
 
-  override def output: Seq[Attribute] = resultExpressions.map(_.toAttribute)
+  override def output: Seq[Attribute] = resultExpressionsForExecution.map(_.toAttribute)
 
-  override protected def outputExpressions: Seq[NamedExpression] = resultExpressions
+  override protected def outputExpressions: Seq[NamedExpression] = resultExpressionsForExecution
 
   override def requiredChildDistribution: List[Distribution] = {
     requiredChildDistributionExpressions match {
@@ -119,8 +144,8 @@ trait BaseAggregateExec extends UnaryExecNode with PartitioningPreservingUnaryEx
    */
   def toSortAggregate: SortAggregateExec = {
     SortAggregateExec(
-      requiredChildDistributionExpressions, isStreaming, numShufflePartitions, groupingExpressions,
-      aggregateExpressions, aggregateAttributes, initialInputBufferOffset, resultExpressions,
-      child)
+      requiredChildDistributionExpressions, isStreaming, numShufflePartitions,
+      groupingExpressionsForExecution, aggregateExpressions, aggregateAttributes,
+      initialInputBufferOffset, resultExpressionsForExecution, child)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/BaseAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/BaseAggregateExec.scala
@@ -18,11 +18,12 @@
 package org.apache.spark.sql.execution.aggregate
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference,
-  AttributeSet, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet,
+  Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Final, PartialMerge}
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, UnspecifiedDistribution}
-import org.apache.spark.sql.execution.{ExplainUtils, PartitioningPreservingUnaryExecNode, UnaryExecNode}
+import org.apache.spark.sql.execution.{ExplainUtils, PartitioningPreservingUnaryExecNode,
+  RowBoundaryOutput, UnaryExecNode}
 import org.apache.spark.sql.execution.streaming.operators.stateful.StatefulOperatorPartitioning
 
 /**
@@ -81,23 +82,24 @@ trait BaseAggregateExec extends UnaryExecNode with PartitioningPreservingUnaryEx
     aggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes)
   }
 
-  // ColumnarToRowExec can make child attributes physically nullable after aggregate planning.
-  // Rebind by exprId so aggregate projections read the actual execution-time nullability instead
-  // of reviving stale non-nullable attributes captured before the row transition was inserted.
   private def withPhysicalInputAttributes(
       expressions: Seq[NamedExpression],
       inputAttributes: Seq[Attribute]): Seq[NamedExpression] = {
-    val inputAttrMap = AttributeMap(inputAttributes.map(attr => attr -> attr))
-    expressions.map(_.transformUp {
-      case attr: Attribute => inputAttrMap.getOrElse(attr, attr)
-    }.asInstanceOf[NamedExpression])
+    if (isCanonicalizedPlan) {
+      expressions
+    } else {
+      RowBoundaryOutput.withPhysicalInputAttributes(expressions, inputAttributes)
+    }
   }
 
   protected lazy val groupingExpressionsForExecution: Seq[NamedExpression] =
     withPhysicalInputAttributes(groupingExpressions, child.output)
 
   protected lazy val groupingAttributesForExecution: Seq[Attribute] =
-    groupingExpressionsForExecution.map(_.toAttribute)
+    groupingExpressions.zip(groupingExpressionsForExecution).map {
+      case (groupingExpression, groupingExpressionForExecution) =>
+        groupingExpression.toAttribute.withNullability(groupingExpressionForExecution.nullable)
+    }
 
   protected lazy val resultExpressionsForExecution: Seq[NamedExpression] =
     withPhysicalInputAttributes(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -99,7 +99,7 @@ case class HashAggregateExec(
 
       val beforeAgg = System.nanoTime()
       val hasInput = iter.hasNext
-      val res = if (!hasInput && groupingExpressions.nonEmpty) {
+      val res = if (!hasInput && groupingExpressionsForExecution.nonEmpty) {
         // This is a grouped aggregate and the input iterator is empty,
         // so return an empty iterator.
         Iterator.empty
@@ -107,11 +107,11 @@ case class HashAggregateExec(
         val aggregationIterator =
           new TungstenAggregationIterator(
             partIndex,
-            groupingExpressions,
+            groupingExpressionsForExecution,
             aggregateExpressions,
             aggregateAttributes,
             initialInputBufferOffset,
-            resultExpressions,
+            resultExpressionsForExecution,
             (expressions, inputSchema) =>
               MutableProjection.create(expressions, inputSchema),
             inputAttributes,
@@ -122,7 +122,7 @@ case class HashAggregateExec(
             spillSize,
             avgHashProbe,
             numTasksFallBacked)
-        if (!hasInput && groupingExpressions.isEmpty) {
+        if (!hasInput && groupingExpressionsForExecution.isEmpty) {
           numOutputRows += 1
           Iterator.single[UnsafeRow](aggregationIterator.outputForEmptyGroupingKeyWithoutInput())
         } else {
@@ -134,7 +134,7 @@ case class HashAggregateExec(
     }
   }
 
-  private val groupingAttributes = groupingExpressions.map(_.toAttribute)
+  private val groupingAttributes = groupingAttributesForExecution
   private val groupingKeySchema = DataTypeUtils.fromAttributes(groupingAttributes)
   private val declFunctions = aggregateExpressions.map(_.aggregateFunction)
     .filter(_.isInstanceOf[DeclarativeAggregate])
@@ -292,7 +292,7 @@ case class HashAggregateExec(
       // generate output using resultExpressions
       ctx.currentVars = null
       ctx.INPUT_ROW = keyTerm
-      val keyVars = groupingExpressions.zipWithIndex.map { case (e, i) =>
+      val keyVars = groupingExpressionsForExecution.zipWithIndex.map { case (e, i) =>
         BoundReference(i, e.dataType, e.nullable).genCode(ctx)
       }
       val evaluateKeyVars = evaluateVariables(keyVars)
@@ -311,10 +311,10 @@ case class HashAggregateExec(
       ctx.currentVars = keyVars ++ aggResults
       val inputAttrs = groupingAttributes ++ aggregateAttributes
       val resultVars = bindReferences[Expression](
-        resultExpressions,
+        resultExpressionsForExecution,
         inputAttrs).map(_.genCode(ctx))
       val evaluateNondeterministicResults =
-        evaluateNondeterministicVariables(output, resultVars, resultExpressions)
+        evaluateNondeterministicVariables(output, resultVars, resultExpressionsForExecution)
       s"""
          |$evaluateKeyVars
          |$evaluateBufferVars
@@ -324,14 +324,14 @@ case class HashAggregateExec(
        """.stripMargin
     } else if (modes.contains(Partial) || modes.contains(PartialMerge)) {
       // resultExpressions are Attributes of groupingExpressions and aggregateBufferAttributes.
-      assert(resultExpressions.forall(_.isInstanceOf[Attribute]))
-      assert(resultExpressions.length ==
-        groupingExpressions.length + aggregateBufferAttributes.length)
+      assert(resultExpressionsForExecution.forall(_.isInstanceOf[Attribute]))
+      assert(resultExpressionsForExecution.length ==
+        groupingExpressionsForExecution.length + aggregateBufferAttributes.length)
 
       ctx.currentVars = null
 
       ctx.INPUT_ROW = keyTerm
-      val keyVars = groupingExpressions.zipWithIndex.map { case (e, i) =>
+      val keyVars = groupingExpressionsForExecution.zipWithIndex.map { case (e, i) =>
         BoundReference(i, e.dataType, e.nullable).genCode(ctx)
       }
       val evaluateKeyVars = evaluateVariables(keyVars)
@@ -343,9 +343,9 @@ case class HashAggregateExec(
       val evaluateResultBufferVars = evaluateVariables(resultBufferVars)
 
       ctx.currentVars = keyVars ++ resultBufferVars
-      val inputAttrs = resultExpressions.map(_.toAttribute)
+      val inputAttrs = resultExpressionsForExecution.map(_.toAttribute)
       val resultVars = bindReferences[Expression](
-        resultExpressions,
+        resultExpressionsForExecution,
         inputAttrs).map(_.genCode(ctx))
       s"""
          |$evaluateKeyVars
@@ -357,10 +357,10 @@ case class HashAggregateExec(
       ctx.INPUT_ROW = keyTerm
       ctx.currentVars = null
       val resultVars = bindReferences[Expression](
-        resultExpressions,
+        resultExpressionsForExecution,
         groupingAttributes).map(_.genCode(ctx))
       val evaluateNondeterministicResults =
-        evaluateNondeterministicVariables(output, resultVars, resultExpressions)
+        evaluateNondeterministicVariables(output, resultVars, resultExpressionsForExecution)
       s"""
          |$evaluateNondeterministicResults
          |${consume(ctx, resultVars)}
@@ -632,9 +632,9 @@ case class HashAggregateExec(
   protected override def doConsumeWithKeys(ctx: CodegenContext, input: Seq[ExprCode]): String = {
     // create grouping key
     val unsafeRowKeyCode = GenerateUnsafeProjection.createCode(
-      ctx, bindReferences[Expression](groupingExpressions, child.output))
+      ctx, bindReferences[Expression](groupingExpressionsForExecution, child.output))
     val fastRowKeys = ctx.generateExpressions(
-      bindReferences[Expression](groupingExpressions, child.output))
+      bindReferences[Expression](groupingExpressionsForExecution, child.output))
     val unsafeRowKeys = unsafeRowKeyCode.value
     val unsafeRowKeyHash = ctx.freshName("unsafeRowKeyHash")
     val unsafeRowBuffer = ctx.freshName("unsafeRowAggBuffer")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
@@ -90,7 +90,7 @@ case class ObjectHashAggregateExec(
     child.execute().mapPartitionsWithIndexInternal { (partIndex, iter) =>
       val beforeAgg = System.nanoTime()
       val hasInput = iter.hasNext
-      val res = if (!hasInput && groupingExpressions.nonEmpty) {
+      val res = if (!hasInput && groupingExpressionsForExecution.nonEmpty) {
         // This is a grouped aggregate and the input kvIterator is empty,
         // so return an empty kvIterator.
         Iterator.empty
@@ -99,11 +99,11 @@ case class ObjectHashAggregateExec(
           new ObjectAggregationIterator(
             partIndex,
             child.output,
-            groupingExpressions,
+            groupingExpressionsForExecution,
             aggregateExpressions,
             aggregateAttributes,
             initialInputBufferOffset,
-            resultExpressions,
+            resultExpressionsForExecution,
             (expressions, inputSchema) =>
               MutableProjection.create(expressions, inputSchema),
             inputAttributes,
@@ -112,7 +112,7 @@ case class ObjectHashAggregateExec(
             numOutputRows,
             spillSize,
             numTasksFallBacked)
-        if (!hasInput && groupingExpressions.isEmpty) {
+        if (!hasInput && groupingExpressionsForExecution.isEmpty) {
           numOutputRows += 1
           Iterator.single[UnsafeRow](aggregationIterator.outputForEmptyGroupingKeyWithoutInput())
         } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
@@ -49,11 +49,11 @@ case class SortAggregateExec(
     "aggTime" -> SQLMetrics.createTimingMetric(sparkContext, "time in aggregation build"))
 
   override def requiredChildOrdering: Seq[Seq[SortOrder]] = {
-    groupingExpressions.map(SortOrder(_, Ascending)) :: Nil
+    groupingExpressionsForExecution.map(SortOrder(_, Ascending)) :: Nil
   }
 
   override protected def orderingExpressions: Seq[SortOrder] = {
-    groupingExpressions.map(SortOrder(_, Ascending))
+    groupingExpressionsForExecution.map(SortOrder(_, Ascending))
   }
 
   protected override def doExecute(): RDD[InternalRow] = {
@@ -63,25 +63,25 @@ case class SortAggregateExec(
       // Because the constructor of an aggregation iterator will read at least the first row,
       // we need to get the value of iter.hasNext first.
       val hasInput = iter.hasNext
-      if (!hasInput && groupingExpressions.nonEmpty) {
+      if (!hasInput && groupingExpressionsForExecution.nonEmpty) {
         // This is a grouped aggregate and the input iterator is empty,
         // so return an empty iterator.
         Iterator[UnsafeRow]()
       } else {
         val outputIter = new SortBasedAggregationIterator(
           partIndex,
-          groupingExpressions,
+          groupingExpressionsForExecution,
           inputAttributes,
           iter,
           aggregateExpressions,
           aggregateAttributes,
           initialInputBufferOffset,
-          resultExpressions,
+          resultExpressionsForExecution,
           (expressions, inputSchema) =>
             MutableProjection.create(expressions, inputSchema),
           numOutputRows,
           aggTime)
-        if (!hasInput && groupingExpressions.isEmpty) {
+        if (!hasInput && groupingExpressionsForExecution.isEmpty) {
           // There is no input and there is no grouping expressions.
           // We need to output a single row as the output.
           numOutputRows += 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -48,18 +48,17 @@ case class ProjectExec(projectList: Seq[NamedExpression], child: SparkPlan)
     with PartitioningPreservingUnaryExecNode
     with OrderPreservingUnaryExecNode {
 
-  override lazy val output: Seq[Attribute] = {
+  private lazy val projectListForExecution: Seq[NamedExpression] =
     if (isCanonicalizedPlan) {
-      projectList.map(_.toAttribute)
+      projectList
     } else {
       // Columnar transitions can make a child output physically nullable after this project was
-      // planned. Recompute the projected output nullability against the actual child output so a
-      // later row/codegen boundary does not revive stale non-nullable metadata.
-      projectList.zip(bindReferences[Expression](projectList, child.output)).map {
-        case (project, boundProject) => project.toAttribute.withNullability(boundProject.nullable)
-      }
+      // planned. Rebind attributes by exprId without binding the whole expression to ordinals, so
+      // custom expression subclasses still see the execution-time child nullability.
+      RowBoundaryOutput.withPhysicalInputAttributes(projectList, child.output)
     }
-  }
+
+  override lazy val output: Seq[Attribute] = projectListForExecution.map(_.toAttribute)
 
   override def inputRDDs(): Seq[RDD[InternalRow]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()
@@ -80,7 +79,7 @@ case class ProjectExec(projectList: Seq[NamedExpression], child: SparkPlan)
   }
 
   override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
-    val exprs = bindReferences[Expression](projectList, child.output)
+    val exprs = bindReferences[Expression](projectListForExecution, child.output)
     val (subExprsCode, resultVars, localValInputs) = if (conf.subexpressionEliminationEnabled) {
       // subexpression elimination
       val subExprs = ctx.subexpressionEliminationForWholeStageCodegen(exprs)
@@ -94,7 +93,8 @@ case class ProjectExec(projectList: Seq[NamedExpression], child: SparkPlan)
     }
 
     // Evaluation of non-deterministic expressions can't be deferred.
-    val nonDeterministicAttrs = projectList.filterNot(_.deterministic).map(_.toAttribute)
+    val nonDeterministicAttrs =
+      projectListForExecution.filterNot(_.deterministic).map(_.toAttribute)
     s"""
        |// common sub-expressions
        |${evaluateVariables(localValInputs)}
@@ -105,7 +105,7 @@ case class ProjectExec(projectList: Seq[NamedExpression], child: SparkPlan)
   }
 
   protected override def doExecute(): RDD[InternalRow] = {
-    val evaluatorFactory = new ProjectEvaluatorFactory(projectList, child.output)
+    val evaluatorFactory = new ProjectEvaluatorFactory(projectListForExecution, child.output)
     if (conf.usePartitionEvaluator) {
       child.execute().mapPartitionsWithEvaluator(
         evaluatorFactory, preservesPartitionSizes = true
@@ -120,7 +120,7 @@ case class ProjectExec(projectList: Seq[NamedExpression], child: SparkPlan)
     }
   }
 
-  override protected def outputExpressions: Seq[NamedExpression] = projectList
+  override protected def outputExpressions: Seq[NamedExpression] = projectListForExecution
 
   override protected def orderingExpressions: Seq[SortOrder] = child.outputOrdering
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -48,7 +48,18 @@ case class ProjectExec(projectList: Seq[NamedExpression], child: SparkPlan)
     with PartitioningPreservingUnaryExecNode
     with OrderPreservingUnaryExecNode {
 
-  override def output: Seq[Attribute] = projectList.map(_.toAttribute)
+  override lazy val output: Seq[Attribute] = {
+    if (isCanonicalizedPlan) {
+      projectList.map(_.toAttribute)
+    } else {
+      // Columnar transitions can make a child output physically nullable after this project was
+      // planned. Recompute the projected output nullability against the actual child output so a
+      // later row/codegen boundary does not revive stale non-nullable metadata.
+      projectList.zip(bindReferences[Expression](projectList, child.output)).map {
+        case (project, boundProject) => project.toAttribute.withNullability(boundProject.nullable)
+      }
+    }
+  }
 
   override def inputRDDs(): Seq[RDD[InternalRow]] = {
     child.asInstanceOf[CodegenSupport].inputRDDs()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
@@ -22,7 +22,6 @@ import org.apache.spark.rdd.{ParallelCollectionRDD, RDD}
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.BindReferences.bindReferences
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode, LazilyGeneratedOrdering}
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.catalyst.util.truncatedString
@@ -315,18 +314,17 @@ case class TakeOrderedAndProjectExec(
     child: SparkPlan,
     offset: Int = 0) extends OrderPreservingUnaryExecNode {
 
-  override lazy val output: Seq[Attribute] = {
+  private lazy val projectListForExecution: Seq[NamedExpression] =
     if (isCanonicalizedPlan) {
-      projectList.map(_.toAttribute)
+      projectList
     } else {
       // Columnar transitions can make a child output physically nullable after this node was
-      // planned. Recompute the projected output nullability against the actual child output so a
-      // later row materialization does not revive stale non-nullable metadata.
-      projectList.zip(bindReferences[Expression](projectList, child.output)).map {
-        case (project, boundProject) => project.toAttribute.withNullability(boundProject.nullable)
-      }
+      // planned. Rebind attributes by exprId without binding the whole expression to ordinals, so
+      // later row materialization keeps the execution-time child nullability.
+      RowBoundaryOutput.withPhysicalInputAttributes(projectList, child.output)
     }
-  }
+
+  override lazy val output: Seq[Attribute] = projectListForExecution.map(_.toAttribute)
 
   override def executeCollect(): Array[InternalRow] = executeQuery {
     val orderingSatisfies = SortOrder.orderingSatisfies(child.outputOrdering, sortOrder)
@@ -337,8 +335,8 @@ case class TakeOrderedAndProjectExec(
       child.execute().mapPartitionsInternal(_.map(_.copy())).takeOrdered(limit)(ord)
     }
     val data = if (offset > 0) limited.drop(offset) else limited
-    if (projectList != child.output) {
-      val proj = UnsafeProjection.create(projectList, child.output)
+    if (projectListForExecution != child.output) {
+      val proj = UnsafeProjection.create(projectListForExecution, child.output)
       proj.initialize(0)
       data.map(r => proj(r).copy())
     } else {
@@ -384,8 +382,8 @@ case class TakeOrderedAndProjectExec(
       singlePartitionRDD.mapPartitionsWithIndexInternal { (idx, iter) =>
         val limited = Utils.takeOrdered(iter.map(_.copy()), limit)(ord)
         val topK = if (offset > 0) limited.drop(offset) else limited
-        if (projectList != child.output) {
-          val proj = UnsafeProjection.create(projectList, child.output)
+        if (projectListForExecution != child.output) {
+          val proj = UnsafeProjection.create(projectListForExecution, child.output)
           proj.initialize(idx)
           topK.map(r => proj(r))
         } else {
@@ -395,7 +393,7 @@ case class TakeOrderedAndProjectExec(
     }
   }
 
-  override protected def outputExpressions: Seq[NamedExpression] = projectList
+  override protected def outputExpressions: Seq[NamedExpression] = projectListForExecution
 
   override protected def orderingExpressions: Seq[SortOrder] = sortOrder
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
@@ -22,6 +22,7 @@ import org.apache.spark.rdd.{ParallelCollectionRDD, RDD}
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.BindReferences.bindReferences
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode, LazilyGeneratedOrdering}
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.catalyst.util.truncatedString
@@ -314,8 +315,17 @@ case class TakeOrderedAndProjectExec(
     child: SparkPlan,
     offset: Int = 0) extends OrderPreservingUnaryExecNode {
 
-  override def output: Seq[Attribute] = {
-    projectList.map(_.toAttribute)
+  override lazy val output: Seq[Attribute] = {
+    if (isCanonicalizedPlan) {
+      projectList.map(_.toAttribute)
+    } else {
+      // Columnar transitions can make a child output physically nullable after this node was
+      // planned. Recompute the projected output nullability against the actual child output so a
+      // later row materialization does not revive stale non-nullable metadata.
+      projectList.zip(bindReferences[Expression](projectList, child.output)).map {
+        case (project, boundProject) => project.toAttribute.withNullability(boundProject.nullable)
+      }
+    }
   }
 
   override def executeCollect(): Array[InternalRow] = executeQuery {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonUDTFExec.scala
@@ -45,8 +45,12 @@ trait EvalPythonUDTFExec extends UnaryExecNode {
   // planned. Keep the passthrough side aligned with the actual child output before the final
   // unsafe-row materialization joins it with Python output.
   private lazy val requiredChildOutputForExecution: Seq[Attribute] = {
-    val childOutput = AttributeMap(child.output.map(attr => attr -> attr))
-    requiredChildOutput.map(attr => childOutput.getOrElse(attr, attr))
+    if (isCanonicalizedPlan) {
+      requiredChildOutput
+    } else {
+      val childOutput = AttributeMap(child.output.map(attr => attr -> attr))
+      requiredChildOutput.map(attr => childOutput.getOrElse(attr, attr))
+    }
   }
 
   override def output: Seq[Attribute] = requiredChildOutputForExecution ++ resultAttrs

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonUDTFExec.scala
@@ -41,7 +41,15 @@ trait EvalPythonUDTFExec extends UnaryExecNode {
 
   def resultAttrs: Seq[Attribute]
 
-  override def output: Seq[Attribute] = requiredChildOutput ++ resultAttrs
+  // ColumnarToRowExec can make required child attributes physically nullable after this UDTF was
+  // planned. Keep the passthrough side aligned with the actual child output before the final
+  // unsafe-row materialization joins it with Python output.
+  private lazy val requiredChildOutputForExecution: Seq[Attribute] = {
+    val childOutput = AttributeMap(child.output.map(attr => attr -> attr))
+    requiredChildOutput.map(attr => childOutput.getOrElse(attr, attr))
+  }
+
+  override def output: Seq[Attribute] = requiredChildOutputForExecution ++ resultAttrs
 
   override def producedAttributes: AttributeSet = AttributeSet(resultAttrs)
 
@@ -104,10 +112,10 @@ trait EvalPythonUDTFExec extends UnaryExecNode {
       val outputRowIterator = evaluate(argMetas, projectedRowIter, schema, context)
 
       val pruneChildForResult: InternalRow => InternalRow =
-        if (child.outputSet == AttributeSet(requiredChildOutput)) {
+        if (child.outputSet == AttributeSet(requiredChildOutputForExecution)) {
           identity
         } else {
-          UnsafeProjection.create(requiredChildOutput, child.output)
+          UnsafeProjection.create(requiredChildOutputForExecution, child.output)
         }
 
       val joined = new JoinedRow

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
@@ -27,14 +27,18 @@ import org.apache.spark.{SparkEnv, SparkException, SparkUnsupportedOperationExce
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{
-  Attribute, AttributeReference, Expression, ExprId, Literal}
+  Alias, Attribute, AttributeReference, Coalesce, CreateArray, Explode, Expression, ExprId,
+  Literal, RLike}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{Count, Partial}
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.plans.logical.Deduplicate
 import org.apache.spark.sql.catalyst.trees.LeafLike
+import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{DataType, IntegerType}
+import org.apache.spark.sql.types.{DataType, IntegerType, StringType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.ThreadUtils
 
@@ -135,6 +139,151 @@ class SparkPlanSuite extends SharedSparkSession {
       Seq(AttributeReference("val", IntegerType)()), Seq(InternalRow(1)), None)
     val nonEmpty = ColumnarOp(relation).toRowBased.executeCollect()
     assert(nonEmpty === relation.executeCollect())
+  }
+
+  test("ColumnarToRowExec should materialize null values from non-nullable columnar output") {
+    val output = Seq(AttributeReference("value", StringType, nullable = false)())
+
+    def assertSingleNull(rows: Array[InternalRow]): Unit = {
+      assert(rows.length === 1)
+      assert(rows.head.isNullAt(0))
+    }
+
+    def assertAllNull(rows: Array[InternalRow]): Unit = {
+      assert(rows.length === 1)
+      assert(rows.head.isNullAt(0))
+      assert(rows.head.isNullAt(1))
+    }
+
+    def columnarLeaf(): NullColumnarOp = NullColumnarOp(output)
+
+    def columnarToRow(): ColumnarToRowExec = ColumnarToRowExec(columnarLeaf())
+
+    def withTransitions(plan: SparkPlan): SparkPlan = {
+      ApplyColumnarRulesAndInsertTransitions(Nil, outputsColumnar = false).apply(plan)
+    }
+
+    def projected(): ProjectExec = {
+      withTransitions(ProjectExec(output, columnarLeaf())).asInstanceOf[ProjectExec]
+    }
+
+    def splitProject(child: SparkPlan): WholeStageCodegenExec = {
+      val projectList = Seq(
+        Alias(child.output.head, "first")(),
+        Alias(child.output.head, "second")())
+      WholeStageCodegenExec(ProjectExec(projectList, child))(codegenStageId = 0)
+    }
+
+    Seq(
+      WholeStageCodegenExec(projected())(codegenStageId = 0).executeCollect(),
+      WholeStageCodegenExec(columnarToRow())(codegenStageId = 0).executeCollect(),
+      columnarToRow().executeCollect()).foreach(assertSingleNull)
+
+    withSQLConf(SQLConf.WHOLESTAGE_SPLIT_CONSUME_FUNC_BY_OPERATOR.key -> "true") {
+      val split = splitProject(projected())
+      assert(split.doCodeGen()._2.body.contains("project_doConsume"))
+      assertAllNull(split.executeCollect())
+    }
+
+    val rowBoundaryProjected = projected()
+    Seq(
+      WholeStageCodegenExec(
+        withTransitions(
+          FilterExec(RLike(output.head, Literal("present")), ProjectExec(output, columnarLeaf()))))(
+          codegenStageId = 0).executeCollect(),
+      WholeStageCodegenExec(
+        FilterExec(
+          RLike(rowBoundaryProjected.output.head, Literal("present")),
+          InputAdapter(rowBoundaryProjected)))(codegenStageId = 0).executeCollect())
+      .foreach { rows =>
+        assert(rows.isEmpty)
+      }
+
+    val splitProjected = projected()
+    assert(splitProjected.output.head.nullable)
+    val rowBoundary = InputAdapter(splitProjected)
+    withSQLConf(SQLConf.WHOLESTAGE_SPLIT_CONSUME_FUNC_BY_OPERATOR.key -> "true") {
+      val splitRegex = splitProject(FilterExec(
+        Coalesce(Seq(RLike(rowBoundary.output.head, Literal("present")), Literal(true))),
+        rowBoundary))
+      assert(splitRegex.doCodeGen()._2.body.contains("project_doConsume"))
+      assertAllNull(splitRegex.executeCollect())
+    }
+
+    def partialGroupedAggregate(): HashAggregateExec = {
+      val partialCount = Count(Literal(1)).toAggregateExpression().copy(mode = Partial)
+      withTransitions(HashAggregateExec(
+        requiredChildDistributionExpressions = None,
+        isStreaming = false,
+        numShufflePartitions = None,
+        groupingExpressions = output,
+        aggregateExpressions = Seq(partialCount),
+        aggregateAttributes = partialCount.aggregateFunction.aggBufferAttributes,
+        initialInputBufferOffset = 0,
+        resultExpressions =
+          output.map(_.toAttribute) ++ partialCount.aggregateFunction.inputAggBufferAttributes,
+        child = columnarLeaf()))
+        .asInstanceOf[HashAggregateExec]
+    }
+
+    def assertPartialAggregateNull(rows: Array[InternalRow]): Unit = {
+      assert(rows.length === 1)
+      assert(rows.head.isNullAt(0))
+      assert(rows.head.getLong(1) === 1L)
+    }
+
+    assert(partialGroupedAggregate().canonicalized != null)
+    assert(partialGroupedAggregate().output.head.nullable)
+    Seq(
+      WholeStageCodegenExec(partialGroupedAggregate())(codegenStageId = 0).executeCollect(),
+      partialGroupedAggregate().executeCollect(),
+      partialGroupedAggregate().toSortAggregate.executeCollect()).foreach(assertPartialAggregateNull)
+
+    def generate(): GenerateExec = {
+      withTransitions(GenerateExec(
+        Explode(CreateArray(Seq(Literal(1)))),
+        requiredChildOutput = output,
+        outer = false,
+        generatorOutput = Seq(AttributeReference("col", IntegerType, nullable = false)()),
+        child = columnarLeaf()))
+        .asInstanceOf[GenerateExec]
+    }
+
+    def assertGeneratedNull(rows: Array[InternalRow]): Unit = {
+      assert(rows.length === 1)
+      assert(rows.head.isNullAt(0))
+      assert(rows.head.getInt(1) === 1)
+    }
+
+    assert(generate().output.head.nullable)
+    Seq(
+      WholeStageCodegenExec(generate())(codegenStageId = 0).executeCollect(),
+      generate().executeCollect()).foreach(assertGeneratedNull)
+
+    def takeOrderedAndProject(): TakeOrderedAndProjectExec = {
+      withTransitions(TakeOrderedAndProjectExec(
+        limit = 1,
+        sortOrder = Nil,
+        projectList = output,
+        child = columnarLeaf()))
+        .asInstanceOf[TakeOrderedAndProjectExec]
+    }
+
+    assert(takeOrderedAndProject().output.head.nullable)
+    assertSingleNull(takeOrderedAndProject().executeCollect())
+
+    def expanded(): ExpandExec = {
+      withTransitions(ExpandExec(
+        projections = Seq(output),
+        output = output,
+        child = columnarLeaf()))
+        .asInstanceOf[ExpandExec]
+    }
+
+    assert(expanded().output.head.nullable)
+    Seq(
+      WholeStageCodegenExec(expanded())(codegenStageId = 0).executeCollect(),
+      expanded().executeCollect()).foreach(assertSingleNull)
   }
 
   test("BatchScanExec hashCode includes keyGroupedPartitioning") {
@@ -242,6 +391,24 @@ case class ColumnarOp(child: SparkPlan) extends UnaryExecNode {
   override def output: Seq[Attribute] = child.output
   override protected def withNewChildInternal(newChild: SparkPlan): ColumnarOp =
     copy(child = newChild)
+}
+
+case class NullColumnarOp(override val output: Seq[Attribute])
+  extends LeafExecNode with CodegenSupport {
+  override val supportsColumnar: Boolean = true
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    sparkContext.parallelize(Seq(0), 1).map { _ =>
+      val column = new OnHeapColumnVector(1, StringType)
+      column.putNull(0)
+      new ColumnarBatch(Array(column), 1)
+    }
+  }
+  override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
+  override def inputRDDs(): Seq[RDD[InternalRow]] = throw new UnsupportedOperationException()
+  override protected def doProduce(ctx: CodegenContext): String =
+    throw new UnsupportedOperationException()
+  override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String =
+    throw new UnsupportedOperationException()
 }
 
 private case class TestSubqueryExec(child: SparkPlan) extends BaseSubqueryExec {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
@@ -237,7 +237,8 @@ class SparkPlanSuite extends SharedSparkSession {
     Seq(
       WholeStageCodegenExec(partialGroupedAggregate())(codegenStageId = 0).executeCollect(),
       partialGroupedAggregate().executeCollect(),
-      partialGroupedAggregate().toSortAggregate.executeCollect()).foreach(assertPartialAggregateNull)
+      partialGroupedAggregate().toSortAggregate.executeCollect())
+      .foreach(assertPartialAggregateNull)
 
     def generate(): GenerateExec = {
       withTransitions(GenerateExec(


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Make `ColumnarToRowExec` expose nullable row output when materializing a columnar batch, because the batch null bitmap is the execution-time source of truth.
- Preserve that execution-time nullability only through downstream row/materialization paths that rebuild attributes after transition insertion: project-like operators, `ExpandExec` / `GenerateExec`, grouped aggregate output/key materialization, and analogous Python UDTF passthrough materialization.
- Add a regression covering whole-stage codegen, split consume, row boundaries, partial grouped `HashAggregateExec` and `SortAggregateExec`, generate, take-ordered/project, and expand paths when a non-nullable columnar output physically contains a null.

### Why are the changes needed?

`ColumnarToRowExec` can materialize a real null from a columnar batch even when the planned output attribute is non-nullable. Downstream row codegen can then trust the stale non-nullable attribute, skip the null check, and fail while materializing or consuming the row.

One observed failing plan had this shape:

```text
HashAggregate
  HashAggregate
    ...
      ColumnarToRow
        Scan parquet ...
```

In that case the Parquet reader produced a physical null for a column whose planned output attribute was non-nullable, and downstream generated row code failed with a `UTF8String.getBaseObject()` `NullPointerException`.

An earlier version rebound attributes across the whole transition insertion rule. That was too broad: it changed unrelated parent expression and schema behavior and triggered failures in DPP reuse, plan-stability, and metadata-schema tests. This version keeps the transition contract local and refreshes only downstream row/materialization paths that can revive stale pre-transition nullability.

### Does this PR introduce _any_ user-facing change?

Yes. Queries that read a physical null through `ColumnarToRowExec` despite stale non-nullable planned metadata now preserve the null through row materialization instead of crashing in downstream row codegen.

### How was this patch tested?

- `build/sbt -java-home /opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home 'sql/testOnly org.apache.spark.sql.execution.SparkPlanSuite -- -z "ColumnarToRowExec should materialize null values from non-nullable columnar output"'`
- `git diff --check`

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex
