### PR TITLE
[SPARK-57498][SQL] Strengthen cookie-signing secret in ThriftHttpServlet

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftHttpServlet.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftHttpServlet.java
@@ -101,9 +101,10 @@ public class ThriftHttpServlet extends TServlet {
     // Initialize the cookie based authentication related variables.
     if (isCookieAuthEnabled) {
       // Generate the signer with secret.
-      String secret = Long.toString(RAN.nextLong());
-      LOG.debug("Using the random number as the secret for cookie generation");
-      this.signer = new CookieSigner(secret.getBytes());
+      byte[] secret = new byte[32];
+      RAN.nextBytes(secret);
+      LOG.debug("Using the random bytes as the secret for cookie generation");
+      this.signer = new CookieSigner(secret);
       this.cookieMaxAge = (int) hiveConf.getTimeVar(
         ConfVars.HIVE_SERVER2_THRIFT_HTTP_COOKIE_MAX_AGE, TimeUnit.SECONDS);
       this.cookieDomain = hiveConf.getVar(ConfVars.HIVE_SERVER2_THRIFT_HTTP_COOKIE_DOMAIN);


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR strengthens the secret used by `CookieSigner` for HTTP cookie-based authentication in `ThriftHttpServlet`.

Previously, the secret was derived from a single `SecureRandom.nextLong()` (64 bits of entropy), converted to a decimal `String`, and then turned back into bytes via `String.getBytes()`. This PR instead generates 32 cryptographically secure random bytes (256 bits) and passes them directly to `CookieSigner`, which already accepts a `byte[]`.

Before:
```java
String secret = Long.toString(RAN.nextLong());
this.signer = new CookieSigner(secret.getBytes());
```

After:
```java
byte[] secret = new byte[32];
RAN.nextBytes(secret);
this.signer = new CookieSigner(secret);
```

### Why are the changes needed?

- The previous secret carried only **64 bits of entropy** and was encoded as a decimal string, which is weak key material for the SHA-512-based `CookieSigner`.
- The `long -> String -> bytes` round-trip relied on `String.getBytes()` with the platform default charset, an unnecessary and platform-dependent step.
- Using 256 bits of secure-random material removes both concerns. `CookieSigner` consumes the secret as raw bytes, so no string encoding is needed.

### Does this PR introduce _any_ user-facing change?

No. The cookie-signing secret is generated internally per server instance and is never persisted or exposed. The cookie format, signing algorithm, and authentication flow are unchanged.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)