### PR TITLE
[SPARK-57503][CORE] Simplify removePendingChunks to avoid redundant re-iteration in ShuffleBlockFetcherIterator

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -1325,15 +1325,12 @@ final class ShuffleBlockFetcherIterator(
     }
 
     def filterRequests(queue: mutable.Queue[FetchRequest]): Unit = {
-      val fetchRequestsToRemove = new mutable.Queue[FetchRequest]()
-      fetchRequestsToRemove ++= queue.dequeueAll { req =>
+      queue.dequeueAll { req =>
         val firstBlock = req.blocks.head
         firstBlock.blockId.isShuffleChunk && req.address.equals(address) &&
           sameShuffleReducePartition(firstBlock.blockId)
-      }
-      fetchRequestsToRemove.foreach { _ =>
-        removedChunkIds ++=
-          fetchRequestsToRemove.flatMap(_.blocks.map(_.blockId.asInstanceOf[ShuffleBlockChunkId]))
+      }.foreach { req =>
+        removedChunkIds ++= req.blocks.map(_.blockId.asInstanceOf[ShuffleBlockChunkId])
       }
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`ShuffleBlockFetcherIterator.removePendingChunks` collected the removed chunk ids with a `foreach { _ => ... }` whose body re-`flatMap`ped the whole `fetchRequestsToRemove` queue on every iteration. With N removed requests it repeated the same work N times; the result was still correct only because the accumulator is a `HashSet` that absorbed the duplicates.

This processes each removed request once and drops the now-unnecessary intermediate queue, so the helper becomes a single `dequeueAll(pred).foreach` pass.

### Why are the changes needed?

To remove accidental O(N^2) work and a redundant intermediate collection on the push-based shuffle fetch-failure fallback path, and to make the intent clearer.

### Does this PR introduce _any_ user-facing change?

No. The returned set of removed chunk ids is unchanged.

### How was this patch tested?

Existing `ShuffleBlockFetcherIteratorSuite`, which covers the SPARK-32922 chunk-fetch fallback paths, still passes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
