### PR TITLE
[SPARK-53209][YARN][FOLLOWUP][4.2] Move `spark.yarn.am.limitActiveProcessorCount.enabled` to yarn module

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2965,15 +2965,6 @@ package object config {
         "The value only can be one or more of 'stdout, stderr'.")
       .createWithDefault(Seq("stdout", "stderr"))
 
-  private[spark] val YARN_AM_LIMIT_ACTIVE_PROCESSOR_COUNT_ENABLED =
-    ConfigBuilder("spark.yarn.am.limitActiveProcessorCount.enabled")
-      .doc("Whether to add -XX:ActiveProcessorCount=<spark.yarn.am.cores> to the YARN " +
-        "Application Master JVM options in client mode. In cluster mode, use " +
-        "`spark.driver.limitActiveProcessorCount.enabled` instead.")
-      .version("4.2.0")
-      .booleanConf
-      .createWithDefault(false)
-
   private[spark] val DRIVER_LIMIT_ACTIVE_PROCESSOR_COUNT_ENABLED =
     ConfigBuilder("spark.driver.limitActiveProcessorCount.enabled")
       .doc("Whether to add -XX:ActiveProcessorCount=<spark.driver.cores> to the driver JVM " +

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config/package.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config/package.scala
@@ -301,6 +301,15 @@ package object config extends Logging {
     .intConf
     .createWithDefault(1)
 
+  private[spark] val YARN_AM_LIMIT_ACTIVE_PROCESSOR_COUNT_ENABLED =
+    ConfigBuilder("spark.yarn.am.limitActiveProcessorCount.enabled")
+      .doc("Whether to add -XX:ActiveProcessorCount=<spark.yarn.am.cores> to the YARN " +
+        "Application Master JVM options in client mode. In cluster mode, use " +
+        "`spark.driver.limitActiveProcessorCount.enabled` instead.")
+      .version("4.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val AM_DEFAULT_JAVA_OPTIONS = ConfigBuilder("spark.yarn.am.defaultJavaOptions")
     .doc("Default Java options for the client-mode AM to prepend to " +
       "`spark.yarn.am.extraJavaOptions`. This is intended to be set by administrators.")


### PR DESCRIPTION
Port https://github.com/apache/spark/pull/56541 to branch-4.2

### What changes were proposed in this pull request?

Move definition of config `spark.yarn.am.limitActiveProcessorCount.enabled` from the core to yarn module

### Why are the changes needed?

The YARN AM config should exist on the yarn module, not core.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass GHA.

### Was this patch authored or co-authored using generative AI tooling?

No.