### PR TITLE
[SPARK-57506][SQL] Fix RTRIM-collation trimRight dropping trailing spaces for strings with supplementary characters

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
@@ -1519,7 +1519,7 @@ public class CollationAwareUTF8String {
     if (charIndex == src.length()) {
       return srcString;
     }
-    if (lastNonSpacePosition == srcString.numChars()) {
+    if (lastNonSpacePosition == src.length()) {
       return UTF8String.fromString(src.substring(0, charIndex));
     }
     return UTF8String.fromString(

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
@@ -3647,15 +3647,32 @@ public class CollationSupportSuite {
     assertStringTrimRight(UTF8_LCASE, "𝔸", "a", "𝔸");
     assertStringTrimRight(UNICODE, "𝔸", "a", "𝔸");
     assertStringTrimRight(UNICODE_CI, "𝔸", "a", "");
-    // RTRIM-modifier collations (ICU path): trailing spaces are ignored while matching but must
-    // be re-appended afterwards. When the number of trailing spaces equals the number of
-    // supplementary code points, a Java-char-index vs code-point-count comparison previously
-    // dropped the preserved spaces.
+    // RTRIM-modifier collations ignore trailing spaces while matching the trim characters, then
+    // re-append them. The behaviour must agree across the UTF8_BINARY (binaryTrimRight),
+    // UTF8_LCASE (lowercaseTrimRight), and ICU (trimRight) paths. The supplementary-character
+    // cases below (trailing-space count == supplementary code-point count) regressed on the ICU
+    // path before SPARK-57506, which compared a Java-char index against a code-point count.
+    assertStringTrimRight("UTF8_BINARY_RTRIM", "x ", "x", " ");
+    assertStringTrimRight("UTF8_LCASE_RTRIM", "x ", "x", " ");
     assertStringTrimRight("UNICODE_RTRIM", "x ", "x", " ");
+    assertStringTrimRight("UTF8_BINARY_RTRIM", "   ", "x", "   ");
+    assertStringTrimRight("UTF8_LCASE_RTRIM", "   ", "x", "   ");
     assertStringTrimRight("UNICODE_RTRIM", "   ", "x", "   ");
+    assertStringTrimRight("UTF8_BINARY_RTRIM", "𝔸 ", "𝔸", " ");
+    assertStringTrimRight("UTF8_LCASE_RTRIM", "𝔸 ", "𝔸", " ");
     assertStringTrimRight("UNICODE_RTRIM", "𝔸 ", "𝔸", " ");
+    assertStringTrimRight("UTF8_BINARY_RTRIM", "𝔸  ", "𝔸", "  ");
+    assertStringTrimRight("UTF8_LCASE_RTRIM", "𝔸  ", "𝔸", "  ");
     assertStringTrimRight("UNICODE_RTRIM", "𝔸  ", "𝔸", "  ");
+    assertStringTrimRight("UTF8_BINARY_RTRIM", "𝔸𝔸  ", "𝔸", "  ");
+    assertStringTrimRight("UTF8_LCASE_RTRIM", "𝔸𝔸  ", "𝔸", "  ");
     assertStringTrimRight("UNICODE_RTRIM", "𝔸𝔸  ", "𝔸", "  ");
+    // Case-folding interacts with space preservation per path: only UTF8_LCASE folds B to b, so
+    // only it trims the trailing 'B' and re-appends the space; binary and (case-sensitive) ICU
+    // leave the input unchanged. This exercises the lcase space-preservation branch on its own.
+    assertStringTrimRight("UTF8_BINARY_RTRIM", "xB ", "b", "xB ");
+    assertStringTrimRight("UTF8_LCASE_RTRIM", "xB ", "b", "x ");
+    assertStringTrimRight("UNICODE_RTRIM", "xB ", "b", "xB ");
   }
 
   /**

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
@@ -3647,6 +3647,15 @@ public class CollationSupportSuite {
     assertStringTrimRight(UTF8_LCASE, "𝔸", "a", "𝔸");
     assertStringTrimRight(UNICODE, "𝔸", "a", "𝔸");
     assertStringTrimRight(UNICODE_CI, "𝔸", "a", "");
+    // RTRIM-modifier collations (ICU path): trailing spaces are ignored while matching but must
+    // be re-appended afterwards. When the number of trailing spaces equals the number of
+    // supplementary code points, a Java-char-index vs code-point-count comparison previously
+    // dropped the preserved spaces.
+    assertStringTrimRight("UNICODE_RTRIM", "x ", "x", " ");
+    assertStringTrimRight("UNICODE_RTRIM", "   ", "x", "   ");
+    assertStringTrimRight("UNICODE_RTRIM", "𝔸 ", "𝔸", " ");
+    assertStringTrimRight("UNICODE_RTRIM", "𝔸  ", "𝔸", "  ");
+    assertStringTrimRight("UNICODE_RTRIM", "𝔸𝔸  ", "𝔸", "  ");
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

`CollationAwareUTF8String.trimRight` — the ICU path used by RTRIM-modifier collations — compared a Java-String (UTF-16) index against a Unicode code-point count: `lastNonSpacePosition == srcString.numChars()`. `lastNonSpacePosition` is a UTF-16 index into `src = srcString.toValidString()` (it is initialized to `src.length()` and decremented via `src.charAt`), so the sentinel must be compared against `src.length()`, matching the `charIndex == src.length()` check immediately above it. This PR changes that one comparison to `src.length()`.

### Why are the changes needed?

For RTRIM-style collations, trailing spaces are ignored while matching the trim characters but must be re-appended to the result. With the code-point count, the "no trailing spaces were skipped" sentinel fired spuriously whenever the number of supplementary characters equaled the number of trailing spaces, so the preserved trailing spaces were dropped. For example, under `UNICODE_RTRIM`, right-trimming a supplementary character (such as U+1D538) followed by a single space returned an empty string instead of a single space.

### Does this PR introduce _any_ user-facing change?

Yes, it fixes incorrect results. Under RTRIM-modifier collations, right-trim on a string containing supplementary characters followed by trailing spaces (when the count of supplementary characters equals the count of trailing spaces) no longer drops the preserved trailing spaces. Only previously-incorrect results change.

### How was this patch tested?

Added cases to `CollationSupportSuite#testStringTrimRight` covering RTRIM-modifier collations across all three trim paths — `UTF8_BINARY_RTRIM`, `UTF8_LCASE_RTRIM`, and `UNICODE_RTRIM`. For each input: supplementary characters with trailing spaces (including the two coincidence cases that previously returned the wrong value on the ICU path), a BMP control, a non-coincidence control, and the all-spaces early-return path. A separate case-folding case (`xB`/`b`) confirms only `UTF8_LCASE` trims the trailing letter while preserving the space, pinning that path independently. The coincidence cases fail on the old code and pass with the fix.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)

