### PR TITLE
[SPARK-57513][INFRA] Remove `Hadoop 3` from GitHub Action workflow names

### DIFF
--- a/.github/workflows/build_branch35.yml
+++ b/.github/workflows/build_branch35.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build (branch-3.5, Scala 2.13, Hadoop 3, JDK 8)"
+name: "Build (branch-3.5, Scala 2.13, JDK 8)"
 
 on:
   schedule:

--- a/.github/workflows/build_branch42.yml
+++ b/.github/workflows/build_branch42.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build (branch-4.2, Scala 2.13, Hadoop 3, JDK 17)"
+name: "Build (branch-4.2, Scala 2.13, JDK 17)"
 
 on:
   schedule:

--- a/.github/workflows/build_branch42_java21.yml
+++ b/.github/workflows/build_branch42_java21.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build (branch-4.2, Scala 2.13, Hadoop 3, JDK 21)"
+name: "Build (branch-4.2, Scala 2.13, JDK 21)"
 
 on:
   schedule:

--- a/.github/workflows/build_branch42_java25.yml
+++ b/.github/workflows/build_branch42_java25.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build (branch-4.2, Scala 2.13, Hadoop 3, JDK 25)"
+name: "Build (branch-4.2, Scala 2.13, JDK 25)"
 
 on:
   schedule:

--- a/.github/workflows/build_branch42_maven.yml
+++ b/.github/workflows/build_branch42_maven.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Maven (branch-4.2, Scala 2.13, Hadoop 3, JDK 17)"
+name: "Build / Maven (branch-4.2, Scala 2.13, JDK 17)"
 
 on:
   schedule:

--- a/.github/workflows/build_branch42_maven_java21.yml
+++ b/.github/workflows/build_branch42_maven_java21.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Maven (branch-4.2, Scala 2.13, Hadoop 3, JDK 21)"
+name: "Build / Maven (branch-4.2, Scala 2.13, JDK 21)"
 
 on:
   schedule:

--- a/.github/workflows/build_branch42_non_ansi.yml
+++ b/.github/workflows/build_branch42_non_ansi.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Non-ANSI (branch-4.2, Hadoop 3, JDK 17, Scala 2.13)"
+name: "Build / Non-ANSI (branch-4.2, JDK 17, Scala 2.13)"
 
 on:
   schedule:

--- a/.github/workflows/build_java17.yml
+++ b/.github/workflows/build_java17.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Java17 (Scala 2.13, Hadoop 3, JDK 17)"
+name: "Build / Java17 (Scala 2.13, JDK 17)"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build_java21.yml
+++ b/.github/workflows/build_java21.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Java21 (Scala 2.13, Hadoop 3, JDK 21)"
+name: "Build / Java21 (Scala 2.13, JDK 21)"
 
 on:
   schedule:

--- a/.github/workflows/build_java25.yml
+++ b/.github/workflows/build_java25.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Java25 (Scala 2.13, Hadoop 3, JDK 25)"
+name: "Build / Java25 (Scala 2.13, JDK 25)"
 
 on:
   schedule:

--- a/.github/workflows/build_maven.yml
+++ b/.github/workflows/build_maven.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Maven (Scala 2.13, Hadoop 3, JDK 17)"
+name: "Build / Maven (Scala 2.13, JDK 17)"
 
 on:
   schedule:

--- a/.github/workflows/build_maven_java21.yml
+++ b/.github/workflows/build_maven_java21.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Maven (Scala 2.13, Hadoop 3, JDK 21)"
+name: "Build / Maven (Scala 2.13, JDK 21)"
 
 on:
   schedule:

--- a/.github/workflows/build_maven_java21_arm.yml
+++ b/.github/workflows/build_maven_java21_arm.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Maven (Scala 2.13, Hadoop 3, JDK 21, ARM)"
+name: "Build / Maven (Scala 2.13, JDK 21, ARM)"
 
 on:
   schedule:

--- a/.github/workflows/build_maven_java21_macos26.yml
+++ b/.github/workflows/build_maven_java21_macos26.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Maven (Scala 2.13, Hadoop 3, JDK 21, MacOS-26)"
+name: "Build / Maven (Scala 2.13, JDK 21, MacOS-26)"
 
 on:
   schedule:

--- a/.github/workflows/build_maven_java25.yml
+++ b/.github/workflows/build_maven_java25.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Maven (Scala 2.13, Hadoop 3, JDK 25)"
+name: "Build / Maven (Scala 2.13, JDK 25)"
 
 on:
   schedule:

--- a/.github/workflows/build_non_ansi.yml
+++ b/.github/workflows/build_non_ansi.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Non-ANSI (Hadoop 3, JDK 17, Scala 2.13)"
+name: "Build / Non-ANSI (JDK 17, Scala 2.13)"
 
 on:
   schedule:

--- a/.github/workflows/build_rockdb_as_ui_backend.yml
+++ b/.github/workflows/build_rockdb_as_ui_backend.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / RocksDB as UI Backend (Hadoop 3, JDK 17, Scala 2.13)"
+name: "Build / RocksDB as UI Backend (JDK 17, Scala 2.13)"
 
 on:
   schedule:

--- a/.github/workflows/build_uds.yml
+++ b/.github/workflows/build_uds.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Unix Domain Socket (Hadoop 3, JDK 17, Scala 2.13)"
+name: "Build / Unix Domain Socket (JDK 17, Scala 2.13)"
 
 on:
   schedule:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes `Hadoop 3` from the GitHub Action workflow names.

### Why are the changes needed?

Apache Spark 3.5+ supports only Hadoop 3, so `Hadoop 3` is redundant in the workflow names in these days because Apache Spark 3.4 and older are EOL. All live branches are `Hadoop 3`.

- https://github.com/apache/spark/pull/40788

Note that this PR focuses only for GitHub Action workflow names, not a profile. We have kept the profile for the cases we need to split Hadoop distributions in a way. For example, hadoop-4 (although it doesn't exist yet) or hadoop-3.6 (if needed).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code