### PR TITLE
[SPARK-57514][INFRA] Remove `Java 17` Maven build test from `build_and_test.yml`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -136,7 +136,6 @@ jobs:
             buf=true
             ui=true
             docs=true
-            java17=true
             java25=true
           else
             pyspark_install=false
@@ -150,7 +149,6 @@ jobs:
             buf=false
             ui=false
             docs=false
-            java17=false
             java25=false
           fi
           build=`./dev/is-changed.py -m "core,unsafe,kvstore,avro,utils,utils-java,network-common,network-shuffle,repl,launcher,examples,sketch,variant,api,catalyst,hive-thriftserver,mllib-local,mllib,graphx,streaming,sql-kafka-0-10,streaming-kafka-0-10,streaming-kinesis-asl,kubernetes,hadoop-cloud,spark-ganglia-lgpl,profiler,protobuf,yarn,connect,sql,hive,pipelines"`
@@ -167,7 +165,6 @@ jobs:
               \"tpcds-1g\": \"$tpcds\",
               \"docker-integration-tests\": \"$docker\",
               \"lint\" : \"true\",
-              \"java17\" : \"$java17\",
               \"java25\" : \"$java25\",
               \"docs\" : \"$docs\",
               \"yarn\" : \"$yarn\",
@@ -1248,24 +1245,6 @@ jobs:
       run: ./R/install-dev.sh
     - name: R linter
       run: ./dev/lint-r
-
-  java17:
-    needs: [precondition]
-    if: fromJson(needs.precondition.outputs.required).java17 == 'true'
-    name: Java 17 build with Maven
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-java@v5
-      with:
-        distribution: zulu
-        java-version: 17
-    - name: Build with Maven
-      run: |
-        export MAVEN_OPTS="-Xss64m -Xmx4g -Xms4g -XX:ReservedCodeCacheSize=128m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        export MAVEN_CLI_OPTS="--no-transfer-progress"
-        ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pjvm-profiler -Pspark-ganglia-lgpl -Pkinesis-asl clean install
 
   java25:
     needs: [precondition]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the `Java 17 build with Maven` job from `build_and_test.yml`, along with its now-unused `java17` precondition entries.

### Why are the changes needed?

Since `Java 25` Maven build test provides the most Mave build coverage, we can remove `Java 17` to save more ASF Infra and reduce the burden of PR contributors. PR contributors have very limited GitHub Action credits. In addition, `Java 25` is faster than `Java 17`.

<img width="370" height="113" alt="Screenshot 2026-06-17 at 15 07 09" src="https://github.com/user-attachments/assets/3e3e377f-9d3c-423c-b8e9-06ccee72cbe9" />


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review on this PR.

- https://github.com/dongjoon-hyun/spark/runs/82011814915
<img width=50% src="https://github.com/user-attachments/assets/065cc7a7-4bac-41e3-b331-4a9be49fba44" />

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)