### PR TITLE
[SPARK-57519][CORE] Fix NoSuchElementException in ErrorClassesJsonReader.isValidErrorClass for error classes without sub-classes

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/ErrorClassesJSONReader.scala
+++ b/common/utils/src/main/scala/org/apache/spark/ErrorClassesJSONReader.scala
@@ -136,7 +136,7 @@ class ErrorClassesJsonReader(jsonFileURLs: Seq[URL]) {
     errorClasses match {
       case Array(mainClass) => errorInfoMap.contains(mainClass)
       case Array(mainClass, subClass) => errorInfoMap.get(mainClass).exists { info =>
-        info.subClass.get.contains(subClass)
+        info.subClass.exists(_.contains(subClass))
       }
       case _ => false
     }

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -503,6 +503,50 @@ class SparkThrowableSuite extends SparkFunSuite {
     }
   }
 
+  test("isValidErrorClass with a main class that has no sub-classes") {
+    withTempDir { dir =>
+      val json = new File(dir, "errors.json")
+      Files.writeString(json.toPath(),
+        """
+          |{
+          |  "MAIN_NO_SUBCLASS" : {
+          |    "message" : [
+          |      "abc"
+          |    ]
+          |  },
+          |  "MAIN_WITH_SUBCLASS" : {
+          |    "message" : [
+          |      "abc"
+          |    ],
+          |    "subClass" : {
+          |      "VALID_SUB" : {
+          |        "message" : [
+          |          "def"
+          |        ]
+          |      }
+          |    }
+          |  }
+          |}
+          |""".stripMargin, StandardCharsets.UTF_8)
+      val reader = new ErrorClassesJsonReader(Seq(errorJsonFilePath.toUri.toURL, json.toURI.toURL))
+      // A main class with no sub-classes is valid on its own, but querying it with a sub-class
+      // must return false rather than throw NoSuchElementException (reachable from user SQL).
+      assert(reader.isValidErrorClass("MAIN_NO_SUBCLASS"))
+      assert(!reader.isValidErrorClass("MAIN_NO_SUBCLASS.NON_EXISTENT"))
+      // A main class that does define sub-classes: main-only and a valid sub are valid; an
+      // unknown sub is not.
+      assert(reader.isValidErrorClass("MAIN_WITH_SUBCLASS"))
+      assert(reader.isValidErrorClass("MAIN_WITH_SUBCLASS.VALID_SUB"))
+      assert(!reader.isValidErrorClass("MAIN_WITH_SUBCLASS.NON_EXISTENT_SUB"))
+      // Unknown main class: well-formed but not registered.
+      assert(!reader.isValidErrorClass("NON_EXISTENT"))
+      assert(!reader.isValidErrorClass("NON_EXISTENT.SUB"))
+      // Malformed: empty string or more than two parts.
+      assert(!reader.isValidErrorClass(""))
+      assert(!reader.isValidErrorClass("MAIN_NO_SUBCLASS.X.Y"))
+    }
+  }
+
   test("breaking changes info") {
     assert(SparkThrowableHelper.getBreakingChangeInfo(null).isEmpty)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`ErrorClassesJsonReader.isValidErrorClass` checks a two-part error class name (`MAIN.SUB`) with `info.subClass.get.contains(subClass)`. When the main class has no sub-classes, `info.subClass` is `None`, so `.get` throws `NoSuchElementException`.

This PR changes that to `info.subClass.exists(_.contains(subClass))`, which returns `false` in that case instead of throwing, and adds a test to `SparkThrowableSuite`.

### Why are the changes needed?

`isValidErrorClass` is meant to return a boolean, but it threw for this input. It is reachable from user SQL: SQL scripting handler declarations validate two-part condition names through `SparkThrowableHelper.isValidErrorClass` (in `AstBuilder`), and so does `RAISE_ERROR`. As a result a name like `DIVIDE_BY_ZERO.X` (a real top-level error class with no sub-classes) surfaced an internal `NoSuchElementException` instead of the intended "condition not found" error.

### Does this PR introduce _any_ user-facing change?

Yes. Validating a two-part error condition name whose main class has no sub-classes no longer throws `NoSuchElementException`; it returns `false`, so the caller can report the proper error. Inputs that already returned without throwing are unaffected.

### How was this patch tested?

Added a unit test in `SparkThrowableSuite` that covers a main class without sub-classes, a main class with sub-classes (valid and unknown sub-class), unknown main classes, and malformed names. `build/sbt 'core/testOnly *SparkThrowableSuite'` passes (34 tests).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
