### PR TITLE
[CONNECT] Use Authorization header for JVM client token auth

### DIFF
--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -25,7 +25,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters._
 
 import com.google.protobuf.{Any => PAny, StringValue}
-import io.grpc.{CallOptions, Channel, ClientCall, ClientInterceptor, Metadata, MethodDescriptor, Server, ServerCall, ServerCallHandler, ServerInterceptor, Status, StatusRuntimeException}
+import io.grpc.{CallCredentials, CallOptions, Channel, ClientCall, ClientInterceptor, Metadata, MethodDescriptor, Server, ServerCall, ServerCallHandler, ServerInterceptor, Status, StatusRuntimeException}
 import io.grpc.netty.NettyServerBuilder
 import io.grpc.stub.StreamObserver
 import org.scalatest.concurrent.Eventually
@@ -81,6 +81,34 @@ class SparkConnectClientSuite extends ConnectFunSuite {
   test("Placeholder test: Create SparkConnectClient") {
     client = SparkConnectClient.builder().userId("abc123").build()
     assert(client.userId == "abc123")
+  }
+
+  test("access token call credentials use Authorization metadata") {
+    val credentials = new SparkConnectClient.AccessTokenCallCredentials("deadbeef")
+    val executor = new java.util.concurrent.Executor {
+      override def execute(command: Runnable): Unit = command.run()
+    }
+    var appliedHeaders: Metadata = null
+    var failedStatus: Status = null
+
+    credentials.applyRequestMetadata(
+      null,
+      executor,
+      new CallCredentials.MetadataApplier {
+        override def apply(headers: Metadata): Unit = {
+          appliedHeaders = headers
+        }
+
+        override def fail(status: Status): Unit = {
+          failedStatus = status
+        }
+      })
+
+    val authorizationKey = Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER)
+    val authenticationKey = Metadata.Key.of("Authentication", Metadata.ASCII_STRING_MARSHALLER)
+    assert(failedStatus == null)
+    assert(appliedHeaders.get(authorizationKey) == "Bearer deadbeef")
+    assert(appliedHeaders.get(authenticationKey) == null)
   }
 
   // Use 0 to start the server at a random port

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -705,7 +705,7 @@ object SparkConnectClient {
   private val DEFAULT_USER_AGENT: String = "_SPARK_CONNECT_SCALA"
 
   private val AUTH_TOKEN_META_DATA_KEY: Metadata.Key[String] =
-    Metadata.Key.of("Authentication", Metadata.ASCII_STRING_MARSHALLER)
+    Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER)
 
   // for internal tests
   private[sql] def apply(channel: ManagedChannel): SparkConnectClient = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes the JVM Spark Connect client token metadata key used by `AccessTokenCallCredentials` from `Authentication` to `Authorization`.

It also adds a regression test for the generated bearer-token metadata.

### Why are the changes needed?

Spark Connect server token authentication validates `Authorization: Bearer <token>`. It does not read an `Authentication` metadata key.

The JVM client `CallCredentials` path is used for non-local token connections and TLS-enabled connections. Before this change, that path sent the token under `Authentication`, so a correctly configured JVM client could still fail with `UNAUTHENTICATED` against a Spark Connect server configured with `spark.connect.authenticate.token`.

`Authentication` came from the older Scala client SSL/access-token work, while later server-side Spark Connect token auth standardized on `Authorization`. This PR aligns the older JVM `CallCredentials` path with the server contract.

### Does this PR introduce _any_ user-facing change?

Yes. A JVM Spark Connect client using token auth through the non-local/TLS `CallCredentials` path can authenticate successfully with a server configured with `spark.connect.authenticate.token`.

There is no API or configuration change.

### How was this patch tested?

Added a regression test in `SparkConnectClientSuite` that verifies `AccessTokenCallCredentials` emits `Authorization: Bearer <token>` and does not emit the old `Authentication` metadata key.

Targeted test command: `./build/sbt "connect-client-jvm/testOnly org.apache.spark.sql.connect.client.SparkConnectClientSuite -- -z 'access token call credentials use Authorization metadata'"`

I was not able to complete the local test run because dependency download in this environment was blocked by a proxy 407 response.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex
