### PR TITLE
[SPARK-57524][SQL] Correct SHOW TABLE EXTENDED property formatting

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExtendedExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExtendedExec.scala
@@ -97,13 +97,12 @@ case class ShowTablesExtendedExec(
         }
       })
 
-    if (!table.properties().isEmpty) {
-      results.put("Table Properties",
-        conf.redactOptions(table.properties.asScala.toMap).toList
-          .filter(kv => !CatalogV2Util.TABLE_RESERVED_PROPERTIES.contains(kv._1))
-          .sortBy(_._1)
-          .map { case (key, value) => key + "=" + value }
-          .mkString("[", ", ", "]"))
+    val displayedTableProperties = conf.redactOptions(table.properties.asScala.toMap).toList
+      .filterNot { case (key, _) => CatalogV2Util.TABLE_RESERVED_PROPERTIES.contains(key) }
+      .sortBy(_._1)
+      .map { case (key, value) => key + "=" + value }
+    if (displayedTableProperties.nonEmpty) {
+      results.put("Table Properties", displayedTableProperties.mkString("[", ", ", "]"))
     }
 
     // Partition Provider & Partition Columns

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExtendedExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExtendedExec.scala
@@ -97,13 +97,13 @@ case class ShowTablesExtendedExec(
         }
       })
 
-    val properties =
-      conf.redactOptions(table.properties.asScala.toMap).toList
-        .filter(kv => !CatalogV2Util.TABLE_RESERVED_PROPERTIES.contains(kv._1))
-        .sortBy(_._1)
-        .map { case (key, value) => key + "=" + value }
     if (!table.properties().isEmpty) {
-      results.put("Table Properties", properties.mkString("[", ", ", "]"))
+      results.put("Table Properties",
+        conf.redactOptions(table.properties.asScala.toMap).toList
+          .filter(kv => !CatalogV2Util.TABLE_RESERVED_PROPERTIES.contains(kv._1))
+          .sortBy(_._1)
+          .map { case (key, value) => key + "=" + value }
+          .mkString("[", ", ", "]"))
     }
 
     // Partition Provider & Partition Columns

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExtendedExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExtendedExec.scala
@@ -100,9 +100,8 @@ case class ShowTablesExtendedExec(
     val properties =
       conf.redactOptions(table.properties.asScala.toMap).toList
         .filter(kv => !CatalogV2Util.TABLE_RESERVED_PROPERTIES.contains(kv._1))
-        .sortBy(_._1).map {
-        case (key, value) => key + "=" + value
-      }.mkString("[", ",", "]")
+        .sortBy(_._1)
+        .map { case (key, value) => key + "=" + value }
     if (!table.properties().isEmpty) {
       results.put("Table Properties", properties.mkString("[", ", ", "]"))
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -62,6 +62,17 @@ class ShowTablesSuite extends command.ShowTablesSuiteBase with CommandSuiteBase 
     }
   }
 
+  test("show table extended omits empty table properties") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (id bigint) $defaultUsing")
+
+      val information = sql(s"SHOW TABLE EXTENDED IN $catalog.ns LIKE 'tbl'")
+        .collect()(0)(3).toString
+
+      assert(!information.split("\n").exists(_.startsWith("Table Properties")))
+    }
+  }
+
   override protected def extendedPartInNonPartedTableError(
       catalog: String,
       namespace: String,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -50,6 +50,18 @@ class ShowTablesSuite extends command.ShowTablesSuiteBase with CommandSuiteBase 
     }
   }
 
+  test("show table extended formats table properties") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (id bigint) $defaultUsing " +
+        "TBLPROPERTIES ('p1'='v1', 'p2'='v2')")
+
+      val information = sql(s"SHOW TABLE EXTENDED IN $catalog.ns LIKE 'tbl'")
+        .collect()(0)(3).toString
+
+      assert(information.split("\n").contains("Table Properties: [p1=v1, p2=v2]"))
+    }
+  }
+
   override protected def extendedPartInNonPartedTableError(
       catalog: String,
       namespace: String,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowTablesSuite.scala
@@ -86,8 +86,7 @@ class ShowTablesSuite extends command.ShowTablesSuiteBase with CommandSuiteBase 
   protected override def extendedTableInfo: String =
     s"""Type: MANAGED
        |Provider: _
-       |Owner: ${Utils.getCurrentUserName()}
-       |Table Properties: <table properties>""".stripMargin
+       |Owner: ${Utils.getCurrentUserName()}""".stripMargin
 
   protected override def extendedTableSchema: String =
     s"""Schema: root


### PR DESCRIPTION
### What changes were proposed in this pull request?
The purpose of this change is to fix how `SHOW TABLE EXTENDED` renders table properties for v2 tables.

It fixes the property formatting bug by keeping the entries as a list until the final `mkString`, and it also makes `SHOW TABLE EXTENDED` omit the `Table Properties` line when no non-reserved properties remain after filtering.

### Why are the changes needed?
Fix a bug. Before this change, the code converted the redacted property entries into a single string too early, and the later `mkString` call operated on that string character by character. As a result, the `Table Properties` output could be formatted incorrectly.

This update keeps the properties as a list of `key=value` entries until the final formatting step, so the command produces the expected bracketed, comma-separated property list. It also avoids printing `Table Properties: []` when all remaining properties are filtered out as reserved properties.

### Does this PR introduce _any_ user-facing change?
Yes.

Execute `SHOW TABLE EXTENDED`:
`show table extended in paimon.\`dev_xxx\` like 'test_show_table_extended';`

Before this PR, the output result is:
<img width="2448" height="604" alt="image" src="https://github.com/user-attachments/assets/c0034197-0848-4bd3-ba42-f08279489d31" />

After this PR:
<img width="1860" height="456" alt="image" src="https://github.com/user-attachments/assets/318e1778-36a5-4ccb-8725-4e48bfd7b4a4" />

This PR also changes the empty-property case for v2 tables: if no non-reserved table properties remain after filtering, `SHOW TABLE EXTENDED` now omits the `Table Properties` line instead of showing `Table Properties: []`.

### How was this patch tested?
Added regression tests in `org.apache.spark.sql.execution.command.v2.ShowTablesSuite` to verify that:

- `SHOW TABLE EXTENDED` formats v2 table properties as `Table Properties: [p1=v1, p2=v2]`
- `SHOW TABLE EXTENDED` omits the `Table Properties` line when no non-reserved properties remain after filtering

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Codex (GPT 5.5)