### PR TITLE
[SPARK-57531][SQL] Reuse OrcTail in non-vectorized ORC reader path

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.mapreduce.lib.input.FileSplit
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 import org.apache.orc.{OrcUtils => _, _}
 import org.apache.orc.OrcConf.COMPRESS
-import org.apache.orc.mapred.{OrcInputFormat => OrcMapredInputFormat, OrcStruct}
+import org.apache.orc.mapred.OrcStruct
 import org.apache.orc.mapreduce._
 
 import org.apache.spark.TaskContext
@@ -226,7 +226,7 @@ class OrcFileFormat
           iter.asInstanceOf[Iterator[InternalRow]]
         } else {
           val orcRecordReader = OrcUtils.createOrcMapreduceRecordReader(
-            filePath, taskConf, fileSplit, readerOptions.getOrcTail)
+            filePath, taskConf, fileSplit, readerOptions)
           val iter = new RecordReaderIterator[OrcStruct](orcRecordReader)
           Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => iter.close()))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -27,7 +27,7 @@ import org.apache.hadoop.mapreduce.lib.input.FileSplit
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 import org.apache.orc.{OrcUtils => _, _}
 import org.apache.orc.OrcConf.COMPRESS
-import org.apache.orc.mapred.OrcStruct
+import org.apache.orc.mapred.{OrcInputFormat => OrcMapredInputFormat, OrcStruct}
 import org.apache.orc.mapreduce._
 
 import org.apache.spark.TaskContext
@@ -225,8 +225,18 @@ class OrcFileFormat
 
           iter.asInstanceOf[Iterator[InternalRow]]
         } else {
-          val orcRecordReader = new OrcInputFormat[OrcStruct]
-            .createRecordReader(fileSplit, taskAttemptContext)
+          val orcRecordReader = {
+            val orcReader = OrcFile.createReader(
+              filePath,
+              OrcFile.readerOptions(taskConf)
+                .maxLength(OrcConf.MAX_FILE_LENGTH.getLong(taskConf))
+                .filesystem(fs)
+                .orcTail(readerOptions.getOrcTail))
+            val options = OrcMapredInputFormat
+              .buildOptions(taskConf, orcReader, fileSplit.getStart, fileSplit.getLength)
+              .useSelected(true)
+            new OrcMapreduceRecordReader[OrcStruct](orcReader, options)
+          }
           val iter = new RecordReaderIterator[OrcStruct](orcRecordReader)
           Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => iter.close()))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -225,18 +225,8 @@ class OrcFileFormat
 
           iter.asInstanceOf[Iterator[InternalRow]]
         } else {
-          val orcRecordReader = {
-            val orcReader = OrcFile.createReader(
-              filePath,
-              OrcFile.readerOptions(taskConf)
-                .maxLength(OrcConf.MAX_FILE_LENGTH.getLong(taskConf))
-                .filesystem(fs)
-                .orcTail(readerOptions.getOrcTail))
-            val options = OrcMapredInputFormat
-              .buildOptions(taskConf, orcReader, fileSplit.getStart, fileSplit.getLength)
-              .useSelected(true)
-            new OrcMapreduceRecordReader[OrcStruct](orcReader, options)
-          }
+          val orcRecordReader = OrcUtils.createOrcMapreduceRecordReader(
+            filePath, taskConf, fileSplit, readerOptions.getOrcTail)
           val iter = new RecordReaderIterator[OrcStruct](orcRecordReader)
           Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => iter.close()))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -29,7 +29,10 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.hive.serde2.io.DateWritable
 import org.apache.hadoop.io.{BooleanWritable, ByteWritable, DoubleWritable, FloatWritable, IntWritable, LongWritable, ShortWritable, WritableComparable}
-import org.apache.orc.{BooleanColumnStatistics, ColumnStatistics, DateColumnStatistics, DoubleColumnStatistics, IntegerColumnStatistics, OrcConf, OrcFile, Reader, TypeDescription, Writer}
+import org.apache.hadoop.mapreduce.lib.input.FileSplit
+import org.apache.orc.{BooleanColumnStatistics, ColumnStatistics, DateColumnStatistics, DoubleColumnStatistics, IntegerColumnStatistics, OrcConf, OrcFile, OrcTail, Reader, TypeDescription, Writer}
+import org.apache.orc.mapred.{OrcInputFormat => OrcMapredInputFormat, OrcStruct}
+import org.apache.orc.mapreduce.OrcMapreduceRecordReader
 
 import org.apache.spark.{SPARK_VERSION_SHORT, SparkException}
 import org.apache.spark.deploy.SparkHadoopUtil
@@ -533,5 +536,23 @@ object OrcUtils extends Logging {
     } else {
       resultRow
     }
+  }
+
+  def createOrcMapreduceRecordReader(
+      filePath: Path,
+      conf: Configuration,
+      fileSplit: FileSplit,
+      orcTail: OrcTail): OrcMapreduceRecordReader[OrcStruct] = {
+    val fs = filePath.getFileSystem(conf)
+    val orcReader = OrcFile.createReader(
+      filePath,
+      OrcFile.readerOptions(conf)
+        .maxLength(OrcConf.MAX_FILE_LENGTH.getLong(conf))
+        .filesystem(fs)
+        .orcTail(orcTail))
+    val options = OrcMapredInputFormat
+      .buildOptions(conf, orcReader, fileSplit.getStart, fileSplit.getLength)
+      .useSelected(true)
+    new OrcMapreduceRecordReader[OrcStruct](orcReader, options)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -30,7 +30,7 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.hive.serde2.io.DateWritable
 import org.apache.hadoop.io.{BooleanWritable, ByteWritable, DoubleWritable, FloatWritable, IntWritable, LongWritable, ShortWritable, WritableComparable}
 import org.apache.hadoop.mapreduce.lib.input.FileSplit
-import org.apache.orc.{BooleanColumnStatistics, ColumnStatistics, DateColumnStatistics, DoubleColumnStatistics, IntegerColumnStatistics, OrcConf, OrcFile, OrcTail, Reader, TypeDescription, Writer}
+import org.apache.orc.{BooleanColumnStatistics, ColumnStatistics, DateColumnStatistics, DoubleColumnStatistics, IntegerColumnStatistics, OrcConf, OrcFile, Reader, TypeDescription, Writer}
 import org.apache.orc.mapred.{OrcInputFormat => OrcMapredInputFormat, OrcStruct}
 import org.apache.orc.mapreduce.OrcMapreduceRecordReader
 
@@ -542,14 +542,14 @@ object OrcUtils extends Logging {
       filePath: Path,
       conf: Configuration,
       fileSplit: FileSplit,
-      orcTail: OrcTail): OrcMapreduceRecordReader[OrcStruct] = {
+      readerOptions: OrcFile.ReaderOptions): OrcMapreduceRecordReader[OrcStruct] = {
     val fs = filePath.getFileSystem(conf)
     val orcReader = OrcFile.createReader(
       filePath,
       OrcFile.readerOptions(conf)
         .maxLength(OrcConf.MAX_FILE_LENGTH.getLong(conf))
         .filesystem(fs)
-        .orcTail(orcTail))
+        .orcTail(readerOptions.getOrcTail))
     val options = OrcMapredInputFormat
       .buildOptions(conf, orcReader, fileSplit.getStart, fileSplit.getLength)
       .useSelected(true)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -106,7 +106,7 @@ case class OrcPartitionReaderFactory(
       val fileSplit = new FileSplit(filePath, file.start, file.length, Array.empty)
 
       val orcRecordReader = OrcUtils.createOrcMapreduceRecordReader(
-        filePath, taskConf, fileSplit, readerOptions.getOrcTail)
+        filePath, taskConf, fileSplit, readerOptions)
 
       val deserializer = new OrcDeserializer(readDataSchema, requestedColIds)
       val fileReader = new PartitionReader[InternalRow] {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -22,7 +22,7 @@ import org.apache.hadoop.mapreduce.{JobID, TaskAttemptID, TaskID, TaskType}
 import org.apache.hadoop.mapreduce.lib.input.FileSplit
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 import org.apache.orc.{OrcConf, OrcFile, Reader, TypeDescription}
-import org.apache.orc.mapred.OrcStruct
+import org.apache.orc.mapred.{OrcInputFormat => OrcMapredInputFormat, OrcStruct}
 import org.apache.orc.mapreduce.{OrcInputFormat, OrcMapreduceRecordReader}
 
 import org.apache.spark.broadcast.Broadcast
@@ -114,7 +114,7 @@ case class OrcPartitionReaderFactory(
             .maxLength(OrcConf.MAX_FILE_LENGTH.getLong(taskConf))
             .filesystem(fs)
             .orcTail(readerOptions.getOrcTail))
-        val options = org.apache.orc.mapred.OrcInputFormat
+        val options = OrcMapredInputFormat
           .buildOptions(taskConf, orcReader, fileSplit.getStart, fileSplit.getLength)
           .useSelected(true)
         new OrcMapreduceRecordReader[OrcStruct](orcReader, options)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -22,8 +22,7 @@ import org.apache.hadoop.mapreduce.{JobID, TaskAttemptID, TaskID, TaskType}
 import org.apache.hadoop.mapreduce.lib.input.FileSplit
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 import org.apache.orc.{OrcConf, OrcFile, Reader, TypeDescription}
-import org.apache.orc.mapred.{OrcInputFormat => OrcMapredInputFormat, OrcStruct}
-import org.apache.orc.mapreduce.{OrcInputFormat, OrcMapreduceRecordReader}
+import org.apache.orc.mapreduce.OrcInputFormat
 
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.memory.MemoryMode
@@ -106,19 +105,8 @@ case class OrcPartitionReaderFactory(
 
       val fileSplit = new FileSplit(filePath, file.start, file.length, Array.empty)
 
-      val orcRecordReader = {
-        val fs = filePath.getFileSystem(taskConf)
-        val orcReader = OrcFile.createReader(
-          filePath,
-          OrcFile.readerOptions(taskConf)
-            .maxLength(OrcConf.MAX_FILE_LENGTH.getLong(taskConf))
-            .filesystem(fs)
-            .orcTail(readerOptions.getOrcTail))
-        val options = OrcMapredInputFormat
-          .buildOptions(taskConf, orcReader, fileSplit.getStart, fileSplit.getLength)
-          .useSelected(true)
-        new OrcMapreduceRecordReader[OrcStruct](orcReader, options)
-      }
+      val orcRecordReader = OrcUtils.createOrcMapreduceRecordReader(
+        filePath, taskConf, fileSplit, readerOptions.getOrcTail)
 
       val deserializer = new OrcDeserializer(readDataSchema, requestedColIds)
       val fileReader = new PartitionReader[InternalRow] {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.mapreduce.lib.input.FileSplit
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 import org.apache.orc.{OrcConf, OrcFile, Reader, TypeDescription}
 import org.apache.orc.mapred.OrcStruct
-import org.apache.orc.mapreduce.OrcInputFormat
+import org.apache.orc.mapreduce.{OrcInputFormat, OrcMapreduceRecordReader}
 
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.memory.MemoryMode
@@ -89,7 +89,8 @@ case class OrcPartitionReaderFactory(
     }
     val filePath = file.toPath
 
-    val orcSchema = Utils.tryWithResource(createORCReader(filePath, conf)._1)(_.getSchema)
+    val (orcSchemaReader, readerOptions) = createORCReader(filePath, conf)
+    val orcSchema = Utils.tryWithResource(orcSchemaReader)(_.getSchema)
     val resultedColPruneInfo = OrcUtils.requestedColumnIds(
       isCaseSensitive, dataSchema, readDataSchema, orcSchema, conf)
 
@@ -104,11 +105,21 @@ case class OrcPartitionReaderFactory(
       val taskConf = new Configuration(conf)
 
       val fileSplit = new FileSplit(filePath, file.start, file.length, Array.empty)
-      val attemptId = new TaskAttemptID(new TaskID(new JobID(), TaskType.MAP, 0), 0)
-      val taskAttemptContext = new TaskAttemptContextImpl(taskConf, attemptId)
 
-      val orcRecordReader = new OrcInputFormat[OrcStruct]
-        .createRecordReader(fileSplit, taskAttemptContext)
+      val orcRecordReader = {
+        val fs = filePath.getFileSystem(taskConf)
+        val orcReader = OrcFile.createReader(
+          filePath,
+          OrcFile.readerOptions(taskConf)
+            .maxLength(OrcConf.MAX_FILE_LENGTH.getLong(taskConf))
+            .filesystem(fs)
+            .orcTail(readerOptions.getOrcTail))
+        val options = org.apache.orc.mapred.OrcInputFormat
+          .buildOptions(taskConf, orcReader, fileSplit.getStart, fileSplit.getLength)
+          .useSelected(true)
+        new OrcMapreduceRecordReader[OrcStruct](orcReader, options)
+      }
+
       val deserializer = new OrcDeserializer(readDataSchema, requestedColIds)
       val fileReader = new PartitionReader[InternalRow] {
         override def next(): Boolean = orcRecordReader.nextKeyValue()


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR mirrors what `buildColumnarReader` already does since SPARK-44556: capture the `readerOptions` returned by `createORCReader`, then pass `readerOptions.getOrcTail` when constructing the per-split record reader so the footer is not re-read.

### Why are the changes needed?
`OrcPartitionReaderFactory.buildReader` (the non-vectorized / row-based read path) previously called `OrcInputFormat.createRecordReader(fileSplit, taskAttemptContext)`, which internally calls `OrcFile.createReader` without an `OrcTail` and therefore re-parses the file footer from storage on every split.
Without OrcTail reuse the non-vectorized path pays this cost a second time when opening the data reader for each split, while the vectorized path has been avoiding it since SPARK-44556. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
GHA

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code