### PR TITLE
[SPARK-57536][SS] Use `maxOption` instead of `sorted.lastOption` in `HDFSMetadataLog`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/HDFSMetadataLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/HDFSMetadataLog.scala
@@ -266,10 +266,10 @@ class HDFSMetadataLog[T <: AnyRef : ClassTag](
   }
 
   /** Return the latest batch id without reading the file. */
-  def getLatestBatchId(): Option[Long] = listBatches.sorted.lastOption
+  def getLatestBatchId(): Option[Long] = listBatches.maxOption
 
   override def getLatest(): Option[(Long, T)] = {
-    listBatches.sorted.lastOption.map { batchId =>
+    listBatches.maxOption.map { batchId =>
       logInfo(log"Getting latest batch ${MDC(BATCH_ID, batchId)}")
       (batchId, getExistingBatch(batchId))
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces `listBatches.sorted.lastOption` with `listBatches.maxOption` in `HDFSMetadataLog.getLatestBatchId()` and `HDFSMetadataLog.getLatest()`.

### Why are the changes needed?

The intent of the code is to find the maximum batch ID. `sorted.lastOption` sorts the entire array in O(n log n) to retrieve only the maximum element, while `maxOption` achieves the same result in O(n). These methods are called on every micro-batch in Structured Streaming, so avoiding unnecessary sorting reduces overhead for long-running streaming jobs with many batches.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Claude
