### PR TITLE
[SPARK-57537][SS] Add metrics support for deleteRange operation in RocksDB

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -1583,6 +1583,18 @@ class RocksDB(
       originalEndKey
     }
 
+    // Count the keys that are about to be deleted (gated on trackTotalNumberOfRows).
+    if (conf.trackTotalNumberOfRows) {
+      val (deletedKeys, deletedInternalKeys) = countKeysInRange(
+        beginKeyWithPrefix,
+        endKeyWithPrefix,
+        cfName,
+        includesPrefix
+      )
+      numKeysOnWritingVersion -= deletedKeys
+      numInternalKeysOnWritingVersion -= deletedInternalKeys
+    }
+
     db.deleteRange(writeOptions, beginKeyWithPrefix, endKeyWithPrefix)
     changelogWriter.foreach { writer =>
       val endKeyForChangelog = if (conf.rowChecksumEnabled) {
@@ -1593,7 +1605,63 @@ class RocksDB(
       }
       writer.deleteRange(beginKeyWithPrefix, endKeyForChangelog)
     }
-    // TODO: Add metrics update for deleteRange operations
+  }
+
+  /** Count the keys currently present in `[beginKeyWithPrefix,
+    * endKeyWithPrefix)`, split into non-internal vs internal column-family
+    * buckets.
+    *
+    * @param beginKeyWithPrefix
+    *   Already-prefixed start key (inclusive)
+    * @param endKeyWithPrefix
+    *   Already-prefixed end key (exclusive); used as the iterator upper bound
+    *   so we never touch keys beyond it.
+    * @param cfName
+    *   Caller-supplied column family. Used when `includesPrefix` is false;
+    * @param includesPrefix
+    *   When true, the keys already carry their cfId prefix.
+    * @return
+    *   (numKeys, numInternalKeys) - the counts to subtract from
+    *   `numKeysOnWritingVersion` and `numInternalKeysOnWritingVersion`
+    *   respectively.
+    */
+  private def countKeysInRange(
+      beginKeyWithPrefix: Array[Byte],
+      endKeyWithPrefix: Array[Byte],
+      cfName: String,
+      includesPrefix: Boolean
+  ): (Long, Long) = {
+    val upperBoundSlice = new Slice(endKeyWithPrefix)
+    val rangeReadOptions = new ReadOptions()
+    rangeReadOptions.setIterateUpperBound(upperBoundSlice)
+    val iter = db.newIterator(rangeReadOptions)
+    try {
+      // Resolve the CF once for the whole range. When the keys carry their cfId prefix, that
+      // on-key prefix is authoritative; otherwise trust the caller-supplied cfName.
+      val cfIsInternal = if (useColumnFamilies) {
+        val resolvedCfName = if (includesPrefix) {
+          decodeStateRowWithPrefix(beginKeyWithPrefix)._2
+        } else {
+          cfName
+        }
+        getColumnFamilyInfo(resolvedCfName).isInternal
+      } else {
+        false
+      }
+
+      iter.seek(beginKeyWithPrefix)
+      var count = 0L
+      while (iter.isValid) {
+        count += 1
+        iter.next()
+      }
+
+      if (cfIsInternal) (0L, count) else (count, 0L)
+    } finally {
+      iter.close()
+      rangeReadOptions.close()
+      upperBoundSlice.close()
+    }
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -2993,6 +2993,138 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     }
   }
 
+  test("deleteRange - numKeys metric is decremented by the number of keys removed") {
+    tryWithProviderResource(
+      newStoreProvider(
+        keySchemaWithRangeScan,
+        RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+        useColumnFamilies = true)) { provider =>
+      val store = provider.getStore(0)
+      try {
+        // Insert 5 keys
+        store.put(dataToKeyRowWithRangeScan(1L, "a"), dataToValueRow(10))
+        store.put(dataToKeyRowWithRangeScan(2L, "b"), dataToValueRow(20))
+        store.put(dataToKeyRowWithRangeScan(3L, "c"), dataToValueRow(30))
+        store.put(dataToKeyRowWithRangeScan(4L, "d"), dataToValueRow(40))
+        store.put(dataToKeyRowWithRangeScan(5L, "e"), dataToValueRow(50))
+
+        // deleteRange [2, 4) removes 2 keys (ts=2 and ts=3) -> numKeys should drop to 3
+        val beginKey = dataToKeyRowWithRangeScan(2L, "")
+        val endKey = dataToKeyRowWithRangeScan(4L, "")
+        store.deleteRange(beginKey, endKey)
+        assert(store.commit() === 1)
+
+        assert(store.metrics.numKeys === 3,
+          "numKeys should reflect the 3 keys remaining after deleteRange removed 2 of 5")
+      } finally {
+        if (!store.hasCommitted) store.abort()
+      }
+    }
+  }
+
+  test("deleteRange - empty range does not change numKeys metric") {
+    tryWithProviderResource(
+      newStoreProvider(
+        keySchemaWithRangeScan,
+        RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+        useColumnFamilies = true)) { provider =>
+      val store = provider.getStore(0)
+      try {
+        store.put(dataToKeyRowWithRangeScan(1L, "a"), dataToValueRow(10))
+        store.put(dataToKeyRowWithRangeScan(5L, "e"), dataToValueRow(50))
+
+        // deleteRange [2, 4) covers no existing keys -> numKeys stays at 2
+        store.deleteRange(
+          dataToKeyRowWithRangeScan(2L, ""),
+          dataToKeyRowWithRangeScan(4L, ""))
+        assert(store.commit() === 1)
+
+        assert(store.metrics.numKeys === 2,
+          "Empty-range deleteRange should not decrement the numKeys metric")
+      } finally {
+        if (!store.hasCommitted) store.abort()
+      }
+    }
+  }
+
+  test("deleteRange - internal column family keys are tracked separately") {
+    val cfName = "testColFamily"
+    val internalCfName = "$internalCf"
+
+    tryWithProviderResource(
+      newStoreProvider(
+        keySchemaWithRangeScan,
+        RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+        useColumnFamilies = true)) { provider =>
+      val store = provider.getStore(0)
+      try {
+        store.createColFamilyIfAbsent(cfName,
+          keySchemaWithRangeScan, valueSchema,
+          RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)))
+        store.createColFamilyIfAbsent(internalCfName,
+          keySchemaWithRangeScan, valueSchema,
+          RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+          isInternal = true)
+
+        // 4 keys in the non-internal cf, 3 in the internal cf
+        store.put(dataToKeyRowWithRangeScan(1L, "a"), dataToValueRow(10), cfName)
+        store.put(dataToKeyRowWithRangeScan(2L, "b"), dataToValueRow(20), cfName)
+        store.put(dataToKeyRowWithRangeScan(3L, "c"), dataToValueRow(30), cfName)
+        store.put(dataToKeyRowWithRangeScan(4L, "d"), dataToValueRow(40), cfName)
+
+        store.put(dataToKeyRowWithRangeScan(1L, "a"), dataToValueRow(11), internalCfName)
+        store.put(dataToKeyRowWithRangeScan(2L, "b"), dataToValueRow(22), internalCfName)
+        store.put(dataToKeyRowWithRangeScan(3L, "c"), dataToValueRow(33), internalCfName)
+
+        // Delete [2, 4) on the internal cf only -> 2 internal keys gone, non-internal untouched
+        store.deleteRange(
+          dataToKeyRowWithRangeScan(2L, ""),
+          dataToKeyRowWithRangeScan(4L, ""),
+          internalCfName)
+        assert(store.commit() === 1)
+
+        assert(store.metrics.numKeys === 4,
+          "Non-internal numKeys should be unchanged when deleteRange targets an internal CF")
+        val internalMetric = store.metrics.customMetrics
+          .find(_._1.name == "rocksdbNumInternalColFamiliesKeys")
+        assert(internalMetric.isDefined && internalMetric.get._2 === 1,
+          "Internal CF key counter should drop from 3 to 1 after deleting 2 internal keys")
+      } finally {
+        if (!store.hasCommitted) store.abort()
+      }
+    }
+  }
+
+  test("deleteRange - metric is not updated when trackTotalNumberOfRows is disabled") {
+    withSQLConf(
+      RocksDBConf.ROCKSDB_SQL_CONF_NAME_PREFIX + ".trackTotalNumberOfRows" -> "false") {
+      tryWithProviderResource(
+        newStoreProvider(
+          keySchemaWithRangeScan,
+          RangeKeyScanStateEncoderSpec(keySchemaWithRangeScan, Seq(0)),
+          useColumnFamilies = true)) { provider =>
+        val store = provider.getStore(0)
+        try {
+          store.put(dataToKeyRowWithRangeScan(1L, "a"), dataToValueRow(10))
+          store.put(dataToKeyRowWithRangeScan(2L, "b"), dataToValueRow(20))
+          store.put(dataToKeyRowWithRangeScan(3L, "c"), dataToValueRow(30))
+
+          // Should complete without iterating the range (and without touching the counter,
+          // which is held at -1 when row-count tracking is disabled).
+          store.deleteRange(
+            dataToKeyRowWithRangeScan(2L, ""),
+            dataToKeyRowWithRangeScan(4L, ""))
+          assert(store.commit() === 1)
+
+          assert(store.metrics.numKeys === -1,
+            "numKeys should remain at -1 (untracked) when trackTotalNumberOfRows is off")
+        } finally {
+          if (!store.hasCommitted) store.abort()
+        }
+      }
+    }
+  }
+
   test("Rocks DB task completion listener does not double unlock acquireThread") {
     // This test verifies that a thread that locks then unlocks the db and then
     // fires a completion listener (Thread 1) does not unlock the lock validly


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Added metrics update for `deleteRange` operation (`numKeysOnWritingVersion` and `numInternalKeysOnWritingVersion`). The metric update is gated on `conf.trackTotalNumberOfRows` so callers that don't expose the metric pay no extra cost. 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`deleteRange` currently does not update the row-count metrics, which can leave `numKeysOnWritingVersion` and `numInternalKeysOnWritingVersion` inaccurate after range deletes. This change keeps the metrics consistent with other write paths while avoiding extra cost when `trackTotalNumberOfRows` is disabled.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Four new unit tests in `RocksDBStateStoreSuite`:
- numKeys metric is decremented by the number of keys removed
- empty range does not change numKeys metric
- internal column family keys are tracked separately
- metric is not updated when trackTotalNumberOfRows is disabled


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude