### PR TITLE
[SPARK-57538][YARN] Revise a warning message in `YarnShuffleService`

### DIFF
--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -433,7 +433,8 @@ public class YarnShuffleService extends AuxiliaryService {
             MDC.of(LogKeys.APP_ID, appId));
         }
       } catch (IOException ioe) {
-        logger.warn("Unable to parse application data for service: " + payload);
+        logger.warn("Unable to parse the application data for application {}",
+          MDC.of(LogKeys.APP_ID, appId));
         metaInfo = null;
       }
       if (isAuthenticationEnabled()) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `YarnShuffleService.initializeApplication`, when the application data fails to parse,
the warning logged the entire `payload`. This PR logs only the application ID instead.

### Why are the changes needed?

With `spark.authenticate` enabled, the default code path sends the raw shuffle secret as
the `payload`, so the warning logged the secret in plaintext to the NodeManager logs.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated-by: Claude Code (Claude Opus 4.8)