### PR TITLE
[SPARK-57540][SQL] Instantiate Woodstox `WstxOutputFactory` directly in `StaxXmlGenerator`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlGenerator.scala
@@ -19,11 +19,11 @@ package org.apache.spark.sql.catalyst.xml
 import java.io.Writer
 import java.sql.Timestamp
 import java.util.Base64
-import javax.xml.stream.XMLOutputFactory
 
 import scala.collection.Map
 
 import org.apache.hadoop.shaded.com.ctc.wstx.api.WstxOutputProperties
+import org.apache.hadoop.shaded.com.ctc.wstx.stax.WstxOutputFactory
 
 import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.catalyst.InternalRow
@@ -72,7 +72,13 @@ class StaxXmlGenerator(
   private val binaryFormatter = ToStringBase.getBinaryFormatter
 
   private val gen = {
-    val factory = XMLOutputFactory.newInstance()
+    // Instantiate the Woodstox factory directly from the shaded Hadoop classes instead of
+    // using XMLOutputFactory.newInstance(). The latter resolves an implementation via the
+    // service-loader mechanism, which could pick up a different (unshaded) StAX provider on the
+    // classpath. Such a provider would not understand the shaded WstxOutputProperties keys set
+    // below and would throw IllegalArgumentException. Constructing the shaded factory directly
+    // guarantees the properties and the implementation always match.
+    val factory = new WstxOutputFactory()
     // to_xml disables structure validation to allow multiple root tags
     factory.setProperty(WstxOutputProperties.P_OUTPUT_VALIDATE_STRUCTURE, validateStructure)
     factory.setProperty(WstxOutputProperties.P_OUTPUT_VALIDATE_NAMES, options.validateName)


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `StaxXmlGenerator`, the StAX `XMLOutputFactory` was obtained via `XMLOutputFactory.newInstance()` and then configured with Woodstox-specific properties from the shaded Hadoop Woodstox (`org.apache.hadoop.shaded.com.ctc.wstx.api.WstxOutputProperties`).

This PR constructs the shaded Woodstox factory directly:

```scala
val factory = new org.apache.hadoop.shaded.com.ctc.wstx.stax.WstxOutputFactory()
```

instead of relying on `XMLOutputFactory.newInstance()`.

### Why are the changes needed?

`XMLOutputFactory.newInstance()` resolves a concrete StAX implementation through the JAXP/service-loader lookup. If any other (unshaded) StAX provider happens to be on the classpath, it can win that lookup and return a factory that is **not** the shaded Woodstox. That factory does not understand the shaded `WstxOutputProperties.P_OUTPUT_VALIDATE_STRUCTURE` / `P_OUTPUT_VALIDATE_NAMES` keys set immediately afterwards, and Woodstox/StAX throws `IllegalArgumentException` for unknown property keys.

By instantiating the shaded `WstxOutputFactory` directly, the factory implementation and the property keys are guaranteed to come from the same shaded Woodstox, eliminating the potential conflict regardless of what else is on the classpath.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing `to_xml` / XML write tests in `XmlSuite` cover this code path. No behavior change is expected; the factory used is the same shaded Woodstox that the configured properties already targeted.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)