### PR TITLE
[SPARK-57546][K8S] Use `eclipse-temurin` to use `Ubuntu 26.04` and `Python 3.14` by default

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ARG java_image_name=azul/zulu-openjdk
+ARG java_image_name=eclipse-temurin
 ARG java_image_tag=25-jre
 
 FROM ${java_image_name}:${java_image_tag}

--- a/resource-managers/kubernetes/integration-tests/README.md
+++ b/resource-managers/kubernetes/integration-tests/README.md
@@ -14,7 +14,7 @@ directory:
     ./dev/dev-run-integration-tests.sh
 
 To run tests with a specific Java version instead of Java 25, use `--java-image-tag` to specify the
-[base image](https://hub.docker.com/r/azul/zulu-openjdk/tags) accordingly.
+[base image](https://hub.docker.com/_/eclipse-temurin/tags) accordingly.
 
     ./dev/dev-run-integration-tests.sh --java-image-tag 21-jre
 
@@ -205,7 +205,7 @@ to the wrapper scripts and using the wrapper scripts will simply set these appro
   <tr>
     <td><code>spark.kubernetes.test.javaImageTag</code></td>
     <td>
-      A specific Azul Zulu OpenJDK base image tag to use, when set uses it instead of 25.
+      A specific Eclipse Temurin OpenJDK base image tag to use, when set uses it instead of 25.
     </td>
     <td><code>N/A</code></td>
   </tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Like `Apache Spark Docker` repository, this PR aims to use `eclipse-temurin` to use `Ubuntu 26.04` and `Python 3.14` by default for Apache Spark 4.3.0.

https://github.com/apache/spark-docker/blob/75f9e755807c67794776276d8f5e3e2ceedfa82b/4.1.2/scala2.13-java17-ubuntu/Dockerfile#L17

### Why are the changes needed?

Apache Spark 4.3.0 dropped Python 3.10.
- #55914

However, `azul/zulu-openjdk` only supports `Ubuntu 22.04` which doesn't support Python 3.11 officially. It only have `Python 3.11.0rc1`.

```
$ docker run -it --rm azul/zulu-openjdk:25 bash
root@3c66cb6be8be:/# cat /etc/os-release | grep VERSION_ID
VERSION_ID="22.04"
root@3c66cb6be8be:/# apt-get update
root@3c66cb6be8be:/# apt-get install -y python3.11
root@3c66cb6be8be:/# python3.11 --version
Python 3.11.0rc1
```

### Does this PR introduce _any_ user-facing change?

Note that previously we support this new combination by the following.
```
$ bin/docker-image-tool.sh -b java_image_name=eclipse-temurin build
```

A user can switch back manually in the same way.
```
$ bin/docker-image-tool.sh -b java_image_name=azul/zulu-openjdk build
```

Although Apache Spark behavior is not changed because it's orthogonal to the underlying JDK, OS and Python versions, yes, the underlying OS becomes `Ubuntu 26.04` and Python becomes `3.14` and Java vendor becomes `Eclipse Temurin`. This is inevitable due to the lack of Python 3.11 support of `Zulu JDK`.

**AFTER**
```
$ docker run -it --rm eclipse-temurin:25-jre bash
root@de506cc01b8a:/# cat /etc/os-release | grep VERSION_ID
VERSION_ID="26.04"
root@de506cc01b8a:/# apt-get update
root@de506cc01b8a:/# apt-get install -y python3
root@de506cc01b8a:/# python3 --version
Python 3.14.4
```

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code