### PR TITLE
[SPARK-56573][SQL] Widen the default tablesample seed to reduce collisions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.types.{LongType, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
-import org.apache.spark.util.ThreadUtils
+import org.apache.spark.util.{ThreadUtils, Utils}
 import org.apache.spark.util.random.{BernoulliCellSampler, PoissonSampler}
 
 /** Physical plan for Project. */
@@ -482,7 +482,7 @@ case class SampleExec(
     seed: Option[Long],
     child: SparkPlan) extends UnaryExecNode with CodegenSupport {
 
-  val resolvedSeed: Long = seed.getOrElse((math.random() * 1000).toLong)
+  val resolvedSeed: Long = seed.getOrElse(Utils.random.nextLong())
 
   override def output: Seq[Attribute] = child.output
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -897,10 +897,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
           sample.lowerBound,
           sample.upperBound,
           sample.withReplacement,
-          // TODO(SPARK-56573): The * 1000 limits the seed to only 1000 distinct values.
-          //   Kept here for consistency with SampleExec.resolvedSeed; will be fixed
-          //   across all call sites in SPARK-56573.
-          sample.seed.getOrElse((math.random() * 1000).toLong),
+          sample.seed.getOrElse(Utils.random.nextLong()),
           sampleMethod = sample.sampleMethod)
         val pushed = PushDownUtils.pushTableSample(sHolder.builder, tableSample)
         if (pushed) {


### PR DESCRIPTION
This PR addresses [SPARK-56573](https://issues.apache.org/jira/browse/SPARK-56573).

### What changes were proposed in this pull request?

When a sample or `TABLESAMPLE` runs without an explicit seed, Spark resolved the default seed via `(math.random() * 1000).toLong`, which only produces about 1000 distinct values (0 to 999). This change replaces that expression at both call sites with `Utils.random.nextLong()`, which draws from the full `Long` range:

- `sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala`: `SampleExec.resolvedSeed` now defaults to `Utils.random.nextLong()` (and adds the `Utils` import).
- `sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala`: `pushDownSample` applies the same default so the two code paths stay consistent, and removes the now-stale `TODO(SPARK-56573)` comment above the call.

The explicit-seed path (`Some(seed)`, including `TABLESAMPLE ... REPEATABLE(n)` and `DataFrame.sample(seed = ...)`) is unchanged, as are the seed type (`Long`) and the pushed `SEED(...)` explain text.

### Why are the changes needed?

A 1000-value default-seed space means independent sample queries that do not set a seed collide on the same seed often, which weakens the statistical independence expected of separate samples. Widening the default to the full `Long` range reduces those collisions. The in-tree `TODO(SPARK-56573)` already flagged this and asked for it to be fixed across both call sites.

### Does this PR introduce _any_ user-facing change?

No. Behavior changes only for samples that do not specify a seed, where the default seed is now drawn from a wider range; results were already non-deterministic in that case. Explicit-seed and `REPEATABLE` behavior is unchanged.

### How was this patch tested?

Existing `sql/core` tests that pin sample behavior with explicit seeds continue to pass, run with `build/sbt -Phadoop-3 "sql/testOnly org.apache.spark.sql.connector.DataSourceV2TableSampleSuite org.apache.spark.sql.DataFrameStatSuite"` (the DSv2 pushdown path and the `SampleExec` path). No new test asserts the default-seed range, since the default seed is non-deterministic by design and a distinct-count assertion would be flaky.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5.5)
