### PR TITLE
[MINOR][DOCS] Fix typo in protobuf guide

### DIFF
--- a/docs/sql-data-sources-protobuf.md
+++ b/docs/sql-data-sources-protobuf.md
@@ -277,7 +277,7 @@ StreamingQuery query = output
 ## Supported types for Protobuf -> Spark SQL conversion
 
 Currently Spark supports reading [protobuf scalar types](https://developers.google.com/protocol-buffers/docs/proto3#scalar), [enum types](https://developers.google.com/protocol-buffers/docs/proto3#enum), [nested type](https://developers.google.com/protocol-buffers/docs/proto3#nested), and [maps type](https://developers.google.com/protocol-buffers/docs/proto3#maps) under messages of Protobuf.
-In addition to the these types, `spark-protobuf` also introduces support for Protobuf `OneOf` fields. which allows you to handle messages that can have multiple possible sets of fields, but only one set can be present at a time. This is useful for situations where the data you are working with is not always in the same format, and you need to be able to handle messages with different sets of fields without encountering errors.
+In addition to these types, `spark-protobuf` also introduces support for Protobuf `OneOf` fields. This allows you to handle messages that can have multiple possible sets of fields, but only one set can be present at a time. This is useful for situations where the data you are working with is not always in the same format, and you need to be able to handle messages with different sets of fields without encountering errors.
 
 <table>
   <thead><tr><th><b>Protobuf type</b></th><th><b>Spark SQL type</b></th></tr></thead>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a duplicated article and sentence break in the Protobuf data source guide:

- `the these types` -> `these types`
- `fields. which` -> `fields. This`

### Why are the changes needed?

The current wording is grammatically incorrect in the supported Protobuf type documentation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Docs-only change. Verified with `git diff --check`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI runtime in VS Code