### PR TITLE
[SPARK-57103][SQL][TEST][FOLLOWUP] Add test coverage for max_by/min_by over nanosecond-precision timestamp types

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
@@ -415,10 +415,10 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite with SQLHelper with Quer
     Seq(TimestampNTZNanosType(9), TimestampLTZNanosType(7)).foreach { dt =>
       val v = AttributeReference("v", dt)()
       val ord = AttributeReference("ord", dt)()
-      assert(MaxBy(v, ord).checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      assert(MinBy(v, ord).checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      assert(MaxBy(v, ord).dataType == dt)
-      assert(MinBy(v, ord).dataType == dt)
+      Seq(MaxBy(v, ord), MinBy(v, ord)).foreach { agg =>
+        assert(agg.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+        assert(agg.dataType == dt)
+      }
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
@@ -408,6 +408,20 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite with SQLHelper with Quer
     }
   }
 
+  test("SPARK-57103: max_by/min_by accept a nanosecond ordering and preserve the value type") {
+    // MaxBy/MinBy gate only on the ordering expression's orderability; a nanosecond ordering is an
+    // orderable AtomicType (SPARK-57103). The value expression is unrestricted, and the result type
+    // is the value's type, so a nanosecond value is returned with its precision preserved.
+    Seq(TimestampNTZNanosType(9), TimestampLTZNanosType(7)).foreach { dt =>
+      val v = AttributeReference("v", dt)()
+      val ord = AttributeReference("ord", dt)()
+      assert(MaxBy(v, ord).checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+      assert(MinBy(v, ord).checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+      assert(MaxBy(v, ord).dataType == dt)
+      assert(MinBy(v, ord).dataType == dt)
+    }
+  }
+
   test("check types for aggregates") {
     // We use AggregateFunction directly at here because the error will be thrown from it
     // instead of from AggregateExpression, which is the wrapper of an AggregateFunction.

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ltz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ltz-nanos.sql.out
@@ -720,3 +720,15 @@ SELECT unix_timestamp(NULL :: timestamp_ltz(9)), to_unix_timestamp(NULL :: times
 -- !query analysis
 Project [unix_timestamp(cast(null as timestamp_ltz(9)), yyyy-MM-dd HH:mm:ss, Some(America/Los_Angeles), true) AS unix_timestamp(CAST(NULL AS TIMESTAMP_LTZ(9)), yyyy-MM-dd HH:mm:ss)#xL, to_unix_timestamp(cast(null as timestamp_ltz(9)), yyyy-MM-dd HH:mm:ss, Some(America/Los_Angeles), true) AS to_unix_timestamp(CAST(NULL AS TIMESTAMP_LTZ(9)), yyyy-MM-dd HH:mm:ss)#xL]
 +- OneRowRelation
+
+
+-- !query
+SELECT max_by(v, k), min_by(v, k) FROM VALUES
+  (TIMESTAMP_LTZ '2020-01-01 00:00:00.000000001 UTC', 1),
+  (TIMESTAMP_LTZ '2020-01-01 00:00:00.000000999 UTC', 3),
+  (TIMESTAMP_LTZ '2020-01-01 00:00:00.000000500 UTC', 2),
+  (TIMESTAMP_LTZ '2020-01-01 00:00:00.000000007 UTC', CAST(NULL AS INT)) AS t(v, k)
+-- !query analysis
+Aggregate [max_by(v#x, k#x) AS max_by(v, k)#x, min_by(v#x, k#x) AS min_by(v, k)#x]
++- SubqueryAlias t
+   +- LocalRelation [v#x, k#x]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp-ntz-nanos.sql.out
@@ -640,3 +640,15 @@ SELECT unix_timestamp(NULL :: timestamp_ntz(9)), to_unix_timestamp(NULL :: times
 -- !query analysis
 Project [unix_timestamp(cast(null as timestamp_ntz(9)), yyyy-MM-dd HH:mm:ss, Some(America/Los_Angeles), true) AS unix_timestamp(CAST(NULL AS TIMESTAMP_NTZ(9)), yyyy-MM-dd HH:mm:ss)#xL, to_unix_timestamp(cast(null as timestamp_ntz(9)), yyyy-MM-dd HH:mm:ss, Some(America/Los_Angeles), true) AS to_unix_timestamp(CAST(NULL AS TIMESTAMP_NTZ(9)), yyyy-MM-dd HH:mm:ss)#xL]
 +- OneRowRelation
+
+
+-- !query
+SELECT max_by(v, k), min_by(v, k) FROM VALUES
+  (TIMESTAMP_NTZ '2020-01-01 00:00:00.000000001', 1),
+  (TIMESTAMP_NTZ '2020-01-01 00:00:00.000000999', 3),
+  (TIMESTAMP_NTZ '2020-01-01 00:00:00.000000500', 2),
+  (TIMESTAMP_NTZ '2020-01-01 00:00:00.000000007', CAST(NULL AS INT)) AS t(v, k)
+-- !query analysis
+Aggregate [max_by(v#x, k#x) AS max_by(v, k)#x, min_by(v#x, k#x) AS min_by(v, k)#x]
++- SubqueryAlias t
+   +- LocalRelation [v#x, k#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/timestamp-ltz-nanos.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/timestamp-ltz-nanos.sql
@@ -202,3 +202,12 @@ SELECT unix_timestamp('2020-01-01 13:24:35.999999999' :: timestamp_ltz(7));
 SELECT unix_timestamp(TIMESTAMP_LTZ '1969-12-31 23:59:59.500000000 UTC');
 -- NULL nanosecond timestamp.
 SELECT unix_timestamp(NULL :: timestamp_ltz(9)), to_unix_timestamp(NULL :: timestamp_ltz(9));
+
+-- SPARK-57103: max_by / min_by return the nanosecond-precision TIMESTAMP_LTZ value at the extreme
+-- ordering key, preserving the nanosecond type. The ordering keys are distinct so the result is
+-- deterministic; a NULL-ordering row is ignored.
+SELECT max_by(v, k), min_by(v, k) FROM VALUES
+  (TIMESTAMP_LTZ '2020-01-01 00:00:00.000000001 UTC', 1),
+  (TIMESTAMP_LTZ '2020-01-01 00:00:00.000000999 UTC', 3),
+  (TIMESTAMP_LTZ '2020-01-01 00:00:00.000000500 UTC', 2),
+  (TIMESTAMP_LTZ '2020-01-01 00:00:00.000000007 UTC', CAST(NULL AS INT)) AS t(v, k);

--- a/sql/core/src/test/resources/sql-tests/inputs/timestamp-ntz-nanos.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/timestamp-ntz-nanos.sql
@@ -176,3 +176,12 @@ SELECT to_unix_timestamp('2020-01-01 13:24:35.000000001' :: timestamp_ntz(9));
 SELECT unix_timestamp(TIMESTAMP_NTZ '1969-12-31 23:59:59.500000000');
 -- NULL nanosecond timestamp.
 SELECT unix_timestamp(NULL :: timestamp_ntz(9)), to_unix_timestamp(NULL :: timestamp_ntz(9));
+
+-- SPARK-57103: max_by / min_by return the nanosecond-precision TIMESTAMP_NTZ value at the extreme
+-- ordering key, preserving the nanosecond type. The ordering keys are distinct so the result is
+-- deterministic; a NULL-ordering row is ignored.
+SELECT max_by(v, k), min_by(v, k) FROM VALUES
+  (TIMESTAMP_NTZ '2020-01-01 00:00:00.000000001', 1),
+  (TIMESTAMP_NTZ '2020-01-01 00:00:00.000000999', 3),
+  (TIMESTAMP_NTZ '2020-01-01 00:00:00.000000500', 2),
+  (TIMESTAMP_NTZ '2020-01-01 00:00:00.000000007', CAST(NULL AS INT)) AS t(v, k);

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ltz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ltz-nanos.sql.out
@@ -806,3 +806,15 @@ SELECT unix_timestamp(NULL :: timestamp_ltz(9)), to_unix_timestamp(NULL :: times
 struct<unix_timestamp(CAST(NULL AS TIMESTAMP_LTZ(9)), yyyy-MM-dd HH:mm:ss):bigint,to_unix_timestamp(CAST(NULL AS TIMESTAMP_LTZ(9)), yyyy-MM-dd HH:mm:ss):bigint>
 -- !query output
 NULL	NULL
+
+
+-- !query
+SELECT max_by(v, k), min_by(v, k) FROM VALUES
+  (TIMESTAMP_LTZ '2020-01-01 00:00:00.000000001 UTC', 1),
+  (TIMESTAMP_LTZ '2020-01-01 00:00:00.000000999 UTC', 3),
+  (TIMESTAMP_LTZ '2020-01-01 00:00:00.000000500 UTC', 2),
+  (TIMESTAMP_LTZ '2020-01-01 00:00:00.000000007 UTC', CAST(NULL AS INT)) AS t(v, k)
+-- !query schema
+struct<max_by(v, k):timestamp_ltz(9),min_by(v, k):timestamp_ltz(9)>
+-- !query output
+2019-12-31 16:00:00.000000999	2019-12-31 16:00:00.000000001

--- a/sql/core/src/test/resources/sql-tests/results/timestamp-ntz-nanos.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp-ntz-nanos.sql.out
@@ -716,3 +716,15 @@ SELECT unix_timestamp(NULL :: timestamp_ntz(9)), to_unix_timestamp(NULL :: times
 struct<unix_timestamp(CAST(NULL AS TIMESTAMP_NTZ(9)), yyyy-MM-dd HH:mm:ss):bigint,to_unix_timestamp(CAST(NULL AS TIMESTAMP_NTZ(9)), yyyy-MM-dd HH:mm:ss):bigint>
 -- !query output
 NULL	NULL
+
+
+-- !query
+SELECT max_by(v, k), min_by(v, k) FROM VALUES
+  (TIMESTAMP_NTZ '2020-01-01 00:00:00.000000001', 1),
+  (TIMESTAMP_NTZ '2020-01-01 00:00:00.000000999', 3),
+  (TIMESTAMP_NTZ '2020-01-01 00:00:00.000000500', 2),
+  (TIMESTAMP_NTZ '2020-01-01 00:00:00.000000007', CAST(NULL AS INT)) AS t(v, k)
+-- !query schema
+struct<max_by(v, k):timestamp_ntz(9),min_by(v, k):timestamp_ntz(9)>
+-- !query output
+2020-01-01 00:00:00.000000999	2020-01-01 00:00:00.000000001

--- a/sql/core/src/test/scala/org/apache/spark/sql/TimestampNanosFunctionsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TimestampNanosFunctionsSuiteBase.scala
@@ -449,6 +449,89 @@ abstract class TimestampNanosFunctionsSuiteBase extends SharedSparkSession {
         ltz.select(unix_timestamp(col("c")), to_unix_timestamp(col("c"))), Row(null, null))
     }
   }
+
+  // ===== max_by / min_by over nanosecond-precision timestamps (SPARK-56822) =====
+  // `MaxBy`/`MinBy` gate only on the ordering expression's orderability
+  // (`MaxMinBy.checkInputDataTypes` -> `TypeUtils.checkForOrderingExpr`), which the nanosecond
+  // types pass (SPARK-57103); the value expression is unrestricted and `dataType = valueExpr
+  // .dataType`, so a nanosecond *value* is returned with its precision preserved. No change to the
+  // aggregates is needed -- these tests lock in both the nanos-as-value and nanos-as-ordering paths.
+
+  test("SPARK-57103: max_by/min_by return a nanosecond value and preserve its precision") {
+    Seq(7, 8, 9).foreach { p =>
+      // Value columns are nanos; the ordering column is a plain int key (max at k=3, min at k=1).
+      // The sub-microsecond parts are multiples of 100ns, so they are exact at every p in [7, 9]
+      // (no flooring) yet still non-zero -- proving the nanos value survives, not truncated to micros.
+      val schema = new StructType()
+        .add("ntz", TimestampNTZNanosType(p))
+        .add("ltz", TimestampLTZNanosType(p))
+        .add("k", IntegerType)
+      val data = Seq(
+        Row(LocalDateTime.parse("2020-01-01T00:00:00.000000100"),
+          Instant.parse("2020-01-01T00:00:00.000000100Z"), 1),
+        Row(LocalDateTime.parse("2020-01-01T00:00:00.000000900"),
+          Instant.parse("2020-01-01T00:00:00.000000900Z"), 3),
+        Row(LocalDateTime.parse("2020-01-01T00:00:00.000000500"),
+          Instant.parse("2020-01-01T00:00:00.000000500Z"), 2))
+      val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+      val res = df.selectExpr(
+        "max_by(ntz, k)", "min_by(ntz, k)", "max_by(ltz, k)", "min_by(ltz, k)")
+      checkAnswer(res, Row(
+        LocalDateTime.parse("2020-01-01T00:00:00.000000900"),
+        LocalDateTime.parse("2020-01-01T00:00:00.000000100"),
+        Instant.parse("2020-01-01T00:00:00.000000900Z"),
+        Instant.parse("2020-01-01T00:00:00.000000100Z")))
+      // The returned value keeps the family (NTZ/LTZ) and precision of the value column.
+      assert(res.schema.map(_.dataType) === Seq(
+        TimestampNTZNanosType(p), TimestampNTZNanosType(p),
+        TimestampLTZNanosType(p), TimestampLTZNanosType(p)))
+    }
+  }
+
+  test("SPARK-57103: max_by/min_by order by a nanosecond key down to the sub-microsecond") {
+    // The ordering values share epochMicros and differ only within the microsecond, so picking the
+    // extreme requires the full TimestampNanosVal comparison; a NULL-ordering row is ignored. Run on
+    // both the codegen and the interpreted paths.
+    Seq(
+      Seq(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
+        SQLConf.CODEGEN_FACTORY_MODE.key -> "CODEGEN_ONLY"),
+      Seq(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
+        SQLConf.CODEGEN_FACTORY_MODE.key -> "NO_CODEGEN")
+    ).foreach { conf =>
+      withSQLConf(conf: _*) {
+        val df = spark.createDataFrame(
+          spark.sparkContext.parallelize(Seq(
+            Row("lo", Instant.parse("2020-01-01T00:00:00.000000001Z")),
+            Row("hi", Instant.parse("2020-01-01T00:00:00.000000999Z")),
+            Row("skip", null))),
+          new StructType().add("label", StringType).add("ts", TimestampLTZNanosType(9)))
+        checkAnswer(df.selectExpr("max_by(label, ts)", "min_by(label, ts)"), Row("hi", "lo"))
+      }
+    }
+  }
+
+  test("SPARK-57103: max_by/min_by over nanos handle all-NULL ordering and GROUP BY") {
+    Seq(7, 8, 9).foreach { p =>
+      // All ordering values NULL -> result NULL.
+      val allNull = spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(Row("a", null), Row("b", null))),
+        new StructType().add("label", StringType).add("ts", TimestampNTZNanosType(p)))
+      checkAnswer(allNull.selectExpr("max_by(label, ts)", "min_by(label, ts)"), Row(null, null))
+
+      // GROUP BY: per group, pick the label at the extreme nanosecond ordering key.
+      val grouped = spark.createDataFrame(
+        spark.sparkContext.parallelize(Seq(
+          Row("g1", "g1-lo", LocalDateTime.parse("2020-01-01T00:00:00.000000001")),
+          Row("g1", "g1-hi", LocalDateTime.parse("2020-01-01T00:00:00.000000999")),
+          Row("g2", "g2-only", LocalDateTime.parse("2020-01-01T00:00:00.000000005")))),
+        new StructType().add("g", StringType).add("label", StringType)
+          .add("ts", TimestampNTZNanosType(p)))
+      checkAnswer(
+        grouped.groupBy("g").agg(
+          expr("max_by(label, ts)").as("mx"), expr("min_by(label, ts)").as("mn")).orderBy("g"),
+        Seq(Row("g1", "g1-hi", "g1-lo"), Row("g2", "g2-only", "g2-only")))
+    }
+  }
 }
 
 // Runs the nanosecond timestamp function tests with ANSI mode enabled explicitly.

--- a/sql/core/src/test/scala/org/apache/spark/sql/TimestampNanosFunctionsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TimestampNanosFunctionsSuiteBase.scala
@@ -476,8 +476,9 @@ abstract class TimestampNanosFunctionsSuiteBase extends SharedSparkSession {
         Row(LocalDateTime.parse("2020-01-01T00:00:00.000000500"),
           Instant.parse("2020-01-01T00:00:00.000000500Z"), 2))
       val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
-      val res = df.selectExpr(
-        "max_by(ntz, k)", "min_by(ntz, k)", "max_by(ltz, k)", "min_by(ltz, k)")
+      val res = df.select(
+        max_by(col("ntz"), col("k")), min_by(col("ntz"), col("k")),
+        max_by(col("ltz"), col("k")), min_by(col("ltz"), col("k")))
       checkAnswer(res, Row(
         LocalDateTime.parse("2020-01-01T00:00:00.000000900"),
         LocalDateTime.parse("2020-01-01T00:00:00.000000100"),
@@ -507,7 +508,9 @@ abstract class TimestampNanosFunctionsSuiteBase extends SharedSparkSession {
             Row("hi", Instant.parse("2020-01-01T00:00:00.000000999Z")),
             Row("skip", null))),
           new StructType().add("label", StringType).add("ts", TimestampLTZNanosType(9)))
-        checkAnswer(df.selectExpr("max_by(label, ts)", "min_by(label, ts)"), Row("hi", "lo"))
+        checkAnswer(
+          df.select(max_by(col("label"), col("ts")), min_by(col("label"), col("ts"))),
+          Row("hi", "lo"))
       }
     }
   }
@@ -518,7 +521,9 @@ abstract class TimestampNanosFunctionsSuiteBase extends SharedSparkSession {
       val allNull = spark.createDataFrame(
         spark.sparkContext.parallelize(Seq(Row("a", null), Row("b", null))),
         new StructType().add("label", StringType).add("ts", TimestampNTZNanosType(p)))
-      checkAnswer(allNull.selectExpr("max_by(label, ts)", "min_by(label, ts)"), Row(null, null))
+      checkAnswer(
+        allNull.select(max_by(col("label"), col("ts")), min_by(col("label"), col("ts"))),
+        Row(null, null))
 
       // GROUP BY: per group, pick the label at the extreme nanosecond ordering key.
       val grouped = spark.createDataFrame(
@@ -530,7 +535,8 @@ abstract class TimestampNanosFunctionsSuiteBase extends SharedSparkSession {
           .add("ts", TimestampNTZNanosType(p)))
       checkAnswer(
         grouped.groupBy("g").agg(
-          expr("max_by(label, ts)").as("mx"), expr("min_by(label, ts)").as("mn")).orderBy("g"),
+          max_by(col("label"), col("ts")).as("mx"),
+          min_by(col("label"), col("ts")).as("mn")).orderBy("g"),
         Seq(Row("g1", "g1-hi", "g1-lo"), Row("g2", "g2-only", "g2-only")))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/TimestampNanosFunctionsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TimestampNanosFunctionsSuiteBase.scala
@@ -455,13 +455,15 @@ abstract class TimestampNanosFunctionsSuiteBase extends SharedSparkSession {
   // (`MaxMinBy.checkInputDataTypes` -> `TypeUtils.checkForOrderingExpr`), which the nanosecond
   // types pass (SPARK-57103); the value expression is unrestricted and `dataType = valueExpr
   // .dataType`, so a nanosecond *value* is returned with its precision preserved. No change to the
-  // aggregates is needed -- these tests lock in both the nanos-as-value and nanos-as-ordering paths.
+  // aggregates is needed -- these tests lock in both the nanos-as-value and nanos-as-ordering
+  // paths.
 
   test("SPARK-57103: max_by/min_by return a nanosecond value and preserve its precision") {
     Seq(7, 8, 9).foreach { p =>
       // Value columns are nanos; the ordering column is a plain int key (max at k=3, min at k=1).
       // The sub-microsecond parts are multiples of 100ns, so they are exact at every p in [7, 9]
-      // (no flooring) yet still non-zero -- proving the nanos value survives, not truncated to micros.
+      // (no flooring) yet still non-zero -- proving the nanos value survives, not truncated to
+      // micros.
       val schema = new StructType()
         .add("ntz", TimestampNTZNanosType(p))
         .add("ltz", TimestampLTZNanosType(p))
@@ -490,8 +492,8 @@ abstract class TimestampNanosFunctionsSuiteBase extends SharedSparkSession {
 
   test("SPARK-57103: max_by/min_by order by a nanosecond key down to the sub-microsecond") {
     // The ordering values share epochMicros and differ only within the microsecond, so picking the
-    // extreme requires the full TimestampNanosVal comparison; a NULL-ordering row is ignored. Run on
-    // both the codegen and the interpreted paths.
+    // extreme requires the full TimestampNanosVal comparison; a NULL-ordering row is ignored.
+    // Run on both the codegen and the interpreted paths.
     Seq(
       Seq(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
         SQLConf.CODEGEN_FACTORY_MODE.key -> "CODEGEN_ONLY"),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Tests-only follow-up to SPARK-57103, extending nanos coverage to `max_by`/`min_by` over `TIMESTAMP_NTZ(p)`/`TIMESTAMP_LTZ(p)` (`p` in `[7,9]`). No production change: `MaxMinby` gates only on the ordering's orderability (which nanos pass) and returns `valueExpr.dataType`, so a nanosecond value keeps its precision. Adds `ExpressionTypeCheckingSuite` contract asserts, `TimestampNanosFunctionsSuiteBase` E2E tests (value-is-nanos precision; sub-microsecond ordering on codegen + interpreted; NULL ordering; GROUP BY), and golden `max_by`/`min_by` queries in `timestamp-{ntz,ltz}-nanos.sql`. Two-arg form only; `k`-variant and mixed precision out of scope.

### Why are the changes needed?
`max_by`/`min_by` over nanos had no coverage, especially the returned-value precision case. Locks in correct behavior and guards against regressions.

### Does this PR introduce any user-facing change?
No. Tests only; types stay behind `spark.sql.timestampNanosTypes.enabled`.

### How was this patch tested?
New tests on JDK 17: `ExpressionTypeCheckingSuite`, `TimestampNanosFunctionsAnsiOn/OffSuite`, and `SQLQueryTestSuite -z nanos` (goldens regenerated, then verified clean).

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Claude Opus 4.8)