### PR TITLE
[SPARK-57616][SQL] Extend SupportsCatalogOptions to allow migration from DSv1 file based data source

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsCatalogOptions.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsCatalogOptions.java
@@ -62,6 +62,8 @@ public interface SupportsCatalogOptions extends TableProvider {
    *
    * @param options the user-specified options that can identify a table, e.g. file path, Kafka
    *                topic name, etc. It's an immutable case-insensitive string-to-string map.
+   *
+   * @since 4.3.0
    */
   default boolean useCatalogResolution(CaseInsensitiveStringMap options) {
     return true;
@@ -75,6 +77,8 @@ public interface SupportsCatalogOptions extends TableProvider {
    *
    * @param options the user-specified options that can identify a table, e.g. file path, Kafka
    *                topic name, etc. It's an immutable case-insensitive string-to-string map.
+   *
+   * @since 4.3.0
    */
   default boolean failWriteIfTableDoesNotExist(CaseInsensitiveStringMap options) {
     return true;

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsCatalogOptions.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsCatalogOptions.java
@@ -56,6 +56,31 @@ public interface SupportsCatalogOptions extends TableProvider {
   }
 
   /**
+   * Whether this interface should be used for table existence checks or creation.
+   * A source may override it to dynamically enable the behavior provided by
+   * SupportsCatalogOptions as they migrate from regular file-based data source behavior.
+   *
+   * @param options the user-specified options that can identify a table, e.g. file path, Kafka
+   *                topic name, etc. It's an immutable case-insensitive string-to-string map.
+   */
+  default boolean useCatalogResolution(CaseInsensitiveStringMap options) {
+    return true;
+  }
+
+  /**
+   * Whether a {@code DataFrameWriter.save()} should fail when the table does not exist. When this
+   * returns {@code false}, Spark instead creates the table from the written query (as
+   * {@code DataFrameWriter.saveAsTable} already does), preserving create-on-write semantics for
+   * file-based {@code save(path)} calls.
+   *
+   * @param options the user-specified options that can identify a table, e.g. file path, Kafka
+   *                topic name, etc. It's an immutable case-insensitive string-to-string map.
+   */
+  default boolean failWriteIfTableDoesNotExist(CaseInsensitiveStringMap options) {
+    return true;
+  }
+
+  /**
    * Extracts the timestamp string for time travel from the given options.
    */
   default Optional<String> extractTimeTravelTimestamp(CaseInsensitiveStringMap options) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameWriter.scala
@@ -168,41 +168,81 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) extends sql.DataFram
 
       import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Implicits._
       val catalogManager = df.sparkSession.sessionState.catalogManager
+
+      def createTableAsSelectCommand(
+          catalog: TableCatalog, ident: Identifier, ignoreIfExists: Boolean): LogicalPlan = {
+        val tableSpec = UnresolvedTableSpec(
+          properties = Map.empty,
+          provider = Some(source),
+          optionExpression = OptionList(Seq.empty),
+          location = extraOptions.get("path"),
+          comment = extraOptions.get(TableCatalog.PROP_COMMENT),
+          collation = extraOptions.get(TableCatalog.PROP_COLLATION),
+          serde = None,
+          external = false,
+          constraints = Seq.empty)
+        CreateTableAsSelect(
+          UnresolvedIdentifier(
+            catalog.name +: ident.namespace.toImmutableArraySeq :+ ident.name),
+          partitioningAsV2,
+          df.queryExecution.analyzed,
+          tableSpec,
+          finalOptions,
+          ignoreIfExists = ignoreIfExists)
+      }
+
+      def appendOrOverwriteCommand(
+          table: Table,
+          catalog: Option[CatalogPlugin],
+          ident: Option[Identifier]): LogicalPlan = {
+        checkPartitioningMatchesV2Table(table)
+        val relation = DataSourceV2Relation.create(table, catalog, ident, dsOptions)
+        if (curmode == SaveMode.Append) {
+          AppendData.byName(relation, df.logicalPlan, finalOptions, _withSchemaEvolution)
+        } else {
+          // Truncate the table. TableCapabilityCheck will throw a nice exception if this
+          // isn't supported
+          OverwriteByExpression.byName(
+            relation, df.logicalPlan, Literal(true), finalOptions, _withSchemaEvolution)
+        }
+      }
+
       curmode match {
         case SaveMode.Append | SaveMode.Overwrite =>
-          val (table, catalog, ident) = provider match {
-            case supportsExtract: SupportsCatalogOptions =>
+          provider match {
+            case supportsExtract: SupportsCatalogOptions
+                if supportsExtract.useCatalogResolution(dsOptions) =>
               val ident = supportsExtract.extractIdentifier(dsOptions)
               val catalog = CatalogV2Util.getTableProviderCatalog(
                 supportsExtract, catalogManager, dsOptions)
-
-              (catalog.loadTable(ident), Some(catalog), Some(ident))
+              val tableOpt =
+                try Some(catalog.loadTable(ident))
+                catch {
+                  // The table does not exist: create it from the query (create-on-write,
+                  // consistent with saveAsTable) unless the provider asks to fail.
+                  case _: NoSuchTableException
+                      if !supportsExtract.failWriteIfTableDoesNotExist(dsOptions) => None
+                }
+              tableOpt match {
+                case Some(table) => appendOrOverwriteCommand(table, Some(catalog), Some(ident))
+                case None => createTableAsSelectCommand(catalog, ident, ignoreIfExists = false)
+              }
             case _: TableProvider =>
               val t = getTable
               if (t.supports(BATCH_WRITE)) {
-                (t, None, None)
+                appendOrOverwriteCommand(t, None, None)
               } else {
                 // Streaming also uses the data source V2 API. So it may be that the data source
                 // implements v2, but has no v2 implementation for batch writes. In that case, we
                 // fall back to saving as though it's a V1 source.
-                return saveToV1SourceCommand(path)
+                saveToV1SourceCommand(path)
               }
-          }
-
-          val relation = DataSourceV2Relation.create(table, catalog, ident, dsOptions)
-          checkPartitioningMatchesV2Table(table)
-          if (curmode == SaveMode.Append) {
-            AppendData.byName(relation, df.logicalPlan, finalOptions, _withSchemaEvolution)
-          } else {
-            // Truncate the table. TableCapabilityCheck will throw a nice exception if this
-            // isn't supported
-            OverwriteByExpression.byName(
-              relation, df.logicalPlan, Literal(true), finalOptions, _withSchemaEvolution)
           }
 
         case createMode =>
           provider match {
-            case supportsExtract: SupportsCatalogOptions =>
+            case supportsExtract: SupportsCatalogOptions
+                if supportsExtract.useCatalogResolution(dsOptions) =>
               if (_withSchemaEvolution) {
                 throw QueryCompilationErrors.schemaEvolutionNotSupportedForCreateTableWriteError()
               }
@@ -210,24 +250,8 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) extends sql.DataFram
               val catalog = CatalogV2Util.getTableProviderCatalog(
                 supportsExtract, catalogManager, dsOptions)
 
-              val tableSpec = UnresolvedTableSpec(
-                properties = Map.empty,
-                provider = Some(source),
-                optionExpression = OptionList(Seq.empty),
-                location = extraOptions.get("path"),
-                comment = extraOptions.get(TableCatalog.PROP_COMMENT),
-                collation = extraOptions.get(TableCatalog.PROP_COLLATION),
-                serde = None,
-                external = false,
-                constraints = Seq.empty)
-              CreateTableAsSelect(
-                UnresolvedIdentifier(
-                  catalog.name +: ident.namespace.toImmutableArraySeq :+ ident.name),
-                partitioningAsV2,
-                df.queryExecution.analyzed,
-                tableSpec,
-                finalOptions,
-                ignoreIfExists = createMode == SaveMode.Ignore)
+              createTableAsSelectCommand(
+                catalog, ident, ignoreIfExists = createMode == SaveMode.Ignore)
             case _: TableProvider =>
               if (getTable.supports(BATCH_WRITE)) {
                 throw QueryCompilationErrors.writeWithSaveModeUnsupportedBySourceError(

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameWriter.scala
@@ -171,6 +171,9 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) extends sql.DataFram
 
       def createTableAsSelectCommand(
           catalog: TableCatalog, ident: Identifier, ignoreIfExists: Boolean): LogicalPlan = {
+        if (_withSchemaEvolution) {
+          throw QueryCompilationErrors.schemaEvolutionNotSupportedForCreateTableWriteError()
+        }
         val tableSpec = UnresolvedTableSpec(
           properties = Map.empty,
           provider = Some(source),
@@ -243,9 +246,6 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) extends sql.DataFram
           provider match {
             case supportsExtract: SupportsCatalogOptions
                 if supportsExtract.useCatalogResolution(dsOptions) =>
-              if (_withSchemaEvolution) {
-                throw QueryCompilationErrors.schemaEvolutionNotSupportedForCreateTableWriteError()
-              }
               val ident = supportsExtract.extractIdentifier(dsOptions)
               val catalog = CatalogV2Util.getTableProviderCatalog(
                 supportsExtract, catalogManager, dsOptions)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Utils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Utils.scala
@@ -116,10 +116,11 @@ private[sql] object DataSourceV2Utils extends Logging {
       optionsWithPath.originalMap
     val dsOptions = new CaseInsensitiveStringMap(finalOptions.asJava)
     val (table, catalog, ident, timeTravelSpec) = provider match {
-      case _: SupportsCatalogOptions if userSpecifiedSchema.nonEmpty =>
+      case c: SupportsCatalogOptions
+          if c.useCatalogResolution(dsOptions) && userSpecifiedSchema.nonEmpty =>
         throw new IllegalArgumentException(
           s"$source does not support user specified schema. Please don't specify the schema.")
-      case hasCatalog: SupportsCatalogOptions =>
+      case hasCatalog: SupportsCatalogOptions if hasCatalog.useCatalogResolution(dsOptions) =>
         val ident = hasCatalog.extractIdentifier(dsOptions)
         val catalog = CatalogV2Util.getTableProviderCatalog(
           hasCatalog,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/SupportsCatalogOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/SupportsCatalogOptionsSuite.scala
@@ -421,6 +421,44 @@ class SupportsCatalogOptionsSuite extends SharedSparkSession with BeforeAndAfter
     }
   }
 
+  test("overwrite to a missing table fails by default (failWriteIfTableDoesNotExist=true)") {
+    // The default provider keeps the prior behavior: append/overwrite to a missing table fails.
+    intercept[NoSuchTableException] {
+      spark.range(10).write.format(format).option("name", "t1").option("catalog", catalogName)
+        .mode(SaveMode.Overwrite).save()
+    }
+  }
+
+  Seq(SaveMode.Append, SaveMode.Overwrite).foreach { mode =>
+    test(s"failWriteIfTableDoesNotExist=false: $mode create-on-write rejects schema evolution") {
+      // Create-on-write goes through CreateTableAsSelect, which does not support schema evolution,
+      // consistent with the create modes (ErrorIfExists/Ignore).
+      checkError(
+        exception = intercept[AnalysisException] {
+          spark.range(10).write.format(createOnWriteFormat).option("name", "t1")
+            .option("catalog", catalogName).mode(mode).withSchemaEvolution().save()
+        },
+        condition = "UNSUPPORTED_SCHEMA_EVOLUTION.CREATE_TABLE",
+        parameters = Map.empty)
+      assert(!catalog(catalogName).tableExists("t1"), "no table should have been created")
+    }
+  }
+
+  Seq(SaveMode.Append, SaveMode.Overwrite).foreach { mode =>
+    test(s"useCatalogResolution=false: $mode write bypasses the catalog") {
+      // Opting out of catalog resolution routes the write through the TableProvider path instead
+      // of the catalog. The opt-out provider's table does not support batch writes, so the write
+      // falls back to the V1 source path (which fails here since it is not a V1 source) rather
+      // than failing with NoSuchTableException from the catalog.
+      val e = intercept[SparkException] {
+        spark.range(10).write.format(optOutFormat).option("name", "t1")
+          .option("catalog", catalogName).mode(mode).save()
+      }
+      assert(e.getMessage.contains("does not allow create table as select"))
+      assert(!catalog(catalogName).tableExists("t1"), "the catalog should not have been used")
+    }
+  }
+
   private def checkV2Identifiers(
       plan: LogicalPlan,
       identifier: String = "t1",

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/SupportsCatalogOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/SupportsCatalogOptionsSuite.scala
@@ -47,6 +47,8 @@ class SupportsCatalogOptionsSuite extends SharedSparkSession with BeforeAndAfter
 
   private val catalogName = "testcat"
   private val format = classOf[CatalogSupportingInMemoryTableProvider].getName
+  private val optOutFormat = classOf[CatalogResolutionOptOutProvider].getName
+  private val createOnWriteFormat = classOf[CreateOnWriteProvider].getName
 
   private def catalog(name: String): TableCatalog = {
     spark.sessionState.catalogManager.catalog(name).asInstanceOf[TableCatalog]
@@ -370,6 +372,55 @@ class SupportsCatalogOptionsSuite extends SharedSparkSession with BeforeAndAfter
       .contains("Cannot specify both version and timestamp when time travelling the table."))
   }
 
+  test("useCatalogResolution=false: read is resolved via the TableProvider path, not the catalog") {
+    // The provider opts out of catalog resolution, so load() goes through getTable instead of
+    // extractIdentifier/extractCatalog. The resulting relation therefore has no catalog/identifier.
+    val df = spark.read.format(optOutFormat).option("name", "t1").load()
+    val relation = df.logicalPlan.collectFirst {
+      case r: DataSourceV2Relation => r
+    }.getOrElse(fail("Expected a DataSourceV2Relation"))
+    assert(relation.catalog.isEmpty && relation.identifier.isEmpty,
+      "Opting out of catalog resolution should bypass the catalog")
+  }
+
+  test("useCatalogResolution=false: a user-specified schema is allowed (no catalog check)") {
+    // The schema check only fires on the catalog-resolution path; opting out skips it.
+    val df = spark.read.format(optOutFormat).option("name", "t1").schema("i int, j int").load()
+    assert(df.schema.fieldNames === Array("i", "j"))
+  }
+
+  test("failWriteIfTableDoesNotExist=false: append creates a missing table (create-on-write)") {
+    val df = spark.range(10)
+    // t1 does not exist yet; append should create it from the query instead of failing.
+    df.write.format(createOnWriteFormat).option("name", "t1").option("catalog", catalogName)
+      .mode(SaveMode.Append).save()
+    assert(catalog(catalogName).tableExists("t1"), "append should have created the table")
+    checkAnswer(load("t1", Some(catalogName)), df.toDF())
+  }
+
+  test("failWriteIfTableDoesNotExist=false: overwrite creates a missing table (create-on-write)") {
+    val df = spark.range(10, 20)
+    df.write.format(createOnWriteFormat).option("name", "t1").option("catalog", catalogName)
+      .mode(SaveMode.Overwrite).save()
+    assert(catalog(catalogName).tableExists("t1"), "overwrite should have created the table")
+    checkAnswer(load("t1", Some(catalogName)), df.toDF())
+  }
+
+  test("failWriteIfTableDoesNotExist=false: append to an existing table still appends") {
+    sql(s"create table $catalogName.t1 (id bigint) using $createOnWriteFormat")
+    spark.range(10).write.format(createOnWriteFormat).option("name", "t1")
+      .option("catalog", catalogName).mode(SaveMode.Append).save()
+    checkAnswer(load("t1", Some(catalogName)), spark.range(10).toDF())
+  }
+
+  test("append to a missing table fails by default (failWriteIfTableDoesNotExist=true)") {
+    // The default provider keeps the prior behavior: append/overwrite to a missing table fails.
+    intercept[NoSuchTableException] {
+      spark.range(10).write.format(format).option("name", "t1").option("catalog", catalogName)
+        .mode(SaveMode.Append).save()
+    }
+  }
+
   private def checkV2Identifiers(
       plan: LogicalPlan,
       identifier: String = "t1",
@@ -442,4 +493,14 @@ class CatalogSupportingInMemoryTableProvider
       Optional.empty[String]
     }
   }
+}
+
+/** Opts out of catalog resolution, so load/save fall back to the plain TableProvider path. */
+class CatalogResolutionOptOutProvider extends CatalogSupportingInMemoryTableProvider {
+  override def useCatalogResolution(options: CaseInsensitiveStringMap): Boolean = false
+}
+
+/** Opts out of failing on a missing table, enabling create-on-write for save(). */
+class CreateOnWriteProvider extends CatalogSupportingInMemoryTableProvider {
+  override def failWriteIfTableDoesNotExist(options: CaseInsensitiveStringMap): Boolean = false
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Extend `SupportsCatalogOption` DSv2 interface with:
- `useCatalogResolution`: dynamically toggles using the behavior offered by `SupportsCatalogOption`. Needed to have a migration path from file-based source (DSv1) to DSv2 + SupportsCatalogOption that's not just a static on/off
- `failWriteIfTableDoesNotExist `: whether `df.write.format(<format>).mode("append"/"overwrite").save()` should succeed when the table doesn't exist.


### Why are the changes needed?
Delta will be migrating from a file-based data source (DSv1) for path based accesses to DSv2 using `SupportsCatalogOption`.
Two blockers are present:
- The migration can't be a static on/off based on the delta `TableProvider` extending `SupportsCatalogOptions` or not. it will be a dynamic decision based on a flag to provide a migration and possibility to disable the new behavior if needed.
- Delta, as a file-based source, allows  `df.write.format(<format>).mode("append"/"overwrite").save()` when the table doesn't exist yet and will create it. This behavior must be preserved.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added tests in `SupportsCatalogOptionSuite`
