### PR TITLE
[MINOR][PYTHON] Fix try_to_date docstring typo

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -11602,7 +11602,7 @@ def to_date(col: "ColumnOrName", format: Optional[str] = None) -> Column:
 
 @_try_remote_functions
 def try_to_date(col: "ColumnOrName", format: Optional[str] = None) -> Column:
-    """This is a special version of `try_to_date` that performs the same operation, but returns a
+    """This is a special version of `to_date` that performs the same operation, but returns a
     NULL value instead of raising an error if date cannot be created.
 
     .. _datetime pattern: https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a docstring typo in `pyspark.sql.functions.try_to_date`.

The current docstring says that `try_to_date` is a special version of `try_to_date`, which is self-referential. It should say that `try_to_date` is a special version of `to_date`, matching the actual relationship and the wording used by similar `try_` functions.

### Why are the changes needed?

The current wording appears to be a typo.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not applicable. This PR only corrects a docstring typo.

### Was this patch authored or co-authored using generative AI tooling?

No.