### PR TITLE
[SPARK-52163][SQL] Cap estimated size in bytes at Long.MaxValue in SizeInBytesOnlyStatsPlanVisitor

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/BasicStatsPlanVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/BasicStatsPlanVisitor.scala
@@ -27,6 +27,14 @@ object BasicStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
   /** Falls back to the estimation computed by [[SizeInBytesOnlyStatsPlanVisitor]]. */
   private def fallback(p: LogicalPlan): Statistics = SizeInBytesOnlyStatsPlanVisitor.visit(p)
 
+  // Cap composite estimates so a sequence of operators (e.g. self-joins) cannot grow the backing
+  // `BigInt` without limit (SPARK-52163). Leaf estimates are left untouched, since they reflect
+  // real source sizes and are never the product of repeatedly combined children.
+  override def visit(p: LogicalPlan): Statistics = p match {
+    case _: LeafNode => super.visit(p)
+    case _ => EstimationUtils.capStats(super.visit(p))
+  }
+
   override def default(p: LogicalPlan): Statistics = p match {
     case p: LeafNode => p.computeStats()
     case _: LogicalPlan =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -26,6 +26,22 @@ import org.apache.spark.sql.types.{DecimalType, _}
 
 object EstimationUtils {
 
+  /**
+   * The maximum size in bytes used to bound an estimated size. Operators such as joins multiply
+   * their children's sizes, so the estimate can grow without limit when a plan repeatedly combines
+   * its own output (e.g. a sequence of self-joins). Left unbounded, the backing `BigInt` keeps
+   * growing until its arithmetic overflows (SPARK-52163). We cap the estimate at `Long.MaxValue`
+   * (8 EiB), which is far larger than any physical dataset.
+   */
+  val MAX_SIZE_IN_BYTES: BigInt = BigInt(Long.MaxValue)
+
+  /** Caps the size in bytes and row count of the given statistics at [[MAX_SIZE_IN_BYTES]]. */
+  def capStats(stats: Statistics): Statistics = {
+    stats.copy(
+      sizeInBytes = stats.sizeInBytes.min(MAX_SIZE_IN_BYTES),
+      rowCount = stats.rowCount.map(_.min(MAX_SIZE_IN_BYTES)))
+  }
+
   /** Check if each plan has rowCount in its statistics. */
   def rowCountsExist(plans: LogicalPlan*): Boolean =
     plans.forall(_.stats.rowCount.isDefined)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
@@ -27,17 +27,8 @@ import org.apache.spark.sql.catalyst.plans.logical._
  */
 object SizeInBytesOnlyStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
 
-  /**
-   * The maximum size in bytes used to bound an estimated size. Operators such as joins multiply
-   * their children's sizes, so the estimate can grow without limit when a plan repeatedly combines
-   * its own output (e.g. a sequence of self-joins). Left unbounded, the backing `BigInt` keeps
-   * growing until its arithmetic overflows (SPARK-52163). We cap the estimate at `Long.MaxValue`
-   * (8 EiB), which is far larger than any physical dataset.
-   */
-  private val MAX_SIZE_IN_BYTES: BigInt = BigInt(Long.MaxValue)
-
   private def cappedStats(sizeInBytes: BigInt): Statistics =
-    Statistics(sizeInBytes = sizeInBytes.min(MAX_SIZE_IN_BYTES))
+    Statistics(sizeInBytes = sizeInBytes.min(EstimationUtils.MAX_SIZE_IN_BYTES))
 
   /**
    * A default, commonly used estimation for unary nodes. We assume the input row number is the
@@ -67,7 +58,11 @@ object SizeInBytesOnlyStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
   override def default(p: LogicalPlan): Statistics = p match {
     case p: LeafNode => p.computeStats()
     case _: LogicalPlan =>
-      val sizeInBytes = p.children.map(_.stats.sizeInBytes).filter(_ > 0L).product
+      // Bound each child's size before the product so the intermediate `BigInt` cannot explode.
+      val sizeInBytes = p.children
+        .map(_.stats.sizeInBytes.min(EstimationUtils.MAX_SIZE_IN_BYTES))
+        .filter(_ > 0L)
+        .product
       cappedStats(sizeInBytes)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
@@ -36,6 +36,9 @@ object SizeInBytesOnlyStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
    */
   private val MAX_SIZE_IN_BYTES: BigInt = BigInt(Long.MaxValue)
 
+  private def cappedStats(sizeInBytes: BigInt): Statistics =
+    Statistics(sizeInBytes = sizeInBytes.min(MAX_SIZE_IN_BYTES))
+
   /**
    * A default, commonly used estimation for unary nodes. We assume the input row number is the
    * same as the output row number, and compute sizes based on the column types.
@@ -54,7 +57,7 @@ object SizeInBytesOnlyStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
     }
 
     // Don't propagate rowCount and attributeStats, since they are not estimated here.
-    Statistics(sizeInBytes = sizeInBytes.min(MAX_SIZE_IN_BYTES))
+    cappedStats(sizeInBytes)
   }
 
   /**
@@ -65,7 +68,7 @@ object SizeInBytesOnlyStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
     case p: LeafNode => p.computeStats()
     case _: LogicalPlan =>
       val sizeInBytes = p.children.map(_.stats.sizeInBytes).filter(_ > 0L).product
-      Statistics(sizeInBytes = sizeInBytes.min(MAX_SIZE_IN_BYTES))
+      cappedStats(sizeInBytes)
   }
 
   override def visitAggregate(p: Aggregate): Statistics = {
@@ -84,7 +87,7 @@ object SizeInBytesOnlyStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
 
   override def visitExpand(p: Expand): Statistics = {
     val sizeInBytes = visitUnaryNode(p).sizeInBytes * p.projections.length
-    Statistics(sizeInBytes = sizeInBytes.min(MAX_SIZE_IN_BYTES))
+    cappedStats(sizeInBytes)
   }
 
   override def visitFilter(p: Filter): Statistics = visitUnaryNode(p)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
@@ -28,6 +28,15 @@ import org.apache.spark.sql.catalyst.plans.logical._
 object SizeInBytesOnlyStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
 
   /**
+   * The maximum size in bytes used to bound an estimated size. Operators such as joins multiply
+   * their children's sizes, so the estimate can grow without limit when a plan repeatedly combines
+   * its own output (e.g. a sequence of self-joins). Left unbounded, the backing `BigInt` keeps
+   * growing until its arithmetic overflows (SPARK-52163). We cap the estimate at `Long.MaxValue`
+   * (8 EiB), which is far larger than any physical dataset.
+   */
+  private val MAX_SIZE_IN_BYTES: BigInt = BigInt(Long.MaxValue)
+
+  /**
    * A default, commonly used estimation for unary nodes. We assume the input row number is the
    * same as the output row number, and compute sizes based on the column types.
    */
@@ -45,7 +54,7 @@ object SizeInBytesOnlyStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
     }
 
     // Don't propagate rowCount and attributeStats, since they are not estimated here.
-    Statistics(sizeInBytes = sizeInBytes)
+    Statistics(sizeInBytes = sizeInBytes.min(MAX_SIZE_IN_BYTES))
   }
 
   /**
@@ -55,7 +64,8 @@ object SizeInBytesOnlyStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
   override def default(p: LogicalPlan): Statistics = p match {
     case p: LeafNode => p.computeStats()
     case _: LogicalPlan =>
-      Statistics(sizeInBytes = p.children.map(_.stats.sizeInBytes).filter(_ > 0L).product)
+      val sizeInBytes = p.children.map(_.stats.sizeInBytes).filter(_ > 0L).product
+      Statistics(sizeInBytes = sizeInBytes.min(MAX_SIZE_IN_BYTES))
   }
 
   override def visitAggregate(p: Aggregate): Statistics = {
@@ -74,7 +84,7 @@ object SizeInBytesOnlyStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
 
   override def visitExpand(p: Expand): Statistics = {
     val sizeInBytes = visitUnaryNode(p).sizeInBytes * p.projections.length
-    Statistics(sizeInBytes = sizeInBytes)
+    Statistics(sizeInBytes = sizeInBytes.min(MAX_SIZE_IN_BYTES))
   }
 
   override def visitFilter(p: Filter): Statistics = visitUnaryNode(p)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
@@ -193,6 +193,30 @@ test("range with invalid long value") {
   checkStats(range, rangeStats, rangeStats)
 }
 
+  test("SPARK-52163: cap estimated size in bytes to avoid BigInt overflow") {
+    val hugeAttr = attr("id")
+    // A leaf node whose estimated size is already at the maximum representable physical size.
+    val hugePlan = StatsTestPlan(
+      outputList = Seq(hugeAttr),
+      attributeStats = AttributeMap(Seq(hugeAttr -> colStat)),
+      rowCount = BigInt(Long.MaxValue),
+      size = Some(BigInt(Long.MaxValue)))
+
+    // A cartesian join multiplies children's sizes, so without a cap the size would explode and
+    // eventually overflow the backing BigInt when compounded across repeated self-joins. The
+    // estimate must stay bounded and the cartesian product itself must be capped.
+    withSQLConf(SQLConf.CBO_ENABLED.key -> "false") {
+      var node: LogicalPlan = hugePlan
+      (1 to 30).foreach { _ =>
+        val joined = node.join(node, Inner, None)
+        joined.invalidateStatsCache()
+        assert(joined.stats.sizeInBytes === BigInt(Long.MaxValue))
+        node = joined.select(hugeAttr)
+        assert(node.stats.sizeInBytes <= BigInt(Long.MaxValue))
+      }
+    }
+  }
+
   test("windows") {
     val windows = plan.window(Seq(min(attribute).as("sum_attr")), Seq(attribute), Nil)
     val windowsStats = Statistics(sizeInBytes = plan.size.get * (4 + 4 + 8) / (4 + 8))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
@@ -217,6 +217,31 @@ test("range with invalid long value") {
     }
   }
 
+  test("SPARK-52163: cap estimated stats with CBO on to avoid BigInt overflow") {
+    val hugeAttr = attr("id")
+    // A leaf node whose estimated size and row count are already at the maximum physical size.
+    val hugePlan = StatsTestPlan(
+      outputList = Seq(hugeAttr),
+      attributeStats = AttributeMap(Seq(hugeAttr -> colStat)),
+      rowCount = BigInt(Long.MaxValue),
+      size = Some(BigInt(Long.MaxValue)))
+
+    // With CBO on, joins flow through JoinEstimation, which multiplies children's row counts and
+    // sizes. The composite estimate must stay bounded across repeated self-joins.
+    withSQLConf(SQLConf.CBO_ENABLED.key -> "true") {
+      var node: LogicalPlan = hugePlan
+      (1 to 30).foreach { _ =>
+        val joined = node.join(node, Inner, None)
+        joined.invalidateStatsCache()
+        assert(joined.stats.sizeInBytes === BigInt(Long.MaxValue))
+        assert(joined.stats.rowCount.forall(_ <= BigInt(Long.MaxValue)))
+        node = joined.select(hugeAttr)
+        assert(node.stats.sizeInBytes <= BigInt(Long.MaxValue))
+        assert(node.stats.rowCount.forall(_ <= BigInt(Long.MaxValue)))
+      }
+    }
+  }
+
   test("windows") {
     val windows = plan.window(Seq(min(attribute).as("sum_attr")), Seq(attribute), Nil)
     val windowsStats = Statistics(sizeInBytes = plan.size.get * (4 + 4 + 8) / (4 + 8))

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.util.{DateTimeTestUtils, DateTimeUtils}
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, PST, UTC}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{getZoneId, TimeZoneUTC}
 import org.apache.spark.sql.execution.LogicalRDD
-import org.apache.spark.sql.functions.timestamp_seconds
+import org.apache.spark.sql.functions.{col, timestamp_seconds}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.test.SQLTestData.ArrayData
@@ -952,6 +952,32 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
       val newExpectedStats = Statistics(sizeInBytes = expectedSize, rowCount = Some(2),
         attributeStats = buildExpectedColumnStats(newLogicalRDD.output))
       assert(newStats === newExpectedStats)
+    }
+  }
+
+  test("SPARK-52163: repeated self-joins with checkpoint do not overflow size estimate") {
+    withTempDir { checkpointDir =>
+      val sc = spark.sparkContext
+      val originalCheckpointDir = sc.getCheckpointDir
+      sc.setCheckpointDir(checkpointDir.getCanonicalPath)
+      try {
+        val schema = StructType(Seq(
+          StructField("id", IntegerType, nullable = true),
+          StructField("name", StringType, nullable = true)))
+        var df = spark.createDataFrame(sc.emptyRDD[Row], schema)
+        (1 to 6).foreach { _ =>
+          df = df.select(col("id"))
+          df = df.join(df, Seq("id"))
+          df = df.select(col("id"))
+          // Truncate the lineage so the estimate is recomputed from the LogicalRDD each iteration.
+          df = df.checkpoint(eager = true)
+        }
+        // Should not throw due to BigInt overflow (SPARK-52163).
+        df.explain("cost")
+        assert(df.queryExecution.optimizedPlan.stats.sizeInBytes <= BigInt(Long.MaxValue))
+      } finally {
+        originalCheckpointDir.foreach(sc.setCheckpointDir)
+      }
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change bounds the estimated `sizeInBytes` produced by `SizeInBytesOnlyStatsPlanVisitor` at `Long.MaxValue`.

Concretely:
- It adds a private `MAX_SIZE_IN_BYTES = BigInt(Long.MaxValue)` constant in `SizeInBytesOnlyStatsPlanVisitor`, with a comment explaining the reason for the cap.
- It adds a private `cappedStats` helper that clamps a size with `.min(MAX_SIZE_IN_BYTES)` before wrapping it in `Statistics`.
- It routes the `sizeInBytes` produced by the `default` visitor (used for multi-child operators such as joins), the `visitUnaryNode` helper, and `visitExpand` through `cappedStats`.

### Why are the changes needed?

`SizeInBytesOnlyStatsPlanVisitor` estimates a plan's `sizeInBytes` by multiplying the sizes of child plans (via `product`), and in `visitExpand` it multiplies the unary visit result by the number of projections. When a plan repeatedly joins its own output, those multiplicative estimates can grow without bound, and the underlying `BigInt` eventually overflows in `BigInteger.multiply`, throwing from `BigInteger.reportOverflow` (SPARK-52163).

Capping each estimate at `Long.MaxValue` (8 EiB) keeps the estimate bounded so pathological self-join chains no longer overflow. The cap is far larger than any physical dataset, so legitimate estimates are unaffected.

### Does this PR introduce _any_ user-facing change?

No. This only bounds an internal size estimate. The cap is far above any real dataset size, so it does not change estimates for legitimate plans. The observable difference is that previously-overflowing self-join chains now produce a bounded estimate instead of throwing during statistics estimation.

### How was this patch tested?

I added a regression test in `BasicStatsEstimationSuite` that builds a leaf node whose estimated size is already `Long.MaxValue`, then drives 30 self-joins of that node (with a projection between each), and asserts that the joined size stays at the cap and the projected size stays at or below the cap. Without the change this sequence overflows the backing `BigInt`; with the change the estimate stays bounded.

JIRA: https://issues.apache.org/jira/browse/SPARK-52163

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code