### PR TITLE
[SPARK-53478][CORE] Resolve SparkFiles.get against root directory when job artifact UUID is set in local mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkFiles.scala
+++ b/core/src/main/scala/org/apache/spark/SparkFiles.scala
@@ -19,6 +19,8 @@ package org.apache.spark
 
 import java.io.File
 
+import org.apache.spark.util.Utils
+
 /**
  * Resolves paths to files added through `SparkContext.addFile()`.
  */
@@ -31,7 +33,20 @@ object SparkFiles {
     val jobArtifactUUID = JobArtifactSet
       .getCurrentJobArtifactState.map(_.uuid).getOrElse("default")
     val withUuid = if (jobArtifactUUID == "default") filename else s"$jobArtifactUUID/$filename"
-    new File(getRootDirectory(), withUuid).getAbsolutePath
+    val file = new File(getRootDirectory(), withUuid)
+    // In local mode, `SparkContext.addFile` places files directly under the root directory
+    // rather than under the job-specific artifact directory used by session isolation. Fall back
+    // to the root directory when the file is not found under the job-specific directory so that
+    // files added through `SparkContext.addFile` remain resolvable. This is scoped to local mode
+    // to preserve session isolation semantics on real executors. See SPARK-53478.
+    if (jobArtifactUUID != "default" && !file.exists() &&
+        Utils.isLocalMaster(SparkEnv.get.conf)) {
+      val fallbackFile = new File(getRootDirectory(), filename)
+      if (fallbackFile.exists()) {
+        return fallbackFile.getAbsolutePath
+      }
+    }
+    file.getAbsolutePath
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -328,6 +328,9 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
     envVars.put("PYTHON_UDF_BATCH_SIZE", batchSizeForPythonUDF.toString)
 
     envVars.put("SPARK_JOB_ARTIFACT_UUID", jobArtifactUUID.getOrElse("default"))
+    // Lets the worker scope the `SparkFiles.get` local-mode fallback to local mode only,
+    // mirroring `org.apache.spark.SparkFiles.get`. See SPARK-53478.
+    envVars.put("SPARK_LOCAL_MODE", Utils.isLocalMaster(conf).toString)
     envVars.put("SPARK_PYTHON_RUNTIME", "PYTHON_WORKER")
 
     val (worker: PythonWorker, handle: Option[ProcessHandle]) = env.createPythonWorker(

--- a/python/pyspark/core/files.py
+++ b/python/pyspark/core/files.py
@@ -110,6 +110,23 @@ class SparkFiles:
         {'.../test.py'}
         """
         path = os.path.join(SparkFiles.getRootDirectory(), filename)
+        # In local mode, `SparkContext.addFile` places files directly under the root directory
+        # rather than under the job-specific artifact directory used by session isolation. When a
+        # non-default job artifact UUID is active, the worker root directory is the job-specific
+        # directory, so fall back to its parent (the actual root directory) so that files added
+        # through `SparkContext.addFile` remain resolvable. This is scoped to local mode and a
+        # non-default UUID to preserve session isolation semantics on real executors. See
+        # SPARK-53478.
+        if (
+            cls._is_running_on_worker
+            and not os.path.exists(path)
+            and os.environ.get("SPARK_LOCAL_MODE", "false") == "true"
+            and os.environ.get("SPARK_JOB_ARTIFACT_UUID", "default") != "default"
+        ):
+            parent_dir = os.path.dirname(SparkFiles.getRootDirectory())
+            parent_path = os.path.join(parent_dir, filename)
+            if os.path.exists(parent_path):
+                return os.path.abspath(parent_path)
         return os.path.abspath(path)
 
     @classmethod

--- a/python/pyspark/sql/tests/test_artifact.py
+++ b/python/pyspark/sql/tests/test_artifact.py
@@ -75,6 +75,28 @@ class ArtifactTests(ArtifactTestsMixin, ReusedSQLTestCase):
         # file from different session.
         self.check_add_file(self.spark.newSession())
 
+    def test_spark_files_get_with_sc_add_file(self):
+        # SPARK-53478: SparkFiles.get should resolve files added through
+        # SparkContext.addFile in local mode, even when a session-specific
+        # artifact directory is active.
+        from pyspark.core.files import SparkFiles
+
+        with tempfile.TemporaryDirectory(prefix="test_spark_files_get_with_sc_add_file") as d:
+            file_path = os.path.join(d, "my_sc_file.txt")
+            with open(file_path, "w") as f:
+                f.write("Hello from SparkContext.addFile")
+
+            self.spark.sparkContext.addFile(file_path)
+
+            @udf("string")
+            def func(x):
+                with open(SparkFiles.get("my_sc_file.txt"), "r") as my_file:
+                    return my_file.read().strip()
+
+            self.spark.range(1).select(
+                assert_true(func("id") == lit("Hello from SparkContext.addFile"))
+            ).show()
+
     def test_add_archive(self):
         self.check_add_archive(self.spark)
 

--- a/python/pyspark/sql/tests/test_artifact.py
+++ b/python/pyspark/sql/tests/test_artifact.py
@@ -93,7 +93,8 @@ class ArtifactTests(ArtifactTestsMixin, ReusedSQLTestCase):
                 with open(SparkFiles.get("my_sc_file.txt"), "r") as my_file:
                     return my_file.read().strip()
 
-            self.spark.range(1).select(
+            session = self.spark.newSession()
+            session.range(1).select(
                 assert_true(func("id") == lit("Hello from SparkContext.addFile"))
             ).show()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
@@ -682,6 +682,25 @@ class ArtifactManagerSuite extends SharedSparkSession {
     }
   }
 
+  test("SPARK-53478: SparkFiles.get resolves files added via SparkContext.addFile " +
+    "in local mode") {
+    withTempDir { dir =>
+      val file = new File(dir, "test_file.txt")
+      Files.writeString(file.toPath, "Hello from SparkContext.addFile",
+        StandardCharsets.UTF_8)
+      spark.sparkContext.addFile(file.getAbsolutePath)
+
+      val s = spark
+      import s.implicits._
+      val result = Seq(1).toDF("value").map { _ =>
+        val path = org.apache.spark.SparkFiles.get("test_file.txt")
+        Files.readString(new File(path).toPath, StandardCharsets.UTF_8)
+      }.collect()
+
+      assert(result.head === "Hello from SparkContext.addFile")
+    }
+  }
+
   private def getCodegenCount: Long = CodegenMetrics.METRIC_COMPILATION_TIME.getCount
 
   private def runCodegenTest(msg: String)(addOneArtifact: => Unit): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

When running in local mode with a non-default job artifact UUID, `SparkFiles.get` resolved filenames against the per-session artifact directory, while files added via `SparkContext.addFile` were placed directly under the root directory. This made such files inaccessible from SQL-planned operations even though they were visible to code that ran outside a SQL session. This change falls back to the root directory when the job-specific path does not exist in local mode, mirroring the same behavior on the Scala, JVM Python worker, and PySpark Python sides.

- `core/src/main/scala/org/apache/spark/SparkFiles.scala`: in `get`, if the job-specific path does not exist and the master is local, fall back to the file directly under `getRootDirectory()`.
- `core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala`: export `SPARK_LOCAL_MODE` to Python workers so they can apply the same fallback.
- `python/pyspark/core/files.py`: in `SparkFiles.get`, when running on a worker, the file is missing under the current root, the master is local, and the job artifact UUID is non-default, fall back to the file under the parent of the current root directory.

JIRA: https://issues.apache.org/jira/browse/SPARK-53478

### Why are the changes needed?

In local mode with a non-default job artifact UUID, files added through `SparkContext.addFile` could not be resolved by `SparkFiles.get` from inside SQL-planned operations. `SparkContext.addFile` writes the file directly under the root directory, but `SparkFiles.get` looked under the per-session artifact directory, so the lookup missed the file and the path was unusable. The fallback restores the ability to read those files from SQL operations in local mode, while keeping the lookup scoped to local mode so session isolation semantics on real executors are unchanged.

### Does this PR introduce _any_ user-facing change?

Yes. In local mode with a non-default job artifact UUID, a file added via `SparkContext.addFile` is now resolvable through `SparkFiles.get` from SQL-planned operations, whereas before it was not found. There is no change on real executors or when the default artifact UUID is in use.

### How was this patch tested?

Added regression tests that add a file via `SparkContext.addFile` and read it back through `SparkFiles.get` from a SQL-planned operation, on both the Scala and Python sides:

- `sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala`: `SPARK-53478: SparkFiles.get resolves files added via SparkContext.addFile in local mode`.
- `python/pyspark/sql/tests/test_artifact.py`: `test_spark_files_get_with_sc_add_file`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code