### PR TITLE
[SPARK-55299][PS] Infer the correct unit for calculated timedeltas

### DIFF
--- a/python/pyspark/pandas/data_type_ops/timedelta_ops.py
+++ b/python/pyspark/pandas/data_type_ops/timedelta_ops.py
@@ -74,14 +74,14 @@ class TimedeltaOps(DataTypeOps):
             return col.astype(self.dtype)
 
     def _with_inferred_unit(
-        self, result: SeriesOrIndex, left: IndexOpsLike, right: Any
+        self, result: SeriesOrIndex, left: IndexOpsLike, right: Union[IndexOpsMixin, timedelta]
     ) -> SeriesOrIndex:
         # pandas 3.0.0+ promotes timedelta arithmetic to the finer resolution of the
         # operands; before that timedelta64 is always nanoseconds.
         if LooseVersion(pd.__version__) < "3.0.0":
             return result
 
-        def unit_of(obj: Any) -> str:
+        def unit_of(obj: Union[IndexOpsMixin, timedelta]) -> str:
             if isinstance(obj, IndexOpsMixin):
                 dtype = obj.dtype
                 if isinstance(dtype, np.dtype) and np.issubdtype(dtype, np.timedelta64):

--- a/python/pyspark/pandas/data_type_ops/timedelta_ops.py
+++ b/python/pyspark/pandas/data_type_ops/timedelta_ops.py
@@ -86,7 +86,9 @@ class TimedeltaOps(DataTypeOps):
                 dtype = obj.dtype
                 if isinstance(dtype, np.dtype) and np.issubdtype(dtype, np.timedelta64):
                     return np.datetime_data(dtype)[0]
-            # timedelta scalars and object-backed interval columns map to microseconds.
+            elif isinstance(obj, pd.Timedelta):
+                return obj.unit
+            # datetime.timedelta scalars and object-backed interval columns map to microseconds.
             return "us"
 
         promoted = np.promote_types(

--- a/python/pyspark/pandas/data_type_ops/timedelta_ops.py
+++ b/python/pyspark/pandas/data_type_ops/timedelta_ops.py
@@ -77,7 +77,7 @@ class TimedeltaOps(DataTypeOps):
         self, result: SeriesOrIndex, left: IndexOpsLike, right: Union[IndexOpsMixin, timedelta]
     ) -> SeriesOrIndex:
         # pandas 3.0.0+ promotes timedelta arithmetic to the finer resolution of the
-        # operands; before that timedelta64 is always nanoseconds.
+        # operands; before that, pandas-on-Spark represented timedelta as nanoseconds.
         if LooseVersion(pd.__version__) < "3.0.0":
             return result
 
@@ -100,6 +100,9 @@ class TimedeltaOps(DataTypeOps):
             promoted = np.dtype("timedelta64[us]")
 
         field = result._internal.data_fields[0]
+        if field.dtype == promoted:
+            # Already the right resolution (the common us case); avoid rebuilding the field.
+            return result
         return result._with_new_scol(result.spark.column, field=field.copy(dtype=promoted))
 
     def sub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:

--- a/python/pyspark/pandas/data_type_ops/timedelta_ops.py
+++ b/python/pyspark/pandas/data_type_ops/timedelta_ops.py
@@ -16,8 +16,9 @@
 #
 
 from datetime import timedelta
-from typing import Any, Union
+from typing import Any, Union, cast
 
+import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
@@ -72,6 +73,36 @@ class TimedeltaOps(DataTypeOps):
         else:
             return col.astype(self.dtype)
 
+    def _with_inferred_unit(
+        self, result: SeriesOrIndex, left: IndexOpsLike, right: Any
+    ) -> SeriesOrIndex:
+        # Before pandas 3.0.0, timedelta64 is always nanosecond resolution, so there is no
+        # unit to infer. From pandas 3.0.0, arithmetic between timedeltas promotes to the
+        # finer resolution of the operands. The computed Spark column is always a
+        # DayTimeIntervalType (microsecond), so the result field would otherwise be reported
+        # as timedelta64[us]; here we override its dtype to match pandas.
+        if LooseVersion(pd.__version__) < "3.0.0":
+            return result
+
+        def unit_of(obj: Any) -> str:
+            if isinstance(obj, IndexOpsMixin):
+                # Timedelta-typed operands always carry a numpy timedelta64 dtype.
+                return np.datetime_data(cast(np.dtype, obj.dtype))[0]
+            # datetime.timedelta scalars have microsecond resolution.
+            return "us"
+
+        promoted = np.promote_types(
+            np.dtype("timedelta64[%s]" % unit_of(left)),
+            np.dtype("timedelta64[%s]" % unit_of(right)),
+        )
+        # Spark's DayTimeIntervalType stores microseconds and cannot represent finer
+        # resolutions, so cap nanosecond promotion at microseconds.
+        if np.datetime_data(promoted)[0] == "ns":
+            promoted = np.dtype("timedelta64[us]")
+
+        field = result._internal.data_fields[0]
+        return result._with_new_scol(result.spark.column, field=field.copy(dtype=promoted))
+
     def sub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
 
@@ -80,7 +111,8 @@ class TimedeltaOps(DataTypeOps):
             and isinstance(right.spark.data_type, DayTimeIntervalType)
             or isinstance(right, timedelta)
         ):
-            return pyspark_column_op("__sub__", left, right)
+            result = pyspark_column_op("__sub__", left, right)
+            return self._with_inferred_unit(result, left, right)
         else:
             raise TypeError("Timedelta subtraction can only be applied to timedelta series.")
 
@@ -88,7 +120,8 @@ class TimedeltaOps(DataTypeOps):
         _sanitize_list_like(right)
 
         if isinstance(right, timedelta):
-            return pyspark_column_op("__rsub__", left, right)
+            result = pyspark_column_op("__rsub__", left, right)
+            return self._with_inferred_unit(result, left, right)
         else:
             raise TypeError("Timedelta subtraction can only be applied to timedelta series.")
 

--- a/python/pyspark/pandas/data_type_ops/timedelta_ops.py
+++ b/python/pyspark/pandas/data_type_ops/timedelta_ops.py
@@ -16,7 +16,7 @@
 #
 
 from datetime import timedelta
-from typing import Any, Union, cast
+from typing import Any, Union
 
 import numpy as np
 import pandas as pd
@@ -86,9 +86,12 @@ class TimedeltaOps(DataTypeOps):
 
         def unit_of(obj: Any) -> str:
             if isinstance(obj, IndexOpsMixin):
-                # Timedelta-typed operands always carry a numpy timedelta64 dtype.
-                return np.datetime_data(cast(np.dtype, obj.dtype))[0]
-            # datetime.timedelta scalars have microsecond resolution.
+                dtype = obj.dtype
+                if isinstance(dtype, np.dtype) and np.issubdtype(dtype, np.timedelta64):
+                    return np.datetime_data(dtype)[0]
+            # Fall back to microseconds for datetime.timedelta scalars and for object-backed
+            # interval columns, which carry no numpy timedelta64 resolution. This matches the
+            # microsecond resolution of the underlying DayTimeIntervalType.
             return "us"
 
         promoted = np.promote_types(

--- a/python/pyspark/pandas/data_type_ops/timedelta_ops.py
+++ b/python/pyspark/pandas/data_type_ops/timedelta_ops.py
@@ -76,11 +76,8 @@ class TimedeltaOps(DataTypeOps):
     def _with_inferred_unit(
         self, result: SeriesOrIndex, left: IndexOpsLike, right: Any
     ) -> SeriesOrIndex:
-        # Before pandas 3.0.0, timedelta64 is always nanosecond resolution, so there is no
-        # unit to infer. From pandas 3.0.0, arithmetic between timedeltas promotes to the
-        # finer resolution of the operands. The computed Spark column is always a
-        # DayTimeIntervalType (microsecond), so the result field would otherwise be reported
-        # as timedelta64[us]; here we override its dtype to match pandas.
+        # pandas 3.0.0+ promotes timedelta arithmetic to the finer resolution of the
+        # operands; before that timedelta64 is always nanoseconds.
         if LooseVersion(pd.__version__) < "3.0.0":
             return result
 
@@ -89,17 +86,14 @@ class TimedeltaOps(DataTypeOps):
                 dtype = obj.dtype
                 if isinstance(dtype, np.dtype) and np.issubdtype(dtype, np.timedelta64):
                     return np.datetime_data(dtype)[0]
-            # Fall back to microseconds for datetime.timedelta scalars and for object-backed
-            # interval columns, which carry no numpy timedelta64 resolution. This matches the
-            # microsecond resolution of the underlying DayTimeIntervalType.
+            # timedelta scalars and object-backed interval columns map to microseconds.
             return "us"
 
         promoted = np.promote_types(
-            np.dtype("timedelta64[%s]" % unit_of(left)),
-            np.dtype("timedelta64[%s]" % unit_of(right)),
+            np.dtype(f"timedelta64[{unit_of(left)}]"),
+            np.dtype(f"timedelta64[{unit_of(right)}]"),
         )
-        # Spark's DayTimeIntervalType stores microseconds and cannot represent finer
-        # resolutions, so cap nanosecond promotion at microseconds.
+        # DayTimeIntervalType stores microseconds and cannot represent finer resolutions.
         if np.datetime_data(promoted)[0] == "ns":
             promoted = np.dtype("timedelta64[us]")
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_timedelta_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_timedelta_ops.py
@@ -89,6 +89,12 @@ class TimedeltaOpsTestsMixin:
             self.assert_eq(pser1 - timedelta(seconds=1), psser1 - timedelta(seconds=1))
             self.assert_eq(timedelta(seconds=1) - pser1, timedelta(seconds=1) - psser1)
 
+            # pd.Timedelta is a datetime.timedelta subclass that carries its own resolution.
+            for unit in ["s", "ms"]:
+                scalar = pd.Timedelta(1, unit=unit)
+                self.assert_eq(pser1 - scalar, psser1 - scalar)
+                self.assert_eq(scalar - pser1, scalar - psser1)
+
         pidx = pd.Index(np.array([3, 5, 8], dtype="timedelta64[s]"))
         psidx = ps.from_pandas(pidx)
         self.assert_eq(pidx - pidx, psidx - psidx)

--- a/python/pyspark/pandas/tests/data_type_ops/test_timedelta_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_timedelta_ops.py
@@ -99,6 +99,16 @@ class TimedeltaOpsTestsMixin:
         psidx = ps.from_pandas(pidx)
         self.assert_eq(pidx - pidx, psidx - psidx)
 
+        # DayTimeIntervalType cannot represent nanoseconds, so nanosecond operands are
+        # capped at microseconds rather than matching pandas' nanosecond result.
+        pser_ns = pd.Series(np.array([3, 5, 8], dtype="timedelta64[ns]"))
+        pser_s = pd.Series(np.array([3, 5, 8], dtype="timedelta64[s]"))
+        psser_ns, psser_s = ps.from_pandas(pser_ns), ps.from_pandas(pser_s)
+        self.assertEqual((psser_ns - psser_ns)._to_pandas().dtype, np.dtype("timedelta64[us]"))
+        self.assertEqual(
+            (psser_s - pd.Timedelta(1, unit="ns"))._to_pandas().dtype, np.dtype("timedelta64[us]")
+        )
+
         # object-backed interval columns carry no numpy resolution; must not fail.
         pser_obj = pd.Series([timedelta(days=1), timedelta(seconds=2)], dtype=object)
         psser_obj = ps.from_pandas(pser_obj)

--- a/python/pyspark/pandas/tests/data_type_ops/test_timedelta_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_timedelta_ops.py
@@ -98,6 +98,15 @@ class TimedeltaOpsTestsMixin:
         psidx = ps.from_pandas(pidx)
         self.assert_eq(pidx - pidx, psidx - psidx)
 
+        # Object-backed interval columns carry no numpy timedelta64 resolution, so unit
+        # inference must not fail trying to read one. pandas-on-Spark materializes the
+        # DayTimeIntervalType as microseconds, so compare against the numpy-backed values.
+        pser_obj = pd.Series([timedelta(days=1), timedelta(seconds=2)], dtype=object)
+        psser_obj = ps.from_pandas(pser_obj)
+        expected = pser_obj.astype("timedelta64[us]")
+        self.assert_eq(expected - timedelta(0), psser_obj - timedelta(0))
+        self.assert_eq(expected - expected, psser_obj - psser_obj)
+
     def test_mul(self):
         self.assertRaises(TypeError, lambda: self.psser * "x")
         self.assertRaises(TypeError, lambda: self.psser * 1)

--- a/python/pyspark/pandas/tests/data_type_ops/test_timedelta_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_timedelta_ops.py
@@ -76,31 +76,24 @@ class TimedeltaOpsTestsMixin:
         self.assert_eq(pdf["that"] - pdf["this"], psdf["that"] - psdf["this"])
 
     def test_sub_unit(self):
-        # Before pandas 3.0.0, timedelta64 is always nanosecond resolution, so there is no
-        # unit to infer. From pandas 3.0.0, the result of subtracting timedeltas takes the
-        # finer resolution of the operands; pandas-on-Spark should follow that instead of
-        # always reporting microseconds (SPARK-55299).
+        # pandas 3.0.0+ takes the finer resolution of the operands instead of always
+        # microseconds (SPARK-55299); before that timedelta64 is always nanoseconds.
         if LooseVersion(pd.__version__) < "3.0.0":
             return
 
         for left_unit, right_unit in [("s", "s"), ("ms", "ms"), ("us", "us"), ("s", "ms")]:
-            pser1 = pd.Series(np.array([3, 5, 8], dtype="timedelta64[%s]" % left_unit))
-            pser2 = pd.Series(np.array([1, 2, 3], dtype="timedelta64[%s]" % right_unit))
+            pser1 = pd.Series(np.array([3, 5, 8], dtype=f"timedelta64[{left_unit}]"))
+            pser2 = pd.Series(np.array([1, 2, 3], dtype=f"timedelta64[{right_unit}]"))
             psser1, psser2 = ps.from_pandas(pser1), ps.from_pandas(pser2)
             self.assert_eq(pser1 - pser2, psser1 - psser2)
-
-            # datetime.timedelta scalars have microsecond resolution.
             self.assert_eq(pser1 - timedelta(seconds=1), psser1 - timedelta(seconds=1))
             self.assert_eq(timedelta(seconds=1) - pser1, timedelta(seconds=1) - psser1)
 
-        # The same unit inference applies to TimedeltaIndex subtraction.
         pidx = pd.Index(np.array([3, 5, 8], dtype="timedelta64[s]"))
         psidx = ps.from_pandas(pidx)
         self.assert_eq(pidx - pidx, psidx - psidx)
 
-        # Object-backed interval columns carry no numpy timedelta64 resolution, so unit
-        # inference must not fail trying to read one. pandas-on-Spark materializes the
-        # DayTimeIntervalType as microseconds, so compare against the numpy-backed values.
+        # object-backed interval columns carry no numpy resolution; must not fail.
         pser_obj = pd.Series([timedelta(days=1), timedelta(seconds=2)], dtype=object)
         psser_obj = ps.from_pandas(pser_obj)
         expected = pser_obj.astype("timedelta64[us]")

--- a/python/pyspark/pandas/tests/data_type_ops/test_timedelta_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_timedelta_ops.py
@@ -17,10 +17,12 @@
 
 from datetime import timedelta
 
+import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
 import pyspark.pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
 
@@ -72,6 +74,29 @@ class TimedeltaOpsTestsMixin:
 
         pdf, psdf = self.timedelta_pdf, self.timedelta_psdf
         self.assert_eq(pdf["that"] - pdf["this"], psdf["that"] - psdf["this"])
+
+    def test_sub_unit(self):
+        # Before pandas 3.0.0, timedelta64 is always nanosecond resolution, so there is no
+        # unit to infer. From pandas 3.0.0, the result of subtracting timedeltas takes the
+        # finer resolution of the operands; pandas-on-Spark should follow that instead of
+        # always reporting microseconds (SPARK-55299).
+        if LooseVersion(pd.__version__) < "3.0.0":
+            return
+
+        for left_unit, right_unit in [("s", "s"), ("ms", "ms"), ("us", "us"), ("s", "ms")]:
+            pser1 = pd.Series(np.array([3, 5, 8], dtype="timedelta64[%s]" % left_unit))
+            pser2 = pd.Series(np.array([1, 2, 3], dtype="timedelta64[%s]" % right_unit))
+            psser1, psser2 = ps.from_pandas(pser1), ps.from_pandas(pser2)
+            self.assert_eq(pser1 - pser2, psser1 - psser2)
+
+            # datetime.timedelta scalars have microsecond resolution.
+            self.assert_eq(pser1 - timedelta(seconds=1), psser1 - timedelta(seconds=1))
+            self.assert_eq(timedelta(seconds=1) - pser1, timedelta(seconds=1) - psser1)
+
+        # The same unit inference applies to TimedeltaIndex subtraction.
+        pidx = pd.Index(np.array([3, 5, 8], dtype="timedelta64[s]"))
+        psidx = ps.from_pandas(pidx)
+        self.assert_eq(pidx - pidx, psidx - psidx)
 
     def test_mul(self):
         self.assertRaises(TypeError, lambda: self.psser * "x")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds `_with_inferred_unit` to `TimedeltaOps.sub`/`rsub` to set the
result dtype from the operand units (numpy `timedelta64` dtype, or
`pd.Timedelta.unit` for scalars)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To match pandas 3 behavior.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. On pandas 3, the dtype of a timedelta produced by subtraction now
follows the finer resolution of the operands (capped at microseconds) instead
of always timedelta64[us]. Behavior on pandas < 3.0.0 is unchanged.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unitetests added.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Opus 4.8
