### PR TITLE
[SPARK-57580][SQL] Redact credentials embedded in JDBC URLs

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -304,38 +304,34 @@ object JDBCOptions {
     name
   }
 
-  // The userinfo of a URL authority (everything between "//" and the authority's last "@") may
-  // carry credentials, e.g. the "user:password" in "//user:password@host". "[^/?#]*" extends
-  // greedily to the last "@" before the authority ends (at the first "/", "?" or "#"), so an "@"
-  // embedded in the password is covered as well; the whole userinfo is redacted.
-  private val URL_USER_INFO_PATTERN = "(//)[^/?#]*(@)".r
-
-  // The query / connection-property portion of a JDBC URL (everything from the first "?" or ";")
-  // can carry credentials as key=value pairs (e.g. "password=...", "token=..."), and the set of
-  // credential-bearing property names is driver-specific and open-ended. Rather than enumerate
-  // them, redact the whole portion, keeping only the structural "scheme://host:port/database".
-  private val URL_PARAMS_PATTERN = "([?;]).*".r
-
   /**
-   * Redacts credentials that may be embedded in a JDBC URL so it is safe to surface in logs and
-   * error messages. Only the structural prefix (scheme, host, port, database/path) is preserved;
-   * the authority's userinfo and the entire query/connection-property string are redacted, since
-   * either may carry secrets and the credential-bearing property names are driver-specific. This
-   * is done unconditionally rather than relying on the optional, user-configured
+   * Redacts a JDBC URL so it is safe to surface in logs and error messages.
+   *
+   * A JDBC URL has the form `jdbc:<subprotocol>:<subname>`, where `<subprotocol>` is a registered
+   * driver name (`mysql`, `oracle`, `postgresql`, ...) and `<subname>` is entirely driver-specific.
+   * Credentials can appear anywhere in `<subname>` and in arbitrary syntaxes -- userinfo in a
+   * `//user:pwd@host` authority, Oracle Thin's `user/pwd@host`, `?`/`;` connection properties, etc.
+   * Rather than enumerate every driver's syntax (and inevitably miss one and leak), we keep only
+   * the `jdbc:<subprotocol>:` prefix -- which is credential-free by construction -- and redact
+   * everything after it. The driver type stays visible for debugging; nothing else does.
+   *
+   * This redaction is unconditional, unlike the optional, user-configured
    * `spark.sql.redaction.string.regex` (which is unset by default and would leave the URL in the
-   * clear). The configured redaction `regex` is still applied on top, preserving existing behavior.
+   * clear). The configured `regex` is still applied on top, preserving existing behavior.
    */
   def redactUrl(url: String, regex: Option[Regex]): String = {
     if (url == null || url.isEmpty) {
       url
     } else {
-      // The function form of replaceAllIn treats the replacement literally (no '$' group
-      // interpolation), so the redaction text is inserted verbatim.
-      val withoutUserInfo = URL_USER_INFO_PATTERN.replaceAllIn(
-        url, m => s"${m.group(1)}${Utils.REDACTION_REPLACEMENT_TEXT}${m.group(2)}")
-      val withoutParams = URL_PARAMS_PATTERN.replaceAllIn(
-        withoutUserInfo, m => s"${m.group(1)}${Utils.REDACTION_REPLACEMENT_TEXT}")
-      Utils.redact(regex, withoutParams)
+      // The second colon terminates the subprotocol: "jdbc" ':' "<subprotocol>" ':' "<subname>".
+      val subprotocolEnd = url.indexOf(':', url.indexOf(':') + 1)
+      val redacted = if (subprotocolEnd < 0) {
+        // No subname delimiter -- the URL is malformed, so don't trust any of it.
+        Utils.REDACTION_REPLACEMENT_TEXT
+      } else {
+        url.substring(0, subprotocolEnd + 1) + Utils.REDACTION_REPLACEMENT_TEXT
+      }
+      Utils.redact(regex, redacted)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -20,6 +20,8 @@ package org.apache.spark.sql.execution.datasources.jdbc
 import java.sql.{Connection, DriverManager}
 import java.util.{Locale, Properties}
 
+import scala.util.matching.Regex
+
 import org.apache.commons.io.FilenameUtils
 
 import org.apache.spark.SparkFiles
@@ -268,7 +270,7 @@ class JDBCOptions(
     case _ => false
   }
 
-  def getRedactUrl(): String = Utils.redact(SQLConf.get.stringRedactionPattern, url)
+  def getRedactUrl(): String = JDBCOptions.redactUrl(url, SQLConf.get.stringRedactionPattern)
 }
 
 class JdbcOptionsInWrite(
@@ -300,6 +302,41 @@ object JDBCOptions {
   private def newOption(name: String): String = {
     jdbcOptionNames += name.toLowerCase(Locale.ROOT)
     name
+  }
+
+  // The userinfo of a URL authority (everything between "//" and the authority's last "@") may
+  // carry credentials, e.g. the "user:password" in "//user:password@host". "[^/?#]*" extends
+  // greedily to the last "@" before the authority ends (at the first "/", "?" or "#"), so an "@"
+  // embedded in the password is covered as well; the whole userinfo is redacted.
+  private val URL_USER_INFO_PATTERN = "(//)[^/?#]*(@)".r
+
+  // The query / connection-property portion of a JDBC URL (everything from the first "?" or ";")
+  // can carry credentials as key=value pairs (e.g. "password=...", "token=..."), and the set of
+  // credential-bearing property names is driver-specific and open-ended. Rather than enumerate
+  // them, redact the whole portion, keeping only the structural "scheme://host:port/database".
+  private val URL_PARAMS_PATTERN = "([?;]).*".r
+
+  /**
+   * Redacts credentials that may be embedded in a JDBC URL so it is safe to surface in logs and
+   * error messages. Only the structural prefix (scheme, host, port, database/path) is preserved;
+   * the authority's userinfo and the entire query/connection-property string are redacted, since
+   * either may carry secrets and the credential-bearing property names are driver-specific. This
+   * is done unconditionally rather than relying on the optional, user-configured
+   * `spark.sql.redaction.string.regex` (which is unset by default and would leave the URL in the
+   * clear). The configured redaction `regex` is still applied on top, preserving existing behavior.
+   */
+  def redactUrl(url: String, regex: Option[Regex]): String = {
+    if (url == null || url.isEmpty) {
+      url
+    } else {
+      // The function form of replaceAllIn treats the replacement literally (no '$' group
+      // interpolation), so the redaction text is inserted verbatim.
+      val withoutUserInfo = URL_USER_INFO_PATTERN.replaceAllIn(
+        url, m => s"${m.group(1)}${Utils.REDACTION_REPLACEMENT_TEXT}${m.group(2)}")
+      val withoutParams = URL_PARAMS_PATTERN.replaceAllIn(
+        withoutUserInfo, m => s"${m.group(1)}${Utils.REDACTION_REPLACEMENT_TEXT}")
+      Utils.redact(regex, withoutParams)
+    }
   }
 
   val JDBC_URL = newOption("url")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtilsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtilsSuite.scala
@@ -71,44 +71,40 @@ class JdbcUtilsSuite extends SparkFunSuite {
       parameters = Map("error" -> "'.'", "hint" -> ""))
   }
 
-  test("redactUrl redacts credentials embedded in a JDBC URL") {
+  test("redactUrl keeps only the jdbc:<subprotocol>: prefix") {
     val redaction = Utils.REDACTION_REPLACEMENT_TEXT
 
-    // URLs with no userinfo and no query/property portion are returned unchanged.
-    Seq(
-      "jdbc:mysql://localhost/db",
-      "jdbc:postgresql://localhost:5432/postgres",
-      "jdbc:h2:mem:testdb").foreach { url =>
-      assert(JDBCOptions.redactUrl(url, None) === url)
-    }
-
-    // The authority's userinfo is redacted wholesale (the scheme, host, port and database are
-    // kept), including a bare username and a password that itself contains an '@'.
+    // Only the "jdbc:<subprotocol>:" prefix is kept; everything after it (host, port, database,
+    // userinfo and connection properties) is redacted, regardless of the driver-specific syntax.
+    // This covers credentials embedded as a "//user:pwd@host" authority, ...
     assert(JDBCOptions.redactUrl("jdbc:mysql://user:secret@host:3306/db", None) ===
-      s"jdbc:mysql://$redaction@host:3306/db")
-    assert(JDBCOptions.redactUrl("jdbc:mysql://user@host:3306/db", None) ===
-      s"jdbc:mysql://$redaction@host:3306/db")
-    assert(JDBCOptions.redactUrl("jdbc:mysql://user:p@ss@host:3306/db", None) ===
-      s"jdbc:mysql://$redaction@host:3306/db")
+      s"jdbc:mysql:$redaction")
+    assert(JDBCOptions.redactUrl("jdbc:mysql://user:p@ss@host:3306/db?password=other", None) ===
+      s"jdbc:mysql:$redaction")
+    // ... as Oracle Thin's "user/pwd@host" form (no "//" authority), ...
+    assert(JDBCOptions.redactUrl("jdbc:oracle:thin:scott/tiger@host:1521/svc", None) ===
+      s"jdbc:oracle:$redaction")
+    assert(JDBCOptions.redactUrl("jdbc:oracle:thin:scott/tiger@//host:1521/svc?x=1", None) ===
+      s"jdbc:oracle:$redaction")
+    // ... and as "?"- or ";"-delimited connection properties.
+    assert(JDBCOptions.redactUrl(
+      "jdbc:postgresql://host/db?user=alice&password=secret", None) ===
+      s"jdbc:postgresql:$redaction")
+    assert(JDBCOptions.redactUrl(
+      "jdbc:sqlserver://localhost:1433;databaseName=testdb;password=secret", None) ===
+      s"jdbc:sqlserver:$redaction")
 
-    // The entire query / connection-property portion (from the first '?' or ';') is redacted,
-    // since the credential-bearing property names are driver-specific and open-ended.
-    assert(JDBCOptions.redactUrl(
-      "jdbc:postgresql://host/db?user=alice&password=secret&ssl=true", None) ===
-      s"jdbc:postgresql://host/db?$redaction")
-    assert(JDBCOptions.redactUrl(
-      "jdbc:redshift://host:5439/db;PWD=secret;LogLevel=1", None) ===
-      s"jdbc:redshift://host:5439/db;$redaction")
-    assert(JDBCOptions.redactUrl(
-      "jdbc:sqlserver://localhost:1433;databaseName=testdb", None) ===
-      s"jdbc:sqlserver://localhost:1433;$redaction")
-    assert(JDBCOptions.redactUrl("jdbc:snowflake://host/?token=abc123", None) ===
-      s"jdbc:snowflake://host/?$redaction")
+    // Even URLs that carry no credentials are reduced to the prefix -- nothing past the
+    // subprotocol is assumed safe.
+    assert(JDBCOptions.redactUrl("jdbc:mysql://localhost/db", None) === s"jdbc:mysql:$redaction")
+    assert(JDBCOptions.redactUrl("jdbc:h2:mem:testdb", None) === s"jdbc:h2:$redaction")
 
-    // Both userinfo and the property portion in the same URL are redacted.
-    assert(JDBCOptions.redactUrl(
-      "jdbc:mysql://user:secret@host:3306/db?password=other", None) ===
-      s"jdbc:mysql://$redaction@host:3306/db?$redaction")
+    // A URL with no subname delimiter (no second colon) is redacted wholesale.
+    assert(JDBCOptions.redactUrl("jdbc:weird-url", None) === redaction)
+
+    // The user-configured regex is still applied on top of the kept prefix.
+    assert(JDBCOptions.redactUrl("jdbc:mysql://host/db", Some("mysql".r)) ===
+      s"jdbc:$redaction:$redaction")
 
     // Null and empty inputs are passed through.
     assert(JDBCOptions.redactUrl(null, None) === null)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtilsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtilsSuite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.types._
+import org.apache.spark.util.Utils
 
 class JdbcUtilsSuite extends SparkFunSuite {
 
@@ -68,5 +69,49 @@ class JdbcUtilsSuite extends SparkFunSuite {
       },
       condition = "PARSE_SYNTAX_ERROR",
       parameters = Map("error" -> "'.'", "hint" -> ""))
+  }
+
+  test("redactUrl redacts credentials embedded in a JDBC URL") {
+    val redaction = Utils.REDACTION_REPLACEMENT_TEXT
+
+    // URLs with no userinfo and no query/property portion are returned unchanged.
+    Seq(
+      "jdbc:mysql://localhost/db",
+      "jdbc:postgresql://localhost:5432/postgres",
+      "jdbc:h2:mem:testdb").foreach { url =>
+      assert(JDBCOptions.redactUrl(url, None) === url)
+    }
+
+    // The authority's userinfo is redacted wholesale (the scheme, host, port and database are
+    // kept), including a bare username and a password that itself contains an '@'.
+    assert(JDBCOptions.redactUrl("jdbc:mysql://user:secret@host:3306/db", None) ===
+      s"jdbc:mysql://$redaction@host:3306/db")
+    assert(JDBCOptions.redactUrl("jdbc:mysql://user@host:3306/db", None) ===
+      s"jdbc:mysql://$redaction@host:3306/db")
+    assert(JDBCOptions.redactUrl("jdbc:mysql://user:p@ss@host:3306/db", None) ===
+      s"jdbc:mysql://$redaction@host:3306/db")
+
+    // The entire query / connection-property portion (from the first '?' or ';') is redacted,
+    // since the credential-bearing property names are driver-specific and open-ended.
+    assert(JDBCOptions.redactUrl(
+      "jdbc:postgresql://host/db?user=alice&password=secret&ssl=true", None) ===
+      s"jdbc:postgresql://host/db?$redaction")
+    assert(JDBCOptions.redactUrl(
+      "jdbc:redshift://host:5439/db;PWD=secret;LogLevel=1", None) ===
+      s"jdbc:redshift://host:5439/db;$redaction")
+    assert(JDBCOptions.redactUrl(
+      "jdbc:sqlserver://localhost:1433;databaseName=testdb", None) ===
+      s"jdbc:sqlserver://localhost:1433;$redaction")
+    assert(JDBCOptions.redactUrl("jdbc:snowflake://host/?token=abc123", None) ===
+      s"jdbc:snowflake://host/?$redaction")
+
+    // Both userinfo and the property portion in the same URL are redacted.
+    assert(JDBCOptions.redactUrl(
+      "jdbc:mysql://user:secret@host:3306/db?password=other", None) ===
+      s"jdbc:mysql://$redaction@host:3306/db?$redaction")
+
+    // Null and empty inputs are passed through.
+    assert(JDBCOptions.redactUrl(null, None) === null)
+    assert(JDBCOptions.redactUrl("", None) === "")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -2172,7 +2172,8 @@ class JDBCSuite extends SharedSparkSession {
         spark.read.format("jdbc").options(opts).load()
       },
       condition = "FAILED_JDBC.CONNECTION",
-      parameters = Map("url" -> url)
+      // getRedactUrl() keeps only the "jdbc:<subprotocol>:" prefix and redacts the rest.
+      parameters = Map("url" -> s"jdbc:mysql:${Utils.REDACTION_REPLACEMENT_TEXT}")
     )
   }
 
@@ -2522,7 +2523,8 @@ class JDBCSuite extends SharedSparkSession {
           }
         },
         condition = "FAILED_JDBC.CONNECTION",
-        parameters = Map("url" -> url)
+        // getRedactUrl() keeps only the "jdbc:<subprotocol>:" prefix and redacts the rest.
+        parameters = Map("url" -> s"$connectionUrl:${Utils.REDACTION_REPLACEMENT_TEXT}")
       )
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`JDBCOptions.getRedactUrl()` is used to surface the JDBC URL in logs and in the
`FAILED_JDBC.*` error messages (e.g. `FAILED_JDBC.CONNECTION`). Today it is implemented as:

```scala
def getRedactUrl(): String = Utils.redact(SQLConf.get.stringRedactionPattern, url)
```

`SQLConf.get.stringRedactionPattern` (`spark.sql.redaction.string.regex`) is **unset by
default**, so `Utils.redact(None, url)` returns the URL unchanged. JDBC URLs routinely embed
credentials — either as userinfo in the authority (`jdbc:mysql://user:password@host/db`), as
connection properties (`...?password=secret`, `...;token=abc`), or in driver-specific inline
forms (Oracle Thin's `jdbc:oracle:thin:user/password@host`) — so by default those secrets are
printed verbatim in error messages and logs.

This PR makes `getRedactUrl()` redact credentials unconditionally, independent of the optional
`spark.sql.redaction.string.regex`. A JDBC URL has the form `jdbc:<subprotocol>:<subname>`, where
`<subprotocol>` is a registered driver name (`mysql`, `oracle`, `postgresql`, …) and `<subname>`
is entirely driver-specific. Credentials can appear anywhere in `<subname>` and in arbitrary,
open-ended syntaxes, so rather than enumerate every driver's syntax (and inevitably miss one and
leak), `JDBCOptions.redactUrl(url, regex)` takes an **allowlist** approach: it keeps only the
`jdbc:<subprotocol>:` prefix — which is credential-free by construction — and redacts everything
after it.

This is deliberately stronger than trying to preserve the host/port/database: the set of
credential-bearing positions and property names is driver-specific and unbounded, so any attempt
to match-and-strip them is a never-ending game of catch-up. Keeping only the subprotocol is safe
regardless of the driver's URL grammar, while still preserving the most useful triage signal
(which database engine the failure came from). The user-configured `regex` is still applied on
top, preserving existing behavior.

### Why are the changes needed?

`FAILED_JDBC.*` errors and connection logs can currently leak JDBC credentials to anyone who can
read query error messages or driver logs, because the default redaction is a no-op. Redacting at
the single `getRedactUrl()` chokepoint fixes every `FAILED_JDBC.*` call site at once.

### Does this PR introduce _any_ user-facing change?

Yes. `FAILED_JDBC.*` error messages (and any log line built from `getRedactUrl()`) now show only
the `jdbc:<subprotocol>:` prefix followed by `*********(redacted)`, instead of the full URL. For
example `jdbc:mysql://user:secret@host:3306/db?password=p` becomes `jdbc:mysql:*********(redacted)`.

### How was this patch tested?

Unit test `redactUrl keeps only the jdbc:<subprotocol>: prefix` in `JdbcUtilsSuite`, covering:
the `//user:pwd@host` authority form, Oracle Thin's `user/pwd@host` inline form (with and without
a trailing `//host` and query string), `?`- and `;`-delimited connection properties, credential-
free URLs (still reduced to the prefix), a malformed URL with no second colon (redacted
wholesale), the user-configured `regex` being applied on top of the kept prefix, and null/empty
inputs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8
