### PR TITLE
[SPARK-56947][SQL] Add `SortLike` trait for sort physical operators

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffset.scala
@@ -71,7 +71,7 @@ object InsertSortForLimitAndOffset extends Rule[SparkPlan] {
   // a best effort to catch the common query patterns that the data ordering should be preserved.
   private def extractOrderingAndPropagateOrderingColumns(
       plan: SparkPlan): Option[(Seq[SortOrder], SparkPlan)] = plan match {
-    case p: SortExec if p.global => Some(p.sortOrder, p)
+    case p: SortLike if p.global => Some(p.sortOrder, p)
     case p: UnaryExecNode if
         p.isInstanceOf[LocalLimitExec] ||
           p.isInstanceOf[WholeStageCodegenExec] ||

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantSorts.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantSorts.scala
@@ -38,9 +38,9 @@ object RemoveRedundantSorts extends Rule[SparkPlan] {
   }
 
   private def removeSorts(plan: SparkPlan): SparkPlan = plan transform {
-    case s @ SortExec(orders, _, child, _)
-        if SortOrder.orderingSatisfies(child.outputOrdering, orders) &&
-          child.outputPartitioning.satisfies(s.requiredChildDistribution.head) =>
-      child
+    case s: SortLike
+        if SortOrder.orderingSatisfies(s.child.outputOrdering, s.sortOrder) &&
+          s.child.outputPartitioning.satisfies(s.requiredChildDistribution.head) =>
+      s.child
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantSorts.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantSorts.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.internal.SQLConf
 
 /**
- * Remove redundant SortExec node from the spark plan. A sort node is redundant when
+ * Remove redundant sort node from the spark plan. A sort node is redundant when
  * its child satisfies both its sort orders and its required child distribution. Note
  * this rule differs from the Optimizer rule EliminateSorts in that this rule also checks
  * if the child satisfies the required distribution so that it is safe to remove not only a

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SortExec.scala
@@ -30,6 +30,16 @@ import org.apache.spark.sql.catalyst.util.DateTimeConstants.NANOS_PER_MILLIS
 import org.apache.spark.sql.execution.metric.SQLMetrics
 
 /**
+ * Common trait for all sort implementations to facilitate pattern matching, so that user-defined
+ * sort operators can also be recognized and optimized by physical optimization rules such as
+ * [[RemoveRedundantSorts]].
+ */
+trait SortLike extends UnaryExecNode {
+  def sortOrder: Seq[SortOrder]
+  def global: Boolean
+}
+
+/**
  * Performs (external) sorting.
  *
  * @param global when true performs a global sort of all partitions by shuffling the data first
@@ -42,7 +52,7 @@ case class SortExec(
     global: Boolean,
     child: SparkPlan,
     testSpillFrequency: Int = 0)
-  extends UnaryExecNode with BlockingOperatorWithCodegen {
+  extends SortLike with BlockingOperatorWithCodegen {
 
   override def output: Seq[Attribute] = child.output
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEUtils.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.adaptive
 
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, HashPartitioning, UnspecifiedDistribution}
-import org.apache.spark.sql.execution.{CollectMetricsExec, DeserializeToObjectExec, FilterExec, ProjectExec, SortExec, SparkPlan}
+import org.apache.spark.sql.execution.{CollectMetricsExec, DeserializeToObjectExec, FilterExec, ProjectExec, SortLike, SparkPlan}
 import org.apache.spark.sql.execution.exchange.{REPARTITION_BY_COL, REPARTITION_BY_NUM, ShuffleExchangeExec}
 
 object AQEUtils {
@@ -39,7 +39,7 @@ object AQEUtils {
       }
       Some(ClusteredDistribution(h.expressions, requiredNumPartitions = numPartitions))
     case f: FilterExec => getRequiredDistribution(f.child)
-    case s: SortExec if !s.global => getRequiredDistribution(s.child)
+    case s: SortLike if !s.global => getRequiredDistribution(s.child)
     case c: CollectMetricsExec => getRequiredDistribution(c.child)
     case d: DeserializeToObjectExec => getRequiredDistribution(d.child)
     case p: ProjectExec =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/bucketing/DisableUnnecessaryBucketedScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/bucketing/DisableUnnecessaryBucketedScan.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.bucketing
 
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.{FileSourceScanExec, FilterExec, ProjectExec, SortExec, SparkPlan}
+import org.apache.spark.sql.execution.{FileSourceScanExec, FilterExec, ProjectExec, SortLike, SparkPlan}
 import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
 import org.apache.spark.sql.execution.exchange.Exchange
 
@@ -133,7 +133,7 @@ object DisableUnnecessaryBucketedScan extends Rule[SparkPlan] {
    */
   private def isAllowedUnaryExecNode(plan: SparkPlan): Boolean = {
     plan match {
-      case _: SortExec | _: ProjectExec | _: FilterExec => true
+      case _: SortLike | _: ProjectExec | _: FilterExec => true
       case partialAgg: BaseAggregateExec =>
         partialAgg.requiredChildDistributionExpressions.isEmpty
       case _ => false

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -309,7 +309,7 @@ case class EnsureRequirements(
   // have sorted-merge enabled (every possible combination). Returns a LazyList so the caller can
   // stop evaluating once a satisfying alternative is found.
   //
-  // Pruning: traversal stops at SortExec (which reorders data, making sorted merge below it
+  // Pruning: traversal stops at SortLike (which reorders data, making sorted merge below it
   // pointless) and at any node whose outputPartitioning no longer carries a KeyedPartitioning.
   // This is a good heuristic, though not strictly equivalent to "ordering no longer propagates":
   // partition-key expressions are constant within each coalesced partition and therefore usually
@@ -323,7 +323,7 @@ case class EnsureRequirements(
   // product across all GPEs in the subtree, giving every combination.
   private[exchange] def tryEnableSortedMerge(plan: SparkPlan): LazyList[SparkPlan] =
     plan.multiTransformDownWithPruning(
-      p => !p.isInstanceOf[SortExec] &&
+      p => !p.isInstanceOf[SortLike] &&
         hasKeyedPartitioning(p.asInstanceOf[SparkPlan].outputPartitioning)) {
       case gpe: GroupPartitionsExec =>
         // Include the original so that peer GPEs are still independently considered.

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression,
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParserInterface}
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, AggregateHint, ColumnStat, Limit, LocalRelation, LogicalPlan, Project, Range, Sort, SortHint, Statistics, UnresolvedHint}
-import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, SinglePartition}
+import org.apache.spark.sql.catalyst.plans.physical.{Distribution, OrderedDistribution, Partitioning, SinglePartition, UnspecifiedDistribution}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.classic.ClassicConversions._
@@ -665,6 +665,21 @@ class SparkSessionExtensionSuite extends PlanTest with AdaptiveSparkPlanHelper {
       }
     }
   }
+
+  test("SPARK-56947: user-defined SortLike can be eliminated by RemoveRedundantSorts") {
+    val extensions = create { extensions =>
+      extensions.injectPlannerStrategy(MySortStrategy)
+    }
+    withSession(extensions) { session =>
+      session.conf.set(SQLConf.REMOVE_REDUNDANT_SORTS_ENABLED.key, true)
+      import session.implicits._
+      val df = session.range(100).select($"id" as "key").sort($"key".desc).sort($"key".desc)
+      val plan = df.queryExecution.executedPlan
+      val sorts = collectWithSubqueries(plan) { case s: SortLike => s }
+      assert(sorts.length == 1)
+      assert(sorts.head.isInstanceOf[MySortExec])
+    }
+  }
 }
 
 case class MyRule(spark: SparkSession) extends Rule[LogicalPlan] {
@@ -690,6 +705,32 @@ case class MyCheckRule(spark: SparkSession) extends (LogicalPlan => Unit) {
 
 case class MySparkStrategy(spark: SparkSession) extends SparkStrategy {
   override def apply(plan: LogicalPlan): Seq[SparkPlan] = Seq.empty
+}
+
+/**
+ * Custom sort operator used in tests to demonstrate that a user-defined [[SortLike]] can be
+ * recognized and eliminated by physical optimization rules such as [[RemoveRedundantSorts]].
+ */
+case class MySortExec(
+    sortOrder: Seq[SortOrder],
+    global: Boolean,
+    child: SparkPlan) extends SortLike {
+  override def output: Seq[Attribute] = child.output
+  override def outputOrdering: Seq[SortOrder] = sortOrder
+  override def outputPartitioning: Partitioning = child.outputPartitioning
+  override def requiredChildDistribution: Seq[Distribution] =
+    if (global) OrderedDistribution(sortOrder) :: Nil else UnspecifiedDistribution :: Nil
+  override protected def doExecute(): RDD[InternalRow] = child.execute()
+  override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
+    copy(child = newChild)
+}
+
+case class MySortStrategy(spark: SparkSession) extends SparkStrategy {
+  override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+    case Sort(sortExprs, global, child, _) =>
+      MySortExec(sortExprs, global, planLater(child)) :: Nil
+    case _ => Nil
+  }
 }
 
 case class MyParser(spark: SparkSession, delegate: ParserInterface) extends ParserInterface {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a `SortLike` trait, analogous to the existing `ShuffleExchangeLike` trait, as a common abstraction over sort physical operators:

```scala
trait SortLike extends UnaryExecNode {
  def sortOrder: Seq[SortOrder]
  def global: Boolean
}
```

`SortExec` now extends `SortLike`, and the physical plan optimization rules that previously matched on the concrete `SortExec` class now match on the `SortLike` trait instead:

- `RemoveRedundantSorts`
- `InsertSortForLimitAndOffset`
- `EnsureRequirements` (sorted-merge pruning)
- `AQEUtils`
- `DisableUnnecessaryBucketedScan`

For the built-in `SortExec` these rules behave exactly as before, since `SortExec` is a `SortLike`.

### Why are the changes needed?

These rules currently pattern-match the concrete `SortExec` class, so a user-defined sort operator injected through a custom planner strategy is invisible to them and cannot be optimized. For example, a redundant user-defined sort is never removed by `RemoveRedundantSorts`. This is the same problem that `ShuffleExchangeLike` already solves for shuffle operators: matching on a trait lets the optimizer recognize alternative implementations. `SortLike` gives sort operators the same extensibility.

### Does this PR introduce _any_ user-facing change?

No. For the built-in `SortExec` the optimization behavior is unchanged. The trait only widens what the existing rules can recognize, so that user-defined sort operators can participate in the same optimizations.

### How was this patch tested?

Added a unit test in `SparkSessionExtensionSuite` that injects a custom `MySortExec extends SortLike` through a planner strategy, then verifies that a redundant user-defined sort is eliminated by `RemoveRedundantSorts`, leaving a single `MySortExec` in the executed plan.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code

