### PR TITLE
[SPARK-57584][CONNECT] Add Spark Connect gRPC health checks

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/SparkConnectPlugin.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/SparkConnectPlugin.scala
@@ -49,6 +49,11 @@ class SparkConnectPlugin extends SparkPlugin {
       Map.empty[String, String].asJava
     }
 
+    override def registerMetrics(appId: String, pluginContext: PluginContext): Unit = {
+      // Called after most Spark subsystems are up, so the context can now serve queries.
+      SparkConnectService.markServing()
+    }
+
     override def shutdown(): Unit = {
       SparkConnectService.stop()
     }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectServer.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectServer.scala
@@ -38,6 +38,9 @@ object SparkConnectServer extends Logging {
     try {
       try {
         SparkConnectService.start(session.sparkContext)
+        // The session above is created from a fully-initialized SparkContext, so the service
+        // can be advertised as SERVING right away.
+        SparkConnectService.markServing()
         val isa = SparkConnectService.bindingAddress
         val host = Utils.normalizeIpIfNeeded(isa.getAddress.getHostAddress)
         logInfo(

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -400,8 +400,8 @@ object SparkConnectService extends Logging {
     val bindAddress = SparkEnv.get.conf.get(CONNECT_GRPC_BINDING_ADDRESS)
     val startPort = SparkEnv.get.conf.get(CONNECT_GRPC_BINDING_PORT)
     val sparkConnectService = new SparkConnectService(debugMode)
-    healthStatusManager = new HealthStatusManager()
-    setHealthStatus(ServingStatus.NOT_SERVING)
+    val newHealthStatusManager = new HealthStatusManager()
+    setHealthStatus(newHealthStatusManager, ServingStatus.NOT_SERVING)
     val protoReflectionService =
       if (debugMode) Some(ProtoReflectionService.newInstance()) else None
     val configuredInterceptors = SparkConnectInterceptorRegistry.createConfiguredInterceptors()
@@ -415,7 +415,7 @@ object SparkConnectService extends Logging {
       }
       sb.maxInboundMessageSize(SparkEnv.get.conf.get(CONNECT_GRPC_MAX_INBOUND_MESSAGE_SIZE).toInt)
         .addService(sparkConnectService)
-        .addService(healthStatusManager.getHealthService)
+        .addService(newHealthStatusManager.getHealthService)
 
       getAuthenticateToken.foreach { token =>
         sb.intercept(new PreSharedKeyAuthenticationInterceptor(token))
@@ -450,6 +450,7 @@ object SparkConnectService extends Logging {
       startServiceFn,
       maxRetries,
       getClass.getName.stripSuffix("$"))
+    healthStatusManager = newHealthStatusManager
   }
 
   // Starts the service
@@ -480,7 +481,7 @@ object SparkConnectService extends Logging {
       throw IllegalStateErrors.serviceNotStarted()
     }
 
-    setHealthStatus(ServingStatus.NOT_SERVING)
+    enterTerminalHealthState()
     if (server != null) {
       if (timeout.isDefined && unit.isDefined) {
         server.shutdown()
@@ -497,13 +498,22 @@ object SparkConnectService extends Logging {
     started = false
     stopped = true
     postSparkConnectServiceEnd()
-    healthStatusManager = null
   }
 
   private def setHealthStatus(status: ServingStatus): Unit = {
     if (healthStatusManager != null) {
-      healthStatusManager.setStatus(OverallHealthServiceName, status)
-      healthStatusManager.setStatus(SparkConnectServiceGrpc.SERVICE_NAME, status)
+      setHealthStatus(healthStatusManager, status)
+    }
+  }
+
+  private def setHealthStatus(manager: HealthStatusManager, status: ServingStatus): Unit = {
+    manager.setStatus(OverallHealthServiceName, status)
+    manager.setStatus(SparkConnectServiceGrpc.SERVICE_NAME, status)
+  }
+
+  private def enterTerminalHealthState(): Unit = {
+    if (healthStatusManager != null) {
+      healthStatusManager.enterTerminalState()
     }
   }
 

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -25,9 +25,10 @@ import scala.jdk.CollectionConverters._
 import com.google.protobuf.Message
 import io.grpc.{BindableService, MethodDescriptor, Server, ServerMethodDefinition, ServerServiceDefinition}
 import io.grpc.MethodDescriptor.PrototypeMarshaller
+import io.grpc.health.v1.HealthCheckResponse.ServingStatus
 import io.grpc.netty.NettyServerBuilder
 import io.grpc.protobuf.ProtoUtils
-import io.grpc.protobuf.services.ProtoReflectionService
+import io.grpc.protobuf.services.{HealthStatusManager, ProtoReflectionService}
 import io.grpc.stub.StreamObserver
 
 import org.apache.spark.{SparkContext, SparkEnv}
@@ -314,8 +315,11 @@ class SparkConnectService(debug: Boolean) extends AsyncService with BindableServ
  */
 object SparkConnectService extends Logging {
 
+  private val OverallHealthServiceName = HealthStatusManager.SERVICE_NAME_ALL_SERVICES
+
   private[connect] var server: Server = _
   private[connect] var bindingAddress: InetSocketAddress = _
+  private[connect] var healthStatusManager: HealthStatusManager = _
 
   private[connect] var uiTab: Option[SparkConnectServerTab] = None
   private[connect] var listener: SparkConnectServerListener = _
@@ -396,6 +400,8 @@ object SparkConnectService extends Logging {
     val bindAddress = SparkEnv.get.conf.get(CONNECT_GRPC_BINDING_ADDRESS)
     val startPort = SparkEnv.get.conf.get(CONNECT_GRPC_BINDING_PORT)
     val sparkConnectService = new SparkConnectService(debugMode)
+    healthStatusManager = new HealthStatusManager()
+    setHealthStatus(ServingStatus.NOT_SERVING)
     val protoReflectionService =
       if (debugMode) Some(ProtoReflectionService.newInstance()) else None
     val configuredInterceptors = SparkConnectInterceptorRegistry.createConfiguredInterceptors()
@@ -409,6 +415,7 @@ object SparkConnectService extends Logging {
       }
       sb.maxInboundMessageSize(SparkEnv.get.conf.get(CONNECT_GRPC_MAX_INBOUND_MESSAGE_SIZE).toInt)
         .addService(sparkConnectService)
+        .addService(healthStatusManager.getHealthService)
 
       getAuthenticateToken.foreach { token =>
         sb.intercept(new PreSharedKeyAuthenticationInterceptor(token))
@@ -459,6 +466,7 @@ object SparkConnectService extends Logging {
 
     started = true
     stopped = false
+    setHealthStatus(ServingStatus.SERVING)
     postSparkConnectServiceStarted()
   }
 
@@ -472,6 +480,7 @@ object SparkConnectService extends Logging {
       throw IllegalStateErrors.serviceNotStarted()
     }
 
+    setHealthStatus(ServingStatus.NOT_SERVING)
     if (server != null) {
       if (timeout.isDefined && unit.isDefined) {
         server.shutdown()
@@ -488,6 +497,14 @@ object SparkConnectService extends Logging {
     started = false
     stopped = true
     postSparkConnectServiceEnd()
+    healthStatusManager = null
+  }
+
+  private def setHealthStatus(status: ServingStatus): Unit = {
+    if (healthStatusManager != null) {
+      healthStatusManager.setStatus(OverallHealthServiceName, status)
+      healthStatusManager.setStatus(SparkConnectServiceGrpc.SERVICE_NAME, status)
+    }
   }
 
   /**

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -467,8 +467,20 @@ object SparkConnectService extends Logging {
 
     started = true
     stopped = false
-    setHealthStatus(ServingStatus.SERVING)
     postSparkConnectServiceStarted()
+  }
+
+  /**
+   * Advertise the service as SERVING for gRPC health checks. Call this only once the SparkContext
+   * is fully initialized: when `start` runs from `DriverPlugin.init` the task scheduler and other
+   * subsystems that query execution needs are not up yet. The plugin path calls this from
+   * `DriverPlugin.registerMetrics` (fired later in initialization); the standalone server calls it
+   * right after `start` returns on an already-built context.
+   */
+  def markServing(): Unit = synchronized {
+    if (started && !stopped) {
+      setHealthStatus(ServingStatus.SERVING)
+    }
   }
 
   def stop(timeout: Option[Long] = None, unit: Option[TimeUnit] = None): Unit = synchronized {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
@@ -22,7 +22,11 @@ import java.util.concurrent.Semaphore
 
 import scala.collection.mutable
 
+import io.grpc.ManagedChannelBuilder
+import io.grpc.health.v1.{HealthCheckRequest, HealthCheckResponse, HealthGrpc}
+
 import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.connect.proto.SparkConnectServiceGrpc
 import org.apache.spark.internal.config._
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
@@ -259,6 +263,42 @@ class SparkConnectServiceInternalServerSuite extends SparkFunSuite with LocalSpa
     assert(SparkConnectService.stopped)
     // The listener should receive the `SparkListenerConnectServiceEnd` event
     endEventSignal.acquire()
+  }
+
+  test("The SparkConnectService exposes standard gRPC health checks") {
+    val conf = new SparkConf()
+      .setAppName(getClass().getName())
+      .set(SparkLauncher.SPARK_MASTER, "local[1]")
+    sc = new SparkContext(conf)
+
+    withSparkEnvConfs((CONNECT_GRPC_BINDING_PORT.key, "0")) {
+      SparkConnectService.start(sc)
+    }
+
+    val channel = ManagedChannelBuilder
+      .forAddress("localhost", SparkConnectService.server.getPort)
+      .usePlaintext()
+      .build()
+    try {
+      val healthStub = HealthGrpc.newBlockingStub(channel)
+
+      val overallStatus = healthStub
+        .check(HealthCheckRequest.newBuilder().build())
+        .getStatus
+      assert(overallStatus == HealthCheckResponse.ServingStatus.SERVING)
+
+      val sparkConnectStatus = healthStub
+        .check(
+          HealthCheckRequest
+            .newBuilder()
+            .setService(SparkConnectServiceGrpc.SERVICE_NAME)
+            .build())
+        .getStatus
+      assert(sparkConnectStatus == HealthCheckResponse.ServingStatus.SERVING)
+    } finally {
+      channel.shutdownNow()
+      SparkConnectService.stop()
+    }
   }
 
   def withPortOccupied(startPort: Int, endPort: Int)(f: => Unit): Unit = {

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
@@ -17,12 +17,13 @@
 package org.apache.spark.sql.connect.service
 
 import java.net.ServerSocket
-import java.util.concurrent.{CopyOnWriteArrayList, Semaphore, TimeUnit}
+import java.util.concurrent.{CopyOnWriteArrayList, LinkedBlockingQueue, Semaphore, TimeUnit}
 
 import scala.collection.mutable
 
 import io.grpc.ManagedChannelBuilder
 import io.grpc.health.v1.{HealthCheckRequest, HealthCheckResponse, HealthGrpc}
+import io.grpc.stub.StreamObserver
 
 import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.connect.proto.SparkConnectServiceGrpc
@@ -281,31 +282,51 @@ class SparkConnectServiceInternalServerSuite extends SparkFunSuite with LocalSpa
     try {
       val healthStub = HealthGrpc.newBlockingStub(channel)
 
-      // `start` only brings up the gRPC server; the service is not advertised as SERVING until
-      // the SparkContext is fully initialized (signalled by `markServing`).
+      def check(service: String): HealthCheckResponse.ServingStatus =
+        healthStub
+          .check(HealthCheckRequest.newBuilder().setService(service).build())
+          .getStatus
+
+      // `start` only brings up the gRPC server; until the SparkContext is fully initialized
+      // (signalled by `markServing`) both the overall and the SparkConnect service are
+      // NOT_SERVING.
+      assert(check("") == HealthCheckResponse.ServingStatus.NOT_SERVING)
       assert(
-        healthStub.check(HealthCheckRequest.newBuilder().build()).getStatus ==
+        check(SparkConnectServiceGrpc.SERVICE_NAME) ==
           HealthCheckResponse.ServingStatus.NOT_SERVING)
 
       SparkConnectService.markServing()
 
-      val overallStatus = healthStub
-        .check(HealthCheckRequest.newBuilder().build())
-        .getStatus
-      assert(overallStatus == HealthCheckResponse.ServingStatus.SERVING)
+      assert(check("") == HealthCheckResponse.ServingStatus.SERVING)
+      assert(
+        check(SparkConnectServiceGrpc.SERVICE_NAME) ==
+          HealthCheckResponse.ServingStatus.SERVING)
 
-      val sparkConnectStatus = healthStub
-        .check(
-          HealthCheckRequest
-            .newBuilder()
-            .setService(SparkConnectServiceGrpc.SERVICE_NAME)
-            .build())
-        .getStatus
-      assert(sparkConnectStatus == HealthCheckResponse.ServingStatus.SERVING)
+      // Watch the overall status to observe the terminal transition on stop(): a unary Check
+      // would race with server shutdown, but the streaming Watch receives the NOT_SERVING push
+      // that stop() emits (via enterTerminalState) before the server is torn down.
+      val statuses = new LinkedBlockingQueue[HealthCheckResponse.ServingStatus]()
+      HealthGrpc
+        .newStub(channel)
+        .watch(
+          HealthCheckRequest.newBuilder().build(),
+          new StreamObserver[HealthCheckResponse] {
+            override def onNext(resp: HealthCheckResponse): Unit = statuses.add(resp.getStatus)
+            override def onError(t: Throwable): Unit = {}
+            override def onCompleted(): Unit = {}
+          })
+      // Watch first replays the current status.
+      assert(statuses.poll(10, TimeUnit.SECONDS) == HealthCheckResponse.ServingStatus.SERVING)
+
+      // Graceful stop so the terminal NOT_SERVING push reaches the watcher before teardown.
+      SparkConnectService.stop(Some(1L), Some(TimeUnit.SECONDS))
+      assert(statuses.poll(10, TimeUnit.SECONDS) == HealthCheckResponse.ServingStatus.NOT_SERVING)
     } finally {
       channel.shutdownNow()
       channel.awaitTermination(10, TimeUnit.SECONDS)
-      SparkConnectService.stop()
+      if (SparkConnectService.started) {
+        SparkConnectService.stop()
+      }
     }
   }
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
@@ -281,6 +281,14 @@ class SparkConnectServiceInternalServerSuite extends SparkFunSuite with LocalSpa
     try {
       val healthStub = HealthGrpc.newBlockingStub(channel)
 
+      // `start` only brings up the gRPC server; the service is not advertised as SERVING until
+      // the SparkContext is fully initialized (signalled by `markServing`).
+      assert(
+        healthStub.check(HealthCheckRequest.newBuilder().build()).getStatus ==
+          HealthCheckResponse.ServingStatus.NOT_SERVING)
+
+      SparkConnectService.markServing()
+
       val overallStatus = healthStub
         .check(HealthCheckRequest.newBuilder().build())
         .getStatus
@@ -298,6 +306,35 @@ class SparkConnectServiceInternalServerSuite extends SparkFunSuite with LocalSpa
       channel.shutdownNow()
       channel.awaitTermination(10, TimeUnit.SECONDS)
       SparkConnectService.stop()
+    }
+  }
+
+  test("The gRPC health check is deferred until the SparkContext is fully initialized " +
+    "when started from the plugin") {
+    val conf = new SparkConf()
+      .setAppName(getClass().getName())
+      .set(PLUGINS, Seq(classOf[SparkConnectPlugin].getName()))
+      .set(CONNECT_GRPC_BINDING_PORT.key, "0")
+      .set(SparkLauncher.SPARK_MASTER, "local[1]")
+
+    // The plugin starts the service from `DriverPlugin.init` (before the task scheduler is up)
+    // and flips it to SERVING from `DriverPlugin.registerMetrics`, which runs near the end of the
+    // SparkContext constructor. So by the time the constructor returns it must be SERVING.
+    sc = new SparkContext(conf)
+    assert(SparkConnectService.started)
+
+    val channel = ManagedChannelBuilder
+      .forAddress("localhost", SparkConnectService.server.getPort)
+      .usePlaintext()
+      .build()
+    try {
+      val healthStub = HealthGrpc.newBlockingStub(channel)
+      assert(
+        healthStub.check(HealthCheckRequest.newBuilder().build()).getStatus ==
+          HealthCheckResponse.ServingStatus.SERVING)
+    } finally {
+      channel.shutdownNow()
+      channel.awaitTermination(10, TimeUnit.SECONDS)
     }
   }
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
@@ -17,8 +17,7 @@
 package org.apache.spark.sql.connect.service
 
 import java.net.ServerSocket
-import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.Semaphore
+import java.util.concurrent.{CopyOnWriteArrayList, Semaphore, TimeUnit}
 
 import scala.collection.mutable
 
@@ -297,6 +296,7 @@ class SparkConnectServiceInternalServerSuite extends SparkFunSuite with LocalSpa
       assert(sparkConnectStatus == HealthCheckResponse.ServingStatus.SERVING)
     } finally {
       channel.shutdownNow()
+      channel.awaitTermination(10, TimeUnit.SECONDS)
       SparkConnectService.stop()
     }
   }


### PR DESCRIPTION


### What changes were proposed in this pull request?

Ref https://issues.apache.org/jira/browse/SPARK-57584

This PR registers the standard gRPC health checking service for Spark Connect.

  Spark Connect now exposes health checks through `grpc.health.v1.Health/Check` for:
  - the overall gRPC server health service
  - the Spark Connect service name, `spark.connect.SparkConnectService`

  The service is initialized as `NOT_SERVING`, marked `SERVING` after Spark Connect startup completes, and marked `NOT_SERVING` during shutdown.


### Why are the changes needed?


  Spark Connect currently exposes Spark Connect RPCs such as `GetStatus`, but it does not expose the standard gRPC health checking protocol. This makes it difficult for Kubernetes operators
  and clients to distinguish between a container that is running and a Spark Connect server that is ready to accept gRPC traffic.

  Adding the standard gRPC health service provides a lightweight readiness signal that can be used by Kubernetes gRPC probes and other gRPC-aware clients.



### Does this PR introduce _any_ user-facing change?
 Yes.

  Spark Connect servers now expose the standard gRPC health checking service. Existing Spark Connect APIs are unchanged.

  Before this change, clients could only infer readiness by opening the port or attempting Spark Connect RPCs. After this change, clients and Kubernetes probes can call the standard gRPC
  health check and receive `SERVING` once Spark Connect startup has completed.



### How was this patch tested?
 Added a test in `SparkConnectServiceInternalServerSuite` that starts Spark Connect, creates a real `HealthGrpc` client, and verifies that both the default health check and the Spark
  Connect service-specific health check return `SERVING`.

```
 build/sbt connect/Test/compile
  build/sbt 'connect/testOnly org.apache.spark.sql.connect.service.SparkConnectServiceInternalServerSuite -- -z "standard gRPC health"'
```
### Was this patch authored or co-authored using generative AI tooling?
Yes
