### PR TITLE
[MINOR][CORE][TESTS] Make "log4j log level change" assert on the root logger

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -723,11 +723,16 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     try {
       Utils.setLogLevel(Level.ALL)
       assert(rootLogger.getLevel == Level.ALL)
-      assert(log.isInfoEnabled())
+      // Assert enablement on the root logger that `Utils.setLogLevel` controls directly, rather
+      // than on this suite's own logger. The latter is fragile: if the logging configuration
+      // contains an intermediate `org.apache.spark*` LoggerConfig, the suite logger resolves to
+      // that config instead of root, so its effective level no longer tracks `setLogLevel` even
+      // though the root level is updated correctly (as the `getLevel` assertions confirm).
+      assert(rootLogger.isInfoEnabled())
       Utils.setLogLevel(Level.ERROR)
       assert(rootLogger.getLevel == Level.ERROR)
-      assert(!log.isInfoEnabled())
-      assert(log.isErrorEnabled())
+      assert(!rootLogger.isInfoEnabled())
+      assert(rootLogger.isErrorEnabled())
     } finally {
       // Best effort at undoing changes this test made.
       Utils.setLogLevel(current)


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `UtilsSuite` "log4j log level change" test calls `Utils.setLogLevel(...)` (which sets the root logger's level) and then asserts the change took effect via this suite's own logger (`log.isInfoEnabled()` / `log.isErrorEnabled()`). This makes the test assert enablement on the **root logger** directly — the logger `setLogLevel` actually controls.

### Why are the changes needed?

Asserting via the suite's own logger is fragile. `setLogLevel` updates the root logger config, but the suite logger reflects it only if it resolves to root. If the logging configuration contains an intermediate `org.apache.spark*` `LoggerConfig`, the suite logger resolves to that instead, so its effective level no longer tracks `setLogLevel` — even though the root level is updated correctly (which the existing `rootLogger.getLevel` assertions already confirm). Asserting on the root logger removes this dependence on the surrounding logger hierarchy and tests exactly what `setLogLevel` is responsible for.

### Does this PR introduce _any_ user-facing change?

No. Test-only change.

### How was this patch tested?

Existing `UtilsSuite` "log4j log level change" test continues to pass.

### Was this patch authored or co-authored using generative AI tooling?

Yes, drafted with assistance from Claude.
