### PR TITLE
[SPARK-57607][BUILD][3.5] Pin black to a Python 3.9-compatible version for the branch-3.5 linter

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1178,7 +1178,7 @@ jobs:
       run: |
         # SPARK-45212: Copy from https://github.com/apache/spark/blob/555c8def51e5951c7bf5165a332795e9e330ec9d/.github/workflows/build_and_test.yml#L631-L638
         # Should delete this section after SPARK 3.5 EOL.
-        python3.9 -m pip install 'flake8==3.9.0' pydata_sphinx_theme 'mypy==0.982' 'pytest==7.1.3' 'pytest-mypy-plugins==1.9.3' numpydoc 'jinja2<3.0.0' 'black==26.3.1'
+        python3.9 -m pip install 'flake8==3.9.0' pydata_sphinx_theme 'mypy==0.982' 'pytest==7.1.3' 'pytest-mypy-plugins==1.9.3' numpydoc 'jinja2<3.0.0' 'black==22.6.0'
         python3.9 -m pip install 'pandas-stubs==1.2.0.53' ipython 'grpcio==1.56.0' 'grpc-stubs==1.24.11' 'googleapis-common-protos-stubs==2.2.0'
     - name: List Python packages
       shell: 'script -q -e -c "bash {0}"'


### PR DESCRIPTION
### What changes were proposed in this pull request?

Pin `black` to `22.6.0` (from `26.3.1`) in the branch-3.5 Python linter dependency
install step in `.github/workflows/build_and_test.yml`.

### Why are the changes needed?

The scheduled "Build (branch-3.5, Scala 2.13, JDK 8)" job runs master's
`build_and_test.yml` against branch-3.5 source. Its linter step installs
dependencies with `python3.9`. `black==26.3.1` only ships wheels that require
Python >= 3.10, so pip fails on Python 3.9:

```
ERROR: Could not find a version that satisfies the requirement black==26.3.1 ...
ERROR: No matching distribution found for black==26.3.1
```

This breaks the branch-3.5 daily build at the "Install Python linter dependencies
for branch-3.5" step before any linting runs. Failing apache/spark run:
https://github.com/apache/spark/actions/runs/27903533450

`black==22.6.0` is the version branch-3.5 already standardizes on (matches its
`dev/pyproject.toml` required version) and installs cleanly on Python 3.9.

### Does this PR introduce any user-facing change?

No. Infra/CI only.

### How was this patch tested?

**Validated GREEN on the fork:** https://github.com/HyukjinKwon/spark/actions/runs/27929091181

That focused validation job (on Python 3.9) does three things, all passing:
1. Reproduces the root cause: the old `black==26.3.1` install fails on Python 3.9.
2. Validates the fix: the exact branch-3.5 linter install line with `black==22.6.0`
   succeeds on Python 3.9.
3. Confirms `22.6.0` matches branch-3.5's `dev/pyproject.toml` required black version.

(Note: the full scheduled "Build (branch-3.5)" cannot be reproduced green on a fork
because it runs master's workflow file against branch-3.5 source and dies at the
unrelated apache-master sync harness step; the focused job above validates exactly
the changed line.)

The `[DO-NOT-MERGE]` CI trigger commit is for fork validation and should be dropped before merge.

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated with Claude Code (Anthropic) under the direction of the repository owner.