### PR TITLE
[SPARK-57598][CONNECT][PYTHON][TESTS] Make test_sql_context importable in Spark Connect client-only mode

### DIFF
--- a/python/pyspark/sql/tests/test_sql_context.py
+++ b/python/pyspark/sql/tests/test_sql_context.py
@@ -18,8 +18,7 @@ import os
 import tempfile
 import warnings
 
-from pyspark import SQLContext
-from pyspark.sql import SparkSession
+from pyspark.sql import SQLContext, SparkSession
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`pyspark/sql/tests/test_sql_context.py` (whose `SQLContextTestsMixin` is reused by the Spark Connect
parity test `pyspark.sql.tests.connect.test_parity_sql_context`) imported the classic SQLContext from
the top-level package:

```python
from pyspark import SQLContext
```

In a remote-only (Spark Connect client-only, i.e. `pyspark-client`) install, `pyspark/__init__.py`
only re-exports `SQLContext` when `not is_remote_only()`, so this raises `ImportError` and the module
fails to import.

This PR imports `SQLContext` the same way the next line of the module already imports `SparkSession`
-- from `pyspark.sql`:

```python
from pyspark.sql import SQLContext, SparkSession
```

`pyspark/sql/__init__.py` exports `SQLContext` (from `pyspark.sql.context`) unconditionally -- no
`is_remote_only()` guard -- so it is importable in both classic and remote-only modes, exactly like
`SparkSession`. No `try`/`except` shim is needed. One line changed.

### Why are the changes needed?

The scheduled "Build / Python-only, Connect-only (Python 3.11)" build was failing: its
`Run tests (local)` step aborted at collection (exit 255) because importing the module raised:

```
File ".../pyspark/sql/tests/test_sql_context.py", line 21, in <module>
    from pyspark import SQLContext
ImportError: cannot import name 'SQLContext' from 'pyspark'
```

### Does this PR introduce _any_ user-facing change?

No. Test-only change.

### How was this patch tested?

Ran the actual scheduled workflow (`build_python_connect.yml`) on a fork; the Connect-only build
passes green end-to-end, with both `Run tests (local)` and `Run tests (local-cluster)` green:

https://github.com/HyukjinKwon/spark/actions/runs/27933341162

(To run the scheduled workflow on the fork, a temporary trigger edit to
`.github/workflows/build_python_connect.yml` was used during validation; that edit is intentionally
NOT part of this PR.)

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
