### PR TITLE
[SPARK-57501][SQL][TESTS] Update stale JDK 21 golden file for nonansi/try_arithmetic.sql

### DIFF
--- a/sql/core/src/test/resources/sql-tests/results/nonansi/try_arithmetic.sql.out.java21
+++ b/sql/core/src/test/resources/sql-tests/results/nonansi/try_arithmetic.sql.out.java21
@@ -196,7 +196,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "inputSql" : "\"INTERVAL '2' YEAR\"",
     "inputType" : "\"INTERVAL YEAR\"",
     "paramIndex" : "first",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
+    "requiredType" : "(\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\" or \"(TIMESTAMP_LTZ(P) OR TIMESTAMP_NTZ(P) WITH P IN [7, 9])\")",
     "sqlExpr" : "\"INTERVAL '2' YEAR + INTERVAL '02' SECOND\""
   },
   "queryContext" : [ {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update the stale JDK 21+ golden file
`sql/core/src/test/resources/sql-tests/results/nonansi/try_arithmetic.sql.out.java21`.

### Why are the changes needed?

SPARK-57501 (commit dea9c30) changed the `DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE`
message for `try_add(interval ...)` and regenerated the base `try_arithmetic.sql.out`,
but missed the JDK 21-specific override `try_arithmetic.sql.out.java21`. `SQLQueryTestSuite`
reads the `.out.java21` override when running on JDK >= 21, so the stale `requiredType`
line makes `nonansi/try_arithmetic.sql` fail on every JDK 21+ scheduled build (Maven JDK 21/25,
Java 21, Java 25). Example failing apache run:
https://github.com/apache/spark/actions/runs/27907992223

### Does this PR introduce any user-facing change?

No. Test golden file only.

### How was this patch tested?

**Validated GREEN on the fork:** the Maven (Scala 2.13, JDK 21) build's SQL lane passes with this
golden update — https://github.com/HyukjinKwon/spark/actions/runs/27935083986

Note: that validation run bundles this golden fix together with the separate `PythonUDFWorker`
AF_UNIX fix (#56646) and the log4j 2.26.0 JDK 25 fix, because the full Maven JDK 21 build exercises
all of them in the same jobs. Each is its own PR; this PR's diff is only the `.out.java21` golden.

The second commit is a clearly-marked `[DO NOT MERGE]` CI trigger edit for fork validation and should
be dropped before merge.

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated with Claude Code (Anthropic) under the direction of the repository owner.