### PR TITLE
[SPARK-57604][BUILD] Upgrade log4j to 2.26.0 to fix JDK 25 ThrowableStackTraceRenderer NPE

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -184,11 +184,11 @@ lapack/3.2.0//lapack-3.2.0.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.16.0//libthrift-0.16.0.jar
-log4j-1.2-api/2.25.4//log4j-1.2-api-2.25.4.jar
-log4j-api/2.25.4//log4j-api-2.25.4.jar
-log4j-core/2.25.4//log4j-core-2.25.4.jar
-log4j-layout-template-json/2.25.4//log4j-layout-template-json-2.25.4.jar
-log4j-slf4j2-impl/2.25.4//log4j-slf4j2-impl-2.25.4.jar
+log4j-1.2-api/2.26.0//log4j-1.2-api-2.26.0.jar
+log4j-api/2.26.0//log4j-api-2.26.0.jar
+log4j-core/2.26.0//log4j-core-2.26.0.jar
+log4j-layout-template-json/2.26.0//log4j-layout-template-json-2.26.0.jar
+log4j-slf4j2-impl/2.26.0//log4j-slf4j2-impl-2.26.0.jar
 lz4-java/1.11.0//lz4-java-1.11.0.jar
 metrics-core/4.2.37//metrics-core-4.2.37.jar
 metrics-graphite/4.2.37//metrics-graphite-4.2.37.jar

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.9.1</asm.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <log4j.version>2.25.4</log4j.version>
+    <log4j.version>2.26.0</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.5.0</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade `log4j` from 2.25.x to **2.26.0** (`pom.xml` and `dev/deps/spark-deps-hadoop-3-hive-2.3`).

### Why are the changes needed?

Under JDK 25, log4j2's `ThrowableStackTraceRenderer` throws
`NullPointerException: Cannot read field "stackLength" because "metadata" is null` when rendering
any logged exception's stack trace. On Spark this surfaces as `FsHistoryProviderSuite`
"provider reports error after FS leaves safe mode" failing on the JDK 25 scheduled build.
Example failing upstream run (Build / Java25):
https://github.com/apache/spark/actions/runs/27894816608

log4j 2.26.0 fixes the renderer (snapshots the stack trace during metadata population; upstream
LOG4J2 #3940 / #3955).

### Does this PR introduce any user-facing change?

No. Build/logging dependency upgrade.

### How was this patch tested?

Validated on a fork.
- `FsHistoryProviderSuite` "provider reports error after FS leaves safe mode" is GREEN on **JDK 25**
  with this bump: https://github.com/HyukjinKwon/spark/actions/runs/27929988232
- Fully GREEN combined Maven (Scala 2.13, JDK 21) run that includes this log4j bump, 0 failed jobs
  (the same suite also fails on JDK 21 without the bump):
  **https://github.com/HyukjinKwon/spark/actions/runs/27935083986**
- A combined JDK 25 proof run is also in progress:
  https://github.com/HyukjinKwon/spark/actions/runs/27943439418



**Validated GREEN on the fork:** the full `Build / Java25 (Scala 2.13, JDK 25)` build is green with this log4j 2.26.0 upgrade (FsHistoryProvider/ThrowableStackTraceRenderer NPE gone): https://github.com/HyukjinKwon/spark/actions/runs/27937860264

### Was this patch authored or co-authored using generative AI tooling?

Yes. Drafted with Claude Code (Anthropic) and reviewed before submission.

