### PR TITLE
[SPARK-56539][CORE] Fix exitStatusCode 0 for unrecognized spark-submit options

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -510,7 +510,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
    */
   override protected def handleUnknown(opt: String): Boolean = {
     if (opt.startsWith("-")) {
-      error(s"Unrecognized option '$opt'.")
+      SparkSubmit.printErrorAndExit(s"Unrecognized option '$opt'.")
+
     }
 
     primaryResource =


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This PR modifies the `handleUnknown` method in `core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala`. 

It replaces the standard `error()` function with `SparkSubmit.printErrorAndExit()` when an unrecognized command-line option is encountered during `spark-submit` argument parsing.



### Why are the changes needed?
The intent was to address SPARK-56539, which reported that unrecognized options passed to spark-submit were resulting in an exit code of 0 instead of a failure code.
Currently, when `spark-submit` encounters an unrecognized option (like a malformed `--master` argument), it prints an error message, but the JVM terminates gracefully. This results in the process returning an OS exit code of `0` (success). 

This causes "silent failures" in downstream orchestrators, bash scripts, and data pipelines (such as Apache Airflow) that rely strictly on the system exit code to determine if a job succeeded or failed. This fix ensures that an unrecognized option properly triggers a non-zero exit code (`1`) to notify the operating system of the failure.



### Does this PR introduce _any_ user-facing change?

No. 



### How was this patch tested?

This was tested manually by running `spark-submit` with a dummy unrecognized flag and verifying the system exit code (`echo $?` in Bash/PowerShell) outputs `1` instead of `0`. 

Because this patch leverages Spark's built-in `SparkSubmit.printErrorAndExit()`, it safely integrates with existing test suites (like `SparkSubmitSuite`) without forcefully crashing the JVM via a hard `sys.exit()`.



### Was this patch authored or co-authored using generative AI tooling?

Yes the documentation and overall navigation through the folders was Generated by :Google Gemini

