### PR TITLE
[SPARK-57610][SQL][TESTS][4.2] Tolerate null ArithmeticException message in TruncTimestamp overflow test on JDK 25

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -862,8 +862,19 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       val minTimestamp = Literal.create(Long.MinValue, TimestampType)
       Seq("YEAR", "QUARTER", "MONTH", "WEEK", "DAY", "HOUR", "MINUTE",
           "SECOND", "MILLISECOND").foreach { fmt =>
-        checkExceptionInExpression[ArithmeticException](
-          TruncTimestamp(Literal.create(fmt, StringType), minTimestamp), "")
+        // The overflow surfaces as a raw `ArithmeticException` from `Math.*Exact`, which
+        // `checkEvaluation` wraps in a scalatest `TestFailedException`. Unwrap it via `getCause`
+        // and assert the type. The exception message is not part of the API contract: JDK 25 may
+        // throw it with a `null` message in codegen mode (JIT "hot throw", see SPARK-55714 /
+        // SPARK-55755 / JDK-8367990), while the interpreter reports "long overflow", so tolerate
+        // a null message. Mirrors the `TimestampAddInterval` overflow check in this suite.
+        val e = intercept[Exception] {
+          checkEvaluation(
+            TruncTimestamp(Literal.create(fmt, StringType), minTimestamp),
+            null)
+        }.getCause
+        assert(e.isInstanceOf[ArithmeticException])
+        assert(e.getMessage == null || e.getMessage.contains("overflow"))
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make `DateExpressionsSuite."TruncTimestamp of Long.MinValue overflows with ArithmeticException"`
tolerant of a null exception message under JDK 25.

### Why are the changes needed?

On the branch-4.2 `Build (branch-4.2, Scala 2.13, JDK 25)` daily build, this test failed. The
overflow from `Math.*Exact` in `TruncTimestamp` does throw a raw `java.lang.ArithmeticException`, but
on JDK 25 the JIT "hot throw" optimization (OmitStackTraceInFastThrow, JDK-8367990) can throw it with a
`null` message in codegen mode, while the interpreter reports `"long overflow"`. The original
assertion required a non-null message, so it failed on JDK 25.

The fix evaluates the expression directly under both `NO_CODEGEN` and `CODEGEN_ONLY` modes, asserts the
exception is an `ArithmeticException`, and tolerates a null-or-"overflow" message (matching the existing
convention used by the SubtractTimestamps / TimestampAddInterval overflow checks in the same suite). The
engine is correct (it does throw on overflow); this is a test-only change.

### Does this PR introduce any user-facing change?

No. Test-only.

### How was this patch tested?

**Validated GREEN on the fork:** the `Build (branch-4.2, Scala 2.13, JDK 25)` build is green with this
fix, including the `api, catalyst, hive-thriftserver` job where `TruncTimestamp` runs:
https://github.com/HyukjinKwon/spark/actions/runs/27942948687

The second commit is a clearly-marked `[DO NOT MERGE]` CI trigger edit for fork validation and should be
dropped before merge.

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated with Claude Code (Anthropic) under the direction of the repository owner.