### PR TITLE
[SPARK-57582][SQL] Remove dead TimeType fallback branches shadowed by the Parquet types framework dispatch

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -526,22 +526,6 @@ private[parquet] class ParquetRowConverter(
           }
         }
 
-      case t: TimeType
-        if parquetType.getLogicalTypeAnnotation.isInstanceOf[TimeLogicalTypeAnnotation] && {
-          val unit = parquetType.getLogicalTypeAnnotation
-            .asInstanceOf[TimeLogicalTypeAnnotation].getUnit
-          unit == TimeUnit.MICROS || unit == TimeUnit.NANOS
-        } =>
-        val fileStoresNanos = parquetType.getLogicalTypeAnnotation
-          .asInstanceOf[TimeLogicalTypeAnnotation].getUnit == TimeUnit.NANOS
-        val precision = t.precision
-        new ParquetPrimitiveConverter(updater) {
-          override def addLong(value: Long): Unit = {
-            val nanos = if (fileStoresNanos) value else DateTimeUtils.microsToNanos(value)
-            this.updater.setLong(DateTimeUtils.truncateTimeToPrecision(nanos, precision))
-          }
-        }
-
       // A repeated field that is neither contained by a `LIST`- or `MAP`-annotated group nor
       // annotated by `LIST` or `MAP` should be interpreted as a required list of required
       // elements where the element type is the type of the field.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
@@ -713,12 +713,6 @@ class SparkToParquetSchemaConverter(
         Types.primitive(INT32, repetition)
           .as(LogicalTypeAnnotation.dateType()).named(field.name)
 
-      case t: TimeType =>
-        // Precision 0..6 is stored as TIME(MICROS); precision 7..9 as TIME(NANOS).
-        val unit = if (t.precision > TimeType.MICROS_PRECISION) TimeUnit.NANOS else TimeUnit.MICROS
-        Types.primitive(INT64, repetition)
-          .as(LogicalTypeAnnotation.timeType(false, unit)).named(field.name)
-
       // NOTE: Spark SQL can write timestamp values to Parquet using INT96, TIMESTAMP_MICROS or
       // TIMESTAMP_MILLIS. TIMESTAMP_MICROS is recommended but INT96 is the default to keep the
       // behavior same as before.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetWriteSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetWriteSupport.scala
@@ -307,15 +307,6 @@ class ParquetWriteSupport extends WriteSupport[InternalRow] with Logging {
           recordConsumer.addLong(
             timestampNanosToEpochNanos(row.getTimestampNTZNanos(ordinal), isNtz = true))
 
-      case t: TimeType if t.precision > TimeType.MICROS_PRECISION =>
-        // Precision 7..9 is stored as TIME(NANOS); internal storage is already nanos.
-        (row: SpecializedGetters, ordinal: Int) =>
-          recordConsumer.addLong(row.getLong(ordinal))
-
-      case _: TimeType =>
-        (row: SpecializedGetters, ordinal: Int) =>
-          recordConsumer.addLong(DateTimeUtils.nanosToMicros(row.getLong(ordinal)))
-
       case BinaryType =>
         (row: SpecializedGetters, ordinal: Int) =>
           recordConsumer.addBinary(Binary.fromReusedByteArray(row.getBinary(ordinal)))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removes three now-dead `TimeType` fallback arms in the Parquet code -- in `ParquetSchemaConverter.convertFieldDefault`, `ParquetWriteSupport.makeWriterDefault`, and `ParquetRowConverter.newConverterDefault`. Since `ParquetTypeOps.apply` returns `Some(TimeTypeParquetOps)` for `TimeType` unconditionally, the framework-first dispatch always intercepts `TimeType`, so these `...Default` arms are unreachable and `TimeTypeParquetOps` is the single source of truth. The reachable paths (the read-path `TIME` annotation -> `TimeType` mapping and the vectorized reader) are left untouched. See [SPARK-57582](https://issues.apache.org/jira/browse/SPARK-57582).

### Why are the changes needed?

Dead code: redundant with `TimeTypeParquetOps` and a maintenance hazard -- e.g. #56622 had to keep the removed arms' `MICROS`/`NANOS` logic in sync with the live op.

### Does this PR introduce _any_ user-facing change?

No. Pure dead-code removal; the framework path is the one that already executes.

### How was this patch tested?

`sql/core` compiles cleanly and `TimeTypeParquetOpsSuite` passes locally; the broader Parquet `TimeType` suites run in CI.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8 (claude-opus-4-8)
