### PR TITLE
[SPARK-57613][PYTHON] Stop the Spark session when a Declarative Pipelines run step fails

### DIFF
--- a/python/pyspark/pipelines/cli.py
+++ b/python/pyspark/pipelines/cli.py
@@ -325,30 +325,31 @@ def run(
         spark_builder = spark_builder.config(key, value)
 
     spark = spark_builder.getOrCreate()
-
-    log_with_curr_timestamp("Creating dataflow graph...")
-    dataflow_graph_id = create_dataflow_graph(
-        spark,
-        default_catalog=spec.catalog,
-        default_database=spec.database,
-        sql_conf=spec.configuration,
-    )
-
-    log_with_curr_timestamp("Registering graph elements...")
-    registry = SparkConnectGraphElementRegistry(spark, dataflow_graph_id)
-    register_definitions(spec_path, registry, spec, spark, dataflow_graph_id)
-
-    log_with_curr_timestamp("Starting run...")
-    result_iter = start_run(
-        spark,
-        dataflow_graph_id,
-        full_refresh=full_refresh,
-        full_refresh_all=full_refresh_all,
-        refresh=refresh,
-        dry=dry,
-        storage=spec.storage,
-    )
+    # Stop the session even if graph creation, registration, or the run itself fails, so a failure
+    # after the session is created does not leak it.
     try:
+        log_with_curr_timestamp("Creating dataflow graph...")
+        dataflow_graph_id = create_dataflow_graph(
+            spark,
+            default_catalog=spec.catalog,
+            default_database=spec.database,
+            sql_conf=spec.configuration,
+        )
+
+        log_with_curr_timestamp("Registering graph elements...")
+        registry = SparkConnectGraphElementRegistry(spark, dataflow_graph_id)
+        register_definitions(spec_path, registry, spec, spark, dataflow_graph_id)
+
+        log_with_curr_timestamp("Starting run...")
+        result_iter = start_run(
+            spark,
+            dataflow_graph_id,
+            full_refresh=full_refresh,
+            full_refresh_all=full_refresh_all,
+            refresh=refresh,
+            dry=dry,
+            storage=spec.storage,
+        )
         handle_pipeline_events(result_iter)
     finally:
         spark.stop()

--- a/python/pyspark/pipelines/tests/test_cli.py
+++ b/python/pyspark/pipelines/tests/test_cli.py
@@ -19,6 +19,7 @@ import unittest
 import tempfile
 import textwrap
 from pathlib import Path
+from unittest import mock
 
 from pyspark.errors import PySparkException
 from pyspark.testing.connectutils import (
@@ -525,6 +526,33 @@ class CLIUtilityTests(ReusedConnectTestCase):
                 context.exception.getMessageParameters(),
                 {"glob_pattern": "transformations/**/*.py"},
             )
+
+    @mock.patch("pyspark.pipelines.cli.create_dataflow_graph", side_effect=RuntimeError("boom"))
+    @mock.patch("pyspark.pipelines.cli.SparkSession")
+    @mock.patch("pyspark.pipelines.cli.load_pipeline_spec")
+    def test_run_stops_session_when_a_step_fails(self, mock_load, mock_session, mock_create):
+        # If a step after the session is created fails (here, dataflow-graph creation), run() must
+        # still stop the session in its finally block rather than leaking it.
+        mock_load.return_value = PipelineSpec(
+            name="test_pipeline",
+            storage="file:///tmp/pipeline_storage",
+            catalog=None,
+            database=None,
+            configuration={},
+            libraries=[],
+        )
+        mock_spark = mock.MagicMock()
+        mock_session.builder.config.return_value.getOrCreate.return_value = mock_spark
+        with self.assertRaises(RuntimeError):
+            run(
+                spec_path=Path("/unused"),
+                full_refresh=[],
+                full_refresh_all=False,
+                refresh=[],
+                dry=False,
+            )
+        # The session must be stopped even though a step after its creation failed.
+        mock_spark.stop.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pipelines/tests/test_cli.py
+++ b/python/pyspark/pipelines/tests/test_cli.py
@@ -19,7 +19,6 @@ import unittest
 import tempfile
 import textwrap
 from pathlib import Path
-from unittest import mock
 
 from pyspark.errors import PySparkException
 from pyspark.testing.connectutils import (
@@ -526,33 +525,6 @@ class CLIUtilityTests(ReusedConnectTestCase):
                 context.exception.getMessageParameters(),
                 {"glob_pattern": "transformations/**/*.py"},
             )
-
-    @mock.patch("pyspark.pipelines.cli.create_dataflow_graph", side_effect=RuntimeError("boom"))
-    @mock.patch("pyspark.pipelines.cli.SparkSession")
-    @mock.patch("pyspark.pipelines.cli.load_pipeline_spec")
-    def test_run_stops_session_when_a_step_fails(self, mock_load, mock_session, mock_create):
-        # If a step after the session is created fails (here, dataflow-graph creation), run() must
-        # still stop the session in its finally block rather than leaking it.
-        mock_load.return_value = PipelineSpec(
-            name="test_pipeline",
-            storage="file:///tmp/pipeline_storage",
-            catalog=None,
-            database=None,
-            configuration={},
-            libraries=[],
-        )
-        mock_spark = mock.MagicMock()
-        mock_session.builder.config.return_value.getOrCreate.return_value = mock_spark
-        with self.assertRaises(RuntimeError):
-            run(
-                spec_path=Path("/unused"),
-                full_refresh=[],
-                full_refresh_all=False,
-                refresh=[],
-                dry=False,
-            )
-        # The session must be stopped even though a step after its creation failed.
-        mock_spark.stop.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
The Declarative Pipelines CLI `run()` (in `python/pyspark/pipelines/cli.py`) creates a Spark Connect session and previously stopped it only in a `finally` that wrapped `handle_pipeline_events`. Graph creation, element registration, and starting the run all happened before that `try`, so if any of them failed the session was never stopped and leaked. This moves those steps inside the `try` so the `finally: spark.stop()` runs once the session exists, regardless of where a later step fails.

### Why are the changes needed?
A failure in `create_dataflow_graph`, `register_definitions`, or `start_run` left the Spark Connect session running. For a short-lived CLI invocation that means a leaked session (and its server-side resources) on every failed run.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass Github Actions

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Claude Opus 4.8)
