### PR TITLE
[SPARK-57614][WEBUI] Use CSP `frame-ancestors` instead of deprecated `X-Frame-Options: ALLOW-FROM`

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -151,10 +151,10 @@ private[spark] object UI {
 
   val UI_CONTENT_SECURITY_POLICY_FRAME_ANCESTORS_ENABLED =
     ConfigBuilder("spark.ui.contentSecurityPolicy.frameAncestors.enabled")
-      .doc("Whether to set the CSP frame-ancestors directive for clickjacking protection, " +
-        "even when the full CSP header (spark.ui.contentSecurityPolicy.enabled) is disabled. " +
-        "When enabled, the frame-ancestors directive is emitted to enforce the " +
-        "spark.ui.allowFramingFrom setting.")
+      .doc("Whether to include the frame-ancestors directive in the CSP header " +
+        "when spark.ui.contentSecurityPolicy.enabled is true. When enabled, the " +
+        "frame-ancestors directive enforces the spark.ui.allowFramingFrom setting. " +
+        "This setting is ignored when spark.ui.contentSecurityPolicy.enabled is false.")
       .version("4.2.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf

--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -151,10 +151,10 @@ private[spark] object UI {
 
   val UI_CONTENT_SECURITY_POLICY_FRAME_ANCESTORS_ENABLED =
     ConfigBuilder("spark.ui.contentSecurityPolicy.frameAncestors.enabled")
-      .doc("Whether to set the CSP frame-ancestors directive for clickjacking protection, " +
-        "even when the full CSP header (spark.ui.contentSecurityPolicy.enabled) is disabled. " +
-        "When enabled, the frame-ancestors directive is emitted to enforce the " +
-        "spark.ui.allowFramingFrom setting.")
+      .doc("Whether to include the frame-ancestors directive in the CSP header " +
+        "when spark.ui.contentSecurityPolicy.enabled is true. When enabled, the " +
+        "frame-ancestors directive enforces the spark.ui.allowFramingFrom setting. " +
+        "This setting is ignored when spark.ui.contentSecurityPolicy.enabled is false.")
       .version("4.3.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf

--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -151,11 +151,11 @@ private[spark] object UI {
 
   val UI_CONTENT_SECURITY_POLICY_FRAME_ANCESTORS_ENABLED =
     ConfigBuilder("spark.ui.contentSecurityPolicy.frameAncestors.enabled")
-      .doc("Whether to include the frame-ancestors directive in the CSP header " +
-        "when spark.ui.contentSecurityPolicy.enabled is true. When enabled, the " +
-        "frame-ancestors directive enforces the spark.ui.allowFramingFrom setting. " +
-        "This setting is ignored when spark.ui.contentSecurityPolicy.enabled is false.")
-      .version("4.2.0")
+      .doc("Whether to set the CSP frame-ancestors directive for clickjacking protection, " +
+        "even when the full CSP header (spark.ui.contentSecurityPolicy.enabled) is disabled. " +
+        "When enabled, the frame-ancestors directive is emitted to enforce the " +
+        "spark.ui.allowFramingFrom setting.")
+      .version("4.3.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .booleanConf
       .createWithDefault(true)

--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -149,6 +149,17 @@ private[spark] object UI {
       .booleanConf
       .createWithDefault(false)
 
+  val UI_CONTENT_SECURITY_POLICY_FRAME_ANCESTORS_ENABLED =
+    ConfigBuilder("spark.ui.contentSecurityPolicy.frameAncestors.enabled")
+      .doc("Whether to set the CSP frame-ancestors directive for clickjacking protection, " +
+        "even when the full CSP header (spark.ui.contentSecurityPolicy.enabled) is disabled. " +
+        "When enabled, the frame-ancestors directive is emitted to enforce the " +
+        "spark.ui.allowFramingFrom setting.")
+      .version("4.2.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .booleanConf
+      .createWithDefault(true)
+
   val UI_REQUEST_HEADER_SIZE = ConfigBuilder("spark.ui.requestHeaderSize")
     .doc("Value for HTTP request header size in bytes.")
     .version("2.2.3")

--- a/core/src/main/scala/org/apache/spark/ui/HttpSecurityFilter.scala
+++ b/core/src/main/scala/org/apache/spark/ui/HttpSecurityFilter.scala
@@ -51,30 +51,36 @@ private class HttpSecurityFilter(
 
     val cspNonce = CspNonce.generate()
     try {
-      // SPARK-10589 avoid frame-related click-jacking vulnerability.
-      // Use CSP frame-ancestors as the primary mechanism (supported by all modern browsers),
-      // with X-Frame-Options: SAMEORIGIN as a fallback for legacy clients.
-      // Note: X-Frame-Options ALLOW-FROM is deprecated and ignored by modern browsers
-      // (Chrome, Firefox, Edge, Safari), so frame-ancestors is used instead.
-      val frameAncestors = conf.get(UI_ALLOW_FRAMING_FROM)
-        .filterNot(v => v.equalsIgnoreCase("SAMEORIGIN") || v.equalsIgnoreCase("DENY"))
-        .map { uri =>
-          // Sanitize the URI: truncate at semicolons to prevent CSP directive injection,
-          // and strip newlines to prevent header injection.
-          val sanitized = uri.replaceAll("[\\r\\n]+", "").split(";", 2)(0).trim
-          s"frame-ancestors 'self' $sanitized"
-        }
-        .getOrElse("frame-ancestors 'self'")
+      val cspEnabled = conf.get(UI_CONTENT_SECURITY_POLICY_ENABLED)
+      val frameAncestorsEnabled = conf.get(UI_CONTENT_SECURITY_POLICY_FRAME_ANCESTORS_ENABLED)
 
-      if (conf.get(UI_CONTENT_SECURITY_POLICY_ENABLED)) {
-        hres.setHeader("Content-Security-Policy",
-          s"default-src 'self'; script-src 'self' 'nonce-$cspNonce'; " +
-          s"style-src 'self' 'unsafe-inline'; img-src 'self' data:; " +
-          s"object-src 'none'; base-uri 'self'; $frameAncestors;")
-      } else {
-        // Even when the full CSP is disabled, set frame-ancestors to enforce
-        // the allowFramingFrom setting in browsers that support CSP.
-        hres.setHeader("Content-Security-Policy", s"$frameAncestors;")
+      if (cspEnabled || frameAncestorsEnabled) {
+        // Use CSP frame-ancestors as the primary clickjacking protection mechanism.
+        // X-Frame-Options ALLOW-FROM is deprecated and ignored by modern browsers
+        // (Chrome, Firefox, Edge, Safari), so frame-ancestors is used instead.
+        val frameAncestors = conf.get(UI_ALLOW_FRAMING_FROM)
+          .filterNot(v => v.equalsIgnoreCase("SAMEORIGIN"))
+          .map { uri =>
+            if (uri.equalsIgnoreCase("DENY")) {
+              "frame-ancestors 'none'"
+            } else {
+              // Sanitize the URI: truncate at semicolons to prevent CSP directive injection,
+              // and strip newlines to prevent header injection.
+              val sanitized = uri.replaceAll("[\\r\\n]+", "").split(";", 2)(0).trim
+              if (sanitized.isEmpty) "frame-ancestors 'self'"
+              else s"frame-ancestors 'self' $sanitized"
+            }
+          }
+          .getOrElse("frame-ancestors 'self'")
+
+        if (cspEnabled) {
+          hres.setHeader("Content-Security-Policy",
+            s"default-src 'self'; script-src 'self' 'nonce-$cspNonce'; " +
+            s"style-src 'self' 'unsafe-inline'; img-src 'self' data:; " +
+            s"object-src 'none'; base-uri 'self'; $frameAncestors;")
+        } else {
+          hres.setHeader("Content-Security-Policy", s"$frameAncestors;")
+        }
       }
 
       // X-Frame-Options is set before access control so that even error responses

--- a/core/src/main/scala/org/apache/spark/ui/HttpSecurityFilter.scala
+++ b/core/src/main/scala/org/apache/spark/ui/HttpSecurityFilter.scala
@@ -51,36 +51,35 @@ private class HttpSecurityFilter(
 
     val cspNonce = CspNonce.generate()
     try {
-      val cspEnabled = conf.get(UI_CONTENT_SECURITY_POLICY_ENABLED)
-      val frameAncestorsEnabled = conf.get(UI_CONTENT_SECURITY_POLICY_FRAME_ANCESTORS_ENABLED)
-
-      if (cspEnabled || frameAncestorsEnabled) {
+      if (conf.get(UI_CONTENT_SECURITY_POLICY_ENABLED)) {
         // Use CSP frame-ancestors as the primary clickjacking protection mechanism.
         // X-Frame-Options ALLOW-FROM is deprecated and ignored by modern browsers
         // (Chrome, Firefox, Edge, Safari), so frame-ancestors is used instead.
-        val frameAncestors = conf.get(UI_ALLOW_FRAMING_FROM)
-          .filterNot(v => v.equalsIgnoreCase("SAMEORIGIN"))
-          .map { uri =>
-            if (uri.equalsIgnoreCase("DENY")) {
-              "frame-ancestors 'none'"
-            } else {
-              // Sanitize the URI: truncate at semicolons to prevent CSP directive injection,
-              // and strip newlines to prevent header injection.
-              val sanitized = uri.replaceAll("[\\r\\n]+", "").split(";", 2)(0).trim
-              if (sanitized.isEmpty) "frame-ancestors 'self'"
-              else s"frame-ancestors 'self' $sanitized"
-            }
+        val frameAncestorsDirective =
+          if (conf.get(UI_CONTENT_SECURITY_POLICY_FRAME_ANCESTORS_ENABLED)) {
+            val frameAncestors = conf.get(UI_ALLOW_FRAMING_FROM)
+              .filterNot(v => v.equalsIgnoreCase("SAMEORIGIN"))
+              .map { uri =>
+                if (uri.equalsIgnoreCase("DENY")) {
+                  "frame-ancestors 'none'"
+                } else {
+                  // Sanitize the URI: truncate at semicolons to prevent CSP directive
+                  // injection, and strip newlines to prevent header injection.
+                  val sanitized = uri.replaceAll("[\\r\\n]+", "").split(";", 2)(0).trim
+                  if (sanitized.isEmpty) "frame-ancestors 'self'"
+                  else s"frame-ancestors 'self' $sanitized"
+                }
+              }
+              .getOrElse("frame-ancestors 'self'")
+            s" $frameAncestors;"
+          } else {
+            ""
           }
-          .getOrElse("frame-ancestors 'self'")
 
-        if (cspEnabled) {
-          hres.setHeader("Content-Security-Policy",
-            s"default-src 'self'; script-src 'self' 'nonce-$cspNonce'; " +
-            s"style-src 'self' 'unsafe-inline'; img-src 'self' data:; " +
-            s"object-src 'none'; base-uri 'self'; $frameAncestors;")
-        } else {
-          hres.setHeader("Content-Security-Policy", s"$frameAncestors;")
-        }
+        hres.setHeader("Content-Security-Policy",
+          s"default-src 'self'; script-src 'self' 'nonce-$cspNonce'; " +
+          s"style-src 'self' 'unsafe-inline'; img-src 'self' data:; " +
+          s"object-src 'none'; base-uri 'self';$frameAncestorsDirective")
       }
 
       // X-Frame-Options is set before access control so that even error responses

--- a/core/src/main/scala/org/apache/spark/ui/HttpSecurityFilter.scala
+++ b/core/src/main/scala/org/apache/spark/ui/HttpSecurityFilter.scala
@@ -51,12 +51,35 @@ private class HttpSecurityFilter(
 
     val cspNonce = CspNonce.generate()
     try {
+      // SPARK-10589 avoid frame-related click-jacking vulnerability.
+      // Use CSP frame-ancestors as the primary mechanism (supported by all modern browsers),
+      // with X-Frame-Options: SAMEORIGIN as a fallback for legacy clients.
+      // Note: X-Frame-Options ALLOW-FROM is deprecated and ignored by modern browsers
+      // (Chrome, Firefox, Edge, Safari), so frame-ancestors is used instead.
+      val frameAncestors = conf.get(UI_ALLOW_FRAMING_FROM)
+        .filterNot(v => v.equalsIgnoreCase("SAMEORIGIN") || v.equalsIgnoreCase("DENY"))
+        .map { uri =>
+          // Sanitize the URI: truncate at semicolons to prevent CSP directive injection,
+          // and strip newlines to prevent header injection.
+          val sanitized = uri.replaceAll("[\\r\\n]+", "").split(";", 2)(0).trim
+          s"frame-ancestors 'self' $sanitized"
+        }
+        .getOrElse("frame-ancestors 'self'")
+
       if (conf.get(UI_CONTENT_SECURITY_POLICY_ENABLED)) {
         hres.setHeader("Content-Security-Policy",
           s"default-src 'self'; script-src 'self' 'nonce-$cspNonce'; " +
           s"style-src 'self' 'unsafe-inline'; img-src 'self' data:; " +
-          s"object-src 'none'; base-uri 'self';")
+          s"object-src 'none'; base-uri 'self'; $frameAncestors;")
+      } else {
+        // Even when the full CSP is disabled, set frame-ancestors to enforce
+        // the allowFramingFrom setting in browsers that support CSP.
+        hres.setHeader("Content-Security-Policy", s"$frameAncestors;")
       }
+
+      // X-Frame-Options is set before access control so that even error responses
+      // include clickjacking protection.
+      hres.setHeader("X-Frame-Options", "SAMEORIGIN")
 
       val requestUser = hreq.getRemoteUser()
 
@@ -79,15 +102,6 @@ private class HttpSecurityFilter(
         return
       }
 
-      // SPARK-10589 avoid frame-related click-jacking vulnerability, using X-Frame-Options
-      // (see http://tools.ietf.org/html/rfc7034). By default allow framing only from the
-      // same origin, but allow framing for a specific named URI.
-      // Example: spark.ui.allowFramingFrom = https://example.com/
-      val xFrameOptionsValue = conf.getOption("spark.ui.allowFramingFrom")
-        .map { uri => s"ALLOW-FROM $uri" }
-        .getOrElse("SAMEORIGIN")
-
-      hres.setHeader("X-Frame-Options", xFrameOptionsValue)
       hres.setHeader("X-XSS-Protection", conf.get(UI_X_XSS_PROTECTION))
       if (conf.get(UI_X_CONTENT_TYPE_OPTIONS)) {
         hres.setHeader("X-Content-Type-Options", "nosniff")

--- a/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
@@ -130,7 +130,7 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     val filter = new HttpSecurityFilter(conf, secMgr)
     filter.doFilter(req, res, chain)
 
-    // CSP header contains a dynamic nonce, so verify it matches the expected pattern
+    // CSP header contains a dynamic nonce and frame-ancestors with the configured URI
     val cspCaptor = ArgumentCaptor.forClass(classOf[String])
     verify(res).setHeader(meq("Content-Security-Policy"), cspCaptor.capture())
     val cspValue = cspCaptor.getValue
@@ -139,9 +139,12 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     assert(cspValue.contains("img-src 'self' data:"))
     assert(cspValue.contains("object-src 'none'"))
     assert(cspValue.contains("base-uri 'self'"))
+    assert(cspValue.contains("frame-ancestors 'self' example.com"))
 
+    // X-Frame-Options is always SAMEORIGIN as a fallback for legacy browsers.
+    // The allowFramingFrom config is honored via CSP frame-ancestors instead.
     Map(
-      "X-Frame-Options" -> "ALLOW-FROM example.com",
+      "X-Frame-Options" -> "SAMEORIGIN",
       "X-XSS-Protection" -> "xssProtection",
       "X-Content-Type-Options" -> "nosniff",
       "Strict-Transport-Security" -> "tsec"
@@ -150,7 +153,7 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     }
   }
 
-  test("Content-Security-Policy header is not set by default") {
+  test("Content-Security-Policy header has only frame-ancestors when CSP is disabled") {
     val conf = new SparkConf(false)
     val secMgr = new SecurityManager(conf)
     val req = mockRequest()
@@ -160,7 +163,10 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     val filter = new HttpSecurityFilter(conf, secMgr)
     filter.doFilter(req, res, chain)
 
-    verify(res, times(0)).setHeader(meq("Content-Security-Policy"), any())
+    // Even with CSP disabled, frame-ancestors should be set for clickjacking protection
+    val cspCaptor = ArgumentCaptor.forClass(classOf[String])
+    verify(res).setHeader(meq("Content-Security-Policy"), cspCaptor.capture())
+    assert(cspCaptor.getValue === "frame-ancestors 'self';")
   }
 
   test("X-XSS-Protection defaults to 0") {
@@ -278,6 +284,44 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
 
     // All nonces should be unique
     assert(nonces.distinct.size === 3)
+  }
+
+  test("allowFramingFrom value is sanitized to prevent CSP directive injection") {
+    val conf = new SparkConf(false)
+      .set(UI_ALLOW_FRAMING_FROM, "evil.com; script-src 'unsafe-inline'")
+    val secMgr = new SecurityManager(conf)
+    val req = mockRequest()
+    val res = mock(classOf[HttpServletResponse])
+    val chain = mock(classOf[FilterChain])
+
+    val filter = new HttpSecurityFilter(conf, secMgr)
+    filter.doFilter(req, res, chain)
+
+    val cspCaptor = ArgumentCaptor.forClass(classOf[String])
+    verify(res).setHeader(meq("Content-Security-Policy"), cspCaptor.capture())
+    val cspValue = cspCaptor.getValue
+    // Semicolons should be stripped, preventing directive injection
+    assert(!cspValue.contains("script-src 'unsafe-inline'"))
+    assert(cspValue.contains("frame-ancestors 'self' evil.com"))
+  }
+
+  test("X-Frame-Options is set even when access is denied") {
+    val conf = new SparkConf(false)
+      .set(ACLS_ENABLE, true)
+      .set(UI_VIEW_ACLS, Seq("alice"))
+    val secMgr = new SecurityManager(conf)
+    val req = mockRequest()
+    val res = mock(classOf[HttpServletResponse])
+    val chain = mock(classOf[FilterChain])
+
+    when(req.getRemoteUser()).thenReturn("unauthorized-user")
+    val filter = new HttpSecurityFilter(conf, secMgr)
+    filter.doFilter(req, res, chain)
+
+    // chain.doFilter should not have been called
+    verify(chain, times(0)).doFilter(any(), any())
+    // But X-Frame-Options should still be set
+    verify(res).setHeader(meq("X-Frame-Options"), meq("SAMEORIGIN"))
   }
 
   private def mockRequest(params: Map[String, Array[String]] = Map()): HttpServletRequest = {

--- a/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
@@ -153,7 +153,7 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     }
   }
 
-  test("Content-Security-Policy header has only frame-ancestors when CSP is disabled") {
+  test("frame-ancestors is set even when full CSP is disabled (frameAncestors enabled by default)") {
     val conf = new SparkConf(false)
     val secMgr = new SecurityManager(conf)
     val req = mockRequest()
@@ -163,7 +163,7 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     val filter = new HttpSecurityFilter(conf, secMgr)
     filter.doFilter(req, res, chain)
 
-    // Even with CSP disabled, frame-ancestors should be set for clickjacking protection
+    // frameAncestors.enabled defaults to true, so frame-ancestors CSP is emitted
     val cspCaptor = ArgumentCaptor.forClass(classOf[String])
     verify(res).setHeader(meq("Content-Security-Policy"), cspCaptor.capture())
     assert(cspCaptor.getValue === "frame-ancestors 'self';")
@@ -180,6 +180,20 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     filter.doFilter(req, res, chain)
 
     verify(res).setHeader(meq("X-XSS-Protection"), meq("0"))
+  }
+
+  test("no CSP header when both CSP and frameAncestors are disabled") {
+    val conf = new SparkConf(false)
+      .set(UI_CONTENT_SECURITY_POLICY_FRAME_ANCESTORS_ENABLED, false)
+    val secMgr = new SecurityManager(conf)
+    val req = mockRequest()
+    val res = mock(classOf[HttpServletResponse])
+    val chain = mock(classOf[FilterChain])
+
+    val filter = new HttpSecurityFilter(conf, secMgr)
+    filter.doFilter(req, res, chain)
+
+    verify(res, times(0)).setHeader(meq("Content-Security-Policy"), any())
   }
 
   test("doAs impersonation") {

--- a/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
@@ -180,19 +180,6 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     verify(res).setHeader(meq("X-XSS-Protection"), meq("0"))
   }
 
-  test("no CSP header when CSP is disabled regardless of frameAncestors setting") {
-    val conf = new SparkConf(false)
-    val secMgr = new SecurityManager(conf)
-    val req = mockRequest()
-    val res = mock(classOf[HttpServletResponse])
-    val chain = mock(classOf[FilterChain])
-
-    val filter = new HttpSecurityFilter(conf, secMgr)
-    filter.doFilter(req, res, chain)
-
-    verify(res, times(0)).setHeader(meq("Content-Security-Policy"), any())
-  }
-
   test("frame-ancestors is included in CSP when both CSP and frameAncestors are enabled") {
     val conf = new SparkConf(false)
       .set(UI_CONTENT_SECURITY_POLICY_ENABLED, true)

--- a/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
@@ -153,7 +153,7 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     }
   }
 
-  test("frame-ancestors is set even when full CSP is disabled (frameAncestors enabled by default)") {
+  test("frame-ancestors is set when full CSP is disabled but frameAncestors is enabled") {
     val conf = new SparkConf(false)
     val secMgr = new SecurityManager(conf)
     val req = mockRequest()

--- a/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/HttpSecurityFilterSuite.scala
@@ -153,7 +153,7 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     }
   }
 
-  test("frame-ancestors is set when full CSP is disabled but frameAncestors is enabled") {
+  test("no CSP header when CSP is disabled regardless of frameAncestors setting") {
     val conf = new SparkConf(false)
     val secMgr = new SecurityManager(conf)
     val req = mockRequest()
@@ -163,10 +163,8 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     val filter = new HttpSecurityFilter(conf, secMgr)
     filter.doFilter(req, res, chain)
 
-    // frameAncestors.enabled defaults to true, so frame-ancestors CSP is emitted
-    val cspCaptor = ArgumentCaptor.forClass(classOf[String])
-    verify(res).setHeader(meq("Content-Security-Policy"), cspCaptor.capture())
-    assert(cspCaptor.getValue === "frame-ancestors 'self';")
+    // CSP is disabled by default, so no CSP header should be emitted
+    verify(res, times(0)).setHeader(meq("Content-Security-Policy"), any())
   }
 
   test("X-XSS-Protection defaults to 0") {
@@ -182,9 +180,8 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     verify(res).setHeader(meq("X-XSS-Protection"), meq("0"))
   }
 
-  test("no CSP header when both CSP and frameAncestors are disabled") {
+  test("no CSP header when CSP is disabled regardless of frameAncestors setting") {
     val conf = new SparkConf(false)
-      .set(UI_CONTENT_SECURITY_POLICY_FRAME_ANCESTORS_ENABLED, false)
     val secMgr = new SecurityManager(conf)
     val req = mockRequest()
     val res = mock(classOf[HttpServletResponse])
@@ -194,6 +191,40 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     filter.doFilter(req, res, chain)
 
     verify(res, times(0)).setHeader(meq("Content-Security-Policy"), any())
+  }
+
+  test("frame-ancestors is included in CSP when both CSP and frameAncestors are enabled") {
+    val conf = new SparkConf(false)
+      .set(UI_CONTENT_SECURITY_POLICY_ENABLED, true)
+      .set(UI_ALLOW_FRAMING_FROM, "https://example.com")
+    val secMgr = new SecurityManager(conf)
+    val req = mockRequest()
+    val res = mock(classOf[HttpServletResponse])
+    val chain = mock(classOf[FilterChain])
+
+    val filter = new HttpSecurityFilter(conf, secMgr)
+    filter.doFilter(req, res, chain)
+
+    val cspCaptor = ArgumentCaptor.forClass(classOf[String])
+    verify(res).setHeader(meq("Content-Security-Policy"), cspCaptor.capture())
+    assert(cspCaptor.getValue.contains("frame-ancestors 'self' https://example.com"))
+  }
+
+  test("frame-ancestors is excluded from CSP when frameAncestors is disabled") {
+    val conf = new SparkConf(false)
+      .set(UI_CONTENT_SECURITY_POLICY_ENABLED, true)
+      .set(UI_CONTENT_SECURITY_POLICY_FRAME_ANCESTORS_ENABLED, false)
+    val secMgr = new SecurityManager(conf)
+    val req = mockRequest()
+    val res = mock(classOf[HttpServletResponse])
+    val chain = mock(classOf[FilterChain])
+
+    val filter = new HttpSecurityFilter(conf, secMgr)
+    filter.doFilter(req, res, chain)
+
+    val cspCaptor = ArgumentCaptor.forClass(classOf[String])
+    verify(res).setHeader(meq("Content-Security-Policy"), cspCaptor.capture())
+    assert(!cspCaptor.getValue.contains("frame-ancestors"))
   }
 
   test("doAs impersonation") {
@@ -303,6 +334,7 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
   test("allowFramingFrom value is sanitized to prevent CSP directive injection") {
     val conf = new SparkConf(false)
       .set(UI_ALLOW_FRAMING_FROM, "evil.com; script-src 'unsafe-inline'")
+      .set(UI_CONTENT_SECURITY_POLICY_ENABLED, true)
     val secMgr = new SecurityManager(conf)
     val req = mockRequest()
     val res = mock(classOf[HttpServletResponse])
@@ -336,6 +368,41 @@ class HttpSecurityFilterSuite extends SparkFunSuite {
     verify(chain, times(0)).doFilter(any(), any())
     // But X-Frame-Options should still be set
     verify(res).setHeader(meq("X-Frame-Options"), meq("SAMEORIGIN"))
+  }
+
+  test("allowFramingFrom=DENY maps to frame-ancestors 'none'") {
+    val conf = new SparkConf(false)
+      .set(UI_ALLOW_FRAMING_FROM, "DENY")
+      .set(UI_CONTENT_SECURITY_POLICY_ENABLED, true)
+    val secMgr = new SecurityManager(conf)
+    val req = mockRequest()
+    val res = mock(classOf[HttpServletResponse])
+    val chain = mock(classOf[FilterChain])
+
+    val filter = new HttpSecurityFilter(conf, secMgr)
+    filter.doFilter(req, res, chain)
+
+    val cspCaptor = ArgumentCaptor.forClass(classOf[String])
+    verify(res).setHeader(meq("Content-Security-Policy"), cspCaptor.capture())
+    assert(cspCaptor.getValue.contains("frame-ancestors 'none'"))
+  }
+
+  test("allowFramingFrom=SAMEORIGIN maps to frame-ancestors 'self'") {
+    val conf = new SparkConf(false)
+      .set(UI_ALLOW_FRAMING_FROM, "SAMEORIGIN")
+      .set(UI_CONTENT_SECURITY_POLICY_ENABLED, true)
+    val secMgr = new SecurityManager(conf)
+    val req = mockRequest()
+    val res = mock(classOf[HttpServletResponse])
+    val chain = mock(classOf[FilterChain])
+
+    val filter = new HttpSecurityFilter(conf, secMgr)
+    filter.doFilter(req, res, chain)
+
+    val cspCaptor = ArgumentCaptor.forClass(classOf[String])
+    verify(res).setHeader(meq("Content-Security-Policy"), cspCaptor.capture())
+    assert(cspCaptor.getValue.contains("frame-ancestors 'self'"))
+    assert(!cspCaptor.getValue.contains("SAMEORIGIN"))
   }
 
   private def mockRequest(params: Map[String, Array[String]] = Map()): HttpServletRequest = {

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -467,7 +467,7 @@ class UISuite extends SparkFunSuite {
     }
   }
 
-  test("SPARK-54563: Jetty sanitizes newlines in X-Frame-Options header") {
+  test("SPARK-54563: Jetty sanitizes newlines in CSP frame-ancestors header") {
     val valueWithNewlines = "example.com\nmalicious\nheader"
     val (conf, securityMgr, sslOptions) = sslDisabledConf()
     // Set the config value directly to bypass validation, simulating what could happen
@@ -482,16 +482,20 @@ class UISuite extends SparkFunSuite {
       val url = new URI(s"http://$localhost:${serverInfo.boundPort}/test/root").toURL
       TestUtils.withHttpConnection(url) { conn =>
         val xFrameOptions = conn.getHeaderField("X-Frame-Options")
-        // Jetty should sanitize newlines by replacing them with spaces
-        assert(xFrameOptions !== null, "X-Frame-Options header should be present")
-        assert(!xFrameOptions.contains("\n"),
-          "X-Frame-Options header should not contain newlines")
-        assert(!xFrameOptions.contains("\r"),
-          "X-Frame-Options header should not contain carriage returns")
-        // The header value should have newlines replaced with spaces
-        val expectedValue = "ALLOW-FROM " + valueWithNewlines.replaceAll("[\r\n]+", " ")
-        assert(xFrameOptions === expectedValue,
-          s"X-Frame-Options header should have newlines replaced with spaces")
+        // X-Frame-Options is always SAMEORIGIN as a legacy fallback
+        assert(xFrameOptions === "SAMEORIGIN",
+          "X-Frame-Options should always be SAMEORIGIN")
+
+        // The allowFramingFrom value is now in the CSP frame-ancestors directive.
+        // Jetty should sanitize newlines in the CSP header.
+        val csp = conn.getHeaderField("Content-Security-Policy")
+        assert(csp !== null, "Content-Security-Policy header should be present")
+        assert(csp.contains("frame-ancestors"),
+          "CSP should contain frame-ancestors directive")
+        assert(!csp.contains("\n"),
+          "CSP header should not contain newlines")
+        assert(!csp.contains("\r"),
+          "CSP header should not contain carriage returns")
       }
     } finally {
       stopServer(serverInfo)

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -473,6 +473,7 @@ class UISuite extends SparkFunSuite {
     // Set the config value directly to bypass validation, simulating what could happen
     // if someone bypasses the config validation (e.g., through direct property setting)
     conf.set("spark.ui.allowFramingFrom", valueWithNewlines)
+    conf.set("spark.ui.contentSecurityPolicy.enabled", "true")
 
     val serverInfo = JettyUtils.startJettyServer("0.0.0.0", 0, sslOptions, conf)
     try {

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -34,6 +34,8 @@ license: |
 
 ## Upgrading from Core 4.1 to 4.2
 
+- Since Spark 4.2, `spark.ui.allowFramingFrom` now uses CSP `frame-ancestors` instead of the deprecated `X-Frame-Options: ALLOW-FROM` (which was ignored by all modern browsers). This setting only takes effect when `spark.ui.contentSecurityPolicy.enabled=true`. When CSP is disabled (the default), `X-Frame-Options: SAMEORIGIN` is always used regardless of the `allowFramingFrom` value. To allow framing from a specific origin, set both `spark.ui.contentSecurityPolicy.enabled=true` and `spark.ui.allowFramingFrom=<uri>`.
+
 - Since Spark 4.2, Spark Master REST API uses Java 21 virtual threads by default when running on Java 21 or later. To restore the legacy behavior, you can set `spark.master.rest.virtualThread.enabled` to `false`.
 
 - Since Spark 4.2, Spark will allocate executor pods with a batch size of `20`. To restore the legacy behavior, you can set `spark.kubernetes.allocation.batch.size` to `10`.

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -32,9 +32,9 @@ license: |
 
 - Since Spark 4.3, the default value of `spark.ui.xXssProtection` has been changed from `1; mode=block` to `0`. The XSS Auditor has been removed from Chrome and Edge, and was never implemented in Firefox. It can introduce side-channel vulnerabilities in browsers that still support it (Safari). To restore the legacy behavior, you can set `spark.ui.xXssProtection` to `1; mode=block`. For modern XSS protection, consider enabling `spark.ui.contentSecurityPolicy.enabled`.
 
-## Upgrading from Core 4.1 to 4.2
+- Since Spark 4.3, `spark.ui.allowFramingFrom` now uses CSP `frame-ancestors` instead of the deprecated `X-Frame-Options: ALLOW-FROM` (which was ignored by all modern browsers). This setting only takes effect when `spark.ui.contentSecurityPolicy.enabled=true`. When CSP is disabled (the default), `X-Frame-Options: SAMEORIGIN` is always used regardless of the `allowFramingFrom` value. To allow framing from a specific origin, set both `spark.ui.contentSecurityPolicy.enabled=true` and `spark.ui.allowFramingFrom=<uri>`.
 
-- Since Spark 4.2, `spark.ui.allowFramingFrom` now uses CSP `frame-ancestors` instead of the deprecated `X-Frame-Options: ALLOW-FROM` (which was ignored by all modern browsers). This setting only takes effect when `spark.ui.contentSecurityPolicy.enabled=true`. When CSP is disabled (the default), `X-Frame-Options: SAMEORIGIN` is always used regardless of the `allowFramingFrom` value. To allow framing from a specific origin, set both `spark.ui.contentSecurityPolicy.enabled=true` and `spark.ui.allowFramingFrom=<uri>`.
+## Upgrading from Core 4.1 to 4.2
 
 - Since Spark 4.2, Spark Master REST API uses Java 21 virtual threads by default when running on Java 21 or later. To restore the legacy behavior, you can set `spark.master.rest.virtualThread.enabled` to `false`.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -348,13 +348,13 @@ The following options control the authentication of Web UIs:
 <tr>
   <td><code>spark.ui.allowFramingFrom</code></td>
   <td><code>SAMEORIGIN</code></td>
-  <td>Allow framing for a specific named URI via CSP <code>frame-ancestors</code> directive. By default, allow only from the same origin. Requires <code>spark.ui.contentSecurityPolicy.enabled=true</code> or <code>spark.ui.contentSecurityPolicy.frameAncestors.enabled=true</code> (the default) to take effect. The <code>X-Frame-Options</code> header is always set to <code>SAMEORIGIN</code> as a fallback for legacy browsers.</td>
+  <td>Allow framing for a specific named URI via CSP <code>frame-ancestors</code> directive. By default, allow only from the same origin. Requires <code>spark.ui.contentSecurityPolicy.enabled=true</code> to take effect. When CSP is disabled, <code>X-Frame-Options: SAMEORIGIN</code> is used regardless of this setting.</td>
   <td>1.6.0</td>
 </tr>
 <tr>
   <td><code>spark.ui.contentSecurityPolicy.frameAncestors.enabled</code></td>
   <td><code>true</code></td>
-  <td>Whether to set the CSP <code>frame-ancestors</code> directive for clickjacking protection, even when the full CSP header (<code>spark.ui.contentSecurityPolicy.enabled</code>) is disabled. When enabled, the <code>frame-ancestors</code> directive is emitted to enforce the <code>spark.ui.allowFramingFrom</code> setting.</td>
+  <td>Whether to include the <code>frame-ancestors</code> directive in the CSP header when <code>spark.ui.contentSecurityPolicy.enabled=true</code>. When enabled, the <code>frame-ancestors</code> directive enforces the <code>spark.ui.allowFramingFrom</code> setting. This setting is ignored when CSP is disabled.</td>
   <td>4.3.0</td>
 </tr>
 <tr>

--- a/docs/security.md
+++ b/docs/security.md
@@ -348,13 +348,13 @@ The following options control the authentication of Web UIs:
 <tr>
   <td><code>spark.ui.allowFramingFrom</code></td>
   <td><code>SAMEORIGIN</code></td>
-  <td>Allow framing for a specific named URI via CSP <code>frame-ancestors</code> directive. By default, allow only from the same origin. Requires <code>spark.ui.contentSecurityPolicy.enabled=true</code> or <code>spark.ui.contentSecurityPolicy.frameAncestors.enabled=true</code> (the default) to take effect. The <code>X-Frame-Options</code> header is always set to <code>SAMEORIGIN</code> as a fallback for legacy browsers.</td>
+  <td>Allow framing for a specific named URI via CSP <code>frame-ancestors</code> directive. By default, allow only from the same origin. Requires <code>spark.ui.contentSecurityPolicy.enabled=true</code> to take effect. When CSP is disabled, <code>X-Frame-Options: SAMEORIGIN</code> is used regardless of this setting.</td>
   <td>1.6.0</td>
 </tr>
 <tr>
   <td><code>spark.ui.contentSecurityPolicy.frameAncestors.enabled</code></td>
   <td><code>true</code></td>
-  <td>Whether to set the CSP <code>frame-ancestors</code> directive for clickjacking protection, even when the full CSP header (<code>spark.ui.contentSecurityPolicy.enabled</code>) is disabled. When enabled, the <code>frame-ancestors</code> directive is emitted to enforce the <code>spark.ui.allowFramingFrom</code> setting.</td>
+  <td>Whether to include the <code>frame-ancestors</code> directive in the CSP header when <code>spark.ui.contentSecurityPolicy.enabled=true</code>. When enabled, the <code>frame-ancestors</code> directive enforces the <code>spark.ui.allowFramingFrom</code> setting. This setting is ignored when CSP is disabled.</td>
   <td>4.2.0</td>
 </tr>
 <tr>

--- a/docs/security.md
+++ b/docs/security.md
@@ -348,14 +348,14 @@ The following options control the authentication of Web UIs:
 <tr>
   <td><code>spark.ui.allowFramingFrom</code></td>
   <td><code>SAMEORIGIN</code></td>
-  <td>Allow framing for a specific named URI via CSP <code>frame-ancestors</code> directive. By default, allow only from the same origin. Requires <code>spark.ui.contentSecurityPolicy.enabled=true</code> to take effect. When CSP is disabled, <code>X-Frame-Options: SAMEORIGIN</code> is used regardless of this setting.</td>
+  <td>Allow framing for a specific named URI via CSP <code>frame-ancestors</code> directive. By default, allow only from the same origin. Requires <code>spark.ui.contentSecurityPolicy.enabled=true</code> or <code>spark.ui.contentSecurityPolicy.frameAncestors.enabled=true</code> (the default) to take effect. The <code>X-Frame-Options</code> header is always set to <code>SAMEORIGIN</code> as a fallback for legacy browsers.</td>
   <td>1.6.0</td>
 </tr>
 <tr>
   <td><code>spark.ui.contentSecurityPolicy.frameAncestors.enabled</code></td>
   <td><code>true</code></td>
-  <td>Whether to include the <code>frame-ancestors</code> directive in the CSP header when <code>spark.ui.contentSecurityPolicy.enabled=true</code>. When enabled, the <code>frame-ancestors</code> directive enforces the <code>spark.ui.allowFramingFrom</code> setting. This setting is ignored when CSP is disabled.</td>
-  <td>4.2.0</td>
+  <td>Whether to set the CSP <code>frame-ancestors</code> directive for clickjacking protection, even when the full CSP header (<code>spark.ui.contentSecurityPolicy.enabled</code>) is disabled. When enabled, the <code>frame-ancestors</code> directive is emitted to enforce the <code>spark.ui.allowFramingFrom</code> setting.</td>
+  <td>4.3.0</td>
 </tr>
 <tr>
   <td><code>spark.ui.filters</code></td>

--- a/docs/security.md
+++ b/docs/security.md
@@ -348,7 +348,7 @@ The following options control the authentication of Web UIs:
 <tr>
   <td><code>spark.ui.allowFramingFrom</code></td>
   <td><code>SAMEORIGIN</code></td>
-  <td>Allow framing for a specific named URI via <code>X-Frame-Options</code>. By default, allow only from the same origin.</td>
+  <td>Allow framing for a specific named URI via CSP <code>frame-ancestors</code> directive. By default, allow only from the same origin. The <code>X-Frame-Options</code> header is always set to <code>SAMEORIGIN</code> as a fallback for legacy browsers.</td>
   <td>1.6.0</td>
 </tr>
 <tr>

--- a/docs/security.md
+++ b/docs/security.md
@@ -348,8 +348,14 @@ The following options control the authentication of Web UIs:
 <tr>
   <td><code>spark.ui.allowFramingFrom</code></td>
   <td><code>SAMEORIGIN</code></td>
-  <td>Allow framing for a specific named URI via CSP <code>frame-ancestors</code> directive. By default, allow only from the same origin. The <code>X-Frame-Options</code> header is always set to <code>SAMEORIGIN</code> as a fallback for legacy browsers.</td>
+  <td>Allow framing for a specific named URI via CSP <code>frame-ancestors</code> directive. By default, allow only from the same origin. Requires <code>spark.ui.contentSecurityPolicy.enabled=true</code> or <code>spark.ui.contentSecurityPolicy.frameAncestors.enabled=true</code> (the default) to take effect. The <code>X-Frame-Options</code> header is always set to <code>SAMEORIGIN</code> as a fallback for legacy browsers.</td>
   <td>1.6.0</td>
+</tr>
+<tr>
+  <td><code>spark.ui.contentSecurityPolicy.frameAncestors.enabled</code></td>
+  <td><code>true</code></td>
+  <td>Whether to set the CSP <code>frame-ancestors</code> directive for clickjacking protection, even when the full CSP header (<code>spark.ui.contentSecurityPolicy.enabled</code>) is disabled. When enabled, the <code>frame-ancestors</code> directive is emitted to enforce the <code>spark.ui.allowFramingFrom</code> setting.</td>
+  <td>4.2.0</td>
 </tr>
 <tr>
   <td><code>spark.ui.filters</code></td>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the `spark.ui.allowFramingFrom` configuration to use CSP `frame-ancestors` directive instead of the deprecated `X-Frame-Options: ALLOW-FROM`.

According to [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options#allow-from_origin):

> **`ALLOW-FROM origin`** — This is an obsolete directive. Modern browsers that encounter response headers with this direc
tive will ignore the header completely. The `Content-Security-Policy` HTTP header has a `frame-ancestors` directive which 
you should use instead.

The fix:
* When `spark.ui.contentSecurityPolicy.enabled=true`, uses CSP `frame-ancestors 'self' <uri>` to enforce the `allowFramingFrom` setting
* Adds `spark.ui.contentSecurityPolicy.frameAncestors.enabled` (default `true`) as a sub-config to control whether `frame-ancestors` is included in the CSP header. Can be set to `false` as a fallback if `frame-ancestors` causes issues
* When CSP is disabled (the default), no CSP header is emitted and `X-Frame-Options: SAMEORIGIN` is used
* Sanitizes the config value to prevent CSP directive injection via semicolons or newlines
* Moves `X-Frame-Options: SAMEORIGIN` header before access control checks so that even 403 error responses include clickjacking protection

### Why are the changes needed?
The `spark.ui.allowFramingFrom` config has been non-functional in all modern browsers since `ALLOW-FROM` was obsoleted. Users relying on this setting for embedding Spark UI in iframes from specific origins have no working clickjacking protection. CSP `frame-ancestors` is the W3C-recommended replacement.

### Does this PR introduce _any_ user-facing change?
Yes.

* `spark.ui.allowFramingFrom` now works correctly when CSP is enabled, via `frame-ancestors`
* `spark.ui.allowFramingFrom` requires `spark.ui.contentSecurityPolicy.enabled=true` to take effect. When CSP is disabled, `X-Frame-Options: SAMEORIGIN` is always used regardless of the `allowFramingFrom` value
* New config `spark.ui.contentSecurityPolicy.frameAncestors.enabled` (default `true`) controls whether `frame-ancestors` is included in the CSP header
* `X-Frame-Options` header is always `SAMEORIGIN` (previously it was `ALLOW-FROM <uri>` which browsers ignored)
* Migration guide updated

### How was this patch tested?

* Unit tests in `HttpSecurityFilterSuite` verify:
  * CSP `frame-ancestors` contains the configured URI when CSP is enabled
  * No CSP header when CSP is disabled
  * `frame-ancestors` excluded when `frameAncestors.enabled=false`
  * `DENY` maps to `frame-ancestors 'none'`
  * `SAMEORIGIN` maps to `frame-ancestors 'self'`
  * CSP directive injection prevention via semicolons
  * `X-Frame-Options: SAMEORIGIN` is always set, even on 403 responses
* Integration test in `UISuite` verifies Jetty sanitizes newlines in the CSP header

### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Claude