### PR TITLE
[SPARK-57594][SDP] Add spark_confs support to create_auto_cdc_flow

### DIFF
--- a/python/pyspark/pipelines/api.py
+++ b/python/pyspark/pipelines/api.py
@@ -541,6 +541,7 @@ def create_auto_cdc_flow(
     *,
     track_history_column_list: Optional[Union[List[str], List[Column]]] = None,
     track_history_except_column_list: Optional[Union[List[str], List[Column]]] = None,
+    spark_conf: Optional[Dict[str, str]] = None,
 ) -> None:
     """
     Create an Auto CDC flow into the target table from the Change Data Capture (CDC) source.
@@ -600,6 +601,9 @@ def create_auto_cdc_flow(
         to be 2.
     :param name: The name of the flow for this create_auto_cdc_flow command. When unspecified, \
         this will build a "default flow" with name equal to the target name.
+    :param spark_conf: A dict whose keys are the conf names and values are the conf values. \
+        These confs will be set when the flow is executed; they can override confs set for the \
+        destination, for the pipeline, or on the cluster.
     """
     # Lazy import: pyspark.sql.connect.functions.builtin transitively imports grpc, which is
     # not available in the docs-build environment. pyspark.pipelines.api is loaded eagerly
@@ -736,6 +740,7 @@ def create_auto_cdc_flow(
         stored_as_scd_type=stored_as_scd_type,
         track_history_column_list=track_history_column_list,
         track_history_except_column_list=track_history_except_column_list,
+        spark_conf=spark_conf or {},
         source_code_location=source_code_location,
     )
 

--- a/python/pyspark/pipelines/flow.py
+++ b/python/pyspark/pipelines/flow.py
@@ -65,6 +65,8 @@ class AutoCdcFlow:
         history record.
     :param track_history_except_column_list: Optional SCD2-only columns excluded from history \
         tracking.
+    :param spark_conf: A dict where the keys are the Spark configuration property names and the
+        values are the property values. These properties will be set on the flow.
     :param source_code_location: The location of the source code that created this flow.
     """
 
@@ -79,4 +81,5 @@ class AutoCdcFlow:
     stored_as_scd_type: Optional[Literal[1, 2, "1", "2"]]
     track_history_column_list: Optional[List[Column]]
     track_history_except_column_list: Optional[List[Column]]
+    spark_conf: Dict[str, str]
     source_code_location: SourceCodeLocation

--- a/python/pyspark/pipelines/spark_connect_graph_element_registry.py
+++ b/python/pyspark/pipelines/spark_connect_graph_element_registry.py
@@ -165,7 +165,7 @@ class SparkConnectGraphElementRegistry(GraphElementRegistry):
             flow_name=flow.name,
             target_dataset_name=flow.target,
             auto_cdc_flow_details=auto_cdc_details,
-            sql_conf={},
+            sql_conf=flow.spark_conf,
             source_code_location=source_code_location_to_proto(flow.source_code_location),
         )
 

--- a/python/pyspark/pipelines/tests/test_auto_cdc_flow.py
+++ b/python/pyspark/pipelines/tests/test_auto_cdc_flow.py
@@ -72,11 +72,27 @@ class AutoCdcFlowConstructionTest(unittest.TestCase):
                 column_list=[col("id"), col("val")],
                 stored_as_scd_type=1,
                 name="my_flow",
+                spark_conf={"spark.sql.shuffle.partitions": "8"},
             )
 
         flow = cast(AutoCdcFlow, registry.auto_cdc_flows[0])
         self.assertEqual(flow.name, "my_flow")
         self.assertEqual(flow.stored_as_scd_type, 1)
+        self.assertEqual(flow.spark_conf, {"spark.sql.shuffle.partitions": "8"})
+
+    def test_create_auto_cdc_flow_spark_conf_defaults_to_empty(self):
+        registry = LocalGraphElementRegistry()
+        with graph_element_registration_context(registry):
+            dp.create_streaming_table("target")
+            dp.create_auto_cdc_flow(
+                target="target",
+                source="source",
+                keys=[col("key")],
+                sequence_by=expr("seq"),
+            )
+
+        flow = cast(AutoCdcFlow, registry.auto_cdc_flows[0])
+        self.assertEqual(flow.spark_conf, {})
 
     def test_create_auto_cdc_flow_with_string_args(self):
         # Verify that string forms of column / expression arguments are normalized to

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/pipelines/PythonPipelineSuite.scala
@@ -1103,6 +1103,26 @@ class PythonPipelineSuite
     assert(flow.destinationIdentifier == graphIdentifier("target"))
   }
 
+  test("AutoCDC API: spark_conf is forwarded to the flow's sqlConf") {
+    val flow = buildAutoCdcFlow("""
+        |@dp.table
+        |def src():
+        |  return spark.readStream.format("rate").load()
+        |
+        |dp.create_streaming_table("target")
+        |
+        |dp.create_auto_cdc_flow(
+        |    target = "target",
+        |    source = "src",
+        |    keys = ["value"],
+        |    sequence_by = "timestamp",
+        |    spark_conf = {"spark.sql.shuffle.partitions": "8"},
+        |)
+        |""".stripMargin)
+
+    assert(flow.sqlConf == Map("spark.sql.shuffle.partitions" -> "8"))
+  }
+
   test("AutoCDC API: multi-part `keys` column is rejected at flow registration") {
     val ex = intercept[RuntimeException] {
       buildAutoCdcFlow("""


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Wires per-flow Spark configuration through to AutoCDC flows on the OSS Spark Connect pipelines path, matching the behavior already supported by regular (relation) flows.

- `python/pyspark/pipelines/flow.py`: add `spark_conf: Dict[str, str]` field to the `AutoCdcFlow` dataclass.
- `python/pyspark/pipelines/api.py`: add `spark_conf: Optional[Dict[str, str]] = None` kwarg (last param, backwards-compatible) to `create_auto_cdc_flow` and thread it into the `AutoCdcFlow` constructor with `spark_conf or {}`.
- `python/pyspark/pipelines/spark_connect_graph_element_registry.py`: in `register_auto_cdc_flow`, replace the hard-coded `sql_conf={}` on the outgoing `DefineFlow` proto with `sql_conf=flow.spark_conf`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`pyspark.pipelines.create_auto_cdc_flow` is the only flow-defining API in the `pyspark.pipelines` surface that does not accept a `spark_conf` keyword. The peer APIs all do:

- `append_flow(spark_conf=...)`
- `@table(spark_conf=...)`
- `@materialized_view(spark_conf=...)`
- `@temporary_view(spark_conf=...)`

The `DefineFlow.sql_conf` proto field already exists and is shared by all flow variants, and the Scala server already reads it into `AutoCdcFlow.sqlConf` for use by `FlowAnalysis`. The Python client simply was not populating the field for AutoCDC flows (the registry hard-coded `sql_conf={}`).
Without this kwarg, users of `create_auto_cdc_flow` have no way to apply per-flow Spark configurations. They are forced to set the conf at the pipeline or cluster scope, which then applies to every flow in the pipeline.
This change closes the gap so AutoCDC flows have the same conf-scoping precedence as the other operators: **flow > destination > pipeline > cluster**.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
AFFECTED VERSIONS: master

`pyspark.pipelines.create_auto_cdc_flow` previously had no way to set per-flow Spark configurations, unlike `append_flow` / `@table` / `@materialized_view`. This adds a `spark_conf` keyword argument so users can override session/cluster confs per AutoCDC flow at execution time.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
- Extended `test_create_auto_cdc_flow_with_all_args` to assert `spark_conf` propagates onto the registered flow.
- Added `test_create_auto_cdc_flow_spark_conf_defaults_to_empty` to verify the default is `{}` when the kwarg is omitted.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude
