### PR TITLE
[SPARK-57620][CORE] Remove redundant S3A Vectored IO Hadoop configurations

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -423,10 +423,6 @@ class SparkContext(config: SparkConf) extends Logging {
     if (!_conf.contains("spark.app.name")) {
       throw new SparkException("An application name must be set in your configuration")
     }
-    // HADOOP-19229 Vector IO on cloud storage: increase threshold for range merging
-    // We can remove this after Apache Hadoop 3.4.2 releases
-    conf.setIfMissing("spark.hadoop.fs.s3a.vectored.read.min.seek.size", "128K")
-    conf.setIfMissing("spark.hadoop.fs.s3a.vectored.read.max.merged.size", "2M")
     // This should be set as early as possible.
     SparkContext.enableMagicCommitterIfNeeded(_conf)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove redundant `S3A Vectored IO` Hadoop configurations from Apache Spark 4.3.0.

### Why are the changes needed?

Apache Spark 4.0.0 added these Hadoop configurations to aline with Apache Hadoop 3.4.2. 
- https://github.com/apache/spark/pull/49748

Since Apache Spark 4.1.0, this is not required because we are using the latest Hadoop.
- #51127 (Apache Spark 4.1.0)
- #54448 (Apache Spark 4.2.0)

### Does this PR introduce _any_ user-facing change?

No behavior change because we used the default value of Apache Hadoop 3.4.2+

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.