### PR TITLE
[SPARK-57621][INFRA][3.5] Make branch-3.5 scheduled build workflows self-contained

### DIFF
--- a/.github/workflows/build_python_3.9.yml
+++ b/.github/workflows/build_python_3.9.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Python-only"
+name: "Build / Python-only (Python 3.9)"
 
 on:
   workflow_dispatch:
@@ -32,11 +32,6 @@ jobs:
     with:
       java: 8
       hadoop: hadoop3
-      envs: >-
-        {
-          "PYSPARK_IMAGE_TO_TEST": "",
-          "PYTHON_TO_TEST": ""
-        }
       jobs: >-
         {
           "pyspark": "true",

--- a/.github/workflows/build_python_3.9.yml
+++ b/.github/workflows/build_python_3.9.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Scala 2.13 (Hadoop 3, JDK 8)"
+name: "Build / Python-only"
 
 on:
   workflow_dispatch:
@@ -34,17 +34,11 @@ jobs:
       hadoop: hadoop3
       envs: >-
         {
-          "SCALA_PROFILE": "scala2.13",
           "PYSPARK_IMAGE_TO_TEST": "",
-          "PYTHON_TO_TEST": "",
-          "ORACLE_DOCKER_IMAGE_NAME": "gvenzl/oracle-xe:21.3.0"
+          "PYTHON_TO_TEST": ""
         }
       jobs: >-
         {
-          "build": "true",
-          "sparkr": "true",
-          "tpcds-1g": "true",
-          "docker-integration-tests": "true",
-          "k8s-integration-tests": "true",
-          "lint" : "true"
+          "pyspark": "true",
+          "pyspark-pandas": "true"
         }

--- a/.github/workflows/build_scala213.yml
+++ b/.github/workflows/build_scala213.yml
@@ -35,8 +35,6 @@ jobs:
       envs: >-
         {
           "SCALA_PROFILE": "scala2.13",
-          "PYSPARK_IMAGE_TO_TEST": "",
-          "PYTHON_TO_TEST": "",
           "ORACLE_DOCKER_IMAGE_NAME": "gvenzl/oracle-xe:21.3.0"
         }
       jobs: >-
@@ -46,5 +44,5 @@ jobs:
           "tpcds-1g": "true",
           "docker-integration-tests": "true",
           "k8s-integration-tests": "true",
-          "lint" : "true"
+          "lint": "true"
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes the `branch-3.5` scheduled build workflow files self-contained, following the same approach as the `branch-4.0` work (SPARK-57398) and the `branch-4.1` / `branch-4.x` efforts:

- Rewrites `build_scala213.yml` so it is triggered by `workflow_dispatch` only (the dormant `schedule:` trigger is removed; scheduled runs on a non-default branch never fire anyway), drops the inherited `branch: master` (so it builds `branch-3.5`), and uses a generic, non-branch-tagged name.
- Adds `build_python_3.9.yml`, the equivalent of `build_branch35_python.yml`.

The per-build configurations are relocated from the active `build_branch35*.yml` files on `master` so the coverage matches what `branch-3.5` schedules today.

Notes:
- `build_and_test.yml` on `branch-3.5` already defaults `branch` to `branch-3.5`, so the callers omit `branch`.
- Unlike `branch-4.0`, `branch-3.5` runs Python directly on the runner (`python3.9`) rather than via container images, so `PYSPARK_IMAGE_TO_TEST` / `PYTHON_TO_TEST` are left empty (matching every existing `branch-3.5` workflow).

### Why are the changes needed?

This is the `branch-3.5` side of decoupling our scheduled CIs (cf. the `branch-4.x`, `branch-4.1`, and `branch-4.0` efforts). Scheduled workflows only fire from the default branch, so `branch-3.5` CI should consist of self-contained, dispatchable workflow files on `branch-3.5` that a single scheduler on `master` can trigger. This PR prepares those targets; a follow-up on `master` will add the scheduler and remove the `build_branch35*.yml` files.

### Does this PR introduce _any_ user-facing change?

No. CI only.

### How was this patch tested?

These workflows can be triggered manually via `workflow_dispatch` once merged.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)

This pull request and its description were written by Isaac.