### PR TITLE
[SPARK-57623][SDP] Drop AutoCDC `requireDestinationSupportsRowLevelOps` Check

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -308,12 +308,6 @@
     ],
     "sqlState" : "0A000"
   },
-  "AUTOCDC_TARGET_DOES_NOT_SUPPORT_MERGE" : {
-    "message" : [
-      "Cannot start AutoCDC flow: the target table <tableName> (format: <format>) does not support row-level operations. AutoCDC requires a target backed by a connector that supports MERGE."
-    ],
-    "sqlState" : "0A000"
-  },
   "AVRO_CANNOT_WRITE_NULL_FIELD" : {
     "message" : [
       "Cannot write null value for field <name> defined as non-null Avro data type <dataType>.",

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -310,7 +310,7 @@
   },
   "AUTOCDC_TARGET_DOES_NOT_SUPPORT_MERGE" : {
     "message" : [
-      "Cannot execute AutoCDC flow: the target table <tableName> does not support row-level operations. AutoCDC requires a target backed by a connector that supports MERGE."
+      "Cannot execute AutoCDC flow: the target table <tableName> is backed by a connector that cannot execute MERGE. AutoCDC applies changes via MERGE, so it requires a target whose connector supports it."
     ],
     "sqlState" : "0A000"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -308,6 +308,12 @@
     ],
     "sqlState" : "0A000"
   },
+  "AUTOCDC_TARGET_DOES_NOT_SUPPORT_MERGE" : {
+    "message" : [
+      "Cannot execute AutoCDC flow: the target table <tableName> does not support row-level operations. AutoCDC requires a target backed by a connector that supports MERGE."
+    ],
+    "sqlState" : "0A000"
+  },
   "AVRO_CANNOT_WRITE_NULL_FIELD" : {
     "message" : [
       "Cannot write null value for field <name> defined as non-null Avro data type <dataType>.",

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/Scd1ForeachBatchHandler.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/Scd1ForeachBatchHandler.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.pipelines.autocdc
 
+import org.apache.spark.SparkUnsupportedOperationException
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.classic.DataFrame
 
@@ -55,19 +57,43 @@ case class Scd1ForeachBatchHandler(
       )
     )
 
-    batchProcessor.mergeMicrobatchOntoAuxiliaryTable(
-      reconciledMicrobatchDf = reconciledMicrobatch,
-      auxiliaryTableIdentifier = auxiliaryTableIdentifier
-    )
+    // Both merges run through [[rewrapTargetMergeUnsupported]] so that a MERGE-incapable target
+    // surfaces as a user-facing AutoCDC error naming the declared target, rather than leaking the
+    // raw planner failure that names the internal auxiliary table (merged first, below).
+    rewrapTargetMergeUnsupported {
+      batchProcessor.mergeMicrobatchOntoAuxiliaryTable(
+        reconciledMicrobatchDf = reconciledMicrobatch,
+        auxiliaryTableIdentifier = auxiliaryTableIdentifier
+      )
 
-    // Failure between these two merges is safe under foreachBatch retry: the aux merge
-    // only ever mutates a tombstone when this batch's event makes it stale (strictly newer
-    // delete advances it) or redundant (`>=` upsert revives the key, GC'ing the tombstone),
-    // so on retry those preconditions no longer hold against the just-advanced aux state -
-    // the aux merge is a no-op and the target merge replays as if for the first time.
-    batchProcessor.mergeMicrobatchOntoTarget(
-      reconciledMicrobatchDf = reconciledMicrobatch,
-      targetTableIdentifier = targetTableIdentifier
-    )
+      // Failure between these two merges is safe under foreachBatch retry: the aux merge
+      // only ever mutates a tombstone when this batch's event makes it stale (strictly newer
+      // delete advances it) or redundant (`>=` upsert revives the key, GC'ing the tombstone),
+      // so on retry those preconditions no longer hold against the just-advanced aux state -
+      // the aux merge is a no-op and the target merge replays as if for the first time.
+      batchProcessor.mergeMicrobatchOntoTarget(
+        reconciledMicrobatchDf = reconciledMicrobatch,
+        targetTableIdentifier = targetTableIdentifier
+      )
+    }
+  }
+
+  /**
+   * Re-wrap the planner's MERGE-unsupported failure so it names the user's declared target rather
+   * than the internal auxiliary table that happens to be merged first. By construction the
+   * auxiliary table must be using the same table format and catalog as the target table.
+   */
+  private def rewrapTargetMergeUnsupported[T](block: => T): T = {
+    try block
+    catch {
+      case e: SparkUnsupportedOperationException
+          if e.getCondition == "UNSUPPORTED_FEATURE.TABLE_OPERATION" &&
+            e.getMessageParameters.get("operation") == "MERGE INTO TABLE" =>
+        throw new AnalysisException(
+          errorClass = "AUTOCDC_TARGET_DOES_NOT_SUPPORT_MERGE",
+          messageParameters = Map("tableName" -> targetTableIdentifier.quotedString),
+          cause = Option(e)
+        )
+    }
   }
 }

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/Scd1ForeachBatchHandler.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/autocdc/Scd1ForeachBatchHandler.scala
@@ -57,9 +57,6 @@ case class Scd1ForeachBatchHandler(
       )
     )
 
-    // Both merges run through [[rewrapTargetMergeUnsupported]] so that a MERGE-incapable target
-    // surfaces as a user-facing AutoCDC error naming the declared target, rather than leaking the
-    // raw planner failure that names the internal auxiliary table (merged first, below).
     rewrapTargetMergeUnsupported {
       batchProcessor.mergeMicrobatchOntoAuxiliaryTable(
         reconciledMicrobatchDf = reconciledMicrobatch,
@@ -79,9 +76,10 @@ case class Scd1ForeachBatchHandler(
   }
 
   /**
-   * Re-wrap the planner's MERGE-unsupported failure so it names the user's declared target rather
-   * than the internal auxiliary table that happens to be merged first. By construction the
-   * auxiliary table must be using the same table format and catalog as the target table.
+   * Run `block` and re-wrap a "MERGE not supported" planner failure into an AutoCDC error that
+   * names the user's declared target. AutoCDC's MERGEs (against both the target and its auxiliary
+   * table) all require the target's format/connector to support MERGE, so this surfaces a single,
+   * user-actionable error.
    */
   private def rewrapTargetMergeUnsupported[T](block: => T): T = {
     try block

--- a/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/FlowExecution.scala
+++ b/sql/pipelines/src/main/scala/org/apache/spark/sql/pipelines/graph/FlowExecution.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.{AnalysisException, Dataset, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.classic.ClassicConversions._
 import org.apache.spark.sql.classic.SparkSession
-import org.apache.spark.sql.connector.catalog.{CatalogV2Util, SupportsRowLevelOperations, Table => CatalogTable, TableCatalog, TableInfo}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Table => CatalogTable, TableCatalog, TableInfo}
 import org.apache.spark.sql.pipelines.autocdc.{
   AutoCdcReservedNames,
   ChangeArgs,
@@ -471,32 +471,6 @@ trait AutoCdcMergeWriteBase {
   private lazy val auxiliaryKeyColumnNames: Seq[String] = expectedAuxiliaryKeyFields.map(_.name)
 
   /**
-   * Validate that the target table's underlying connector implements
-   * [[SupportsRowLevelOperations]], which is the V2 connector contract for MERGE/UPDATE/DELETE
-   * with rewrite - all operations that the AutoCDC transformation executes.
-   */
-  protected def requireDestinationSupportsRowLevelOps(): Unit = {
-    val (catalog, v2Identifier) =
-      PipelinesCatalogUtils.resolveTableCatalog(spark, destination.identifier)
-    val destinationTable = catalog.loadTable(v2Identifier)
-
-    if (!destinationTable.isInstanceOf[SupportsRowLevelOperations]) {
-      throw new AnalysisException(
-        errorClass = "AUTOCDC_TARGET_DOES_NOT_SUPPORT_MERGE",
-        messageParameters = Map(
-          "tableName" -> destination.identifier.quotedString,
-          "format" -> destination.format.orElse(
-              Option(
-                destinationTable.properties.get(TableCatalog.PROP_PROVIDER)
-              )
-            )
-            .getOrElse("<unknown>")
-        )
-      )
-    }
-  }
-
-  /**
    * If the auxiliary table for this flow's destination already exists, validate that the
    * AutoCDC keys the flow expects line up with the keys recorded in the auxiliary
    * table. On a fresh pipeline (or after a full refresh dropped the auxiliary), the
@@ -620,7 +594,6 @@ class Scd1MergeStreamingWrite(
     val sqlConf: Map[String, String]
 ) extends StreamingFlowExecution with AutoCdcMergeWriteBase {
 
-  requireDestinationSupportsRowLevelOps()
   validateNoAutoCdcKeyDriftIfAuxTableExists()
 
   override def getOrigin: QueryOrigin = flow.origin

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd1SinglePipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd1SinglePipelineSuite.scala
@@ -168,7 +168,7 @@ class AutoCdcScd1SinglePipelineSuite
   }
 
   test("an AutoCDC flow whose target connector does not support MERGE fails during " +
-    "flow execution") {
+    "flow execution with AUTOCDC_TARGET_DOES_NOT_SUPPORT_MERGE") {
     val session = spark
     import session.implicits._
 
@@ -205,20 +205,15 @@ class AutoCdcScd1SinglePipelineSuite
       ))
     }
 
-    // The auxiliary-table MERGE runs before the target-table MERGE, so the auxiliary table is the
-    // one named in the connector's MERGE-unsupported failure.
-    val auxIdent = AutoCdcAuxiliaryTable.identifier(
-      TableIdentifier("target_no_merge", Some(database), Some(catalog))
-    )
+    val targetIdent = TableIdentifier("target_no_merge", Some(database), Some(catalog))
 
     val ex = intercept[RuntimeException] { runPipeline(ctx) }
     checkErrorInPipelineFailure(
       failure = ex,
-      condition = "UNSUPPORTED_FEATURE.TABLE_OPERATION",
+      condition = "AUTOCDC_TARGET_DOES_NOT_SUPPORT_MERGE",
       sqlState = Some("0A000"),
       parameters = Map(
-        "tableName" -> auxIdent.quotedString,
-        "operation" -> "MERGE INTO TABLE"
+        "tableName" -> targetIdent.quotedString
       )
     )
   }

--- a/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd1SinglePipelineSuite.scala
+++ b/sql/pipelines/src/test/scala/org/apache/spark/sql/pipelines/graph/AutoCdcScd1SinglePipelineSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.pipelines.graph
 
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.streaming.runtime.MemoryStream
 import org.apache.spark.sql.functions
 import org.apache.spark.sql.pipelines.autocdc.{
@@ -166,12 +167,14 @@ class AutoCdcScd1SinglePipelineSuite
     assert(spark.catalog.tableExists(auxTableNameFor("t_b")))
   }
 
-  test("an AutoCDC flow targeting a table whose format does not support row-level " +
-    "operations fails with AUTOCDC_TARGET_DOES_NOT_SUPPORT_MERGE") {
+  test("an AutoCDC flow whose target connector does not support MERGE fails during " +
+    "flow execution") {
     val session = spark
     import session.implicits._
 
-    // Intentionally use a non-merge-compatible catalog, whose default table format is parquet.
+    // Use the session catalog (default parquet table format), whose tables are not backed by a
+    // MERGE-capable connector - unlike the in-memory row-level-operation catalog the other tests
+    // in this suite run against.
     val catalog = TestGraphRegistrationContext.DEFAULT_CATALOG
     val database = TestGraphRegistrationContext.DEFAULT_DATABASE
 
@@ -202,14 +205,20 @@ class AutoCdcScd1SinglePipelineSuite
       ))
     }
 
+    // The auxiliary-table MERGE runs before the target-table MERGE, so the auxiliary table is the
+    // one named in the connector's MERGE-unsupported failure.
+    val auxIdent = AutoCdcAuxiliaryTable.identifier(
+      TableIdentifier("target_no_merge", Some(database), Some(catalog))
+    )
+
     val ex = intercept[RuntimeException] { runPipeline(ctx) }
     checkErrorInPipelineFailure(
       failure = ex,
-      condition = "AUTOCDC_TARGET_DOES_NOT_SUPPORT_MERGE",
+      condition = "UNSUPPORTED_FEATURE.TABLE_OPERATION",
       sqlState = Some("0A000"),
       parameters = Map(
-        "tableName" -> s"`$catalog`.`$database`.`target_no_merge`",
-        "format" -> "parquet"
+        "tableName" -> auxIdent.quotedString,
+        "operation" -> "MERGE INTO TABLE"
       )
     )
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
`requireDestinationSupportsRowLevelOps` is a check executed during AutoCDC flow execution today that asserts the configured catalog implements the  `SupportsRowLevelOperations` DSv2 interface.

This check is unnecessarily strict; the intention was to validate that the configured catalog supports MERGE (which requires row level operations) but indifferent to DSv2 vs DSv1 API.

The check however by construction also asserts the catalog is implementing row level operations via DSv2 specifically. There are real catalogs connectors (ex. Delta) that do indeed support MERGE but not via DSv2 contract, and instead through custom analyzer rules.

The proposal is to drop this unnecessarily strict check, and instead rely on execution-time failure/validation for MERGE support.


### Why are the changes needed?
Enables support for catalogs/connectors that implement MERGE, but do not implement via DSv2.


### Does this PR introduce _any_ user-facing change?
Yes, ungates additional catalog/connectors for use with AutoCDC. For incompatible catalogs, an exception is still thrown during flow execution, but now specifically when attempting to execute MERGE and with a different error message.


### How was this patch tested?
Updated test in `AutoCdcScd1SinglePipelineSuite`.


### Was this patch authored or co-authored using generative AI tooling?
Yes, co-authored with Claude Opus 4.8
