### PR TITLE
[SPARK-57627][CONNECT] Support primary key, foreign key, and SQL type metadata in DatabaseMetaData

### DIFF
--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaData.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaData.scala
@@ -903,7 +903,7 @@ object SparkConnectDatabaseMetaData {
         Short,   // MAXIMUM_SCALE
         Int,     // SQL_DATA_TYPE
         Int,     // SQL_DATETIME_SUB
-        Int      // NUM_PREC_RADIX
+        Integer  // NUM_PREC_RADIX (null for non-numeric types)
     )
 
   // Fills the columns that are constant across all Spark atomic types: every type is
@@ -919,7 +919,7 @@ object SparkConnectDatabaseMetaData {
       caseSensitive: Boolean,
       minScale: Short,
       maxScale: Short,
-      numPrecRadix: Int,
+      numPrecRadix: Integer,
       literalSuffix: String = null): TypeInfoRow =
     (
       typeName,
@@ -948,7 +948,7 @@ object SparkConnectDatabaseMetaData {
   // TIME is omitted for now because its maximum PRECISION/scale representation
   // in getTypeInfo is not yet settled.
   private[jdbc] val TYPE_INFO: Seq[TypeInfoRow] = Seq(
-    typeRow("BOOLEAN", Types.BOOLEAN, 1, null, null, false, 0, 0, 0),
+    typeRow("BOOLEAN", Types.BOOLEAN, 1, null, null, false, 0, 0, null),
     typeRow("TINYINT", Types.TINYINT, 3, null, null, false, 0, 0, 10),
     typeRow("SMALLINT", Types.SMALLINT, 5, null, null, false, 0, 0, 10),
     typeRow("INT", Types.INTEGER, 10, null, null, false, 0, 0, 10),
@@ -956,9 +956,9 @@ object SparkConnectDatabaseMetaData {
     typeRow("FLOAT", Types.FLOAT, 7, null, null, false, 0, 0, 10),
     typeRow("DOUBLE", Types.DOUBLE, 15, null, null, false, 0, 0, 10),
     typeRow("DECIMAL", Types.DECIMAL, 38, null, "precision,scale", false, 0, 38, 10),
-    typeRow("STRING", Types.VARCHAR, Int.MaxValue, "'", null, true, 0, 0, 0),
-    typeRow("BINARY", Types.VARBINARY, Int.MaxValue, "X'", null, false, 0, 0, 0,
+    typeRow("STRING", Types.VARCHAR, Int.MaxValue, "'", null, true, 0, 0, null),
+    typeRow("BINARY", Types.VARBINARY, Int.MaxValue, "X'", null, false, 0, 0, null,
       literalSuffix = "'"),
-    typeRow("DATE", Types.DATE, 10, "'", null, false, 0, 0, 0),
-    typeRow("TIMESTAMP", Types.TIMESTAMP, 29, "'", null, false, 0, 6, 0))
+    typeRow("DATE", Types.DATE, 10, "'", null, false, 0, 0, null),
+    typeRow("TIMESTAMP", Types.TIMESTAMP, 29, "'", null, false, 0, 6, null))
 }

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaData.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaData.scala
@@ -614,10 +614,10 @@ class SparkConnectDatabaseMetaData(conn: SparkConnectConnection) extends Databas
     new SparkConnectResultSet(df.collectResult())
   }
 
-  // getImportedKeys and getExportedKeys share the JDBC foreign-key result schema. Spark supports
-  // informational FOREIGN KEY constraints on DSv2 tables (SPARK-51207), but the Spark Connect JDBC
-  // client cannot retrieve them in a structured way yet, so both return an empty result set
-  // instead of throwing.
+  // getImportedKeys, getExportedKeys and getCrossReference share the JDBC foreign-key result
+  // schema. Spark supports informational FOREIGN KEY constraints on DSv2 tables (SPARK-51207),
+  // but the Spark Connect JDBC client cannot retrieve them in a structured way yet, so they all
+  // return an empty result set instead of throwing.
   private def emptyForeignKeys: ResultSet = {
     val df = conn.spark.emptyDataFrame
       .withColumn("PKTABLE_CAT", lit(""))
@@ -653,8 +653,10 @@ class SparkConnectDatabaseMetaData(conn: SparkConnectConnection) extends Databas
       parentTable: String,
       foreignCatalog: String,
       foreignSchema: String,
-      foreignTable: String): ResultSet =
-    throw new SQLFeatureNotSupportedException
+      foreignTable: String): ResultSet = {
+    conn.checkOpen()
+    emptyForeignKeys
+  }
 
   // Static catalog of the Spark SQL atomic types, so JDBC clients can resolve type
   // information instead of failing on a thrown exception.

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaData.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaData.scala
@@ -943,7 +943,10 @@ object SparkConnectDatabaseMetaData {
 
   // Static JDBC type metadata for the Spark SQL atomic types, mirroring the
   // JdbcTypeUtils type-code/precision mapping. Only STRING is case-sensitive.
-  // TIME and TIMESTAMP_NTZ are omitted (new and duplicate JDBC type codes).
+  // TIMESTAMP_NTZ is omitted because it maps to the same JDBC type code
+  // (Types.TIMESTAMP) as TIMESTAMP, so the TIMESTAMP row already covers it.
+  // TIME is omitted for now because its maximum PRECISION/scale representation
+  // in getTypeInfo is not yet settled.
   private[jdbc] val TYPE_INFO: Seq[TypeInfoRow] = Seq(
     typeRow("BOOLEAN", Types.BOOLEAN, 1, null, null, false, 0, 0, 0),
     typeRow("TINYINT", Types.TINYINT, 3, null, null, false, 0, 0, 10),

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaData.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaData.scala
@@ -908,23 +908,25 @@ object SparkConnectDatabaseMetaData {
 
   // Fills the columns that are constant across all Spark atomic types: every type is
   // nullable and searchable, and none are unsigned, fixed-prec-scale, or auto-increment.
-  // `literalQuote` is used as both the literal prefix and suffix.
+  // `literalPrefix` is also used as the literal suffix unless `literalSuffix` is given;
+  // BINARY is the exception, whose literals use the hex syntax X'...'.
   private def typeRow(
       typeName: String,
       dataType: Int,
       precision: Int,
-      literalQuote: String,
+      literalPrefix: String,
       createParams: String,
       caseSensitive: Boolean,
       minScale: Short,
       maxScale: Short,
-      numPrecRadix: Int): TypeInfoRow =
+      numPrecRadix: Int,
+      literalSuffix: String = null): TypeInfoRow =
     (
       typeName,
       dataType,
       precision,
-      literalQuote,
-      literalQuote,
+      literalPrefix,
+      if (literalSuffix != null) literalSuffix else literalPrefix,
       createParams,
       typeNullable.toShort,
       caseSensitive,
@@ -952,7 +954,8 @@ object SparkConnectDatabaseMetaData {
     typeRow("DOUBLE", Types.DOUBLE, 15, null, null, false, 0, 0, 10),
     typeRow("DECIMAL", Types.DECIMAL, 38, null, "precision,scale", false, 0, 38, 10),
     typeRow("STRING", Types.VARCHAR, Int.MaxValue, "'", null, true, 0, 0, 0),
-    typeRow("BINARY", Types.VARBINARY, Int.MaxValue, "'", null, false, 0, 0, 0),
+    typeRow("BINARY", Types.VARBINARY, Int.MaxValue, "X'", null, false, 0, 0, 0,
+      literalSuffix = "'"),
     typeRow("DATE", Types.DATE, 10, "'", null, false, 0, 0, 0),
     typeRow("TIMESTAMP", Types.TIMESTAMP, 29, "'", null, false, 0, 6, 0))
 }

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaData.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaData.scala
@@ -598,14 +598,51 @@ class SparkConnectDatabaseMetaData(conn: SparkConnectConnection) extends Databas
       catalog: String, schema: String, table: String): ResultSet =
     throw new SQLFeatureNotSupportedException
 
-  override def getPrimaryKeys(catalog: String, schema: String, table: String): ResultSet =
-    throw new SQLFeatureNotSupportedException
+  // Spark has no primary keys, so return an empty result set with the JDBC schema
+  // instead of throwing, because JDBC clients call this during schema introspection.
+  override def getPrimaryKeys(catalog: String, schema: String, table: String): ResultSet = {
+    conn.checkOpen()
 
-  override def getImportedKeys(catalog: String, schema: String, table: String): ResultSet =
-    throw new SQLFeatureNotSupportedException
+    val df = conn.spark.emptyDataFrame
+      .withColumn("TABLE_CAT", lit(""))
+      .withColumn("TABLE_SCHEM", lit(""))
+      .withColumn("TABLE_NAME", lit(""))
+      .withColumn("COLUMN_NAME", lit(""))
+      .withColumn("KEY_SEQ", lit(0.toShort))
+      .withColumn("PK_NAME", lit(""))
+    new SparkConnectResultSet(df.collectResult())
+  }
 
-  override def getExportedKeys(catalog: String, schema: String, table: String): ResultSet =
-    throw new SQLFeatureNotSupportedException
+  // getImportedKeys and getExportedKeys share the JDBC foreign-key result schema.
+  // Spark has no foreign keys, so both return an empty result set instead of throwing.
+  private def emptyForeignKeys: ResultSet = {
+    val df = conn.spark.emptyDataFrame
+      .withColumn("PKTABLE_CAT", lit(""))
+      .withColumn("PKTABLE_SCHEM", lit(""))
+      .withColumn("PKTABLE_NAME", lit(""))
+      .withColumn("PKCOLUMN_NAME", lit(""))
+      .withColumn("FKTABLE_CAT", lit(""))
+      .withColumn("FKTABLE_SCHEM", lit(""))
+      .withColumn("FKTABLE_NAME", lit(""))
+      .withColumn("FKCOLUMN_NAME", lit(""))
+      .withColumn("KEY_SEQ", lit(0.toShort))
+      .withColumn("UPDATE_RULE", lit(0.toShort))
+      .withColumn("DELETE_RULE", lit(0.toShort))
+      .withColumn("FK_NAME", lit(""))
+      .withColumn("PK_NAME", lit(""))
+      .withColumn("DEFERRABILITY", lit(0.toShort))
+    new SparkConnectResultSet(df.collectResult())
+  }
+
+  override def getImportedKeys(catalog: String, schema: String, table: String): ResultSet = {
+    conn.checkOpen()
+    emptyForeignKeys
+  }
+
+  override def getExportedKeys(catalog: String, schema: String, table: String): ResultSet = {
+    conn.checkOpen()
+    emptyForeignKeys
+  }
 
   override def getCrossReference(
       parentCatalog: String,
@@ -616,8 +653,34 @@ class SparkConnectDatabaseMetaData(conn: SparkConnectConnection) extends Databas
       foreignTable: String): ResultSet =
     throw new SQLFeatureNotSupportedException
 
-  override def getTypeInfo: ResultSet =
-    throw new SQLFeatureNotSupportedException
+  // Static catalog of the Spark SQL atomic types, so JDBC clients can resolve type
+  // information instead of failing on a thrown exception.
+  override def getTypeInfo: ResultSet = {
+    conn.checkOpen()
+
+    val df = TYPE_INFO
+      .toDF(
+        "TYPE_NAME",
+        "DATA_TYPE",
+        "PRECISION",
+        "LITERAL_PREFIX",
+        "LITERAL_SUFFIX",
+        "CREATE_PARAMS",
+        "NULLABLE",
+        "CASE_SENSITIVE",
+        "SEARCHABLE",
+        "UNSIGNED_ATTRIBUTE",
+        "FIXED_PREC_SCALE",
+        "AUTO_INCREMENT",
+        "LOCAL_TYPE_NAME",
+        "MINIMUM_SCALE",
+        "MAXIMUM_SCALE",
+        "SQL_DATA_TYPE",
+        "SQL_DATETIME_SUB",
+        "NUM_PREC_RADIX")
+      .orderBy("DATA_TYPE")
+    new SparkConnectResultSet(df.collectResult())
+  }
 
   override def getIndexInfo(
       catalog: String,
@@ -816,4 +879,77 @@ object SparkConnectDatabaseMetaData {
   )
 
   private[jdbc] val TABLE_TYPES = Seq("TABLE", "VIEW")
+
+  // One row of the java.sql.DatabaseMetaData.getTypeInfo result.
+  private type TypeInfoRow =
+    (
+        String,  // TYPE_NAME
+        Int,     // DATA_TYPE
+        Int,     // PRECISION
+        String,  // LITERAL_PREFIX
+        String,  // LITERAL_SUFFIX
+        String,  // CREATE_PARAMS
+        Short,   // NULLABLE
+        Boolean, // CASE_SENSITIVE
+        Short,   // SEARCHABLE
+        Boolean, // UNSIGNED_ATTRIBUTE
+        Boolean, // FIXED_PREC_SCALE
+        Boolean, // AUTO_INCREMENT
+        String,  // LOCAL_TYPE_NAME
+        Short,   // MINIMUM_SCALE
+        Short,   // MAXIMUM_SCALE
+        Int,     // SQL_DATA_TYPE
+        Int,     // SQL_DATETIME_SUB
+        Int      // NUM_PREC_RADIX
+    )
+
+  // Fills the columns that are constant across all Spark atomic types: every type is
+  // nullable and searchable, and none are unsigned, fixed-prec-scale, or auto-increment.
+  // `literalQuote` is used as both the literal prefix and suffix.
+  private def typeRow(
+      typeName: String,
+      dataType: Int,
+      precision: Int,
+      literalQuote: String,
+      createParams: String,
+      caseSensitive: Boolean,
+      minScale: Short,
+      maxScale: Short,
+      numPrecRadix: Int): TypeInfoRow =
+    (
+      typeName,
+      dataType,
+      precision,
+      literalQuote,
+      literalQuote,
+      createParams,
+      typeNullable.toShort,
+      caseSensitive,
+      typeSearchable.toShort,
+      false,
+      false,
+      false,
+      null,
+      minScale,
+      maxScale,
+      0,
+      0,
+      numPrecRadix)
+
+  // Static JDBC type metadata for the Spark SQL atomic types, mirroring the
+  // JdbcTypeUtils type-code/precision mapping. Only STRING is case-sensitive.
+  // TIME and TIMESTAMP_NTZ are omitted (new and duplicate JDBC type codes).
+  private[jdbc] val TYPE_INFO: Seq[TypeInfoRow] = Seq(
+    typeRow("BOOLEAN", Types.BOOLEAN, 1, null, null, false, 0, 0, 0),
+    typeRow("TINYINT", Types.TINYINT, 3, null, null, false, 0, 0, 10),
+    typeRow("SMALLINT", Types.SMALLINT, 5, null, null, false, 0, 0, 10),
+    typeRow("INT", Types.INTEGER, 10, null, null, false, 0, 0, 10),
+    typeRow("BIGINT", Types.BIGINT, 19, null, null, false, 0, 0, 10),
+    typeRow("FLOAT", Types.FLOAT, 7, null, null, false, 0, 0, 10),
+    typeRow("DOUBLE", Types.DOUBLE, 15, null, null, false, 0, 0, 10),
+    typeRow("DECIMAL", Types.DECIMAL, 38, null, "precision,scale", false, 0, 38, 10),
+    typeRow("STRING", Types.VARCHAR, Int.MaxValue, "'", null, true, 0, 0, 0),
+    typeRow("BINARY", Types.VARBINARY, Int.MaxValue, "'", null, false, 0, 0, 0),
+    typeRow("DATE", Types.DATE, 10, "'", null, false, 0, 0, 0),
+    typeRow("TIMESTAMP", Types.TIMESTAMP, 29, "'", null, false, 0, 6, 0))
 }

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaData.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaData.scala
@@ -598,8 +598,9 @@ class SparkConnectDatabaseMetaData(conn: SparkConnectConnection) extends Databas
       catalog: String, schema: String, table: String): ResultSet =
     throw new SQLFeatureNotSupportedException
 
-  // Spark has no primary keys, so return an empty result set with the JDBC schema
-  // instead of throwing, because JDBC clients call this during schema introspection.
+  // Spark supports informational PRIMARY KEY constraints on DSv2 tables (SPARK-51207), but the
+  // Spark Connect JDBC client cannot retrieve them in a structured way yet, so return an empty
+  // result set instead of throwing. JDBC clients call this during schema introspection.
   override def getPrimaryKeys(catalog: String, schema: String, table: String): ResultSet = {
     conn.checkOpen()
 
@@ -613,8 +614,10 @@ class SparkConnectDatabaseMetaData(conn: SparkConnectConnection) extends Databas
     new SparkConnectResultSet(df.collectResult())
   }
 
-  // getImportedKeys and getExportedKeys share the JDBC foreign-key result schema.
-  // Spark has no foreign keys, so both return an empty result set instead of throwing.
+  // getImportedKeys and getExportedKeys share the JDBC foreign-key result schema. Spark supports
+  // informational FOREIGN KEY constraints on DSv2 tables (SPARK-51207), but the Spark Connect JDBC
+  // client cannot retrieve them in a structured way yet, so both return an empty result set
+  // instead of throwing.
   private def emptyForeignKeys: ResultSet = {
     val df = conn.spark.emptyDataFrame
       .withColumn("PKTABLE_CAT", lit(""))

--- a/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaData.scala
+++ b/sql/connect/client/jdbc/src/main/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaData.scala
@@ -884,7 +884,7 @@ object SparkConnectDatabaseMetaData {
   private[jdbc] val TABLE_TYPES = Seq("TABLE", "VIEW")
 
   // One row of the java.sql.DatabaseMetaData.getTypeInfo result.
-  private type TypeInfoRow =
+  private[jdbc] type TypeInfoRow =
     (
         String,  // TYPE_NAME
         Int,     // DATA_TYPE
@@ -910,7 +910,7 @@ object SparkConnectDatabaseMetaData {
   // nullable and searchable, and none are unsigned, fixed-prec-scale, or auto-increment.
   // `literalPrefix` is also used as the literal suffix unless `literalSuffix` is given;
   // BINARY is the exception, whose literals use the hex syntax X'...'.
-  private def typeRow(
+  private[jdbc] def typeRow(
       typeName: String,
       dataType: Int,
       precision: Int,

--- a/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaDataSuite.scala
+++ b/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaDataSuite.scala
@@ -882,7 +882,8 @@ class SparkConnectDatabaseMetaDataSuite extends ConnectFunSuite with RemoteSpark
             searchable = rs.getShort("SEARCHABLE"),
             minScale = rs.getShort("MINIMUM_SCALE"),
             maxScale = rs.getShort("MAXIMUM_SCALE"),
-            numPrecRadix = Option(rs.getObject("NUM_PREC_RADIX")).map(_.asInstanceOf[Integer].toInt))
+            numPrecRadix =
+              Option(rs.getObject("NUM_PREC_RADIX")).map(_.asInstanceOf[Integer].toInt))
         }.toSeq
 
         // results are ordered by DATA_TYPE

--- a/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaDataSuite.scala
+++ b/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaDataSuite.scala
@@ -863,7 +863,8 @@ class SparkConnectDatabaseMetaDataSuite extends ConnectFunSuite with RemoteSpark
             nullable: Short,
             searchable: Short,
             minScale: Short,
-            maxScale: Short)
+            maxScale: Short,
+            numPrecRadix: Option[Int])
         val types = new Iterator[TypeInfo] {
           def hasNext: Boolean = rs.next()
           def next(): TypeInfo = TypeInfo(
@@ -876,7 +877,8 @@ class SparkConnectDatabaseMetaDataSuite extends ConnectFunSuite with RemoteSpark
             nullable = rs.getShort("NULLABLE"),
             searchable = rs.getShort("SEARCHABLE"),
             minScale = rs.getShort("MINIMUM_SCALE"),
-            maxScale = rs.getShort("MAXIMUM_SCALE"))
+            maxScale = rs.getShort("MAXIMUM_SCALE"),
+            numPrecRadix = Option(rs.getObject("NUM_PREC_RADIX")).map(_.asInstanceOf[Integer].toInt))
         }.toSeq
 
         // results are ordered by DATA_TYPE
@@ -918,6 +920,14 @@ class SparkConnectDatabaseMetaDataSuite extends ConnectFunSuite with RemoteSpark
         assert(decimal.precision === 38)
         assert(decimal.minScale === 0)
         assert(decimal.maxScale === 38)
+
+        // NUM_PREC_RADIX is 10 for numeric types and NULL otherwise, mirroring JdbcTypeUtils
+        val numericTypes =
+          Set("TINYINT", "SMALLINT", "INT", "BIGINT", "FLOAT", "DOUBLE", "DECIMAL")
+        types.foreach { t =>
+          val expected = if (numericTypes.contains(t.name)) Some(10) else None
+          assert(t.numPrecRadix === expected, s"unexpected NUM_PREC_RADIX for ${t.name}")
+        }
       }
     }
   }

--- a/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaDataSuite.scala
+++ b/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaDataSuite.scala
@@ -822,17 +822,19 @@ class SparkConnectDatabaseMetaDataSuite extends ConnectFunSuite with RemoteSpark
     }
   }
 
-  test("SparkConnectDatabaseMetaData getImportedKeys and getExportedKeys") {
+  test("SparkConnectDatabaseMetaData getImportedKeys, getExportedKeys and getCrossReference") {
     withConnection { conn =>
       val metadata = conn.getMetaData
       val foreignKeySchema = Seq(
         "PKTABLE_CAT", "PKTABLE_SCHEM", "PKTABLE_NAME", "PKCOLUMN_NAME",
         "FKTABLE_CAT", "FKTABLE_SCHEM", "FKTABLE_NAME", "FKCOLUMN_NAME",
         "KEY_SEQ", "UPDATE_RULE", "DELETE_RULE", "FK_NAME", "PK_NAME", "DEFERRABILITY")
-      // Spark has no foreign keys, so both return an empty result set with the JDBC schema.
+      // Spark has no foreign keys, so all three return an empty result set with the JDBC schema.
       Seq(
         () => metadata.getImportedKeys(null, null, null),
-        () => metadata.getExportedKeys(null, null, null)).foreach { getForeignKeys =>
+        () => metadata.getExportedKeys(null, null, null),
+        () => metadata.getCrossReference(null, null, null, null, null, null))
+        .foreach { getForeignKeys =>
         Using.resource(getForeignKeys()) { rs =>
           val rsmd = rs.getMetaData
           assert((1 to rsmd.getColumnCount).map(rsmd.getColumnName) === foreignKeySchema)

--- a/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaDataSuite.scala
+++ b/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaDataSuite.scala
@@ -859,6 +859,7 @@ class SparkConnectDatabaseMetaDataSuite extends ConnectFunSuite with RemoteSpark
             precision: Int,
             literalPrefix: String,
             literalSuffix: String,
+            createParams: String,
             caseSensitive: Boolean,
             nullable: Short,
             searchable: Short,
@@ -873,6 +874,7 @@ class SparkConnectDatabaseMetaDataSuite extends ConnectFunSuite with RemoteSpark
             precision = rs.getInt("PRECISION"),
             literalPrefix = rs.getString("LITERAL_PREFIX"),
             literalSuffix = rs.getString("LITERAL_SUFFIX"),
+            createParams = rs.getString("CREATE_PARAMS"),
             caseSensitive = rs.getBoolean("CASE_SENSITIVE"),
             nullable = rs.getShort("NULLABLE"),
             searchable = rs.getShort("SEARCHABLE"),
@@ -915,11 +917,29 @@ class SparkConnectDatabaseMetaDataSuite extends ConnectFunSuite with RemoteSpark
           assert(t.literalSuffix === suffix, s"unexpected LITERAL_SUFFIX for ${t.name}")
         }
 
-        // DECIMAL carries precision and scale
-        val decimal = types.find(_.name == "DECIMAL").get
-        assert(decimal.precision === 38)
-        assert(decimal.minScale === 0)
-        assert(decimal.maxScale === 38)
+        // PRECISION mirrors JdbcTypeUtils.getPrecision for every type
+        val precisions = Map(
+          "BOOLEAN" -> 1, "TINYINT" -> 3, "SMALLINT" -> 5, "INT" -> 10, "BIGINT" -> 19,
+          "FLOAT" -> 7, "DOUBLE" -> 15, "DECIMAL" -> 38, "STRING" -> Int.MaxValue,
+          "BINARY" -> Int.MaxValue, "DATE" -> 10, "TIMESTAMP" -> 29)
+        types.foreach { t =>
+          assert(t.precision === precisions(t.name), s"unexpected PRECISION for ${t.name}")
+        }
+
+        // CREATE_PARAMS is set only for the parameterized types
+        val createParams = Map("DECIMAL" -> "precision,scale")
+        types.foreach { t =>
+          assert(t.createParams === createParams.getOrElse(t.name, null),
+            s"unexpected CREATE_PARAMS for ${t.name}")
+        }
+
+        // (MINIMUM_SCALE, MAXIMUM_SCALE); types not listed carry no scale (0, 0)
+        val scales = Map("DECIMAL" -> (0, 38), "TIMESTAMP" -> (0, 6))
+        types.foreach { t =>
+          val (minScale, maxScale) = scales.getOrElse(t.name, (0, 0))
+          assert(t.minScale === minScale.toShort, s"unexpected MINIMUM_SCALE for ${t.name}")
+          assert(t.maxScale === maxScale.toShort, s"unexpected MAXIMUM_SCALE for ${t.name}")
+        }
 
         // NUM_PREC_RADIX is 10 for numeric types and NULL otherwise, mirroring JdbcTypeUtils
         val numericTypes =

--- a/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaDataSuite.scala
+++ b/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaDataSuite.scala
@@ -857,6 +857,8 @@ class SparkConnectDatabaseMetaDataSuite extends ConnectFunSuite with RemoteSpark
             name: String,
             dataType: Int,
             precision: Int,
+            literalPrefix: String,
+            literalSuffix: String,
             caseSensitive: Boolean,
             nullable: Short,
             searchable: Short,
@@ -868,6 +870,8 @@ class SparkConnectDatabaseMetaDataSuite extends ConnectFunSuite with RemoteSpark
             name = rs.getString("TYPE_NAME"),
             dataType = rs.getInt("DATA_TYPE"),
             precision = rs.getInt("PRECISION"),
+            literalPrefix = rs.getString("LITERAL_PREFIX"),
+            literalSuffix = rs.getString("LITERAL_SUFFIX"),
             caseSensitive = rs.getBoolean("CASE_SENSITIVE"),
             nullable = rs.getShort("NULLABLE"),
             searchable = rs.getShort("SEARCHABLE"),
@@ -895,6 +899,19 @@ class SparkConnectDatabaseMetaDataSuite extends ConnectFunSuite with RemoteSpark
         assert(types.forall(_.searchable == DatabaseMetaData.typeSearchable))
         // only STRING is case-sensitive
         assert(types.filter(_.caseSensitive).map(_.name) === Seq("STRING"))
+
+        // string-like types are quoted with a single quote on both sides, except BINARY,
+        // whose literals use the hex syntax X'...'. Numeric types carry no literal quote.
+        val quoted = Map(
+          "STRING" -> ("'", "'"),
+          "DATE" -> ("'", "'"),
+          "TIMESTAMP" -> ("'", "'"),
+          "BINARY" -> ("X'", "'"))
+        types.foreach { t =>
+          val (prefix, suffix) = quoted.getOrElse(t.name, (null, null))
+          assert(t.literalPrefix === prefix, s"unexpected LITERAL_PREFIX for ${t.name}")
+          assert(t.literalSuffix === suffix, s"unexpected LITERAL_SUFFIX for ${t.name}")
+        }
 
         // DECIMAL carries precision and scale
         val decimal = types.find(_.name == "DECIMAL").get

--- a/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaDataSuite.scala
+++ b/sql/connect/client/jdbc/src/test/scala/org/apache/spark/sql/connect/client/jdbc/SparkConnectDatabaseMetaDataSuite.scala
@@ -808,4 +808,100 @@ class SparkConnectDatabaseMetaDataSuite extends ConnectFunSuite with RemoteSpark
       }
     }
   }
+
+  test("SparkConnectDatabaseMetaData getPrimaryKeys") {
+    withConnection { conn =>
+      val metadata = conn.getMetaData
+      // Spark has no primary keys, so an empty result set with the JDBC schema is returned.
+      Using.resource(metadata.getPrimaryKeys(null, null, null)) { rs =>
+        val rsmd = rs.getMetaData
+        assert((1 to rsmd.getColumnCount).map(rsmd.getColumnName) === Seq(
+          "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "KEY_SEQ", "PK_NAME"))
+        assert(!rs.next())
+      }
+    }
+  }
+
+  test("SparkConnectDatabaseMetaData getImportedKeys and getExportedKeys") {
+    withConnection { conn =>
+      val metadata = conn.getMetaData
+      val foreignKeySchema = Seq(
+        "PKTABLE_CAT", "PKTABLE_SCHEM", "PKTABLE_NAME", "PKCOLUMN_NAME",
+        "FKTABLE_CAT", "FKTABLE_SCHEM", "FKTABLE_NAME", "FKCOLUMN_NAME",
+        "KEY_SEQ", "UPDATE_RULE", "DELETE_RULE", "FK_NAME", "PK_NAME", "DEFERRABILITY")
+      // Spark has no foreign keys, so both return an empty result set with the JDBC schema.
+      Seq(
+        () => metadata.getImportedKeys(null, null, null),
+        () => metadata.getExportedKeys(null, null, null)).foreach { getForeignKeys =>
+        Using.resource(getForeignKeys()) { rs =>
+          val rsmd = rs.getMetaData
+          assert((1 to rsmd.getColumnCount).map(rsmd.getColumnName) === foreignKeySchema)
+          assert(!rs.next())
+        }
+      }
+    }
+  }
+
+  test("SparkConnectDatabaseMetaData getTypeInfo") {
+    withConnection { conn =>
+      val metadata = conn.getMetaData
+      Using.resource(metadata.getTypeInfo) { rs =>
+        val rsmd = rs.getMetaData
+        assert((1 to rsmd.getColumnCount).map(rsmd.getColumnName) === Seq(
+          "TYPE_NAME", "DATA_TYPE", "PRECISION", "LITERAL_PREFIX", "LITERAL_SUFFIX",
+          "CREATE_PARAMS", "NULLABLE", "CASE_SENSITIVE", "SEARCHABLE", "UNSIGNED_ATTRIBUTE",
+          "FIXED_PREC_SCALE", "AUTO_INCREMENT", "LOCAL_TYPE_NAME", "MINIMUM_SCALE",
+          "MAXIMUM_SCALE", "SQL_DATA_TYPE", "SQL_DATETIME_SUB", "NUM_PREC_RADIX"))
+
+        case class TypeInfo(
+            name: String,
+            dataType: Int,
+            precision: Int,
+            caseSensitive: Boolean,
+            nullable: Short,
+            searchable: Short,
+            minScale: Short,
+            maxScale: Short)
+        val types = new Iterator[TypeInfo] {
+          def hasNext: Boolean = rs.next()
+          def next(): TypeInfo = TypeInfo(
+            name = rs.getString("TYPE_NAME"),
+            dataType = rs.getInt("DATA_TYPE"),
+            precision = rs.getInt("PRECISION"),
+            caseSensitive = rs.getBoolean("CASE_SENSITIVE"),
+            nullable = rs.getShort("NULLABLE"),
+            searchable = rs.getShort("SEARCHABLE"),
+            minScale = rs.getShort("MINIMUM_SCALE"),
+            maxScale = rs.getShort("MAXIMUM_SCALE"))
+        }.toSeq
+
+        // results are ordered by DATA_TYPE
+        assert(types.map(t => (t.name, t.dataType)) === Seq(
+          ("TINYINT", Types.TINYINT),
+          ("BIGINT", Types.BIGINT),
+          ("BINARY", Types.VARBINARY),
+          ("DECIMAL", Types.DECIMAL),
+          ("INT", Types.INTEGER),
+          ("SMALLINT", Types.SMALLINT),
+          ("FLOAT", Types.FLOAT),
+          ("DOUBLE", Types.DOUBLE),
+          ("STRING", Types.VARCHAR),
+          ("BOOLEAN", Types.BOOLEAN),
+          ("DATE", Types.DATE),
+          ("TIMESTAMP", Types.TIMESTAMP)))
+
+        // every type is nullable and searchable
+        assert(types.forall(_.nullable == DatabaseMetaData.typeNullable))
+        assert(types.forall(_.searchable == DatabaseMetaData.typeSearchable))
+        // only STRING is case-sensitive
+        assert(types.filter(_.caseSensitive).map(_.name) === Seq("STRING"))
+
+        // DECIMAL carries precision and scale
+        val decimal = types.find(_.name == "DECIMAL").get
+        assert(decimal.precision === 38)
+        assert(decimal.minScale === 0)
+        assert(decimal.maxScale === 38)
+      }
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR implements five `DatabaseMetaData` methods in the Spark Connect JDBC driver (`SparkConnectDatabaseMetaData`) that previously threw `SQLFeatureNotSupportedException`:

- `getPrimaryKeys` — returns an empty `ResultSet` with the JDBC-defined schema. Spark Connect does not expose primary keys over JDBC, so "no primary keys" is represented as an empty result rather than an error.
- `getImportedKeys` / `getExportedKeys` / `getCrossReference` — return an empty `ResultSet` with the JDBC foreign-key schema, for the same reason. All three share a private `emptyForeignKeys` helper.
- `getTypeInfo` — returns a static catalog of the Spark SQL atomic types (12 rows), ordered by `DATA_TYPE`, mirroring the type-code/precision mapping already used by `JdbcTypeUtils`. `TIMESTAMP_NTZ` is omitted because it maps to the same JDBC type code (`Types.TIMESTAMP`) as `TIMESTAMP`; `TIME` is omitted for now because its maximum `PRECISION`/scale representation in `getTypeInfo` is not yet settled.

The result-set schemas (column names, order, and types) match the canonical definitions already used by Spark's Thrift server operations (`GetPrimaryKeysOperation`, `GetCrossReferenceOperation`, `GetTypeInfoOperation`), with one intentional correction: the `KEY_SEQ` column uses the JDBC-spec name `KEY_SEQ` rather than the `KEQ_SEQ` typo inherited from Hive in the Thrift operations.

`getFunctions` is intentionally left throwing and is out of scope for this PR.

### Why are the changes needed?

Returning an empty `ResultSet` (rather than throwing) for metadata that a driver does not support is the conventional JDBC behavior, and it is what other engines in this ecosystem do: Trino returns an empty result set for `getPrimaryKeys`/`getImportedKeys`, and Hive does so for `getImportedKeys`. Throwing `SQLFeatureNotSupportedException` breaks otherwise-recoverable client introspection — for example, BI tools that probe primary/foreign keys to infer table relationships abort the metadata step instead of degrading to "no keys."

`getTypeInfo` is the one method here for which Spark can return real data: its atomic types are statically known. Hive, Trino, and the Databricks JDBC driver all implement `getTypeInfo`; Spark Connect was the outlier in throwing.

### Does this PR introduce _any_ user-facing change?

Yes. Previously these five methods threw `SQLFeatureNotSupportedException`. After this change:
- `getPrimaryKeys`, `getImportedKeys`, `getExportedKeys`, and `getCrossReference` return an empty `ResultSet` with the JDBC-defined columns.
- `getTypeInfo` returns the catalog of Spark SQL atomic types.

This is a change within the unreleased branch only; the Spark Connect JDBC driver has not been released.

### How was this patch tested?

Added in-process tests to `SparkConnectDatabaseMetaDataSuite`:
- `getPrimaryKeys` and `getImportedKeys`/`getExportedKeys`/`getCrossReference` assert the result-set column schema and that the result is empty.
- `getTypeInfo` asserts the column schema, the rows ordered by `DATA_TYPE`, that every type is nullable and searchable, that only `STRING` is case-sensitive, the per-type `LITERAL_PREFIX`/`LITERAL_SUFFIX` (including the `X'...'` hex syntax for `BINARY`), the `NUM_PREC_RADIX` (10 for numeric types, NULL otherwise), and that `DECIMAL` carries the expected precision and scale.

```
build/sbt 'connect-client-jdbc/testOnly *SparkConnectDatabaseMetaDataSuite'
```
All 10 tests pass.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
