### PR TITLE
[SPARK-57611][SQL] Reuse JsonFactory instances in the variant module

### DIFF
--- a/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
@@ -241,12 +241,17 @@ public final class Variant {
     return sb.toString();
   }
 
+  // Jackson's JsonFactory is thread-safe and intended to be reused. `escapeJson` is called once
+  // per string value and object key while serializing, so sharing a single factory avoids
+  // allocating one for every string.
+  private static final JsonFactory JSON_FACTORY = new JsonFactory();
+
   // Escape a string so that it can be pasted into JSON structure.
   // For example, if `str` only contains a new-line character, then the result content is "\n"
   // (4 characters).
   static String escapeJson(String str) {
     try (CharArrayWriter writer = new CharArrayWriter();
-         JsonGenerator gen = new JsonFactory().createGenerator(writer)) {
+         JsonGenerator gen = JSON_FACTORY.createGenerator(writer)) {
       gen.writeString(str);
       gen.flush();
       return writer.toString();

--- a/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
@@ -17,7 +17,6 @@
 
 package org.apache.spark.types.variant;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 
 import java.io.CharArrayWriter;
@@ -240,11 +239,6 @@ public final class Variant {
     toJsonImpl(value, metadata, pos, sb, zoneId);
     return sb.toString();
   }
-
-  // Jackson's JsonFactory is thread-safe and intended to be reused. `escapeJson` is called once
-  // per string value and object key while serializing, so sharing a single factory avoids
-  // allocating one for every string.
-  private static final JsonFactory JSON_FACTORY = new JsonFactory();
 
   // Escape a string so that it can be pasted into JSON structure.
   // For example, if `str` only contains a new-line character, then the result content is "\n"

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
@@ -30,7 +30,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.*;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonToken;
@@ -42,11 +41,6 @@ import static org.apache.spark.types.variant.VariantUtil.*;
  * Build variant value and metadata by parsing JSON values.
  */
 public class VariantBuilder {
-  // Jackson's JsonFactory is thread-safe and intended to be reused. parseJson is invoked once per
-  // input JSON value (e.g. per row in parse_json), so sharing a single factory avoids allocating
-  // one (and its symbol tables) on every call.
-  private static final JsonFactory JSON_FACTORY = new JsonFactory();
-
   public VariantBuilder(boolean allowDuplicateKeys) {
     this(allowDuplicateKeys, true);
   }

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
@@ -42,6 +42,11 @@ import static org.apache.spark.types.variant.VariantUtil.*;
  * Build variant value and metadata by parsing JSON values.
  */
 public class VariantBuilder {
+  // Jackson's JsonFactory is thread-safe and intended to be reused. parseJson is invoked once per
+  // input JSON value (e.g. per row in parse_json), so sharing a single factory avoids allocating
+  // one (and its symbol tables) on every call.
+  private static final JsonFactory JSON_FACTORY = new JsonFactory();
+
   public VariantBuilder(boolean allowDuplicateKeys) {
     this(allowDuplicateKeys, true);
   }
@@ -70,7 +75,7 @@ public class VariantBuilder {
    */
   public static Variant parseJson(String json, boolean allowDuplicateKeys,
       boolean validateUnicodeInJsonParsing) throws IOException {
-    try (JsonParser parser = new JsonFactory().createParser(json)) {
+    try (JsonParser parser = JSON_FACTORY.createParser(json)) {
       parser.nextToken();
       return parseJson(parser, allowDuplicateKeys, validateUnicodeInJsonParsing);
     }

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
@@ -29,6 +29,8 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.UUID;
 
+import com.fasterxml.jackson.core.JsonFactory;
+
 /**
  * This class defines constants related to the variant format and provides functions for
  * manipulating variant binaries.
@@ -50,6 +52,12 @@ import java.util.UUID;
  * - UTF-8 string data.
  */
 public class VariantUtil {
+  // Jackson's JsonFactory is thread-safe and intended to be reused, so the variant module shares a
+  // single instance. Variant.escapeJson (one call per serialized string or key) and
+  // VariantBuilder.parseJson (one call per parsed JSON value) both use it, which avoids a per-call
+  // factory allocation (including its symbol tables) and keeps one source of configuration.
+  static final JsonFactory JSON_FACTORY = new JsonFactory();
+
   public static final int BASIC_TYPE_BITS = 2;
   public static final int BASIC_TYPE_MASK = 0x3;
   public static final int TYPE_INFO_MASK = 0x3F;


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR reuses a single shared `JsonFactory` in the variant module instead of allocating a new one on every call. `Variant.escapeJson` and `VariantBuilder.parseJson` each created a `new JsonFactory()` per invocation; both now reference a `private static final` instance.

### Why are the changes needed?

`JsonFactory` is thread-safe and designed to be reused. `escapeJson` runs once per string value and object key while serializing a variant, and `parseJson` runs once per input JSON value (e.g. per row in `parse_json`), so creating a fresh factory on each call adds avoidable allocation (including its symbol tables) on these hot paths. Sharing one instance removes that overhead.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing variant tests cover both the parsing and serialization paths. There is no behavior change: both factories use the default configuration and are never mutated, so a shared instance produces identical results.

### Was this patch authored or co-authored using generative AI tooling?

No.
