### PR TITLE
[SPARK-57631][WEBUI] Require modifier key for wheel-zoom on SQL plan DAG to restore page scrolling

### DIFF
--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.css
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.css
@@ -243,3 +243,23 @@ svg g.cluster.search-dimmed {
 .sql-cell-details[open] > summary {
   margin-bottom: 0.25rem;
 }
+
+/* Zoom hint overlay */
+.plan-viz-zoom-hint {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 14px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s;
+  z-index: 10;
+}
+.plan-viz-zoom-hint.visible {
+  opacity: 1;
+}

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -804,7 +804,7 @@ function showZoomHint() {
   clearTimeout(zoomHintTimeout);
   zoomHintTimeout = setTimeout(function () {
     hint.classList.remove("visible");
-  }, 1500);
+  }, 1000);
 }
 
 function updateZoomLevelLabel(scale) {

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -773,6 +773,8 @@ function setupZoomAndPan(svg, zoomLayer) {
   svg.on("wheel.zoom", null);
   svgNode.addEventListener("wheel", function (e) {
     if (e.ctrlKey || e.metaKey) {
+      // Prevent the browser's native page zoom so only the DAG zooms.
+      e.preventDefault();
       // Forward to d3-zoom's original handler for zoom behavior.
       // Note: trackpad pinch gestures fire as wheel events with ctrlKey=true,
       // so pinch-to-zoom still works as expected.
@@ -793,8 +795,11 @@ function showZoomHint() {
     hint = document.createElement("div");
     hint.id = "plan-viz-zoom-hint";
     hint.className = "plan-viz-zoom-hint";
-    var isMac = /Mac|iPhone|iPad/.test(navigator.platform || navigator.userAgent);
-    hint.textContent = (isMac ? "\u2318" : "Ctrl") + " + scroll to zoom";
+    var platform = navigator.platform || navigator.userAgent;
+    var isMac = /Mac|iPhone|iPad/.test(platform);
+    var isLinux = /Linux/.test(platform);
+    var modKey = isMac ? "\u2318" : isLinux ? "Super" : "Ctrl";
+    hint.textContent = modKey + " + scroll to zoom";
     container.appendChild(hint);
   }
   hint.classList.add("visible");

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -745,6 +745,11 @@ function setupZoomAndPan(svg, zoomLayer) {
       // (foreignObject) so text inside metrics tables remains selectable.
       // Also ignore right-click to leave the browser context menu intact.
       if (event.button === 2) return false;
+      // Require Ctrl (or Cmd on Mac) for wheel-zoom so that unmodified
+      // scroll gestures pass through to the page for normal scrolling.
+      // Note: trackpad pinch gestures fire as wheel events with ctrlKey=true,
+      // so pinch-to-zoom still works as expected.
+      if (event.type === "wheel" && !event.ctrlKey && !event.metaKey) return false;
       var target = event.target;
       while (target && target !== svgNode) {
         if (target.nodeName === "foreignObject") return false;
@@ -765,6 +770,41 @@ function setupZoomAndPan(svg, zoomLayer) {
   // provides the natural fit, and the zoom-layer has no transform, so no
   // explicit transform is required here.
   updateZoomLevelLabel(1);
+
+  // Remove d3-zoom's wheel listener (which is registered as non-passive and
+  // can block page scrolling) and replace it with a gated wrapper that only
+  // forwards Ctrl/Cmd+wheel to d3, letting unmodified scrolls pass through.
+  var d3WheelHandler = svg.on("wheel.zoom");
+  svg.on("wheel.zoom", null);
+  svgNode.addEventListener("wheel", function (e) {
+    if (e.ctrlKey || e.metaKey) {
+      // Forward to d3-zoom's original handler for zoom behavior
+      d3WheelHandler.call(this, e);
+    } else {
+      // Let the event propagate naturally for page scrolling and show hint
+      showZoomHint();
+    }
+  });
+}
+
+var zoomHintTimeout;
+function showZoomHint() {
+  var container = document.getElementById("plan-viz-graph");
+  if (!container) return;
+  var hint = document.getElementById("plan-viz-zoom-hint");
+  if (!hint) {
+    hint = document.createElement("div");
+    hint.id = "plan-viz-zoom-hint";
+    hint.className = "plan-viz-zoom-hint";
+    var isMac = /Mac|iPhone|iPad/.test(navigator.platform || navigator.userAgent);
+    hint.textContent = (isMac ? "\u2318" : "Ctrl") + " + scroll to zoom";
+    container.appendChild(hint);
+  }
+  hint.classList.add("visible");
+  clearTimeout(zoomHintTimeout);
+  zoomHintTimeout = setTimeout(function () {
+    hint.classList.remove("visible");
+  }, 1500);
 }
 
 function updateZoomLevelLabel(scale) {

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -745,11 +745,6 @@ function setupZoomAndPan(svg, zoomLayer) {
       // (foreignObject) so text inside metrics tables remains selectable.
       // Also ignore right-click to leave the browser context menu intact.
       if (event.button === 2) return false;
-      // Require Ctrl (or Cmd on Mac) for wheel-zoom so that unmodified
-      // scroll gestures pass through to the page for normal scrolling.
-      // Note: trackpad pinch gestures fire as wheel events with ctrlKey=true,
-      // so pinch-to-zoom still works as expected.
-      if (event.type === "wheel" && !event.ctrlKey && !event.metaKey) return false;
       var target = event.target;
       while (target && target !== svgNode) {
         if (target.nodeName === "foreignObject") return false;
@@ -778,8 +773,10 @@ function setupZoomAndPan(svg, zoomLayer) {
   svg.on("wheel.zoom", null);
   svgNode.addEventListener("wheel", function (e) {
     if (e.ctrlKey || e.metaKey) {
-      // Forward to d3-zoom's original handler for zoom behavior
-      d3WheelHandler.call(this, e);
+      // Forward to d3-zoom's original handler for zoom behavior.
+      // Note: trackpad pinch gestures fire as wheel events with ctrlKey=true,
+      // so pinch-to-zoom still works as expected.
+      if (d3WheelHandler) d3WheelHandler.call(this, e);
     } else {
       // Let the event propagate naturally for page scrolling and show hint
       showZoomHint();

--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -769,6 +769,8 @@ function setupZoomAndPan(svg, zoomLayer) {
   // Remove d3-zoom's wheel listener (which is registered as non-passive and
   // can block page scrolling) and replace it with a gated wrapper that only
   // forwards Ctrl/Cmd+wheel to d3, letting unmodified scrolls pass through.
+  // "wheel.zoom" is d3-zoom's internal event namespace (stable since d3 v4).
+  // The null-guard below protects against future d3 changes.
   var d3WheelHandler = svg.on("wheel.zoom");
   svg.on("wheel.zoom", null);
   svgNode.addEventListener("wheel", function (e) {
@@ -783,11 +785,13 @@ function setupZoomAndPan(svg, zoomLayer) {
       // Let the event propagate naturally for page scrolling and show hint
       showZoomHint();
     }
-  });
+  }, {passive: false});
 }
 
 var zoomHintTimeout;
+var zoomHintCooldown = false;
 function showZoomHint() {
+  if (zoomHintCooldown) return;
   var container = document.getElementById("plan-viz-graph");
   if (!container) return;
   var hint = document.getElementById("plan-viz-zoom-hint");
@@ -803,9 +807,11 @@ function showZoomHint() {
     container.appendChild(hint);
   }
   hint.classList.add("visible");
+  zoomHintCooldown = true;
   clearTimeout(zoomHintTimeout);
   zoomHintTimeout = setTimeout(function () {
     hint.classList.remove("visible");
+    setTimeout(function () { zoomHintCooldown = false; }, 3000);
   }, 1000);
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Require Ctrl (or Cmd on macOS, Super on Linux) + scroll wheel to zoom the SQL plan DAG on the `/SQL/execution` page. Unmodified scroll gestures now pass through for normal page scrolling.

Additionally, a transient overlay hint ("⌘ + scroll to zoom" on Mac, "Super + scroll to zoom" ,"Ctrl + scroll to zoom" otherwise) is shown when the user scrolls without the modifier key, following the same UX pattern as Google Maps.

### Why are the changes needed?

The DAG visualization occupies a 70vh viewport and captures all wheel events for zoom via d3-zoom. This makes it nearly impossible to scroll past the DAG without moving the cursor to the narrow margins on either side of the graph area. The problem is especially pronounced on pages with additional content below the DAG (e.g., when a node detail panel is not open).

### How does this fix work?
1. Added a `wheel` event type check in the `d3.zoom().filter()` to reject unmodified wheel events.
2. After `svg.call(planVizZoom)`, the d3-zoom wheel listener (registered with `{passive: false}`) is detached and replaced with a custom wrapper that only forwards Ctrl/Cmd+wheel to the original d3 handler. This ensures the browser's native scrolling is never blocked by d3's non-passive listener registration.
3. A CSS-animated hint overlay is shown on unmodified scroll to inform users how to zoom.

Notes:
- Trackpad pinch-to-zoom still works because browsers synthesize pinch gestures as `wheel` events with `ctrlKey: true`.
- Drag-to-pan behavior is unchanged.
- The `+`/`-` toolbar buttons and keyboard shortcuts continue to work as before.

### Does this PR introduce _any_ user-facing change?
Yes. Wheel-zoom on the SQL plan DAG now requires holding Ctrl (Cmd on Mac). Plain scroll gestures scroll the page. A hint overlay guides users to the new behavior.

### How was this patch tested?

Manual testing with Chrome and Firefox on macOS and Ubuntu, and Safari  on macOS:
- Verified unmodified scroll scrolls the page past the DAG
- Verified Ctrl+scroll zooms the DAG
- Verified trackpad pinch zooms the DAG
- Verified drag-to-pan works as before
- Verified Hint overlay appears for 1.0s then enters a 3s cooldown before it can reappear
- Verified toolbar +/- buttons and keyboard shortcuts still work


https://github.com/user-attachments/assets/f2b856c5-9cb4-4128-bd60-df5990af47bb



### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Claude