### PR TITLE
[SPARK-57632][SQL] Remove unused method addVariantValueVariant in VariantShreddingWriter

### DIFF
--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantShreddingWriter.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantShreddingWriter.java
@@ -294,10 +294,4 @@ public class VariantShreddingWriter {
     return null;
   }
 
-  // Add the result to the shredding result.
-  private static void addVariantValueVariant(Variant variantResult,
-      VariantSchema schema, ShreddedResult result) {
-    result.addVariantValue(variantResult.getValue());
-  }
-
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes `VariantShreddingWriter.addVariantValueVariant`, a `private static` method that has no callers. It is a one-line delegation to `ShreddedResult.addVariantValue`; the live shredding path already calls `result.addVariantValue(...)` directly.

### Why are the changes needed?

Dead code cleanup. The method has been unreferenced since it was first added in [SPARK-48898](https://issues.apache.org/jira/browse/SPARK-48898) (`Add Variant shredding functions`) - it never had a caller. Removing it keeps `VariantShreddingWriter` easier to read.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No new tests are needed; this only removes unreachable code. Existing variant tests still pass.

### Was this patch authored or co-authored using generative AI tooling?

No.
