### PR TITLE
[SPARK-57633][DOC] Update `concurrent-ruby` gem version to 1.3.7

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (3.2.2)
     colorator (1.1.0)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.7)
     csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the `concurrent-ruby` gem from 1.3.5 to 1.3.7 in `docs/Gemfile.lock`. It is a transitive dependency (pulled in by `i18n`), and 1.3.7 satisfies i18n's `concurrent-ruby (~> 1.0)` constraint, so only the locked spec version changes.

### Why are the changes needed?

1.3.7 fixes three security advisories that affect all earlier versions (`< 1.3.7`):

- [GHSA-h8w8-99g7-qmvj](https://github.com/advisories/GHSA-h8w8-99g7-qmvj) / CVE-2026-54904 (high): `AtomicReference#update` livelocks when the stored value is `Float::NAN`.
- [GHSA-wv3x-4vxv-whpp](https://github.com/advisories/GHSA-wv3x-4vxv-whpp) / CVE-2026-54905 (low): `ReentrantReadWriteLock` read-count overflow grants a write lock without exclusivity.
- [GHSA-6wx8-w4f5-wwcr](https://github.com/advisories/GHSA-6wx8-w4f5-wwcr) / CVE-2026-54906 (low): `ReadWriteLock` allows wrong-thread write release and stray read-release counter corruption.

### Does this PR introduce _any_ user-facing change?

No. This only affects the documentation build toolchain.

### How was this patch tested?

N/A - this is a lock-file-only dependency bump for the docs build. `concurrent-ruby` has no runtime dependencies, so no other lock entries change.

### Was this patch authored or co-authored using generative AI tooling?

No.
