### PR TITLE
[SPARK-57640][SQL][UDF] Implement gRPC WorkerSession and test it against an echo server

### DIFF
--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/Termination.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/Termination.scala
@@ -22,9 +22,9 @@ import org.apache.spark.udf.worker.{CancelResponse, ExecutionError, FinishRespon
 /**
  * :: Experimental ::
  * The terminal outcome a [[WorkerSession]] settles on, returned by
- * [[WorkerSession#close]]. Mirrors the four terminal `WorkerSession.SessionState`s,
- * so close() reports the outcome faithfully rather than collapsing failures into
- * a clean cancel.
+ * [[WorkerSession#close]]. Enumerates the four terminal outcomes, carried by the
+ * single `WorkerSession.SessionState.Terminal`, so close() reports the outcome
+ * faithfully rather than collapsing failures into a clean cancel.
  *
  * '''Clean outcomes''' ([[Finished]] / [[Cancelled]]) wrap the worker's
  * `FinishResponse` / `CancelResponse` -- per-execution metrics, an optional

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/Termination.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/Termination.scala
@@ -68,13 +68,15 @@ object Termination {
   /**
    * The session was interrupted (an [[InterruptedException]] on the engine
    * thread driving it, e.g. a Spark task kill) before a terminator arrived. A
-   * best-effort `Cancel` is sent but its `CancelResponse` is not awaited -- the
-   * interrupted thread must unwind rather than block -- so this is distinct from
-   * a cooperative [[Cancelled]] (which carries the drained `CancelResponse`) and
-   * from a [[TransportFailed]] (a genuine transport fault). The interrupt is an
-   * engine-side event, not a worker fault, so the worker is treated as
-   * salvageable (see [[WorkerSession.isWorkerSalvageable]]). Carries the
-   * interrupt cause.
+   * best-effort `Cancel` is sent and its `CancelResponse` awaited only briefly
+   * (the interrupted thread must unwind promptly rather than block); this
+   * terminal is settled only when that brief wait expires without an ack -- if
+   * the worker acks in time the session settles a cooperative [[Cancelled]]
+   * instead. So it is distinct from a [[Cancelled]] (which carries the drained
+   * `CancelResponse`) and from a [[TransportFailed]] (a genuine transport
+   * fault). The interrupt is an engine-side event, not a worker fault, so the
+   * worker is treated as salvageable (see [[WorkerSession.isWorkerSalvageable]]).
+   * Carries the interrupt cause.
    */
   final case class Interrupted(cause: Throwable) extends Termination
 }

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/Termination.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/Termination.scala
@@ -35,11 +35,12 @@ import org.apache.spark.udf.worker.{CancelResponse, ExecutionError, FinishRespon
  * `FinishResponse` was already produced when a `Cancel` arrives the engine still
  * receives [[Finished]], otherwise [[Cancelled]].
  *
- * '''Failure outcomes''' ([[Failed]] / [[TransportFailed]]) carry the cause
- * instead of a proto terminator (none arrived, so they have no metrics). They
- * exist so a failure is not reported as a benign cancel -- in particular an
- * error raised during finish/close, '''after all data has been drained''',
- * reaches the caller only through this value, never through the result iterator.
+ * '''Failure outcomes''' ([[Failed]] / [[TransportFailed]] / [[Interrupted]])
+ * carry the cause instead of a proto terminator (none arrived, so they have no
+ * metrics). They prevent a failure from being reported as a benign cancel. In
+ * particular, an error raised during finish/close, '''after all data has been
+ * drained''', reaches the caller only through this value, never through the
+ * result iterator.
  */
 @Experimental
 sealed trait Termination

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/Termination.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/Termination.scala
@@ -74,8 +74,9 @@ object Termination {
    * the worker acks in time the session settles a cooperative [[Cancelled]]
    * instead. So it is distinct from a [[Cancelled]] (which carries the drained
    * `CancelResponse`) and from a [[TransportFailed]] (a genuine transport
-   * fault). The interrupt is an engine-side event, not a worker fault, so the
-   * worker is treated as salvageable (see [[WorkerSession.isWorkerSalvageable]]).
+   * fault). Although the interrupt is an engine-side event, the missing
+   * acknowledgement leaves the worker's state unknown, so it is not salvageable
+   * without a separate liveness proof (see [[WorkerSession.isWorkerSalvageable]]).
    * Carries the interrupt cause.
    */
   final case class Interrupted(cause: Throwable) extends Termination

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/Termination.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/Termination.scala
@@ -22,7 +22,7 @@ import org.apache.spark.udf.worker.{CancelResponse, ExecutionError, FinishRespon
 /**
  * :: Experimental ::
  * The terminal outcome a [[WorkerSession]] settles on, returned by
- * [[WorkerSession#close]]. Enumerates the four terminal outcomes, carried by the
+ * [[WorkerSession#close]]. Enumerates the terminal outcomes, carried by the
  * single `WorkerSession.SessionState.Terminal`, so close() reports the outcome
  * faithfully rather than collapsing failures into a clean cancel.
  *
@@ -59,8 +59,22 @@ object Termination {
   final case class Failed(error: ExecutionError) extends Termination
 
   /**
-   * A transport failure, timeout, or interrupt tore the stream down before any
-   * terminator arrived. Carries the underlying cause.
+   * A transport failure or timeout tore the stream down before any terminator
+   * arrived. Carries the underlying cause. Leaves the worker in an unknown state,
+   * so it is not salvageable (see [[WorkerSession.isWorkerSalvageable]]).
    */
   final case class TransportFailed(cause: Throwable) extends Termination
+
+  /**
+   * The session was interrupted (an [[InterruptedException]] on the engine
+   * thread driving it, e.g. a Spark task kill) before a terminator arrived. A
+   * best-effort `Cancel` is sent but its `CancelResponse` is not awaited -- the
+   * interrupted thread must unwind rather than block -- so this is distinct from
+   * a cooperative [[Cancelled]] (which carries the drained `CancelResponse`) and
+   * from a [[TransportFailed]] (a genuine transport fault). The interrupt is an
+   * engine-side event, not a worker fault, so the worker is treated as
+   * salvageable (see [[WorkerSession.isWorkerSalvageable]]). Carries the
+   * interrupt cause.
+   */
+  final case class Interrupted(cause: Throwable) extends Termination
 }

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/UDFDispatcherManager.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/UDFDispatcherManager.scala
@@ -44,9 +44,10 @@ class UDFDispatcherManager(
     workerLogger: WorkerLogger = WorkerLogger.NoOp
 ) {
 
-  // Guarded by `rwLock`. The read lock is used by getDispatcher
-  // (with upgrade when a new dispatcher must be added) and the
-  // write lock is used by close.
+  // Guarded by `rwLock`. getDispatcher takes the read lock, releasing it
+  // and re-acquiring the write lock when a new dispatcher must be added
+  // (ReentrantReadWriteLock does not support upgrading a held read lock);
+  // close takes the write lock.
   private val rwLock = new ReentrantReadWriteLock()
   private val dispatchers =
     new HashMap[UDFWorkerSpecification, WorkerDispatcher]()

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/WorkerDispatcher.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/WorkerDispatcher.scala
@@ -32,8 +32,8 @@ import org.apache.spark.udf.worker.UDFWorkerSpecification
  * worker that backed it MUST NOT be returned to any reuse pool. A transport
  * error leaves the worker in an unknown state; only workers that complete
  * sessions cleanly are eligible for reuse. Implementations are responsible for
- * tracking this condition -- typically [[WorkerSession.doProcess]] flags the
- * worker as invalid before [[WorkerSession.doClose]] releases it, so the
+ * tracking this condition -- [[WorkerSession.close]] marks the worker invalid
+ * (via [[WorkerSession.isWorkerSalvageable]]) before releasing it, so the
  * dispatcher can distinguish a clean release from a failed one.
  */
 @Experimental

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/WorkerSession.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/WorkerSession.scala
@@ -156,6 +156,7 @@ abstract class WorkerSession(
    *                the worker needs to start processing.
    */
   final def init(message: Init): InitResponse = {
+    require(message != null, "message is required")
     if (!state.compareAndSet(SessionState.Created, SessionState.Initializing)) {
       throw new IllegalStateException(
         s"init must be called exactly once before process (current state: ${state.get()})")

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/WorkerSession.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/WorkerSession.scala
@@ -349,18 +349,19 @@ abstract class WorkerSession(
    * Whether the underlying worker is in a state safe to reuse after this
    * session ends. The default treats only a dead or unknown transport as
    * unsafe: a [[Termination.TransportFailed]] outcome (transport failure or
-   * timeout) -- or a session that never settled -- leaves the worker in an
-   * unknown state and is not salvageable. Every other terminal is salvageable:
-   * a clean [[Termination.Finished]], a cooperative [[Termination.Cancelled]],
-   * an execution [[Termination.Failed]] (typically a user-code (UDF) error
-   * reported by a still-healthy worker rather than a worker fault), and an
-   * [[Termination.Interrupted]] (an engine-side task kill, not a worker fault).
+   * timeout), a [[Termination.Interrupted]] without a worker acknowledgement, or
+   * a session that never settled leaves the worker in an unknown state and is
+   * not salvageable. The salvageable terminals are a clean
+   * [[Termination.Finished]], a cooperative [[Termination.Cancelled]], and an
+   * execution [[Termination.Failed]] (typically a user-code (UDF) error reported
+   * by a still-healthy worker rather than a worker fault).
    * A `false` result tells [[close]] to mark `workerHandle` invalid so no reuse
    * pool recycles the worker. Subclasses may override for protocol-specific
    * nuances.
    */
   protected def isWorkerSalvageable: Boolean = state.get() match {
     case SessionState.Terminal(_: Termination.TransportFailed) => false
+    case SessionState.Terminal(_: Termination.Interrupted) => false
     case t if t.isTerminal => true
     case _ => false
   }

--- a/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/WorkerSession.scala
+++ b/udf/worker/core/src/main/scala/org/apache/spark/udf/worker/core/WorkerSession.scala
@@ -89,10 +89,10 @@ import org.apache.spark.udf.worker.{Cancel, DataRequest, DataResponse, Finish, I
  *                                           |   (from any non-terminal state)
  * }}}
  * The clean path (via Finishing) and the cancel path (via Cancelling) settle the
- * same `(terminal)`. The four terminals are:
+ * same `(terminal)`. The terminals are:
  * {{{
  *   Finished(FinishResponse) | Cancelled(CancelResponse)
- *   Failed(ExecutionError)   | TransportFailed(Throwable)
+ *   Failed(ExecutionError)   | TransportFailed(Throwable) | Interrupted(Throwable)
  * }}}
  * The two clean terminals carry the worker's `FinishResponse` / `CancelResponse`
  * (metrics + finish/cancel callback `data`/`error`); the failure terminals carry
@@ -348,15 +348,16 @@ abstract class WorkerSession(
   /**
    * Whether the underlying worker is in a state safe to reuse after this
    * session ends. The default treats only a dead or unknown transport as
-   * unsafe: a [[Termination.TransportFailed]] outcome (transport failure,
-   * timeout, or interrupt) -- or a session that never settled -- leaves the
-   * worker in an unknown state and is not salvageable. Every other terminal is
-   * salvageable: a clean [[Termination.Finished]], a cooperative
-   * [[Termination.Cancelled]], and also an execution [[Termination.Failed]],
-   * which is typically a user-code (UDF) error reported by a still-healthy
-   * worker rather than a worker fault. A `false` result tells [[close]] to mark
-   * `workerHandle` invalid so no reuse pool recycles the worker. Subclasses may
-   * override for protocol-specific nuances.
+   * unsafe: a [[Termination.TransportFailed]] outcome (transport failure or
+   * timeout) -- or a session that never settled -- leaves the worker in an
+   * unknown state and is not salvageable. Every other terminal is salvageable:
+   * a clean [[Termination.Finished]], a cooperative [[Termination.Cancelled]],
+   * an execution [[Termination.Failed]] (typically a user-code (UDF) error
+   * reported by a still-healthy worker rather than a worker fault), and an
+   * [[Termination.Interrupted]] (an engine-side task kill, not a worker fault).
+   * A `false` result tells [[close]] to mark `workerHandle` invalid so no reuse
+   * pool recycles the worker. Subclasses may override for protocol-specific
+   * nuances.
    */
   protected def isWorkerSalvageable: Boolean = state.get() match {
     case SessionState.Terminal(_: Termination.TransportFailed) => false
@@ -461,8 +462,9 @@ object WorkerSession {
     /**
      * The session is over; no further writes are valid. The single terminal
      * state carries the public [[Termination]] outcome (`Finished` /
-     * `Cancelled` / `Failed` / `TransportFailed`), so those four outcome cases
-     * live once on [[Termination]] rather than being mirrored on the state.
+     * `Cancelled` / `Failed` / `TransportFailed` / `Interrupted`), so those
+     * outcome cases live once on [[Termination]] rather than being mirrored on
+     * the state.
      */
     final case class Terminal(termination: Termination) extends SessionState {
       override def isTerminal: Boolean = true

--- a/udf/worker/core/src/test/scala/org/apache/spark/udf/worker/core/WorkerSessionSuite.scala
+++ b/udf/worker/core/src/test/scala/org/apache/spark/udf/worker/core/WorkerSessionSuite.scala
@@ -95,6 +95,18 @@ class WorkerSessionSuite extends AnyFunSuite {
     assert(ex.getMessage.contains("exactly once"))
   }
 
+  test("init rejects a null message before changing state") {
+    var initCalled = false
+    val s = new FakeWorkerSession(onInit = _ => {
+      initCalled = true
+      InitResponse.getDefaultInstance
+    })
+    val ex = intercept[IllegalArgumentException](s.init(null))
+    assert(ex.getMessage.contains("message is required"))
+    assert(!initCalled)
+    assert(s.state == SessionState.Created)
+  }
+
   test("process before init is rejected") {
     val s = new FakeWorkerSession()
     val ex = intercept[IllegalStateException](s.process(Iterator.empty))

--- a/udf/worker/core/src/test/scala/org/apache/spark/udf/worker/core/WorkerSessionSuite.scala
+++ b/udf/worker/core/src/test/scala/org/apache/spark/udf/worker/core/WorkerSessionSuite.scala
@@ -166,18 +166,18 @@ class WorkerSessionSuite extends AnyFunSuite {
     assert(h.released == 1)
   }
 
-  test("close leaves a worker salvageable after an Interrupted termination") {
+  test("close marks a worker invalid after an unacknowledged Interrupted termination") {
     val h = new RecordingHandle
     val cause = new InterruptedException("task killed")
-    // An Interrupted terminal is an engine-side event (cancelled query / killed
-    // task), not a worker fault, so the worker stays reusable: markInvalid must
-    // NOT be called.
+    // The interrupt itself is an engine-side event, but Interrupted means no
+    // CancelResponse was received. Without that acknowledgement (or a separate
+    // liveness proof), the worker's state is unknown and it must not be reused.
     val s = new FakeWorkerSession(handle = h, onCloseHook = (self, _) => {
       self.settle(Termination.Interrupted(cause))
       self.term
     })
     assert(s.close() == Termination.Interrupted(cause))
-    assert(h.invalidated == 0)
+    assert(h.invalidated == 1)
     assert(h.released == 1)
   }
 

--- a/udf/worker/core/src/test/scala/org/apache/spark/udf/worker/core/WorkerSessionSuite.scala
+++ b/udf/worker/core/src/test/scala/org/apache/spark/udf/worker/core/WorkerSessionSuite.scala
@@ -166,6 +166,21 @@ class WorkerSessionSuite extends AnyFunSuite {
     assert(h.released == 1)
   }
 
+  test("close leaves a worker salvageable after an Interrupted termination") {
+    val h = new RecordingHandle
+    val cause = new InterruptedException("task killed")
+    // An Interrupted terminal is an engine-side event (cancelled query / killed
+    // task), not a worker fault, so the worker stays reusable: markInvalid must
+    // NOT be called.
+    val s = new FakeWorkerSession(handle = h, onCloseHook = (self, _) => {
+      self.settle(Termination.Interrupted(cause))
+      self.term
+    })
+    assert(s.close() == Termination.Interrupted(cause))
+    assert(h.invalidated == 0)
+    assert(h.released == 1)
+  }
+
   test("close enforces the doClose terminal post-condition") {
     val h = new RecordingHandle
     // doClose returns a Termination without settling any terminal -- a subclass
@@ -261,6 +276,7 @@ class WorkerSessionSuite extends AnyFunSuite {
     assert(termFor(Termination.Cancelled(can)) == Termination.Cancelled(can))
     assert(termFor(Termination.Failed(err)) == Termination.Failed(err))
     assert(termFor(Termination.TransportFailed(cause)) == Termination.TransportFailed(cause))
+    assert(termFor(Termination.Interrupted(cause)) == Termination.Interrupted(cause))
   }
 
   test("settledTermination throws before a terminal is settled") {

--- a/udf/worker/grpc/pom.xml
+++ b/udf/worker/grpc/pom.xml
@@ -66,6 +66,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-udf-worker-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
     </dependency>

--- a/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
+++ b/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
@@ -1,0 +1,816 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.udf.worker.grpc
+
+import java.util.concurrent.{CountDownLatch, LinkedBlockingQueue, TimeoutException, TimeUnit}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+
+import scala.util.control.NonFatal
+
+import io.grpc.{ConnectivityState, ManagedChannel}
+import io.grpc.stub.StreamObserver
+
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.udf.worker.{Cancel, CancelResponse, DataRequest, DataResponse,
+  ExecutionError, Finish, Init, InitResponse, UdfControlRequest,
+  UdfControlResponse, UdfRequest, UdfResponse, UdfWorkerGrpc}
+import org.apache.spark.udf.worker.core.{Termination, WorkerHandle, WorkerLogger, WorkerSession}
+import org.apache.spark.udf.worker.core.WorkerSession.SessionState
+import org.apache.spark.udf.worker.grpc.GrpcWorkerSession._
+
+/**
+ * :: Experimental ::
+ * gRPC implementation of [[WorkerSession]] for the `UdfWorker.Execute`
+ * bidirectional RPC.
+ *
+ * Drives one bidirectional `Execute` stream against the worker per the
+ * ordering invariants documented in `udf_message.proto`:
+ * {{{
+ *   Engine -> Worker:  Init -> (DataRequest)* -> Finish (Cancel)?
+ *                                              | Cancel
+ *   Worker -> Engine:  InitResponse -> (DataResponse)* ->
+ *                      (ErrorResponse)? -> (FinishResponse | CancelResponse)
+ * }}}
+ *
+ * Knows nothing about how the worker was provisioned (locally spawned,
+ * indirectly looked up, ...) -- the dispatcher constructs this with a
+ * [[WorkerHandle]] and channel; the base [[WorkerSession]] handles
+ * dispatcher-side cleanup on close.
+ *
+ * '''Driving model.''' Consumption-driven (Volcano / pull): the thread that
+ * consumes the [[doProcess]] result iterator is the one that pulls the next
+ * input batch and sends its `DataRequest`. Nothing is sent until the iterator
+ * is consumed, and input flows one batch per output pull. The gRPC callback
+ * thread only receives output.
+ *
+ * '''State machine.''' This class does not keep its own state machine: it
+ * drives the single [[WorkerSession.SessionState]] owned by the base. The base
+ * advances `Created -> Initializing` (in `init`) and `Initialized -> Streaming`
+ * (in `process`); this class advances the protocol-event edges through
+ * [[compareAndSetState]] / [[completeTerminal]] as it exchanges messages:
+ * {{{
+ *   Initializing --(InitResponse ok)--> Initialized   [handleControl]
+ *   Streaming ----(Finish written)----> Finishing      [ProcessIterator]
+ *   <any non-terminal> --(Cancel written)--> Cancelling [sendCancelInternal]
+ *   <any non-terminal> --(terminator/error)--> terminal [completeTerminal]
+ * }}}
+ * The two clean terminals carry the worker's `FinishResponse` / `CancelResponse`
+ * (metrics + finish/cancel callback `data`/`error`) so [[close]] can return
+ * them. The only flag kept outside the machine is [[cancelRequested]]: a
+ * cancellation can be requested before the stream exists (so it cannot be a
+ * state transition yet), and it must both fast-fail the result iterator and
+ * suppress any in-flight Data/Finish.
+ *
+ * Threading:
+ *  - [[doInit]] is synchronous: sends `Init` and blocks on `InitResponse`,
+ *    returning it.
+ *  - [[doProcess]] returns an iterator. Input batches are forwarded inline
+ *    (the iterator's `next()` thread also sends `DataRequest`). Output
+ *    batches arrive via the response observer (gRPC callback thread) and
+ *    are consumed by the same iterator. A terminator (`FinishResponse`,
+ *    `CancelResponse`, `ErrorResponse`, gRPC stream error) is published
+ *    once.
+ *  - [[doClose]] is thread-safe and idempotent: it settles + returns the
+ *    terminator (cancelling in-flight work if the stream had not finished)
+ *    and half-closes the request side.
+ *
+ * TODO [SPARK-55278]: this class does not yet implement payload chunking;
+ * the entire [[Init.udf]] payload is sent inline. Chunking will be added
+ * when a UDF payload large enough to exceed gRPC's default message size
+ * limit is introduced.
+ *
+ * @param workerHandle dispatcher-side handle for releasing the worker on
+ *                     [[close]] (see [[WorkerSession]]).
+ * @param channel      a gRPC channel built and owned by the caller (the
+ *                     dispatcher). Not closed here -- the dispatcher tears it
+ *                     down via [[WorkerHandle]].
+ * @param logger       diagnostics. Defaults to [[WorkerLogger.NoOp]].
+ * @param initResponseTimeoutMs upper bound on the wait for `InitResponse`
+ *                              after [[doInit]] sends `Init`.
+ * @param terminalTimeoutMs     upper bound on the wait for a stream
+ *                              terminator (`FinishResponse`,
+ *                              `CancelResponse`, or `ErrorResponse`).
+ *                              Each output-queue poll resets this wait;
+ *                              see [[doProcess]] / `ProcessIterator`.
+ */
+@Experimental
+class GrpcWorkerSession(
+    workerHandle: WorkerHandle,
+    channel: ManagedChannel,
+    logger: WorkerLogger = WorkerLogger.NoOp,
+    initResponseTimeoutMs: Long = DEFAULT_INIT_RESPONSE_TIMEOUT_MS,
+    terminalTimeoutMs: Long = DEFAULT_TERMINAL_TIMEOUT_MS)
+  extends WorkerSession(workerHandle, logger) {
+
+  require(channel != null, "channel is required")
+
+  private val asyncStub = UdfWorkerGrpc.newStub(channel)
+
+  // Output batches from the worker, drained by the process() iterator.
+  // Intentionally unbounded: a bounded queue would block the gRPC callback
+  // (Netty event-loop) thread when full, stalling control-message and
+  // terminator delivery on the whole channel. HTTP/2 flow control bounds the
+  // wire and the consumer normally drains promptly, so it stays small. A
+  // stalled downstream can still grow it; the real fix is protocol-level
+  // back-pressure (out of scope here), not bounding the queue.
+  //
+  // TODO [SPARK-57324]: expose queue depth as a metric (early warning for a
+  // stalled consumer).
+  private val outputQueue = new LinkedBlockingQueue[QueueItem]()
+
+  // Latch fired when `InitResponse` (success or error) or a transport error
+  // arrives. init() blocks on this; until it fires we have no proof the
+  // worker actually accepted the session.
+  private val initLatch = new CountDownLatch(1)
+
+  // The InitResponse the worker sent (success or error), captured so init()
+  // can return it. None until InitResponse arrives.
+  private val initResponse = new AtomicReference[Option[InitResponse]](None)
+
+  // Fired when the session reaches a terminal [[SessionState]]. doClose() and
+  // the init-error path block on this to drain the terminator.
+  private val terminalLatch = new CountDownLatch(1)
+
+  // Captures an ErrorResponse encountered during the data phase so that
+  // the CancelResponse terminator can attribute the failure to the original
+  // user / worker / protocol error rather than reporting a bare "Cancelled".
+  private val executionError = new AtomicReference[Option[ExecutionError]](None)
+
+  // Cancellation intent. Kept outside the [[SessionState]] machine because a
+  // cancel can be requested before the stream exists (pre-init), where there is
+  // no wire transition to make yet -- only an intent to record. Used to (a)
+  // make cancel idempotent across all call sites, (b) fast-fail ProcessIterator
+  // on a pre-init cancel, and (c) suppress any Data/Finish that would otherwise
+  // race a Cancel onto the wire (re-read inside [[requestLock]]).
+  private val cancelRequested = new AtomicBoolean(false)
+
+  // gRPC requires serialized writes to a request StreamObserver.
+  private val requestLock = new Object
+
+  // Initialised in init() -- before that, close() is a no-op on the request
+  // side, which is exactly the contract the wrapping WorkerSession expects.
+  @volatile private var requestObserver: StreamObserver[UdfRequest] = _
+
+  private val responseObserver: StreamObserver[UdfResponse] = new StreamObserver[UdfResponse] {
+    override def onNext(response: UdfResponse): Unit = {
+      response.getResponseCase match {
+        case UdfResponse.ResponseCase.DATA =>
+          outputQueue.put(QueueItem.Batch(response.getData))
+
+        case UdfResponse.ResponseCase.CONTROL =>
+          handleControl(response.getControl)
+
+        case other =>
+          // A malformed response (empty / unknown oneof) is a terminal
+          // transport failure. Count down initLatch like every other
+          // terminal-settling path here (onError / onCompleted / each
+          // handleControl branch): if this arrives before InitResponse, doInit
+          // must fail fast with this cause rather than block until
+          // initResponseTimeoutMs and report a misleading "timed out" error.
+          completeTerminal(Termination.TransportFailed(new IllegalStateException(
+            s"unexpected response oneof: $other")))
+          initLatch.countDown()
+      }
+    }
+
+    override def onError(t: Throwable): Unit = {
+      // Transport-level failure: the stream is dead. No further writes are
+      // possible (reaching a terminal state closes the write side). Settle the
+      // terminal BEFORE counting down initLatch: init() blocks on that latch,
+      // and only await/countDown establish a happens-before edge, so a thread
+      // woken by the countDown must already be able to observe the terminal.
+      // That lets init() surface the transport cause instead of timing out
+      // after initResponseTimeoutMs with a misleading "timed out" message --
+      // or, if it saw a transient non-terminal state, the defensive "init latch
+      // fired without an InitResponse or terminal" error.
+      completeTerminal(Termination.TransportFailed(t))
+      initLatch.countDown()
+    }
+
+    override def onCompleted(): Unit = {
+      // Worker half-closed its side without sending a terminator (FinishResponse
+      // / CancelResponse). Treat as transport error so the engine sees a
+      // failure, not a silent end-of-stream.
+      if (!currentState.isTerminal) {
+        completeTerminal(Termination.TransportFailed(new IllegalStateException(
+          "worker response stream closed without a terminator")))
+      }
+      // Defensive: if onCompleted reached us before InitResponse, doInit is
+      // still blocked on initLatch and would otherwise time out.
+      initLatch.countDown()
+    }
+  }
+
+  /**
+   * Wakes the result iterator (blocked on [[outputQueue]]) and any thread
+   * waiting on [[terminalLatch]] when the base settles a terminal. Invoked once,
+   * by the caller that wins [[completeTerminal]].
+   */
+  override protected def onTerminalSettled(termination: Termination): Unit = {
+    outputQueue.put(QueueItem.EndOfStream)
+    terminalLatch.countDown()
+  }
+
+  private def handleControl(ctrl: UdfControlResponse): Unit = ctrl.getControlCase match {
+    case UdfControlResponse.ControlCase.INIT =>
+      val resp = ctrl.getInit
+      // Capture the InitResponse so init() can return it (or throw on its error).
+      initResponse.set(Some(resp))
+      if (resp.hasError) {
+        initLatch.countDown()
+        // Per the protocol the engine follows an init error with Cancel; send it
+        // if the request stream is up. If the Cancel cannot be written -- e.g. a
+        // directExecutor worker delivered InitResponse reentrantly, before
+        // doInit published requestObserver -- settle the terminal here so doInit
+        // does not wait the full terminalTimeoutMs for a CancelResponse that can
+        // never arrive. (When the Cancel is sent, the CancelResponse settles the
+        // terminal instead.)
+        if (!sendCancelInternal(() => cancelWithReason("init failed")) &&
+            !currentState.isTerminal) {
+          completeTerminal(Termination.Failed(resp.getError))
+        }
+      } else {
+        // InitResponse OK: init succeeded. A terminal that arrived first (e.g. a
+        // racing transport error) must win, so only advance from the expected
+        // Initializing state; process() then opens the data phase (Streaming).
+        compareAndSetState(SessionState.Initializing, SessionState.Initialized)
+        initLatch.countDown()
+      }
+
+    case UdfControlResponse.ControlCase.ERROR =>
+      val err = ctrl.getError.getError
+      executionError.compareAndSet(None, Some(err))
+      // ERROR before InitResponse is special: under directExecutor or with
+      // a fast worker, sendCancelInternal may run while requestObserver is
+      // still null (we're inside stream.onNext(initRequest) and have not
+      // yet published the field), so no Cancel reaches the wire and no
+      // CancelResponse will follow to settle the terminal. Settle it here
+      // (as Failed, since there is no proto terminator to carry) so doInit
+      // doesn't return as if init succeeded. "Init not yet resolved" is exactly
+      // "the stream has not reached Initialized"; completeTerminal is idempotent,
+      // so the data-phase ERROR -> Cancel -> CancelResponse path is unaffected.
+      if (!initResolved) {
+        completeTerminal(Termination.Failed(err))
+      }
+      // Surface the error to doInit. Count down AFTER settling the terminal
+      // above: init() blocks on this latch and only await/countDown establish
+      // happens-before, so a woken doInit must be able to observe the terminal
+      // rather than a transient non-terminal state. Idempotent, so the normal
+      // data-phase path (latch already fired during init) is unaffected.
+      initLatch.countDown()
+      sendCancelInternal(() => cancelWithReason("aborting after ErrorResponse"))
+
+    case UdfControlResponse.ControlCase.FINISH =>
+      // The FinishResponse carries metrics + the finish-callback data/error.
+      // Keep it on the terminal so close() can return it; the iterator inspects
+      // its error field to decide whether to throw.
+      completeTerminal(Termination.Finished(ctrl.getFinish))
+      // Defensive: FINISH before InitResponse is a worker protocol bug, but
+      // we should fail init fast rather than hang the 30s init timeout.
+      initLatch.countDown()
+
+    case UdfControlResponse.ControlCase.CANCEL =>
+      // The CancelResponse carries metrics + the cancel-callback error. Keep it
+      // on the terminal so close() can return it; any prior ErrorResponse is
+      // tracked in executionError and surfaced by the iterator.
+      completeTerminal(Termination.Cancelled(ctrl.getCancel))
+      // Defensive: CANCEL before InitResponse unblocks doInit so it can
+      // surface the cancellation instead of timing out.
+      initLatch.countDown()
+
+    case UdfControlResponse.ControlCase.CONTROL_NOT_SET =>
+      completeTerminal(Termination.TransportFailed(new IllegalStateException(
+        "empty UdfControlResponse oneof")))
+      initLatch.countDown()
+  }
+
+  /** True once init has resolved (Initialized or beyond). */
+  private def initResolved: Boolean = currentState match {
+    case SessionState.Created | SessionState.Initializing => false
+    case _ => true
+  }
+
+  private def cancelWithReason(reason: String): Cancel =
+    Cancel.newBuilder().setReason(reason).build()
+
+  // ---- WorkerSession hooks ------------------------------------------------
+
+  override protected def doInit(message: Init): InitResponse = {
+    // Fail fast if the channel is already shut down. Without this check,
+    // asyncStub.execute(...) would still succeed and the failure would
+    // surface ~initResponseTimeoutMs later as a misleading "InitResponse
+    // timed out" error.
+    if (channel.getState(false) == ConnectivityState.SHUTDOWN) {
+      val ex = new IllegalStateException("gRPC channel is shut down")
+      completeTerminal(Termination.TransportFailed(ex))
+      throw new GrpcWorkerSessionException("UDF worker channel is closed", ex)
+    }
+    // Open the stream as a local first; only publish `requestObserver`
+    // AFTER the Init has been put on the wire. close()'s cancel reads
+    // `requestObserver` outside [[requestLock]] and returns early when
+    // it is null, so this ordering prevents a concurrent cancel from
+    // sneaking a Cancel ahead of Init.
+    val stream = asyncStub.execute(responseObserver)
+    val initRequest = UdfRequest.newBuilder()
+      .setControl(UdfControlRequest.newBuilder().setInit(message).build())
+      .build()
+    try {
+      requestLock.synchronized {
+        // The base advanced Created -> Initializing before calling doInit, so a
+        // directExecutor worker's InitResponse -- delivered reentrantly inside
+        // onNext -- finds Initializing and advances to Initialized.
+        stream.onNext(initRequest)
+        requestObserver = stream
+      }
+    } catch {
+      case NonFatal(e) =>
+        // Expose the stream so a subsequent close() can still attempt a
+        // best-effort half-close; the terminal already reflects the failure.
+        requestObserver = stream
+        completeTerminal(Termination.TransportFailed(e))
+        // Surface as GrpcWorkerSessionException so the engine integration layer
+        // (which catches that type and wraps it) sees a uniform init-failure
+        // exception rather than the raw transport error.
+        throw new GrpcWorkerSessionException("UDF worker stream failed during init", e)
+    }
+
+    val responded = try {
+      initLatch.await(initResponseTimeoutMs, TimeUnit.MILLISECONDS)
+    } catch {
+      case _: InterruptedException =>
+        Thread.currentThread().interrupt()
+        sendCancelInternal(() => cancelWithReason("interrupted during init"))
+        // Make sure close() does not block waiting for a terminator that
+        // will never arrive on this thread's behalf.
+        completeTerminal(Termination.TransportFailed(
+          new InterruptedException("interrupted while waiting for InitResponse")))
+        throw new InterruptedException("interrupted while waiting for InitResponse")
+    }
+
+    if (!responded) {
+      sendCancelInternal(() => cancelWithReason("InitResponse timed out"))
+      val timeout = new TimeoutException(
+        s"timed out waiting for InitResponse after ${initResponseTimeoutMs}ms")
+      // Settle the terminal so a subsequent close() does not stall for a
+      // second `terminalTimeoutMs` waiting for a worker that already missed
+      // its init deadline.
+      completeTerminal(Termination.TransportFailed(timeout))
+      // Surface as GrpcWorkerSessionException (carrying the timeout cause) so
+      // the engine integration layer that catches that type can wrap it.
+      throw new GrpcWorkerSessionException(
+        s"timed out waiting for InitResponse after ${initResponseTimeoutMs}ms", timeout)
+    }
+
+    initResponse.get() match {
+      case Some(resp) if resp.hasError =>
+        // The protocol requires the engine to send Cancel after an init
+        // error and the worker to respond with CancelResponse. Drain it
+        // before throwing so we don't leave a dangling stream.
+        awaitTerminal()
+        throw new GrpcWorkerSessionException(
+          s"UDF worker init failed: ${describeError(resp.getError)}", resp.getError)
+      case Some(resp) =>
+        resp
+      case None =>
+        // No InitResponse arrived but the latch fired. The defensive
+        // initLatch.countDown() in handleControl / onError / onCompleted
+        // means we get here when the worker terminated the stream before
+        // sending InitResponse. Surface that as an init failure rather than
+        // letting the caller proceed as if init succeeded.
+        currentState match {
+          case SessionState.Terminal(Termination.TransportFailed(cause)) =>
+            throw new GrpcWorkerSessionException(
+              "UDF worker stream failed during init", cause)
+          case SessionState.Terminal(Termination.Failed(err)) =>
+            throw new GrpcWorkerSessionException(
+              s"UDF worker reported an error before init completed: " +
+                describeError(err), err)
+          case SessionState.Terminal(Termination.Cancelled(_)) =>
+            throw new GrpcWorkerSessionException(
+              "UDF worker stream was cancelled before init completed")
+          case SessionState.Terminal(Termination.Finished(_)) =>
+            throw new GrpcWorkerSessionException(
+              "UDF worker finished before init completed")
+          case other =>
+            throw new IllegalStateException(
+              s"init latch fired without an InitResponse or terminal: $other")
+        }
+    }
+  }
+
+  override protected def doProcess(
+      input: Iterator[DataRequest],
+      finish: () => Finish): Iterator[DataResponse] = {
+    // Init success is guaranteed by the base [[WorkerSession]] lifecycle: if
+    // doInit had failed it would have thrown and process() would never run.
+    new ProcessIterator(input, finish)
+  }
+
+  override protected def doClose(cancel: () => Cancel): Termination = {
+    if (requestObserver == null) {
+      // init() never put a stream on the wire (closed before/around init, or
+      // init threw before publishing). There is no protocol terminator; treat
+      // the session as cancelled-before-start. The base WorkerSession still
+      // releases the worker handle, so the worker is torn down.
+      completeTerminal(Termination.Cancelled(CancelResponse.getDefaultInstance))
+      return Termination.Cancelled(CancelResponse.getDefaultInstance)
+    }
+    // If the stream has not finished on its own, cancel anything in flight so
+    // the worker can clean up, then wait for the terminator. sendCancelInternal
+    // evaluates the cancel thunk only when it actually writes a Cancel, and at
+    // most once across all callers.
+    if (!currentState.isTerminal) {
+      sendCancelInternal(cancel)
+      try {
+        terminalLatch.await(terminalTimeoutMs, TimeUnit.MILLISECONDS)
+      } catch {
+        case _: InterruptedException => Thread.currentThread().interrupt()
+      }
+    }
+    // If the worker still has not settled (timeout or interrupt above),
+    // record a terminal so isWorkerSalvageable returns a definite answer
+    // and any other thread reading the state sees a stable value.
+    if (!currentState.isTerminal) {
+      completeTerminal(Termination.TransportFailed(new TimeoutException(
+        s"timed out waiting for stream terminator after ${terminalTimeoutMs}ms")))
+    }
+    // Half-close the request side regardless of whether we sent Cancel or
+    // Finish earlier -- the worker's onCompleted handler relies on this to
+    // tear down the per-stream state cleanly. onCompleted on an
+    // already-torn-down stream throws and is caught, so this stays idempotent
+    // across repeat close() calls.
+    try {
+      requestLock.synchronized { requestObserver.onCompleted() }
+    } catch {
+      case NonFatal(e) =>
+        logger.debug("Error half-closing UDF Execute stream", e)
+    }
+    // Derive the Termination from the settled terminal. close() is the
+    // finalizer/cleanup path and must NOT re-throw: a UDF / data-phase error is
+    // already surfaced while the result iterator is consumed, and an init error
+    // from init(). settledTermination returns the response proto for the clean
+    // terminators and a best-effort empty Cancelled for the failure terminals.
+    settledTermination
+  }
+
+  // ---- Internal request helpers ---------------------------------------------
+
+  /**
+   * Sends a Data or Finish request to the worker. Two invariants are
+   * checked inside [[requestLock]]:
+   *  - terminal state: writes are unsafe (transport dead or terminal
+   *    received). Throws, so the caller's terminal/exception path runs.
+   *  - [[cancelRequested]]: a Cancel has been (or is about to be) sent.
+   *    Silently no-ops so a Data/Finish never appears on the wire after
+   *    Cancel; the caller's iterator falls through to the terminator wait.
+   *
+   * Init is NOT sent through this helper -- [[doInit]] writes Init
+   * directly under [[requestLock]] before publishing
+   * [[requestObserver]], so there is no path through which a concurrent
+   * cancel could send Cancel before Init.
+   */
+  private def sendRequest(req: UdfRequest): Unit =
+    requestLock.synchronized {
+      if (currentState.isTerminal) {
+        throw new IllegalStateException(
+          "cannot send request: UDF Execute stream is already closed")
+      }
+      // Suppress the write when a cancel has been (or is about to be) flushed
+      // through this lock; that preserves the proto ordering invariant (no
+      // Data/Finish after Cancel). We test the flag rather than `return`-ing
+      // from the block: a non-local return out of this by-name `synchronized`
+      // body compiles to a thrown NonLocalReturnControl, which is brittle.
+      if (!cancelRequested.get()) {
+        requestObserver.onNext(req)
+      }
+    }
+
+  /**
+   * Sends a `Cancel` control message, returning `true` iff a `Cancel` was
+   * actually written to the wire. Idempotent across ALL call sites (close()'s
+   * cancel, in-band cancels from `handleControl`'s INIT error / ERROR paths,
+   * and engine-internal cancels from the iterator) via [[cancelRequested]]:
+   * only the first caller puts a `Cancel` on the wire, and the `cancel` thunk is
+   * evaluated only by that caller and only when the message is actually sent --
+   * so a side-effecting thunk (e.g. one carrying a client cancel callback) runs
+   * at most once. Setting [[cancelRequested]] also blocks subsequent Data/Finish
+   * writes from [[ProcessIterator]] (see [[sendRequest]]), preserving the proto
+   * invariant that nothing follows `Cancel` on the engine-to-worker side.
+   */
+  private def sendCancelInternal(cancel: () => Cancel): Boolean = {
+    if (!cancelRequested.compareAndSet(false, true)) return false
+    if (requestObserver == null) return false
+    if (currentState.isTerminal) return false
+    try {
+      requestLock.synchronized {
+        // A terminal that arrived first must win; bail without writing. We
+        // compute the block's value rather than `return`-ing from this by-name
+        // `synchronized` body, whose non-local return would compile to a thrown
+        // NonLocalReturnControl that the surrounding NonFatal catch must not
+        // swallow -- brittle to rely on. Reads naturally as the block result.
+        val cur = currentState
+        if (cur.isTerminal) {
+          false
+        } else {
+          // Record that a Cancel is on the wire by advancing to Cancelling.
+          compareAndSetState(cur, SessionState.Cancelling)
+          requestObserver.onNext(UdfRequest.newBuilder()
+            .setControl(UdfControlRequest.newBuilder().setCancel(cancel()).build())
+            .build())
+          true
+        }
+      }
+    } catch {
+      case NonFatal(e) =>
+        logger.debug(s"Cancel send failed (stream may already be torn down): ${e.getMessage}")
+        completeTerminal(Termination.TransportFailed(e))
+        false
+    }
+  }
+
+  private def awaitTerminal(): Unit = {
+    if (currentState.isTerminal) return
+    try {
+      if (!terminalLatch.await(terminalTimeoutMs, TimeUnit.MILLISECONDS)) {
+        completeTerminal(Termination.TransportFailed(new TimeoutException(
+          s"timed out waiting for stream terminator after ${terminalTimeoutMs}ms")))
+      }
+    } catch {
+      case _: InterruptedException =>
+        // Attribute the terminal to the interrupt, not a timeout: the wait was
+        // cut short, it did not exhaust terminalTimeoutMs. Reporting "timed
+        // out" here would misdiagnose an interrupted close as a slow worker.
+        Thread.currentThread().interrupt()
+        completeTerminal(Termination.TransportFailed(
+          new InterruptedException("interrupted while waiting for stream terminator")))
+    }
+  }
+
+  // ---- ProcessIterator ------------------------------------------------------
+
+  /**
+   * Iterator returned by [[doProcess]]. Drives the data phase of the
+   * stream end-to-end: each call to `hasNext` / `next` may send a
+   * `DataRequest` or `Finish` to the worker, and reads result batches
+   * out of [[outputQueue]] as the worker emits them.
+   *
+   * The iterator is single-threaded with respect to the engine, but
+   * coexists with the gRPC callback thread (which enqueues responses
+   * and may settle the state) and with any thread that finalizes via
+   * [[close]]. It drives the `Streaming -> Finishing` transition (sending
+   * `Finish` once input is exhausted, built lazily from the `finish` thunk).
+   */
+  private class ProcessIterator(input: Iterator[DataRequest], finish: () => Finish)
+      extends Iterator[DataResponse] {
+
+    // Latched once the terminator sentinel has been observed. Without this,
+    // a second hasNext() after the iterator naturally exhausts would re-enter
+    // advance(), fall through all branches, and block branch 4 for the
+    // full terminalTimeoutMs before returning. Callers that probe hasNext
+    // an extra time (iterator.size, instrumentation wrappers) would hang.
+    // Iterator-local and only touched by the single engine thread.
+    private val exhausted = new AtomicBoolean(false)
+    @volatile private var prefetched: DataResponse = _
+
+    // Pre-init cancel fast-fail: if a cancel ran before doInit published the
+    // requestObserver, no Cancel was sent on the wire and the worker may
+    // never emit a terminator. Trip the terminal explicitly so the first
+    // hasNext / next surfaces a cancellation instead of blocking for
+    // terminalTimeoutMs in branch 4.
+    if (cancelRequested.get() && !currentState.isTerminal) {
+      completeTerminal(Termination.Cancelled(CancelResponse.getDefaultInstance))
+    }
+
+    override def hasNext: Boolean = {
+      if (prefetched ne null) return true
+      advance()
+      prefetched ne null
+    }
+
+    override def next(): DataResponse = {
+      if (prefetched eq null) advance()
+      val out = prefetched
+      if (out eq null) {
+        throw new NoSuchElementException("ProcessIterator exhausted")
+      }
+      prefetched = null
+      out
+    }
+
+    /**
+     * Single loop that, each iteration, tries in order: (1) drain queued output
+     * (a batch, or the terminator sentinel); (2) while `Streaming`, send the next
+     * input batch; (3) once input is exhausted, send `Finish` (CAS `Streaming ->
+     * Finishing`, once); (4) otherwise block for late output or the terminator.
+     * Each branch is commented inline below.
+     *
+     * '''Per-poll timeout.''' Branch 4 waits up to [[terminalTimeoutMs]] per
+     * poll, reset by every worker event -- the contract is "emit at least one
+     * event every [[terminalTimeoutMs]] after Finish", not "finish the UDF within
+     * [[terminalTimeoutMs]]". A worker expecting a long post-Finish silence MAY
+     * emit an empty `DataResponse` as a heartbeat to reset the wait; it is
+     * surfaced to the caller, so it should be a batch the caller recognises as
+     * empty (e.g. a zero-row Arrow batch).
+     */
+    private def advance(): Unit = {
+      if (exhausted.get()) return // terminator already seen; never re-block
+      while (prefetched eq null) {
+        // (1) Drain anything the worker has already produced.
+        outputQueue.poll() match {
+          case null => // queue empty, fall through to send/wait branches below
+          case QueueItem.EndOfStream =>
+            exhausted.set(true)
+            throwIfTerminalError()
+            return
+          case QueueItem.Batch(b) =>
+            prefetched = b
+            return
+        }
+
+        // (2) Send next input batch while the stream is open for data.
+        if (!cancelRequested.get() && currentState == SessionState.Streaming && input.hasNext) {
+          val batch = try input.next() catch {
+            case NonFatal(e) =>
+              sendCancelInternal(() => cancelWithReason("input iterator failed"))
+              throw e
+          }
+          if (!sendOrEndOnRacedTerminal(UdfRequest.newBuilder().setData(batch).build())) return
+        } else if (!cancelRequested.get() &&
+            compareAndSetState(SessionState.Streaming, SessionState.Finishing)) {
+          // (3) No more input; send Finish exactly once (unless cancelled).
+          if (!sendOrEndOnRacedTerminal(UdfRequest.newBuilder()
+              .setControl(UdfControlRequest.newBuilder().setFinish(finish()).build())
+              .build())) {
+            return
+          }
+        } else {
+          // (4) Block for late output or the terminator. See class doc
+          //     above for the per-poll-vs-total-session timeout semantics.
+          val item = try {
+            outputQueue.poll(terminalTimeoutMs, TimeUnit.MILLISECONDS)
+          } catch {
+            case _: InterruptedException =>
+              Thread.currentThread().interrupt()
+              sendCancelInternal(() => cancelWithReason("iterator interrupted"))
+              exhausted.set(true)
+              throw new InterruptedException("interrupted while reading UDF result")
+          }
+          item match {
+            case null =>
+              completeTerminal(Termination.TransportFailed(new IllegalStateException(
+                s"timed out waiting for UDF output after ${terminalTimeoutMs}ms")))
+              exhausted.set(true)
+              throwIfTerminalError()
+              return
+            case QueueItem.EndOfStream =>
+              exhausted.set(true)
+              throwIfTerminalError()
+              return
+            case QueueItem.Batch(b) =>
+              prefetched = b
+              return
+          }
+        }
+      }
+    }
+
+    /**
+     * Sends one data-phase request (`DataRequest` / `Finish`), recovering from a
+     * terminator that raced the write. Returns `true` to keep looping (sent, or
+     * suppressed by a pending cancel), `false` if a terminator settled and the
+     * iterator should end (caller `return`s).
+     *
+     * On a write failure a terminator usually already settled (the worker
+     * finished/failed early) and the write only failed because the stream is
+     * closed: record a transport terminal if none is set ([[completeTerminal]] is
+     * a no-op once settled), then [[throwIfTerminalError]] -- which throws for an
+     * error/transport terminal, or returns for a clean `Finished` that raced the
+     * send, in which case the benign "stream closed" error is dropped.
+     */
+    private def sendOrEndOnRacedTerminal(req: UdfRequest): Boolean = {
+      try {
+        sendRequest(req)
+        true
+      } catch {
+        case NonFatal(e) =>
+          if (!currentState.isTerminal) {
+            completeTerminal(Termination.TransportFailed(e))
+          }
+          exhausted.set(true)
+          throwIfTerminalError()
+          false
+      }
+    }
+
+    /**
+     * Surfaces a failed terminator as an exception when the result iterator is
+     * drained. A data-phase [[ExecutionError]] (captured in [[executionError]])
+     * takes precedence over the terminator's own error, then the finish/cancel
+     * callback error carried on the terminator, then a bare cancellation.
+     */
+    private def throwIfTerminalError(): Unit = currentState match {
+      case SessionState.Terminal(Termination.Finished(response)) =>
+        responseError(response.hasError, response.getError, executionError.get())
+          .foreach(err => throw new GrpcWorkerSessionException(
+            s"UDF execution failed: ${describeError(err)}", err))
+      case SessionState.Terminal(Termination.Cancelled(response)) =>
+        responseError(response.hasError, response.getError, executionError.get()) match {
+          case Some(err) =>
+            throw new GrpcWorkerSessionException(
+              s"UDF execution failed: ${describeError(err)}", err)
+          case None =>
+            throw new GrpcWorkerSessionException("UDF execution was cancelled")
+        }
+      case SessionState.Terminal(Termination.Failed(err)) =>
+        throw new GrpcWorkerSessionException(
+          s"UDF execution failed: ${describeError(err)}", err)
+      case SessionState.Terminal(Termination.TransportFailed(t)) =>
+        throw new GrpcWorkerSessionException("UDF worker stream failed", t)
+      case other =>
+        throw new IllegalStateException(s"terminator sentinel without terminal: $other")
+    }
+
+    /** Picks the error to surface: prior data-phase error, else the terminator's. */
+    private def responseError(
+        hasError: Boolean,
+        error: ExecutionError,
+        priorError: Option[ExecutionError]): Option[ExecutionError] =
+      priorError.orElse(if (hasError) Some(error) else None)
+  }
+}
+
+object GrpcWorkerSession {
+  /** Upper bound on the wait for `InitResponse`. */
+  val DEFAULT_INIT_RESPONSE_TIMEOUT_MS: Long = 30000L
+
+  /** Upper bound on the wait for `FinishResponse` / `CancelResponse`. */
+  val DEFAULT_TERMINAL_TIMEOUT_MS: Long = 30000L
+
+  // Distinguishes a (possibly empty) data batch from end-of-stream, and makes
+  // the iterator's match exhaustive.
+  private sealed trait QueueItem
+  private object QueueItem {
+    final case class Batch(response: DataResponse) extends QueueItem
+    case object EndOfStream extends QueueItem
+  }
+
+  private[grpc] def describeError(err: ExecutionError): String = err.getKindCase match {
+    case ExecutionError.KindCase.USER =>
+      val u = err.getUser
+      val cls = if (u.hasErrorClass) s"[${u.getErrorClass}] " else ""
+      s"$cls${u.getMessage}"
+    case ExecutionError.KindCase.WORKER =>
+      s"WorkerError: ${err.getWorker.getMessage}"
+    case ExecutionError.KindCase.PROTOCOL =>
+      s"ProtocolError: ${err.getProtocol.getMessage}"
+    case ExecutionError.KindCase.KIND_NOT_SET =>
+      "ExecutionError without kind"
+  }
+}
+
+/**
+ * :: Experimental ::
+ * Exception thrown by [[GrpcWorkerSession]] when the UDF execution fails
+ * at the engine-protocol layer: init failure, ErrorResponse from the
+ * worker, a failure terminator with no response, transport failure, or
+ * (from the result iterator) a cancellation.
+ *
+ * This extends plain [[RuntimeException]] rather than Spark's
+ * `SparkRuntimeException` so the udf-worker modules stay free of a spark-core
+ * dependency. The engine integration layer (which already depends on
+ * spark-core) is expected to catch this and wrap it in a
+ * `SparkRuntimeException` with an appropriate error class when surfacing UDF
+ * failures to users. [[executionError]] is preserved to carry the structured
+ * cause across that boundary.
+ *
+ * @param executionError the structured protocol error when the failure carries
+ *                       one (a worker `ErrorResponse`, an init error, or a
+ *                       failure terminator with an error). `null` when there is
+ *                       no structured cause: a transport failure, a timeout, or
+ *                       a cancellation without an error. Callers must null-check
+ *                       before use.
+ */
+@Experimental
+class GrpcWorkerSessionException(
+    message: String,
+    cause: Throwable = null,
+    @javax.annotation.Nullable val executionError: ExecutionError = null)
+  extends RuntimeException(message, cause) {
+
+  def this(message: String, error: ExecutionError) =
+    this(message, null, error)
+}

--- a/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
+++ b/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
@@ -26,7 +26,7 @@ import io.grpc.stub.StreamObserver
 
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.udf.worker.{Cancel, CancelResponse, DataRequest, DataResponse,
-  ExecutionError, Finish, Init, InitResponse, UdfControlRequest,
+  ExecutionError, Finish, FinishResponse, Init, InitResponse, UdfControlRequest,
   UdfControlResponse, UdfRequest, UdfResponse, UdfWorkerGrpc}
 import org.apache.spark.udf.worker.core.{Termination, WorkerHandle, WorkerLogger, WorkerSession}
 import org.apache.spark.udf.worker.core.WorkerSession.SessionState
@@ -54,8 +54,11 @@ import org.apache.spark.udf.worker.grpc.GrpcWorkerSession._
  * '''Driving model.''' Consumption-driven (Volcano / pull): the thread that
  * consumes the [[doProcess]] result iterator is the one that pulls the next
  * input batch and sends its `DataRequest`. Nothing is sent until the iterator
- * is consumed, and input flows one batch per output pull. The gRPC callback
- * thread only receives output.
+ * is consumed, and the gRPC callback thread only receives output. Note this is
+ * pull-driven, not strictly one-input-per-output: `advance` sends the next input
+ * batch whenever the output queue is momentarily empty, so under asynchronous
+ * delivery it can push several input batches before any output is read (bounded
+ * only by HTTP/2 flow control), rather than lock-stepping one input per output.
  *
  * '''State machine.''' This class does not keep its own state machine: it
  * drives the single [[WorkerSession.SessionState]] owned by the base. The base
@@ -132,14 +135,14 @@ class GrpcWorkerSession(
   // stalled consumer).
   private val outputQueue = new LinkedBlockingQueue[QueueItem]()
 
-  // Latch fired when `InitResponse` (success or error) or a transport error
-  // arrives. init() blocks on this; until it fires we have no proof the
-  // worker actually accepted the session.
-  private val initLatch = new CountDownLatch(1)
-
-  // The InitResponse the worker sent (success or error), captured so init()
-  // can return it. None until InitResponse arrives.
-  private val initResponse = new AtomicReference[Option[InitResponse]](None)
+  // The worker's `InitResponse` (success or error) coupled with the latch that
+  // init() blocks on. Fires when the InitResponse arrives (`complete`) or when a
+  // terminal settles first without one -- transport error, half-close, or a
+  // premature terminator (`signalWithoutValue`). Until it fires we have no proof
+  // the worker accepted the session. Bundling the value and the latch in one
+  // object keeps the "publish then release" ordering in a single place rather
+  // than leaving callers to remember to count down after setting the reference.
+  private val initValue = new OneShotValue[InitResponse]
 
   // Fired when the session reaches a terminal [[SessionState]]. doClose() and
   // the init-error path block on this to drain the terminator.
@@ -169,36 +172,48 @@ class GrpcWorkerSession(
     override def onNext(response: UdfResponse): Unit = {
       response.getResponseCase match {
         case UdfResponse.ResponseCase.DATA =>
-          outputQueue.put(QueueItem.Batch(response.getData))
+          // A DataResponse before InitResponse violates the protocol
+          // (InitResponse must precede any DataResponse). Enqueuing it would
+          // leave init() blocked on initValue until initResponseTimeoutMs, then
+          // fail with a misleading "timed out" instead of the real protocol
+          // fault. Settle a transport-failure terminal and release init(), the
+          // same fast-fail discipline the malformed / terminator branches use.
+          if (!initResolved) {
+            Transitions.transportFailed(new IllegalStateException(
+              "worker sent a DataResponse before InitResponse"))
+            initValue.signalWithoutValue()
+          } else {
+            outputQueue.put(QueueItem.Batch(response.getData))
+          }
 
         case UdfResponse.ResponseCase.CONTROL =>
           handleControl(response.getControl)
 
         case other =>
           // A malformed response (empty / unknown oneof) is a terminal
-          // transport failure. Count down initLatch like every other
+          // transport failure. Release initValue like every other
           // terminal-settling path here (onError / onCompleted / each
           // handleControl branch): if this arrives before InitResponse, doInit
           // must fail fast with this cause rather than block until
           // initResponseTimeoutMs and report a misleading "timed out" error.
-          completeTerminal(Termination.TransportFailed(new IllegalStateException(
-            s"unexpected response oneof: $other")))
-          initLatch.countDown()
+          Transitions.transportFailed(new IllegalStateException(
+            s"unexpected response oneof: $other"))
+          initValue.signalWithoutValue()
       }
     }
 
     override def onError(t: Throwable): Unit = {
       // Transport-level failure: the stream is dead. No further writes are
       // possible (reaching a terminal state closes the write side). Settle the
-      // terminal BEFORE counting down initLatch: init() blocks on that latch,
-      // and only await/countDown establish a happens-before edge, so a thread
-      // woken by the countDown must already be able to observe the terminal.
-      // That lets init() surface the transport cause instead of timing out
-      // after initResponseTimeoutMs with a misleading "timed out" message --
-      // or, if it saw a transient non-terminal state, the defensive "init latch
-      // fired without an InitResponse or terminal" error.
-      completeTerminal(Termination.TransportFailed(t))
-      initLatch.countDown()
+      // terminal BEFORE releasing initValue: init() blocks on that latch, and
+      // only await/release establish a happens-before edge, so a thread woken by
+      // the release must already be able to observe the terminal. That lets
+      // init() surface the transport cause instead of timing out after
+      // initResponseTimeoutMs with a misleading "timed out" message -- or, if it
+      // saw a transient non-terminal state, the defensive "init latch fired
+      // without an InitResponse or terminal" error.
+      Transitions.transportFailed(t)
+      initValue.signalWithoutValue()
     }
 
     override def onCompleted(): Unit = {
@@ -206,12 +221,12 @@ class GrpcWorkerSession(
       // / CancelResponse). Treat as transport error so the engine sees a
       // failure, not a silent end-of-stream.
       if (!currentState.isTerminal) {
-        completeTerminal(Termination.TransportFailed(new IllegalStateException(
-          "worker response stream closed without a terminator")))
+        Transitions.transportFailed(new IllegalStateException(
+          "worker response stream closed without a terminator"))
       }
       // Defensive: if onCompleted reached us before InitResponse, doInit is
-      // still blocked on initLatch and would otherwise time out.
-      initLatch.countDown()
+      // still blocked on initValue and would otherwise time out.
+      initValue.signalWithoutValue()
     }
   }
 
@@ -228,27 +243,33 @@ class GrpcWorkerSession(
   private def handleControl(ctrl: UdfControlResponse): Unit = ctrl.getControlCase match {
     case UdfControlResponse.ControlCase.INIT =>
       val resp = ctrl.getInit
-      // Capture the InitResponse so init() can return it (or throw on its error).
-      initResponse.set(Some(resp))
       if (resp.hasError) {
-        initLatch.countDown()
-        // Per the protocol the engine follows an init error with Cancel; send it
-        // if the request stream is up. If the Cancel cannot be written -- e.g. a
-        // directExecutor worker delivered InitResponse reentrantly, before
-        // doInit published requestObserver -- settle the terminal here so doInit
-        // does not wait the full terminalTimeoutMs for a CancelResponse that can
-        // never arrive. (When the Cancel is sent, the CancelResponse settles the
-        // terminal instead.)
-        if (!sendCancelInternal(() => cancelWithReason("init failed")) &&
-            !currentState.isTerminal) {
-          completeTerminal(Termination.Failed(resp.getError))
-        }
+        // Attribute a subsequent close()'s terminator to the init error rather
+        // than a bare Cancelled, mirroring the data-phase ERROR branch.
+        executionError.compareAndSet(None, Some(resp.getError))
+        // Settle the terminal as Failed(err) BEFORE attempting Cancel so close()
+        // reports the init error (Termination.Failed) instead of the empty
+        // Cancelled the worker's CancelResponse would otherwise leave. The
+        // terminal is sticky, so the Cancel we send next is purely for worker
+        // cleanup and its CancelResponse is a no-op; if the Cancel cannot be
+        // written (e.g. a directExecutor worker delivered InitResponse
+        // reentrantly, before doInit published requestObserver), the terminal is
+        // already set, so doInit does not wait the full terminalTimeoutMs for a
+        // CancelResponse that can never arrive.
+        Transitions.failed(resp.getError)
+        // Publish the InitResponse + release init() only after the terminal is
+        // settled: init() blocks on this latch and only await/release establish
+        // happens-before, so a woken init() must be able to observe the terminal.
+        initValue.complete(resp)
+        sendCancelInternal(() => cancelWithReason("init failed"))
       } else {
         // InitResponse OK: init succeeded. A terminal that arrived first (e.g. a
         // racing transport error) must win, so only advance from the expected
         // Initializing state; process() then opens the data phase (Streaming).
-        compareAndSetState(SessionState.Initializing, SessionState.Initialized)
-        initLatch.countDown()
+        Transitions.initAccepted()
+        // Publish + release only after the CAS so a woken init() observes
+        // Initialized rather than the transient Initializing state.
+        initValue.complete(resp)
       }
 
     case UdfControlResponse.ControlCase.ERROR =>
@@ -264,38 +285,39 @@ class GrpcWorkerSession(
       // "the stream has not reached Initialized"; completeTerminal is idempotent,
       // so the data-phase ERROR -> Cancel -> CancelResponse path is unaffected.
       if (!initResolved) {
-        completeTerminal(Termination.Failed(err))
+        Transitions.failed(err)
       }
-      // Surface the error to doInit. Count down AFTER settling the terminal
-      // above: init() blocks on this latch and only await/countDown establish
+      // Surface the error to doInit. Release AFTER settling the terminal above:
+      // init() blocks on this latch and only await/release establish
       // happens-before, so a woken doInit must be able to observe the terminal
       // rather than a transient non-terminal state. Idempotent, so the normal
-      // data-phase path (latch already fired during init) is unaffected.
-      initLatch.countDown()
+      // data-phase path (latch already fired during init) is unaffected. No value
+      // to publish -- an ERROR is not an InitResponse.
+      initValue.signalWithoutValue()
       sendCancelInternal(() => cancelWithReason("aborting after ErrorResponse"))
 
     case UdfControlResponse.ControlCase.FINISH =>
       // The FinishResponse carries metrics + the finish-callback data/error.
       // Keep it on the terminal so close() can return it; the iterator inspects
       // its error field to decide whether to throw.
-      completeTerminal(Termination.Finished(ctrl.getFinish))
+      Transitions.finished(ctrl.getFinish)
       // Defensive: FINISH before InitResponse is a worker protocol bug, but
       // we should fail init fast rather than hang the 30s init timeout.
-      initLatch.countDown()
+      initValue.signalWithoutValue()
 
     case UdfControlResponse.ControlCase.CANCEL =>
       // The CancelResponse carries metrics + the cancel-callback error. Keep it
       // on the terminal so close() can return it; any prior ErrorResponse is
       // tracked in executionError and surfaced by the iterator.
-      completeTerminal(Termination.Cancelled(ctrl.getCancel))
+      Transitions.cancelled(ctrl.getCancel)
       // Defensive: CANCEL before InitResponse unblocks doInit so it can
       // surface the cancellation instead of timing out.
-      initLatch.countDown()
+      initValue.signalWithoutValue()
 
     case UdfControlResponse.ControlCase.CONTROL_NOT_SET =>
-      completeTerminal(Termination.TransportFailed(new IllegalStateException(
-        "empty UdfControlResponse oneof")))
-      initLatch.countDown()
+      Transitions.transportFailed(new IllegalStateException(
+        "empty UdfControlResponse oneof"))
+      initValue.signalWithoutValue()
   }
 
   /** True once init has resolved (Initialized or beyond). */
@@ -307,6 +329,48 @@ class GrpcWorkerSession(
   private def cancelWithReason(reason: String): Cancel =
     Cancel.newBuilder().setReason(reason).build()
 
+  /**
+   * The protocol transition graph in one place. Every edge acts on the single
+   * [[WorkerSession.SessionState]] owned by the base via [[compareAndSetState]]
+   * (non-terminal edges) or [[completeTerminal]] (terminals) -- this adds names
+   * for the edges, not a second source of truth or any new synchronization. Each
+   * method is driven by whichever thread reaches that point (the gRPC callback
+   * thread for worker-event edges, the engine/consumer thread for the
+   * `Finish`/`Cancel` edges); atomicity is the base's CAS, and a terminal that
+   * arrived first still wins (the non-terminal CASes fail against it, and
+   * [[completeTerminal]] is first-wins). Reading these five non-terminal edges
+   * and four terminals together is the transition diagram in the class scaladoc.
+   */
+  private object Transitions {
+    /** `InitResponse` OK: `Initializing -> Initialized`. */
+    def initAccepted(): Boolean =
+      compareAndSetState(SessionState.Initializing, SessionState.Initialized)
+
+    /** Input exhausted and `Finish` written: `Streaming -> Finishing` (once). */
+    def finishSent(): Boolean =
+      compareAndSetState(SessionState.Streaming, SessionState.Finishing)
+
+    /** `Cancel` written: `cur -> Cancelling`, from any non-terminal `cur`. */
+    def cancelSentFrom(cur: SessionState): Boolean =
+      !cur.isTerminal && compareAndSetState(cur, SessionState.Cancelling)
+
+    /** Clean terminal carrying the worker's `FinishResponse`. */
+    def finished(response: FinishResponse): Boolean =
+      completeTerminal(Termination.Finished(response))
+
+    /** Clean terminal carrying the worker's `CancelResponse`. */
+    def cancelled(response: CancelResponse): Boolean =
+      completeTerminal(Termination.Cancelled(response))
+
+    /** Failure terminal carrying a structured [[ExecutionError]]. */
+    def failed(error: ExecutionError): Boolean =
+      completeTerminal(Termination.Failed(error))
+
+    /** Failure terminal carrying a transport-level cause. */
+    def transportFailed(cause: Throwable): Boolean =
+      completeTerminal(Termination.TransportFailed(cause))
+  }
+
   // ---- WorkerSession hooks ------------------------------------------------
 
   override protected def doInit(message: Init): InitResponse = {
@@ -316,7 +380,7 @@ class GrpcWorkerSession(
     // timed out" error.
     if (channel.getState(false) == ConnectivityState.SHUTDOWN) {
       val ex = new IllegalStateException("gRPC channel is shut down")
-      completeTerminal(Termination.TransportFailed(ex))
+      Transitions.transportFailed(ex)
       throw new GrpcWorkerSessionException("UDF worker channel is closed", ex)
     }
     // Open the stream as a local first; only publish `requestObserver`
@@ -341,7 +405,7 @@ class GrpcWorkerSession(
         // Expose the stream so a subsequent close() can still attempt a
         // best-effort half-close; the terminal already reflects the failure.
         requestObserver = stream
-        completeTerminal(Termination.TransportFailed(e))
+        Transitions.transportFailed(e)
         // Surface as GrpcWorkerSessionException so the engine integration layer
         // (which catches that type and wraps it) sees a uniform init-failure
         // exception rather than the raw transport error.
@@ -349,15 +413,15 @@ class GrpcWorkerSession(
     }
 
     val responded = try {
-      initLatch.await(initResponseTimeoutMs, TimeUnit.MILLISECONDS)
+      initValue.await(initResponseTimeoutMs)
     } catch {
       case _: InterruptedException =>
         Thread.currentThread().interrupt()
         sendCancelInternal(() => cancelWithReason("interrupted during init"))
         // Make sure close() does not block waiting for a terminator that
         // will never arrive on this thread's behalf.
-        completeTerminal(Termination.TransportFailed(
-          new InterruptedException("interrupted while waiting for InitResponse")))
+        Transitions.transportFailed(
+          new InterruptedException("interrupted while waiting for InitResponse"))
         throw new InterruptedException("interrupted while waiting for InitResponse")
     }
 
@@ -368,14 +432,14 @@ class GrpcWorkerSession(
       // Settle the terminal so a subsequent close() does not stall for a
       // second `terminalTimeoutMs` waiting for a worker that already missed
       // its init deadline.
-      completeTerminal(Termination.TransportFailed(timeout))
+      Transitions.transportFailed(timeout)
       // Surface as GrpcWorkerSessionException (carrying the timeout cause) so
       // the engine integration layer that catches that type can wrap it.
       throw new GrpcWorkerSessionException(
         s"timed out waiting for InitResponse after ${initResponseTimeoutMs}ms", timeout)
     }
 
-    initResponse.get() match {
+    initValue.get match {
       case Some(resp) if resp.hasError =>
         // The protocol requires the engine to send Cancel after an init
         // error and the worker to respond with CancelResponse. Drain it
@@ -387,10 +451,10 @@ class GrpcWorkerSession(
         resp
       case None =>
         // No InitResponse arrived but the latch fired. The defensive
-        // initLatch.countDown() in handleControl / onError / onCompleted
-        // means we get here when the worker terminated the stream before
-        // sending InitResponse. Surface that as an init failure rather than
-        // letting the caller proceed as if init succeeded.
+        // initValue.signalWithoutValue() in handleControl / onError /
+        // onCompleted means we get here when the worker terminated the stream
+        // before sending InitResponse. Surface that as an init failure rather
+        // than letting the caller proceed as if init succeeded.
         currentState match {
           case SessionState.Terminal(Termination.TransportFailed(cause)) =>
             throw new GrpcWorkerSessionException(
@@ -426,7 +490,7 @@ class GrpcWorkerSession(
       // init threw before publishing). There is no protocol terminator; treat
       // the session as cancelled-before-start. The base WorkerSession still
       // releases the worker handle, so the worker is torn down.
-      completeTerminal(Termination.Cancelled(CancelResponse.getDefaultInstance))
+      Transitions.cancelled(CancelResponse.getDefaultInstance)
       return Termination.Cancelled(CancelResponse.getDefaultInstance)
     }
     // If the stream has not finished on its own, cancel anything in flight so
@@ -445,8 +509,8 @@ class GrpcWorkerSession(
     // record a terminal so isWorkerSalvageable returns a definite answer
     // and any other thread reading the state sees a stable value.
     if (!currentState.isTerminal) {
-      completeTerminal(Termination.TransportFailed(new TimeoutException(
-        s"timed out waiting for stream terminator after ${terminalTimeoutMs}ms")))
+      Transitions.transportFailed(new TimeoutException(
+        s"timed out waiting for stream terminator after ${terminalTimeoutMs}ms"))
     }
     // Half-close the request side regardless of whether we sent Cancel or
     // Finish earlier -- the worker's onCompleted handler relies on this to
@@ -527,7 +591,7 @@ class GrpcWorkerSession(
           false
         } else {
           // Record that a Cancel is on the wire by advancing to Cancelling.
-          compareAndSetState(cur, SessionState.Cancelling)
+          Transitions.cancelSentFrom(cur)
           requestObserver.onNext(UdfRequest.newBuilder()
             .setControl(UdfControlRequest.newBuilder().setCancel(cancel()).build())
             .build())
@@ -537,7 +601,7 @@ class GrpcWorkerSession(
     } catch {
       case NonFatal(e) =>
         logger.debug(s"Cancel send failed (stream may already be torn down): ${e.getMessage}")
-        completeTerminal(Termination.TransportFailed(e))
+        Transitions.transportFailed(e)
         false
     }
   }
@@ -546,8 +610,8 @@ class GrpcWorkerSession(
     if (currentState.isTerminal) return
     try {
       if (!terminalLatch.await(terminalTimeoutMs, TimeUnit.MILLISECONDS)) {
-        completeTerminal(Termination.TransportFailed(new TimeoutException(
-          s"timed out waiting for stream terminator after ${terminalTimeoutMs}ms")))
+        Transitions.transportFailed(new TimeoutException(
+          s"timed out waiting for stream terminator after ${terminalTimeoutMs}ms"))
       }
     } catch {
       case _: InterruptedException =>
@@ -555,8 +619,8 @@ class GrpcWorkerSession(
         // cut short, it did not exhaust terminalTimeoutMs. Reporting "timed
         // out" here would misdiagnose an interrupted close as a slow worker.
         Thread.currentThread().interrupt()
-        completeTerminal(Termination.TransportFailed(
-          new InterruptedException("interrupted while waiting for stream terminator")))
+        Transitions.transportFailed(
+          new InterruptedException("interrupted while waiting for stream terminator"))
     }
   }
 
@@ -592,8 +656,24 @@ class GrpcWorkerSession(
     // hasNext / next surfaces a cancellation instead of blocking for
     // terminalTimeoutMs in branch 4.
     if (cancelRequested.get() && !currentState.isTerminal) {
-      completeTerminal(Termination.Cancelled(CancelResponse.getDefaultInstance))
+      Transitions.cancelled(CancelResponse.getDefaultInstance)
     }
+
+    /**
+     * Runs a caller-supplied thunk (`input.hasNext`, `input.next()`, or the
+     * `finish` builder) that may throw, and on failure Cancels the in-flight
+     * stream before rethrowing. Without the Cancel a failure would leave the
+     * worker awaiting more input with no terminator owed on the wire; with it the
+     * worker tears down and the exception still propagates to the engine. Setting
+     * `cancelRequested` also suppresses any further Data/Finish this loop might
+     * otherwise attempt (see [[sendRequest]]).
+     */
+    private def cancelOnThrow[T](reason: String)(op: => T): T =
+      try op catch {
+        case NonFatal(e) =>
+          sendCancelInternal(() => cancelWithReason(reason))
+          throw e
+      }
 
     override def hasNext: Boolean = {
       if (prefetched ne null) return true
@@ -642,18 +722,24 @@ class GrpcWorkerSession(
         }
 
         // (2) Send next input batch while the stream is open for data.
-        if (!cancelRequested.get() && currentState == SessionState.Streaming && input.hasNext) {
-          val batch = try input.next() catch {
-            case NonFatal(e) =>
-              sendCancelInternal(() => cancelWithReason("input iterator failed"))
-              throw e
-          }
+        // `input.hasNext` may itself fetch/compute the next element (many Spark
+        // iterators prefetch), so it can throw just like `input.next()`; both go
+        // through cancelOnThrow so a failing upstream Cancels the stream instead
+        // of stranding the worker waiting for input that will never arrive.
+        if (!cancelRequested.get() && currentState == SessionState.Streaming &&
+            cancelOnThrow("input iterator failed")(input.hasNext)) {
+          val batch = cancelOnThrow("input iterator failed")(input.next())
           if (!sendOrEndOnRacedTerminal(UdfRequest.newBuilder().setData(batch).build())) return
-        } else if (!cancelRequested.get() &&
-            compareAndSetState(SessionState.Streaming, SessionState.Finishing)) {
-          // (3) No more input; send Finish exactly once (unless cancelled).
+        } else if (!cancelRequested.get() && Transitions.finishSent()) {
+          // (3) No more input; send Finish exactly once (unless cancelled). The
+          // `finish` thunk is caller-supplied (it may run a finish callback), so
+          // it can throw; cancelOnThrow Cancels the stream before rethrowing. The
+          // Streaming -> Finishing CAS has already run, but we have not written
+          // Finish yet, so the Cancel is the only engine-to-worker message that
+          // reaches the wire -- the proto "nothing after Cancel" invariant holds.
+          val finishMsg = cancelOnThrow("finish callback failed")(finish())
           if (!sendOrEndOnRacedTerminal(UdfRequest.newBuilder()
-              .setControl(UdfControlRequest.newBuilder().setFinish(finish()).build())
+              .setControl(UdfControlRequest.newBuilder().setFinish(finishMsg).build())
               .build())) {
             return
           }
@@ -671,8 +757,8 @@ class GrpcWorkerSession(
           }
           item match {
             case null =>
-              completeTerminal(Termination.TransportFailed(new IllegalStateException(
-                s"timed out waiting for UDF output after ${terminalTimeoutMs}ms")))
+              Transitions.transportFailed(new IllegalStateException(
+                s"timed out waiting for UDF output after ${terminalTimeoutMs}ms"))
               exhausted.set(true)
               throwIfTerminalError()
               return
@@ -708,7 +794,7 @@ class GrpcWorkerSession(
       } catch {
         case NonFatal(e) =>
           if (!currentState.isTerminal) {
-            completeTerminal(Termination.TransportFailed(e))
+            Transitions.transportFailed(e)
           }
           exhausted.set(true)
           throwIfTerminalError()
@@ -766,6 +852,36 @@ object GrpcWorkerSession {
   private object QueueItem {
     final case class Batch(response: DataResponse) extends QueueItem
     case object EndOfStream extends QueueItem
+  }
+
+  /**
+   * A write-once value paired with the latch a waiter blocks on, so the "publish
+   * the value, then release the waiter" ordering lives in one place instead of
+   * every call site having to remember to count the latch down after setting the
+   * reference. The value is set at most once ([[complete]]); the latch can also
+   * be released without a value ([[signalWithoutValue]]) when the waiter must be
+   * woken by a terminal that arrived instead of the value. All reads/writes go
+   * through the latch, so a waiter released by [[await]] has a happens-before
+   * edge to the [[complete]] that set the value.
+   */
+  private final class OneShotValue[A] {
+    private val latch = new CountDownLatch(1)
+    private val ref = new AtomicReference[Option[A]](None)
+
+    /** Publishes the value (first writer wins) and releases any waiter. */
+    def complete(value: A): Unit = {
+      ref.compareAndSet(None, Some(value))
+      latch.countDown()
+    }
+
+    /** Releases the waiter without a value (a terminal arrived, not the value). */
+    def signalWithoutValue(): Unit = latch.countDown()
+
+    /** Blocks up to `timeoutMs` for a release; true iff released in time. */
+    def await(timeoutMs: Long): Boolean = latch.await(timeoutMs, TimeUnit.MILLISECONDS)
+
+    /** The published value, or None if none was ever set. */
+    def get: Option[A] = ref.get()
   }
 
   private[grpc] def describeError(err: ExecutionError): String = err.getKindCase match {

--- a/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
+++ b/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
@@ -52,13 +52,12 @@ import org.apache.spark.udf.worker.grpc.GrpcWorkerSession._
  * dispatcher-side cleanup on close.
  *
  * '''Driving model.''' Consumption-driven (Volcano / pull): the thread that
- * consumes the [[doProcess]] result iterator is the one that pulls the next
- * input batch and sends its `DataRequest`. Nothing is sent until the iterator
- * is consumed, and the gRPC callback thread only receives output. Note this is
- * pull-driven, not strictly one-input-per-output: `advance` sends the next input
- * batch whenever the output queue is momentarily empty, so under asynchronous
- * delivery it can push several input batches before any output is read (bounded
- * only by HTTP/2 flow control), rather than lock-stepping one input per output.
+ * consumes the [[doProcess]] result iterator is the one that pulls input and
+ * sends each `DataRequest`; the gRPC callback thread only receives output. It is
+ * pull-driven but not one-input-per-output -- `advance` sends the next input
+ * whenever the output queue is momentarily empty, so under async delivery it may
+ * push several input batches before any output is read (bounded by HTTP/2 flow
+ * control).
  *
  * '''State machine.''' This class does not keep its own state machine: it
  * drives the single [[WorkerSession.SessionState]] owned by the base. The base
@@ -125,11 +124,10 @@ class GrpcWorkerSession(
 
   // Output batches from the worker, drained by the process() iterator.
   // Intentionally unbounded: a bounded queue would block the gRPC callback
-  // (Netty event-loop) thread when full, stalling control-message and
-  // terminator delivery on the whole channel. HTTP/2 flow control bounds the
-  // wire and the consumer normally drains promptly, so it stays small. A
-  // stalled downstream can still grow it; the real fix is protocol-level
-  // back-pressure (out of scope here), not bounding the queue.
+  // (Netty event-loop) thread when full, stalling terminator/control delivery on
+  // the whole channel. HTTP/2 flow control bounds the wire and the consumer
+  // normally drains promptly; a stalled downstream can still grow it, but the fix
+  // is protocol-level back-pressure (out of scope), not bounding the queue.
   //
   // TODO [SPARK-57324]: expose queue depth as a metric (early warning for a
   // stalled consumer).
@@ -139,9 +137,15 @@ class GrpcWorkerSession(
   // init() blocks on. Fires when the InitResponse arrives (`complete`) or when a
   // terminal settles first without one -- transport error, half-close, or a
   // premature terminator (`signalWithoutValue`). Until it fires we have no proof
-  // the worker accepted the session. Bundling the value and the latch in one
-  // object keeps the "publish then release" ordering in a single place rather
-  // than leaving callers to remember to count down after setting the reference.
+  // the worker accepted the session.
+  //
+  // Settle-before-release rule (referenced from every callback that both settles
+  // a terminal and fires this latch): settle the terminal FIRST, then complete /
+  // signal. init() blocks on the latch, and only latch await/release establish a
+  // happens-before edge, so a woken init() is guaranteed to observe the terminal
+  // rather than a transient state. OneShotValue keeps that publish-then-release
+  // in one place instead of every caller remembering to count down after setting
+  // the reference.
   private val initValue = new OneShotValue[InitResponse]
 
   // Fired when the session reaches a terminal [[SessionState]]. doClose() and
@@ -153,9 +157,12 @@ class GrpcWorkerSession(
   // user / worker / protocol error rather than reporting a bare "Cancelled".
   private val executionError = new AtomicReference[Option[ExecutionError]](None)
 
-  // Cancellation intent. Kept outside the [[SessionState]] machine because a
-  // cancel can be requested before the stream exists (pre-init), where there is
-  // no wire transition to make yet -- only an intent to record. Used to (a)
+  // Cancellation INTENT -- distinct from the `Cancelling` state, which is reached
+  // only once a Cancel is actually written to the wire ([[sendCancelInternal]]).
+  // Intent is set first and can outrun (or never reach) that write, so
+  // `cancelRequested` does NOT imply state `Cancelling`. Kept outside the
+  // [[SessionState]] machine because a cancel can be requested before the stream
+  // exists (pre-init), where there is no wire transition to make yet. Used to (a)
   // make cancel idempotent across all call sites, (b) fast-fail ProcessIterator
   // on a pre-init cancel, and (c) suppress any Data/Finish that would otherwise
   // race a Cancel onto the wire (re-read inside [[requestLock]]).
@@ -172,12 +179,9 @@ class GrpcWorkerSession(
     override def onNext(response: UdfResponse): Unit = {
       response.getResponseCase match {
         case UdfResponse.ResponseCase.DATA =>
-          // A DataResponse before InitResponse violates the protocol
-          // (InitResponse must precede any DataResponse). Enqueuing it would
-          // leave init() blocked on initValue until initResponseTimeoutMs, then
-          // fail with a misleading "timed out" instead of the real protocol
-          // fault. Settle a transport-failure terminal and release init(), the
-          // same fast-fail discipline the malformed / terminator branches use.
+          // A DataResponse before InitResponse violates the protocol (InitResponse
+          // must precede any DataResponse): fast-fail rather than enqueue it and let
+          // init() block to its timeout. Settle-before-release (see initValue).
           if (!initResolved) {
             Transitions.transportFailed(new IllegalStateException(
               "worker sent a DataResponse before InitResponse"))
@@ -190,12 +194,8 @@ class GrpcWorkerSession(
           handleControl(response.getControl)
 
         case other =>
-          // A malformed response (empty / unknown oneof) is a terminal
-          // transport failure. Release initValue like every other
-          // terminal-settling path here (onError / onCompleted / each
-          // handleControl branch): if this arrives before InitResponse, doInit
-          // must fail fast with this cause rather than block until
-          // initResponseTimeoutMs and report a misleading "timed out" error.
+          // A malformed response (empty / unknown oneof) is a terminal transport
+          // failure; fast-fail init the same way. Settle-before-release (see initValue).
           Transitions.transportFailed(new IllegalStateException(
             s"unexpected response oneof: $other"))
           initValue.signalWithoutValue()
@@ -203,15 +203,9 @@ class GrpcWorkerSession(
     }
 
     override def onError(t: Throwable): Unit = {
-      // Transport-level failure: the stream is dead. No further writes are
-      // possible (reaching a terminal state closes the write side). Settle the
-      // terminal BEFORE releasing initValue: init() blocks on that latch, and
-      // only await/release establish a happens-before edge, so a thread woken by
-      // the release must already be able to observe the terminal. That lets
-      // init() surface the transport cause instead of timing out after
-      // initResponseTimeoutMs with a misleading "timed out" message -- or, if it
-      // saw a transient non-terminal state, the defensive "init latch fired
-      // without an InitResponse or terminal" error.
+      // Transport-level failure: the stream is dead, no further writes possible.
+      // Settle-before-release (see initValue) so init() surfaces the transport
+      // cause instead of the initResponseTimeoutMs "timed out" error.
       Transitions.transportFailed(t)
       initValue.signalWithoutValue()
     }
@@ -247,52 +241,37 @@ class GrpcWorkerSession(
         // Attribute a subsequent close()'s terminator to the init error rather
         // than a bare Cancelled, mirroring the data-phase ERROR branch.
         executionError.compareAndSet(None, Some(resp.getError))
-        // Settle the terminal as Failed(err) BEFORE attempting Cancel so close()
-        // reports the init error (Termination.Failed) instead of the empty
-        // Cancelled the worker's CancelResponse would otherwise leave. The
-        // terminal is sticky, so the Cancel we send next is purely for worker
-        // cleanup and its CancelResponse is a no-op; if the Cancel cannot be
-        // written (e.g. a directExecutor worker delivered InitResponse
-        // reentrantly, before doInit published requestObserver), the terminal is
-        // already set, so doInit does not wait the full terminalTimeoutMs for a
-        // CancelResponse that can never arrive.
+        // Settle Failed(err) before the Cancel below (not after its CancelResponse):
+        // the sticky terminal makes close() report the init error, and the Cancel
+        // becomes best-effort worker cleanup -- so if it can't be written (a
+        // directExecutor worker delivered this reentrantly, before doInit published
+        // requestObserver), doInit still doesn't wait terminalTimeoutMs for a
+        // CancelResponse that can never arrive. Settle-before-release (see initValue).
         Transitions.failed(resp.getError)
-        // Publish the InitResponse + release init() only after the terminal is
-        // settled: init() blocks on this latch and only await/release establish
-        // happens-before, so a woken init() must be able to observe the terminal.
         initValue.complete(resp)
         sendCancelInternal(() => cancelWithReason("init failed"))
       } else {
-        // InitResponse OK: init succeeded. A terminal that arrived first (e.g. a
-        // racing transport error) must win, so only advance from the expected
-        // Initializing state; process() then opens the data phase (Streaming).
+        // InitResponse OK. Only advance from Initializing so a terminal that raced
+        // in (e.g. a transport error) still wins; process() then opens the data
+        // phase. Settle-before-release (see initValue): publish after the CAS.
         Transitions.initAccepted()
-        // Publish + release only after the CAS so a woken init() observes
-        // Initialized rather than the transient Initializing state.
         initValue.complete(resp)
       }
 
     case UdfControlResponse.ControlCase.ERROR =>
       val err = ctrl.getError.getError
       executionError.compareAndSet(None, Some(err))
-      // ERROR before InitResponse is special: under directExecutor or with
-      // a fast worker, sendCancelInternal may run while requestObserver is
-      // still null (we're inside stream.onNext(initRequest) and have not
-      // yet published the field), so no Cancel reaches the wire and no
-      // CancelResponse will follow to settle the terminal. Settle it here
-      // (as Failed, since there is no proto terminator to carry) so doInit
-      // doesn't return as if init succeeded. "Init not yet resolved" is exactly
-      // "the stream has not reached Initialized"; completeTerminal is idempotent,
-      // so the data-phase ERROR -> Cancel -> CancelResponse path is unaffected.
+      // Before init resolves, settle Failed here rather than rely on the Cancel
+      // below: sendCancelInternal may find requestObserver still null (reentrant
+      // delivery inside stream.onNext, before doInit published it), so no Cancel --
+      // hence no CancelResponse -- would settle the terminal, and doInit would
+      // return as if init succeeded. completeTerminal is idempotent, so the
+      // data-phase ERROR -> Cancel -> CancelResponse path is unaffected.
       if (!initResolved) {
         Transitions.failed(err)
       }
-      // Surface the error to doInit. Release AFTER settling the terminal above:
-      // init() blocks on this latch and only await/release establish
-      // happens-before, so a woken doInit must be able to observe the terminal
-      // rather than a transient non-terminal state. Idempotent, so the normal
-      // data-phase path (latch already fired during init) is unaffected. No value
-      // to publish -- an ERROR is not an InitResponse.
+      // Settle-before-release (see initValue). No value to publish -- ERROR is not
+      // an InitResponse; on the data-phase path the latch already fired in init.
       initValue.signalWithoutValue()
       sendCancelInternal(() => cancelWithReason("aborting after ErrorResponse"))
 
@@ -320,7 +299,10 @@ class GrpcWorkerSession(
       initValue.signalWithoutValue()
   }
 
-  /** True once init has resolved (Initialized or beyond). */
+  /**
+   * True once init is no longer pending -- i.e. the stream is past `Initializing`.
+   * Not "init succeeded": a terminal (including a failure) also counts as resolved.
+   */
   private def initResolved: Boolean = currentState match {
     case SessionState.Created | SessionState.Initializing => false
     case _ => true
@@ -330,16 +312,28 @@ class GrpcWorkerSession(
     Cancel.newBuilder().setReason(reason).build()
 
   /**
-   * The protocol transition graph in one place. Every edge acts on the single
+   * The protocol transition graph in one place: names for the edges, not a
+   * second source of truth. Every edge acts on the single
    * [[WorkerSession.SessionState]] owned by the base via [[compareAndSetState]]
-   * (non-terminal edges) or [[completeTerminal]] (terminals) -- this adds names
-   * for the edges, not a second source of truth or any new synchronization. Each
-   * method is driven by whichever thread reaches that point (the gRPC callback
-   * thread for worker-event edges, the engine/consumer thread for the
-   * `Finish`/`Cancel` edges); atomicity is the base's CAS, and a terminal that
-   * arrived first still wins (the non-terminal CASes fail against it, and
-   * [[completeTerminal]] is first-wins). Reading these five non-terminal edges
-   * and four terminals together is the transition diagram in the class scaladoc.
+   * (non-terminal) or [[completeTerminal]] (terminal), so the base's CAS is the
+   * only synchronization and a terminal that arrived first always wins (the
+   * non-terminal CASes fail against it; [[completeTerminal]] is first-wins).
+   *
+   * Edges this class drives -- edge, method, then driver site(s) / thread (the
+   * base drives the API-call edges: `Created -> Initializing` in `init`,
+   * `Initialized -> Streaming` in `process`):
+   * {{{
+   *   Initializing -> Initialized     initAccepted    handleControl INIT-ok  [gRPC cb]
+   *   Streaming -> Finishing          finishSent      advance branch 3       [engine]
+   *   non-terminal -> Cancelling      cancelSentFrom  sendCancelInternal, iff a Cancel
+   *                                     reaches the wire  [gRPC cb | engine | init | close]
+   *   non-terminal -> Terminal        finished/cancelled/failed/transportFailed
+   *                                     handleControl / doInit / doClose / advance / onError
+   * }}}
+   * `Cancelling` is reached only if a Cancel is actually written; a pre-stream or
+   * raced cancel goes straight to a `Cancelled`/`TransportFailed` terminal (see
+   * [[sendCancelInternal]], [[doClose]], `ProcessIterator`) or nowhere -- so
+   * `cancelRequested` (intent) does not imply state `Cancelling`.
    */
   private object Transitions {
     /** `InitResponse` OK: `Initializing -> Initialized`. */
@@ -394,9 +388,14 @@ class GrpcWorkerSession(
       .build()
     try {
       requestLock.synchronized {
-        // The base advanced Created -> Initializing before calling doInit, so a
-        // directExecutor worker's InitResponse -- delivered reentrantly inside
-        // onNext -- finds Initializing and advances to Initialized.
+        // Reentrant delivery: a directExecutor worker (one whose gRPC callbacks run
+        // synchronously on the caller's thread) can deliver InitResponse -- and thus
+        // run responseObserver/handleControl -- from *inside* this stream.onNext,
+        // before requestObserver below is published. The base advanced
+        // Created -> Initializing before calling doInit, so that reentrant
+        // InitResponse still finds Initializing and advances to Initialized; the
+        // handleControl error paths guard the still-null requestObserver. This is
+        // the scenario the "before doInit published requestObserver" comments mean.
         stream.onNext(initRequest)
         requestObserver = stream
       }
@@ -557,9 +556,9 @@ class GrpcWorkerSession(
       }
       // Suppress the write when a cancel has been (or is about to be) flushed
       // through this lock; that preserves the proto ordering invariant (no
-      // Data/Finish after Cancel). We test the flag rather than `return`-ing
-      // from the block: a non-local return out of this by-name `synchronized`
-      // body compiles to a thrown NonLocalReturnControl, which is brittle.
+      // Data/Finish after Cancel). Test the flag rather than `return`-ing from
+      // this by-name `synchronized` body: a non-local return compiles to a thrown
+      // NonLocalReturnControl, which is brittle (also relied on in sendCancelInternal).
       if (!cancelRequested.get()) {
         requestObserver.onNext(req)
       }
@@ -583,11 +582,9 @@ class GrpcWorkerSession(
     if (currentState.isTerminal) return false
     try {
       requestLock.synchronized {
-        // A terminal that arrived first must win; bail without writing. We
-        // compute the block's value rather than `return`-ing from this by-name
-        // `synchronized` body, whose non-local return would compile to a thrown
-        // NonLocalReturnControl that the surrounding NonFatal catch must not
-        // swallow -- brittle to rely on. Reads naturally as the block result.
+        // A terminal that arrived first must win; bail without writing. Compute
+        // the block's value rather than `return` (see sendRequest on why non-local
+        // return is avoided -- here it would also escape the NonFatal catch below).
         val cur = currentState
         if (cur.isTerminal) {
           false
@@ -694,11 +691,13 @@ class GrpcWorkerSession(
     }
 
     /**
-     * Single loop that, each iteration, tries in order: (1) drain queued output
-     * (a batch, or the terminator sentinel); (2) while `Streaming`, send the next
-     * input batch; (3) once input is exhausted, send `Finish` (CAS `Streaming ->
-     * Finishing`, once); (4) otherwise block for late output or the terminator.
-     * Each branch is commented inline below.
+     * Fills [[prefetched]] with the next output batch, or leaves it null at the
+     * terminator (which also sets [[exhausted]], so `hasNext` reads null as "done").
+     * Each loop iteration tries in order: (1) drain queued output -- a batch (fill
+     * and return) or the terminator sentinel (return); (2) while `Streaming`, send
+     * the next input batch and loop; (3) once input is exhausted, send `Finish`
+     * (CAS `Streaming -> Finishing`, once) and loop; (4) otherwise block for late
+     * output or the terminator, then return. Branches 2-3 loop; 1 and 4 return.
      *
      * '''Per-poll timeout.''' Branch 4 waits up to [[terminalTimeoutMs]] per
      * poll, reset by every worker event -- the contract is "emit at least one

--- a/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
+++ b/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
@@ -526,8 +526,10 @@ class GrpcWorkerSession(
     // Derive the Termination from the settled terminal. close() is the
     // finalizer/cleanup path and must NOT re-throw: a UDF / data-phase error is
     // already surfaced while the result iterator is consumed, and an init error
-    // from init(). settledTermination returns the response proto for the clean
-    // terminators and a best-effort empty Cancelled for the failure terminals.
+    // is surfaced from init(). settledTermination returns the settled terminal
+    // as-is: the response proto for the clean terminators, and the failure
+    // terminals (Failed / TransportFailed) carrying their cause -- not a bare
+    // Cancelled.
     settledTermination
   }
 

--- a/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
+++ b/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.udf.worker.grpc
 
+import java.util.Objects
 import java.util.concurrent.{CountDownLatch, LinkedBlockingQueue, TimeoutException, TimeUnit}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
@@ -27,7 +28,7 @@ import io.grpc.stub.StreamObserver
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.udf.worker.{Cancel, CancelResponse, DataRequest, DataResponse,
   ExecutionError, Finish, FinishResponse, Init, InitResponse, UdfControlRequest,
-  UdfControlResponse, UdfRequest, UdfResponse, UdfWorkerGrpc}
+  UdfControlResponse, UdfPayload, UdfRequest, UdfResponse, UdfWorkerGrpc}
 import org.apache.spark.udf.worker.core.{Termination, WorkerHandle, WorkerLogger, WorkerSession}
 import org.apache.spark.udf.worker.core.WorkerSession.SessionState
 import org.apache.spark.udf.worker.grpc.GrpcWorkerSession._
@@ -48,10 +49,9 @@ import org.apache.spark.udf.worker.grpc.GrpcWorkerSession._
  *                      (ErrorResponse)? -> (FinishResponse | CancelResponse)
  * }}}
  *
- * Knows nothing about how the worker was provisioned (locally spawned,
- * indirectly looked up, ...) -- the dispatcher constructs this with a
- * [[WorkerHandle]] and channel; the base [[WorkerSession]] handles
- * dispatcher-side cleanup on close.
+ * Knows nothing about how the worker was provisioned -- the dispatcher
+ * constructs this with a [[WorkerHandle]] and channel; the base
+ * [[WorkerSession]] handles dispatcher-side cleanup on close.
  *
  * '''Driving model.''' Consumption-driven (Volcano / pull): the thread that
  * consumes the [[doProcess]] result iterator is the one that pulls input and
@@ -69,15 +69,15 @@ import org.apache.spark.udf.worker.grpc.GrpcWorkerSession._
  * [[compareAndSetState]] / [[completeTerminal]] as it exchanges messages:
  * {{{
  *   Initializing --(InitResponse ok)--> Initialized   [handleControl]
- *   Streaming ----(Finish written)----> Finishing      [ProcessIterator]
- *   <any non-terminal> --(Cancel written)--> Cancelling [sendCancelInternal]
+ *   Streaming ----(input exhausted)-------> Finishing      [ProcessIterator]
+ *   <any non-terminal> --(Cancel send starts)--> Cancelling [sendCancelInternal]
  *   <any non-terminal> --(terminator/error)--> terminal [completeTerminal]
  * }}}
  * The two clean terminals carry the worker's `FinishResponse` / `CancelResponse`
  * (metrics + finish/cancel callback `data`/`error`) so [[close]] can return
- * them. The only flag kept outside the machine is [[cancelRequested]], which
- * makes the wire write idempotent and suppresses any in-flight Data/Finish once
- * cancellation begins.
+ * them. Cancellation intent is deliberately tracked outside the machine in
+ * [[cancelRequested]], which makes the wire write idempotent and suppresses any
+ * in-flight Data/Finish once cancellation begins.
  *
  * Threading:
  *  - [[doInit]] is synchronous: sends `Init` and blocks on `InitResponse`,
@@ -90,10 +90,10 @@ import org.apache.spark.udf.worker.grpc.GrpcWorkerSession._
  *    once.
  *  - [[doClose]] is thread-safe and idempotent: it settles + returns the
  *    terminator (cancelling in-flight work if the stream had not finished)
- *    and half-closes the request side.
+ *    and terminates the request side.
  *
  * TODO [SPARK-55278]: this class does not yet implement payload chunking;
- * the entire [[Init.udf]] payload is sent inline. Chunking will be added
+ * the entire [[UdfPayload]] is sent inline. Chunking will be added
  * when a UDF payload large enough to exceed gRPC's default message size
  * limit is introduced.
  *
@@ -144,19 +144,19 @@ class GrpcWorkerSession(
   // stalled consumer).
   private val outputQueue = new LinkedBlockingQueue[QueueItem]()
 
-  // The worker's `InitResponse` (success or error) coupled with the latch that
-  // init() blocks on. Fires when the InitResponse arrives (`complete`), when a
-  // pre-init ErrorResponse arrives, or when a terminal settles first without an
-  // InitResponse (`signalWithoutValue`). Until it fires we have no proof the
-  // worker accepted the session.
+  // This value couples the worker's `InitResponse` (success or error) with the
+  // latch on which init() blocks. The latch fires when the InitResponse arrives
+  // (`complete`), when a pre-init ErrorResponse arrives, or when a terminal
+  // settles first without an InitResponse (`signalWithoutValue`). Until it fires
+  // we have no proof the worker accepted the session.
   //
   // Settle-before-release rule (referenced from every callback that both settles
   // a terminal and fires this latch): settle the terminal FIRST, then complete /
-  // signal. init() blocks on the latch, and only latch await/release establish a
-  // happens-before edge, so a woken init() is guaranteed to observe the terminal
-  // rather than a transient state. OneShotValue keeps that publish-then-release
-  // in one place instead of every caller remembering to count down after setting
-  // the reference.
+  // signal. init() blocks on the latch, and only a latch await/release pair
+  // establishes a happens-before edge, so a woken init() is guaranteed to
+  // observe the terminal rather than a transient state. OneShotValue keeps that
+  // publish-then-release in one place instead of every caller remembering to
+  // count down after setting the reference.
   private val initValue = new OneShotValue[InitResponse]
 
   // Fired when the session reaches a terminal [[SessionState]]. doClose() and
@@ -171,11 +171,11 @@ class GrpcWorkerSession(
   // True immediately before Finish is handed to the request observer. It is set
   // before onNext so a reentrant callback may deliver FinishResponse while the
   // Finish request is still being written.
-  private val finishWritten = new AtomicBoolean(false)
+  private val finishSendStarted = new AtomicBoolean(false)
 
   // Cancellation INTENT -- distinct from the `Cancelling` state, which is reached
-  // only once a Cancel is actually written to the wire ([[sendCancelInternal]]).
-  // Intent is set first and can outrun (or never reach) that write, so
+  // once a Cancel send is attempted under [[requestLock]] ([[sendCancelInternal]]).
+  // Intent is set first and can outrun (or never reach) that attempt, so
   // `cancelRequested` does NOT imply state `Cancelling`. It is kept outside the
   // [[SessionState]] machine to (a) make cancellation idempotent across all call
   // sites and (b) suppress any Data/Finish that would otherwise race a Cancel
@@ -188,6 +188,11 @@ class GrpcWorkerSession(
   // Initialized in init() -- before that, close() is a no-op on the request
   // side, which is exactly the contract the wrapping WorkerSession expects.
   @volatile private var requestObserver: StreamObserver[UdfRequest] = _
+
+  // True after the request side has been half-closed, aborted, or observed the
+  // transport closing. It prevents this session from issuing duplicate terminal
+  // calls, including following onError with onCompleted from close().
+  private val requestSideTerminated = new AtomicBoolean(false)
 
   private val responseObserver: StreamObserver[UdfResponse] = new StreamObserver[UdfResponse] {
     override def onNext(response: UdfResponse): Unit = {
@@ -219,6 +224,7 @@ class GrpcWorkerSession(
       // Transport-level failure: the stream is dead, no further writes possible.
       // Settling the terminal wakes a blocked init() (via onTerminalSettled) so it
       // surfaces the transport cause instead of the initResponseTimeoutMs error.
+      requestSideTerminated.set(true)
       Transitions.transportFailed(t)
     }
 
@@ -227,6 +233,7 @@ class GrpcWorkerSession(
       // / CancelResponse). Treat as transport error so the engine sees a
       // failure, not a silent end-of-stream. Settling the terminal wakes a blocked
       // init() via onTerminalSettled.
+      requestSideTerminated.set(true)
       if (!currentState.isTerminal) {
         Transitions.transportFailed(new IllegalStateException(
           "worker response stream closed without a terminator"))
@@ -246,7 +253,8 @@ class GrpcWorkerSession(
    * terminal CAS in [[completeTerminal]]. The only direct [[initValue]] signals
    * left are the non-terminal init paths ([[handleControl]]'s INIT-ok / INIT-error
    * / pre-init-ERROR branches), which must wake [[doInit]] '''without''' settling a
-   * terminal -- the session stays `Initializing` so `process()` can still run.
+   * terminal. INIT-ok first advances the session to `Initialized`; the error
+   * branches remain `Initializing` only until [[doInit]] sends Cancel and throws.
    */
   override protected def onTerminalSettled(termination: Termination): Unit = {
     outputQueue.put(QueueItem.EndOfStream)
@@ -295,9 +303,9 @@ class GrpcWorkerSession(
       // The FinishResponse carries metrics + the finish-callback data/error.
       // Keep it on the terminal so close() can return it; the iterator inspects
       // its error field to decide whether to throw. A FinishResponse is valid only
-      // after the engine has actually written Finish; accepting one earlier could
+      // after the engine has started sending Finish; accepting one earlier could
       // silently truncate input and report a clean result.
-      if (finishWritten.get()) {
+      if (finishSendStarted.get()) {
         Transitions.finished(ctrl.getFinish)
       } else {
         Transitions.transportFailed(new IllegalStateException(
@@ -343,13 +351,13 @@ class GrpcWorkerSession(
    * `Initialized -> Streaming` in `process`):
    * {{{
    *   Initializing -> Initialized     initAccepted    handleControl INIT-ok  [gRPC cb]
-   *   Streaming -> Finishing          finishSent      advance branch 3       [engine]
-   *   non-terminal -> Cancelling      cancelSentFrom  sendCancelInternal, iff a Cancel
-   *                                     reaches the wire  [gRPC cb | engine | init | close]
-   *   non-terminal -> Terminal        finished/cancelled/transportFailed
+   *   Streaming -> Finishing          beginFinish      advance branch 3       [engine]
+   *   non-terminal -> Cancelling      beginCancelFrom  sendCancelInternal, immediately
+   *                                      before the Cancel send  [gRPC cb | engine | init | close]
+   *   non-terminal -> Terminal        finished/cancelled/transportFailed/interrupted
    *                                     handleControl / doInit / doClose / advance / onError
    * }}}
-   * `Cancelling` is reached only if a Cancel is actually written; a pre-stream or
+   * `Cancelling` is reached only when a Cancel send starts; a pre-stream or
    * raced cancel goes straight to a `Cancelled`/`TransportFailed` terminal (see
    * [[sendCancelInternal]], [[doClose]], `ProcessIterator`) or nowhere -- so
    * `cancelRequested` (intent) does not imply state `Cancelling`.
@@ -359,12 +367,12 @@ class GrpcWorkerSession(
     def initAccepted(): Boolean =
       compareAndSetState(SessionState.Initializing, SessionState.Initialized)
 
-    /** Input exhausted and `Finish` written: `Streaming -> Finishing` (once). */
-    def finishSent(): Boolean =
+    /** Input exhausted: `Streaming -> Finishing` (once). */
+    def beginFinish(): Boolean =
       compareAndSetState(SessionState.Streaming, SessionState.Finishing)
 
-    /** `Cancel` written: `cur -> Cancelling`, from any non-terminal `cur`. */
-    def cancelSentFrom(cur: SessionState): Boolean =
+    /** `Cancel` send starts: `cur -> Cancelling`, from any non-terminal `cur`. */
+    def beginCancelFrom(cur: SessionState): Boolean =
       !cur.isTerminal && compareAndSetState(cur, SessionState.Cancelling)
 
     /** Clean terminal carrying the worker's `FinishResponse`. */
@@ -394,6 +402,12 @@ class GrpcWorkerSession(
   // ---- WorkerSession hooks ------------------------------------------------
 
   override protected def doInit(message: Init): InitResponse = {
+    // Construct the request before opening the RPC. A malformed Init must not
+    // leave an otherwise-unused Execute stream waiting for its first request.
+    val initRequest = UdfRequest.newBuilder()
+      .setControl(UdfControlRequest.newBuilder().setInit(message).build())
+      .build()
+
     // Fail fast if the channel is already shut down. Without this check,
     // asyncStub.execute(...) would still succeed and the failure would
     // surface ~initResponseTimeoutMs later as a misleading "InitResponse
@@ -403,39 +417,24 @@ class GrpcWorkerSession(
       Transitions.transportFailed(ex)
       throw new GrpcWorkerSessionException("UDF worker channel is closed", ex)
     }
-    // Open the stream as a local first. Publication and the Init write are
-    // serialized with close/cancel below so close either settles the session
-    // before Init is sent, or writes Cancel only after Init.
-    val stream = try {
-      asyncStub.execute(responseObserver)
-    } catch {
-      case NonFatal(e) =>
-        Transitions.transportFailed(e)
-        throw new GrpcWorkerSessionException("UDF worker stream failed during init", e)
-    }
-    val initRequest = UdfRequest.newBuilder()
-      .setControl(UdfControlRequest.newBuilder().setInit(message).build())
-      .build()
-    var initSent = false
     try {
       requestLock.synchronized {
-        // Publish while holding the same lock used by close/cancel, before
-        // onNext. A concurrent close that observes this value waits for Init to
-        // be written before it can write Cancel. If close won the lock first and
-        // settled a terminal, do not put Init on an already-closed session.
-        if (currentState.isTerminal) {
-          // No request is written below. The local stream is half-closed after
-          // releasing requestLock so an RPC opened just before close is not left
-          // dangling.
-        } else {
+        // Serialize stream creation, publication, and Init with close/cancel. A
+        // close that wins the lock first prevents the RPC from opening; one that
+        // loses cannot release the worker until the initial write returns.
+        if (!currentState.isTerminal) {
+          val stream = asyncStub.execute(responseObserver)
           requestObserver = stream
-          // With directExecutor, gRPC callbacks run synchronously on the caller's
-          // thread, so InitResponse can reach responseObserver/handleControl from
-          // *inside* this stream.onNext.
-          // requestObserver is already published, so an immediate ErrorResponse
-          // can write its required Cancel reentrantly without losing the request.
-          stream.onNext(initRequest)
-          initSent = true
+          // Stream creation may invoke a response callback synchronously. Do not
+          // send Init if that callback has already settled a terminal.
+          if (!currentState.isTerminal) {
+            // With directExecutor, gRPC callbacks run synchronously on the caller's
+            // thread, so InitResponse can reach responseObserver/handleControl from
+            // *inside* this stream.onNext.
+            // requestObserver is already published, so an immediate ErrorResponse
+            // can write its required Cancel reentrantly without losing the request.
+            sendOnNext(initRequest)
+          }
         }
       }
     } catch {
@@ -445,11 +444,6 @@ class GrpcWorkerSession(
         // (which catches that type and wraps it) sees a uniform init-failure
         // exception rather than the raw transport error.
         throw new GrpcWorkerSessionException("UDF worker stream failed during init", e)
-    }
-    if (!initSent) {
-      try stream.onCompleted() catch {
-        case NonFatal(e) => logger.debug("Error half-closing unopened UDF Execute stream", e)
-      }
     }
 
     try {
@@ -576,7 +570,7 @@ class GrpcWorkerSession(
     // Coordinate the no-stream decision with doInit's publication + Init write.
     // If close wins this lock, doInit observes the terminal and never sends Init;
     // if doInit wins, close observes the published observer and sends Cancel only
-    // after Init has gone on the wire.
+    // after the Init send has returned.
     val noPublishedStream = requestLock.synchronized {
       if (requestObserver == null) {
         // init() never put a stream on the wire (closed before/around init, or
@@ -599,7 +593,7 @@ class GrpcWorkerSession(
     }
     // If the stream has not finished on its own, cancel anything in flight so
     // the worker can clean up, then wait for the terminator. sendCancelInternal
-    // evaluates the cancel thunk only when it actually writes a Cancel, and at
+    // evaluates the cancel thunk only when it attempts a Cancel, and at
     // most once across all callers.
     if (!currentState.isTerminal) {
       sendCancelInternal(cancel)
@@ -609,7 +603,7 @@ class GrpcWorkerSession(
         case _: InterruptedException =>
           // Interrupted mid-close: settle Interrupted via the
           // shared handler rather than falling through to the TransportFailed
-          // guard below. The Cancel is already on the wire, so handleInterrupt's
+          // guard below. The Cancel was already attempted, so handleInterrupt's
           // sendCancelInternal is a no-op and it just runs the bounded drain.
           //
           // TODO [SPARK-57640]: close() is a finalizer often already on the task
@@ -632,34 +626,79 @@ class GrpcWorkerSession(
       Transitions.transportFailed(new TimeoutException(
         s"timed out waiting for stream terminator after ${terminalTimeoutMs}ms"))
     }
-    // Half-close the request side regardless of whether we sent Cancel or
-    // Finish earlier -- the worker's onCompleted handler relies on this to
-    // tear down the per-stream state cleanly. onCompleted on an
-    // already-torn-down stream throws and is caught, so this stays idempotent
-    // across repeat close() calls.
-    try {
-      requestLock.synchronized { requestObserver.onCompleted() }
-    } catch {
-      case NonFatal(e) =>
-        logger.debug("Error half-closing UDF Execute stream", e)
+    // Close the request side according to the settled outcome. Clean protocol
+    // terminators are half-closed; failures abort the RPC so close() never follows
+    // an onError with onCompleted.
+    currentState match {
+      case SessionState.Terminal(Termination.Finished(_)) |
+          SessionState.Terminal(Termination.Cancelled(_)) =>
+        completeRequestSide()
+      case SessionState.Terminal(Termination.Failed(error)) =>
+        abortRequestSide(new GrpcWorkerSessionException(
+          s"UDF execution failed: ${describeError(error)}", error))
+      case SessionState.Terminal(Termination.TransportFailed(cause)) =>
+        abortRequestSide(cause)
+      case SessionState.Terminal(Termination.Interrupted(cause)) =>
+        abortRequestSide(cause)
+      case other =>
+        logger.debug(s"UDF Execute stream closed without a terminal outcome: $other")
     }
     // Derive the Termination from the settled terminal. close() is the
     // finalizer/cleanup path and must NOT re-throw: a UDF / data-phase error is
     // already surfaced while the result iterator is consumed, and an init error
     // is surfaced from init(). settledTermination returns the settled terminal
     // as-is: the response proto for the clean terminators, and the failure
-    // terminals (Failed / TransportFailed) carrying their cause -- not a bare
-    // Cancelled.
+    // terminals (Failed / TransportFailed / Interrupted) carrying their cause --
+    // not a bare Cancelled.
     settledTermination
   }
 
   // ---- Internal request helpers ---------------------------------------------
 
   /**
-   * Sends a Data or Finish request to the worker. Two invariants are
+   * Writes one request and aborts the request side if the observer rejects it.
+   * Callers hold [[requestLock]], so this also serializes the compensating
+   * `onError` with every other request-side operation.
+   */
+  private def sendOnNext(req: UdfRequest): Unit = {
+    try {
+      requestObserver.onNext(req)
+    } catch {
+      case NonFatal(e) =>
+        abortRequestSide(e)
+        throw e
+    }
+  }
+
+  /** Aborts the request side at most once. Safe to call while holding [[requestLock]]. */
+  private def abortRequestSide(cause: Throwable): Unit = requestLock.synchronized {
+    if (requestObserver != null && requestSideTerminated.compareAndSet(false, true)) {
+      try {
+        requestObserver.onError(cause)
+      } catch {
+        case NonFatal(e) => logger.debug("Error aborting UDF Execute stream", e)
+      }
+    }
+  }
+
+  /** Half-closes the request side at most once. */
+  private def completeRequestSide(): Unit = requestLock.synchronized {
+    if (requestObserver != null && requestSideTerminated.compareAndSet(false, true)) {
+      try {
+        requestObserver.onCompleted()
+      } catch {
+        case NonFatal(e) => logger.debug("Error half-closing UDF Execute stream", e)
+      }
+    }
+  }
+
+  /**
+   * Sends a Data or Finish request to the worker. Three invariants are
    * checked inside [[requestLock]]:
    *  - terminal state: writes are unsafe (transport dead or terminal
    *    received). Throws, so the caller's terminal/exception path runs.
+   *  - request-side termination: no write may follow `onError` / `onCompleted`.
+   *    Throws so the caller settles or surfaces the failure.
    *  - [[cancelRequested]]: a Cancel has been (or is about to be) sent.
    *    Silently no-ops so a Data/Finish never appears on the wire after
    *    Cancel; the caller's iterator falls through to the terminator wait.
@@ -675,6 +714,10 @@ class GrpcWorkerSession(
         throw new IllegalStateException(
           "cannot send request: UDF Execute stream is already closed")
       }
+      if (requestSideTerminated.get()) {
+        throw new IllegalStateException(
+          "cannot send request: UDF Execute request stream is already closed")
+      }
       // Suppress the write when a cancel has been (or is about to be) flushed
       // through this lock; that preserves the proto ordering invariant (no
       // Data/Finish after Cancel). Test the flag rather than `return`-ing from
@@ -684,19 +727,19 @@ class GrpcWorkerSession(
         if (req.hasControl && req.getControl.hasFinish) {
           // Set before onNext: directExecutor delivery may return FinishResponse
           // reentrantly from inside this call.
-          finishWritten.set(true)
+          finishSendStarted.set(true)
         }
-        requestObserver.onNext(req)
+        sendOnNext(req)
       }
     }
 
   /**
-   * Sends a `Cancel` control message, returning `true` iff a `Cancel` was
-   * actually written to the wire. Idempotent across ALL call sites (close()'s
+   * Sends a `Cancel` control message, returning `true` iff the request observer
+   * accepts the `Cancel`. Idempotent across ALL call sites (close()'s
    * cancel, in-band cancels from `handleControl`'s INIT error / ERROR paths,
    * and engine-internal cancels from the iterator) via [[cancelRequested]]:
-   * only the first caller puts a `Cancel` on the wire, and the `cancel` thunk is
-   * evaluated only by that caller and only when the message is actually sent --
+   * only the first caller attempts a `Cancel`, and the `cancel` thunk is evaluated
+   * only by that caller and only when the send is about to start --
    * so a side-effecting thunk (e.g. one carrying a client cancel callback) runs
    * at most once. Setting [[cancelRequested]] also blocks subsequent Data/Finish
    * writes from [[ProcessIterator]] (see [[sendRequest]]), preserving the proto
@@ -712,17 +755,18 @@ class GrpcWorkerSession(
     try {
       requestLock.synchronized {
         // A terminal that arrived first must win; bail without writing. Compute
-        // the block's value rather than `return` (see sendRequest on why non-local
+        // the block's value rather than `return` (see sendRequest for why non-local
         // return is avoided -- here it would also escape the NonFatal catch below).
         val cur = currentState
-        if (cur.isTerminal) {
+        if (cur.isTerminal || requestSideTerminated.get()) {
           false
         } else {
-          // Record that a Cancel is on the wire by advancing to Cancelling.
-          Transitions.cancelSentFrom(cur)
-          requestObserver.onNext(UdfRequest.newBuilder()
+          val request = UdfRequest.newBuilder()
             .setControl(UdfControlRequest.newBuilder().setCancel(cancel()).build())
-            .build())
+            .build()
+          // Record that a Cancel send has started by advancing to Cancelling.
+          Transitions.beginCancelFrom(cur)
+          sendOnNext(request)
           true
         }
       }
@@ -893,19 +937,27 @@ class GrpcWorkerSession(
         // of stranding the worker waiting for input that will never arrive.
         if (!cancelRequested.get() && currentState == SessionState.Streaming &&
             cancelOnThrow("input iterator failed")(input.hasNext)) {
-          val batch = cancelOnThrow("input iterator failed")(input.next())
-          if (!sendOrEndOnRacedTerminal(UdfRequest.newBuilder().setData(batch).build())) return
-        } else if (!cancelRequested.get() && Transitions.finishSent()) {
+          val request = cancelOnThrow("input iterator failed") {
+            val batch = Objects.requireNonNull(
+              input.next(), "input iterator returned null")
+            UdfRequest.newBuilder().setData(batch).build()
+          }
+          if (!sendOrEndOnRacedTerminal(request)) return
+        } else if (!cancelRequested.get() && Transitions.beginFinish()) {
           // (3) No more input; send Finish exactly once (unless cancelled). The
           // `finish` thunk is caller-supplied (it may run a finish callback), so
           // it can throw; cancelOnThrow Cancels the stream before rethrowing. The
           // Streaming -> Finishing CAS has already run, but we have not written
           // Finish yet, so the Cancel is the only engine-to-worker message that
           // reaches the wire -- the proto "nothing after Cancel" invariant holds.
-          val finishMsg = cancelOnThrow("finish callback failed")(finish())
-          if (!sendOrEndOnRacedTerminal(UdfRequest.newBuilder()
+          val request = cancelOnThrow("finish callback failed") {
+            val finishMsg = Objects.requireNonNull(
+              finish(), "finish callback returned null")
+            UdfRequest.newBuilder()
               .setControl(UdfControlRequest.newBuilder().setFinish(finishMsg).build())
-              .build())) {
+              .build()
+          }
+          if (!sendOrEndOnRacedTerminal(request)) {
             return
           }
         } else {
@@ -1107,12 +1159,11 @@ object GrpcWorkerSession {
  * failures to users. [[executionError]] is preserved to carry the structured
  * cause across that boundary.
  *
- * @param executionError the structured protocol error when the failure carries
- *                       one (a worker `ErrorResponse`, an init error, or a
- *                       failure terminator with an error). `null` when there is
- *                       no structured cause: a transport failure, a timeout, or
- *                       a cancellation without an error. Callers must null-check
- *                       before use.
+ * @param executionError the structured protocol error, when present: a worker
+ *                       `ErrorResponse`, an init error, or a failure terminator
+ *                       with an error. `null` when there is no structured cause:
+ *                       a transport failure, a timeout, or a cancellation without
+ *                       an error. Callers must null-check before use.
  */
 @Experimental
 class GrpcWorkerSessionException(

--- a/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
+++ b/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
@@ -171,7 +171,7 @@ class GrpcWorkerSession(
   // gRPC requires serialized writes to a request StreamObserver.
   private val requestLock = new Object
 
-  // Initialised in init() -- before that, close() is a no-op on the request
+  // Initialized in init() -- before that, close() is a no-op on the request
   // side, which is exactly the contract the wrapping WorkerSession expects.
   @volatile private var requestObserver: StreamObserver[UdfRequest] = _
 
@@ -225,12 +225,23 @@ class GrpcWorkerSession(
   }
 
   /**
-   * Wakes the result iterator (blocked on [[outputQueue]]) and any thread
-   * waiting on [[terminalLatch]] when the base settles a terminal. Invoked once,
-   * by the caller that wins [[completeTerminal]].
+   * Wakes everything that can be blocked when the base settles a terminal:
+   * the result iterator (on [[outputQueue]]), a thread on [[terminalLatch]]
+   * (close), and a thread still blocked in [[doInit]] on [[initValue]]. Invoked
+   * once, by the caller that wins [[completeTerminal]], so waking [[initValue]]
+   * here covers every terminal-settling path uniformly -- including the close()
+   * path, which settles a terminal without going through the response callback
+   * that would otherwise signal [[initValue]]. Settle-before-release (see
+   * [[initValue]]) holds because this runs after the terminal CAS in
+   * [[completeTerminal]]. The per-callback [[initValue.signalWithoutValue]] calls
+   * that also settle a terminal are now redundant with this but harmless (the
+   * latch countDown is idempotent); the non-terminal init signals
+   * ([[handleControl]]'s INIT / pre-init ERROR branches) are still required, as
+   * they wake [[initValue]] without settling a terminal.
    */
   override protected def onTerminalSettled(termination: Termination): Unit = {
     outputQueue.put(QueueItem.EndOfStream)
+    initValue.signalWithoutValue()
     terminalLatch.countDown()
   }
 
@@ -282,7 +293,7 @@ class GrpcWorkerSession(
       // its error field to decide whether to throw.
       Transitions.finished(ctrl.getFinish)
       // Defensive: FINISH before InitResponse is a worker protocol bug, but
-      // we should fail init fast rather than hang the 30s init timeout.
+      // we should fail init fast rather than hang for the init timeout.
       initValue.signalWithoutValue()
 
     case UdfControlResponse.ControlCase.CANCEL =>
@@ -806,7 +817,7 @@ class GrpcWorkerSession(
      * suppressed by a pending cancel), `false` if a terminator settled and the
      * iterator should end (caller `return`s).
      *
-     * On a write failure a terminator usually already settled (the worker
+     * On a write failure a terminator has usually already settled (the worker
      * finished/failed early) and the write only failed because the stream is
      * closed: record a transport terminal if none is set ([[completeTerminal]] is
      * a no-op once settled), then [[throwIfTerminalError]] -- which throws for an

--- a/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
+++ b/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
@@ -28,7 +28,7 @@ import io.grpc.stub.StreamObserver
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.udf.worker.{Cancel, CancelResponse, DataRequest, DataResponse,
   ExecutionError, Finish, FinishResponse, Init, InitResponse, UdfControlRequest,
-  UdfControlResponse, UdfPayload, UdfRequest, UdfResponse, UdfWorkerGrpc}
+  UdfControlResponse, UdfRequest, UdfResponse, UdfWorkerGrpc}
 import org.apache.spark.udf.worker.core.{Termination, WorkerHandle, WorkerLogger, WorkerSession}
 import org.apache.spark.udf.worker.core.WorkerSession.SessionState
 import org.apache.spark.udf.worker.grpc.GrpcWorkerSession._
@@ -93,7 +93,7 @@ import org.apache.spark.udf.worker.grpc.GrpcWorkerSession._
  *    and terminates the request side.
  *
  * TODO [SPARK-55278]: this class does not yet implement payload chunking;
- * the entire [[UdfPayload]] is sent inline. Chunking will be added
+ * the entire [[org.apache.spark.udf.worker.UdfPayload]] is sent inline. Chunking will be added
  * when a UDF payload large enough to exceed gRPC's default message size
  * limit is introduced.
  *
@@ -873,10 +873,15 @@ class GrpcWorkerSession(
      * worker awaiting more input with no terminator owed on the wire; with it the
      * worker tears down and the exception still propagates to the engine. Setting
      * `cancelRequested` also suppresses any further Data/Finish this loop might
-     * otherwise attempt (see [[sendRequest]]).
+     * otherwise attempt (see [[sendRequest]]). An [[InterruptedException]] uses
+     * [[handleInterrupt]] so its CancelResponse drain remains bounded by
+     * [[interruptCancelTimeoutMs]].
      */
     private def cancelOnThrow[T](reason: String)(op: => T): T =
       try op catch {
+        case _: InterruptedException =>
+          handleInterrupt(reason)
+          throw new InterruptedException(s"interrupted while $reason")
         case NonFatal(e) =>
           sendCancelInternal(() => cancelWithReason(reason))
           throw e
@@ -1123,7 +1128,7 @@ object GrpcWorkerSession {
     def await(timeoutMs: Long): Unit =
       if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
         throw new TimeoutException(
-          s"timed out waiting for InitResponse after ${timeoutMs}ms")
+          s"timed out waiting for value after ${timeoutMs}ms")
       }
 
     /** The published value, or None if none was ever set. */

--- a/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
+++ b/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
@@ -38,7 +38,9 @@ import org.apache.spark.udf.worker.grpc.GrpcWorkerSession._
  * bidirectional RPC.
  *
  * Drives one bidirectional `Execute` stream against the worker per the
- * ordering invariants documented in `udf_message.proto`:
+ * ordering invariants documented in `udf_message.proto` (`PayloadChunk*`
+ * between Init and InitResponse omitted here; chunking is not yet
+ * implemented -- see the TODO below):
  * {{{
  *   Engine -> Worker:  Init -> (DataRequest)* -> Finish (Cancel)?
  *                                              | Cancel

--- a/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
+++ b/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
@@ -238,18 +238,17 @@ class GrpcWorkerSession(
     case UdfControlResponse.ControlCase.INIT =>
       val resp = ctrl.getInit
       if (resp.hasError) {
-        // Attribute a subsequent close()'s terminator to the init error rather
-        // than a bare Cancelled, mirroring the data-phase ERROR branch.
+        // Record the error and publish the InitResponse; do NOT settle a terminal
+        // or send Cancel here. The proto requires the engine to Cancel after an
+        // init error (udf_message.proto), but a Cancel written from this callback
+        // could race requestObserver still being null (a directExecutor worker
+        // delivers this reentrantly, inside doInit's stream.onNext, before doInit
+        // publishes requestObserver). So we leave the session in Initializing and
+        // let doInit -- which runs only after requestObserver is published -- send
+        // the Cancel and drain the CancelResponse. Settle-before-release (see
+        // initValue): there is no terminal to settle first here, just publish.
         executionError.compareAndSet(None, Some(resp.getError))
-        // Settle Failed(err) before the Cancel below (not after its CancelResponse):
-        // the sticky terminal makes close() report the init error, and the Cancel
-        // becomes best-effort worker cleanup -- so if it can't be written (a
-        // directExecutor worker delivered this reentrantly, before doInit published
-        // requestObserver), doInit still doesn't wait terminalTimeoutMs for a
-        // CancelResponse that can never arrive. Settle-before-release (see initValue).
-        Transitions.failed(resp.getError)
         initValue.complete(resp)
-        sendCancelInternal(() => cancelWithReason("init failed"))
       } else {
         // InitResponse OK. Only advance from Initializing so a terminal that raced
         // in (e.g. a transport error) still wins; process() then opens the data
@@ -261,19 +260,21 @@ class GrpcWorkerSession(
     case UdfControlResponse.ControlCase.ERROR =>
       val err = ctrl.getError.getError
       executionError.compareAndSet(None, Some(err))
-      // Before init resolves, settle Failed here rather than rely on the Cancel
-      // below: sendCancelInternal may find requestObserver still null (reentrant
-      // delivery inside stream.onNext, before doInit published it), so no Cancel --
-      // hence no CancelResponse -- would settle the terminal, and doInit would
-      // return as if init succeeded. completeTerminal is idempotent, so the
-      // data-phase ERROR -> Cancel -> CancelResponse path is unaffected.
       if (!initResolved) {
-        Transitions.failed(err)
+        // Pre-init ErrorResponse. Leave the session in Initializing and just wake
+        // init(): the recorded executionError tells doInit the worker failed, and
+        // doInit -- running after requestObserver is published -- sends the Cancel
+        // and drains the CancelResponse. Same reasoning as the INIT-error branch:
+        // a Cancel from this callback could race requestObserver still being null
+        // under reentrant (directExecutor) delivery.
+        initValue.signalWithoutValue()
+      } else {
+        // Data-phase ErrorResponse: requestObserver is published, so cancel here.
+        // Cancel -> CancelResponse settles the terminal; the iterator surfaces the
+        // recorded executionError. The init latch already fired in init(), so no
+        // signalWithoutValue is needed.
+        sendCancelInternal(() => cancelWithReason("aborting after ErrorResponse"))
       }
-      // Settle-before-release (see initValue). No value to publish -- ERROR is not
-      // an InitResponse; on the data-phase path the latch already fired in init.
-      initValue.signalWithoutValue()
-      sendCancelInternal(() => cancelWithReason("aborting after ErrorResponse"))
 
     case UdfControlResponse.ControlCase.FINISH =>
       // The FinishResponse carries metrics + the finish-callback data/error.
@@ -327,7 +328,7 @@ class GrpcWorkerSession(
    *   Streaming -> Finishing          finishSent      advance branch 3       [engine]
    *   non-terminal -> Cancelling      cancelSentFrom  sendCancelInternal, iff a Cancel
    *                                     reaches the wire  [gRPC cb | engine | init | close]
-   *   non-terminal -> Terminal        finished/cancelled/failed/transportFailed
+   *   non-terminal -> Terminal        finished/cancelled/transportFailed
    *                                     handleControl / doInit / doClose / advance / onError
    * }}}
    * `Cancelling` is reached only if a Cancel is actually written; a pre-stream or
@@ -355,10 +356,6 @@ class GrpcWorkerSession(
     /** Clean terminal carrying the worker's `CancelResponse`. */
     def cancelled(response: CancelResponse): Boolean =
       completeTerminal(Termination.Cancelled(response))
-
-    /** Failure terminal carrying a structured [[ExecutionError]]. */
-    def failed(error: ExecutionError): Boolean =
-      completeTerminal(Termination.Failed(error))
 
     /** Failure terminal carrying a transport-level cause. */
     def transportFailed(cause: Throwable): Boolean =
@@ -411,68 +408,91 @@ class GrpcWorkerSession(
         throw new GrpcWorkerSessionException("UDF worker stream failed during init", e)
     }
 
-    val responded = try {
+    try {
       initValue.await(initResponseTimeoutMs)
     } catch {
       case _: InterruptedException =>
         Thread.currentThread().interrupt()
         sendCancelInternal(() => cancelWithReason("interrupted during init"))
-        // Make sure close() does not block waiting for a terminator that
-        // will never arrive on this thread's behalf.
+        // Attribute the terminal to a transport failure, not a cancel: the
+        // interrupt comes from the engine/task thread that called init() (e.g.
+        // Spark task kill), and after it the worker's state is unknown -- the
+        // Cancel above is best-effort and may not have been acked -- so the
+        // worker is not salvageable. It also stops close() from blocking on a
+        // terminator that will never arrive on this thread's behalf.
         Transitions.transportFailed(
           new InterruptedException("interrupted while waiting for InitResponse"))
         throw new InterruptedException("interrupted while waiting for InitResponse")
-    }
-
-    if (!responded) {
-      sendCancelInternal(() => cancelWithReason("InitResponse timed out"))
-      val timeout = new TimeoutException(
-        s"timed out waiting for InitResponse after ${initResponseTimeoutMs}ms")
-      // Settle the terminal so a subsequent close() does not stall for a
-      // second `terminalTimeoutMs` waiting for a worker that already missed
-      // its init deadline.
-      Transitions.transportFailed(timeout)
-      // Surface as GrpcWorkerSessionException (carrying the timeout cause) so
-      // the engine integration layer that catches that type can wrap it.
-      throw new GrpcWorkerSessionException(
-        s"timed out waiting for InitResponse after ${initResponseTimeoutMs}ms", timeout)
+      case e: TimeoutException =>
+        sendCancelInternal(() => cancelWithReason("InitResponse timed out"))
+        // Settle the terminal so a subsequent close() does not stall for a
+        // second `terminalTimeoutMs` waiting for a worker that already missed
+        // its init deadline.
+        Transitions.transportFailed(e)
+        // Surface as GrpcWorkerSessionException (carrying the timeout cause) so
+        // the engine integration layer that catches that type can wrap it.
+        throw new GrpcWorkerSessionException(
+          s"timed out waiting for InitResponse after ${initResponseTimeoutMs}ms", e)
     }
 
     initValue.get match {
       case Some(resp) if resp.hasError =>
-        // The protocol requires the engine to send Cancel after an init
-        // error and the worker to respond with CancelResponse. Drain it
-        // before throwing so we don't leave a dangling stream.
-        awaitTerminal()
-        throw new GrpcWorkerSessionException(
-          s"UDF worker init failed: ${describeError(resp.getError)}", resp.getError)
+        failInitWithError(resp.getError,
+          s"UDF worker init failed: ${describeError(resp.getError)}")
       case Some(resp) =>
         resp
       case None =>
-        // No InitResponse arrived but the latch fired. The defensive
-        // initValue.signalWithoutValue() in handleControl / onError /
-        // onCompleted means we get here when the worker terminated the stream
-        // before sending InitResponse. Surface that as an init failure rather
-        // than letting the caller proceed as if init succeeded.
-        currentState match {
-          case SessionState.Terminal(Termination.TransportFailed(cause)) =>
-            throw new GrpcWorkerSessionException(
-              "UDF worker stream failed during init", cause)
-          case SessionState.Terminal(Termination.Failed(err)) =>
-            throw new GrpcWorkerSessionException(
-              s"UDF worker reported an error before init completed: " +
-                describeError(err), err)
-          case SessionState.Terminal(Termination.Cancelled(_)) =>
-            throw new GrpcWorkerSessionException(
-              "UDF worker stream was cancelled before init completed")
-          case SessionState.Terminal(Termination.Finished(_)) =>
-            throw new GrpcWorkerSessionException(
-              "UDF worker finished before init completed")
-          case other =>
-            throw new IllegalStateException(
-              s"init latch fired without an InitResponse or terminal: $other")
+        // No InitResponse arrived but the latch fired.
+        //
+        // A pre-init ErrorResponse leaves the session in Initializing with the
+        // error recorded in executionError (see handleControl ERROR branch): the
+        // engine must now Cancel and drain the CancelResponse, which failInit does.
+        executionError.get() match {
+          case Some(err) if !currentState.isTerminal =>
+            failInitWithError(err,
+              s"UDF worker reported an error before init completed: ${describeError(err)}")
+          case _ =>
+            // Otherwise a terminal already settled -- the worker terminated the
+            // stream before sending InitResponse (transport error, half-close, or
+            // a premature FinishResponse/CancelResponse). Surface it as an init
+            // failure rather than letting the caller proceed as if init succeeded.
+            currentState match {
+              case SessionState.Terminal(Termination.TransportFailed(cause)) =>
+                throw new GrpcWorkerSessionException(
+                  "UDF worker stream failed during init", cause)
+              case SessionState.Terminal(Termination.Failed(err)) =>
+                throw new GrpcWorkerSessionException(
+                  s"UDF worker reported an error before init completed: " +
+                    describeError(err), err)
+              case SessionState.Terminal(Termination.Cancelled(_)) =>
+                throw new GrpcWorkerSessionException(
+                  "UDF worker stream was cancelled before init completed")
+              case SessionState.Terminal(Termination.Finished(_)) =>
+                throw new GrpcWorkerSessionException(
+                  "UDF worker finished before init completed")
+              case other =>
+                throw new IllegalStateException(
+                  s"init latch fired without an InitResponse or terminal: $other")
+            }
         }
     }
+  }
+
+  /**
+   * Fail init after the worker reported an error before accepting the session
+   * (an `InitResponse` carrying an error, or a pre-init `ErrorResponse`). The
+   * protocol requires the engine to send `Cancel` after an init error and the
+   * worker to reply with `CancelResponse` (udf_message.proto); we do that here --
+   * where [[requestObserver]] is published, unlike the response callback that
+   * recorded the error -- then drain the terminator so no stream is left
+   * dangling, and throw. The settled terminal is `Cancelled`; the structured
+   * error is surfaced through this throw and kept on [[executionError]] for the
+   * iterator / close()'s salvage decision.
+   */
+  private def failInitWithError(err: ExecutionError, message: String): Nothing = {
+    sendCancelInternal(() => cancelWithReason("init failed"))
+    awaitTerminal()
+    throw new GrpcWorkerSessionException(message, err)
   }
 
   override protected def doProcess(
@@ -486,11 +506,16 @@ class GrpcWorkerSession(
   override protected def doClose(cancel: () => Cancel): Termination = {
     if (requestObserver == null) {
       // init() never put a stream on the wire (closed before/around init, or
-      // init threw before publishing). There is no protocol terminator; treat
-      // the session as cancelled-before-start. The base WorkerSession still
-      // releases the worker handle, so the worker is torn down.
-      Transitions.cancelled(CancelResponse.getDefaultInstance)
-      return Termination.Cancelled(CancelResponse.getDefaultInstance)
+      // init threw before publishing). There is no protocol terminator; if no
+      // terminal has settled yet, treat the session as cancelled-before-start.
+      // A terminal may already be settled here (e.g. the channel-shutdown
+      // TransportFailed in doInit also leaves requestObserver null); return the
+      // settled terminal as-is rather than a bare Cancelled that disagrees with
+      // the state. The base WorkerSession still releases the worker handle.
+      if (!currentState.isTerminal) {
+        Transitions.cancelled(CancelResponse.getDefaultInstance)
+      }
+      return settledTermination
     }
     // If the stream has not finished on its own, cancel anything in flight so
     // the worker can clean up, then wait for the terminator. sendCancelInternal
@@ -878,8 +903,16 @@ object GrpcWorkerSession {
     /** Releases the waiter without a value (a terminal arrived, not the value). */
     def signalWithoutValue(): Unit = latch.countDown()
 
-    /** Blocks up to `timeoutMs` for a release; true iff released in time. */
-    def await(timeoutMs: Long): Boolean = latch.await(timeoutMs, TimeUnit.MILLISECONDS)
+    /**
+     * Blocks up to `timeoutMs` for a release, throwing [[TimeoutException]] if
+     * none arrives so the caller handles the timeout on the exception path rather
+     * than by inspecting a return value.
+     */
+    def await(timeoutMs: Long): Unit =
+      if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+        throw new TimeoutException(
+          s"timed out waiting for InitResponse after ${timeoutMs}ms")
+      }
 
     /** The published value, or None if none was ever set. */
     def get: Option[A] = ref.get()

--- a/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
+++ b/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
@@ -376,8 +376,9 @@ class GrpcWorkerSession(
     /**
      * Terminal for an engine-thread interrupt (e.g. a Spark task kill). Distinct
      * from [[transportFailed]]: the worker is salvageable (the interrupt is not a
-     * worker fault) and a best-effort `Cancel` is sent but its `CancelResponse`
-     * is not awaited, since the interrupted thread must unwind rather than block.
+     * worker fault). Settled by [[handleInterrupt]] only when the brief
+     * post-Cancel drain expires without a `CancelResponse`; if the worker acks in
+     * time the session settles a cooperative [[cancelled]] instead.
      */
     def interrupted(cause: Throwable): Boolean =
       completeTerminal(Termination.Interrupted(cause))
@@ -549,6 +550,16 @@ class GrpcWorkerSession(
           // shared handler rather than falling through to the TransportFailed
           // guard below. The Cancel is already on the wire, so handleInterrupt's
           // sendCancelInternal is a no-op and it just runs the bounded drain.
+          //
+          // TODO [SPARK-57640]: close() is a finalizer often already on the task
+          // kill path, yet this makes an interrupted close block up to another
+          // interruptCancelTimeoutMs (chasing a clean, salvageable Cancelled
+          // rather than immediately unwinding to Interrupted). Current choice:
+          // spend the bounded wait to keep the worker recyclable; it is small
+          // next to terminalTimeoutMs. Revisit if killed-task teardown latency
+          // (esp. many sessions torn down at once) makes an immediate unwind
+          // preferable -- e.g. skip this second drain in the close() path, since
+          // close already gave the worker its terminalTimeoutMs window.
           handleInterrupt("closing the session")
       }
     }
@@ -662,7 +673,7 @@ class GrpcWorkerSession(
           s"timed out waiting for stream terminator after ${terminalTimeoutMs}ms"))
       }
     } catch {
-      case _: InterruptedException => handleInterrupt(s"waiting for stream terminator")
+      case _: InterruptedException => handleInterrupt("waiting for stream terminator")
     }
   }
 

--- a/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
+++ b/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
@@ -58,8 +58,9 @@ import org.apache.spark.udf.worker.grpc.GrpcWorkerSession._
  * sends each `DataRequest`; the gRPC callback thread only receives output. It is
  * pull-driven but not one-input-per-output -- `advance` sends the next input
  * whenever the output queue is momentarily empty, so under async delivery it may
- * push several input batches before any output is read (bounded by HTTP/2 flow
- * control).
+ * push several input batches before any output is read. HTTP/2 flow control
+ * bounds wire traffic, but application-level buffering is intentionally left to
+ * a follow-up (see the TODO on [[outputQueue]]).
  *
  * '''State machine.''' This class does not keep its own state machine: it
  * drives the single [[WorkerSession.SessionState]] owned by the base. The base
@@ -74,10 +75,9 @@ import org.apache.spark.udf.worker.grpc.GrpcWorkerSession._
  * }}}
  * The two clean terminals carry the worker's `FinishResponse` / `CancelResponse`
  * (metrics + finish/cancel callback `data`/`error`) so [[close]] can return
- * them. The only flag kept outside the machine is [[cancelRequested]]: a
- * cancellation can be requested before the stream exists (so it cannot be a
- * state transition yet), and it must both fast-fail the result iterator and
- * suppress any in-flight Data/Finish.
+ * them. The only flag kept outside the machine is [[cancelRequested]], which
+ * makes the wire write idempotent and suppresses any in-flight Data/Finish once
+ * cancellation begins.
  *
  * Threading:
  *  - [[doInit]] is synchronous: sends `Init` and blocks on `InitResponse`,
@@ -131,21 +131,24 @@ class GrpcWorkerSession(
   private val asyncStub = UdfWorkerGrpc.newStub(channel)
 
   // Output batches from the worker, drained by the process() iterator.
-  // Intentionally unbounded: a bounded queue would block the gRPC callback
-  // (Netty event-loop) thread when full, stalling terminator/control delivery on
-  // the whole channel. HTTP/2 flow control bounds the wire and the consumer
-  // normally drains promptly; a stalled downstream can still grow it, but the fix
-  // is protocol-level back-pressure (out of scope), not bounding the queue.
+  // Intentionally unbounded in this first implementation: a bounded queue would
+  // block the gRPC callback (Netty event-loop) thread when full, stalling
+  // terminator/control delivery on the whole channel. The consumer normally
+  // drains promptly, but HTTP/2 flow control alone does not bound this application
+  // queue or gRPC's asynchronous send buffers.
   //
+  // TODO [SPARK-55278]: add application-level gRPC flow control in a follow-up,
+  // using ClientCallStreamObserver readiness for requests and manual inbound
+  // demand for responses, before wiring this transport into a production path.
   // TODO [SPARK-57324]: expose queue depth as a metric (early warning for a
   // stalled consumer).
   private val outputQueue = new LinkedBlockingQueue[QueueItem]()
 
   // The worker's `InitResponse` (success or error) coupled with the latch that
-  // init() blocks on. Fires when the InitResponse arrives (`complete`) or when a
-  // terminal settles first without one -- transport error, half-close, or a
-  // premature terminator (`signalWithoutValue`). Until it fires we have no proof
-  // the worker accepted the session.
+  // init() blocks on. Fires when the InitResponse arrives (`complete`), when a
+  // pre-init ErrorResponse arrives, or when a terminal settles first without an
+  // InitResponse (`signalWithoutValue`). Until it fires we have no proof the
+  // worker accepted the session.
   //
   // Settle-before-release rule (referenced from every callback that both settles
   // a terminal and fires this latch): settle the terminal FIRST, then complete /
@@ -165,15 +168,18 @@ class GrpcWorkerSession(
   // user / worker / protocol error rather than reporting a bare "Cancelled".
   private val executionError = new AtomicReference[Option[ExecutionError]](None)
 
+  // True immediately before Finish is handed to the request observer. It is set
+  // before onNext so a reentrant callback may deliver FinishResponse while the
+  // Finish request is still being written.
+  private val finishWritten = new AtomicBoolean(false)
+
   // Cancellation INTENT -- distinct from the `Cancelling` state, which is reached
   // only once a Cancel is actually written to the wire ([[sendCancelInternal]]).
   // Intent is set first and can outrun (or never reach) that write, so
-  // `cancelRequested` does NOT imply state `Cancelling`. Kept outside the
-  // [[SessionState]] machine because a cancel can be requested before the stream
-  // exists (pre-init), where there is no wire transition to make yet. Used to (a)
-  // make cancel idempotent across all call sites, (b) fast-fail ProcessIterator
-  // on a pre-init cancel, and (c) suppress any Data/Finish that would otherwise
-  // race a Cancel onto the wire (re-read inside [[requestLock]]).
+  // `cancelRequested` does NOT imply state `Cancelling`. It is kept outside the
+  // [[SessionState]] machine to (a) make cancellation idempotent across all call
+  // sites and (b) suppress any Data/Finish that would otherwise race a Cancel
+  // onto the wire (re-read inside [[requestLock]]).
   private val cancelRequested = new AtomicBoolean(false)
 
   // gRPC requires serialized writes to a request StreamObserver.
@@ -254,13 +260,10 @@ class GrpcWorkerSession(
       if (resp.hasError) {
         // Record the error and publish the InitResponse; do NOT settle a terminal
         // or send Cancel here. The proto requires the engine to Cancel after an
-        // init error (udf_message.proto), but a Cancel written from this callback
-        // could race requestObserver still being null (a directExecutor worker
-        // delivers this reentrantly, inside doInit's stream.onNext, before doInit
-        // publishes requestObserver). So we leave the session in Initializing and
-        // let doInit -- which runs only after requestObserver is published -- send
-        // the Cancel and drain the CancelResponse. Settle-before-release (see
-        // initValue): there is no terminal to settle first here, just publish.
+        // init error (udf_message.proto); doInit owns that synchronous cleanup
+        // after the initial onNext returns, then drains the CancelResponse before
+        // throwing. Settle-before-release (see initValue): there is no terminal to
+        // settle first here, just publish.
         executionError.compareAndSet(None, Some(resp.getError))
         initValue.complete(resp)
       } else {
@@ -277,10 +280,8 @@ class GrpcWorkerSession(
       if (!initResolved) {
         // Pre-init ErrorResponse. Leave the session in Initializing and just wake
         // init(): the recorded executionError tells doInit the worker failed, and
-        // doInit -- running after requestObserver is published -- sends the Cancel
-        // and drains the CancelResponse. Same reasoning as the INIT-error branch:
-        // a Cancel from this callback could race requestObserver still being null
-        // under reentrant (directExecutor) delivery.
+        // doInit sends the Cancel and drains the CancelResponse after the initial
+        // onNext returns, just like the INIT-error branch.
         initValue.signalWithoutValue()
       } else {
         // Data-phase ErrorResponse: requestObserver is published, so cancel here.
@@ -293,10 +294,15 @@ class GrpcWorkerSession(
     case UdfControlResponse.ControlCase.FINISH =>
       // The FinishResponse carries metrics + the finish-callback data/error.
       // Keep it on the terminal so close() can return it; the iterator inspects
-      // its error field to decide whether to throw. Settling the terminal wakes a
-      // blocked init() (a FINISH before InitResponse is a worker protocol bug, but
-      // fails init fast rather than hanging the init timeout) via onTerminalSettled.
-      Transitions.finished(ctrl.getFinish)
+      // its error field to decide whether to throw. A FinishResponse is valid only
+      // after the engine has actually written Finish; accepting one earlier could
+      // silently truncate input and report a clean result.
+      if (finishWritten.get()) {
+        Transitions.finished(ctrl.getFinish)
+      } else {
+        Transitions.transportFailed(new IllegalStateException(
+          "worker sent FinishResponse before the engine sent Finish"))
+      }
 
     case UdfControlResponse.ControlCase.CANCEL =>
       // The CancelResponse carries metrics + the cancel-callback error. Keep it
@@ -375,10 +381,11 @@ class GrpcWorkerSession(
 
     /**
      * Terminal for an engine-thread interrupt (e.g. a Spark task kill). Distinct
-     * from [[transportFailed]]: the worker is salvageable (the interrupt is not a
-     * worker fault). Settled by [[handleInterrupt]] only when the brief
-     * post-Cancel drain expires without a `CancelResponse`; if the worker acks in
-     * time the session settles a cooperative [[cancelled]] instead.
+     * from [[transportFailed]] because the cause is an engine-side interrupt, but
+     * still unsalvageable without a worker acknowledgement. Settled by
+     * [[handleInterrupt]] only when the brief post-Cancel drain expires without a
+     * `CancelResponse`; if the worker acks in time the session settles a
+     * cooperative [[cancelled]] instead.
      */
     def interrupted(cause: Throwable): Boolean =
       completeTerminal(Termination.Interrupted(cause))
@@ -396,38 +403,53 @@ class GrpcWorkerSession(
       Transitions.transportFailed(ex)
       throw new GrpcWorkerSessionException("UDF worker channel is closed", ex)
     }
-    // Open the stream as a local first; only publish `requestObserver`
-    // AFTER the Init has been put on the wire. close()'s cancel reads
-    // `requestObserver` outside [[requestLock]] and returns early when
-    // it is null, so this ordering prevents a concurrent cancel from
-    // sneaking a Cancel ahead of Init.
-    val stream = asyncStub.execute(responseObserver)
+    // Open the stream as a local first. Publication and the Init write are
+    // serialized with close/cancel below so close either settles the session
+    // before Init is sent, or writes Cancel only after Init.
+    val stream = try {
+      asyncStub.execute(responseObserver)
+    } catch {
+      case NonFatal(e) =>
+        Transitions.transportFailed(e)
+        throw new GrpcWorkerSessionException("UDF worker stream failed during init", e)
+    }
     val initRequest = UdfRequest.newBuilder()
       .setControl(UdfControlRequest.newBuilder().setInit(message).build())
       .build()
+    var initSent = false
     try {
       requestLock.synchronized {
-        // Reentrant delivery: a directExecutor worker (one whose gRPC callbacks run
-        // synchronously on the caller's thread) can deliver InitResponse -- and thus
-        // run responseObserver/handleControl -- from *inside* this stream.onNext,
-        // before requestObserver below is published. The base advanced
-        // Created -> Initializing before calling doInit, so that reentrant
-        // InitResponse still finds Initializing and advances to Initialized; the
-        // handleControl error paths guard the still-null requestObserver. This is
-        // the scenario the "before doInit published requestObserver" comments mean.
-        stream.onNext(initRequest)
-        requestObserver = stream
+        // Publish while holding the same lock used by close/cancel, before
+        // onNext. A concurrent close that observes this value waits for Init to
+        // be written before it can write Cancel. If close won the lock first and
+        // settled a terminal, do not put Init on an already-closed session.
+        if (currentState.isTerminal) {
+          // No request is written below. The local stream is half-closed after
+          // releasing requestLock so an RPC opened just before close is not left
+          // dangling.
+        } else {
+          requestObserver = stream
+          // With directExecutor, gRPC callbacks run synchronously on the caller's
+          // thread, so InitResponse can reach responseObserver/handleControl from
+          // *inside* this stream.onNext.
+          // requestObserver is already published, so an immediate ErrorResponse
+          // can write its required Cancel reentrantly without losing the request.
+          stream.onNext(initRequest)
+          initSent = true
+        }
       }
     } catch {
       case NonFatal(e) =>
-        // Expose the stream so a subsequent close() can still attempt a
-        // best-effort half-close; the terminal already reflects the failure.
-        requestObserver = stream
         Transitions.transportFailed(e)
         // Surface as GrpcWorkerSessionException so the engine integration layer
         // (which catches that type and wraps it) sees a uniform init-failure
         // exception rather than the raw transport error.
         throw new GrpcWorkerSessionException("UDF worker stream failed during init", e)
+    }
+    if (!initSent) {
+      try stream.onCompleted() catch {
+        case NonFatal(e) => logger.debug("Error half-closing unopened UDF Execute stream", e)
+      }
     }
 
     try {
@@ -456,7 +478,24 @@ class GrpcWorkerSession(
         failInitWithError(resp.getError,
           s"UDF worker init failed: ${describeError(resp.getError)}")
       case Some(resp) =>
-        resp
+        executionError.get() match {
+          case Some(err) =>
+            // A reentrant callback can report an ErrorResponse immediately after
+            // InitResponse and before the initial onNext returns. The callback
+            // has already sent Cancel; drain its response
+            // and surface the original error instead of returning init success
+            // for a session that is already cancelling or terminal.
+            failInitWithError(err,
+              s"UDF worker reported an error as init completed: ${describeError(err)}")
+          case None if currentState != SessionState.Initialized =>
+            // Likewise, an immediate protocol failure or concurrent close may
+            // have moved the session out of Initialized after publishing the
+            // InitResponse. A normal return would violate init()'s contract and
+            // leave process() to fail later with only an ordering error.
+            failInitFromCurrentState()
+          case None =>
+            resp
+        }
       case None =>
         // No InitResponse arrived but the latch fired.
         //
@@ -472,41 +511,52 @@ class GrpcWorkerSession(
             // stream before sending InitResponse (transport error, half-close, or
             // a premature FinishResponse/CancelResponse). Surface it as an init
             // failure rather than letting the caller proceed as if init succeeded.
-            currentState match {
-              case SessionState.Terminal(Termination.TransportFailed(cause)) =>
-                throw new GrpcWorkerSessionException(
-                  "UDF worker stream failed during init", cause)
-              case SessionState.Terminal(Termination.Failed(err)) =>
-                throw new GrpcWorkerSessionException(
-                  s"UDF worker reported an error before init completed: " +
-                    describeError(err), err)
-              case SessionState.Terminal(Termination.Cancelled(_)) =>
-                throw new GrpcWorkerSessionException(
-                  "UDF worker stream was cancelled before init completed")
-              case SessionState.Terminal(Termination.Interrupted(cause)) =>
-                throw new GrpcWorkerSessionException(
-                  "UDF worker init was interrupted", cause)
-              case SessionState.Terminal(Termination.Finished(_)) =>
-                throw new GrpcWorkerSessionException(
-                  "UDF worker finished before init completed")
-              case other =>
-                throw new IllegalStateException(
-                  s"init latch fired without an InitResponse or terminal: $other")
-            }
+            failInitFromCurrentState()
         }
     }
   }
 
+  /** Surfaces the terminal that prevented init from completing normally. */
+  private def failInitFromCurrentState(): Nothing = {
+    executionError.get() match {
+      case Some(err) =>
+        failInitWithError(err,
+          s"UDF worker reported an error as init completed: ${describeError(err)}")
+      case None => ()
+    }
+    // Cancelling can be observed after a concurrent close or a reentrant error
+    // before its CancelResponse arrives. Drain it so the exception reflects the
+    // stable terminal rather than a transient state.
+    if (currentState == SessionState.Cancelling) {
+      awaitTerminal()
+    }
+    currentState match {
+      case SessionState.Terminal(Termination.TransportFailed(cause)) =>
+        throw new GrpcWorkerSessionException("UDF worker stream failed during init", cause)
+      case SessionState.Terminal(Termination.Failed(err)) =>
+        throw new GrpcWorkerSessionException(
+          s"UDF worker reported an error before init completed: ${describeError(err)}", err)
+      case SessionState.Terminal(Termination.Cancelled(_)) =>
+        throw new GrpcWorkerSessionException(
+          "UDF worker stream was cancelled before init completed")
+      case SessionState.Terminal(Termination.Interrupted(cause)) =>
+        throw new GrpcWorkerSessionException("UDF worker init was interrupted", cause)
+      case SessionState.Terminal(Termination.Finished(_)) =>
+        throw new GrpcWorkerSessionException("UDF worker finished before init completed")
+      case other =>
+        throw new IllegalStateException(
+          s"init completed without an accepted session or terminal: $other")
+    }
+  }
+
   /**
-   * Fail init after the worker reported an error before accepting the session
-   * (an `InitResponse` carrying an error, or a pre-init `ErrorResponse`). The
-   * protocol requires the engine to send `Cancel` after an init error and the
-   * worker to reply with `CancelResponse` (udf_message.proto); we do that here --
-   * where [[requestObserver]] is published, unlike the response callback that
-   * recorded the error -- then drain the terminator so no stream is left
-   * dangling, and throw. The settled terminal is `Cancelled`; the structured
-   * error is surfaced through this throw and kept on [[executionError]] for the
-   * iterator / close()'s salvage decision.
+   * Fails init when the worker reports an error before init returns: an
+   * `InitResponse` carrying an error, a pre-init `ErrorResponse`, or an immediate
+   * post-init `ErrorResponse`. The protocol requires the engine to send `Cancel`
+   * and the worker to reply with `CancelResponse` (udf_message.proto); we send it,
+   * drain the terminator so no stream is left dangling, and throw the structured
+   * error. A responsive worker settles `Cancelled`; a failed drain settles
+   * `TransportFailed`.
    */
   private def failInitWithError(err: ExecutionError, message: String): Nothing = {
     sendCancelInternal(() => cancelWithReason("init failed"))
@@ -523,17 +573,28 @@ class GrpcWorkerSession(
   }
 
   override protected def doClose(cancel: () => Cancel): Termination = {
-    if (requestObserver == null) {
-      // init() never put a stream on the wire (closed before/around init, or
-      // init threw before publishing). There is no protocol terminator; if no
-      // terminal has settled yet, treat the session as cancelled-before-start.
-      // A terminal may already be settled here (e.g. the channel-shutdown
-      // TransportFailed in doInit also leaves requestObserver null); return the
-      // settled terminal as-is rather than a bare Cancelled that disagrees with
-      // the state. The base WorkerSession still releases the worker handle.
-      if (!currentState.isTerminal) {
-        Transitions.cancelled(CancelResponse.getDefaultInstance)
+    // Coordinate the no-stream decision with doInit's publication + Init write.
+    // If close wins this lock, doInit observes the terminal and never sends Init;
+    // if doInit wins, close observes the published observer and sends Cancel only
+    // after Init has gone on the wire.
+    val noPublishedStream = requestLock.synchronized {
+      if (requestObserver == null) {
+        // init() never put a stream on the wire (closed before/around init, or
+        // init threw before publishing). There is no protocol terminator; if no
+        // terminal has settled yet, treat the session as cancelled-before-start.
+        // A terminal may already be settled here (e.g. the channel-shutdown
+        // TransportFailed in doInit also leaves requestObserver null); return the
+        // settled terminal as-is rather than a bare Cancelled that disagrees with
+        // the state. The base WorkerSession still releases the worker handle.
+        if (!currentState.isTerminal) {
+          Transitions.cancelled(CancelResponse.getDefaultInstance)
+        }
+        true
+      } else {
+        false
       }
+    }
+    if (noPublishedStream) {
       return settledTermination
     }
     // If the stream has not finished on its own, cancel anything in flight so
@@ -546,7 +607,7 @@ class GrpcWorkerSession(
         terminalLatch.await(terminalTimeoutMs, TimeUnit.MILLISECONDS)
       } catch {
         case _: InterruptedException =>
-          // Interrupted mid-close: settle Interrupted (salvageable) via the
+          // Interrupted mid-close: settle Interrupted via the
           // shared handler rather than falling through to the TransportFailed
           // guard below. The Cancel is already on the wire, so handleInterrupt's
           // sendCancelInternal is a no-op and it just runs the bounded drain.
@@ -555,11 +616,11 @@ class GrpcWorkerSession(
           // kill path, yet this makes an interrupted close block up to another
           // interruptCancelTimeoutMs (chasing a clean, salvageable Cancelled
           // rather than immediately unwinding to Interrupted). Current choice:
-          // spend the bounded wait to keep the worker recyclable; it is small
-          // next to terminalTimeoutMs. Revisit if killed-task teardown latency
-          // (esp. many sessions torn down at once) makes an immediate unwind
-          // preferable -- e.g. skip this second drain in the close() path, since
-          // close already gave the worker its terminalTimeoutMs window.
+          // spend the bounded wait to obtain proof the worker is recyclable; it
+          // is small next to terminalTimeoutMs. Revisit if killed-task teardown
+          // latency (especially many sessions torn down at once) makes an
+          // immediate unwind preferable -- e.g. skip this second drain in the
+          // close() path, since close already gave the worker its terminalTimeoutMs window.
           handleInterrupt("closing the session")
       }
     }
@@ -603,10 +664,10 @@ class GrpcWorkerSession(
    *    Silently no-ops so a Data/Finish never appears on the wire after
    *    Cancel; the caller's iterator falls through to the terminator wait.
    *
-   * Init is NOT sent through this helper -- [[doInit]] writes Init
-   * directly under [[requestLock]] before publishing
-   * [[requestObserver]], so there is no path through which a concurrent
-   * cancel could send Cancel before Init.
+   * Init is NOT sent through this helper -- [[doInit]] publishes
+   * [[requestObserver]] and writes Init together under [[requestLock]], so a
+   * concurrent cancel observes the observer but cannot acquire the lock and send
+   * Cancel until after Init.
    */
   private def sendRequest(req: UdfRequest): Unit =
     requestLock.synchronized {
@@ -620,6 +681,11 @@ class GrpcWorkerSession(
       // this by-name `synchronized` body: a non-local return compiles to a thrown
       // NonLocalReturnControl, which is brittle (also relied on in sendCancelInternal).
       if (!cancelRequested.get()) {
+        if (req.hasControl && req.getControl.hasFinish) {
+          // Set before onNext: directExecutor delivery may return FinishResponse
+          // reentrantly from inside this call.
+          finishWritten.set(true)
+        }
         requestObserver.onNext(req)
       }
     }
@@ -637,8 +703,11 @@ class GrpcWorkerSession(
    * invariant that nothing follows `Cancel` on the engine-to-worker side.
    */
   private def sendCancelInternal(cancel: () => Cancel): Boolean = {
-    if (!cancelRequested.compareAndSet(false, true)) return false
+    // Do not consume the one-shot cancellation intent until there is an observer
+    // that can carry it. doInit publishes the observer before sending Init while
+    // holding requestLock, so every response to Init sees a non-null observer.
     if (requestObserver == null) return false
+    if (!cancelRequested.compareAndSet(false, true)) return false
     if (currentState.isTerminal) return false
     try {
       requestLock.synchronized {
@@ -681,7 +750,7 @@ class GrpcWorkerSession(
    * Handles an [[InterruptedException]] observed while blocked on a worker event
    * (init, terminal drain, close, or the result-iterator poll). An interrupt is
    * an engine-side event -- typically a cancelled query / killed task -- not a
-   * worker fault, so we cancel cooperatively and keep the worker salvageable
+   * worker fault, so we cancel cooperatively and keep the worker salvageable only
    * when it acks:
    *
    *  1. Send a best-effort `Cancel` (idempotent across call sites).
@@ -689,10 +758,9 @@ class GrpcWorkerSession(
    *     thread unwinds promptly -- for the worker's `CancelResponse`. A healthy
    *     worker acks in that window and the callback settles a clean `Cancelled`
    *     terminal (worker salvageable, response drained).
-   *  3. If the ack does not arrive in time, settle `Interrupted` (also
-   *     salvageable): the worker is optimistically assumed reusable, and a
-   *     genuinely dead worker is expected to be caught by a separate liveness
-   *     check (see TODO below).
+   *  3. If the ack does not arrive in time, settle `Interrupted`. Without a
+   *     terminator or liveness proof the worker is not salvageable and must not
+   *     be returned to a reuse pool.
    *
    * The bounded wait deliberately runs '''before''' the thread's interrupt flag
    * is restored: [[InterruptedException]] clears the flag on throw, so re-setting
@@ -700,9 +768,9 @@ class GrpcWorkerSession(
    * The flag is restored at the end so the caller's unwind still observes the
    * interrupt.
    *
-   * TODO [SPARK-57640]: back the optimistic salvageable assumption with a worker
-   * liveness/heartbeat check, so an interrupt that leaves a wedged (but not
-   * transport-dead) worker still marks it invalid rather than recycling it.
+   * TODO [SPARK-57640]: add a worker liveness/heartbeat check so a future version
+   * may prove that an interrupted worker which missed the short ack window is
+   * nevertheless safe to recycle.
    */
   private def handleInterrupt(waitContext: String): Unit = {
     // NB: flag is currently clear (InterruptedException cleared it); do not
@@ -717,9 +785,10 @@ class GrpcWorkerSession(
           false
       }
       if (!acked && !currentState.isTerminal) {
-        // No CancelResponse in time: settle Interrupted (salvageable) rather
-        // than TransportFailed, and stop a later close() from blocking on a
-        // terminator that will not be drained on this thread's behalf.
+        // No CancelResponse in time: settle Interrupted rather than
+        // TransportFailed, and stop a later close() from blocking on a terminator
+        // that will not be drained on this thread's behalf. Interrupted remains
+        // unsalvageable until a separate liveness check can prove otherwise.
         Transitions.interrupted(
           new InterruptedException(s"interrupted while $waitContext"))
       }
@@ -752,15 +821,6 @@ class GrpcWorkerSession(
     // Iterator-local and only touched by the single engine thread.
     private val exhausted = new AtomicBoolean(false)
     @volatile private var prefetched: DataResponse = _
-
-    // Pre-init cancel fast-fail: if a cancel ran before doInit published the
-    // requestObserver, no Cancel was sent on the wire and the worker may
-    // never emit a terminator. Trip the terminal explicitly so the first
-    // hasNext / next surfaces a cancellation instead of blocking for
-    // terminalTimeoutMs in branch 4.
-    if (cancelRequested.get() && !currentState.isTerminal) {
-      Transitions.cancelled(CancelResponse.getDefaultInstance)
-    }
 
     /**
      * Runs a caller-supplied thunk (`input.hasNext`, `input.next()`, or the
@@ -961,7 +1021,7 @@ object GrpcWorkerSession {
    * [[DEFAULT_TERMINAL_TIMEOUT_MS]]: the interrupted thread must unwind
    * promptly, so a healthy worker gets a brief window to ack the Cancel (clean
    * `Cancelled` terminal, worker salvageable) before the session falls back to
-   * an `Interrupted` terminal. See `handleInterrupt`.
+   * an unsalvageable `Interrupted` terminal. See `handleInterrupt`.
    */
   val DEFAULT_INTERRUPT_CANCEL_TIMEOUT_MS: Long = 2000L
 
@@ -978,23 +1038,30 @@ object GrpcWorkerSession {
    * the value, then release the waiter" ordering lives in one place instead of
    * every call site having to remember to count the latch down after setting the
    * reference. The value is set at most once ([[complete]]); the latch can also
-   * be released without a value ([[signalWithoutValue]]) when the waiter must be
-   * woken by a terminal that arrived instead of the value. All reads/writes go
-   * through the latch, so a waiter released by [[await]] has a happens-before
-   * edge to the [[complete]] that set the value.
+   * be released without a value ([[signalWithoutValue]]) when init fails through
+   * a pre-init error or terminal. All reads/writes go through the latch, so a
+   * waiter released by [[await]] has a happens-before edge to the [[complete]]
+   * that set the value.
    */
   private final class OneShotValue[A] {
     private val latch = new CountDownLatch(1)
     private val ref = new AtomicReference[Option[A]](None)
+    private val completed = new AtomicBoolean(false)
 
     /** Publishes the value (first writer wins) and releases any waiter. */
     def complete(value: A): Unit = {
-      ref.compareAndSet(None, Some(value))
-      latch.countDown()
+      if (completed.compareAndSet(false, true)) {
+        ref.set(Some(value))
+        latch.countDown()
+      }
     }
 
-    /** Releases the waiter without a value (a terminal arrived, not the value). */
-    def signalWithoutValue(): Unit = latch.countDown()
+    /** Completes without a value (init failed through another event) and releases the waiter. */
+    def signalWithoutValue(): Unit = {
+      if (completed.compareAndSet(false, true)) {
+        latch.countDown()
+      }
+    }
 
     /**
      * Blocks up to `timeoutMs` for a release, throwing [[TimeoutException]] if

--- a/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
+++ b/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
@@ -189,11 +189,11 @@ class GrpcWorkerSession(
         case UdfResponse.ResponseCase.DATA =>
           // A DataResponse before InitResponse violates the protocol (InitResponse
           // must precede any DataResponse): fast-fail rather than enqueue it and let
-          // init() block to its timeout. Settle-before-release (see initValue).
+          // init() block to its timeout. Settling the terminal wakes a blocked
+          // init() via onTerminalSettled.
           if (!initResolved) {
             Transitions.transportFailed(new IllegalStateException(
               "worker sent a DataResponse before InitResponse"))
-            initValue.signalWithoutValue()
           } else {
             outputQueue.put(QueueItem.Batch(response.getData))
           }
@@ -203,32 +203,28 @@ class GrpcWorkerSession(
 
         case other =>
           // A malformed response (empty / unknown oneof) is a terminal transport
-          // failure; fast-fail init the same way. Settle-before-release (see initValue).
+          // failure; fast-fail init the same way.
           Transitions.transportFailed(new IllegalStateException(
             s"unexpected response oneof: $other"))
-          initValue.signalWithoutValue()
       }
     }
 
     override def onError(t: Throwable): Unit = {
       // Transport-level failure: the stream is dead, no further writes possible.
-      // Settle-before-release (see initValue) so init() surfaces the transport
-      // cause instead of the initResponseTimeoutMs "timed out" error.
+      // Settling the terminal wakes a blocked init() (via onTerminalSettled) so it
+      // surfaces the transport cause instead of the initResponseTimeoutMs error.
       Transitions.transportFailed(t)
-      initValue.signalWithoutValue()
     }
 
     override def onCompleted(): Unit = {
       // Worker half-closed its side without sending a terminator (FinishResponse
       // / CancelResponse). Treat as transport error so the engine sees a
-      // failure, not a silent end-of-stream.
+      // failure, not a silent end-of-stream. Settling the terminal wakes a blocked
+      // init() via onTerminalSettled.
       if (!currentState.isTerminal) {
         Transitions.transportFailed(new IllegalStateException(
           "worker response stream closed without a terminator"))
       }
-      // Defensive: if onCompleted reached us before InitResponse, doInit is
-      // still blocked on initValue and would otherwise time out.
-      initValue.signalWithoutValue()
     }
   }
 
@@ -236,16 +232,15 @@ class GrpcWorkerSession(
    * Wakes everything that can be blocked when the base settles a terminal:
    * the result iterator (on [[outputQueue]]), a thread on [[terminalLatch]]
    * (close), and a thread still blocked in [[doInit]] on [[initValue]]. Invoked
-   * once, by the caller that wins [[completeTerminal]], so waking [[initValue]]
-   * here covers every terminal-settling path uniformly -- including the close()
-   * path, which settles a terminal without going through the response callback
-   * that would otherwise signal [[initValue]]. Settle-before-release (see
-   * [[initValue]]) holds because this runs after the terminal CAS in
-   * [[completeTerminal]]. The per-callback [[initValue.signalWithoutValue]] calls
-   * that also settle a terminal are now redundant with this but harmless (the
-   * latch countDown is idempotent); the non-terminal init signals
-   * ([[handleControl]]'s INIT / pre-init ERROR branches) are still required, as
-   * they wake [[initValue]] without settling a terminal.
+   * once, by the caller that wins [[completeTerminal]], so this is the '''single'''
+   * place a settled terminal wakes a blocked [[doInit]] -- callers that settle a
+   * terminal (any response-callback failure/terminator branch, the timeout paths,
+   * or close()) do NOT signal [[initValue]] themselves; settling is enough.
+   * Settle-before-release (see [[initValue]]) holds because this runs after the
+   * terminal CAS in [[completeTerminal]]. The only direct [[initValue]] signals
+   * left are the non-terminal init paths ([[handleControl]]'s INIT-ok / INIT-error
+   * / pre-init-ERROR branches), which must wake [[doInit]] '''without''' settling a
+   * terminal -- the session stays `Initializing` so `process()` can still run.
    */
   override protected def onTerminalSettled(termination: Termination): Unit = {
     outputQueue.put(QueueItem.EndOfStream)
@@ -298,25 +293,23 @@ class GrpcWorkerSession(
     case UdfControlResponse.ControlCase.FINISH =>
       // The FinishResponse carries metrics + the finish-callback data/error.
       // Keep it on the terminal so close() can return it; the iterator inspects
-      // its error field to decide whether to throw.
+      // its error field to decide whether to throw. Settling the terminal wakes a
+      // blocked init() (a FINISH before InitResponse is a worker protocol bug, but
+      // fails init fast rather than hanging the init timeout) via onTerminalSettled.
       Transitions.finished(ctrl.getFinish)
-      // Defensive: FINISH before InitResponse is a worker protocol bug, but
-      // we should fail init fast rather than hang for the init timeout.
-      initValue.signalWithoutValue()
 
     case UdfControlResponse.ControlCase.CANCEL =>
       // The CancelResponse carries metrics + the cancel-callback error. Keep it
       // on the terminal so close() can return it; any prior ErrorResponse is
-      // tracked in executionError and surfaced by the iterator.
+      // tracked in executionError and surfaced by the iterator. Settling the
+      // terminal wakes a blocked init() (a CANCEL before InitResponse) via
+      // onTerminalSettled.
       Transitions.cancelled(ctrl.getCancel)
-      // Defensive: CANCEL before InitResponse unblocks doInit so it can
-      // surface the cancellation instead of timing out.
-      initValue.signalWithoutValue()
 
     case UdfControlResponse.ControlCase.CONTROL_NOT_SET =>
+      // Settling the terminal wakes a blocked init() via onTerminalSettled.
       Transitions.transportFailed(new IllegalStateException(
         "empty UdfControlResponse oneof"))
-      initValue.signalWithoutValue()
   }
 
   /**

--- a/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
+++ b/udf/worker/grpc/src/main/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSession.scala
@@ -110,6 +110,11 @@ import org.apache.spark.udf.worker.grpc.GrpcWorkerSession._
  *                              `CancelResponse`, or `ErrorResponse`).
  *                              Each output-queue poll resets this wait;
  *                              see [[doProcess]] / `ProcessIterator`.
+ * @param interruptCancelTimeoutMs upper bound on the wait for a `CancelResponse`
+ *                              after an interrupt (cancelled query / killed
+ *                              task) sends `Cancel`. Short by design; on expiry
+ *                              the session settles `Interrupted`. See
+ *                              `handleInterrupt`.
  */
 @Experimental
 class GrpcWorkerSession(
@@ -117,7 +122,8 @@ class GrpcWorkerSession(
     channel: ManagedChannel,
     logger: WorkerLogger = WorkerLogger.NoOp,
     initResponseTimeoutMs: Long = DEFAULT_INIT_RESPONSE_TIMEOUT_MS,
-    terminalTimeoutMs: Long = DEFAULT_TERMINAL_TIMEOUT_MS)
+    terminalTimeoutMs: Long = DEFAULT_TERMINAL_TIMEOUT_MS,
+    interruptCancelTimeoutMs: Long = DEFAULT_INTERRUPT_CANCEL_TIMEOUT_MS)
   extends WorkerSession(workerHandle, logger) {
 
   require(channel != null, "channel is required")
@@ -373,6 +379,15 @@ class GrpcWorkerSession(
     /** Failure terminal carrying a transport-level cause. */
     def transportFailed(cause: Throwable): Boolean =
       completeTerminal(Termination.TransportFailed(cause))
+
+    /**
+     * Terminal for an engine-thread interrupt (e.g. a Spark task kill). Distinct
+     * from [[transportFailed]]: the worker is salvageable (the interrupt is not a
+     * worker fault) and a best-effort `Cancel` is sent but its `CancelResponse`
+     * is not awaited, since the interrupted thread must unwind rather than block.
+     */
+    def interrupted(cause: Throwable): Boolean =
+      completeTerminal(Termination.Interrupted(cause))
   }
 
   // ---- WorkerSession hooks ------------------------------------------------
@@ -425,16 +440,10 @@ class GrpcWorkerSession(
       initValue.await(initResponseTimeoutMs)
     } catch {
       case _: InterruptedException =>
-        Thread.currentThread().interrupt()
-        sendCancelInternal(() => cancelWithReason("interrupted during init"))
-        // Attribute the terminal to a transport failure, not a cancel: the
-        // interrupt comes from the engine/task thread that called init() (e.g.
-        // Spark task kill), and after it the worker's state is unknown -- the
-        // Cancel above is best-effort and may not have been acked -- so the
-        // worker is not salvageable. It also stops close() from blocking on a
-        // terminator that will never arrive on this thread's behalf.
-        Transitions.transportFailed(
-          new InterruptedException("interrupted while waiting for InitResponse"))
+        // Interrupt (cancelled query / killed task) while awaiting InitResponse:
+        // cooperatively Cancel with a bounded drain, settling Cancelled if the
+        // worker acks in time, else Interrupted. See handleInterrupt.
+        handleInterrupt("waiting for InitResponse")
         throw new InterruptedException("interrupted while waiting for InitResponse")
       case e: TimeoutException =>
         sendCancelInternal(() => cancelWithReason("InitResponse timed out"))
@@ -480,6 +489,9 @@ class GrpcWorkerSession(
               case SessionState.Terminal(Termination.Cancelled(_)) =>
                 throw new GrpcWorkerSessionException(
                   "UDF worker stream was cancelled before init completed")
+              case SessionState.Terminal(Termination.Interrupted(cause)) =>
+                throw new GrpcWorkerSessionException(
+                  "UDF worker init was interrupted", cause)
               case SessionState.Terminal(Termination.Finished(_)) =>
                 throw new GrpcWorkerSessionException(
                   "UDF worker finished before init completed")
@@ -539,12 +551,18 @@ class GrpcWorkerSession(
       try {
         terminalLatch.await(terminalTimeoutMs, TimeUnit.MILLISECONDS)
       } catch {
-        case _: InterruptedException => Thread.currentThread().interrupt()
+        case _: InterruptedException =>
+          // Interrupted mid-close: settle Interrupted (salvageable) via the
+          // shared handler rather than falling through to the TransportFailed
+          // guard below. The Cancel is already on the wire, so handleInterrupt's
+          // sendCancelInternal is a no-op and it just runs the bounded drain.
+          handleInterrupt("closing the session")
       }
     }
-    // If the worker still has not settled (timeout or interrupt above),
-    // record a terminal so isWorkerSalvageable returns a definite answer
-    // and any other thread reading the state sees a stable value.
+    // If the worker still has not settled (timeout above, or an interrupt whose
+    // bounded drain did not settle a terminal), record a terminal so
+    // isWorkerSalvageable returns a definite answer and any other thread reading
+    // the state sees a stable value.
     if (!currentState.isTerminal) {
       Transitions.transportFailed(new TimeoutException(
         s"timed out waiting for stream terminator after ${terminalTimeoutMs}ms"))
@@ -651,14 +669,58 @@ class GrpcWorkerSession(
           s"timed out waiting for stream terminator after ${terminalTimeoutMs}ms"))
       }
     } catch {
-      case _: InterruptedException =>
-        // Attribute the terminal to the interrupt, not a timeout: the wait was
-        // cut short, it did not exhaust terminalTimeoutMs. Reporting "timed
-        // out" here would misdiagnose an interrupted close as a slow worker.
-        Thread.currentThread().interrupt()
-        Transitions.transportFailed(
-          new InterruptedException("interrupted while waiting for stream terminator"))
+      case _: InterruptedException => handleInterrupt(s"waiting for stream terminator")
     }
+  }
+
+  /**
+   * Handles an [[InterruptedException]] observed while blocked on a worker event
+   * (init, terminal drain, close, or the result-iterator poll). An interrupt is
+   * an engine-side event -- typically a cancelled query / killed task -- not a
+   * worker fault, so we cancel cooperatively and keep the worker salvageable
+   * when it acks:
+   *
+   *  1. Send a best-effort `Cancel` (idempotent across call sites).
+   *  2. Wait up to [[interruptCancelTimeoutMs]] -- short, so the interrupted
+   *     thread unwinds promptly -- for the worker's `CancelResponse`. A healthy
+   *     worker acks in that window and the callback settles a clean `Cancelled`
+   *     terminal (worker salvageable, response drained).
+   *  3. If the ack does not arrive in time, settle `Interrupted` (also
+   *     salvageable): the worker is optimistically assumed reusable, and a
+   *     genuinely dead worker is expected to be caught by a separate liveness
+   *     check (see TODO below).
+   *
+   * The bounded wait deliberately runs '''before''' the thread's interrupt flag
+   * is restored: [[InterruptedException]] clears the flag on throw, so re-setting
+   * it first would make the wait below throw immediately and defeat the drain.
+   * The flag is restored at the end so the caller's unwind still observes the
+   * interrupt.
+   *
+   * TODO [SPARK-57640]: back the optimistic salvageable assumption with a worker
+   * liveness/heartbeat check, so an interrupt that leaves a wedged (but not
+   * transport-dead) worker still marks it invalid rather than recycling it.
+   */
+  private def handleInterrupt(waitContext: String): Unit = {
+    // NB: flag is currently clear (InterruptedException cleared it); do not
+    // restore it until after the bounded drain below.
+    if (!currentState.isTerminal) {
+      sendCancelInternal(() => cancelWithReason(s"interrupted while $waitContext"))
+      val acked = try {
+        terminalLatch.await(interruptCancelTimeoutMs, TimeUnit.MILLISECONDS)
+      } catch {
+        case _: InterruptedException =>
+          // A second interrupt during the drain: give up the wait immediately.
+          false
+      }
+      if (!acked && !currentState.isTerminal) {
+        // No CancelResponse in time: settle Interrupted (salvageable) rather
+        // than TransportFailed, and stop a later close() from blocking on a
+        // terminator that will not be drained on this thread's behalf.
+        Transitions.interrupted(
+          new InterruptedException(s"interrupted while $waitContext"))
+      }
+    }
+    Thread.currentThread().interrupt()
   }
 
   // ---- ProcessIterator ------------------------------------------------------
@@ -789,8 +851,10 @@ class GrpcWorkerSession(
             outputQueue.poll(terminalTimeoutMs, TimeUnit.MILLISECONDS)
           } catch {
             case _: InterruptedException =>
-              Thread.currentThread().interrupt()
-              sendCancelInternal(() => cancelWithReason("iterator interrupted"))
+              // Interrupt (cancelled query / killed task) while reading results:
+              // cooperatively Cancel with a bounded drain, settling Cancelled if
+              // the worker acks in time, else Interrupted. See handleInterrupt.
+              handleInterrupt("reading UDF result")
               exhausted.set(true)
               throw new InterruptedException("interrupted while reading UDF result")
           }
@@ -865,6 +929,8 @@ class GrpcWorkerSession(
           s"UDF execution failed: ${describeError(err)}", err)
       case SessionState.Terminal(Termination.TransportFailed(t)) =>
         throw new GrpcWorkerSessionException("UDF worker stream failed", t)
+      case SessionState.Terminal(Termination.Interrupted(t)) =>
+        throw new GrpcWorkerSessionException("UDF execution was interrupted", t)
       case other =>
         throw new IllegalStateException(s"terminator sentinel without terminal: $other")
     }
@@ -884,6 +950,16 @@ object GrpcWorkerSession {
 
   /** Upper bound on the wait for `FinishResponse` / `CancelResponse`. */
   val DEFAULT_TERMINAL_TIMEOUT_MS: Long = 30000L
+
+  /**
+   * Upper bound on the wait for a `CancelResponse` after an interrupt (e.g. a
+   * cancelled query / killed task) sends `Cancel`. Much shorter than
+   * [[DEFAULT_TERMINAL_TIMEOUT_MS]]: the interrupted thread must unwind
+   * promptly, so a healthy worker gets a brief window to ack the Cancel (clean
+   * `Cancelled` terminal, worker salvageable) before the session falls back to
+   * an `Interrupted` terminal. See `handleInterrupt`.
+   */
+  val DEFAULT_INTERRUPT_CANCEL_TIMEOUT_MS: Long = 2000L
 
   // Distinguishes a (possibly empty) data batch from end-of-stream, and makes
   // the iterator's match exhaustive.

--- a/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
+++ b/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
@@ -1,0 +1,742 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.udf.worker.grpc
+
+import java.util.Locale
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+
+import scala.jdk.CollectionConverters._
+
+import com.google.protobuf.ByteString
+import io.grpc.{ManagedChannel, Server}
+import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
+import io.grpc.stub.StreamObserver
+import org.scalatest.BeforeAndAfterEach
+// scalastyle:off funsuite
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.udf.worker.{Cancel, CancelResponse, DataRequest, DataResponse,
+  ErrorResponse, ExecutionError, Finish, FinishResponse, Init, InitResponse, UdfControlResponse,
+  UdfPayload, UdfRequest, UdfResponse, UDFWorkerDataFormat, UdfWorkerGrpc, UserError,
+  WorkerRequest, WorkerResponse}
+import org.apache.spark.udf.worker.core.{Termination, WorkerHandle, WorkerLogger}
+
+/**
+ * Concurrency tests for [[GrpcWorkerSession]] that pin the wire-ordering and
+ * fast-fail invariants under concurrent and worker-misbehavior scenarios:
+ *  - Cancel must never appear on the wire before Init.
+ *  - A worker terminator (ERROR / FINISH / CANCEL / onCompleted) arriving
+ *    before InitResponse must fail [[GrpcWorkerSession#init]] fast, not hang
+ *    for `initResponseTimeoutMs`.
+ *  - Repeated [[Iterator#hasNext]] after natural iterator exhaustion must
+ *    return immediately, not block for `terminalTimeoutMs`.
+ *  - Cancel issued before [[GrpcWorkerSession#init]] makes a subsequent
+ *    [[GrpcWorkerSession#doProcess]] surface the cancellation immediately,
+ *    instead of blocking for `terminalTimeoutMs`.
+ *  - Cancel / close concurrent with an in-progress data phase terminate
+ *    cleanly without leaks or unbounded hangs.
+ *
+ * Runs entirely in-process: no subprocess, no UDS. Server services are
+ * custom-built per test so we can drive specific worker misbehavior.
+ */
+class GrpcWorkerSessionConcurrencySuite
+    extends AnyFunSuite with BeforeAndAfterEach {
+// scalastyle:on funsuite
+
+  /** Used by tests to keep stale in-flight infra reachable for teardown. */
+  private val openServers = new ConcurrentLinkedQueue[Server]()
+  private val openChannels = new ConcurrentLinkedQueue[ManagedChannel]()
+  private val openSessions = new ConcurrentLinkedQueue[GrpcWorkerSession]()
+
+  override def afterEach(): Unit = {
+    // Shut channels down first. This fires onError on any still-live stream,
+    // which settles the session terminal and counts down the init/terminal
+    // latches. That unblocks both the session.close() below and any worker
+    // thread a failing test left parked on a (deliberately large) timeout, so
+    // teardown never hangs even when a test asserts via assertFinishesWithin.
+    openChannels.asScala.foreach { c =>
+      try c.shutdownNow().awaitTermination(2, TimeUnit.SECONDS) catch { case _: Throwable => () }
+    }
+    openChannels.clear()
+    openSessions.asScala.foreach { s => try s.close(emptyCancel) catch { case _: Throwable => () } }
+    openSessions.clear()
+    openServers.asScala.foreach { s =>
+      try s.shutdownNow().awaitTermination(2, TimeUnit.SECONDS) catch { case _: Throwable => () }
+    }
+    openServers.clear()
+    super.afterEach()
+  }
+
+  // A session timeout large enough that a correct test never reaches it; a
+  // regression that fails to short-circuit blocks here for minutes and is caught
+  // by assertFinishesWithin (below) instead of a flaky `elapsed < timeout` bound.
+  private val NeverReachedTimeoutMs = TimeUnit.MINUTES.toMillis(10)
+
+  /**
+   * Runs `body` on a daemon thread and asserts it finishes within `withinMs`,
+   * rethrowing whatever `body` threw (so an `intercept` inside `body` still
+   * works). Pair with [[NeverReachedTimeoutMs]]: the correct fast path returns
+   * in milliseconds, so `withinMs` (seconds) has an enormous safety margin and
+   * does not flake, while a regression that parks on the timeout never returns
+   * within `withinMs` and fails the assertion.
+   */
+  private def assertFinishesWithin(withinMs: Long, name: String)(body: => Unit): Unit = {
+    val thrown = new AtomicReference[Throwable]()
+    val done = new CountDownLatch(1)
+    val worker = new Thread(() => {
+      try body catch { case t: Throwable => thrown.set(t) } finally done.countDown()
+    }, name)
+    worker.setDaemon(true)
+    worker.start()
+    assert(done.await(withinMs, TimeUnit.MILLISECONDS),
+      s"$name did not finish within ${withinMs}ms; it parked on a session timeout " +
+        "that the fast path should have short-circuited")
+    Option(thrown.get()).foreach(t => throw t)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private class TestWorkerHandle extends WorkerHandle {
+    val invalidated = new AtomicBoolean(false)
+    val released = new AtomicBoolean(false)
+    override def id: String = "test-worker"
+    override def markInvalid(): Unit = invalidated.set(true)
+    override def releaseSession(): Unit = released.set(true)
+  }
+
+  /**
+   * Builds an in-process server/channel pair.
+   *
+   * @param directExecutor when `true` (default), responses are delivered
+   *        reentrantly on the calling thread -- the worst case for the session's
+   *        reentrancy handling. When `false`, both server and channel use their
+   *        default executors, so responses arrive on a *separate* thread. That
+   *        cross-thread delivery mirrors the production Netty transport (the gRPC
+   *        callback runs on an event-loop thread, never reentrantly), which the
+   *        directExecutor tests deliberately do not exercise.
+   */
+  private def startServer(
+      service: UdfWorkerGrpc.UdfWorkerImplBase,
+      directExecutor: Boolean = true): (Server, ManagedChannel) = {
+    val name = InProcessServerBuilder.generateName()
+    val serverBuilder = InProcessServerBuilder.forName(name).addService(service)
+    val channelBuilder = InProcessChannelBuilder.forName(name)
+    if (directExecutor) {
+      serverBuilder.directExecutor()
+      channelBuilder.directExecutor()
+    }
+    val server = serverBuilder.build().start()
+    val channel = channelBuilder.build()
+    openServers.add(server)
+    openChannels.add(channel)
+    (server, channel)
+  }
+
+  private def newSession(
+      channel: ManagedChannel,
+      initResponseTimeoutMs: Long = 5000L,
+      terminalTimeoutMs: Long = 5000L): GrpcWorkerSession = {
+    val session = new GrpcWorkerSession(
+      new TestWorkerHandle, channel, WorkerLogger.NoOp,
+      initResponseTimeoutMs = initResponseTimeoutMs,
+      terminalTimeoutMs = terminalTimeoutMs)
+    openSessions.add(session)
+    session
+  }
+
+  // Protocol version carried on Init. The in-process fake workers in this suite
+  // do not validate it; any sane value is fine.
+  private val SupportedVersion = 1
+
+  private def basicInit(payload: String = "echo"): Init = Init.newBuilder()
+    .setProtocolVersion(SupportedVersion)
+    .setDataFormat(UDFWorkerDataFormat.ARROW)
+    .setUdf(UdfPayload.newBuilder()
+      .setPayload(ByteString.copyFromUtf8(payload))
+      .setFormat("echo")
+      .build())
+    .build()
+
+  // Default lifecycle messages for the data phase and finalization.
+  private val emptyFinish: () => Finish = () => Finish.getDefaultInstance
+  private val emptyCancel: () => Cancel = () => Cancel.getDefaultInstance
+
+  /** Wraps strings as input [[DataRequest]] batches. */
+  private def echoIn(batches: String*): Iterator[DataRequest] =
+    batches.iterator.map(s => DataRequest.newBuilder()
+      .setData(ByteString.copyFromUtf8(s)).build())
+
+  /**
+   * Captures every incoming request in order. Replies follow a user-supplied
+   * function, so tests can drive arbitrary worker misbehavior. The default
+   * `onRequest` matches an Echo worker: InitResponse on Init, echo on Data,
+   * FinishResponse on Finish, CancelResponse on Cancel.
+   */
+  private class CapturingService(
+      val captured: ConcurrentLinkedQueue[UdfRequest] = new ConcurrentLinkedQueue(),
+      onRequest: (UdfRequest, StreamObserver[UdfResponse]) => Unit = null)
+    extends UdfWorkerGrpc.UdfWorkerImplBase {
+
+    private val handler: (UdfRequest, StreamObserver[UdfResponse]) => Unit =
+      if (onRequest != null) onRequest else defaultEcho
+
+    override def execute(resp: StreamObserver[UdfResponse]): StreamObserver[UdfRequest] =
+      new StreamObserver[UdfRequest] {
+        // gRPC requires serialized writes to a request StreamObserver; the
+        // capturing service may reply from multiple control paths so we
+        // synchronize on `resp` rather than relying on directExecutor.
+        override def onNext(req: UdfRequest): Unit = {
+          captured.add(req)
+          resp.synchronized { handler(req, resp) }
+        }
+        override def onError(t: Throwable): Unit = ()
+        override def onCompleted(): Unit = resp.synchronized { resp.onCompleted() }
+      }
+
+    override def manage(
+        request: WorkerRequest,
+        responseObserver: StreamObserver[WorkerResponse]): Unit = ()
+
+    private def defaultEcho(req: UdfRequest, resp: StreamObserver[UdfResponse]): Unit = {
+      req.getRequestCase match {
+        case UdfRequest.RequestCase.CONTROL =>
+          val c = req.getControl
+          c.getControlCase match {
+            case _ if c.hasInit =>
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setInit(
+                  InitResponse.getDefaultInstance).build()
+              ).build())
+            case _ if c.hasFinish =>
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setFinish(
+                  FinishResponse.getDefaultInstance).build()
+              ).build())
+            case _ if c.hasCancel =>
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setCancel(
+                  CancelResponse.getDefaultInstance).build()
+              ).build())
+            case _ => ()
+          }
+        case UdfRequest.RequestCase.DATA =>
+          resp.onNext(UdfResponse.newBuilder()
+            .setData(DataResponse.newBuilder().setData(req.getData.getData).build())
+            .build())
+        case _ => ()
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cancel-never-precedes-Init invariant.
+  //
+  // The former cancel()-vs-init() race test was retired when cancel() folded
+  // into close(): close() transitions the session to Closed and blocks init(),
+  // so a Cancel-before-Init race is no longer reachable through the public API
+  // (close() almost always wins and aborts init() before any control is sent,
+  // making such a race test vacuous). The invariant is now structural --
+  // sendCancelInternal early-returns while requestObserver is null, and
+  // requestObserver is published only after Init is on the wire -- and is
+  // exercised by "worker emits InitResponse with error: init fails fast" (the
+  // requestObserver-null path: a Cancel that cannot be written) and by "close
+  // concurrent with process" (a Cancel written only after Init + data).
+  // ---------------------------------------------------------------------------
+
+  // ---------------------------------------------------------------------------
+  // Terminator-before-InitResponse: must fail init fast, not hang for
+  // initResponseTimeoutMs (defensive initLatch.countDown() in handleControl).
+  // ---------------------------------------------------------------------------
+
+  test("worker emits ErrorResponse before InitResponse: init fails fast") {
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setError(
+              ErrorResponse.newBuilder().setError(
+                ExecutionError.newBuilder().setUser(
+                  UserError.newBuilder().setMessage("simulated pre-init error")
+                    .setErrorClass("PreInitError").build()).build()).build()).build())
+            .build())
+        } else if (req.hasControl && req.getControl.hasCancel) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setCancel(
+              CancelResponse.getDefaultInstance).build()).build())
+        }
+      })
+    val (_, channel) = startServer(service)
+    // Huge init timeout: a regression that dropped the defensive
+    // initLatch.countDown() would park init here until the timeout, so finishing
+    // quickly is proof the fast path ran -- no wall-clock threshold needed.
+    val session = newSession(channel, initResponseTimeoutMs = NeverReachedTimeoutMs)
+
+    assertFinishesWithin(10000, "init") {
+      val ex = intercept[GrpcWorkerSessionException] { session.init(basicInit()) }
+      assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("error") ||
+        ex.getMessage.toLowerCase(Locale.ROOT).contains("init"),
+        s"expected init/error in message, got: ${ex.getMessage}")
+    }
+    session.close(emptyCancel)
+  }
+
+  test("worker emits InitResponse with error: init fails fast (no terminal-timeout stall)") {
+    // Regression for the directExecutor reentrancy where InitResponse(error) is
+    // delivered inside stream.onNext, before doInit publishes requestObserver,
+    // so the in-band Cancel cannot be written. The INIT-error path must settle a
+    // terminal itself rather than block awaiting a CancelResponse that can never
+    // arrive (which would stall for the full terminalTimeoutMs).
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setInit(
+              InitResponse.newBuilder().setError(
+                ExecutionError.newBuilder().setUser(
+                  UserError.newBuilder().setMessage("simulated init failure")
+                    .setErrorClass("InitError").build()).build()).build()).build())
+            .build())
+        } else if (req.hasControl && req.getControl.hasCancel) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setCancel(
+              CancelResponse.getDefaultInstance).build()).build())
+        }
+      })
+    val (_, channel) = startServer(service)
+    // Huge terminalTimeoutMs: a regression (awaiting a CancelResponse that never
+    // arrives) would park init in awaitTerminal for the full timeout; the fix
+    // settles the terminal at once so init returns in milliseconds. Finishing
+    // well within assertFinishesWithin is the signal the stall did not happen.
+    val session = newSession(channel,
+      initResponseTimeoutMs = NeverReachedTimeoutMs, terminalTimeoutMs = NeverReachedTimeoutMs)
+
+    assertFinishesWithin(10000, "init") {
+      val ex = intercept[GrpcWorkerSessionException] { session.init(basicInit()) }
+      assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("init"),
+        s"expected an init-failure message, got: ${ex.getMessage}")
+    }
+    session.close(emptyCancel)
+  }
+
+  test("worker emits FinishResponse before InitResponse: init fails fast") {
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setFinish(
+              FinishResponse.getDefaultInstance).build()).build())
+        }
+      })
+    val (_, channel) = startServer(service)
+    val session = newSession(channel, initResponseTimeoutMs = NeverReachedTimeoutMs)
+
+    assertFinishesWithin(10000, "init") {
+      val ex = intercept[GrpcWorkerSessionException] { session.init(basicInit()) }
+      assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("finish") ||
+        ex.getMessage.toLowerCase(Locale.ROOT).contains("init"),
+        s"expected init/finish in message, got: ${ex.getMessage}")
+    }
+    session.close(emptyCancel)
+  }
+
+  test("worker emits CancelResponse before InitResponse: init fails fast") {
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setCancel(
+              CancelResponse.getDefaultInstance).build()).build())
+        }
+      })
+    val (_, channel) = startServer(service)
+    val session = newSession(channel, initResponseTimeoutMs = NeverReachedTimeoutMs)
+
+    assertFinishesWithin(10000, "init") {
+      val ex = intercept[GrpcWorkerSessionException] { session.init(basicInit()) }
+      assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("cancel") ||
+        ex.getMessage.toLowerCase(Locale.ROOT).contains("init"),
+        s"expected init/cancel in message, got: ${ex.getMessage}")
+    }
+    session.close(emptyCancel)
+  }
+
+  test("worker half-closes response stream before InitResponse: init fails fast") {
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          resp.onCompleted()
+        }
+      })
+    val (_, channel) = startServer(service)
+    val session = newSession(channel, initResponseTimeoutMs = NeverReachedTimeoutMs)
+
+    assertFinishesWithin(10000, "init") {
+      intercept[GrpcWorkerSessionException] { session.init(basicInit()) }
+    }
+    session.close(emptyCancel)
+  }
+
+  test("worker emits malformed UdfResponse before InitResponse: init fails fast") {
+    // A UdfResponse with no oneof set (RESPONSE_NOT_SET) is malformed: the
+    // session's responseObserver settles a transport-failure terminal in its
+    // catch-all `case other` branch. Regression guard for the missing
+    // initLatch.countDown() on that branch -- without it, init() blocks until
+    // initResponseTimeoutMs and reports a misleading "timed out" error instead
+    // of failing fast with the malformed-response cause.
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          resp.onNext(UdfResponse.getDefaultInstance)
+        }
+      })
+    val (_, channel) = startServer(service)
+    val session = newSession(channel, initResponseTimeoutMs = NeverReachedTimeoutMs)
+
+    assertFinishesWithin(10000, "init") {
+      val ex = intercept[GrpcWorkerSessionException] { session.init(basicInit()) }
+      assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("init"),
+        s"expected init in message, got: ${ex.getMessage}")
+    }
+    session.close(emptyCancel)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Exhaustion guard: repeated hasNext after the iterator drains must not
+  // block for terminalTimeoutMs (exhausted flag fix).
+  // ---------------------------------------------------------------------------
+
+  test("repeated hasNext after natural exhaustion returns immediately") {
+    val service = new CapturingService()
+    val (_, channel) = startServer(service)
+    // Huge terminalTimeoutMs: without the exhausted-flag short-circuit, a second
+    // hasNext() would re-enter the output-queue poll and park for the full
+    // timeout. Probing within assertFinishesWithin therefore proves the probes
+    // are non-blocking, with no dependence on a wall-clock threshold.
+    val session = newSession(channel, terminalTimeoutMs = NeverReachedTimeoutMs)
+    session.init(basicInit())
+    val it = session.process(echoIn("hello"), emptyFinish)
+    assert(new String(it.next().getData.toByteArray) == "hello")
+    // Drain to terminator.
+    assert(!it.hasNext, "iterator should be exhausted after the single echo batch")
+    // Now probe many times; each call must return false without blocking.
+    assertFinishesWithin(10000, "repeated-hasNext") {
+      (1 to 5).foreach { _ =>
+        assert(!it.hasNext, "exhausted iterator should keep returning false")
+      }
+    }
+    session.close(emptyCancel)
+  }
+
+  // ---------------------------------------------------------------------------
+  // close() concurrent with process(): clean termination.
+  // ---------------------------------------------------------------------------
+
+  test("close concurrent with process: iterator surfaces cancellation cleanly") {
+    // Worker echoes data but never sends FinishResponse (only after Cancel
+    // arrives, it sends CancelResponse). This pins the timing so the
+    // engine-side iterator is genuinely waiting when close() intervenes.
+    val readyToCancel = new CountDownLatch(1)
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        req.getRequestCase match {
+          case UdfRequest.RequestCase.CONTROL =>
+            val c = req.getControl
+            if (c.hasInit) {
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setInit(
+                  InitResponse.getDefaultInstance).build()).build())
+            } else if (c.hasCancel) {
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setCancel(
+                  CancelResponse.getDefaultInstance).build()).build())
+            }
+          // Finish ignored: the worker never replies, so the iterator is
+          // blocked waiting on output until cancel intervenes.
+          case UdfRequest.RequestCase.DATA =>
+            resp.onNext(UdfResponse.newBuilder()
+              .setData(DataResponse.newBuilder().setData(req.getData.getData).build())
+              .build())
+            readyToCancel.countDown()
+          case _ => ()
+        }
+      })
+    val (_, channel) = startServer(service)
+    val session = newSession(channel, terminalTimeoutMs = 30000L)
+    session.init(basicInit())
+
+    val handle = new AtomicReference[Throwable]()
+    val processThread = new Thread(() => {
+      try session.process(echoIn("hello"), emptyFinish).foreach(_ => ())
+      catch { case t: Throwable => handle.set(t) }
+    }, "process-cancel")
+    processThread.start()
+    assert(readyToCancel.await(5, TimeUnit.SECONDS),
+      "worker never received the data batch")
+    // close() from another thread is the cancellation trigger: it sends Cancel,
+    // the worker replies CancelResponse, and the in-flight iterator surfaces it.
+    session.close(emptyCancel)
+    processThread.join(10000)
+    assert(!processThread.isAlive, "process thread should terminate after close")
+    val t = handle.get()
+    assert(t != null, "expected the iterator to surface a cancellation exception")
+    assert(t.isInstanceOf[GrpcWorkerSessionException],
+      s"expected GrpcWorkerSessionException, got ${t.getClass.getName}")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Close concurrent with in-progress process(): bounded, no hang.
+  // ---------------------------------------------------------------------------
+
+  test("close concurrent with process: bounded shutdown, no leak") {
+    val readyToClose = new CountDownLatch(1)
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        req.getRequestCase match {
+          case UdfRequest.RequestCase.CONTROL =>
+            val c = req.getControl
+            if (c.hasInit) {
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setInit(
+                  InitResponse.getDefaultInstance).build()).build())
+            } else if (c.hasCancel) {
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setCancel(
+                  CancelResponse.getDefaultInstance).build()).build())
+            }
+          case UdfRequest.RequestCase.DATA =>
+            resp.onNext(UdfResponse.newBuilder()
+              .setData(DataResponse.newBuilder().setData(req.getData.getData).build())
+              .build())
+            readyToClose.countDown()
+          case _ => ()
+        }
+      })
+    val (_, channel) = startServer(service)
+    // Huge terminalTimeoutMs: the worker replies CancelResponse, so a correct
+    // close() returns on that terminator in milliseconds. A regression that
+    // failed to terminate on the terminator would instead park on the timeout,
+    // which assertFinishesWithin catches without a wall-clock threshold.
+    val session = newSession(channel, terminalTimeoutMs = NeverReachedTimeoutMs)
+    session.init(basicInit())
+
+    val processThread = new Thread(() => {
+      try session.process(echoIn("hello"), emptyFinish).foreach(_ => ())
+      catch { case _: Throwable => () }
+    }, "process-close")
+    processThread.start()
+    assert(readyToClose.await(5, TimeUnit.SECONDS),
+      "worker never received the data batch")
+
+    assertFinishesWithin(10000, "close")(session.close(emptyCancel))
+    processThread.join(10000)
+    assert(!processThread.isAlive, "process thread should terminate after close")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cross-thread delivery (no directExecutor).
+  //
+  // The tests above deliver worker responses reentrantly on the caller's thread
+  // (directExecutor), which is the harness for the reentrancy-hardening paths
+  // but is NOT how the production Netty transport behaves -- there the gRPC
+  // callback always runs on a separate event-loop thread. These tests re-run the
+  // key fast-fail and data-phase paths with cross-thread delivery so the
+  // session's correctness does not silently depend on reentrant delivery.
+  // ---------------------------------------------------------------------------
+
+  test("cross-thread delivery: ErrorResponse before InitResponse fails init fast") {
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setError(
+              ErrorResponse.newBuilder().setError(
+                ExecutionError.newBuilder().setUser(
+                  UserError.newBuilder().setMessage("simulated pre-init error")
+                    .setErrorClass("PreInitError").build()).build()).build()).build())
+            .build())
+        } else if (req.hasControl && req.getControl.hasCancel) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setCancel(
+              CancelResponse.getDefaultInstance).build()).build())
+        }
+      })
+    val (_, channel) = startServer(service, directExecutor = false)
+    // requestObserver is published before the cross-thread ErrorResponse can be
+    // delivered, so unlike the directExecutor case a Cancel does reach the wire;
+    // either way init must fail fast rather than park on a session timeout.
+    val session = newSession(channel,
+      initResponseTimeoutMs = NeverReachedTimeoutMs, terminalTimeoutMs = NeverReachedTimeoutMs)
+
+    assertFinishesWithin(10000, "init") {
+      val ex = intercept[GrpcWorkerSessionException] { session.init(basicInit()) }
+      assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("error") ||
+        ex.getMessage.toLowerCase(Locale.ROOT).contains("init"),
+        s"expected init/error in message, got: ${ex.getMessage}")
+    }
+    session.close(emptyCancel)
+  }
+
+  test("cross-thread delivery: InitResponse with error fails init fast") {
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setInit(
+              InitResponse.newBuilder().setError(
+                ExecutionError.newBuilder().setUser(
+                  UserError.newBuilder().setMessage("simulated init failure")
+                    .setErrorClass("InitError").build()).build()).build()).build())
+            .build())
+        } else if (req.hasControl && req.getControl.hasCancel) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setCancel(
+              CancelResponse.getDefaultInstance).build()).build())
+        }
+      })
+    val (_, channel) = startServer(service, directExecutor = false)
+    val session = newSession(channel,
+      initResponseTimeoutMs = NeverReachedTimeoutMs, terminalTimeoutMs = NeverReachedTimeoutMs)
+
+    assertFinishesWithin(10000, "init") {
+      val ex = intercept[GrpcWorkerSessionException] { session.init(basicInit()) }
+      assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("init"),
+        s"expected an init-failure message, got: ${ex.getMessage}")
+    }
+    session.close(emptyCancel)
+  }
+
+  test("cross-thread delivery: data-phase ErrorResponse surfaces through the iterator") {
+    // Worker accepts init, then replies to the first DataRequest with an
+    // ErrorResponse instead of an echo. Per the protocol the engine follows with
+    // Cancel and the worker replies CancelResponse. Exercises the data-phase
+    // race-recovery (sendOrEndOnRacedTerminal) under cross-thread delivery: the
+    // error terminal can settle while the iterator is mid-send.
+    val erroredOnce = new AtomicBoolean(false)
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        req.getRequestCase match {
+          case UdfRequest.RequestCase.CONTROL =>
+            val c = req.getControl
+            if (c.hasInit) {
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setInit(
+                  InitResponse.getDefaultInstance).build()).build())
+            } else if (c.hasCancel) {
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setCancel(
+                  CancelResponse.getDefaultInstance).build()).build())
+            }
+          case UdfRequest.RequestCase.DATA =>
+            if (erroredOnce.compareAndSet(false, true)) {
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setError(
+                  ErrorResponse.newBuilder().setError(
+                    ExecutionError.newBuilder().setUser(
+                      UserError.newBuilder().setMessage("boom in UDF")
+                        .setErrorClass("UdfError").build()).build()).build()).build())
+                .build())
+            }
+          case _ => ()
+        }
+      })
+    val (_, channel) = startServer(service, directExecutor = false)
+    val session = newSession(channel, terminalTimeoutMs = 5000L)
+    session.init(basicInit())
+
+    val it = session.process(echoIn("a", "b", "c"), emptyFinish)
+    val ex = intercept[GrpcWorkerSessionException] { it.foreach(_ => ()) }
+    assert(ex.getMessage.contains("boom in UDF"),
+      s"expected the worker's UDF error to surface, got: ${ex.getMessage}")
+    assert(ex.executionError != null, "structured executionError should be preserved")
+    assert(ex.executionError.getUser.getErrorClass == "UdfError")
+    session.close(emptyCancel)
+  }
+
+  test("cross-thread delivery: multi-batch echo round-trips in order then finishes") {
+    val service = new CapturingService()
+    val (_, channel) = startServer(service, directExecutor = false)
+    val session = newSession(channel, terminalTimeoutMs = 5000L)
+    session.init(basicInit())
+
+    val it = session.process(echoIn("a", "b", "c"), emptyFinish)
+    val out = it.map(r => new String(r.getData.toByteArray)).toList
+    assert(out == List("a", "b", "c"),
+      s"echo worker should return inputs in order over cross-thread delivery, got: $out")
+    assert(!it.hasNext, "iterator should be exhausted after the FinishResponse terminator")
+    session.close(emptyCancel)
+  }
+
+  // ---------------------------------------------------------------------------
+  // close() reports failures faithfully (Termination.Failed / TransportFailed)
+  // rather than collapsing them into a clean Cancelled, so a failure that occurs
+  // during finish/close -- where nothing is consuming the result iterator -- is
+  // not lost.
+  // ---------------------------------------------------------------------------
+
+  test("close after a pre-init error returns a Failed termination carrying the error") {
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setError(
+              ErrorResponse.newBuilder().setError(
+                ExecutionError.newBuilder().setUser(
+                  UserError.newBuilder().setMessage("pre-init boom")
+                    .setErrorClass("PreInitError").build()).build()).build()).build())
+            .build())
+        }
+      })
+    val (_, channel) = startServer(service)
+    val session = newSession(channel, terminalTimeoutMs = 3000L)
+    intercept[GrpcWorkerSessionException](session.init(basicInit()))
+
+    val termination = session.close(emptyCancel)
+    termination match {
+      case Termination.Failed(err) =>
+        assert(err.getUser.getErrorClass == "PreInitError",
+          s"the structured error must be carried on the Termination, got: $err")
+      case other =>
+        fail(s"expected Termination.Failed carrying the error, got: $other")
+    }
+  }
+
+  test("close that times out without a terminator returns a TransportFailed termination") {
+    // Worker accepts Init but never replies to Cancel, so close() must give up
+    // after terminalTimeoutMs and report the failure rather than masquerade as a
+    // clean Cancelled. This is the "error only during close" case: nothing is
+    // draining the iterator, so the Termination is the only channel for it.
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setInit(
+              InitResponse.getDefaultInstance).build()).build())
+        }
+        // Deliberately ignore Cancel: no terminator ever arrives.
+      })
+    val (_, channel) = startServer(service)
+    val session = newSession(channel, terminalTimeoutMs = 1000L)
+    session.init(basicInit())
+
+    val termination = session.close(emptyCancel)
+    assert(termination.isInstanceOf[Termination.TransportFailed],
+      s"a close that times out without a terminator must report TransportFailed, got: $termination")
+  }
+}

--- a/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
+++ b/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
@@ -161,6 +161,14 @@ class GrpcWorkerSessionConcurrencySuite
     session
   }
 
+  /**
+   * The [[TestWorkerHandle]] backing a session, for asserting the handle
+   * lifecycle. `workerHandle` is `private[worker]`, and this suite lives under
+   * `org.apache.spark.udf.worker`, so the access is in scope.
+   */
+  private def handleOf(session: GrpcWorkerSession): TestWorkerHandle =
+    session.workerHandle.asInstanceOf[TestWorkerHandle]
+
   // Protocol version carried on Init. The in-process fake workers in this suite
   // do not validate it; any sane value is fine.
   private val SupportedVersion = 1
@@ -680,7 +688,20 @@ class GrpcWorkerSessionConcurrencySuite
     assert(out == List("a", "b", "c"),
       s"echo worker should return inputs in order over cross-thread delivery, got: $out")
     assert(!it.hasNext, "iterator should be exhausted after the FinishResponse terminator")
+    val handle = handleOf(session)
+    val termination = session.close(emptyCancel)
+    // Handle lifecycle on a clean finish: the session is released back to the
+    // dispatcher exactly once and, because a Finished terminal is salvageable,
+    // the worker is NOT marked invalid (it stays eligible for reuse).
+    assert(termination.isInstanceOf[Termination.Finished],
+      s"a fully drained echo session should settle Finished, got: $termination")
+    assert(handle.released.get(), "close() must release the worker handle")
+    assert(!handle.invalidated.get(),
+      "a clean Finished termination is salvageable; the worker must not be marked invalid")
+    // Idempotent close(): still released exactly once, still not invalidated.
     session.close(emptyCancel)
+    assert(handle.released.get() && !handle.invalidated.get(),
+      "a repeat close() must not change the handle lifecycle outcome")
   }
 
   // ---------------------------------------------------------------------------
@@ -735,8 +756,188 @@ class GrpcWorkerSessionConcurrencySuite
     val session = newSession(channel, terminalTimeoutMs = 1000L)
     session.init(basicInit())
 
+    val handle = handleOf(session)
     val termination = session.close(emptyCancel)
     assert(termination.isInstanceOf[Termination.TransportFailed],
       s"a close that times out without a terminator must report TransportFailed, got: $termination")
+    // Handle lifecycle on an unsalvageable termination: the session is released
+    // AND the worker is marked invalid so the dispatcher will not recycle a
+    // worker left in an unknown state by the timed-out stream.
+    assert(handle.released.get(), "close() must release the worker handle")
+    assert(handle.invalidated.get(),
+      "a TransportFailed termination is unsalvageable; the worker must be marked invalid")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Worker sends a DataResponse before InitResponse: a protocol violation that
+  // must fail init fast (fast-fail in responseObserver.onNext DATA branch),
+  // not enqueue the stray batch and let init() hang for initResponseTimeoutMs.
+  // ---------------------------------------------------------------------------
+
+  test("worker emits DataResponse before InitResponse: init fails fast") {
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          // Reply with a DATA response instead of the required InitResponse.
+          resp.onNext(UdfResponse.newBuilder()
+            .setData(DataResponse.newBuilder()
+              .setData(ByteString.copyFromUtf8("premature")).build())
+            .build())
+        }
+      })
+    val (_, channel) = startServer(service)
+    // Huge init timeout: a regression that enqueued the stray batch instead of
+    // fast-failing would park init here until the timeout, so finishing quickly
+    // is the proof the fast path ran -- no wall-clock threshold needed.
+    val session = newSession(channel, initResponseTimeoutMs = NeverReachedTimeoutMs)
+
+    assertFinishesWithin(10000, "init") {
+      val ex = intercept[GrpcWorkerSessionException] { session.init(basicInit()) }
+      assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("init"),
+        s"expected an init-failure message, got: ${ex.getMessage}")
+    }
+    session.close(emptyCancel)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Init-error terminal carries the error (Termination.Failed), symmetric with
+  // the data-phase ERROR branch, even when a Cancel reaches the wire and the
+  // worker replies CancelResponse (cross-thread delivery). Without carrying the
+  // error onto the terminal, close() would return a bare Cancelled.
+  // ---------------------------------------------------------------------------
+
+  test("cross-thread InitResponse error: close carries Failed, not a bare Cancelled") {
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setInit(
+              InitResponse.newBuilder().setError(
+                ExecutionError.newBuilder().setUser(
+                  UserError.newBuilder().setMessage("init failure")
+                    .setErrorClass("InitError").build()).build()).build()).build())
+            .build())
+        } else if (req.hasControl && req.getControl.hasCancel) {
+          // Defensive: reply CancelResponse if a Cancel ever arrives. With the
+          // init error settled as Failed BEFORE any Cancel is attempted, the
+          // terminal is already set, so sendCancelInternal suppresses the wire
+          // Cancel and this branch should not fire -- but were a regression to
+          // write the Cancel, this CancelResponse settling the terminal as a bare
+          // Cancelled is exactly what the Failed-before-Cancel ordering prevents.
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setCancel(
+              CancelResponse.getDefaultInstance).build()).build())
+        }
+      })
+    // Cross-thread delivery: requestObserver is published before the InitResponse
+    // error arrives. Under the older "Cancel then let CancelResponse settle"
+    // design a Cancel would have reached the wire here and its CancelResponse
+    // would have overwritten the outcome with a bare Cancelled; the fix settles
+    // Failed first, so close() reports the init error either way.
+    val (_, channel) = startServer(service, directExecutor = false)
+    val session = newSession(channel,
+      initResponseTimeoutMs = NeverReachedTimeoutMs, terminalTimeoutMs = NeverReachedTimeoutMs)
+    intercept[GrpcWorkerSessionException](session.init(basicInit()))
+
+    val termination = session.close(emptyCancel)
+    termination match {
+      case Termination.Failed(err) =>
+        assert(err.getUser.getErrorClass == "InitError",
+          s"the init error must be carried on the Termination, got: $err")
+      case other =>
+        fail(s"expected Termination.Failed carrying the init error, got: $other")
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // A throwing input iterator (hasNext or next) must Cancel the stream so the
+  // worker is not stranded awaiting input, and rethrow to the engine.
+  // ---------------------------------------------------------------------------
+
+  test("input iterator throwing in hasNext: cancels the stream and surfaces the error") {
+    val cancelSeen = new CountDownLatch(1)
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        req.getRequestCase match {
+          case UdfRequest.RequestCase.CONTROL =>
+            val c = req.getControl
+            if (c.hasInit) {
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setInit(
+                  InitResponse.getDefaultInstance).build()).build())
+            } else if (c.hasCancel) {
+              cancelSeen.countDown()
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setCancel(
+                  CancelResponse.getDefaultInstance).build()).build())
+            }
+          case _ => ()
+        }
+      })
+    val (_, channel) = startServer(service, directExecutor = false)
+    val session = newSession(channel, terminalTimeoutMs = 5000L)
+    session.init(basicInit())
+
+    // An input iterator whose hasNext throws on first probe (mimics a Spark
+    // upstream that computes the next element eagerly in hasNext).
+    val boom = new Iterator[DataRequest] {
+      override def hasNext: Boolean = throw new RuntimeException("hasNext boom")
+      override def next(): DataRequest = throw new NoSuchElementException()
+    }
+    val it = session.process(boom, emptyFinish)
+    val ex = intercept[RuntimeException] { it.foreach(_ => ()) }
+    assert(ex.getMessage.contains("hasNext boom"),
+      s"the upstream failure must propagate, got: ${ex.getMessage}")
+    assert(cancelSeen.await(5, TimeUnit.SECONDS),
+      "a throwing input iterator must Cancel the stream so the worker is not stranded")
+    session.close(emptyCancel)
+  }
+
+  // ---------------------------------------------------------------------------
+  // A throwing finish() thunk (caller-supplied, may run a finish callback) must
+  // Cancel the stream and rethrow rather than escaping uncaught.
+  // ---------------------------------------------------------------------------
+
+  test("finish thunk throwing: cancels the stream and surfaces the error") {
+    val cancelSeen = new CountDownLatch(1)
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        req.getRequestCase match {
+          case UdfRequest.RequestCase.CONTROL =>
+            val c = req.getControl
+            if (c.hasInit) {
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setInit(
+                  InitResponse.getDefaultInstance).build()).build())
+            } else if (c.hasCancel) {
+              cancelSeen.countDown()
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setCancel(
+                  CancelResponse.getDefaultInstance).build()).build())
+            }
+          case UdfRequest.RequestCase.DATA =>
+            resp.onNext(UdfResponse.newBuilder()
+              .setData(DataResponse.newBuilder().setData(req.getData.getData).build())
+              .build())
+          case _ => ()
+        }
+      })
+    val (_, channel) = startServer(service, directExecutor = false)
+    val session = newSession(channel, terminalTimeoutMs = 5000L)
+    session.init(basicInit())
+
+    // finish() throws when the input is exhausted and the iterator tries to
+    // build the Finish message. Drive the whole iterator inside intercept:
+    // under cross-thread delivery input flows ahead of output, so finish() may
+    // fire before the echo of "only" is read back -- the throw can surface on
+    // any probe, so we must not read a batch outside the intercept.
+    val throwingFinish: () => Finish = () => throw new RuntimeException("finish boom")
+    val it = session.process(echoIn("only"), throwingFinish)
+    val ex = intercept[RuntimeException] { it.foreach(_ => ()) }
+    assert(ex.getMessage.contains("finish boom"),
+      s"the finish-thunk failure must propagate, got: ${ex.getMessage}")
+    assert(cancelSeen.await(5, TimeUnit.SECONDS),
+      "a throwing finish thunk must Cancel the stream so the worker is not stranded")
+    session.close(emptyCancel)
   }
 }

--- a/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
+++ b/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
@@ -18,12 +18,13 @@ package org.apache.spark.udf.worker.grpc
 
 import java.util.Locale
 import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
 
 import scala.jdk.CollectionConverters._
 
 import com.google.protobuf.ByteString
-import io.grpc.{ManagedChannel, Server}
+import io.grpc.{CallOptions, ClientCall, ConnectivityState, ForwardingClientCall, ManagedChannel,
+  Metadata, MethodDescriptor, Server}
 import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
 import io.grpc.stub.StreamObserver
 import org.scalatest.BeforeAndAfterEach
@@ -49,7 +50,7 @@ import org.apache.spark.udf.worker.core.{Termination, WorkerHandle, WorkerLogger
  *    after Init without releasing the worker underneath an active stream.
  *  - An immediate ErrorResponse after InitResponse must fail init and send the
  *    protocol-required Cancel; a premature FinishResponse must not truncate input.
- *  - Cancel / close concurrent with an in-progress data phase terminate
+ *  - Cancel and close concurrent with an in-progress data phase terminate
  *    cleanly without leaks or unbounded hangs.
  *
  * Runs entirely in-process: no subprocess, no UDS. Server services are
@@ -148,6 +149,44 @@ class GrpcWorkerSessionConcurrencySuite
     openServers.add(server)
     openChannels.add(channel)
     (server, channel)
+  }
+
+  /** A [[ManagedChannel]] wrapper whose operations delegate to `underlying`. */
+  private class DelegatingManagedChannel(underlying: ManagedChannel) extends ManagedChannel {
+    override def shutdown(): ManagedChannel = {
+      underlying.shutdown()
+      this
+    }
+
+    override def isShutdown: Boolean = underlying.isShutdown
+
+    override def isTerminated: Boolean = underlying.isTerminated
+
+    override def shutdownNow(): ManagedChannel = {
+      underlying.shutdownNow()
+      this
+    }
+
+    override def awaitTermination(timeout: Long, unit: TimeUnit): Boolean =
+      underlying.awaitTermination(timeout, unit)
+
+    override def newCall[ReqT, RespT](
+        methodDescriptor: MethodDescriptor[ReqT, RespT],
+        callOptions: CallOptions): ClientCall[ReqT, RespT] =
+      underlying.newCall(methodDescriptor, callOptions)
+
+    override def authority(): String = underlying.authority()
+
+    override def getState(requestConnection: Boolean): ConnectivityState =
+      underlying.getState(requestConnection)
+
+    override def notifyWhenStateChanged(
+        source: ConnectivityState,
+        callback: Runnable): Unit = underlying.notifyWhenStateChanged(source, callback)
+
+    override def resetConnectBackoff(): Unit = underlying.resetConnectBackoff()
+
+    override def enterIdle(): Unit = underlying.enterIdle()
   }
 
   private def newSession(
@@ -825,7 +864,7 @@ class GrpcWorkerSessionConcurrencySuite
     assert(ex.executionError != null && ex.executionError.getUser.getErrorClass == "PreInitError",
       s"init() must throw the structured error, got: ${ex.executionError}")
 
-    // close() returns the proto terminator: Cancelled, not a bare/Failed outcome.
+    // close() returns the proto terminator: Cancelled, not a generic Failed outcome.
     val termination = session.close(emptyCancel)
     assert(termination.isInstanceOf[Termination.Cancelled],
       s"expected the proto terminator Termination.Cancelled, got: $termination")
@@ -981,9 +1020,27 @@ class GrpcWorkerSessionConcurrencySuite
     session.close(emptyCancel)
   }
 
+  test("input iterator returning null: cancels the stream and surfaces the error") {
+    val service = new CapturingService()
+    val (_, channel) = startServer(service)
+    val session = newSession(channel)
+    session.init(basicInit())
+
+    val input = Iterator.single(null.asInstanceOf[DataRequest])
+    val it = session.process(input, emptyFinish)
+    val ex = intercept[NullPointerException] { it.hasNext }
+    assert(ex.getMessage.contains("input iterator returned null"),
+      s"the invalid input must propagate, got: ${ex.getMessage}")
+    val requests = service.captured.asScala.toSeq
+    assert(requests.size == 2 && requests.head.getControl.hasInit &&
+      requests(1).getControl.hasCancel,
+      s"a null input must produce exactly Init then Cancel, got: $requests")
+    assert(session.close(emptyCancel).isInstanceOf[Termination.Cancelled])
+  }
+
   // ---------------------------------------------------------------------------
   // A throwing finish() thunk (caller-supplied, may run a finish callback) must
-  // Cancel the stream and rethrow rather than escaping uncaught.
+  // Cancel the stream before rethrowing the callback failure.
   // ---------------------------------------------------------------------------
 
   test("finish thunk throwing: cancels the stream and surfaces the error") {
@@ -1029,9 +1086,26 @@ class GrpcWorkerSessionConcurrencySuite
     session.close(emptyCancel)
   }
 
+  test("finish thunk returning null: cancels the stream and surfaces the error") {
+    val service = new CapturingService()
+    val (_, channel) = startServer(service)
+    val session = newSession(channel)
+    session.init(basicInit())
+
+    val it = session.process(Iterator.empty, () => null)
+    val ex = intercept[NullPointerException] { it.hasNext }
+    assert(ex.getMessage.contains("finish callback returned null"),
+      s"the invalid finish result must propagate, got: ${ex.getMessage}")
+    val requests = service.captured.asScala.toSeq
+    assert(requests.size == 2 && requests.head.getControl.hasInit &&
+      requests(1).getControl.hasCancel,
+      s"a null finish result must produce exactly Init then Cancel, got: $requests")
+    assert(session.close(emptyCancel).isInstanceOf[Termination.Cancelled])
+  }
+
   // ---------------------------------------------------------------------------
-  // close() concurrent with a blocked init(): close() settles the terminal, so
-  // init() must be woken and fail fast rather than park for initResponseTimeoutMs.
+  // close() concurrent with init(): close must serialize with stream opening, and
+  // a close-settled terminal must wake an init blocked on its response.
   //
   // Regression guard for onTerminalSettled waking initValue. The terminal here is
   // settled by close() ITSELF (the terminalTimeoutMs path in doClose, because the
@@ -1041,35 +1115,43 @@ class GrpcWorkerSessionConcurrencySuite
   // stays parked until initResponseTimeoutMs.
   // ---------------------------------------------------------------------------
 
-  test("close concurrent with the initial write sends Cancel only after Init") {
-    val initHandlerEntered = new CountDownLatch(1)
-    val releaseInitHandler = new CountDownLatch(1)
-    val cancelSeen = new CountDownLatch(1)
+  test("close concurrent with stream opening waits and sends Cancel only after Init") {
+    val callStartEntered = new CountDownLatch(1)
+    val releaseCallStart = new CountDownLatch(1)
     val service = new CapturingService(
       onRequest = (req, resp) => {
-        if (req.hasControl && req.getControl.hasInit) {
-          // Hold the directExecutor Init write inside the server handler. close()
-          // must wait for this write rather than treating requestObserver as
-          // absent, releasing the worker, and letting Init escape afterward.
-          initHandlerEntered.countDown()
-          releaseInitHandler.await(10, TimeUnit.SECONDS)
-        } else if (req.hasControl && req.getControl.hasCancel) {
-          cancelSeen.countDown()
+        if (req.hasControl && req.getControl.hasCancel) {
           resp.onNext(UdfResponse.newBuilder().setControl(
             UdfControlResponse.newBuilder().setCancel(
               CancelResponse.getDefaultInstance).build()).build())
         }
       })
-    val (_, channel) = startServer(service)
+    val (_, underlying) = startServer(service)
+    val channel = new DelegatingManagedChannel(underlying) {
+      override def newCall[ReqT, RespT](
+          methodDescriptor: MethodDescriptor[ReqT, RespT],
+          callOptions: CallOptions): ClientCall[ReqT, RespT] =
+        new ForwardingClientCall.SimpleForwardingClientCall[ReqT, RespT](
+          super.newCall(methodDescriptor, callOptions)) {
+          override def start(
+              responseListener: ClientCall.Listener[RespT],
+              headers: Metadata): Unit = {
+            callStartEntered.countDown()
+            assert(releaseCallStart.await(10, TimeUnit.SECONDS),
+              "timed out waiting to release ClientCall.start")
+            super.start(responseListener, headers)
+          }
+        }
+    }
     val session = newSession(channel,
       initResponseTimeoutMs = NeverReachedTimeoutMs, terminalTimeoutMs = NeverReachedTimeoutMs)
 
     val initThrown = new AtomicReference[Throwable]()
     val initThread = new Thread(() => {
       try session.init(basicInit()) catch { case t: Throwable => initThrown.set(t) }
-    }, "init-write-close-race")
+    }, "init-open-close-race")
     initThread.start()
-    assert(initHandlerEntered.await(5, TimeUnit.SECONDS), "worker never entered the Init handler")
+    assert(callStartEntered.await(5, TimeUnit.SECONDS), "client call never started opening")
 
     val closeResult = new AtomicReference[Termination]()
     val closeThrown = new AtomicReference[Throwable]()
@@ -1078,21 +1160,23 @@ class GrpcWorkerSessionConcurrencySuite
       try closeResult.set(session.close(emptyCancel))
       catch { case t: Throwable => closeThrown.set(t) }
       finally closeDone.countDown()
-    }, "close-during-init-write")
+    }, "close-during-stream-open")
     closeThread.start()
 
-    // The close thread must block on requestLock while the Init write is in the
-    // directExecutor handler. Before the fix it returned immediately through the
-    // requestObserver-null path and released the worker under the active stream.
+    // The close thread must block on requestLock while ClientCall.start is still
+    // opening the RPC. Before the fix it returned through the requestObserver-null
+    // path and released the worker while stream creation was still in progress.
     val blockedDeadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
     while (closeThread.getState != Thread.State.BLOCKED && closeDone.getCount != 0 &&
         System.nanoTime() < blockedDeadlineNanos) {
       Thread.sleep(10L)
     }
     assert(closeThread.getState == Thread.State.BLOCKED,
-      s"close must wait for the initial write, state=${closeThread.getState}")
+      s"close must wait for stream creation, state=${closeThread.getState}")
+    assert(!handleOf(session).released.get(),
+      "close must not release the worker while the RPC is still opening")
 
-    releaseInitHandler.countDown()
+    releaseCallStart.countDown()
     closeThread.join(10000)
     initThread.join(10000)
     assert(!closeThread.isAlive && !initThread.isAlive,
@@ -1100,13 +1184,59 @@ class GrpcWorkerSessionConcurrencySuite
     assert(closeThrown.get() == null, s"close failed: ${closeThrown.get()}")
     assert(initThrown.get().isInstanceOf[GrpcWorkerSessionException],
       s"init must fail after concurrent close, got: ${initThrown.get()}")
-    assert(cancelSeen.getCount == 0, "close must send Cancel after the in-flight Init")
     assert(closeResult.get().isInstanceOf[Termination.Cancelled],
       s"worker acknowledgement should settle Cancelled, got: ${closeResult.get()}")
     val requests = service.captured.asScala.toSeq
     assert(requests.size == 2 && requests.head.getControl.hasInit &&
       requests(1).getControl.hasCancel,
       s"expected exactly Init then Cancel, got: $requests")
+  }
+
+  test("outgoing send failure aborts the request side and close does not half-close") {
+    val cancelCalls = new AtomicInteger(0)
+    val halfCloseCalls = new AtomicInteger(0)
+    val failNextSend = new AtomicBoolean(true)
+    val service = new CapturingService()
+    val (_, underlying) = startServer(service)
+    val channel = new DelegatingManagedChannel(underlying) {
+      override def newCall[ReqT, RespT](
+          methodDescriptor: MethodDescriptor[ReqT, RespT],
+          callOptions: CallOptions): ClientCall[ReqT, RespT] =
+        new ForwardingClientCall.SimpleForwardingClientCall[ReqT, RespT](
+          super.newCall(methodDescriptor, callOptions)) {
+          override def sendMessage(message: ReqT): Unit = {
+            if (failNextSend.compareAndSet(true, false)) {
+              throw new RuntimeException("send boom")
+            }
+            super.sendMessage(message)
+          }
+
+          override def cancel(message: String, cause: Throwable): Unit = {
+            cancelCalls.incrementAndGet()
+            super.cancel(message, cause)
+          }
+
+          override def halfClose(): Unit = {
+            halfCloseCalls.incrementAndGet()
+            super.halfClose()
+          }
+        }
+    }
+    val session = newSession(channel)
+
+    val ex = intercept[GrpcWorkerSessionException] { session.init(basicInit()) }
+    assert(ex.getCause != null && ex.getCause.getMessage.contains("send boom"),
+      s"the outgoing failure must surface from init, got: $ex")
+    assert(cancelCalls.get() == 1,
+      "an outgoing onNext failure must terminate the request side with onError")
+
+    val termination = session.close(emptyCancel)
+    assert(termination.isInstanceOf[Termination.TransportFailed],
+      s"the outgoing failure must settle TransportFailed, got: $termination")
+    assert(halfCloseCalls.get() == 0,
+      "close must not invoke onCompleted after the request side was aborted")
+    assert(cancelCalls.get() == 1,
+      "close must not terminate an already-aborted request side again")
   }
 
   test("close concurrent with blocked init: init is woken and fails fast") {

--- a/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
+++ b/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
@@ -45,9 +45,10 @@ import org.apache.spark.udf.worker.core.{Termination, WorkerHandle, WorkerLogger
  *    for `initResponseTimeoutMs`.
  *  - Repeated [[Iterator#hasNext]] after natural iterator exhaustion must
  *    return immediately, not block for `terminalTimeoutMs`.
- *  - Cancel issued before [[GrpcWorkerSession#init]] makes a subsequent
- *    [[GrpcWorkerSession#doProcess]] surface the cancellation immediately,
- *    instead of blocking for `terminalTimeoutMs`.
+ *  - Close racing the initial write must either prevent Init or send Cancel
+ *    after Init without releasing the worker underneath an active stream.
+ *  - An immediate ErrorResponse after InitResponse must fail init and send the
+ *    protocol-required Cancel; a premature FinishResponse must not truncate input.
  *  - Cancel / close concurrent with an in-progress data phase terminate
  *    cleanly without leaks or unbounded hangs.
  *
@@ -256,23 +257,15 @@ class GrpcWorkerSessionConcurrencySuite
   }
 
   // ---------------------------------------------------------------------------
-  // Cancel-never-precedes-Init invariant.
-  //
-  // The former cancel()-vs-init() race test was retired when cancel() folded
-  // into close(): close() settles a terminal and blocks init(),
-  // so a Cancel-before-Init race is no longer reachable through the public API
-  // (close() almost always wins and aborts init() before any control is sent,
-  // making such a race test vacuous). The invariant is now structural --
-  // sendCancelInternal early-returns while requestObserver is null, and
-  // requestObserver is published only after Init is on the wire -- and is
-  // exercised by "worker emits InitResponse with error: init fails fast" (the
-  // requestObserver-null path: a Cancel that cannot be written) and by "close
-  // concurrent with process" (a Cancel written only after Init + data).
+  // Cancel-never-precedes-Init invariant. Publication of requestObserver and the
+  // Init write are serialized with close/cancel under requestLock: close either
+  // wins first and prevents Init entirely, or waits until Init is on the wire
+  // before writing Cancel.
   // ---------------------------------------------------------------------------
 
   // ---------------------------------------------------------------------------
   // Terminator-before-InitResponse: must fail init fast, not hang for
-  // initResponseTimeoutMs (defensive initLatch.countDown() in handleControl).
+  // initResponseTimeoutMs (onTerminalSettled completes initValue without a value).
   // ---------------------------------------------------------------------------
 
   test("worker emits ErrorResponse before InitResponse: init fails fast") {
@@ -293,9 +286,9 @@ class GrpcWorkerSessionConcurrencySuite
         }
       })
     val (_, channel) = startServer(service)
-    // Huge init timeout: a regression that dropped the defensive
-    // initLatch.countDown() would park init here until the timeout, so finishing
-    // quickly is proof the fast path ran -- no wall-clock threshold needed.
+    // Huge init timeout: a regression that failed to complete initValue would
+    // park init here until the timeout, so finishing quickly is proof the fast
+    // path ran -- no wall-clock threshold needed.
     val session = newSession(channel, initResponseTimeoutMs = NeverReachedTimeoutMs)
 
     assertFinishesWithin(10000, "init") {
@@ -308,11 +301,10 @@ class GrpcWorkerSessionConcurrencySuite
   }
 
   test("worker emits InitResponse with error: init fails fast (no terminal-timeout stall)") {
-    // Regression for the directExecutor reentrancy where InitResponse(error) is
-    // delivered inside stream.onNext, before doInit publishes requestObserver,
-    // so the in-band Cancel cannot be written. The INIT-error path must settle a
-    // terminal itself rather than block awaiting a CancelResponse that can never
-    // arrive (which would stall for the full terminalTimeoutMs).
+    // Regression for directExecutor reentrancy where InitResponse(error) is
+    // delivered inside stream.onNext. requestObserver is already published, so
+    // doInit can send the required Cancel after onNext returns and drain the
+    // CancelResponse without stalling on terminalTimeoutMs.
     val service = new CapturingService(
       onRequest = (req, resp) => {
         if (req.hasControl && req.getControl.hasInit) {
@@ -343,6 +335,98 @@ class GrpcWorkerSessionConcurrencySuite
         s"expected an init-failure message, got: ${ex.getMessage}")
     }
     session.close(emptyCancel)
+  }
+
+  test("terminal signal wins over a late InitResponse") {
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          // DATA before InitResponse is a protocol failure and completes the
+          // init one-shot without a value. A later InitResponse must not overwrite
+          // that completion and make init() return successfully.
+          resp.onNext(UdfResponse.newBuilder()
+            .setData(DataResponse.newBuilder()
+              .setData(ByteString.copyFromUtf8("premature")).build())
+            .build())
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setInit(
+              InitResponse.getDefaultInstance).build()).build())
+        }
+      })
+    val (_, channel) = startServer(service)
+    val session = newSession(channel, initResponseTimeoutMs = NeverReachedTimeoutMs)
+
+    val ex = intercept[GrpcWorkerSessionException] { session.init(basicInit()) }
+    assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("init") ||
+      ex.getMessage.toLowerCase(Locale.ROOT).contains("stream"),
+      s"expected the earlier protocol failure to win, got: ${ex.getMessage}")
+    assert(session.close(emptyCancel).isInstanceOf[Termination.TransportFailed])
+  }
+
+  test("ErrorResponse immediately after InitResponse fails init and sends Cancel") {
+    val cancelSeen = new CountDownLatch(1)
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          // Both responses are delivered reentrantly from inside the Init write.
+          // The second response is a valid generator-style data-phase failure.
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setInit(
+              InitResponse.getDefaultInstance).build()).build())
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setError(
+              ErrorResponse.newBuilder().setError(
+                ExecutionError.newBuilder().setUser(
+                  UserError.newBuilder().setMessage("generator failed")
+                    .setErrorClass("GeneratorError").build()).build()).build()).build())
+            .build())
+        } else if (req.hasControl && req.getControl.hasCancel) {
+          cancelSeen.countDown()
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setCancel(
+              CancelResponse.getDefaultInstance).build()).build())
+        }
+      })
+    val (_, channel) = startServer(service)
+    val session = newSession(channel, terminalTimeoutMs = NeverReachedTimeoutMs)
+
+    val ex = intercept[GrpcWorkerSessionException] { session.init(basicInit()) }
+    assert(ex.getMessage.contains("generator failed"),
+      s"the immediate ErrorResponse must fail init with the worker error, got: ${ex.getMessage}")
+    assert(cancelSeen.await(5, TimeUnit.SECONDS),
+      "an immediate post-init ErrorResponse must send the protocol-required Cancel")
+    assert(session.close(emptyCancel).isInstanceOf[Termination.Cancelled])
+  }
+
+  test("FinishResponse before Finish is rejected instead of truncating input") {
+    val replied = new AtomicBoolean(false)
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setInit(
+              InitResponse.getDefaultInstance).build()).build())
+        } else if (req.hasData && replied.compareAndSet(false, true)) {
+          // A buggy worker claims success after the first batch even though the
+          // engine has neither exhausted its input nor sent Finish.
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setFinish(
+              FinishResponse.getDefaultInstance).build()).build())
+        }
+      })
+    val (_, channel) = startServer(service)
+    val session = newSession(channel, terminalTimeoutMs = NeverReachedTimeoutMs)
+    session.init(basicInit())
+
+    val ex = intercept[GrpcWorkerSessionException] {
+      session.process(echoIn("first", "must-not-be-consumed"), emptyFinish).foreach(_ => ())
+    }
+    assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("stream failed"),
+      s"a premature FinishResponse must be a protocol failure, got: ${ex.getMessage}")
+    val dataRequests = service.captured.asScala.count(_.hasData)
+    assert(dataRequests == 1,
+      s"the premature terminator should stop input after one batch, got: $dataRequests")
+    assert(session.close(emptyCancel).isInstanceOf[Termination.TransportFailed])
   }
 
   test("worker emits FinishResponse before InitResponse: init fails fast") {
@@ -406,10 +490,10 @@ class GrpcWorkerSessionConcurrencySuite
   test("worker emits malformed UdfResponse before InitResponse: init fails fast") {
     // A UdfResponse with no oneof set (RESPONSE_NOT_SET) is malformed: the
     // session's responseObserver settles a transport-failure terminal in its
-    // catch-all `case other` branch. Regression guard for the missing
-    // initLatch.countDown() on that branch -- without it, init() blocks until
-    // initResponseTimeoutMs and reports a misleading "timed out" error instead
-    // of failing fast with the malformed-response cause.
+    // catch-all `case other` branch. Regression guard for failing to wake the
+    // initValue waiter when that terminal settles: without it, init() blocks
+    // until initResponseTimeoutMs and reports a misleading "timed out" error
+    // instead of failing fast with the malformed-response cause.
     val service = new CapturingService(
       onRequest = (req, resp) => {
         if (req.hasControl && req.getControl.hasInit) {
@@ -957,6 +1041,74 @@ class GrpcWorkerSessionConcurrencySuite
   // stays parked until initResponseTimeoutMs.
   // ---------------------------------------------------------------------------
 
+  test("close concurrent with the initial write sends Cancel only after Init") {
+    val initHandlerEntered = new CountDownLatch(1)
+    val releaseInitHandler = new CountDownLatch(1)
+    val cancelSeen = new CountDownLatch(1)
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          // Hold the directExecutor Init write inside the server handler. close()
+          // must wait for this write rather than treating requestObserver as
+          // absent, releasing the worker, and letting Init escape afterward.
+          initHandlerEntered.countDown()
+          releaseInitHandler.await(10, TimeUnit.SECONDS)
+        } else if (req.hasControl && req.getControl.hasCancel) {
+          cancelSeen.countDown()
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setCancel(
+              CancelResponse.getDefaultInstance).build()).build())
+        }
+      })
+    val (_, channel) = startServer(service)
+    val session = newSession(channel,
+      initResponseTimeoutMs = NeverReachedTimeoutMs, terminalTimeoutMs = NeverReachedTimeoutMs)
+
+    val initThrown = new AtomicReference[Throwable]()
+    val initThread = new Thread(() => {
+      try session.init(basicInit()) catch { case t: Throwable => initThrown.set(t) }
+    }, "init-write-close-race")
+    initThread.start()
+    assert(initHandlerEntered.await(5, TimeUnit.SECONDS), "worker never entered the Init handler")
+
+    val closeResult = new AtomicReference[Termination]()
+    val closeThrown = new AtomicReference[Throwable]()
+    val closeDone = new CountDownLatch(1)
+    val closeThread = new Thread(() => {
+      try closeResult.set(session.close(emptyCancel))
+      catch { case t: Throwable => closeThrown.set(t) }
+      finally closeDone.countDown()
+    }, "close-during-init-write")
+    closeThread.start()
+
+    // The close thread must block on requestLock while the Init write is in the
+    // directExecutor handler. Before the fix it returned immediately through the
+    // requestObserver-null path and released the worker under the active stream.
+    val blockedDeadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+    while (closeThread.getState != Thread.State.BLOCKED && closeDone.getCount != 0 &&
+        System.nanoTime() < blockedDeadlineNanos) {
+      Thread.sleep(10L)
+    }
+    assert(closeThread.getState == Thread.State.BLOCKED,
+      s"close must wait for the initial write, state=${closeThread.getState}")
+
+    releaseInitHandler.countDown()
+    closeThread.join(10000)
+    initThread.join(10000)
+    assert(!closeThread.isAlive && !initThread.isAlive,
+      "close and init must both finish after the worker receives Cancel")
+    assert(closeThrown.get() == null, s"close failed: ${closeThrown.get()}")
+    assert(initThrown.get().isInstanceOf[GrpcWorkerSessionException],
+      s"init must fail after concurrent close, got: ${initThrown.get()}")
+    assert(cancelSeen.getCount == 0, "close must send Cancel after the in-flight Init")
+    assert(closeResult.get().isInstanceOf[Termination.Cancelled],
+      s"worker acknowledgement should settle Cancelled, got: ${closeResult.get()}")
+    val requests = service.captured.asScala.toSeq
+    assert(requests.size == 2 && requests.head.getControl.hasInit &&
+      requests(1).getControl.hasCancel,
+      s"expected exactly Init then Cancel, got: $requests")
+  }
+
   test("close concurrent with blocked init: init is woken and fails fast") {
     val initReceived = new CountDownLatch(1)
     val service = new CapturingService(
@@ -1149,7 +1301,8 @@ class GrpcWorkerSessionConcurrencySuite
   // Interrupt handling (cancelled query / killed task). An interrupt while
   // blocked on init sends a best-effort Cancel and waits interruptCancelTimeoutMs
   // for the CancelResponse: a responsive worker settles a clean, salvageable
-  // Cancelled; an unresponsive one falls back to Interrupted (also salvageable).
+  // Cancelled; an unresponsive one falls back to Interrupted and is invalidated
+  // because no acknowledgement or liveness proof makes it safe to reuse.
   // ---------------------------------------------------------------------------
 
   test("interrupt during init: responsive worker settles Cancelled, worker salvageable") {
@@ -1190,11 +1343,11 @@ class GrpcWorkerSessionConcurrencySuite
     assert(termination.isInstanceOf[Termination.Cancelled],
       s"a responsive worker's ack should settle Cancelled, got: $termination")
     assert(!handle.invalidated.get(),
-      "an Interrupted/Cancelled outcome is salvageable; the worker must not be invalidated")
+      "an acknowledged Cancelled outcome is salvageable; the worker must not be invalidated")
     assert(handle.released.get(), "close() must release the worker handle")
   }
 
-  test("interrupt during init: unresponsive worker settles Interrupted, worker salvageable") {
+  test("interrupt during init: unresponsive worker settles Interrupted and is invalidated") {
     // Worker never sends InitResponse and ignores Cancel -- so the interrupt's
     // bounded drain times out and the session falls back to Interrupted.
     val initReceived = new CountDownLatch(1)
@@ -1230,8 +1383,8 @@ class GrpcWorkerSessionConcurrencySuite
     val termination = session.close(emptyCancel)
     assert(termination.isInstanceOf[Termination.Interrupted],
       s"an unresponsive worker should settle Interrupted, got: $termination")
-    assert(!handle.invalidated.get(),
-      "an Interrupted outcome is salvageable; the worker must not be invalidated")
+    assert(handle.invalidated.get(),
+      "an unacknowledged Interrupted outcome must invalidate the worker")
     assert(handle.released.get(), "close() must release the worker handle")
   }
 }

--- a/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
+++ b/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
@@ -152,11 +152,13 @@ class GrpcWorkerSessionConcurrencySuite
   private def newSession(
       channel: ManagedChannel,
       initResponseTimeoutMs: Long = 5000L,
-      terminalTimeoutMs: Long = 5000L): GrpcWorkerSession = {
+      terminalTimeoutMs: Long = 5000L,
+      interruptCancelTimeoutMs: Long = 5000L): GrpcWorkerSession = {
     val session = new GrpcWorkerSession(
       new TestWorkerHandle, channel, WorkerLogger.NoOp,
       initResponseTimeoutMs = initResponseTimeoutMs,
-      terminalTimeoutMs = terminalTimeoutMs)
+      terminalTimeoutMs = terminalTimeoutMs,
+      interruptCancelTimeoutMs = interruptCancelTimeoutMs)
     openSessions.add(session)
     session
   }
@@ -1141,5 +1143,95 @@ class GrpcWorkerSessionConcurrencySuite
         s"expected a timeout/transport-failure message, got: ${ex.getMessage}")
     }
     session.close(emptyCancel)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Interrupt handling (cancelled query / killed task). An interrupt while
+  // blocked on init sends a best-effort Cancel and waits interruptCancelTimeoutMs
+  // for the CancelResponse: a responsive worker settles a clean, salvageable
+  // Cancelled; an unresponsive one falls back to Interrupted (also salvageable).
+  // ---------------------------------------------------------------------------
+
+  test("interrupt during init: responsive worker settles Cancelled, worker salvageable") {
+    // Worker never sends InitResponse (so init() blocks), but DOES reply to
+    // Cancel -- so the interrupt's bounded drain observes the CancelResponse and
+    // settles a clean Cancelled.
+    val initReceived = new CountDownLatch(1)
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          initReceived.countDown() // block: no InitResponse
+        } else if (req.hasControl && req.getControl.hasCancel) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setCancel(
+              CancelResponse.getDefaultInstance).build()).build())
+        }
+      })
+    val (_, channel) = startServer(service, directExecutor = false)
+    // Huge initResponseTimeoutMs so only the interrupt can end the init wait;
+    // generous interruptCancelTimeoutMs so the ack is observed.
+    val session = newSession(channel,
+      initResponseTimeoutMs = NeverReachedTimeoutMs, interruptCancelTimeoutMs = 5000L)
+    val handle = handleOf(session)
+
+    val thrown = new AtomicReference[Throwable]()
+    val initThread = new Thread(() => {
+      try session.init(basicInit()) catch { case t: Throwable => thrown.set(t) }
+    }, "interrupt-init-responsive")
+    initThread.start()
+    assert(initReceived.await(5, TimeUnit.SECONDS), "worker never received Init")
+    initThread.interrupt()
+    initThread.join(10000)
+    assert(!initThread.isAlive, "init() must return after the interrupt")
+    assert(thrown.get().isInstanceOf[InterruptedException],
+      s"init() must rethrow InterruptedException, got: ${thrown.get()}")
+
+    val termination = session.close(emptyCancel)
+    assert(termination.isInstanceOf[Termination.Cancelled],
+      s"a responsive worker's ack should settle Cancelled, got: $termination")
+    assert(!handle.invalidated.get(),
+      "an Interrupted/Cancelled outcome is salvageable; the worker must not be invalidated")
+    assert(handle.released.get(), "close() must release the worker handle")
+  }
+
+  test("interrupt during init: unresponsive worker settles Interrupted, worker salvageable") {
+    // Worker never sends InitResponse and ignores Cancel -- so the interrupt's
+    // bounded drain times out and the session falls back to Interrupted.
+    val initReceived = new CountDownLatch(1)
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          initReceived.countDown() // block: no InitResponse, and Cancel ignored
+        }
+      })
+    val (_, channel) = startServer(service, directExecutor = false)
+    // Short interruptCancelTimeoutMs so the fallback fires quickly; huge
+    // terminalTimeoutMs so a regression that used the wrong timeout would stall.
+    val session = newSession(channel,
+      initResponseTimeoutMs = NeverReachedTimeoutMs,
+      terminalTimeoutMs = NeverReachedTimeoutMs,
+      interruptCancelTimeoutMs = 500L)
+    val handle = handleOf(session)
+
+    val thrown = new AtomicReference[Throwable]()
+    val initThread = new Thread(() => {
+      try session.init(basicInit()) catch { case t: Throwable => thrown.set(t) }
+    }, "interrupt-init-unresponsive")
+    initThread.start()
+    assert(initReceived.await(5, TimeUnit.SECONDS), "worker never received Init")
+    initThread.interrupt()
+    // Bounded by interruptCancelTimeoutMs (500ms), not terminalTimeoutMs (10min):
+    // if init parked on the wrong timeout this join would fail.
+    initThread.join(10000)
+    assert(!initThread.isAlive, "init() must return within interruptCancelTimeoutMs of the interrupt")
+    assert(thrown.get().isInstanceOf[InterruptedException],
+      s"init() must rethrow InterruptedException, got: ${thrown.get()}")
+
+    val termination = session.close(emptyCancel)
+    assert(termination.isInstanceOf[Termination.Interrupted],
+      s"an unresponsive worker should settle Interrupted, got: $termination")
+    assert(!handle.invalidated.get(),
+      "an Interrupted outcome is salvageable; the worker must not be invalidated")
+    assert(handle.released.get(), "close() must release the worker handle")
   }
 }

--- a/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
+++ b/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
@@ -1429,10 +1429,11 @@ class GrpcWorkerSessionConcurrencySuite
 
   // ---------------------------------------------------------------------------
   // Interrupt handling (cancelled query / killed task). An interrupt while
-  // blocked on init sends a best-effort Cancel and waits interruptCancelTimeoutMs
-  // for the CancelResponse: a responsive worker settles a clean, salvageable
-  // Cancelled; an unresponsive one falls back to Interrupted and is invalidated
-  // because no acknowledgement or liveness proof makes it safe to reuse.
+  // blocked on init or pulling input sends a best-effort Cancel and waits
+  // interruptCancelTimeoutMs for the CancelResponse: a responsive worker settles
+  // a clean, salvageable Cancelled; an unresponsive one falls back to Interrupted
+  // and is invalidated because no acknowledgement or liveness proof makes it safe
+  // to reuse.
   // ---------------------------------------------------------------------------
 
   test("interrupt during init: responsive worker settles Cancelled, worker salvageable") {
@@ -1506,13 +1507,73 @@ class GrpcWorkerSessionConcurrencySuite
     // Bounded by interruptCancelTimeoutMs (500ms), not terminalTimeoutMs (10min):
     // if init parked on the wrong timeout this join would fail.
     initThread.join(10000)
-    assert(!initThread.isAlive, "init() must return within interruptCancelTimeoutMs of the interrupt")
+    assert(!initThread.isAlive,
+      "init() must return within interruptCancelTimeoutMs of the interrupt")
     assert(thrown.get().isInstanceOf[InterruptedException],
       s"init() must rethrow InterruptedException, got: ${thrown.get()}")
 
     val termination = session.close(emptyCancel)
     assert(termination.isInstanceOf[Termination.Interrupted],
       s"an unresponsive worker should settle Interrupted, got: $termination")
+    assert(handle.invalidated.get(),
+      "an unacknowledged Interrupted outcome must invalidate the worker")
+    assert(handle.released.get(), "close() must release the worker handle")
+  }
+
+  test("interrupt while pulling input: bounded Cancel drain settles Interrupted") {
+    // Worker accepts Init but ignores Cancel. The interrupted input pull must use
+    // interruptCancelTimeoutMs rather than leaving close() to wait terminalTimeoutMs.
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        if (req.hasControl && req.getControl.hasInit) {
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setInit(
+              InitResponse.getDefaultInstance).build()).build())
+        }
+      })
+    val (_, channel) = startServer(service)
+    val session = newSession(channel,
+      terminalTimeoutMs = NeverReachedTimeoutMs,
+      interruptCancelTimeoutMs = 500L)
+    val handle = handleOf(session)
+    session.init(basicInit())
+
+    val inputNextEntered = new CountDownLatch(1)
+    val neverReleaseInput = new CountDownLatch(1)
+    val input = new Iterator[DataRequest] {
+      override def hasNext: Boolean = true
+      override def next(): DataRequest = {
+        inputNextEntered.countDown()
+        neverReleaseInput.await()
+        throw new AssertionError("blocked input unexpectedly resumed")
+      }
+    }
+    val thrown = new AtomicReference[Throwable]()
+    val termination = new AtomicReference[Termination]()
+    val processThread = new Thread(() => {
+      try {
+        session.process(input, emptyFinish).hasNext
+      } catch {
+        case t: Throwable => thrown.set(t)
+      } finally {
+        termination.set(session.close(emptyCancel))
+      }
+    }, "interrupt-input-pull")
+    processThread.setDaemon(true)
+    processThread.start()
+    assert(inputNextEntered.await(5, TimeUnit.SECONDS), "input.next() was never entered")
+
+    processThread.interrupt()
+    // Bounded by interruptCancelTimeoutMs (500ms), not terminalTimeoutMs (10min).
+    processThread.join(10000)
+    assert(!processThread.isAlive,
+      "input interruption must unwind within interruptCancelTimeoutMs")
+    assert(thrown.get().isInstanceOf[InterruptedException],
+      s"processing must rethrow InterruptedException, got: ${thrown.get()}")
+    assert(termination.get().isInstanceOf[Termination.Interrupted],
+      s"an unresponsive worker should settle Interrupted, got: ${termination.get()}")
+    assert(service.captured.asScala.exists(r => r.hasControl && r.getControl.hasCancel),
+      "interrupting an input pull must send Cancel")
     assert(handle.invalidated.get(),
       "an unacknowledged Interrupted outcome must invalidate the worker")
     assert(handle.released.get(), "close() must release the worker handle")

--- a/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
+++ b/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
@@ -705,13 +705,15 @@ class GrpcWorkerSessionConcurrencySuite
   }
 
   // ---------------------------------------------------------------------------
-  // close() reports failures faithfully (Termination.Failed / TransportFailed)
-  // rather than collapsing them into a clean Cancelled, so a failure that occurs
-  // during finish/close -- where nothing is consuming the result iterator -- is
-  // not lost.
+  // An init error surfaces through init()'s exception (carrying the structured
+  // ExecutionError); per the protocol the engine then sends Cancel and the worker
+  // replies CancelResponse, so the terminal -- and close()'s return -- is the
+  // proto terminator Cancelled, not Failed. A genuine transport failure (worker
+  // never replies to Cancel) still reports TransportFailed faithfully rather than
+  // collapsing into a clean Cancelled.
   // ---------------------------------------------------------------------------
 
-  test("close after a pre-init error returns a Failed termination carrying the error") {
+  test("pre-init error: init throws the structured error; close returns Cancelled") {
     val service = new CapturingService(
       onRequest = (req, resp) => {
         if (req.hasControl && req.getControl.hasInit) {
@@ -722,20 +724,25 @@ class GrpcWorkerSessionConcurrencySuite
                   UserError.newBuilder().setMessage("pre-init boom")
                     .setErrorClass("PreInitError").build()).build()).build()).build())
             .build())
+        } else if (req.hasControl && req.getControl.hasCancel) {
+          // Proto: the engine must Cancel after an init error and the worker
+          // replies CancelResponse, settling the terminal as Cancelled.
+          resp.onNext(UdfResponse.newBuilder().setControl(
+            UdfControlResponse.newBuilder().setCancel(
+              CancelResponse.getDefaultInstance).build()).build())
         }
       })
     val (_, channel) = startServer(service)
-    val session = newSession(channel, terminalTimeoutMs = 3000L)
-    intercept[GrpcWorkerSessionException](session.init(basicInit()))
+    val session = newSession(channel, terminalTimeoutMs = NeverReachedTimeoutMs)
+    // The structured error is surfaced through init()'s exception, not the terminal.
+    val ex = intercept[GrpcWorkerSessionException](session.init(basicInit()))
+    assert(ex.executionError != null && ex.executionError.getUser.getErrorClass == "PreInitError",
+      s"init() must throw the structured error, got: ${ex.executionError}")
 
+    // close() returns the proto terminator: Cancelled, not a bare/Failed outcome.
     val termination = session.close(emptyCancel)
-    termination match {
-      case Termination.Failed(err) =>
-        assert(err.getUser.getErrorClass == "PreInitError",
-          s"the structured error must be carried on the Termination, got: $err")
-      case other =>
-        fail(s"expected Termination.Failed carrying the error, got: $other")
-    }
+    assert(termination.isInstanceOf[Termination.Cancelled],
+      s"expected the proto terminator Termination.Cancelled, got: $termination")
   }
 
   test("close that times out without a terminator returns a TransportFailed termination") {
@@ -800,13 +807,15 @@ class GrpcWorkerSessionConcurrencySuite
   }
 
   // ---------------------------------------------------------------------------
-  // Init-error terminal carries the error (Termination.Failed), symmetric with
-  // the data-phase ERROR branch, even when a Cancel reaches the wire and the
-  // worker replies CancelResponse (cross-thread delivery). Without carrying the
-  // error onto the terminal, close() would return a bare Cancelled.
+  // Proto compliance on an init error: the engine MUST send Cancel after an init
+  // error and the worker replies CancelResponse (udf_message.proto). init()
+  // sends the Cancel -- from where requestObserver is published, not the response
+  // callback that may still see it null under reentrant delivery -- and drains
+  // the CancelResponse, so the terminal is Cancelled. The structured error is
+  // surfaced through init()'s exception, not the terminal.
   // ---------------------------------------------------------------------------
 
-  test("cross-thread InitResponse error: close carries Failed, not a bare Cancelled") {
+  test("cross-thread InitResponse error: engine sends Cancel, close returns Cancelled") {
     val service = new CapturingService(
       onRequest = (req, resp) => {
         if (req.hasControl && req.getControl.hasInit) {
@@ -818,35 +827,28 @@ class GrpcWorkerSessionConcurrencySuite
                     .setErrorClass("InitError").build()).build()).build()).build())
             .build())
         } else if (req.hasControl && req.getControl.hasCancel) {
-          // Defensive: reply CancelResponse if a Cancel ever arrives. With the
-          // init error settled as Failed BEFORE any Cancel is attempted, the
-          // terminal is already set, so sendCancelInternal suppresses the wire
-          // Cancel and this branch should not fire -- but were a regression to
-          // write the Cancel, this CancelResponse settling the terminal as a bare
-          // Cancelled is exactly what the Failed-before-Cancel ordering prevents.
           resp.onNext(UdfResponse.newBuilder().setControl(
             UdfControlResponse.newBuilder().setCancel(
               CancelResponse.getDefaultInstance).build()).build())
         }
       })
     // Cross-thread delivery: requestObserver is published before the InitResponse
-    // error arrives. Under the older "Cancel then let CancelResponse settle"
-    // design a Cancel would have reached the wire here and its CancelResponse
-    // would have overwritten the outcome with a bare Cancelled; the fix settles
-    // Failed first, so close() reports the init error either way.
+    // error arrives, so the Cancel reaches the wire and its CancelResponse settles
+    // the terminal Cancelled -- the proto terminator.
     val (_, channel) = startServer(service, directExecutor = false)
     val session = newSession(channel,
       initResponseTimeoutMs = NeverReachedTimeoutMs, terminalTimeoutMs = NeverReachedTimeoutMs)
-    intercept[GrpcWorkerSessionException](session.init(basicInit()))
+    val ex = intercept[GrpcWorkerSessionException](session.init(basicInit()))
+    assert(ex.executionError != null && ex.executionError.getUser.getErrorClass == "InitError",
+      s"init() must throw the structured error, got: ${ex.executionError}")
+
+    // Proto invariant: a Cancel was actually written to the worker on the init error.
+    assert(service.captured.asScala.exists(r => r.hasControl && r.getControl.hasCancel),
+      "the engine must send Cancel after an init error (udf_message.proto)")
 
     val termination = session.close(emptyCancel)
-    termination match {
-      case Termination.Failed(err) =>
-        assert(err.getUser.getErrorClass == "InitError",
-          s"the init error must be carried on the Termination, got: $err")
-      case other =>
-        fail(s"expected Termination.Failed carrying the init error, got: $other")
-    }
+    assert(termination.isInstanceOf[Termination.Cancelled],
+      s"expected the proto terminator Termination.Cancelled, got: $termination")
   }
 
   // ---------------------------------------------------------------------------

--- a/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
+++ b/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
@@ -1545,7 +1545,7 @@ class GrpcWorkerSessionConcurrencySuite
       override def next(): DataRequest = {
         inputNextEntered.countDown()
         neverReleaseInput.await()
-        throw new AssertionError("blocked input unexpectedly resumed")
+        throw new IllegalStateException("blocked input unexpectedly resumed")
       }
     }
     val thrown = new AtomicReference[Throwable]()

--- a/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
+++ b/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
@@ -942,4 +942,204 @@ class GrpcWorkerSessionConcurrencySuite
       "a throwing finish thunk must Cancel the stream so the worker is not stranded")
     session.close(emptyCancel)
   }
+
+  // ---------------------------------------------------------------------------
+  // close() concurrent with a blocked init(): close() settles the terminal, so
+  // init() must be woken and fail fast rather than park for initResponseTimeoutMs.
+  //
+  // Regression guard for onTerminalSettled waking initValue. The terminal here is
+  // settled by close() ITSELF (the terminalTimeoutMs path in doClose, because the
+  // worker ignores Cancel), NOT by the response callback -- so unlike every other
+  // terminator this path does not run handleControl's signalWithoutValue(). Only
+  // onTerminalSettled can wake the init() blocked on initValue; without it, init()
+  // stays parked until initResponseTimeoutMs.
+  // ---------------------------------------------------------------------------
+
+  test("close concurrent with blocked init: init is woken and fails fast") {
+    val initReceived = new CountDownLatch(1)
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        // Accept the Init stream but never reply -- init() blocks awaiting
+        // InitResponse. Ignore Cancel too, so the terminator never arrives from
+        // the worker and close() must settle the terminal on its own timeout.
+        if (req.hasControl && req.getControl.hasInit) {
+          initReceived.countDown()
+        }
+      })
+    val (_, channel) = startServer(service)
+    // Huge initResponseTimeoutMs: a regression that fails to wake init() on the
+    // close-settled terminal would park it here for 10 minutes, so finishing
+    // within the join below is the proof it was woken -- no wall-clock threshold.
+    // Small terminalTimeoutMs: close() gives up waiting for the (never-arriving)
+    // CancelResponse quickly and settles TransportFailed itself.
+    val session = newSession(channel,
+      initResponseTimeoutMs = NeverReachedTimeoutMs, terminalTimeoutMs = 1000L)
+
+    val thrown = new AtomicReference[Throwable]()
+    val initThread = new Thread(() => {
+      try session.init(basicInit()) catch { case t: Throwable => thrown.set(t) }
+    }, "blocked-init")
+    initThread.start()
+    assert(initReceived.await(5, TimeUnit.SECONDS),
+      "worker never received the Init request")
+
+    // close() from the test thread settles the terminal (TransportFailed, after
+    // terminalTimeoutMs of no CancelResponse), which must wake the parked init().
+    session.close(emptyCancel)
+    initThread.join(10000)
+    assert(!initThread.isAlive,
+      "init() parked on initResponseTimeoutMs; the close-settled terminal did not " +
+        "wake it (onTerminalSettled must signal initValue)")
+    val t = thrown.get()
+    assert(t != null, "init() must surface an init-failure exception")
+    assert(t.isInstanceOf[GrpcWorkerSessionException],
+      s"expected GrpcWorkerSessionException, got ${if (t == null) "null" else t.getClass.getName}")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Terminator-carried callback errors: a FinishResponse / CancelResponse may
+  // carry an error raised by the finish / cancel callback (udf_message.proto).
+  // The result iterator must surface it, and a prior data-phase ErrorResponse
+  // must take precedence over the terminator's own callback error
+  // (throwIfTerminalError / responseError).
+  // ---------------------------------------------------------------------------
+
+  test("FinishResponse carrying a callback error: iterator throws it") {
+    // Worker echoes the single batch, then finishes with a FinishResponse whose
+    // error field is set (a finish-callback failure). No data-phase ErrorResponse
+    // precedes it, so the terminator's own error is the one surfaced.
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        req.getRequestCase match {
+          case UdfRequest.RequestCase.CONTROL =>
+            val c = req.getControl
+            if (c.hasInit) {
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setInit(
+                  InitResponse.getDefaultInstance).build()).build())
+            } else if (c.hasFinish) {
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setFinish(
+                  FinishResponse.newBuilder().setError(
+                    ExecutionError.newBuilder().setUser(
+                      UserError.newBuilder().setMessage("finish callback boom")
+                        .setErrorClass("FinishCallbackError").build()).build())
+                    .build()).build()).build())
+            }
+          case UdfRequest.RequestCase.DATA =>
+            resp.onNext(UdfResponse.newBuilder()
+              .setData(DataResponse.newBuilder().setData(req.getData.getData).build())
+              .build())
+          case _ => ()
+        }
+      })
+    val (_, channel) = startServer(service, directExecutor = false)
+    val session = newSession(channel, terminalTimeoutMs = 5000L)
+    session.init(basicInit())
+
+    val it = session.process(echoIn("hello"), emptyFinish)
+    val ex = intercept[GrpcWorkerSessionException] { it.foreach(_ => ()) }
+    assert(ex.getMessage.contains("finish callback boom"),
+      s"the FinishResponse callback error must surface, got: ${ex.getMessage}")
+    assert(ex.executionError != null &&
+      ex.executionError.getUser.getErrorClass == "FinishCallbackError",
+      "the structured finish-callback error should be preserved")
+    session.close(emptyCancel)
+  }
+
+  test("data-phase ErrorResponse takes precedence over a CancelResponse callback error") {
+    // Worker replies to the first DataRequest with an ErrorResponse (data-phase
+    // failure), then -- per the protocol, the engine sends Cancel -- answers with
+    // a CancelResponse that ALSO carries a (cancel-callback) error. The iterator
+    // must surface the original data-phase error, not the terminator's, per
+    // responseError's precedence rule.
+    val erroredOnce = new AtomicBoolean(false)
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        req.getRequestCase match {
+          case UdfRequest.RequestCase.CONTROL =>
+            val c = req.getControl
+            if (c.hasInit) {
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setInit(
+                  InitResponse.getDefaultInstance).build()).build())
+            } else if (c.hasCancel) {
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setCancel(
+                  CancelResponse.newBuilder().setError(
+                    ExecutionError.newBuilder().setUser(
+                      UserError.newBuilder().setMessage("cancel callback boom")
+                        .setErrorClass("CancelCallbackError").build()).build())
+                    .build()).build()).build())
+            }
+          case UdfRequest.RequestCase.DATA =>
+            if (erroredOnce.compareAndSet(false, true)) {
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setError(
+                  ErrorResponse.newBuilder().setError(
+                    ExecutionError.newBuilder().setUser(
+                      UserError.newBuilder().setMessage("data-phase boom")
+                        .setErrorClass("DataPhaseError").build()).build()).build())
+                  .build()).build())
+            }
+          case _ => ()
+        }
+      })
+    val (_, channel) = startServer(service, directExecutor = false)
+    val session = newSession(channel, terminalTimeoutMs = 5000L)
+    session.init(basicInit())
+
+    val it = session.process(echoIn("a", "b", "c"), emptyFinish)
+    val ex = intercept[GrpcWorkerSessionException] { it.foreach(_ => ()) }
+    assert(ex.getMessage.contains("data-phase boom"),
+      s"the prior data-phase error must take precedence, got: ${ex.getMessage}")
+    assert(ex.executionError != null &&
+      ex.executionError.getUser.getErrorClass == "DataPhaseError",
+      s"expected the data-phase error to be preserved, got: ${ex.executionError}")
+    session.close(emptyCancel)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Data-phase output timeout: after Finish, if the worker goes silent without a
+  // terminator, advance()'s per-poll wait (terminalTimeoutMs) must expire and the
+  // iterator must surface a TransportFailed rather than block forever.
+  // ---------------------------------------------------------------------------
+
+  test("data-phase output timeout: silent worker after Finish surfaces a timeout") {
+    // Worker accepts Init and echoes data, but never sends a terminator and
+    // ignores Finish/Cancel -- so once input is exhausted the iterator's output
+    // poll has nothing to drain and must time out on terminalTimeoutMs.
+    val service = new CapturingService(
+      onRequest = (req, resp) => {
+        req.getRequestCase match {
+          case UdfRequest.RequestCase.CONTROL =>
+            val c = req.getControl
+            if (c.hasInit) {
+              resp.onNext(UdfResponse.newBuilder().setControl(
+                UdfControlResponse.newBuilder().setInit(
+                  InitResponse.getDefaultInstance).build()).build())
+            }
+          // Finish and Cancel ignored: no terminator ever arrives.
+          case UdfRequest.RequestCase.DATA =>
+            resp.onNext(UdfResponse.newBuilder()
+              .setData(DataResponse.newBuilder().setData(req.getData.getData).build())
+              .build())
+          case _ => ()
+        }
+      })
+    val (_, channel) = startServer(service, directExecutor = false)
+    // Small terminalTimeoutMs: the poll gives up quickly; assertFinishesWithin
+    // guards against a regression that blocks the iterator indefinitely.
+    val session = newSession(channel, terminalTimeoutMs = 1000L)
+    session.init(basicInit())
+
+    val it = session.process(echoIn("hello"), emptyFinish)
+    assertFinishesWithin(10000, "output-timeout") {
+      val ex = intercept[GrpcWorkerSessionException] { it.foreach(_ => ()) }
+      assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("timed out") ||
+        ex.getMessage.toLowerCase(Locale.ROOT).contains("stream failed"),
+        s"expected a timeout/transport-failure message, got: ${ex.getMessage}")
+    }
+    session.close(emptyCancel)
+  }
 }

--- a/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
+++ b/udf/worker/grpc/src/test/scala/org/apache/spark/udf/worker/grpc/GrpcWorkerSessionConcurrencySuite.scala
@@ -257,7 +257,7 @@ class GrpcWorkerSessionConcurrencySuite
   // Cancel-never-precedes-Init invariant.
   //
   // The former cancel()-vs-init() race test was retired when cancel() folded
-  // into close(): close() transitions the session to Closed and blocks init(),
+  // into close(): close() settles a terminal and blocks init(),
   // so a Cancel-before-Init race is no longer reachable through the public API
   // (close() almost always wins and aborts init() before any control is sent,
   // making such a race test vacuous). The invariant is now structural --


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds `GrpcWorkerSession`, the engine-side `WorkerSession` implementation that drives one bidirectional gRPC `Execute` stream per UDF execution. It is the first concrete protocol implementation on top of the abstractions already in `master` (the `WorkerSession` `SessionState` machine, `Termination`, `WorkerHandle`, and the `udf_message.proto` / `udf_service.proto` split).

It is deliberately **scoped to the session driver and its in-process tests**, split out of the larger gRPC-backend change (#55683) so the concurrency-heavy core can be reviewed in isolation. The UDS transport, channel, and dispatcher follow in a second PR.

Added:

- **`GrpcWorkerSession`** (`udf/worker/grpc`) — drives the `Init -> DataRequest* -> Finish | Cancel` / `InitResponse -> DataResponse* -> terminator` exchange. Design highlights:
  - **No shadow state machine** — it advances the single `SessionState` owned by the base `WorkerSession` along the protocol-event edges; the only out-of-band flag is `cancelRequested` (a cancel can be requested before the stream exists).
  - **Consumption-driven (Volcano pull)** — the thread consuming the result iterator sends the next input batch; the gRPC callback thread only receives.
  - **All wire writes serialized under one `requestLock`**, with `cancelRequested` enforcing the proto invariant "no `Data`/`Finish` after `Cancel`".
  - **Every wait is timeout-bounded**; the post-`Finish` terminal wait is *per-poll* (reset by each worker event), so the contract is "emit an event every `terminalTimeoutMs`", not "finish within it".
  - `GrpcWorkerSessionException` extends `RuntimeException` (not `SparkRuntimeException`) so the `udf-worker` modules stay free of a `spark-core` dependency; the engine integration layer wraps it.
- **`GrpcWorkerSessionConcurrencySuite`** — in-process tests pinning the wire-ordering and fast-fail invariants.
- **`grpc/pom.xml`** — adds the `spark-udf-worker-core` module dependency (the session needs `core`; the module previously depended only on `udf-worker-proto`).

Class relationship: `GrpcWorkerSession` depends only on a raw `io.grpc.ManagedChannel`, not on any transport/channel class — which is what lets it (and its tests) stand alone here, with the channel/dispatcher wiring landing in the follow-up.


### Why are the changes needed?

The UDF worker protocol defines a language-agnostic execution surface but, prior to this work, had no engine-side driver to run it. `GrpcWorkerSession` is that driver — the piece that turns the protocol abstractions into an actual UDF execution over gRPC bidirectional streaming. Landing it separately from the transport and dispatcher keeps the most correctness-sensitive component (the concurrent stream/state-machine interaction) small and independently testable.

### Does this PR introduce _any_ user-facing change?

No. `udf/worker` is `@Experimental` and not wired into any Spark execution path; there are no production callers yet.

### How was this patch tested?

- New **`GrpcWorkerSessionConcurrencySuite`** (in-process gRPC via `InProcessServerBuilder`/`InProcessChannelBuilder`; no UDS, no subprocess) pins the invariants: a worker-emitted `ErrorResponse` / `FinishResponse` / `CancelResponse` / stream half-close / malformed (`RESPONSE_NOT_SET`) response before `InitResponse` all fail `init()` fast rather than hanging on the init timeout; repeated `hasNext` after exhaustion returns immediately; `close()` concurrent with `process()` settles cleanly. The fast-fail and data-phase paths are re-run under cross-thread (non-`directExecutor`) delivery so correctness does not silently depend on reentrant delivery.
- The existing **`EchoProtocolSuite`** continues to exercise the full wire protocol end-to-end against an in-process echo worker.
- Verified locally: `build/sbt "udf-worker-grpc/testOnly *GrpcWorkerSessionConcurrencySuite *EchoProtocolSuite"` — 2 suites, **33 tests, 0 failures**.

### Was this patch authored or co-authored using generative AI tooling?

Yes