### PR TITLE
[SPARK-57636][SQL] Support REPLACE USING with row-level DSv2 writes

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3223,6 +3223,18 @@
     ],
     "sqlState" : "0A000"
   },
+  "INSERT_REPLACE_USING_DUPLICATE_SCOPE_COLUMN" : {
+    "message" : [
+      "INSERT INTO ... REPLACE USING references the scope column <columnName> more than once. Each scope column must be listed at most once."
+    ],
+    "sqlState" : "42701"
+  },
+  "INSERT_REPLACE_USING_NON_DETERMINISTIC_SOURCE" : {
+    "message" : [
+      "INSERT INTO ... REPLACE USING requires a deterministic source query because the source determines both which target rows are deleted and which rows are inserted. Remove non-deterministic expressions (e.g. rand()) from the source."
+    ],
+    "sqlState" : "42K0E"
+  },
   "INSERT_REPLACE_USING_NOT_ENABLED" : {
     "message" : [
       "INSERT INTO ... REPLACE USING is not enabled. Set 'spark.sql.insertIntoReplaceUsing.enabled' to true to enable it."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3229,11 +3229,11 @@
     ],
     "sqlState" : "42701"
   },
-  "INSERT_REPLACE_USING_NON_DETERMINISTIC_SOURCE" : {
+  "INSERT_REPLACE_USING_NON_DETERMINISTIC_SOURCE_QUERY_NOT_SUPPORTED" : {
     "message" : [
-      "INSERT INTO ... REPLACE USING requires a deterministic source query because the source determines both which target rows are deleted and which rows are inserted. Remove non-deterministic expressions (e.g. rand()) from the source."
+      "INSERT INTO ... REPLACE USING does not support a non-deterministic source query. The source determines both which target rows are deleted and which rows are inserted, so it must be deterministic."
     ],
-    "sqlState" : "42K0E"
+    "sqlState" : "0A000"
   },
   "INSERT_REPLACE_USING_NOT_ENABLED" : {
     "message" : [

--- a/docs/sql-v2-data-sources.md
+++ b/docs/sql-v2-data-sources.md
@@ -216,6 +216,10 @@ A `Table` gains read and write abilities by implementing mix-in interfaces:
   batch or streaming writes. See [Write Path](#write-path).
 - **`SupportsRowLevelOperations`** enables `DELETE`, `UPDATE`, and `MERGE INTO` through
   a read-and-rewrite cycle. See [Row-Level DML](#row-level-dml).
+- **`SupportsRowLevelReplace`** additionally enables `INSERT INTO ... REPLACE USING (cols)`,
+  which lowers to `RowLevelOperation.Command.REPLACE`. A table must implement this in addition to
+  `SupportsRowLevelOperations`; otherwise `INSERT INTO ... REPLACE` is rejected during analysis and
+  the `REPLACE` command is never passed to the row-level operation builder.
 
 Additional mix-ins enable further capabilities:
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsRowLevelOperations.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsRowLevelOperations.java
@@ -24,7 +24,7 @@ import org.apache.spark.sql.connector.write.RowLevelOperationInfo;
 
 /**
  * A mix-in interface for {@link Table} row-level operations support. Data sources can implement
- * this interface to indicate they support rewriting data for DELETE, UPDATE, MERGE operations.
+ * this interface to indicate they support rewriting data for row-level operations.
  *
  * @since 3.3.0
  */
@@ -32,8 +32,7 @@ import org.apache.spark.sql.connector.write.RowLevelOperationInfo;
 public interface SupportsRowLevelOperations extends Table {
   /**
    * Returns a {@link RowLevelOperationBuilder} to build a {@link RowLevelOperation}.
-   * Spark will call this method while planning DELETE, UPDATE and MERGE operations
-   * that require rewriting data.
+   * Spark will call this method while planning row-level operations that require rewriting data.
    *
    * @param info the row-level operation info such as command (e.g. DELETE) and options
    * @return the row-level operation builder

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsRowLevelReplace.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsRowLevelReplace.java
@@ -32,7 +32,7 @@ import org.apache.spark.sql.connector.write.RowLevelOperation;
  * expect {@code DELETE}, {@code UPDATE}, or {@code MERGE} are never asked to build a
  * {@code REPLACE} operation.
  *
- * @since 4.2.0
+ * @since 4.3.0
  */
 @Experimental
 public interface SupportsRowLevelReplace extends SupportsRowLevelOperations {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsRowLevelReplace.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsRowLevelReplace.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog;
+
+import org.apache.spark.annotation.Experimental;
+import org.apache.spark.sql.connector.write.RowLevelOperation;
+
+/**
+ * A mix-in interface for {@link SupportsRowLevelOperations} that signals a table can handle the
+ * {@link RowLevelOperation.Command#REPLACE} command.
+ * <p>
+ * Spark dispatches {@code INSERT INTO ... REPLACE USING (cols)} through this command.
+ * {@link RowLevelOperation.Command#REPLACE} is dispatched to a connector's
+ * {@link SupportsRowLevelOperations#newRowLevelOperationBuilder} only when the table implements
+ * this interface. Tables that support row-level operations but do not implement this interface
+ * will have {@code INSERT INTO ... REPLACE} rejected during analysis, so connectors that only
+ * expect {@code DELETE}, {@code UPDATE}, or {@code MERGE} are never asked to build a
+ * {@code REPLACE} operation.
+ *
+ * @since 4.2.0
+ */
+@Experimental
+public interface SupportsRowLevelReplace extends SupportsRowLevelOperations {
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/ReplaceSummary.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/ReplaceSummary.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.write;
+
+import org.apache.spark.annotation.Evolving;
+
+/**
+ * Provides an informational summary of the REPLACE operation producing write.
+ *
+ * @since 4.2.0
+ */
+@Evolving
+public interface ReplaceSummary extends WriteSummary {
+
+  /**
+   * Returns the number of source rows appended by the replace, including rows that share a scope
+   * tuple, or -1 if not found.
+   */
+  long numInsertedRows();
+
+  /**
+   * Returns the number of target rows removed because their scope tuple matched the source,
+   * or -1 if not found.
+   */
+  long numDeletedRows();
+
+  /**
+   * Returns the number of target rows physically re-emitted by copy-on-write replacement, or -1 if
+   * not found. This is 0 for merge-on-read row-level replacement, and it is not the number of
+   * logical target rows left unaffected by the replace.
+   */
+  long numCopiedRows();
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/ReplaceSummary.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/ReplaceSummary.java
@@ -22,7 +22,7 @@ import org.apache.spark.annotation.Evolving;
 /**
  * Provides an informational summary of the REPLACE operation producing write.
  *
- * @since 4.2.0
+ * @since 4.3.0
  */
 @Evolving
 public interface ReplaceSummary extends WriteSummary {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RowLevelOperation.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RowLevelOperation.java
@@ -25,8 +25,8 @@ import org.apache.spark.sql.connector.read.SupportsRuntimeV2Filtering;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 /**
- * A logical representation of a data source DELETE, UPDATE, or MERGE operation that requires
- * rewriting data.
+ * A logical representation of a data source DELETE, UPDATE, MERGE, or REPLACE operation that
+ * requires rewriting data.
  *
  * @since 3.3.0
  */
@@ -39,7 +39,7 @@ public interface RowLevelOperation {
    * @since 3.3.0
    */
   enum Command {
-    DELETE, UPDATE, MERGE
+    DELETE, UPDATE, MERGE, REPLACE
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1348,12 +1348,12 @@ class Analyzer(
             i.query.resolved &&
             i.replaceCriteriaOpt.exists(_.isInstanceOf[InsertReplaceUsing]) =>
         val r = i.table.asInstanceOf[DataSourceV2Relation]
-        val scopeColumns = i.replaceCriteriaOpt.get.asInstanceOf[InsertReplaceUsing].cols
+        val replaceUsingCols = i.replaceCriteriaOpt.get.asInstanceOf[InsertReplaceUsing].cols
         // Align the source to the target with standard INSERT resolution so RewriteReplaceUsing can
         // compare scope columns and build the insert payload positionally by ordinal.
         val alignedQuery = TableOutputResolver.resolveOutputColumns(
           r.table.name, r.output, i.query, byName = i.byName, conf)
-        ReplaceUsingTable(r, scopeColumns, alignedQuery)
+        ReplaceUsingTable(r, replaceUsingCols, alignedQuery)
 
       case i: InsertIntoStatement
           if i.table.isInstanceOf[DataSourceV2Relation] &&

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -631,6 +631,7 @@ class Analyzer(
       RewriteDeleteFromTable ::
       RewriteUpdateTable ::
       RewriteMergeIntoTable ::
+      RewriteReplaceUsing ::
       MoveParameterizedQueriesDown ::
       BindParameters ::
       typeCoercionRules() ++
@@ -1345,7 +1346,21 @@ class Analyzer(
       case i: InsertIntoStatement
           if i.table.isInstanceOf[DataSourceV2Relation] &&
             i.query.resolved &&
+            i.replaceCriteriaOpt.exists(_.isInstanceOf[InsertReplaceUsing]) =>
+        val r = i.table.asInstanceOf[DataSourceV2Relation]
+        val scopeColumns = i.replaceCriteriaOpt.get.asInstanceOf[InsertReplaceUsing].cols
+        // Align the source to the target with standard INSERT resolution so RewriteReplaceUsing can
+        // compare scope columns and build the insert payload positionally by ordinal.
+        val alignedQuery = TableOutputResolver.resolveOutputColumns(
+          r.table.name, r.output, i.query, byName = i.byName, conf)
+        ReplaceUsingTable(r, scopeColumns, alignedQuery)
+
+      case i: InsertIntoStatement
+          if i.table.isInstanceOf[DataSourceV2Relation] &&
+            i.query.resolved &&
             i.replaceCriteriaOpt.isDefined =>
+        // REPLACE USING has a scope-based row-level rewrite path. REPLACE ON remains unsupported
+        // for DSv2 tables.
         throw QueryCompilationErrors.unsupportedInsertReplaceOnOrUsing(
           i.table.asInstanceOf[DataSourceV2Relation].table.name())
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1358,9 +1358,8 @@ class Analyzer(
       case i: InsertIntoStatement
           if i.table.isInstanceOf[DataSourceV2Relation] &&
             i.query.resolved &&
-            i.replaceCriteriaOpt.isDefined =>
-        // REPLACE USING has a scope-based row-level rewrite path. REPLACE ON remains unsupported
-        // for DSv2 tables.
+            i.replaceCriteriaOpt.exists(_.isInstanceOf[InsertReplaceOn]) =>
+        // INSERT REPLACE ON remains unsupported for DSv2 tables.
         throw QueryCompilationErrors.unsupportedInsertReplaceOnOrUsing(
           i.table.asInstanceOf[DataSourceV2Relation].table.name())
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteReplaceUsing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteReplaceUsing.scala
@@ -160,7 +160,9 @@ object RewriteReplaceUsing extends RewriteRowLevelCommand {
 
     // Every source row is inserted; row IDs and metadata are null for new rows.
     val relationValueByExprId =
-      relation.output.zipWithIndex.map { case (attr, i) => attr.exprId -> insertRef.output(i) }.toMap
+      relation.output.zipWithIndex.map {
+        case (attr, i) => attr.exprId -> insertRef.output(i)
+      }.toMap
     val insertAssignments = rowPart.map { attr =>
       val value = relationValueByExprId.getOrElse(attr.exprId, Literal(null, attr.dataType))
       Assignment(attr, value)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteReplaceUsing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteReplaceUsing.scala
@@ -50,7 +50,7 @@ object RewriteReplaceUsing extends RewriteRowLevelCommand {
       // Evaluating a non-deterministic source in those independent plan locations could produce
       // mutually inconsistent results.
       if (!source.deterministic) {
-        throw QueryCompilationErrors.insertReplaceUsingNonDeterministicSource()
+        throw QueryCompilationErrors.insertReplaceUsingNonDeterministicSourceQueryNotSupported()
       }
 
       val (rel, operationTable) = buildReplaceOperationTable(aliasedTable)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteReplaceUsing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteReplaceUsing.scala
@@ -22,9 +22,7 @@ import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi}
 import org.apache.spark.sql.catalyst.plans.logical.{Assignment, CTERelationDef, CTERelationRef, Filter, Join, JoinHint, LogicalPlan, Project, ReplaceData, ReplaceUsingTable, Union, WithCTE, WriteDelta}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils.{COPY_OPERATION, INSERT_OPERATION, OPERATION_COLUMN}
-import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
 import org.apache.spark.sql.connector.write.{RowLevelOperationTable, SupportsDelta}
-import org.apache.spark.sql.connector.write.RowLevelOperation.Command.REPLACE
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.IntegerType
@@ -55,25 +53,13 @@ object RewriteReplaceUsing extends RewriteRowLevelCommand {
         throw QueryCompilationErrors.insertReplaceUsingNonDeterministicSource()
       }
 
-      EliminateSubqueryAliases(aliasedTable) match {
-        case rel: DataSourceV2Relation =>
-          rel.table match {
-            case tbl: SupportsRowLevelOperations =>
-              val operationTable = buildOperationTable(tbl, REPLACE, rel.options)
-              val scopeOrdinals = resolveScopeOrdinals(rel, scopeColumns)
-              operationTable.operation match {
-                case _: SupportsDelta =>
-                  buildWriteDeltaPlan(rel, operationTable, scopeOrdinals, source)
-                case _ =>
-                  buildReplaceDataPlan(rel, operationTable, scopeOrdinals, source)
-              }
-            case _ =>
-              throw QueryCompilationErrors.unsupportedInsertReplaceOnOrUsing(rel.table.name())
-          }
-
-        case other =>
-          throw QueryCompilationErrors.unsupportedInsertReplaceOnOrUsing(
-            other.simpleString(maxFields = 2))
+      val (rel, operationTable) = buildReplaceOperationTable(aliasedTable)
+      val scopeOrdinals = resolveScopeOrdinals(rel, scopeColumns)
+      operationTable.operation match {
+        case _: SupportsDelta =>
+          buildWriteDeltaPlan(rel, operationTable, scopeOrdinals, source)
+        case _ =>
+          buildReplaceDataPlan(rel, operationTable, scopeOrdinals, source)
       }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteReplaceUsing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteReplaceUsing.scala
@@ -85,15 +85,7 @@ object RewriteReplaceUsing extends RewriteRowLevelCommand {
     val carryoverJoin = Join(readRelation, scopeRef, LeftAnti, Some(antiJoinCond), JoinHint.NONE)
     val carryover = addOperationColumn(COPY_OPERATION, carryoverJoin)
 
-    // All source rows are inserted. Carryover supplies target metadata; insert rows null it out.
-    val insertData = rowAttrs.indices.map { i =>
-      Alias(insertRef.output(i), rowAttrs(i).name)()
-    }
-    val insertMetadata = metadataAttrs.map(attr => Alias(Literal(null, attr.dataType), attr.name)())
-    val insertOutput = operationAlias(INSERT_OPERATION) +: (insertData ++ insertMetadata)
-    val inserts = Project(insertOutput, insertRef)
-
-    val replacementQuery = Union(carryover :: inserts :: Nil)
+    val replacementQuery = buildReplacementQuery(carryover, insertRef, rowAttrs, metadataAttrs)
     val projections = buildReplaceDataProjections(replacementQuery, rowAttrs, metadataAttrs)
 
     val groupFilterCond = if (groupFilterEnabled) {
@@ -110,6 +102,22 @@ object RewriteReplaceUsing extends RewriteRowLevelCommand {
       ReplaceData(writeRelation, TrueLiteral, replacementQuery, relation, projections,
         groupFilterCond)
     WithCTE(replaceData, sourceCte :: Nil)
+  }
+
+  // The COW replacement is the carryover (retained target rows) unioned with every source row
+  // re-emitted as an insert. Insert rows have no target metadata, so metadata columns are nulled.
+  private def buildReplacementQuery(
+      carryover: LogicalPlan,
+      insertRef: CTERelationRef,
+      rowAttrs: Seq[Attribute],
+      metadataAttrs: Seq[Attribute]): LogicalPlan = {
+    val insertData = rowAttrs.indices.map { i =>
+      Alias(insertRef.output(i), rowAttrs(i).name)()
+    }
+    val insertMetadata = metadataAttrs.map(attr => Alias(Literal(null, attr.dataType), attr.name)())
+    val insertOutput = operationAlias(INSERT_OPERATION) +: (insertData ++ insertMetadata)
+    val inserts = Project(insertOutput, insertRef)
+    Union(carryover :: inserts :: Nil)
   }
 
   // Build a merge-on-read delta from matched-row deletes and inserted source rows.
@@ -212,8 +220,8 @@ object RewriteReplaceUsing extends RewriteRowLevelCommand {
   }
 
   private def scopeEquality(
-      targetOutput: Seq[Attribute],
-      sourceOutput: Seq[Attribute],
+      targetOutput: Seq[Expression],
+      sourceOutput: Seq[Expression],
       scopeOrdinals: Seq[Int]): Expression = {
     scopeOrdinals
       .map(ordinal => EqualNullSafe(targetOutput(ordinal), sourceOutput(ordinal)): Expression)
@@ -225,12 +233,10 @@ object RewriteReplaceUsing extends RewriteRowLevelCommand {
       relation: DataSourceV2Relation,
       sourceRef: CTERelationRef,
       scopeOrdinals: Seq[Int]): Expression = {
-    val cond = scopeOrdinals
-      .map { ordinal =>
-        EqualNullSafe(OuterReference(relation.output(ordinal)), sourceRef.output(ordinal))
-          : Expression
-      }
-      .reduce(And)
+    // scopeEquality indexes both sides by scope ordinal, so the target must be the full row
+    // output (outer-referenced), not only the scope columns.
+    val outerTarget = relation.output.map(attr => OuterReference(attr))
+    val cond = scopeEquality(outerTarget, sourceRef.output, scopeOrdinals)
     val outerRefs = scopeOrdinals.map(ordinal => relation.output(ordinal))
     Exists(Filter(cond, sourceRef), outerRefs)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteReplaceUsing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteReplaceUsing.scala
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, EqualNullSafe, Exists, Expression, Literal, MetadataAttribute, NamedExpression, OuterReference}
+import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
+import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi}
+import org.apache.spark.sql.catalyst.plans.logical.{Assignment, CTERelationDef, CTERelationRef, Filter, Join, JoinHint, LogicalPlan, Project, ReplaceData, ReplaceUsingTable, Union, WithCTE, WriteDelta}
+import org.apache.spark.sql.catalyst.util.RowDeltaUtils.{COPY_OPERATION, INSERT_OPERATION, OPERATION_COLUMN}
+import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
+import org.apache.spark.sql.connector.write.{RowLevelOperationTable, SupportsDelta}
+import org.apache.spark.sql.connector.write.RowLevelOperation.Command.REPLACE
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.types.IntegerType
+
+/**
+ * Rewrites `INSERT INTO ... REPLACE USING (cols) <query>` (a [[ReplaceUsingTable]]) onto the
+ * row-level write machinery via a [[RowLevelOperation.Command.REPLACE]] operation.
+ *
+ * Scoped replace deletes every target row whose scope-column tuple appears in the source and
+ * appends all source rows, including duplicates that share a scope tuple. The replacement state
+ * is computed from independent target and source branches so that source rows are inserted
+ * regardless of whether their scope tuple already exists in the target.
+ *
+ * The source is shared through a CTE so the delete/carryover join, the insert branch, and the
+ * runtime group filter all refer to the same analyzed source plan. A non-deterministic source is
+ * rejected because it could otherwise delete based on a different source result than it inserts.
+ */
+object RewriteReplaceUsing extends RewriteRowLevelCommand {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
+    case r @ ReplaceUsingTable(aliasedTable, scopeColumns, source)
+        if r.resolved && source.resolved =>
+
+      // The source feeds the delete decision, insert payload, and runtime group filter.
+      // Evaluating a non-deterministic source in those independent plan locations could produce
+      // mutually inconsistent results.
+      if (!source.deterministic) {
+        throw QueryCompilationErrors.insertReplaceUsingNonDeterministicSource()
+      }
+
+      EliminateSubqueryAliases(aliasedTable) match {
+        case rel: DataSourceV2Relation =>
+          rel.table match {
+            case tbl: SupportsRowLevelOperations =>
+              val operationTable = buildOperationTable(tbl, REPLACE, rel.options)
+              val scopeOrdinals = resolveScopeOrdinals(rel, scopeColumns)
+              operationTable.operation match {
+                case _: SupportsDelta =>
+                  buildWriteDeltaPlan(rel, operationTable, scopeOrdinals, source)
+                case _ =>
+                  buildReplaceDataPlan(rel, operationTable, scopeOrdinals, source)
+              }
+            case _ =>
+              throw QueryCompilationErrors.unsupportedInsertReplaceOnOrUsing(rel.table.name())
+          }
+
+        case other =>
+          throw QueryCompilationErrors.unsupportedInsertReplaceOnOrUsing(
+            other.simpleString(maxFields = 2))
+      }
+  }
+
+  // Build a copy-on-write replacement from retained target rows and inserted source rows.
+  private def buildReplaceDataPlan(
+      relation: DataSourceV2Relation,
+      operationTable: RowLevelOperationTable,
+      scopeOrdinals: Seq[Int],
+      source: LogicalPlan): LogicalPlan = {
+
+    val rowAttrs = relation.output
+    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
+    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+
+    val sourceCte = CTERelationDef(source)
+    val scopeRef = newSourceRef(sourceCte)
+    val insertRef = newSourceRef(sourceCte)
+    val filterRef = newSourceRef(sourceCte)
+
+    // COW rewrites whole groups, so target rows whose scope tuple is absent from the source must
+    // be re-emitted as COPY to preserve them (and their metadata).
+    val antiJoinCond = scopeEquality(readRelation.output, scopeRef.output, scopeOrdinals)
+    val carryoverJoin = Join(readRelation, scopeRef, LeftAnti, Some(antiJoinCond), JoinHint.NONE)
+    val carryover = addOperationColumn(COPY_OPERATION, carryoverJoin)
+
+    // All source rows are inserted. Carryover supplies target metadata; insert rows null it out.
+    val insertData = rowAttrs.indices.map { i =>
+      Alias(insertRef.output(i), rowAttrs(i).name)()
+    }
+    val insertMetadata = metadataAttrs.map(attr => Alias(Literal(null, attr.dataType), attr.name)())
+    val insertOutput = operationAlias(INSERT_OPERATION) +: (insertData ++ insertMetadata)
+    val inserts = Project(insertOutput, insertRef)
+
+    val replacementQuery = Union(carryover :: inserts :: Nil)
+    val projections = buildReplaceDataProjections(replacementQuery, rowAttrs, metadataAttrs)
+
+    val groupFilterCond = if (groupFilterEnabled) {
+      Some(scopeExists(relation, filterRef, scopeOrdinals))
+    } else {
+      None
+    }
+
+    // The replaced scope is source-defined, so there is no static target-only predicate to push
+    // down during planning. File pruning flows through groupFilterCond, which
+    // RowLevelOperationRuntimeGroupFiltering turns into a dynamic subquery.
+    val writeRelation = relation.copy(table = operationTable)
+    val replaceData =
+      ReplaceData(writeRelation, TrueLiteral, replacementQuery, relation, projections,
+        groupFilterCond)
+    WithCTE(replaceData, sourceCte :: Nil)
+  }
+
+  // Build a merge-on-read delta from matched-row deletes and inserted source rows.
+  private def buildWriteDeltaPlan(
+      relation: DataSourceV2Relation,
+      operationTable: RowLevelOperationTable,
+      scopeOrdinals: Seq[Int],
+      source: LogicalPlan): LogicalPlan = {
+
+    val operation = operationTable.operation.asInstanceOf[SupportsDelta]
+    val rowAttrs = relation.output
+    val rowIdAttrs = resolveRowIdAttrs(relation, operation)
+    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operation)
+    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs, rowIdAttrs)
+
+    // Keep row columns before metadata columns, matching the schema shape expected by
+    // buildWriteDeltaProjections. Row ID attributes are metadata-classified and land in metaPart.
+    val (metaPart, rowPart) = readRelation.output.partition { attr =>
+      MetadataAttribute.isValid(attr.metadata)
+    }
+    val branchNames = OPERATION_COLUMN +: (rowPart ++ metaPart).map(_.name)
+
+    val sourceCte = CTERelationDef(source)
+    val scopeRef = newSourceRef(sourceCte)
+    val insertRef = newSourceRef(sourceCte)
+    val filterRef = newSourceRef(sourceCte)
+
+    // Matched target rows are encoded as deletes: row ID and metadata are retained, row columns
+    // are nulled out.
+    val semiJoinCond = scopeEquality(readRelation.output, scopeRef.output, scopeOrdinals)
+    val matchingRows = Join(readRelation, scopeRef, LeftSemi, Some(semiJoinCond), JoinHint.NONE)
+    val deleteOutput = deltaDeleteOutput(rowPart, rowIdAttrs, metaPart)
+    val deletes = Project(named(deleteOutput, branchNames), matchingRows)
+
+    // Every source row is inserted; row IDs and metadata are null for new rows.
+    val relationValueByExprId =
+      relation.output.zipWithIndex.map { case (attr, i) => attr.exprId -> insertRef.output(i) }.toMap
+    val insertAssignments = rowPart.map { attr =>
+      val value = relationValueByExprId.getOrElse(attr.exprId, Literal(null, attr.dataType))
+      Assignment(attr, value)
+    }
+    val insertOutput = deltaInsertOutput(insertAssignments, metaPart)
+    val inserts = Project(named(insertOutput, branchNames), insertRef)
+
+    val deltaQuery = Union(deletes :: inserts :: Nil)
+    val projections = buildWriteDeltaProjections(deltaQuery, rowAttrs, rowIdAttrs, metadataAttrs)
+
+    val groupFilterCond = if (groupFilterEnabled) {
+      Some(scopeExists(relation, filterRef, scopeOrdinals))
+    } else {
+      None
+    }
+
+    val writeRelation = relation.copy(table = operationTable)
+    val writeDelta =
+      WriteDelta(writeRelation, TrueLiteral, deltaQuery, relation, projections, groupFilterCond)
+    WithCTE(writeDelta, sourceCte :: Nil)
+  }
+
+  private def operationAlias(operation: Int): NamedExpression = {
+    Alias(Literal(operation, IntegerType), OPERATION_COLUMN)()
+  }
+
+  private def named(exprs: Seq[Expression], names: Seq[String]): Seq[NamedExpression] = {
+    exprs.zip(names).map {
+      case (ne: NamedExpression, name) if ne.name == name => ne
+      case (e, name) => Alias(e, name)()
+    }
+  }
+
+  private def resolveScopeOrdinals(
+      relation: DataSourceV2Relation,
+      scopeColumns: Seq[String]): Seq[Int] = {
+
+    val seen = scala.collection.mutable.HashSet.empty[Int]
+    scopeColumns.map { name =>
+      val resolved = relation.resolve(Seq(name), conf.resolver).getOrElse {
+        throw QueryCompilationErrors.unresolvedColumnError(name, relation.output.map(_.name))
+      }
+      val ordinal = relation.output.indexWhere(_.exprId == resolved.toAttribute.exprId)
+      if (ordinal < 0) {
+        throw QueryCompilationErrors.unresolvedColumnError(name, relation.output.map(_.name))
+      }
+      if (!seen.add(ordinal)) {
+        throw QueryCompilationErrors.insertReplaceUsingDuplicateScopeColumn(name)
+      }
+      ordinal
+    }
+  }
+
+  private def newSourceRef(sourceDef: CTERelationDef): CTERelationRef = {
+    val ref = CTERelationRef(
+      sourceDef.id,
+      _resolved = true,
+      sourceDef.child.output,
+      sourceDef.child.isStreaming)
+    ref.newInstance().asInstanceOf[CTERelationRef]
+  }
+
+  private def scopeEquality(
+      targetOutput: Seq[Attribute],
+      sourceOutput: Seq[Attribute],
+      scopeOrdinals: Seq[Int]): Expression = {
+    scopeOrdinals
+      .map(ordinal => EqualNullSafe(targetOutput(ordinal), sourceOutput(ordinal)): Expression)
+      .reduce(And)
+  }
+
+  // A correlated EXISTS over the source on scope equality, used as the runtime group filter.
+  private def scopeExists(
+      relation: DataSourceV2Relation,
+      sourceRef: CTERelationRef,
+      scopeOrdinals: Seq[Int]): Expression = {
+    val cond = scopeOrdinals
+      .map { ordinal =>
+        EqualNullSafe(OuterReference(relation.output(ordinal)), sourceRef.output(ordinal))
+          : Expression
+      }
+      .reduce(And)
+    val outerRefs = scopeOrdinals.map(ordinal => relation.output(ordinal))
+    Exists(Filter(cond, sourceRef), outerRefs)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteReplaceUsing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteReplaceUsing.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.types.IntegerType
 object RewriteReplaceUsing extends RewriteRowLevelCommand {
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
-    case r @ ReplaceUsingTable(aliasedTable, scopeColumns, source)
+    case r @ ReplaceUsingTable(aliasedTable, replaceUsingCols, source)
         if r.resolved && source.resolved =>
 
       // The source feeds the delete decision, insert payload, and runtime group filter.
@@ -54,7 +54,7 @@ object RewriteReplaceUsing extends RewriteRowLevelCommand {
       }
 
       val (rel, operationTable) = buildReplaceOperationTable(aliasedTable)
-      val scopeOrdinals = resolveScopeOrdinals(rel, scopeColumns)
+      val scopeOrdinals = resolveScopeOrdinals(rel, replaceUsingCols)
       operationTable.operation match {
         case _: SupportsDelta =>
           buildWriteDeltaPlan(rel, operationTable, scopeOrdinals, source)
@@ -192,10 +192,10 @@ object RewriteReplaceUsing extends RewriteRowLevelCommand {
 
   private def resolveScopeOrdinals(
       relation: DataSourceV2Relation,
-      scopeColumns: Seq[String]): Seq[Int] = {
+      replaceUsingCols: Seq[String]): Seq[Int] = {
 
     val seen = scala.collection.mutable.HashSet.empty[Int]
-    scopeColumns.map { name =>
+    replaceUsingCols.map { name =>
       val resolved = relation.resolve(Seq(name), conf.resolver).getOrElse {
         throw QueryCompilationErrors.unresolvedColumnError(name, relation.output.map(_.name))
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala
@@ -27,10 +27,11 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.{GeneratedColumn, ReplaceDataProjections,
   WriteDeltaProjections}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils._
-import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
+import org.apache.spark.sql.connector.catalog.{SupportsRowLevelOperations, SupportsRowLevelReplace}
 import org.apache.spark.sql.connector.expressions.FieldReference
 import org.apache.spark.sql.connector.write.{RowLevelOperation, RowLevelOperationInfoImpl, RowLevelOperationTable, SupportsDelta}
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command
+import org.apache.spark.sql.connector.write.RowLevelOperation.Command.REPLACE
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
@@ -76,6 +77,33 @@ trait RewriteRowLevelCommand extends Rule[LogicalPlan] {
     val info = RowLevelOperationInfoImpl(command, options)
     val operation = table.newRowLevelOperationBuilder(info).build()
     RowLevelOperationTable(table, operation)
+  }
+
+  /**
+   * Resolves the target of an `INSERT INTO ... REPLACE` command and builds its
+   * [[RowLevelOperation.Command.REPLACE]] operation table, gating on the connector opt-in.
+   *
+   * REPLACE is dispatched only to connectors that explicitly opt in via
+   * [[SupportsRowLevelReplace]]. A table that supports row-level operations but not REPLACE takes
+   * the same unsupported-operation path as a non-row-level table, so its operation builder is
+   * never invoked with a command it did not expect. Keeping the gate here ensures rewrites that
+   * dispatch [[RowLevelOperation.Command.REPLACE]] reject unsupported tables identically.
+   */
+  protected def buildReplaceOperationTable(
+      aliasedTable: LogicalPlan): (DataSourceV2Relation, RowLevelOperationTable) = {
+    EliminateSubqueryAliases(aliasedTable) match {
+      case rel: DataSourceV2Relation =>
+        rel.table match {
+          case tbl: SupportsRowLevelReplace =>
+            (rel, buildOperationTable(tbl, REPLACE, rel.options))
+          case _ =>
+            throw QueryCompilationErrors.unsupportedInsertReplaceOnOrUsing(rel.table.name())
+        }
+
+      case other =>
+        throw QueryCompilationErrors.unsupportedInsertReplaceOnOrUsing(
+          other.simpleString(maxFields = 2))
+    }
   }
 
   protected def buildRelationWithAttrs(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -536,11 +536,9 @@ case class WriteDelta(
 
   private def isMetadataNullabilityPreserved(attr: Attribute): Boolean = {
     operation.command match {
-      case DELETE =>
-        MetadataAttribute.isPreservedOnDelete(attr)
-      case REPLACE =>
+      case DELETE | REPLACE =>
         // REPLACE emits delete rows for matched target rows and insert rows for source rows.
-        // Insert rows carry no metadata, so metadata nullability only needs delete preservation.
+        // Insert rows carry no metadata, so like DELETE it only needs delete preservation.
         MetadataAttribute.isPreservedOnDelete(attr)
       case UPDATE | MERGE if operation.representUpdateAsDeleteAndInsert =>
         MetadataAttribute.isPreservedOnDelete(attr) && MetadataAttribute.isPreservedOnReinsert(attr)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1243,7 +1243,7 @@ case class ReplaceUsingTable(
 
   lazy val rewritable: Boolean = {
     EliminateSubqueryAliases(targetTable) match {
-      case ExtractV2Table(_: SupportsRowLevelOperations) => true
+      case ExtractV2Table(_: SupportsRowLevelReplace) => true
       case _ => false
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1241,13 +1241,6 @@ case class ReplaceUsingTable(
 
   override def table: LogicalPlan = EliminateSubqueryAliases(targetTable)
 
-  lazy val rewritable: Boolean = {
-    EliminateSubqueryAliases(targetTable) match {
-      case ExtractV2Table(_: SupportsRowLevelReplace) => true
-      case _ => false
-    }
-  }
-
   override def left: LogicalPlan = targetTable
   override def right: LogicalPlan = query
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.connector.catalog.procedures.BoundProcedure
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.connector.write.{DeltaWrite, RowLevelOperation, RowLevelOperationTable, SupportsDelta, Write}
-import org.apache.spark.sql.connector.write.RowLevelOperation.Command.{DELETE, MERGE, UPDATE}
+import org.apache.spark.sql.connector.write.RowLevelOperation.Command.{DELETE, MERGE, REPLACE, UPDATE}
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLType
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, ExtractV2Table}
@@ -369,8 +369,8 @@ trait RowLevelWrite extends V2WriteCommand with SupportsSubquery {
 /**
  * Replace groups of data in an existing table during a row-level operation.
  *
- * This node is constructed in rules that rewrite DELETE, UPDATE, MERGE operations for data sources
- * that can replace groups of data (e.g. files, partitions).
+ * This node is constructed in rules that rewrite DELETE, UPDATE, MERGE, and REPLACE operations for
+ * data sources that can replace groups of data (e.g. files, partitions).
  *
  * @param table a plan that references a row-level operation table
  * @param condition a condition that defines matching groups
@@ -452,12 +452,12 @@ case class ReplaceData(
 /**
  * Writes a delta of rows to an existing table during a row-level operation.
  *
- * This node references a query that translates a logical DELETE, UPDATE, MERGE operation into
- * a set of row-level changes to be encoded in the table. Each row in the query represents either
- * a delete, update or insert and stores the operation type in a special column.
+ * This node references a query that translates a logical DELETE, UPDATE, MERGE, or REPLACE
+ * operation into a set of row-level changes to be encoded in the table. Each row in the query
+ * represents either a delete, update, or insert and stores the operation type in a special column.
  *
- * This node is constructed in rules that rewrite DELETE, UPDATE, MERGE operations for data sources
- * that can handle deltas of rows.
+ * This node is constructed in rules that rewrite DELETE, UPDATE, MERGE, and REPLACE operations for
+ * data sources that can handle deltas of rows.
  *
  * @param table a plan that references a row-level operation table
  * @param condition a condition that defines matching records
@@ -537,6 +537,10 @@ case class WriteDelta(
   private def isMetadataNullabilityPreserved(attr: Attribute): Boolean = {
     operation.command match {
       case DELETE =>
+        MetadataAttribute.isPreservedOnDelete(attr)
+      case REPLACE =>
+        // REPLACE emits delete rows for matched target rows and insert rows for source rows.
+        // Insert rows carry no metadata, so metadata nullability only needs delete preservation.
         MetadataAttribute.isPreservedOnDelete(attr)
       case UPDATE | MERGE if operation.representUpdateAsDeleteAndInsert =>
         MetadataAttribute.isPreservedOnDelete(attr) && MetadataAttribute.isPreservedOnReinsert(attr)
@@ -1213,6 +1217,44 @@ case class MergeIntoTable(
       newLeft: LogicalPlan,
       newRight: LogicalPlan): MergeIntoTable = {
     copy(targetTable = newLeft, sourceTable = newRight)
+  }
+}
+
+/**
+ * The logical plan of the `INSERT INTO t REPLACE USING (cols) <query>` command, resolved from
+ * [[InsertIntoStatement]] when its replace criteria is an [[InsertReplaceUsing]].
+ *
+ * Scoped replace deletes every target row whose scope-column tuple appears in the source and
+ * appends all source rows, including duplicates that share the same scope tuple. The command uses
+ * [[RowLevelOperation.Command.REPLACE]] so connectors can distinguish this scope-level replacement
+ * from per-row MERGE semantics.
+ *
+ * @param targetTable the target relation to replace rows in
+ * @param scopeColumns unqualified target column names whose values define a replace scope tuple
+ * @param query        the source query, already aligned to the target table output
+ */
+case class ReplaceUsingTable(
+    targetTable: LogicalPlan,
+    scopeColumns: Seq[String],
+    query: LogicalPlan)
+    extends BinaryCommand with SupportsSubquery with TransactionalWrite {
+
+  override def table: LogicalPlan = EliminateSubqueryAliases(targetTable)
+
+  lazy val rewritable: Boolean = {
+    EliminateSubqueryAliases(targetTable) match {
+      case ExtractV2Table(_: SupportsRowLevelOperations) => true
+      case _ => false
+    }
+  }
+
+  override def left: LogicalPlan = targetTable
+  override def right: LogicalPlan = query
+
+  override protected def withNewChildrenInternal(
+      newLeft: LogicalPlan,
+      newRight: LogicalPlan): ReplaceUsingTable = {
+    copy(targetTable = newLeft, query = newRight)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1227,13 +1227,13 @@ case class MergeIntoTable(
  * [[RowLevelOperation.Command.REPLACE]] so connectors can distinguish this scope-level replacement
  * from per-row MERGE semantics.
  *
- * @param targetTable the target relation to replace rows in
- * @param scopeColumns unqualified target column names whose values define a replace scope tuple
- * @param query        the source query, already aligned to the target table output
+ * @param targetTable    the target relation to replace rows in
+ * @param replaceUsingCols unqualified target column names whose values define a replace scope tuple
+ * @param query          the source query, already aligned to the target table output
  */
 case class ReplaceUsingTable(
     targetTable: LogicalPlan,
-    scopeColumns: Seq[String],
+    replaceUsingCols: Seq[String],
     query: LogicalPlan)
     extends BinaryCommand with SupportsSubquery with TransactionalWrite {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/ReplaceSummaryImpl.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/ReplaceSummaryImpl.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.write
+
+/**
+ * Implementation of [[ReplaceSummary]] that provides REPLACE operation summary.
+ */
+private[sql] case class ReplaceSummaryImpl(
+    numInsertedRows: Long,
+    numDeletedRows: Long,
+    numCopiedRows: Long)
+  extends ReplaceSummary {
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -682,9 +682,9 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     unsupportedTableOperationError(tableName, "INSERT INTO ... REPLACE ON/USING")
   }
 
-  def insertReplaceUsingNonDeterministicSource(): Throwable = {
+  def insertReplaceUsingNonDeterministicSourceQueryNotSupported(): Throwable = {
     new AnalysisException(
-      errorClass = "INSERT_REPLACE_USING_NON_DETERMINISTIC_SOURCE",
+      errorClass = "INSERT_REPLACE_USING_NON_DETERMINISTIC_SOURCE_QUERY_NOT_SUPPORTED",
       messageParameters = Map.empty)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -682,6 +682,18 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     unsupportedTableOperationError(tableName, "INSERT INTO ... REPLACE ON/USING")
   }
 
+  def insertReplaceUsingNonDeterministicSource(): Throwable = {
+    new AnalysisException(
+      errorClass = "INSERT_REPLACE_USING_NON_DETERMINISTIC_SOURCE",
+      messageParameters = Map.empty)
+  }
+
+  def insertReplaceUsingDuplicateScopeColumn(columnName: String): Throwable = {
+    new AnalysisException(
+      errorClass = "INSERT_REPLACE_USING_DUPLICATE_SCOPE_COLUMN",
+      messageParameters = Map("columnName" -> toSQLId(columnName)))
+  }
+
   def writeIntoViewNotAllowedError(identifier: TableIdentifier, t: TreeNode[_]): Throwable = {
     new AnalysisException(
       errorClass = "VIEW_WRITE_NOT_ALLOWED",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTable.scala
@@ -40,7 +40,7 @@ trait RowLevelOperationWithOptions {
   def options: CaseInsensitiveStringMap
 }
 
-class InMemoryRowLevelOperationTable private (
+class InMemoryRowLevelOperationTable protected (
     name: String,
     columns: Array[Column],
     partitioning: Array[Transform],
@@ -87,14 +87,21 @@ class InMemoryRowLevelOperationTable private (
   // (operation, id, metadata, row)
   var lastWriteLog: Seq[InternalRow] = Seq.empty
 
-  override def copy(): Table = {
-    val copied = InMemoryRowLevelOperationTable.withColumns(
+  // Creates an empty instance for copy() to populate. Subclasses override this so that copying a
+  // loaded table preserves the concrete type (e.g. the row-level REPLACE opt-in marker), which the
+  // catalog's loadTable -> copy path would otherwise drop.
+  protected def newEmptyCopy(): InMemoryRowLevelOperationTable = {
+    InMemoryRowLevelOperationTable.withColumns(
       name = name,
       columns = columns(),
       partitioning = partitioning,
       properties = properties,
       constraints = constraints,
       tableId = id)
+  }
+
+  override def copy(): Table = {
+    val copied = newEmptyCopy()
     dataMap.synchronized {
       dataMap.foreach { case (key, splits) =>
         val copiedSplits = splits.map { bufferedRows =>
@@ -312,6 +319,9 @@ private class DeltaBufferWriter(schema: StructType) extends BufferWriter(schema)
 }
 
 object InMemoryRowLevelOperationTable {
+  // Test-only table property that selects the REPLACE-capable subclass on create/alter.
+  val SUPPORTS_ROW_LEVEL_REPLACE = "supports-row-level-replace"
+
   def withColumns(
       name: String,
       columns: Array[Column],
@@ -320,6 +330,62 @@ object InMemoryRowLevelOperationTable {
       constraints: Array[Constraint] = Array.empty,
       tableId: String = java.util.UUID.randomUUID().toString): InMemoryRowLevelOperationTable = {
     new InMemoryRowLevelOperationTable(
+      name, columns, partitioning, properties, constraints, tableId)
+  }
+}
+
+/**
+ * A row-level operation table that opts into the {@code REPLACE} command via
+ * [[SupportsRowLevelReplace]]. Used to exercise `INSERT INTO ... REPLACE USING` execution; the
+ * unmarked [[InMemoryRowLevelOperationTable]] is left as the negative case for the analysis gate.
+ */
+class InMemoryRowLevelReplaceTable protected (
+    name: String,
+    columns: Array[Column],
+    partitioning: Array[Transform],
+    properties: util.Map[String, String],
+    constraints: Array[Constraint],
+    tableId: String)
+  extends InMemoryRowLevelOperationTable(
+    name, columns, partitioning, properties, constraints, tableId)
+  with SupportsRowLevelReplace {
+
+  def this(
+      name: String,
+      schema: StructType,
+      partitioning: Array[Transform],
+      properties: util.Map[String, String],
+      constraints: Array[Constraint] = Array.empty,
+      tableId: String = java.util.UUID.randomUUID().toString) = {
+    this(
+      name = name,
+      columns = CatalogV2Util.structTypeToV2Columns(schema),
+      partitioning = partitioning,
+      properties = properties,
+      constraints = constraints,
+      tableId = tableId)
+  }
+
+  override protected def newEmptyCopy(): InMemoryRowLevelOperationTable = {
+    InMemoryRowLevelReplaceTable.withColumns(
+      name = name,
+      columns = columns(),
+      partitioning = partitioning,
+      properties = properties,
+      constraints = constraints,
+      tableId = id)
+  }
+}
+
+object InMemoryRowLevelReplaceTable {
+  def withColumns(
+      name: String,
+      columns: Array[Column],
+      partitioning: Array[Transform],
+      properties: util.Map[String, String],
+      constraints: Array[Constraint] = Array.empty,
+      tableId: String = java.util.UUID.randomUUID().toString): InMemoryRowLevelReplaceTable = {
+    new InMemoryRowLevelReplaceTable(
       name, columns, partitioning, properties, constraints, tableId)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryRowLevelOperationTableCatalog.scala
@@ -17,10 +17,14 @@
 
 package org.apache.spark.sql.connector.catalog
 
+import java.util
+
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
+import org.apache.spark.sql.connector.catalog.constraints.Constraint
 import org.apache.spark.sql.connector.catalog.transactions.{Transaction, TransactionInfo}
+import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.types.StructType
 
 class InMemoryRowLevelOperationTableCatalog
@@ -60,6 +64,43 @@ class InMemoryRowLevelOperationTableCatalog
     txn
   }
 
+  private def supportsRowLevelReplace(properties: util.Map[String, String]): Boolean = {
+    properties != null &&
+      properties.getOrDefault(InMemoryRowLevelOperationTable.SUPPORTS_ROW_LEVEL_REPLACE, "false") ==
+        "true"
+  }
+
+  protected def newRowLevelOperationTable(
+      name: String,
+      schema: StructType,
+      partitioning: Array[Transform],
+      properties: util.Map[String, String],
+      constraints: Array[Constraint],
+      tableId: String = java.util.UUID.randomUUID().toString): InMemoryRowLevelOperationTable = {
+    if (supportsRowLevelReplace(properties)) {
+      new InMemoryRowLevelReplaceTable(name, schema, partitioning, properties, constraints, tableId)
+    } else {
+      new InMemoryRowLevelOperationTable(
+        name, schema, partitioning, properties, constraints, tableId)
+    }
+  }
+
+  protected def newRowLevelOperationTableWithColumns(
+      name: String,
+      columns: Array[Column],
+      partitioning: Array[Transform],
+      properties: util.Map[String, String],
+      constraints: Array[Constraint],
+      tableId: String): InMemoryRowLevelOperationTable = {
+    if (supportsRowLevelReplace(properties)) {
+      InMemoryRowLevelReplaceTable.withColumns(
+        name, columns, partitioning, properties, constraints, tableId)
+    } else {
+      InMemoryRowLevelOperationTable.withColumns(
+        name, columns, partitioning, properties, constraints, tableId)
+    }
+  }
+
   override def createTable(ident: Identifier, tableInfo: TableInfo): Table = {
     if (tables.containsKey(ident)) {
       throw new TableAlreadyExistsException(ident.asMultipartIdentifier)
@@ -69,7 +110,7 @@ class InMemoryRowLevelOperationTableCatalog
 
     val tableName = s"$name.${ident.quoted}"
     val schema = CatalogV2Util.v2ColumnsToStructType(tableInfo.columns)
-    val table = new InMemoryRowLevelOperationTable(
+    val table = newRowLevelOperationTable(
       tableName, schema, tableInfo.partitions, tableInfo.properties, tableInfo.constraints())
     tables.put(ident, table)
     namespaces.putIfAbsent(ident.namespace.toList, Map())
@@ -91,7 +132,7 @@ class InMemoryRowLevelOperationTableCatalog
     val columnsWithIds = InMemoryBaseTable.assignMissingIds(
       CatalogV2Util.structTypeToV2Columns(schema))
 
-    val newTable = InMemoryRowLevelOperationTable.withColumns(
+    val newTable = newRowLevelOperationTableWithColumns(
       name = table.name,
       columns = columnsWithIds,
       partitioning = partitioning,
@@ -134,12 +175,13 @@ class PartialSchemaEvolutionCatalog extends InMemoryRowLevelOperationTableCatalo
     }
     val properties = CatalogV2Util.applyPropertiesChanges(table.properties, propertyChanges)
     val schema = computeAlterTableSchema(table.schema, changes.toSeq)
-    val newTable = new InMemoryRowLevelOperationTable(
+    val newTable = newRowLevelOperationTable(
       name = table.name,
       schema = schema,
       partitioning = table.partitioning,
       properties = properties,
-      constraints = table.constraints)
+      constraints = table.constraints,
+      tableId = table.id)
     newTable.alterTableWithData(table.data, table.schema)
     newTable.setVersionAndValidatedVersionFrom(table)
     tables.put(ident, newTable)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/txns.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/txns.scala
@@ -163,6 +163,18 @@ class TxnTable(
   }
 }
 
+// Variant of TxnTable that also advertises the REPLACE opt-in. Capability marker interfaces such
+// as SupportsRowLevelReplace are checked on the resolved relation's table, so a transactional
+// wrapper must carry the same markers as its delegate (TxnTable already preserves
+// SupportsRowLevelOperations by extending the base table); otherwise REPLACE commands would be
+// rejected for tables that opted in. Selected by TxnTableCatalog when the delegate opts in.
+class TxnReplaceTable(
+    delegate: InMemoryRowLevelOperationTable,
+    schema: StructType,
+    catalog: TxnTableCatalog)
+  extends TxnTable(delegate, schema, catalog)
+  with SupportsRowLevelReplace
+
 // A special table catalog used in row-level operation transactions. The lifecycle of this catalog
 // is tied to the transaction. A new catalog instance is created at the beginning of a transaction
 // and discarded at the end. The catalog is responsible for pinning all tables involved in the
@@ -192,8 +204,19 @@ class TxnTableCatalog(delegate: InMemoryRowLevelOperationTableCatalog) extends T
       // Wrap the live underlying instance (not a snapshot copy from loadTable) so commits
       // propagate back to the catalog's authoritative state.
       val table = delegate.liveTable(ident).asInstanceOf[InMemoryRowLevelOperationTable]
-      new TxnTable(table, table.schema(), this)
+      newTxnTable(table, table.schema())
     })
+  }
+
+  // The wrapper must mirror the delegate's capability markers (see TxnReplaceTable) so that
+  // marker-gated operations resolve consistently whether or not a transaction is active.
+  private def newTxnTable(
+      delegate: InMemoryRowLevelOperationTable,
+      schema: StructType): TxnTable = {
+    delegate match {
+      case _: SupportsRowLevelReplace => new TxnReplaceTable(delegate, schema, this)
+      case _ => new TxnTable(delegate, schema, this)
+    }
   }
 
   override def alterTable(ident: Identifier, changes: TableChange*): Table = {
@@ -211,10 +234,10 @@ class TxnTableCatalog(delegate: InMemoryRowLevelOperationTableCatalog) extends T
       throw new IllegalArgumentException(s"Cannot drop all fields")
     }
 
-    val newTxnTable = new TxnTable(txnTable.delegate, schema, this)
-    newTxnTable.scanEvents ++= txnTable.scanEvents
-    tables.put(ident, newTxnTable)
-    newTxnTable
+    val updatedTxnTable = newTxnTable(txnTable.delegate, schema)
+    updatedTxnTable.scanEvents ++= txnTable.scanEvents
+    tables.put(ident, updatedTxnTable)
+    updatedTxnTable
   }
 
   // TODO: Currently not transactional. Should be revised when Atomic CTAS/RTAS is implemented.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -51,8 +51,9 @@ case class BatchScanExec(
     val name = "number of output rows"
     val metric = table match {
       // Use SLAM for the scan-output count when this scan reads on behalf of a row-level DELETE or
-      // REPLACE, so that the driver-side derivation `numDeletedRows = numScannedRows -
-      // numCopiedRows` in `ReplaceDataExec` stays correct under stage retries.
+      // INSERT INTO ... REPLACE USING, so that the driver-side derivation
+      // `numDeletedRows = numScannedRows - numCopiedRows` in `ReplaceDataExec` stays correct under
+      // stage retries.
       case rlot: RowLevelOperationTable
           if rlot.operation.command() == DELETE || rlot.operation.command() == REPLACE =>
         SQLLastAttemptMetrics.createMetric(sparkContext, name)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -54,7 +54,7 @@ case class BatchScanExec(
       // REPLACE, so that the driver-side derivation `numDeletedRows = numScannedRows -
       // numCopiedRows` in `ReplaceDataExec` stays correct under stage retries.
       case rlot: RowLevelOperationTable
-          if Seq(DELETE, REPLACE).contains(rlot.operation.command()) =>
+          if rlot.operation.command() == DELETE || rlot.operation.command() == REPLACE =>
         SQLLastAttemptMetrics.createMetric(sparkContext, name)
       case _ =>
         SQLMetrics.createMetric(sparkContext, name)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.read._
-import org.apache.spark.sql.connector.write.RowLevelOperation.Command.DELETE
+import org.apache.spark.sql.connector.write.RowLevelOperation.Command.{DELETE, REPLACE}
 import org.apache.spark.sql.connector.write.RowLevelOperationTable
 import org.apache.spark.sql.execution.EmptyRDDWithPartitions
 import org.apache.spark.sql.execution.metric.{SQLLastAttemptMetrics, SQLMetric, SQLMetrics}
@@ -50,10 +50,11 @@ case class BatchScanExec(
   override protected lazy val sparkMetrics: Map[String, SQLMetric] = {
     val name = "number of output rows"
     val metric = table match {
-      // Use SLAM for the scan-output count when this scan reads on behalf of a row-level DELETE,
-      // so that the driver-side derivation `numDeletedRows = numScannedRows - numCopiedRows` in
-      // `ReplaceDataExec.getWriteSummary` stays correct under stage retries.
-      case rlot: RowLevelOperationTable if rlot.operation.command() == DELETE =>
+      // Use SLAM for the scan-output count when this scan reads on behalf of a row-level DELETE or
+      // REPLACE, so that the driver-side derivation `numDeletedRows = numScannedRows -
+      // numCopiedRows` in `ReplaceDataExec` stays correct under stage retries.
+      case rlot: RowLevelOperationTable
+          if Seq(DELETE, REPLACE).contains(rlot.operation.command()) =>
         SQLLastAttemptMetrics.createMetric(sparkContext, name)
       case _ =>
         SQLMetrics.createMetric(sparkContext, name)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Column, Identifier
 import org.apache.spark.sql.connector.catalog.transactions.Transaction
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.metric.CustomMetric
-import org.apache.spark.sql.connector.write.{BatchWrite, DataWriter, DataWriterFactory, DeleteSummaryImpl, DeltaWrite, DeltaWriter, InsertSummaryImpl, MergeSummaryImpl, PhysicalWriteInfoImpl, RowLevelOperation, RowLevelOperationTable, UpdateSummaryImpl, Write, WriterCommitMessage, WriteSummary}
+import org.apache.spark.sql.connector.write.{BatchWrite, DataWriter, DataWriterFactory, DeleteSummaryImpl, DeltaWrite, DeltaWriter, InsertSummaryImpl, MergeSummaryImpl, PhysicalWriteInfoImpl, ReplaceSummaryImpl, RowLevelOperation, RowLevelOperationTable, UpdateSummaryImpl, Write, WriterCommitMessage, WriteSummary}
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command._
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.{EmptyRDDWithPartitions, QueryExecution, SparkPlan, SQLExecution, UnaryExecNode}
@@ -396,9 +396,12 @@ case class ReplaceDataExec(
     copy(query = newChild)
   }
 
-  override protected def getDeleteSummary(): Option[DeleteSummaryImpl] = {
-    // DELETE ReplaceData plans filter out the deleted rows early in the plan, and they don't
-    // reach this node. We need to calculate this value as numScannedRows - numCopiedRows.
+  /**
+   * Derives the number of deleted rows for copy-on-write row-level operations. Matched rows are
+   * removed before the writer, so DELETE and REPLACE both compute this count as numScannedRows -
+   * numCopiedRows to keep the execution metric and connector summary aligned.
+   */
+  private def deriveDeletedRows(): Long = {
     val numScannedRows = collectFirst(query) {
       case b: BatchScanExec if b.table.isInstanceOf[RowLevelOperationTable] =>
         getMetricValue(b.metrics, "numOutputRows")
@@ -413,7 +416,20 @@ case class ReplaceDataExec(
 
     // SQLMetric.set is a no-op if value is -1, leaving the metric in its invalid state.
     sparkMetrics("numDeletedRows").set(numDeletedRows)
+    numDeletedRows
+  }
+
+  override protected def getDeleteSummary(): Option[DeleteSummaryImpl] = {
+    val numDeletedRows = deriveDeletedRows()
     super.getDeleteSummary().map(_.copy(numDeletedRows = numDeletedRows))
+  }
+
+  override protected def getReplaceSummary(): Option[ReplaceSummaryImpl] = {
+    val numDeletedRows = deriveDeletedRows()
+    Some(ReplaceSummaryImpl(
+      numInsertedRows = getMetricValue(sparkMetrics, "numInsertedRows"),
+      numDeletedRows = numDeletedRows,
+      numCopiedRows = getMetricValue(sparkMetrics, "numCopiedRows")))
   }
 }
 
@@ -522,6 +538,16 @@ trait RowLevelWriteExec extends V2ExistingTableWriteExec {
             SQLLastAttemptMetrics.createMetric(sparkContext, "number of deleted rows"),
           "numCopiedRows" ->
             SQLLastAttemptMetrics.createMetric(sparkContext, "number of copied rows"))
+      case REPLACE =>
+        // The COW and MOR rewrites populate different subsets of these counters, but exposing a
+        // stable metric set keeps the REPLACE summary and SQL UI consistent across both paths.
+        Map(
+          "numInsertedRows" ->
+            SQLLastAttemptMetrics.createMetric(sparkContext, "number of inserted rows"),
+          "numDeletedRows" ->
+            SQLLastAttemptMetrics.createMetric(sparkContext, "number of deleted rows"),
+          "numCopiedRows" ->
+            SQLLastAttemptMetrics.createMetric(sparkContext, "number of copied rows"))
       case _ => Map.empty
     })
 
@@ -544,10 +570,7 @@ trait RowLevelWriteExec extends V2ExistingTableWriteExec {
       case MERGE => getMergeSummary()
       case UPDATE => getUpdateSummary()
       case DELETE => getDeleteSummary()
-      // Scoped REPLACE has no dedicated write summary yet: existing row-level tasks do not count
-      // inserted rows, and numOutputRows conflates copied/deleted/inserted rows, so any derived
-      // count would be wrong. Returning None until we add metrics.
-      case REPLACE => None
+      case REPLACE => getReplaceSummary()
     }
   }
 
@@ -576,6 +599,18 @@ trait RowLevelWriteExec extends V2ExistingTableWriteExec {
     Some(DeleteSummaryImpl(
       getMetricValue(sparkMetrics, "numDeletedRows"),
       getMetricValue(sparkMetrics, "numCopiedRows")))
+  }
+
+  /**
+   * Builds the REPLACE summary from the writing-task metrics. The base implementation covers the
+   * merge-on-read path, where the writing task counts deleted rows directly and no target rows are
+   * copied. The copy-on-write path overrides this to derive numDeletedRows from the scan.
+   */
+  protected def getReplaceSummary(): Option[ReplaceSummaryImpl] = {
+    Some(ReplaceSummaryImpl(
+      numInsertedRows = getMetricValue(sparkMetrics, "numInsertedRows"),
+      numDeletedRows = getMetricValue(sparkMetrics, "numDeletedRows"),
+      numCopiedRows = 0L))
   }
 }
 
@@ -783,6 +818,7 @@ case class DataAndMetadataWritingSparkTask(
       writer: DataWriter[InternalRow], iter: java.util.Iterator[InternalRow]): Unit = {
     var numUpdatedRows = 0L
     var numCopiedRows = 0L
+    var numInsertedRows = 0L
 
     while (iter.hasNext) {
       val row = iter.next()
@@ -802,6 +838,7 @@ case class DataAndMetadataWritingSparkTask(
           writer.write(metadataProj, dataProj)
 
         case INSERT_OPERATION =>
+          numInsertedRows += 1L
           dataProj.project(row)
           writer.write(dataProj)
 
@@ -812,6 +849,7 @@ case class DataAndMetadataWritingSparkTask(
 
     sparkMetrics.get("numUpdatedRows").foreach(_.add(numUpdatedRows))
     sparkMetrics.get("numCopiedRows").foreach(_.add(numCopiedRows))
+    sparkMetrics.get("numInsertedRows").foreach(_.add(numInsertedRows))
   }
 }
 
@@ -824,6 +862,7 @@ case class DataWithProjectionWritingSparkTask(
       writer: DataWriter[InternalRow], iter: java.util.Iterator[InternalRow]): Unit = {
     var numUpdatedRows = 0L
     var numCopiedRows = 0L
+    var numInsertedRows = 0L
 
     while (iter.hasNext) {
       val row = iter.next()
@@ -841,6 +880,7 @@ case class DataWithProjectionWritingSparkTask(
           writer.write(dataProj)
 
         case INSERT_OPERATION =>
+          numInsertedRows += 1L
           dataProj.project(row)
           writer.write(dataProj)
 
@@ -851,6 +891,7 @@ case class DataWithProjectionWritingSparkTask(
 
     sparkMetrics.get("numUpdatedRows").foreach(_.add(numUpdatedRows))
     sparkMetrics.get("numCopiedRows").foreach(_.add(numCopiedRows))
+    sparkMetrics.get("numInsertedRows").foreach(_.add(numInsertedRows))
   }
 }
 
@@ -873,6 +914,7 @@ case class DeltaWritingSparkTask(
       writer: DeltaWriter[InternalRow], iter: java.util.Iterator[InternalRow]): Unit = {
     var numUpdatedRows = 0L
     var numDeletedRows = 0L
+    var numInsertedRows = 0L
 
     while (iter.hasNext) {
       val row = iter.next()
@@ -898,6 +940,7 @@ case class DeltaWritingSparkTask(
           writer.reinsert(null, rowProjection)
 
         case INSERT_OPERATION =>
+          numInsertedRows += 1L
           rowProjection.project(row)
           writer.insert(rowProjection)
 
@@ -908,6 +951,7 @@ case class DeltaWritingSparkTask(
 
     sparkMetrics.get("numUpdatedRows").foreach(_.add(numUpdatedRows))
     sparkMetrics.get("numDeletedRows").foreach(_.add(numDeletedRows))
+    sparkMetrics.get("numInsertedRows").foreach(_.add(numInsertedRows))
   }
 }
 
@@ -924,6 +968,7 @@ case class DeltaWithMetadataWritingSparkTask(
       writer: DeltaWriter[InternalRow], iter: java.util.Iterator[InternalRow]): Unit = {
     var numUpdatedRows = 0L
     var numDeletedRows = 0L
+    var numInsertedRows = 0L
 
     while (iter.hasNext) {
       val row = iter.next()
@@ -952,6 +997,7 @@ case class DeltaWithMetadataWritingSparkTask(
           writer.reinsert(metadataProjection, rowProjection)
 
         case INSERT_OPERATION =>
+          numInsertedRows += 1L
           rowProjection.project(row)
           writer.insert(rowProjection)
 
@@ -962,6 +1008,7 @@ case class DeltaWithMetadataWritingSparkTask(
 
     sparkMetrics.get("numUpdatedRows").foreach(_.add(numUpdatedRows))
     sparkMetrics.get("numDeletedRows").foreach(_.add(numDeletedRows))
+    sparkMetrics.get("numInsertedRows").foreach(_.add(numInsertedRows))
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
@@ -503,7 +503,7 @@ trait V2ExistingTableWriteExec extends V2TableWriteExec with TransactionalExec {
 }
 
 /**
- * A trait for row-level write operations (UPDATE, DELETE, MERGE).
+ * A trait for row-level write operations (UPDATE, DELETE, MERGE, REPLACE).
  */
 trait RowLevelWriteExec extends V2ExistingTableWriteExec {
   def rowLevelCommand: RowLevelOperation.Command
@@ -544,6 +544,10 @@ trait RowLevelWriteExec extends V2ExistingTableWriteExec {
       case MERGE => getMergeSummary()
       case UPDATE => getUpdateSummary()
       case DELETE => getDeleteSummary()
+      // Scoped REPLACE has no dedicated write summary yet: existing row-level tasks do not count
+      // inserted rows, and numOutputRows conflates copied/deleted/inserted rows, so any derived
+      // count would be wrong. Returning None until we add metrics.
+      case REPLACE => None
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
@@ -110,14 +110,9 @@ class RowLevelOperationRuntimeGroupFiltering(optimizeSubqueries: Rule[LogicalPla
         }
         Filter(transformedCond, relation)
 
-      case MERGE =>
-        // rewrite the group filter subquery as joins
-        val filter = Filter(cond, relation)
-        RewritePredicateSubquery(filter)
-
-      case REPLACE =>
-        // REPLACE group filters are expressed as correlated subqueries and must be rewritten
-        // before the dynamic pruning query is planned.
+      case MERGE | REPLACE =>
+        // MERGE and REPLACE group filters are expressed as correlated subqueries and must be
+        // rewritten as joins before the dynamic pruning query is planned.
         val filter = Filter(cond, relation)
         RewritePredicateSubquery(filter)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.planning.{DeltaBasedRowLevelOperation, Grou
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, LogicalPlan, RowLevelWrite}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.read.SupportsRuntimeV2Filtering
-import org.apache.spark.sql.connector.write.RowLevelOperation.Command.{DELETE, MERGE, UPDATE}
+import org.apache.spark.sql.connector.write.RowLevelOperation.Command.{DELETE, MERGE, REPLACE, UPDATE}
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Implicits, DataSourceV2Relation, DataSourceV2ScanRelation, ExtractV2Scan}
 import org.apache.spark.util.ArrayImplicits._
 
@@ -112,6 +112,12 @@ class RowLevelOperationRuntimeGroupFiltering(optimizeSubqueries: Rule[LogicalPla
 
       case MERGE =>
         // rewrite the group filter subquery as joins
+        val filter = Filter(cond, relation)
+        RewritePredicateSubquery(filter)
+
+      case REPLACE =>
+        // REPLACE group filters are expressed as correlated subqueries and must be rewritten
+        // before the dynamic pruning query is planned.
         val filter = Filter(cond, relation)
         RewritePredicateSubquery(filter)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedReplaceUsingTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedReplaceUsingTableSuite.scala
@@ -15,20 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.connector.write;
-
-import org.apache.spark.annotation.Experimental;
+package org.apache.spark.sql.connector
 
 /**
- * An interface for building a {@link RowLevelOperation}.
- *
- * @since 3.3.0
+ * Runs the scoped-replace coverage against a delta-based (merge-on-read) row-level table, which
+ * lowers `REPLACE USING` to a [[org.apache.spark.sql.catalyst.plans.logical.WriteDelta]] node.
  */
-@Experimental
-public interface RowLevelOperationBuilder {
-  /**
-   * Returns a {@link RowLevelOperation} that controls how Spark rewrites data
-   * for DELETE, UPDATE, MERGE, and REPLACE commands.
-   */
-  RowLevelOperation build();
+class DeltaBasedReplaceUsingTableSuite extends ReplaceUsingTableSuiteBase {
+
+  override protected def isDeltaBasedReplace: Boolean = true
+
+  override protected lazy val extraTableProps: java.util.Map[String, String] = {
+    val props = new java.util.HashMap[String, String]()
+    props.put("supports-deltas", "true")
+    props
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedReplaceUsingTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedReplaceUsingTableSuite.scala
@@ -25,8 +25,8 @@ class DeltaBasedReplaceUsingTableSuite extends ReplaceUsingTableSuiteBase {
 
   override protected def isDeltaBasedReplace: Boolean = true
 
-  override protected lazy val extraTableProps: java.util.Map[String, String] = {
-    val props = new java.util.HashMap[String, String]()
+  override protected def extraTableProps: java.util.Map[String, String] = {
+    val props = new java.util.HashMap[String, String](super.extraTableProps)
     props.put("supports-deltas", "true")
     props
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedReplaceUsingTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedReplaceUsingTableSuite.scala
@@ -15,20 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.connector.write;
-
-import org.apache.spark.annotation.Experimental;
+package org.apache.spark.sql.connector
 
 /**
- * An interface for building a {@link RowLevelOperation}.
- *
- * @since 3.3.0
+ * Runs the scoped-replace coverage against a group-based (copy-on-write) row-level table, which
+ * lowers `REPLACE USING` to a [[org.apache.spark.sql.catalyst.plans.logical.ReplaceData]] node.
  */
-@Experimental
-public interface RowLevelOperationBuilder {
-  /**
-   * Returns a {@link RowLevelOperation} that controls how Spark rewrites data
-   * for DELETE, UPDATE, MERGE, and REPLACE commands.
-   */
-  RowLevelOperation build();
-}
+class GroupBasedReplaceUsingTableSuite extends ReplaceUsingTableSuiteBase

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ReplaceUsingTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ReplaceUsingTableSuiteBase.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.connector
 
 import org.apache.spark.internal.config
 import org.apache.spark.sql.{AnalysisException, Row}
-import org.apache.spark.sql.connector.catalog.InMemoryTable
+import org.apache.spark.sql.connector.catalog.{InMemoryRowLevelOperationTable, InMemoryTable}
 import org.apache.spark.sql.connector.write.{BatchWrite, ReplaceSummary, ReplaceSummaryImpl, WriterCommitMessage, WriteSummary}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.v2.{ReplaceDataExec, WriteDeltaExec}
@@ -43,6 +43,13 @@ abstract class ReplaceUsingTableSuiteBase extends RowLevelOperationSuiteBase {
 
   protected def isDeltaBasedReplace: Boolean = false
 
+  // Select the in-memory table subclass that implements SupportsRowLevelReplace via props.
+  override protected def extraTableProps: java.util.Map[String, String] = {
+    val props = new java.util.HashMap[String, String]()
+    props.put(InMemoryRowLevelOperationTable.SUPPORTS_ROW_LEVEL_REPLACE, "true")
+    props
+  }
+
   test("replace using deletes matching scopes and inserts all source rows") {
     createAndInitTable(schemaString,
       """{ "pk": 1, "id": 1, "dep": "hr" }
@@ -60,6 +67,26 @@ abstract class ReplaceUsingTableSuiteBase extends RowLevelOperationSuiteBase {
     checkAnswer(
       sql(s"SELECT * FROM $tableNameAsString"),
       Row(2, 2, "software") :: Row(10, 10, "hr") :: Row(11, 11, "hr") :: Nil)
+  }
+
+  test("replace using still works after an ALTER TABLE that preserves the opt-in") {
+    createAndInitTable(schemaString,
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    // Altering an unrelated property must not rebuild the table as the unmarked base class, which
+    // would cause the REPLACE USING below to fail the analysis gate.
+    sql(s"ALTER TABLE $tableNameAsString SET TBLPROPERTIES ('comment' = 'updated')")
+
+    sql(
+      s"""INSERT INTO $tableNameAsString REPLACE USING (dep)
+         |SELECT * FROM VALUES (10, 10, 'hr') AS t(pk, id, dep)
+         |""".stripMargin)
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Row(2, 2, "software") :: Row(10, 10, "hr") :: Nil)
   }
 
   test("replace using leaves scopes absent from the source untouched") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ReplaceUsingTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ReplaceUsingTableSuiteBase.scala
@@ -257,7 +257,7 @@ abstract class ReplaceUsingTableSuiteBase extends RowLevelOperationSuiteBase {
              |SELECT * FROM VALUES (1, 1, 'hr') AS t(pk, id, dep) WHERE rand() > 0.5
              |""".stripMargin)
       },
-      condition = "INSERT_REPLACE_USING_NON_DETERMINISTIC_SOURCE",
+      condition = "INSERT_REPLACE_USING_NON_DETERMINISTIC_SOURCE_QUERY_NOT_SUPPORTED",
       parameters = Map.empty[String, String])
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ReplaceUsingTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ReplaceUsingTableSuiteBase.scala
@@ -17,7 +17,13 @@
 
 package org.apache.spark.sql.connector
 
+import org.apache.spark.internal.config
 import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.connector.catalog.InMemoryTable
+import org.apache.spark.sql.connector.write.{BatchWrite, ReplaceSummary, ReplaceSummaryImpl, WriterCommitMessage, WriteSummary}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.v2.{ReplaceDataExec, WriteDeltaExec}
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 
@@ -30,6 +36,8 @@ import org.apache.spark.sql.types.StructType
  * against final table contents so they hold for both backends.
  */
 abstract class ReplaceUsingTableSuiteBase extends RowLevelOperationSuiteBase {
+
+  import testImplicits._
 
   private val schemaString = "pk INT NOT NULL, id INT, dep STRING"
 
@@ -283,5 +291,187 @@ abstract class ReplaceUsingTableSuiteBase extends RowLevelOperationSuiteBase {
       }
       assert(groupFilterCond.isEmpty, "no group filter when runtime filtering is disabled")
     }
+  }
+
+  private def getReplaceSummary(): ReplaceSummary = {
+    val t = catalog.loadTable(ident).asInstanceOf[InMemoryTable]
+    t.commits.last.writeSummary.get.asInstanceOf[ReplaceSummary]
+  }
+
+  // numCopiedRows reports rows physically re-emitted by copy-on-write replacement. Merge-on-read
+  // replacement records deletes and inserts without copying target rows.
+  private def checkReplaceSummary(
+      numInsertedRows: Long,
+      numDeletedRows: Long,
+      numCopiedRows: Long): Unit = {
+    val summary = getReplaceSummary()
+    assert(summary.numInsertedRows() === numInsertedRows,
+      s"Expected numInsertedRows=$numInsertedRows, got ${summary.numInsertedRows()}")
+    assert(summary.numDeletedRows() === numDeletedRows,
+      s"Expected numDeletedRows=$numDeletedRows, got ${summary.numDeletedRows()}")
+    val expectedCopied = if (isDeltaBasedReplace) 0L else numCopiedRows
+    assert(summary.numCopiedRows() === expectedCopied,
+      s"Expected numCopiedRows=$expectedCopied, got ${summary.numCopiedRows()}")
+  }
+
+  private def replaceWriteMetrics(plan: SparkPlan): Map[String, SQLMetric] = {
+    collectFirst(plan) {
+      case e: ReplaceDataExec => e.metrics
+      case e: WriteDeltaExec => e.metrics
+    }.getOrElse(fail("expected a ReplaceDataExec or WriteDeltaExec in the executed plan"))
+  }
+
+  private def assertWriteMetric(
+      metrics: Map[String, SQLMetric],
+      name: String,
+      expected: Long): Unit = {
+    val metric = metrics.getOrElse(name, fail(s"missing SQL UI metric: $name"))
+    assert(metric.value === expected, s"Expected $name=$expected, got ${metric.value}")
+  }
+
+  test("replace using reports summary and SQL UI metrics for matching scopes") {
+    withSQLConf(SQLConf.RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED.key -> "true") {
+      createAndInitTable(schemaString,
+        """{ "pk": 1, "id": 1, "dep": "hr" }
+          |{ "pk": 2, "id": 2, "dep": "software" }
+          |{ "pk": 3, "id": 3, "dep": "hr" }
+          |""".stripMargin)
+
+      val plan = executeAndKeepPlan {
+        sql(
+          s"""INSERT INTO $tableNameAsString REPLACE USING (dep)
+             |SELECT * FROM VALUES (10, 10, 'hr'), (11, 11, 'hr') AS t(pk, id, dep)
+             |""".stripMargin)
+      }
+
+      // Runtime group filtering limits the COW scan to the matched group, so no rows are copied.
+      checkReplaceSummary(numInsertedRows = 2, numDeletedRows = 2, numCopiedRows = 0)
+      val metrics = replaceWriteMetrics(plan)
+      assertWriteMetric(metrics, "numInsertedRows", 2)
+      assertWriteMetric(metrics, "numDeletedRows", 2)
+      assertWriteMetric(metrics, "numCopiedRows", 0)
+    }
+  }
+
+  test("replace using reports copied rows for copy-on-write carryover") {
+    withSQLConf(SQLConf.RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED.key -> "false") {
+      createAndInitTable(schemaString,
+        """{ "pk": 1, "id": 1, "dep": "hr" }
+          |{ "pk": 2, "id": 2, "dep": "software" }
+          |{ "pk": 3, "id": 3, "dep": "hr" }
+          |""".stripMargin)
+
+      val plan = executeAndKeepPlan {
+        sql(
+          s"""INSERT INTO $tableNameAsString REPLACE USING (dep)
+             |SELECT * FROM VALUES (10, 10, 'hr'), (11, 11, 'hr') AS t(pk, id, dep)
+             |""".stripMargin)
+      }
+
+      checkReplaceSummary(numInsertedRows = 2, numDeletedRows = 2, numCopiedRows = 1)
+      val metrics = replaceWriteMetrics(plan)
+      assertWriteMetric(metrics, "numInsertedRows", 2)
+      assertWriteMetric(metrics, "numDeletedRows", 2)
+      assertWriteMetric(metrics, "numCopiedRows", if (isDeltaBasedReplace) 0 else 1)
+    }
+  }
+
+  test("replace using reports inserts only when no scope matches") {
+    withSQLConf(SQLConf.RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED.key -> "true") {
+      createAndInitTable(schemaString,
+        """{ "pk": 1, "id": 1, "dep": "hr" }
+          |{ "pk": 2, "id": 2, "dep": "software" }
+          |""".stripMargin)
+
+      val plan = executeAndKeepPlan {
+        sql(
+          s"""INSERT INTO $tableNameAsString REPLACE USING (dep)
+             |SELECT * FROM VALUES (20, 20, 'finance') AS t(pk, id, dep)
+             |""".stripMargin)
+      }
+
+      checkReplaceSummary(numInsertedRows = 1, numDeletedRows = 0, numCopiedRows = 0)
+      val metrics = replaceWriteMetrics(plan)
+      assertWriteMetric(metrics, "numInsertedRows", 1)
+      assertWriteMetric(metrics, "numDeletedRows", 0)
+      assertWriteMetric(metrics, "numCopiedRows", 0)
+    }
+  }
+
+  test("replace using reports all-zero metrics for an empty source") {
+    withSQLConf(SQLConf.RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED.key -> "true") {
+      createAndInitTable(schemaString,
+        """{ "pk": 1, "id": 1, "dep": "hr" }
+          |{ "pk": 2, "id": 2, "dep": "software" }
+          |""".stripMargin)
+
+      val plan = executeAndKeepPlan {
+        sql(
+          s"""INSERT INTO $tableNameAsString REPLACE USING (dep)
+             |SELECT * FROM VALUES (0, 0, 'x') AS t(pk, id, dep) WHERE 1 = 0
+             |""".stripMargin)
+      }
+
+      checkReplaceSummary(numInsertedRows = 0, numDeletedRows = 0, numCopiedRows = 0)
+      val metrics = replaceWriteMetrics(plan)
+      assertWriteMetric(metrics, "numInsertedRows", 0)
+      assertWriteMetric(metrics, "numDeletedRows", 0)
+      assertWriteMetric(metrics, "numCopiedRows", 0)
+    }
+  }
+
+  test("replace metric values are stable across scan-stage retries") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withTempView("source") {
+        createAndInitTable(schemaString,
+          """{ "pk": 1, "id": 1, "dep": "hr" }
+            |{ "pk": 2, "id": 2, "dep": "software" }
+            |{ "pk": 3, "id": 3, "dep": "hr" }
+            |{ "pk": 4, "id": 4, "dep": "software" }
+            |""".stripMargin)
+
+        Seq((10, 1, "legal"), (20, 2, "finance")).toDF("pk", "id", "dep")
+          .createOrReplaceTempView("source")
+
+        withSparkContextConf(config.Tests.INJECT_SHUFFLE_FETCH_FAILURES.key -> "true") {
+          sql(
+            s"""INSERT INTO $tableNameAsString REPLACE USING (id)
+               |SELECT * FROM source
+               |""".stripMargin)
+        }
+
+        checkReplaceSummary(numInsertedRows = 2, numDeletedRows = 2, numCopiedRows = 2)
+      }
+    }
+  }
+
+  test("replace summary commit falls back to the no-summary commit for legacy connectors") {
+    // Connectors that do not override commit(messages, WriteSummary) use BatchWrite's default
+    // delegation.
+    val committedMessages =
+      new java.util.concurrent.atomic.AtomicReference[Array[WriterCommitMessage]]
+
+    val legacyWrite = new BatchWrite {
+      override def createBatchWriterFactory(
+          info: org.apache.spark.sql.connector.write.PhysicalWriteInfo)
+        : org.apache.spark.sql.connector.write.DataWriterFactory = {
+        throw new UnsupportedOperationException("not needed for this test")
+      }
+
+      override def commit(messages: Array[WriterCommitMessage]): Unit = {
+        committedMessages.set(messages)
+      }
+
+      override def abort(messages: Array[WriterCommitMessage]): Unit = {}
+    }
+
+    val summary: WriteSummary = ReplaceSummaryImpl(
+      numInsertedRows = 5L, numDeletedRows = 2L, numCopiedRows = 0L)
+
+    val messages = Array.empty[WriterCommitMessage]
+    legacyWrite.commit(messages, summary)
+
+    assert(committedMessages.get() != null, "default commit(messages, summary) must delegate")
+    assert(committedMessages.get() eq messages, "the original commit messages must be forwarded")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ReplaceUsingTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ReplaceUsingTableSuiteBase.scala
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Shared end-to-end coverage for `INSERT INTO ... REPLACE USING` execution.
+ *
+ * Scoped replace deletes every target row whose scope-column tuple appears in the source and
+ * appends all source rows. Concrete subclasses fix the table layout to a group-based
+ * (copy-on-write) or delta-based (merge-on-read) row-level operation. Assertions are written
+ * against final table contents so they hold for both backends.
+ */
+abstract class ReplaceUsingTableSuiteBase extends RowLevelOperationSuiteBase {
+
+  private val schemaString = "pk INT NOT NULL, id INT, dep STRING"
+
+  protected def isDeltaBasedReplace: Boolean = false
+
+  test("replace using deletes matching scopes and inserts all source rows") {
+    createAndInitTable(schemaString,
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(
+      s"""INSERT INTO $tableNameAsString REPLACE USING (dep)
+         |SELECT * FROM VALUES (10, 10, 'hr'), (11, 11, 'hr') AS t(pk, id, dep)
+         |""".stripMargin)
+
+    // Both `hr` target rows are removed, the unrelated `software` row is untouched, and every
+    // source row (including two sharing the `hr` scope) is appended.
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Row(2, 2, "software") :: Row(10, 10, "hr") :: Row(11, 11, "hr") :: Nil)
+  }
+
+  test("replace using leaves scopes absent from the source untouched") {
+    createAndInitTable(schemaString,
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(
+      s"""INSERT INTO $tableNameAsString REPLACE USING (dep)
+         |SELECT * FROM VALUES (20, 20, 'finance') AS t(pk, id, dep)
+         |""".stripMargin)
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Row(1, 1, "hr") :: Row(2, 2, "software") :: Row(20, 20, "finance") :: Nil)
+  }
+
+  test("replace using scope can differ from the data grouping columns") {
+    createAndInitTable(schemaString,
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 1, "dep": "finance" }
+        |""".stripMargin)
+
+    sql(
+      s"""INSERT INTO $tableNameAsString REPLACE USING (id)
+         |SELECT * FROM VALUES (10, 1, 'legal') AS t(pk, id, dep)
+         |""".stripMargin)
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Row(2, 2, "software") :: Row(10, 1, "legal") :: Nil)
+  }
+
+  test("replace using matches null scope values with EqualNullSafe") {
+    createAndInitTable(schemaString,
+      """{ "pk": 1, "id": 1, "dep": null }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(
+      s"""INSERT INTO $tableNameAsString REPLACE USING (dep)
+         |SELECT * FROM VALUES (30, 30, CAST(NULL AS STRING)) AS t(pk, id, dep)
+         |""".stripMargin)
+
+    // The existing null-scope row is replaced by the null-scope source row.
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Row(2, 2, "software") :: Row(30, 30, null) :: Nil)
+  }
+
+  test("replace using with an empty source deletes nothing and inserts nothing") {
+    createAndInitTable(schemaString,
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    sql(
+      s"""INSERT INTO $tableNameAsString REPLACE USING (dep)
+         |SELECT * FROM VALUES (0, 0, 'x') AS t(pk, id, dep) WHERE 1 = 0
+         |""".stripMargin)
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Row(1, 1, "hr") :: Row(2, 2, "software") :: Nil)
+  }
+
+  test("replace using aligns the source by position") {
+    createAndInitTable(schemaString,
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    sql(
+      s"""INSERT INTO $tableNameAsString REPLACE USING (dep)
+         |SELECT * FROM VALUES (40, 40, 'hr') AS t(a, b, c)
+         |""".stripMargin)
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Row(40, 40, "hr") :: Nil)
+  }
+
+  test("replace using exposes expected connector write schema and rows") {
+    createAndInitTable(schemaString,
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "hr" }
+        |{ "pk": 3, "id": 3, "dep": "software" }
+        |""".stripMargin)
+
+    sql(
+      s"""INSERT INTO $tableNameAsString REPLACE USING (id)
+         |SELECT * FROM VALUES (10, 1, 'legal'), (11, 4, 'finance') AS t(pk, id, dep)
+         |""".stripMargin)
+
+    if (isDeltaBasedReplace) {
+      checkLastWriteInfo(
+        expectedRowSchema = StructType(table.schema.map(_.copy(nullable = false))),
+        expectedRowIdSchema = Some(StructType(Array(PK_FIELD))),
+        expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD_NULLABLE))))
+
+      checkLastWriteLog(
+        deleteWriteLogEntry(id = 1, metadata = Row("hr", null)),
+        insertWriteLogEntry(data = Row(10, 1, "legal")),
+        insertWriteLogEntry(data = Row(11, 4, "finance")))
+    } else {
+      checkLastWriteInfo(
+        expectedRowSchema = table.schema,
+        expectedMetadataSchema = Some(StructType(Array(PARTITION_FIELD, INDEX_FIELD))))
+
+      checkLastWriteLog(
+        writeWithMetadataLogEntry(metadata = Row("hr", 1), data = Row(2, 2, "hr")),
+        writeLogEntry(data = Row(10, 1, "legal")),
+        writeLogEntry(data = Row(11, 4, "finance")))
+    }
+  }
+
+  test("replace using aligns the source by name") {
+    withTempView("source") {
+      createAndInitTable(schemaString,
+        """{ "pk": 1, "id": 1, "dep": "hr" }
+          |""".stripMargin)
+
+      // BY NAME reorders the source columns to the target layout: (pk, id, dep).
+      sql("SELECT 'hr' AS dep, 50 AS id, 41 AS pk").createOrReplaceTempView("source")
+
+      sql(
+        s"""INSERT INTO $tableNameAsString BY NAME REPLACE USING (dep)
+           |SELECT * FROM source
+           |""".stripMargin)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Row(41, 50, "hr") :: Nil)
+    }
+  }
+
+  test("replace using rejects a non-deterministic source") {
+    createAndInitTable(schemaString,
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(
+          s"""INSERT INTO $tableNameAsString REPLACE USING (dep)
+             |SELECT * FROM VALUES (1, 1, 'hr') AS t(pk, id, dep) WHERE rand() > 0.5
+             |""".stripMargin)
+      },
+      condition = "INSERT_REPLACE_USING_NON_DETERMINISTIC_SOURCE",
+      parameters = Map.empty[String, String])
+  }
+
+  test("replace using rejects an unknown scope column") {
+    createAndInitTable(schemaString,
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(
+          s"""INSERT INTO $tableNameAsString REPLACE USING (missing)
+             |SELECT * FROM VALUES (1, 1, 'hr') AS t(pk, id, dep)
+             |""".stripMargin)
+      },
+      condition = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
+      parameters = Map(
+        "objectName" -> "`missing`",
+        "proposal" -> "`pk`, `id`, `dep`"))
+  }
+
+  test("replace using rejects a duplicate scope column") {
+    createAndInitTable(schemaString,
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(
+          s"""INSERT INTO $tableNameAsString REPLACE USING (dep, dep)
+             |SELECT * FROM VALUES (1, 1, 'hr') AS t(pk, id, dep)
+             |""".stripMargin)
+      },
+      condition = "INSERT_REPLACE_USING_DUPLICATE_SCOPE_COLUMN",
+      parameters = Map("columnName" -> "`dep`"))
+  }
+
+  test("replace using resolves duplicate scope columns with the active resolver") {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+      val caseSensitiveSchema = "pk INT NOT NULL, id INT, dep STRING, Dep STRING"
+      createAndInitTable(caseSensitiveSchema,
+        """{ "pk": 1, "id": 1, "dep": "lower", "Dep": "upper-a" }
+          |{ "pk": 2, "id": 2, "dep": "lower", "Dep": "upper-b" }
+          |""".stripMargin)
+
+      sql(
+        s"""INSERT INTO $tableNameAsString REPLACE USING (Dep, dep)
+           |SELECT * FROM VALUES (10, 10, 'lower', 'upper-a') AS t(pk, id, dep, Dep)
+           |""".stripMargin)
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Row(2, 2, "lower", "upper-b") :: Row(10, 10, "lower", "upper-a") :: Nil)
+    }
+  }
+
+  test("replace using populates a runtime group filter only when enabled") {
+    createAndInitTable(schemaString,
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |""".stripMargin)
+
+    withSQLConf(SQLConf.RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED.key -> "true") {
+      val (_, groupFilterCond) = executeAndKeepConditions {
+        sql(
+          s"""INSERT INTO $tableNameAsString REPLACE USING (dep)
+             |SELECT * FROM VALUES (3, 3, 'hr') AS t(pk, id, dep)
+             |""".stripMargin)
+      }
+      assert(groupFilterCond.isDefined, "scoped replace must populate a runtime group filter")
+    }
+
+    withSQLConf(SQLConf.RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED.key -> "false") {
+      val (_, groupFilterCond) = executeAndKeepConditions {
+        sql(
+          s"""INSERT INTO $tableNameAsString REPLACE USING (dep)
+             |SELECT * FROM VALUES (4, 4, 'hr') AS t(pk, id, dep)
+             |""".stripMargin)
+      }
+      assert(groupFilterCond.isEmpty, "no group filter when runtime filtering is disabled")
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ReplaceUsingTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ReplaceUsingTableSuiteBase.scala
@@ -122,6 +122,27 @@ abstract class ReplaceUsingTableSuiteBase extends RowLevelOperationSuiteBase {
       Row(2, 2, "software") :: Row(10, 1, "legal") :: Nil)
   }
 
+  test("replace using matches a multi-column scope as a full tuple") {
+    createAndInitTable(schemaString,
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 1, "dep": "software" }
+        |{ "pk": 3, "id": 2, "dep": "hr" }
+        |{ "pk": 4, "id": 2, "dep": "finance" }
+        |""".stripMargin)
+
+    // Scope is the (id, dep) tuple. Only the row whose full tuple equals the source tuple
+    // (1, 'hr') is replaced; rows that match just one of the two scope columns are preserved,
+    // confirming the scope predicate is an AND of all columns rather than a per-column match.
+    sql(
+      s"""INSERT INTO $tableNameAsString REPLACE USING (id, dep)
+         |SELECT * FROM VALUES (10, 1, 'hr') AS t(pk, id, dep)
+         |""".stripMargin)
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Row(2, 1, "software") :: Row(3, 2, "hr") :: Row(4, 2, "finance") :: Row(10, 1, "hr") :: Nil)
+  }
+
   test("replace using matches null scope values with EqualNullSafe") {
     createAndInitTable(schemaString,
       """{ "pk": 1, "id": 1, "dep": null }
@@ -272,6 +293,26 @@ abstract class ReplaceUsingTableSuiteBase extends RowLevelOperationSuiteBase {
       },
       condition = "INSERT_REPLACE_USING_DUPLICATE_SCOPE_COLUMN",
       parameters = Map("columnName" -> "`dep`"))
+  }
+
+  test("replace using rejects a case-insensitive duplicate scope column") {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
+      createAndInitTable(schemaString,
+        """{ "pk": 1, "id": 1, "dep": "hr" }
+          |""".stripMargin)
+
+      // Under case-insensitive resolution `dep` and `DEP` resolve to the same target column, so
+      // the pair must be flagged as a duplicate scope column rather than silently deduplicated.
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql(
+            s"""INSERT INTO $tableNameAsString REPLACE USING (dep, DEP)
+               |SELECT * FROM VALUES (1, 1, 'hr') AS t(pk, id, dep)
+               |""".stripMargin)
+        },
+        condition = "INSERT_REPLACE_USING_DUPLICATE_SCOPE_COLUMN",
+        parameters = Map("columnName" -> "`DEP`"))
+    }
   }
 
   test("replace using resolves duplicate scope columns with the active resolver") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ReplaceUsingUnsupportedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ReplaceUsingUnsupportedTableSuite.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import org.apache.spark.sql.AnalysisException
+
+/**
+ * Verifies the analysis gate for `INSERT INTO ... REPLACE USING`: a table that supports row-level
+ * operations but does not opt into the REPLACE command (i.e. does not implement
+ * `SupportsRowLevelReplace`) must be rejected before its row-level operation builder is invoked.
+ *
+ * The base [[RowLevelOperationSuiteBase]] leaves `extraTableProps` empty, so the backing table is
+ * the unmarked [[org.apache.spark.sql.connector.catalog.InMemoryRowLevelOperationTable]].
+ */
+class ReplaceUsingUnsupportedTableSuite extends RowLevelOperationSuiteBase {
+
+  private val schemaString = "pk INT NOT NULL, id INT, dep STRING"
+
+  test("replace using is rejected for a row-level table that does not opt in") {
+    createAndInitTable(schemaString,
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |""".stripMargin)
+
+    val ex = intercept[AnalysisException] {
+      sql(
+        s"""INSERT INTO $tableNameAsString REPLACE USING (dep)
+           |SELECT * FROM VALUES (10, 10, 'hr') AS t(pk, id, dep)
+           |""".stripMargin)
+    }
+    checkError(
+      exception = ex,
+      condition = "UNSUPPORTED_FEATURE.TABLE_OPERATION",
+      parameters = Map(
+        "tableName" -> "`cat`.`ns1`.`test_table`",
+        "operation" -> "INSERT INTO ... REPLACE ON/USING"))
+  }
+}


### PR DESCRIPTION
[jira link](https://issues.apache.org/jira/browse/SPARK-57636)

### What changes were proposed in this pull request?

[SPARK-56001](https://issues.apache.org/jira/browse/SPARK-56001) added parser and logical syntax support.

This PR is a continuation of that work, and adds row-level DSv2 execution support for `INSERT INTO ... REPLACE USING`.

It introduces a dedicated `RowLevelOperation.Command.REPLACE` command and rewrites scoped replace operations onto Spark's existing row-level write machinery:

- copy-on-write tables use `ReplaceData`
- merge-on-read tables use `WriteDelta`
- replace write metrics are reported through `ReplaceSummary`
- existing row-level connectors are protected by a new `SupportsRowLevelReplace` opt-in marker

The PR also updates the in-memory DSv2 test fixtures to cover positive and negative opt-in behavior, including copy, ALTER, and transactional wrapper paths.

### Key design decisions

- Use a new `RowLevelOperation.Command.REPLACE` instead of reusing `MERGE`. `REPLACE USING` deletes target rows by source-defined scope tuples and inserts all source rows, including duplicate source scopes, which is not the same cardinality model as `MERGE`.
- Keep the execution path in Spark's row-level DSv2 framework. Group-based/copy-on-write connectors reuse `ReplaceData`; delta-based/merge-on-read connectors reuse `WriteDelta`.
- Resolve the source with normal `INSERT INTO` alignment rules. By-position and `BY NAME` behavior continue to use Spark's standard output resolution before the rewrite builds scope joins and insert rows by ordinal.
- Treat the replacement scope as dynamic source state. Static planning predicates stay broad, while runtime group filtering is populated when enabled so capable scans can prune affected groups dynamically.
- Require deterministic source queries. The source determines both the delete scope and inserted rows, so non-deterministic sources are rejected during analysis.
- Gate connector adoption explicitly with `SupportsRowLevelReplace`. Non-row-level DSv2 tables and row-level tables that do not opt in fail with an unsupported table operation error before Spark calls the connector's row-level operation builder with `REPLACE`.
- Report REPLACE-specific metrics separately through `ReplaceSummary` so inserted, deleted, and copied rows are not derived from ambiguous generic row-level task counters.
- Targets spark 4.2 in current code, but if missed release window, need to modify `@since` annotations to use 4.3 instead

### Out of scope

- `REPLACE ON` execution support.
- DataFrame API support for scoped replace.

### Why are the changes needed?

`INSERT INTO ... REPLACE USING` needs a row-level execution path so DSv2 tables can replace source-defined scopes without relying on table-wide overwrite behavior.

The explicit `SupportsRowLevelReplace` opt-in prevents existing row-level connectors that only implemented DELETE, UPDATE, or MERGE from unexpectedly receiving the new `REPLACE` command.

### Does this PR introduce _any_ user-facing change?

Yes. DSv2 connectors that implement `SupportsRowLevelReplace` can support `INSERT INTO ... REPLACE USING (cols)` through row-level operations. Row-level tables that do not opt in fail analysis with an unsupported table operation error instead of invoking the connector's row-level operation builder with an unexpected command.

### How was this patch tested?

Tested with:

```
export JAVA_HOME=/Library/Java/JavaVirtualMachines/amazon-corretto-17.jdk/Contents/Home
export SPARK_LOCAL_IP=127.0.0.1
build/sbt 'catalyst/Test/compile' 'sql/testOnly org.apache.spark.sql.connector.GroupBasedReplaceUsingTableSuite org.apache.spark.sql.connector.DeltaBasedReplaceUsingTableSuite org.apache.spark.sql.connector.ReplaceUsingUnsupportedTableSuite'
```

Also ran representative row-level regression suites during development:

```
build/sbt 'sql/testOnly *DeltaBasedReplaceUsingTableSuite *ReplaceUsingUnsupportedTableSuite *GroupBasedDeleteFromTableSuite *DeltaBasedMergeIntoTableSuite'
```

### Was this patch authored or co-authored using generative AI tooling?

co-authored with the help of a combination of GPT-5.5 and Claude Opus 4.8