### PR TITLE
[SPARK-57644][SQL] TxnTableCatalog should delegate capabilities to underlying catalog

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/txns.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/txns.scala
@@ -179,6 +179,8 @@ class TxnTableCatalog(delegate: InMemoryRowLevelOperationTableCatalog) extends T
 
   override def name: String = delegate.name
 
+  override def capabilities: java.util.Set[TableCatalogCapability] = delegate.capabilities
+
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {}
 
   override def listTables(namespace: Array[String]): Array[Identifier] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`TxnTableCatalog` wraps `InMemoryRowLevelOperationTableCatalog` for transactional row-level operation tests but does not delegate `capabilities()` to the underlying catalog. This means any capability check through the transactional wrapper returns an empty set.

Fix by delegating `capabilities()` to the underlying catalog.

### Why are the changes needed?

Without this delegation, capability-gated features are invisible through the transactional catalog wrapper. For example, `SUPPORT_GENERATED_COLUMN_ON_WRITE` (added in SPARK-57644) cannot be checked when the catalog is accessed through `TxnTableCatalog`, even though the underlying `InMemoryRowLevelOperationTableCatalog` declares the capability.

### Does this PR introduce _any_ user-facing change?

The TxnTableCatalog will expose the capabilities of the underlying Catalog.

### How was this patch tested?

Existing tests pass. This is a prerequisite for testing generated column MERGE/UPDATE blocking in SPARK-57644.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)