### PR TITLE
[DO-NOT-MERGE][CONNECT] Stabilize flaky SparkSessionE2ESuite + ClientStreamingQuerySuite listener events

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -34,7 +34,12 @@ jobs:
     #     integration/staging branch is disabled to save resources.
     #   - pushes to `master` on forks: the "Sync fork" button mirrors
     #     apache/spark and would otherwise re-run the full build on every sync.
+    # DO-NOT-MERGE: also skip this fork branch. The full scala matrix is not needed to validate a
+    # test-only fix in SparkSessionE2ESuite and would surface unrelated failing CI lanes on this
+    # draft PR; the focused ci_fix_connect_e2e.yml workflow validates this change instead. Revert
+    # this extra condition before merging.
     if: >-
       (github.repository == 'apache/spark' && github.ref != 'refs/heads/branch-4.x')
-      || (github.repository != 'apache/spark' && github.ref != 'refs/heads/master')
+      || (github.repository != 'apache/spark' && github.ref != 'refs/heads/master'
+          && github.ref != 'refs/heads/ci-fix/connect-sparksession-e2e-flaky')
     uses: ./.github/workflows/build_and_test.yml

--- a/.github/workflows/ci_fix_connect_e2e.yml
+++ b/.github/workflows/ci_fix_connect_e2e.yml
@@ -1,0 +1,85 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# DO-NOT-MERGE: temporary focused workflow used only to validate the
+# SparkSessionE2ESuite flakiness fix on a fork. It builds the connect module once
+# (via the proven dev/run-tests path) and then re-runs ONLY SparkSessionE2ESuite
+# several times to confirm the test is no longer flaky. This file must be dropped
+# before the real fix is merged.
+name: "DO-NOT-MERGE CI fix - connect SparkSessionE2ESuite"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'ci-fix/connect-sparksession-e2e-flaky'
+
+jobs:
+  connect-e2e:
+    name: "Build connect + repeat SparkSessionE2ESuite"
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      SPARK_LOCAL_IP: localhost
+      SKIP_UNIDOC: true
+      SKIP_MIMA: true
+      SKIP_PACKAGING: true
+      SERIAL_SBT_TESTS: 1
+      HADOOP_PROFILE: hadoop3
+      HIVE_PROFILE: hive2.3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Free up disk space
+        run: |
+          if [ -f ./dev/free_disk_space ]; then ./dev/free_disk_space; fi
+      - name: Install Java 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 17
+      - name: Install Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          architecture: x64
+      - name: Install Python packages (Python 3.12)
+        run: |
+          python3.12 -m pip install 'numpy>=1.23.2' pyarrow 'pandas==2.3.3' pyyaml scipy unittest-xml-reporting 'lxml==4.9.4' 'grpcio==1.76.0' 'grpcio-status==1.76.0' 'protobuf==6.33.5' 'zstandard==0.25.0'
+          python3.12 -m pip list
+      # Phase 1: build everything for the connect module and run the full connect
+      # module once via the standard tooling (validates the fix in the real path).
+      - name: Build + run connect module (dev/run-tests)
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          export TERM=vt100
+          ./dev/run-tests --parallelism 1 --modules connect
+      # Phase 2: re-run ONLY SparkSessionE2ESuite several times, reusing the jars
+      # built above, to confirm the previously-flaky interrupt tests are stable.
+      - name: Repeat SparkSessionE2ESuite (flakiness check)
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          export TERM=vt100
+          for i in $(seq 1 8); do
+            echo "==================== SparkSessionE2ESuite iteration $i ===================="
+            ./build/sbt -Phive -Phadoop-3 \
+              "connect-client-jvm/testOnly org.apache.spark.sql.connect.SparkSessionE2ESuite"
+          done

--- a/.github/workflows/ci_fix_connect_e2e.yml
+++ b/.github/workflows/ci_fix_connect_e2e.yml
@@ -83,3 +83,12 @@ jobs:
             ./build/sbt -Phive -Phadoop-3 \
               "connect-client-jvm/testOnly org.apache.spark.sql.connect.SparkSessionE2ESuite"
           done
+      - name: Repeat ClientStreamingQuerySuite "listener events" (flakiness check)
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          export TERM=vt100
+          for i in $(seq 1 8); do
+            echo "============== ClientStreamingQuerySuite listener events iteration $i =============="
+            ./build/sbt -Phive -Phadoop-3 \
+              "connect-client-jvm/testOnly org.apache.spark.sql.connect.streaming.ClientStreamingQuerySuite -- -z \"listener events\""
+          done

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionE2ESuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/SparkSessionE2ESuite.scala
@@ -41,11 +41,20 @@ class SparkSessionE2ESuite extends ConnectFunSuite with RemoteSparkSession {
     val session = spark
     import session.implicits._
     implicit val ec: ExecutionContextExecutor = ExecutionContext.global
+    // Run the long-running query through a single call site, and warm it up once before any
+    // interrupt. Otherwise the very first execution has to ship/fetch the map closure and its
+    // TypeTag artifact classes to the executor on demand; if an interrupt lands during that
+    // first-time remote class fetch, it surfaces as a RemoteClassLoaderError instead of
+    // OPERATION_CANCELED, making this test flaky (see SparkSessionE2ESuite$$typecreatorNN).
+    def runMapQuery(sleepMs: Long): Unit = {
+      spark.range(10).map(n => { Thread.sleep(sleepMs); n }).collect()
+    }
+    runMapQuery(0)
     val q1 = Future {
-      spark.range(10).map(n => { Thread.sleep(30000); n }).collect()
+      runMapQuery(30000)
     }
     val q2 = Future {
-      spark.range(10).map(n => { Thread.sleep(30000); n }).collect()
+      runMapQuery(30000)
     }
     var q1Interrupted = false
     var q2Interrupted = false
@@ -88,6 +97,16 @@ class SparkSessionE2ESuite extends ConnectFunSuite with RemoteSparkSession {
     @volatile var finished = false
     val interrupted = mutable.ListBuffer[String]()
 
+    // Run the long-running query through a single call site, and warm it up once before the
+    // background interruptor starts. Otherwise the first execution has to ship/fetch the map
+    // closure and its TypeTag artifact classes to the executor on demand; if an interrupt lands
+    // during that first-time remote class fetch, it surfaces as a RemoteClassLoaderError instead
+    // of OPERATION_CANCELED, making this test flaky (see SparkSessionE2ESuite$$typecreatorNN).
+    def runMapQuery(sleepMs: Long): Unit = {
+      spark.range(10).map(n => { Thread.sleep(sleepMs); n }).collect()
+    }
+    runMapQuery(0)
+
     val interruptor = Future {
       eventually(timeout(20.seconds), interval(1.seconds)) {
         val ids = spark.interruptAll()
@@ -96,15 +115,22 @@ class SparkSessionE2ESuite extends ConnectFunSuite with RemoteSparkSession {
       }
       finished
     }
-    val e1 = intercept[SparkException] {
-      spark.range(10).map(n => { Thread.sleep(30.seconds.toMillis); n }).collect()
+    try {
+      val e1 = intercept[SparkException] {
+        runMapQuery(30.seconds.toMillis)
+      }
+      assert(e1.getMessage.contains("OPERATION_CANCELED"), s"Unexpected exception: $e1")
+      val e2 = intercept[SparkException] {
+        runMapQuery(30.seconds.toMillis)
+      }
+      assert(e2.getMessage.contains("OPERATION_CANCELED"), s"Unexpected exception: $e2")
+    } finally {
+      // Always release the background interruptor. If an assertion above fails, this prevents the
+      // interruptor Future from continuing to call interruptAll() and canceling operations of the
+      // subsequent tests in this suite (which previously caused cascading OPERATION_CANCELED
+      // failures across the whole suite).
+      finished = true
     }
-    assert(e1.getMessage.contains("OPERATION_CANCELED"), s"Unexpected exception: $e1")
-    val e2 = intercept[SparkException] {
-      spark.range(10).map(n => { Thread.sleep(30.seconds.toMillis); n }).collect()
-    }
-    assert(e2.getMessage.contains("OPERATION_CANCELED"), s"Unexpected exception: $e2")
-    finished = true
     assert(awaitResult(interruptor, 10.seconds))
     assert(interrupted.length == 2, s"Interrupted operations: $interrupted.")
   }

--- a/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/streaming/ClientStreamingQuerySuite.scala
+++ b/sql/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/streaming/ClientStreamingQuerySuite.scala
@@ -568,18 +568,28 @@ class ClientStreamingQuerySuite extends QueryTest with RemoteSparkSession with L
       .format("console")
       .start()
 
+    // Diagnostic context attached to assertion failures so that, if this test ever flakes again in
+    // a scheduled job, the log pinpoints which event was missing and the surrounding client state
+    // (e.g. whether the client-side listener is still registered, whether the query errored). The
+    // server-side listener can silently self-remove on a send failure, dropping later events.
+    def diag(stage: String): String =
+      s"[$stage] q.isActive=${q.isActive}, q.exception=${q.exception}, " +
+        s"start=${listener.start.size}, progress=${listener.progress.size}, " +
+        s"terminate=${listener.terminate.size}, " +
+        s"clientListeners=${spark.streams.listListeners().length}"
+
     try {
       q.processAllAvailable()
       eventually(timeout(30.seconds)) {
-        assert(q.isActive)
-        assert(listener.start.length == 1)
-        assert(listener.progress.nonEmpty)
+        assert(q.isActive, diag("active"))
+        assert(listener.start.length == 1, diag("start"))
+        assert(listener.progress.nonEmpty, diag("progress"))
       }
     } finally {
       q.stop()
       eventually(timeout(60.seconds), interval(1.seconds)) {
-        assert(!q.isActive)
-        assert(listener.terminate.nonEmpty)
+        assert(!q.isActive, diag("stopped"))
+        assert(listener.terminate.nonEmpty, diag("terminate"))
       }
     }
   }
@@ -746,9 +756,10 @@ class ClientStreamingQuerySuite extends QueryTest with RemoteSparkSession with L
   }
 
   class MyListener extends StreamingQueryListener {
-    var start: Seq[String] = Seq.empty
-    var progress: Seq[String] = Seq.empty
-    var terminate: Seq[String] = Seq.empty
+    // @volatile so the test thread reliably observes updates made on the listener dispatch thread.
+    @volatile var start: Seq[String] = Seq.empty
+    @volatile var progress: Seq[String] = Seq.empty
+    @volatile var terminate: Seq[String] = Seq.empty
 
     override def onQueryStarted(event: QueryStartedEvent): Unit = {
       start = start :+ event.json

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListener.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListener.scala
@@ -99,41 +99,73 @@ private[sql] class SparkConnectListenerBusListener(
     with Logging {
 
   val sessionHolder = serverSideListenerHolder.sessionHolder
+
+  // Number of attempts to transmit an event to the client before giving up. A single transient
+  // failure (e.g. a momentary gRPC flow-control / response-observer hiccup) should not permanently
+  // remove the listener and silently drop all subsequent events for the session, including the
+  // terminal QueryTerminatedEvent. Only tear down the listener when sending keeps failing across
+  // retries (which is what actually indicates an unresponsive client).
+  private val maxSendAttempts = 3
+  private val sendRetryBackoffMs = 200L
+
   // The method used to stream back the events to the client.
   // The event is serialized to json and sent to the client.
-  // If any exception is thrown while transmitting back the event, the listener is removed,
+  // It is retried a few times on a transient failure; if it keeps failing, the listener is removed,
   // all related sources are cleaned up, and the long-running thread will proceed to send
   // the final ResultComplete response.
   private def send(eventJson: String, eventType: StreamingQueryEventType): Unit = {
-    try {
-      val event = StreamingQueryListenerEvent
-        .newBuilder()
-        .setEventJson(eventJson)
-        .setEventType(eventType)
-        .build()
+    val event = StreamingQueryListenerEvent
+      .newBuilder()
+      .setEventJson(eventJson)
+      .setEventType(eventType)
+      .build()
 
-      val respBuilder = StreamingQueryListenerEventsResult.newBuilder()
-      val eventResult = respBuilder
-        .addAllEvents(Array[StreamingQueryListenerEvent](event).toImmutableArraySeq.asJava)
-        .build()
+    val eventResult = StreamingQueryListenerEventsResult
+      .newBuilder()
+      .addAllEvents(Array[StreamingQueryListenerEvent](event).toImmutableArraySeq.asJava)
+      .build()
 
-      responseObserver.onNext(
-        ExecutePlanResponse
-          .newBuilder()
-          .setSessionId(sessionHolder.sessionId)
-          .setServerSideSessionId(sessionHolder.serverSessionId)
-          .setStreamingQueryListenerEventsResult(eventResult)
-          .build())
-    } catch {
-      case NonFatal(e) =>
-        logError(log"[SessionId: ${MDC(LogKeys.SESSION_ID, sessionHolder.sessionId)}]" +
-          log"[UserId: ${MDC(LogKeys.USER_ID, sessionHolder.userId)}] " +
-          log"Removing SparkConnectListenerBusListener and terminating the long-running thread " +
-          log"because of exception: ${MDC(LogKeys.EXCEPTION, e)}")
-        // This likely means that the client is not responsive even with retry, we should
-        // remove this listener and cleanup resources.
-        serverSideListenerHolder.cleanUp()
+    val response = ExecutePlanResponse
+      .newBuilder()
+      .setSessionId(sessionHolder.sessionId)
+      .setServerSideSessionId(sessionHolder.serverSessionId)
+      .setStreamingQueryListenerEventsResult(eventResult)
+      .build()
+
+    var attempt = 1
+    var lastError: Option[Throwable] = None
+    while (attempt <= maxSendAttempts) {
+      try {
+        responseObserver.onNext(response)
+        return
+      } catch {
+        case NonFatal(e) =>
+          lastError = Some(e)
+          logWarning(
+            s"[SessionId: ${sessionHolder.sessionId}][UserId: ${sessionHolder.userId}] " +
+              s"Failed to send $eventType to client (attempt $attempt/$maxSendAttempts).",
+            e)
+          if (attempt < maxSendAttempts) {
+            try {
+              Thread.sleep(sendRetryBackoffMs)
+            } catch {
+              case _: InterruptedException =>
+                Thread.currentThread().interrupt()
+                attempt = maxSendAttempts // stop retrying
+            }
+          }
+      }
+      attempt += 1
     }
+    // All attempts failed: this likely means the client is not responsive even with retry, so we
+    // remove this listener and cleanup resources. The long-running thread will then proceed to send
+    // the final ResultComplete response.
+    logError(
+      s"[SessionId: ${sessionHolder.sessionId}][UserId: ${sessionHolder.userId}] " +
+        s"Removing SparkConnectListenerBusListener and terminating the long-running thread " +
+        s"because sending $eventType failed $maxSendAttempts times.",
+      lastError.orNull)
+    serverSideListenerHolder.cleanUp()
   }
 
   def sendResultComplete(): Unit = {


### PR DESCRIPTION
> **[DO-NOT-MERGE]** — draft used to stabilize flaky connect CI tests and validate the fixes
> on a fork. The two `[DO-NOT-MERGE]` commits add temporary CI scaffolding (a focused workflow that
> rebuilds the connect module and re-runs only the affected suites several times, and skips the full
> scala matrix for this fork branch) and **must be dropped before any real merge**. The two real
> fixes are independent and can be split into separate PRs.

This draft bundles two independent Spark Connect CI flakiness fixes.

## Fix 1 — `SparkSessionE2ESuite` interrupt-all tests (test-only)

The foreground typed-`.map` ships its closure/`TypeTag` classes as Connect artifacts; the background
`interruptAll()` can land during the executor's **first-time** remote fetch of `$$typecreatorNN`,
surfacing as `RemoteClassLoaderError` instead of `OPERATION_CANCELED`. When that assertion failed,
the `interruptor` Future was never stopped and kept canceling **subsequent** tests' operations →
cascade of `OPERATION_CANCELED` failures across the suite.

- Warm up the map closure once (via a single call site) before any interrupt, so its classes are
  already loaded on the executor.
- Wrap the body in `try/finally { finished = true }` so a failure can't leak the interruptor.

## Fix 2 — `ClientStreamingQuerySuite."listener events"` lost terminate event

`QueryStartedEvent`/`QueryProgressEvent` arrive but the terminal `QueryTerminatedEvent` is never
received (`listener.terminate` empty after 60s) though the query has stopped. The server-side
`SparkConnectListenerBusListener.send` removes the listener and stops sending **all** further events
on the first `onNext` failure, so a single transient gRPC hiccup on a frequent progress event
silently drops the later terminate event.

- Retry `onNext` a small bounded number of times before tearing the listener down.
- Add `diag(stage)` context to the test assertions and make the test listener fields `@volatile`, so
  a future scheduled-job recurrence is debuggable (server logs aren't captured in CI, so the exact
  failure is inferred — these diagnostics confirm/refine it next time).

### Does this PR introduce any user-facing change?

No (test-only + server hardening).

### How was this patch tested?

Focused fork workflow: rebuild connect, then re-run `SparkSessionE2ESuite` ×8 and
`ClientStreamingQuerySuite."listener events"` ×8. Existing `SparkConnectListenerBusListenerSuite`
onNext-throw tests still pass.

### Was this patch authored or co-authored using generative AI tooling?

Yes, drafted with Claude Code.
