### PR TITLE
[SPARK-57647][SQL][TESTS] Make `FileSourceStrategySuite` be independent from the default value of `maxPartitionBytes`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -605,25 +605,27 @@ class FileSourceStrategySuite extends SharedSparkSession {
   }
 
   test(s"SPARK-44021: Test ${SQLConf.FILES_MAX_PARTITION_NUM.key} works as expected") {
-    val files =
-      Range(0, 300000).map(p => PartitionedFile(InternalRow.empty, sp(s"$p"), 0, 50000000))
-    val maxPartitionBytes = conf.filesMaxPartitionBytes
-    val defaultPartitions = FilePartition.getFilePartitions(spark, files, maxPartitionBytes)
-    assert(defaultPartitions.size === 150000)
+    withSQLConf(SQLConf.FILES_MAX_PARTITION_BYTES.key -> "128MB") {
+      val files =
+        Range(0, 300000).map(p => PartitionedFile(InternalRow.empty, sp(s"$p"), 0, 50000000))
+      val maxPartitionBytes = conf.filesMaxPartitionBytes
+      val defaultPartitions = FilePartition.getFilePartitions(spark, files, maxPartitionBytes)
+      assert(defaultPartitions.size === 150000)
 
-    withSQLConf(SQLConf.FILES_MAX_PARTITION_NUM.key -> "20000") {
-      val partitions = FilePartition.getFilePartitions(spark, files, maxPartitionBytes)
-      assert(partitions.size === 20000)
-    }
+      withSQLConf(SQLConf.FILES_MAX_PARTITION_NUM.key -> "20000") {
+        val partitions = FilePartition.getFilePartitions(spark, files, maxPartitionBytes)
+        assert(partitions.size === 20000)
+      }
 
-    withSQLConf(SQLConf.FILES_MAX_PARTITION_NUM.key -> "50000") {
-      val partitions = FilePartition.getFilePartitions(spark, files, maxPartitionBytes)
-      assert(partitions.size === 50000)
-    }
+      withSQLConf(SQLConf.FILES_MAX_PARTITION_NUM.key -> "50000") {
+        val partitions = FilePartition.getFilePartitions(spark, files, maxPartitionBytes)
+        assert(partitions.size === 50000)
+      }
 
-    withSQLConf(SQLConf.FILES_MAX_PARTITION_NUM.key -> "200000") {
-      val partitions = FilePartition.getFilePartitions(spark, files, maxPartitionBytes)
-      assert(partitions.size === defaultPartitions.size)
+      withSQLConf(SQLConf.FILES_MAX_PARTITION_NUM.key -> "200000") {
+        val partitions = FilePartition.getFilePartitions(spark, files, maxPartitionBytes)
+        assert(partitions.size === defaultPartitions.size)
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `FileSourceStrategySuite` be independent from the default value of `maxPartitionBytes`.

### Why are the changes needed?

The following `maxPartitionNum` test case fails like the following when the default value of `maxPartitionBytes` is changed. If a test case assume some other configurations, it should be set explicitly inside the test case.

```
[info] - SPARK-44021: Test spark.sql.files.maxPartitionNum works as expected *** FAILED *** (33 milliseconds)
[info]   300000 did not equal 150000 (FileSourceStrategySuite.scala:613)
```

Since the current value of `maxPartitionBytes` is `128MB`, this PR explicitly sets it.

https://github.com/apache/spark/blob/f2cbc7803c18648130db862cd85581a57c1dad98/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L2721-L2727

### Does this PR introduce _any_ user-facing change?

No, this is a test case fix.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.