### PR TITLE
[SPARK-57649][SQL][TESTS] Regenerate stale datetime-formatting.sql.out.java21 golden file

### DIFF
--- a/sql/core/src/test/resources/sql-tests/results/datetime-formatting.sql.out.java21
+++ b/sql/core/src/test/resources/sql-tests/results/datetime-formatting.sql.out.java21
@@ -450,3 +450,19 @@ select date_format(timestamp_ntz'2023-08-18 09:13:14.123456', 'yyyy-MM-dd HH:mm:
 struct<date_format(TIMESTAMP_NTZ '2023-08-18 09:13:14.123456', yyyy-MM-dd HH:mm:ss.SSSSSS):string,date_format(TIMESTAMP_NTZ '2023-08-18 09:13:14.123456', yyyy-MM-dd HH:mm:ss.SSSSSS):string,date_format(TIMESTAMP_NTZ '2023-08-18 09:13:14.123456', yyyy-MM-dd HH:mm:ss.SSSSSS):string>
 -- !query output
 2023-08-18 09:13:14.123456	2023-08-18 09:13:14.123456	2023-08-18 09:13:14.123456
+
+
+-- !query
+select to_char(TIME'12:13:14', 'HH:mm:ss'), to_varchar(TIME'12:13:14', 'HH:mm:ss')
+-- !query schema
+struct<date_format(TIME '12:13:14', HH:mm:ss):string,date_format(TIME '12:13:14', HH:mm:ss):string>
+-- !query output
+12:13:14	12:13:14
+
+
+-- !query
+select to_char(TIME'23:59:59.123456', 'HH:mm:ss.SSSSSS'), to_varchar(TIME'23:59:59.123456', 'HH:mm:ss.SSSSSS')
+-- !query schema
+struct<date_format(TIME '23:59:59.123456', HH:mm:ss.SSSSSS):string,date_format(TIME '23:59:59.123456', HH:mm:ss.SSSSSS):string>
+-- !query output
+23:59:59.123456	23:59:59.123456


### PR DESCRIPTION
### What changes were proposed in this pull request?
[SPARK-57575](https://issues.apache.org/jira/browse/SPARK-57575) added two `TIME`-type `to_char`/`to_varchar` queries to `datetime-formatting.sql` and regenerated `datetime-formatting.sql.out` and `datetime-formatting-legacy.sql.out`, but not the Java 21 variant `datetime-formatting.sql.out.java21`. This PR regenerates the Java 21 golden by appending the two new `TIME`-type query blocks (their `HH:mm:ss` output is not locale/JDK sensitive, so it matches the default golden), restoring the expected 36 query blocks.

### Why are the changes needed?
`SQLQueryTestSuite` uses the `.out.java21` golden for any JDK >= 21, so the stale file breaks the scheduled **Maven (Scala 2.13, JDK 21)** and **Maven (Scala 2.13, JDK 25)** builds:

```
datetime-formatting.sql
Expected 109, but got 103 blocks in result file 'datetime-formatting.sql.out.java21'. Try regenerating the result files.
```

### Does this PR introduce _any_ user-facing change?
No. Test-only.

### How was this patch tested?
- **Before (failing job):** [`Build / Maven (Scala 2.13, JDK 21)` → `sql#core - extended tests`](https://github.com/apache/spark/actions/runs/28035705490/job/82998279873) — `datetime-formatting.sql *** FAILED ***`.
- **After (passing):** ran `sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z datetime-formatting` on JDK 21 → [✅ all tests passed](https://github.com/HyukjinKwon/spark/actions/runs/28065758228/job/83089561688) (`Tests: succeeded 6, failed 0`).

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Opus 4.8
