### PR TITLE
[SPARK-57653][CORE] Make UTF8String.getByte honor its documented out-of-bounds contract

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -703,6 +703,9 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    * Returns the byte at (byte) position `byteIndex`. If byte index is invalid, returns 0.
    */
   public byte getByte(int byteIndex) {
+    if (byteIndex < 0 || byteIndex >= numBytes) {
+      return 0;
+    }
     return Platform.getByte(base, offset + byteIndex);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
`UTF8String.getByte(int)` is documented as *"If byte index is invalid, returns 0"*, but the implementation performed an unchecked `Platform.getByte(base, offset + byteIndex)`, returning adjacent/uninitialized memory for out-of-range indices. This PR adds the bounds check so the method honors its documented contract:

```java
public byte getByte(int byteIndex) {
  if (byteIndex < 0 || byteIndex >= numBytes) {
    return 0;
  }
  return Platform.getByte(base, offset + byteIndex);
}
```

### Why are the changes needed?
Under JDK 25 the out-of-bounds read returned non-zero adjacent memory, making `UTF8StringSuite.testGetByte` fail with `expected: <0> but was: <47>` in the **Maven (Scala 2.13, JDK 25)** scheduled build. The previous `0` was never guaranteed — it depended on memory layout. The fix makes the behavior deterministic across JDKs.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Existing `UTF8StringSuite` (including `testGetByte`).

**Before (failing on master, JDK 25):** `UTF8StringSuite.testGetByte` — `expected: <0> but was: <47>`
https://github.com/apache/spark/actions/runs/28035606804/job/82996960386

**After (this fix, JDK 25):** `UTF8StringSuite` — *Tests: succeeded 34, failed 0*; `testGetByte` passes
https://github.com/HyukjinKwon/spark/actions/runs/28065895861/job/83089981477

This pull request and its description were written by Isaac.
