### PR TITLE
[SPARK-42839][SQL] Convert _LEGACY_ERROR_TEMP_2003 to an internal error

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -10113,11 +10113,6 @@
       "Sinks cannot request distribution and ordering in continuous execution mode."
     ]
   },
-  "_LEGACY_ERROR_TEMP_2003" : {
-    "message" : [
-      "Unsuccessful try to zip maps with <size> unique keys due to exceeding the array size limit <maxRoundedArrayLength>."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_2017" : {
     "message" : [
       "not resolved."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -342,12 +342,10 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
     arithmeticOverflowError("Overflow in function conv()", context = context)
   }
 
-  def mapSizeExceedArraySizeWhenZipMapError(size: Int): SparkRuntimeException = {
-    new SparkRuntimeException(
-      errorClass = "_LEGACY_ERROR_TEMP_2003",
-      messageParameters = Map(
-        "size" -> size.toString(),
-        "maxRoundedArrayLength" -> ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH.toString()))
+  def mapSizeExceedArraySizeWhenZipMapError(size: Int): SparkException = {
+    SparkException.internalError(
+      s"Unsuccessful try to zip maps with $size unique keys due to exceeding the array size " +
+        s"limit ${ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH}.")
   }
 
   def literalTypeUnsupportedError(v: Any): RuntimeException = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Convert `_LEGACY_ERROR_TEMP_2003` into an internal error. `mapSizeExceedArraySizeWhenZipMapError` now returns `SparkException.internalError(...)` and the `_LEGACY_ERROR_TEMP_2003` entry is removed from `error-conditions.json`.

### Why are the changes needed?

Part of the effort to assign proper names to legacy error classes (SPARK-42839). This error is thrown only by `map_zip_with` (`MapZipWith.assertSizeOfArrayBuffer`) when the number of unique keys exceeds `ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH` (~2^31). That condition is not reachable from user code, so the error is not user-facing. Per the ticket, errors that cannot be reproduced from user space should become internal errors rather than be given a user-facing name.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No test triggers this error (the array-size limit cannot be reached from user code, so there is nothing to assert with `checkError()`). Verified that no references to `_LEGACY_ERROR_TEMP_2003` remain in the tree and that `error-conditions.json` is still valid JSON with sorted keys.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI (Claude Opus 4.8)