### PR TITLE
[SPARK-56672][SQL][DOCS] Fix remaining try to date version annotations

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -8170,7 +8170,7 @@ object functions {
    * value instead of raising an error if date cannot be created.
    *
    * @group datetime_funcs
-   * @since 4.0.0
+   * @since 4.1.0
    */
   def try_to_date(e: Column): Column = Column.fn("try_to_date", e)
 
@@ -8179,7 +8179,7 @@ object functions {
    * value instead of raising an error if date cannot be created.
    *
    * @group datetime_funcs
-   * @since 4.0.0
+   * @since 4.1.0
    */
   def try_to_date(e: Column, fmt: String): Column = Column.fn("try_to_date", e, lit(fmt))
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -2585,7 +2585,7 @@ case class ParseToDate(
        NULL
   """,
   group = "datetime_funcs",
-  since = "4.0.0")
+  since = "4.1.0")
 // scalastyle:on line.size.limit
 object TryToDateExpressionBuilder extends ExpressionBuilder {
   override def build(funcName: String, expressions: Seq[Expression]): Expression = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the `try_to_date` version annotations to reflect the actual version in which the feature became available.

I think this change needs to land in the branch-4.1 branch as well as the master branch.

PR https://github.com/apache/spark/pull/56704 fixed one version annotation. This PR completes this, correcting the related try_to_date version annotations I missed. This follow-up to https://github.com/apache/spark/pull/56704 was requested by a reviewer. Thank you to @uros-b and @HyukjinKwon.

### Why are the changes needed?

See https://github.com/apache/spark/issues/56672.

Current version annotations incorrectly say that try_to_date was introduced in 4.0.0, but it was actually introduced in 4.1.0. 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

I confirmed the issue by comparing Spark 4.0 and Spark 4.1 source and the actual runtime behavior of Pyspark.

You can see that try_to_date was introduced in 4.1 by comparing:
- https://github.com/apache/spark/blob/branch-4.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala vs https://github.com/apache/spark/blob/branch-4.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
- https://github.com/apache/spark/blob/branch-4.0/sql/api/src/main/scala/org/apache/spark/sql/functions.scala vs https://github.com/apache/spark/blob/branch-4.1/sql/api/src/main/scala/org/apache/spark/sql/functions.scala

### Was this patch authored or co-authored using generative AI tooling?

No
