### PR TITLE
[SPARK-56539][CORE] Fix zero exit code on Standalone remote driver failure

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/Client.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/Client.scala
@@ -180,11 +180,14 @@ private class ClientEndpoint(
           System.exit(-1)
         case _ =>
           state.get match {
-            case DriverState.FINISHED | DriverState.FAILED |
-                 DriverState.ERROR | DriverState.KILLED =>
+            case DriverState.FINISHED =>
               logInfo(log"State of driver ${MDC(DRIVER_ID, submittedDriverID)}" +
                 log" is ${MDC(DRIVER_STATE, state.get)}, exiting spark-submit JVM.")
               System.exit(0)
+            case DriverState.FAILED | DriverState.ERROR | DriverState.KILLED =>
+                  logError(log"State of driver ${MDC(DRIVER_ID, submittedDriverID)}" +
+                    log" is ${MDC(DRIVER_STATE, state.get)}, exiting spark-submit JVM.")
+                  System.exit(-1)
             case _ =>
               if (!waitAppCompletion) {
                 logInfo("spark-submit not configured to wait for completion, " +


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR modifies the reportDriverStatus method within the Standalone ClientEndpoint to properly map remote driver failure states to a non-zero OS exit code when spark.standalone.submit.waitAppCompletion=true.
Previously, the JVM shutdown sequence was unconditionally calling System.exit(0) for all terminal driver states (FINISHED, FAILED, ERROR, KILLED). This PR decouples the success state from the failure states, ensuring that FAILED, ERROR, and KILLED trigger a System.exit(-1) and log an error rather than an info message.

### Why are the changes needed?
When users submit jobs to a Standalone cluster using --conf spark.standalone.submit.waitAppCompletion=true, the local client is expected to mirror the final execution state of the remote driver. As demonstrated by the issue reporter, when wrapping spark-submit in a Bash script and evaluating the OS exit code via $?, the script incorrectly evaluates to 0 (success) despite the client acknowledging a FAILED remote driver state.

Because the client was swallowing the remote failure, external orchestration tools (like Apache Airflow, Jenkins, or standard Bash scripts) were falsely interpreting crashed jobs as successful, leading to silent pipeline failures.
### Does this PR introduce _any_ user-facing change?
Yes. Users running spark-submit in Standalone cluster mode with waitAppCompletion=true will now correctly receive a non-zero exit code (-1) in their local terminal/OS if the remote driver fails, errors out, or is killed.


### How was this patch tested?
Relying on existing CI integration test suites for Standalone cluster submission and endpoint state handling.


### Was this patch authored or co-authored using generative AI tooling?
Yes the documentation of PR and initial error find in the terminal of issue reporter was Generated by: Google Gemini
