### PR TITLE
[SPARK-34525][DOCS] Document optional equals sign in OPTIONS and TBLPROPERTIES

### DIFF
--- a/docs/sql-ref-syntax-ddl-create-table-datasource.md
+++ b/docs/sql-ref-syntax-ddl-create-table-datasource.md
@@ -29,14 +29,14 @@ The `CREATE TABLE` statement defines a new table using a Data Source.
 CREATE TABLE [ IF NOT EXISTS ] table_identifier
     [ ( col_name1 col_type1 [ COMMENT col_comment1 ], ... ) ]
     USING data_source
-    [ OPTIONS ( key1=val1, key2=val2, ... ) ]
+    [ OPTIONS ( key1[=]val1, key2[=]val2, ... ) ]
     [ PARTITIONED BY ( col_name1, col_name2, ... ) ]
     [ CLUSTERED BY ( col_name3, col_name4, ... ) 
         [ SORTED BY ( col_name [ ASC | DESC ], ... ) ] 
         INTO num_buckets BUCKETS ]
     [ LOCATION path ]
     [ COMMENT table_comment ]
-    [ TBLPROPERTIES ( key1=val1, key2=val2, ... ) ]
+    [ TBLPROPERTIES ( key1[=]val1, key2[=]val2, ... ) ]
     [ AS select_statement ]
 ```
 
@@ -57,7 +57,7 @@ as any order. For example, you can write COMMENT table_comment after TBLPROPERTI
 
 * **OPTIONS**
 
-    Options of data source which will be injected to storage properties.
+    Options of data source which will be injected to storage properties. Each option is a key-value pair. The equals sign (`=`) separating the key and value is optional; whitespace can be used instead.
 
 * **PARTITIONED BY**
 
@@ -88,7 +88,7 @@ as any order. For example, you can write COMMENT table_comment after TBLPROPERTI
 
 * **TBLPROPERTIES**
 
-    A list of key-value pairs that is used to tag the table definition.
+    A list of key-value pairs that is used to tag the table definition. The equals sign (`=`) separating each key and value is optional; whitespace can be used instead.
 
 * **AS select_statement**
 
@@ -136,6 +136,11 @@ CREATE TABLE student_parquet(id INT, name STRING, age INT) USING PARQUET
 CREATE TABLE student (id INT, name STRING, age INT) USING CSV
     COMMENT 'this is a comment'
     TBLPROPERTIES ('foo'='bar');
+
+--The equals sign is optional in OPTIONS and TBLPROPERTIES; whitespace can be used instead
+CREATE TABLE student (id INT, name STRING, age INT) USING CSV
+    OPTIONS ('header' 'true')
+    TBLPROPERTIES ('foo' 'bar');
 
 --Specify table comment and properties with different clauses order
 CREATE TABLE student (id INT, name STRING, age INT) USING CSV

--- a/docs/sql-ref-syntax-ddl-create-table-hiveformat.md
+++ b/docs/sql-ref-syntax-ddl-create-table-hiveformat.md
@@ -37,7 +37,7 @@ CREATE [ EXTERNAL ] TABLE [ IF NOT EXISTS ] table_identifier
     [ ROW FORMAT row_format ]
     [ STORED AS file_format ]
     [ LOCATION path ]
-    [ TBLPROPERTIES ( key1=val1, key2=val2, ... ) ]
+    [ TBLPROPERTIES ( key1[=]val1, key2[=]val2, ... ) ]
     [ AS select_statement ]
 ```
 
@@ -93,7 +93,7 @@ as any order. For example, you can write COMMENT table_comment after TBLPROPERTI
 
 * **TBLPROPERTIES**
 
-    A list of key-value pairs that is used to tag the table definition.
+    A list of key-value pairs that is used to tag the table definition. The equals sign (`=`) separating each key and value is optional; whitespace can be used instead.
 
 * **AS select_statement**
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `CREATE TABLE` docs for both the datasource and Hive-format syntax describe the `OPTIONS` and `TBLPROPERTIES` clauses using only the `key=val` form. The grammar (`property` rule in `SqlBaseParser.g4`) also accepts a space-separated `key val` form, where the `=` is optional. This updates the docs to document both forms:

- `docs/sql-ref-syntax-ddl-create-table-datasource.md`: note the optional `=` in the `OPTIONS` and `TBLPROPERTIES` syntax (`key1[=]val1`) and parameter descriptions, plus a short example.
- `docs/sql-ref-syntax-ddl-create-table-hiveformat.md`: same for `TBLPROPERTIES`.

### Why are the changes needed?

The docs only show the `key=val` form, so users aren't aware the equals sign is optional even though the parser supports it (see the `propertyWithKeyNoEquals` alternative in `SqlBaseParser.g4`). This addresses SPARK-34525.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only change.

### How was this patch tested?

Documentation-only change. Verified the claim against the `property` rule in `sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4`, which has both `propertyWithKeyAndEquals` and `propertyWithKeyNoEquals` (`value=propertyValue?`) alternatives, confirming `OPTIONS ('header' 'true')` and `TBLPROPERTIES ('foo' 'bar')` are valid.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI