### PR TITLE
[SPARK-57663][BUILD] Simplify gRPC deps management by using BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1111,6 +1111,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>${io.grpc.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.apache.ws.xmlschema</groupId>
         <artifactId>xmlschema-core</artifactId>
         <version>${ws.xmlschema.version}</version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1280,7 +1280,9 @@ object KubernetesIntegrationTests {
 object DependencyOverrides {
   lazy val jacksonVersion = sys.props.get("fasterxml.jackson.version").getOrElse("2.21.4")
   lazy val jacksonDeps = Bom.dependencies("com.fasterxml.jackson" % "jackson-bom" % jacksonVersion)
-  lazy val settings = jacksonDeps ++ Seq(
+  lazy val grpcVersion = sys.props.get("io.grpc.version").getOrElse("1.76.0")
+  lazy val grpcDeps = Bom.dependencies("io.grpc" % "grpc-bom" % grpcVersion)
+  lazy val settings = jacksonDeps ++ grpcDeps ++ Seq(
     dependencyOverrides ++= {
       val guavaVersion = sys.props.get("guava.version").getOrElse(
         SbtPomKeys.effectivePom.value.getProperties.get("guava.version").asInstanceOf[String])
@@ -1302,7 +1304,7 @@ object DependencyOverrides {
         "org.slf4j" % "slf4j-api" % slf4jVersion,
         "org.tukaani" % "xz" % xzVersion,
         "org.scala-lang" % "scalap" % scalaVersion.value
-      ) ++ jacksonDeps.key.value
+      ) ++ jacksonDeps.key.value ++ grpcDeps.key.value
     }
   )
 }

--- a/sql/connect/common/pom.xml
+++ b/sql/connect/common/pom.xml
@@ -50,27 +50,22 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
-            <version>${io.grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
-            <version>${io.grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-services</artifactId>
-            <version>${io.grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
-            <version>${io.grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-inprocess</artifactId>
-            <version>${io.grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/sql/connect/server/pom.xml
+++ b/sql/connect/server/pom.xml
@@ -203,22 +203,18 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
-      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
-      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-services</artifactId>
-      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
-      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/udf/worker/grpc/pom.xml
+++ b/udf/worker/grpc/pom.xml
@@ -77,22 +77,18 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
-      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
-      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
-      <version>${io.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-inprocess</artifactId>
-      <version>${io.grpc.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR uses `io.grpc:grpc-bom` to manage `io.grpc` artifact versions, replacing the per-artifact `<version>${io.grpc.version}</version>` declarations across `sql/connect/common`, `sql/connect/server`, and `udf/worker/grpc`. Mirrors the existing `jackson-bom` (apache/spark#52668) and `jjwt-bom` (apache/spark#56155) imports.

### Why are the changes needed?

Simplify dependency management.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs. No-op on dependency resolution — `io.grpc` resolves identically (`1.76.0`, direct and transitive) before/after, verified with `build/mvn help:effective-pom` and `build/mvn dependency:tree`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
