### PR TITLE
[SPARK-57659][CORE] Fix ArrayWrappers int[]/long[] comparator overflow for opposite-sign values

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/ArrayWrappers.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/ArrayWrappers.java
@@ -83,7 +83,7 @@ class ArrayWrappers {
     public int compareTo(ComparableIntArray other) {
       int len = Math.min(array.length, other.array.length);
       for (int i = 0; i < len; i++) {
-        int diff = array[i] - other.array[i];
+        int diff = Integer.compare(array[i], other.array[i]);
         if (diff != 0) {
           return diff;
         }
@@ -122,9 +122,9 @@ class ArrayWrappers {
     public int compareTo(ComparableLongArray other) {
       int len = Math.min(array.length, other.array.length);
       for (int i = 0; i < len; i++) {
-        long diff = array[i] - other.array[i];
+        int diff = Long.compare(array[i], other.array[i]);
         if (diff != 0) {
-          return diff > 0 ? 1 : -1;
+          return diff;
         }
       }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/ArrayWrappersSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/ArrayWrappersSuite.java
@@ -56,4 +56,17 @@ public class ArrayWrappersSuite {
    assertTrue(ArrayWrappers.forArray(s1).compareTo(ArrayWrappers.forArray(s2)) > 0);
   }
 
+  @Test
+  public void testOppositeSignArrayKeyComparison() {
+    int[] minInt = new int[] { Integer.MIN_VALUE };
+    int[] maxInt = new int[] { Integer.MAX_VALUE };
+    assertTrue(ArrayWrappers.forArray(minInt).compareTo(ArrayWrappers.forArray(maxInt)) < 0);
+    assertTrue(ArrayWrappers.forArray(maxInt).compareTo(ArrayWrappers.forArray(minInt)) > 0);
+
+    long[] minLong = new long[] { Long.MIN_VALUE };
+    long[] maxLong = new long[] { Long.MAX_VALUE };
+    assertTrue(ArrayWrappers.forArray(minLong).compareTo(ArrayWrappers.forArray(maxLong)) < 0);
+    assertTrue(ArrayWrappers.forArray(maxLong).compareTo(ArrayWrappers.forArray(minLong)) > 0);
+  }
+
 }


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
ComparableIntArray and ComparableLongArray in ArrayWrappers now compare elements with Integer.compare and Long.compare instead of subtraction.

A unit test (testOppositeSignArrayKeyComparison) was added to cover MIN_VALUE vs MAX_VALUE for both int[] and long[].


### Why are the changes needed?
ArrayWrappers is used as a key comparator in InMemoryStore for array-typed indices. The previous implementation compared elements via subtraction:

```
int diff = array[i] - other.array[i];   // int[]
long diff = array[i] - other.array[i];  // long[]
```
For large opposite-sign values (e.g. Integer.MIN_VALUE vs Integer.MAX_VALUE), subtraction overflows and can return the wrong sign, breaking sort order and map lookups. The long[] path tried to mitigate this with diff > 0 ? 1 : -1, but overflow can still flip the sign of diff, so the result is still wrong.



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added testOppositeSignArrayKeyComparison in ArrayWrappersSuite.

build/sbt 'kvstore/testOnly *ArrayWrappersSuite'
Both tests in the suite passed.


### Was this patch authored or co-authored using generative AI tooling?
No.
