### PR TITLE
[SPARK-57637][BUILD][TESTS][4.1] Upgrade `oracle-free` docker image to `23.26.2-slim`

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleDatabaseOnDocker.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleDatabaseOnDocker.scala
@@ -23,7 +23,7 @@ class OracleDatabaseOnDocker extends DatabaseOnDocker with Logging {
   // sarutak/oracle-free is a custom fork of gvenzl/oracle-free which allows to set timeout for
   // password initialization. See SPARK-54076 for details.
   lazy override val imageName =
-    sys.env.getOrElse("ORACLE_DOCKER_IMAGE_NAME", "sarutak/oracle-free:23.9-slim")
+    sys.env.getOrElse("ORACLE_DOCKER_IMAGE_NAME", "sarutak/oracle-free:23.26.2-slim")
   val oracle_password = "Th1s1sThe0racle#Pass"
   override val env = Map(
     "ORACLE_PWD" -> oracle_password, // oracle images uses this


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR backports #56699 to `branch-4.1`.

This PR aims to upgrade `sarutak/oracle-free` docker image to `23.26.2-slim`.
This image is built from [a forked repository](https://github.com/sarutak/oci-oracle-free/tree/password-initialization-timeout) from [gvenzl/oci-oracle-free](https://github.com/gvenzl/oci-oracle-free), which includes fixes for the flakiness of `OracleIntegrationSuite` and `OracleJoinPushdownIntegrationSuite`.

* https://github.com/sarutak/oci-oracle-free/commit/7d10cc653421e6d799972daf36e6ea01c68d9b1a
* https://github.com/sarutak/oci-oracle-free/commit/25427b34f6d55a4e7fdb2d074d3dcb99955fcb83

### Why are the changes needed?
* Ensure the JDBC source works with the newer Oracle Database.
* Fix the flakiness of `OracleIntegrationSuite` and `OracleJoinPushdownIntegrationSuite`

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
No.