### PR TITLE
[SPARK-57671][BUILD] Upgrade `tink` to 1.22.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -270,7 +270,7 @@ stax-api/1.0.1//stax-api-1.0.1.jar
 stream/2.9.8//stream-2.9.8.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.8.0//threeten-extra-1.8.0.jar
-tink/1.20.0//tink-1.20.0.jar
+tink/1.22.0//tink-1.22.0.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 vertx-auth-common/4.5.26//vertx-auth-common-4.5.26.jar

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.11.0</commons-cli.version>
     <bouncycastle.version>1.84</bouncycastle.version>
-    <tink.version>1.20.0</tink.version>
+    <tink.version>1.22.0</tink.version>
     <!--
       TODO: Once upgrade datasketches to a version that supports Java 25,
             SPARK-53327 workaround should be reverted.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the `Tink` dependency to 1.22.0 for Apache Spark 5.0.0.

### Why are the changes needed?

To pick up the latest bug fixes and improvements:

- https://github.com/tink-crypto/tink-java/releases/tag/v1.22.0 (2026-06-18)
    - Key derivation no longer runs inside a synchronized block in `MutableKeyDerivationRegistry`
    - Added `SLH-DSA` signature parameters and the `ML-DSA-44` signature primitive with PEM import
    - Introduced `SignatureJwkSetConverter` for signature public keys to/from JWK sets

- https://github.com/tink-crypto/tink-java/releases/tag/v1.21.0 (2026-03-24)
    - Added `addAnnotations` to `KeysetHandle.Builder` and `getAnnotationsOrNull`
    - Added support for the `ML-DSA-87` signature algorithm
    - `SignaturePemKeysetReader` now handles `ML-DSA-65`, `ML-DSA-87`, and `Ed25519`

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the existing tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8