### PR TITLE
[SPARK-57675][SQL][TESTS] Mark `StateDataSourceTransformWithStateSuiteCheckpointV2` as `ExtendedSQLTest`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceTransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceTransformWithStateSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.functions.{col, explode, timestamp_seconds}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{InputMapRow, ListState, MapInputEvent, MapOutputEvent, MapStateTTLProcessor, MaxEventTimeStatefulProcessor, OutputMode, RunningCountStatefulProcessor, RunningCountStatefulProcessorWithProcTimeTimerUpdates, StatefulProcessor, StateStoreMetricsTest, TestMapStateProcessor, TimeMode, TimerValues, TransformWithStateSuiteUtils, Trigger, TTLConfig, ValueState}
 import org.apache.spark.sql.streaming.util.StreamManualClock
-import org.apache.spark.tags.SlowSQLTest
+import org.apache.spark.tags.{ExtendedSQLTest, SlowSQLTest}
 import org.apache.spark.util.Utils
 
 /** Stateful processor of single value state var with non-primitive type */
@@ -1201,6 +1201,7 @@ class StateDataSourceTransformWithStateSuite extends StateStoreMetricsTest
   }
 }
 
+@ExtendedSQLTest
 class StateDataSourceTransformWithStateSuiteCheckpointV2 extends
   StateDataSourceTransformWithStateSuite {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to mark `StateDataSourceTransformWithStateSuiteCheckpointV2` as `ExtendedSQLTest`.

### Why are the changes needed?

To rebalance SQL jobs. Currently, `extended tests` is shorter. Since `StateDataSourceTransformWithStateSuiteCheckpointV2` is the most time-communing test suite which takes over 8 minutes (484s), we had better move it from `other tests` to `extended tests` by marking `ExtendedSQLTest`.

- https://github.com/apache/spark/actions/runs/28099615476

<img width="719" height="133" alt="Screenshot 2026-06-24 at 14 11 38" src="https://github.com/user-attachments/assets/22192cd6-c1fc-49e6-b79c-0543f931066b" />

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8