### PR TITLE
[SPARK-57677][PYTHON][TESTS] Make UDTF cleanup tests tolerate task retries

### DIFF
--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -565,8 +565,11 @@ class BaseUDTFTestsMixin:
             with open(path, "r") as f:
                 data = f.read()
 
-            # Only cleanup method should be called.
-            self.assertEqual(data, "cleanup")
+            # Only the cleanup method should be called, not terminate. The UDTF may be retried,
+            # so cleanup can run more than once and the file may contain multiple "cleanup"
+            # strings; just check that "cleanup" is present and "terminate" is not.
+            self.assertIn("cleanup", data)
+            self.assertNotIn("terminate", data)
 
     def test_udtf_cleanup_with_exception_in_terminate(self):
         with tempfile.TemporaryDirectory(
@@ -595,7 +598,10 @@ class BaseUDTFTestsMixin:
             with open(path, "r") as f:
                 data = f.read()
 
-            self.assertEqual(data, "cleanup")
+            # The cleanup method should be called even when terminate raises. The UDTF may be
+            # retried, so cleanup can run more than once and the file may contain multiple
+            # "cleanup" strings; just check that "cleanup" is present.
+            self.assertIn("cleanup", data)
 
     def test_init_with_exception(self):
         @udtf(returnType="x: int")


### PR DESCRIPTION
### What changes were proposed in this pull request?

The two UDTF cleanup tests `test_udtf_cleanup_with_exception_in_eval` and `test_udtf_cleanup_with_exception_in_terminate` asserted that the file written by the UDTF's `cleanup` method contained exactly the string `"cleanup"`. This relaxes the assertions to check that `"cleanup"` is present (and, for the eval test, that `"terminate"` is not), instead of requiring an exact match.

### Why are the changes needed?

A UDTF task may be retried by the scheduler, in which case `cleanup` runs more than once and the file ends up with multiple `"cleanup"` strings. The exact-match assertion would then fail. Checking for presence makes the tests robust to retries.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

CI.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Yes, Claude Code (Opus 4.8 high)