### PR TITLE
[SPARK-57683][SQL][TESTS] Move `StateDataSourceTransformWithStateSuiteWithRowChecksum` to `ExtendedSQLTest`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceTransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceTransformWithStateSuite.scala
@@ -1214,6 +1214,6 @@ class StateDataSourceTransformWithStateSuiteCheckpointV2 extends
 /**
  * Test suite that runs all StateDataSourceTransformWithStateSuite tests with row checksum enabled.
  */
-@SlowSQLTest
+@ExtendedSQLTest
 class StateDataSourceTransformWithStateSuiteWithRowChecksum
   extends StateDataSourceTransformWithStateSuite with EnableStateStoreRowChecksum


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to move `StateDataSourceTransformWithStateSuiteWithRowChecksum` to `ExtendedSQLTest` from `SlowSQLTest` to rebalance the CI test time.

### Why are the changes needed?

`StateDataSourceTransformWithStateSuiteWithRowChecksum` took over 14 minutes in `slow tests` suite (Total: `121 min`). We had better move this to `ExtendedSQLTest` whose running time is shorter (Total: `82 min`)

- https://github.com/apache/spark/actions/runs/28135351057/job/83322926462

<img width="612" height="138" alt="Screenshot 2026-06-24 at 19 14 57" src="https://github.com/user-attachments/assets/6b998c20-280f-4015-9e09-366831da0eca" />

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.