### PR TITLE
[SPARK-57686][BUILD] Fix `log4j-slf4j2-impl` artifact name in `LICENSE-binary`

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -349,7 +349,7 @@ org.apache.logging.log4j:log4j-1.2-api
 org.apache.logging.log4j:log4j-api
 org.apache.logging.log4j:log4j-core
 org.apache.logging.log4j:log4j-layout-template-json
-org.apache.logging.log4j:log4j-slf4j-impl
+org.apache.logging.log4j:log4j-slf4j2-impl
 org.apache.orc:orc-core
 org.apache.orc:orc-format
 org.apache.orc:orc-mapreduce


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the artifact name in `LICENSE-binary` from `log4j-slf4j-impl` to `log4j-slf4j2-impl` to match the bundled jar.

### Why are the changes needed?

Apache Spark 3.4.0+ distributions bundle `log4j-slf4j2-impl-*.jar`, but `LICENSE-binary` listed the old `log4j-slf4j-impl` name.

- https://github.com/apache/spark/pull/37844

https://github.com/apache/spark/blob/e6fcb8440915e6e0f4f4945b486bfb2c568f9562/pom.xml#L840-L841


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)