### PR TITLE
[SPARK-57687][BUILD] Add `arrow-compression` to `LICENSE-binary`

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -305,6 +305,7 @@ joda-time:joda-time
 net.sf.opencsv:opencsv
 net.sf.supercsv:super-csv
 net.sf.jpam:jpam
+org.apache.arrow:arrow-compression
 org.apache.arrow:arrow-format
 org.apache.arrow:arrow-memory-core
 org.apache.arrow:arrow-memory-netty


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `arrow-compression` to LICENSE-binary

### Why are the changes needed?

Apache Spark 4.1.0+ distributions bundle `arrow-compression-*.jar`, but LICENSE-binary missed this.

- https://github.com/apache/spark/pull/52747

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)