### PR TITLE
[SPARK-57682][BUILD] Add `javax.servlet-api` to `LICENSE-binary`

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -510,6 +510,7 @@ javax.transaction:transaction-api
 Common Development and Distribution License (CDDL) 1.1
 ------------------------------------------------------
 javax.transaction:jta http://www.oracle.com/technetwork/java/index.html
+javax.servlet:javax.servlet-api https://oss.oracle.com/licenses/CDDL+GPL-1.1
 javax.xml.bind:jaxb-api    https://github.com/javaee/jaxb-v2
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `javax.servlet-api` to `LICENSE-binary`.

### Why are the changes needed?

Apache Spark 4.0.0+ distributions bundles `javax.servlet-api-*.jar` which is missed in `LICENSE-binary`.

- https://github.com/apache/spark/pull/45154

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)