### PR TITLE
[SPARK-57689][BUILD] Replace `kubernetes-httpclient-okhttp` with `kubernetes-httpclient-vertx` in `LICENSE-binary`

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -242,7 +242,7 @@ io.dropwizard.metrics:metrics-json
 io.dropwizard.metrics:metrics-jvm
 io.fabric8:kubernetes-client
 io.fabric8:kubernetes-client-api
-io.fabric8:kubernetes-httpclient-okhttp
+io.fabric8:kubernetes-httpclient-vertx
 io.fabric8:kubernetes-model-admissionregistration
 io.fabric8:kubernetes-model-apiextensions
 io.fabric8:kubernetes-model-apps


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `LICENSE-binary` to replace `io.fabric8:kubernetes-httpclient-okhttp`
with `io.fabric8:kubernetes-httpclient-vertx`:

```
-io.fabric8:kubernetes-httpclient-okhttp
+io.fabric8:kubernetes-httpclient-vertx
```

### Why are the changes needed?

After the fabric8 `kubernetes-client` 7.x upgrade (SPARK-50493) switched the HTTP
backend from OkHttp to Vert.x, the distribution bundles `kubernetes-httpclient-vertx`
instead of `kubernetes-httpclient-okhttp`. This keeps `LICENSE-binary` consistent
with the actual bundled jars. Both are Apache License 2.0.

- https://github.com/apache/spark/pull/49159

https://github.com/apache/spark/blob/e6fcb8440915e6e0f4f4945b486bfb2c568f9562/dev/deps/spark-deps-hadoop-3-hive-2.3#L160

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)