### PR TITLE
[SPARK-57691][INFRA] Use default oracle docker image for the CIs

### DIFF
--- a/.github/workflows/build_branch42.yml
+++ b/.github/workflows/build_branch42.yml
@@ -39,8 +39,7 @@ jobs:
         {
           "SCALA_PROFILE": "scala2.13",
           "PYSPARK_IMAGE_TO_TEST": "",
-          "PYTHON_TO_TEST": "",
-          "ORACLE_DOCKER_IMAGE_NAME": "gvenzl/oracle-free:23.7-slim"
+          "PYTHON_TO_TEST": ""
         }
       jobs: >-
         {

--- a/.github/workflows/build_java17.yml
+++ b/.github/workflows/build_java17.yml
@@ -36,8 +36,7 @@ jobs:
         {
           "SCALA_PROFILE": "scala2.13",
           "PYSPARK_IMAGE_TO_TEST": "",
-          "PYTHON_TO_TEST": "",
-          "ORACLE_DOCKER_IMAGE_NAME": "gvenzl/oracle-free:23.7-slim"
+          "PYTHON_TO_TEST": ""
         }
       jobs: >-
         {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR removes `ORACLE_DOCKER_IMAGE_NAME` from the GA workflow definition files to use default oracle docker image for scheduled CIs.

### Why are the changes needed?
The default oracle docker image is not `gvenzl/oracle-free:23.26.2-slim` but `sarutak/oracle-free:23.26.2-slim` which contains fixes for flakiness of `OracleIntegrationSuite` and `OracleJoinPushdownIntegrationSuite`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Self review and will observe the result of scheduled CIs.

### Was this patch authored or co-authored using generative AI tooling?
No.
