### PR TITLE
[SPARK-57692][INFRA] Skip test report when no test results exist

### DIFF
--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Check if test results exist
       id: check
       run: |
-        if find . -path '*/target/test-reports/*.xml' | grep -q .; then
+        if find . -path '*/target/test-reports/*.xml' -print -quit | grep -q .; then
           echo "has_results=true" >> $GITHUB_OUTPUT
         else
           echo "No test result files found. Skipping report."

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -41,7 +41,17 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         run-id: ${{ github.event.workflow_run.id }}
         pattern: "test-*"
+    - name: Check if test results exist
+      id: check
+      run: |
+        if find . -path '*/target/test-reports/*.xml' | grep -q .; then
+          echo "has_results=true" >> $GITHUB_OUTPUT
+        else
+          echo "No test result files found. Skipping report."
+          echo "has_results=false" >> $GITHUB_OUTPUT
+        fi
     - name: Publish test report
+      if: steps.check.outputs.has_results == 'true'
       uses: scacap/action-surefire-report@5609ce4db72c09db044803b344a8968fd1f315da
       with:
         check_name: Report test results


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a check in `test_report.yml` to skip the test report publishing step when no test result XML files are found after downloading artifacts.

### Why are the changes needed?
When a commit only modifies files in the `dev-tools` module (e.g., `LICENSE-binary`), no build or tests are executed. However, the "Report test results" workflow still triggers on the Build workflow's completion and fails with "No test results found!" because there are no test artifacts to report on.

* https://github.com/apache/spark/runs/83376805611
* https://github.com/apache/spark/runs/83376713136
* https://github.com/apache/spark/runs/83376067066

SPARK-55594 (78ab6e2e2f) previously addressed the same "No test results found!" error for the `pages.yml` case by filtering out that specific workflow path. However, the `dev-tools` module case was not covered. This PR takes a more general approach by checking for the actual presence of test result files, which handles all cases where tests are legitimately not executed, including any future ones.

Note: The existing `pages.yml` filter in the job's `if` condition is intentionally kept. It avoids spinning up the job entirely for a known no-op case, saving runner resources.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
Self review. Also, this will be validated by observing that commits which only modify files in the `dev-tools` module (e.g., `LICENSE-binary`, `README.md`, `.gitignore`) no longer produce a failed "Report test results" check.

### Was this patch authored or co-authored using generative AI tooling?
Kiro CLI / Claude