### PR TITLE
[SPARK-58259][BUILD] Remove redundant Jackson version declarations managed by jackson-bom

### DIFF
--- a/connector/kinesis-asl/pom.xml
+++ b/connector/kinesis-asl/pom.xml
@@ -134,7 +134,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-cbor</artifactId>
-      <version>${fasterxml.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/hadoop-cloud/pom.xml
+++ b/hadoop-cloud/pom.xml
@@ -139,7 +139,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-cbor</artifactId>
-      <version>${fasterxml.jackson.version}</version>
     </dependency>
     <!--Explicit declaration to force in Spark version into transitive dependencies -->
     <dependency>

--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -160,7 +160,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>${fasterxml.jackson.version}</version>
     </dependency>
 
     <!-- Explicitly depend on shaded dependencies from the parent, since shaded deps aren't transitive -->


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR drops the redundant per-module `<version>${fasterxml.jackson.version}</version>` declarations on the `com.fasterxml.jackson.dataformat` artifacts in `connector/kinesis-asl`, `hadoop-cloud`, and `resource-managers/kubernetes/core`. These artifacts are already managed by the `com.fasterxml.jackson:jackson-bom` import (apache/spark#52668), so the per-module versions are redundant. Completes the `jackson-bom` adoption, consistent with the `jjwt-bom` (apache/spark#56155) and `grpc-bom` (apache/spark#56741) imports.

### Why are the changes needed?

Simplify dependency management.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs. No-op on dependency resolution — the `com.fasterxml.jackson.dataformat` artifacts resolve identically (`2.22.0`, direct and transitive) before/after, verified with `build/mvn dependency:tree`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
