### PR TITLE
[SPARK-57693][BUILD] Simplify `kubernetes-client` deps management by using BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1118,6 +1118,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-client-bom</artifactId>
+        <version>${kubernetes-client.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.apache.ws.xmlschema</groupId>
         <artifactId>xmlschema-core</artifactId>
         <version>${ws.xmlschema.version}</version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1282,7 +1282,9 @@ object DependencyOverrides {
   lazy val jacksonDeps = Bom.dependencies("com.fasterxml.jackson" % "jackson-bom" % jacksonVersion)
   lazy val grpcVersion = sys.props.get("io.grpc.version").getOrElse("1.76.0")
   lazy val grpcDeps = Bom.dependencies("io.grpc" % "grpc-bom" % grpcVersion)
-  lazy val settings = jacksonDeps ++ grpcDeps ++ Seq(
+  lazy val k8sClientVersion = sys.props.get("kubernetes-client.version").getOrElse("7.7.0")
+  lazy val k8sClientDeps = Bom.dependencies("io.fabric8" % "kubernetes-client-bom" % k8sClientVersion)
+  lazy val settings = jacksonDeps ++ grpcDeps ++ k8sClientDeps ++ Seq(
     dependencyOverrides ++= {
       val guavaVersion = sys.props.get("guava.version").getOrElse(
         SbtPomKeys.effectivePom.value.getProperties.get("guava.version").asInstanceOf[String])
@@ -1304,7 +1306,7 @@ object DependencyOverrides {
         "org.slf4j" % "slf4j-api" % slf4jVersion,
         "org.tukaani" % "xz" % xzVersion,
         "org.scala-lang" % "scalap" % scalaVersion.value
-      ) ++ jacksonDeps.key.value ++ grpcDeps.key.value
+      ) ++ jacksonDeps.key.value ++ grpcDeps.key.value ++ k8sClientDeps.key.value
     }
   )
 }

--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -41,12 +41,10 @@
         <dependency>
           <groupId>io.fabric8</groupId>
           <artifactId>volcano-model</artifactId>
-          <version>${kubernetes-client.version}</version>
         </dependency>
         <dependency>
           <groupId>io.fabric8</groupId>
           <artifactId>volcano-client</artifactId>
-          <version>${kubernetes-client.version}</version>
         </dependency>
       </dependencies>
       <build>
@@ -111,7 +109,6 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
-      <version>${kubernetes-client.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -66,7 +66,6 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
-      <version>${kubernetes-client.version}</version>
       <exclusions>
         <exclusion>
           <groupId>io.vertx</groupId>
@@ -232,7 +231,6 @@
         <dependency>
           <groupId>io.fabric8</groupId>
           <artifactId>volcano-client</artifactId>
-          <version>${kubernetes-client.version}</version>
         </dependency>
       </dependencies>
       <build>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR uses `io.fabric8:kubernetes-client-bom` to manage `io.fabric8` artifact versions, replacing the per-artifact `<version>${kubernetes-client.version}</version>` declarations across `resource-managers/kubernetes/core` and `resource-managers/kubernetes/integration-tests` (`kubernetes-client`, `volcano-client`, `volcano-model`). The BOM is mirrored in `project/SparkBuild.scala` (sbt-pom-reader does not process import-scope BOMs). Mirrors the existing `jackson-bom` (apache/spark#52668), `jjwt-bom` (apache/spark#56155), and `grpc-bom` (apache/spark#56741) imports.

### Why are the changes needed?

Simplify dependency management.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs. No-op on dependency resolution — `io.fabric8` resolves identically (`7.7.0`, direct and transitive) before/after, verified with `build/mvn help:effective-pom` and `build/mvn dependency:tree`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
