### PR TITLE
[SPARK-57694][INFRA] Upgrade test-summary/action to `v2.6`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -453,7 +453,7 @@ jobs:
           **/target/surefire-reports/*.xml
     - name: Test Summary
       if: always()
-      uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
+      uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
       with:
         paths: |
           **/target/test-reports/*.xml
@@ -868,7 +868,7 @@ jobs:
           **/target/surefire-reports/*.xml
     - name: Test Summary
       if: always()
-      uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
+      uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
       with:
         paths: |
           **/target/test-reports/*.xml
@@ -977,7 +977,7 @@ jobs:
           **/target/surefire-reports/*.xml
     - name: Test Summary
       if: always()
-      uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
+      uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
       with:
         paths: |
           **/target/test-reports/*.xml
@@ -1585,7 +1585,7 @@ jobs:
           **/target/surefire-reports/*.xml
     - name: Test Summary
       if: always()
-      uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
+      uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
       with:
         paths: |
           **/target/test-reports/*.xml
@@ -1679,7 +1679,7 @@ jobs:
           **/target/surefire-reports/*.xml
     - name: Test Summary
       if: always()
-      uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
+      uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
       with:
         paths: |
           **/target/test-reports/*.xml


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR upgrades `test-summary/action` from [v2.4 (31493c76ec9e7aa675f1585d3ed6f1da69269a86)](https://github.com/test-summary/action/releases/tag/v2.4) to [v2.6 (37b508cfee6d4d080eedd00b5bb240a6a784a6a5](https://github.com/test-summary/action/releases/tag/v2.6)).

The following link shows changes after v2.4.
https://github.com/test-summary/action/compare/v2.4...v2.6

### Why are the changes needed?
v2.6 includes Node.js 24 support. Node.js 20 is already EOL and deprecated in GA.
https://github.com/apache/spark/actions/runs/28157559069
```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
