### PR TITLE
[SPARK-57587][SQL][TEST] Generate TIME values with the declared precision in RandomDataGenerator

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RandomDataGenerator.scala
@@ -319,11 +319,17 @@ object RandomDataGenerator {
             .map(i => Instant.ofEpochSecond(i.getEpochSecond, truncate(i.getNano).toLong))
         )
       case t: TimeType =>
+        // Honor the declared precision: both the uniform random draw and the special values are
+        // truncated to `t.precision` so the generated TIME(p) values carry at most p
+        // fractional-second digits (mirrors the nanosecond-timestamp branches above).
         val specialTimes = Seq(
           "00:00:00",
           "23:59:59.999999",
           "23:59:59.999999999"
-        )
+        ).map(LocalTime.parse)
+          .map(lt => DateTimeUtils.nanosToLocalTime(
+            DateTimeUtils.truncateTimeToPrecision(
+              DateTimeUtils.localTimeToNanos(lt), t.precision)))
         randomNumeric[LocalTime](
           rand,
           (rand: Random) => {
@@ -332,7 +338,7 @@ object RandomDataGenerator {
               rand.between(0L, 24 * 60 * 60 * 1000 * 1000 * 1000L), t.precision)
             DateTimeUtils.nanosToLocalTime(nanos)
           },
-          specialTimes.map(LocalTime.parse)
+          specialTimes
         )
       case CalendarIntervalType => Some(() => {
         val months = rand.nextInt(1000)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
@@ -71,6 +71,7 @@ object DataTypeTestUtils {
 
   val timeTypes: Seq[TimeType] = Seq(
     TimeType(TimeType.MIN_PRECISION),
+    TimeType(3),
     TimeType(TimeType.MAX_PRECISION))
 
   val timestampNanosTypes: Seq[DatetimeType] = Seq(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make TIME test-data generation honor the declared `TimeType` precision:
- `RandomDataGenerator`: in the `case t: TimeType =>` branch, truncate the special/interesting TIME values to `t.precision`. Previously only the uniform random draw was truncated, while the special values (`00:00:00`, `23:59:59.999999`, `23:59:59.999999999`) were emitted unmodified, so the interesting-value path produced non-conforming values such as `23:59:59.999999999` even for low precisions like `TimeType(0)`.
- `DataTypeTestUtils.timeTypes`: add an intermediate `TimeType(3)` between `MIN_PRECISION` (0) and `MAX_PRECISION` (9), so the suites looping over `ordered` / `atomicTypes` / `propertyCheckSupported` actually exercise a non-endpoint precision.

`LiteralGenerator.timeLiteralGen` is already precision-aware (landed with SPARK-57551), so no change is needed there.

This is the precision-conformance follow-up to SPARK-51403 (TIME as ordered/atomic type) and SPARK-51669 (random TIME values in tests). SPARK-57551 raised `TimeType.MAX_PRECISION` from 6 to 9, widening the gap the generators must cover.

### Why are the changes needed?
The precision dimension of `DataTypeTestUtils.timeTypes` was effectively not exercised: the interesting-value path produced TIME values that do not conform to the declared precision, and only the two endpoints (0 and 9) were covered. Suites that loop over `ordered` / `atomicTypes` / `propertyCheckSupported` (e.g. `PredicateSuite`, `ConditionalExpressionSuite`, `ArithmeticExpressionSuite`, `OrderingSuite`, `SortSuite`, `CastSuite`, `RandomDataGeneratorSuite`) therefore silently tested a single precision.

### Does this PR introduce _any_ user-facing change?
No. This only fixes test data generation; there is no production code or versioning change.

### How was this patch tested?
By running the affected TIME-covering suites and confirming they pass:
`RandomDataGeneratorSuite`, `PredicateSuite`, `ConditionalExpressionSuite`, `ArithmeticExpressionSuite`, `OrderingSuite`, `CastSuite`, `CastWithAnsiOnSuite`, `UnsafeRowSuite`, and `SortSuite`.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Cursor (Claude Opus 4.8)