### PR TITLE
[SPARK-57697][SQL][TESTS] Mark `HiveClientSuite` as `SlowHiveTest` like `HiveClientSuites`

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
@@ -37,8 +37,10 @@ import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.hive.HiveExternalCatalog
 import org.apache.spark.sql.hive.test.TestHiveVersion
 import org.apache.spark.sql.types.{IntegerType, StructType}
+import org.apache.spark.tags.SlowHiveTest
 import org.apache.spark.util.{MutableURLClassLoader, Utils}
 
+@SlowHiveTest
 class HiveClientSuite(version: String) extends HiveVersionSuite(version) {
 
   private var versionSpark: TestHiveVersion = null


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds `SlowHiveTest` to the version-parameterized `HiveClientSuite` to run it correctly.

### Why are the changes needed?

A ScalaTest tag annotation applies only to a suite's own tests, not to its nested suites. The `HiveClientSuites` wrapper already carries `@SlowHiveTest`, but it runs the per-version `HiveClientSuite` instances as nested suites, so those tests were left untagged. This PR tags the inner suite so they are classified as slow Hive tests too.

https://github.com/apache/spark/blob/526d88da65e0ba200fcca80285733731f4d3e2ba/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuites.scala#L37-L39

In other words, `HiveClientSuites` is currently running inside `hive - other tests` although it is marked as `SlowHiveTest`. After this PR, it will run inside `hive - slow tests` correctly.
- https://github.com/apache/spark/actions/runs/28171846893/job/83441883795

```
HiveClientSuites:
[info] HiveClientSuite(2.0):
[info] - 2.0: create client (431 milliseconds)
[info] - 2.0: createDatabase (2 seconds, 602 milliseconds)
...
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)