### PR TITLE
[SPARK-57700][K8S] Support opt-in `jemalloc` in Spark Docker images

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -37,7 +37,6 @@ RUN set -ex && \
     apt-get update && \
     ln -s /lib /lib64 && \
     apt install -y --no-install-recommends bash tini libc6 libjemalloc2 libpam-modules krb5-user libnss3 procps net-tools logrotate libssl-dev && \
-    ln -s "$(find /usr/lib -name 'libjemalloc.so.2' | head -n1)" /usr/lib/libjemalloc.so.2 && \
     mkdir -p /opt/spark && \
     mkdir -p /opt/spark/examples && \
     mkdir -p /opt/spark/work-dir && \

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -36,7 +36,8 @@ ARG spark_uid=185
 RUN set -ex && \
     apt-get update && \
     ln -s /lib /lib64 && \
-    apt install -y --no-install-recommends bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools logrotate libssl-dev && \
+    apt install -y --no-install-recommends bash tini libc6 libjemalloc2 libpam-modules krb5-user libnss3 procps net-tools logrotate libssl-dev && \
+    ln -s "$(find /usr/lib -name 'libjemalloc.so.2' | head -n1)" /usr/lib/libjemalloc.so.2 && \
     mkdir -p /opt/spark && \
     mkdir -p /opt/spark/examples && \
     mkdir -p /opt/spark/work-dir && \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to install `libjemalloc2` in the Spark Docker image while the default allocator is unchanged — the library is not preloaded unless a user opts in:

```
spark.executorEnv.LD_PRELOAD=libjemalloc.so.2
spark.kubernetes.driverEnv.LD_PRELOAD=libjemalloc.so.2
```

### Why are the changes needed?

[jemalloc](http://jemalloc.net) reduces native/off-heap memory fragmentation, especially `off-heap`, `PySpark`, `Apache Arrow`, and `Spark-accellerator`  use-cases. Shipping the package lets operators enable it with one env var instead of building a custom image, with no regression for anyone else.

### Does this PR introduce _any_ user-facing change?

No behavior change because the default allocator is unchanged; the image just additionally ships `libjemalloc2`.

```
$ ls -al /usr/lib/aarch64-linux-gnu/libjemalloc.so.2
-rw-r--r-- 1 root root 527176 Apr 18  2024 /usr/lib/aarch64-linux-gnu/libjemalloc.so.2
```

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8