### PR TITLE
[DO-NOT-MERGE][PS][PYTHON] Make as_spark_type handle numpy>=2.5 NDArray annotations

### DIFF
--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -137,6 +137,43 @@ class NameTypeHolder:
     short_name: str = "NameType"
 
 
+def _numpy_ndarray_element_type(tpe: Any) -> Optional[Any]:
+    """
+    If ``tpe`` is a ``numpy.typing.NDArray[...]`` annotation, return its element
+    (scalar) type; otherwise return ``None``.
+
+    numpy 2.5 changed the internal structure of ``NDArray`` aliases: ``tpe.__origin__``
+    is no longer the bare ``numpy.ndarray`` class but a subscripted generic alias, which
+    is not a class. Relying on ``tpe.__origin__ is np.ndarray`` (and calling
+    ``issubclass`` on it) therefore breaks on numpy >= 2.5. We instead unwrap the
+    ``__origin__`` chain to detect ndarray robustly across numpy versions, and locate
+    the dtype scalar by scanning the type arguments for an ``np.dtype[...]``.
+    """
+    origin = getattr(tpe, "__origin__", None)
+    # Unwrap nested generic-alias origins until we reach a class (or run out).
+    probe = origin
+    for _ in range(5):
+        if probe is None or isclass(probe):
+            break
+        probe = getattr(probe, "__origin__", None)
+    if probe is not np.ndarray:
+        return None
+
+    def _find_scalar(args: Any) -> Optional[Any]:
+        for arg in args or ():
+            arg_origin = getattr(arg, "__origin__", None)
+            if arg is np.dtype or arg_origin is np.dtype:
+                inner = getattr(arg, "__args__", None)
+                if inner:
+                    return inner[0]
+            nested = _find_scalar(getattr(arg, "__args__", None))
+            if nested is not None:
+                return nested
+        return None
+
+    return _find_scalar(getattr(tpe, "__args__", None))
+
+
 def as_spark_type(
     tpe: Union[str, type, Dtype], *, raise_error: bool = True, prefer_timestamp_ntz: bool = False
 ) -> types.DataType:
@@ -149,21 +186,19 @@ def as_spark_type(
     - dictionaries of field_name -> type
     - Python3's typing system
     """
-    if (
-        hasattr(tpe, "__origin__")
-        and tpe.__origin__ is np.ndarray
-        and hasattr(tpe, "__args__")
-        and len(tpe.__args__) > 1
-    ):
+    ndarray_element_type = _numpy_ndarray_element_type(tpe)
+    if ndarray_element_type is not None:
         # numpy.typing.NDArray
-        return types.ArrayType(as_spark_type(tpe.__args__[1].__args__[0], raise_error=raise_error))
+        return types.ArrayType(as_spark_type(ndarray_element_type, raise_error=raise_error))
 
     if isinstance(tpe, np.dtype) and tpe == np.dtype("object"):
         pass
     # ArrayType
     elif tpe in (np.ndarray,):
         return types.ArrayType(types.StringType())
-    elif hasattr(tpe, "__origin__") and issubclass(tpe.__origin__, list):
+    elif (
+        hasattr(tpe, "__origin__") and isclass(tpe.__origin__) and issubclass(tpe.__origin__, list)
+    ):
         element_type = as_spark_type(
             tpe.__args__[0],  # type: ignore[union-attr]
             raise_error=raise_error,


### PR DESCRIPTION
### What changes were proposed in this pull request?

`as_spark_type` detected `numpy.typing.NDArray[...]` annotations via `tpe.__origin__ is np.ndarray` and, when that did not match, fell through to `issubclass(tpe.__origin__, list)`.

numpy 2.5 changed the internal structure of `NDArray` aliases so that `tpe.__origin__` is no longer the bare `numpy.ndarray` class but a subscripted generic alias (which is not a class). As a result the NDArray branch is skipped and `issubclass(tpe.__origin__, list)` raises `TypeError: issubclass() arg 1 must be a class` (surfaced to the user as `TypeError: Cannot interpret 'NDArray[int]' as a data type`).

This PR:
- adds a `_numpy_ndarray_element_type` helper that unwraps the `__origin__` chain to detect `numpy.ndarray` robustly across numpy versions, then scans the type arguments for the `np.dtype[...]` scalar and returns it;
- guards the list branch with `isclass(...)` so the `issubclass` call cannot raise on a non-class origin.

### Why are the changes needed?

The scheduled `Build / Python-only (Python 3.12, MacOS26)` job installs numpy 2.5.0 and fails `pyspark.pandas` and `pyspark.pandas.connect` `test_apply_batch_with_type` with the `TypeError` above (e.g. apache/spark Actions run 28064134730). The breakage blocks that CI job and breaks numpy `NDArray` return-type inference for pandas-on-Spark `apply_batch`/`transform_batch` under numpy >= 2.5.

### Does this PR introduce _any_ user-facing change?

No. It restores correct Spark type inference for numpy `NDArray` return annotations under numpy >= 2.5; behavior on older numpy is unchanged.

### How was this patch tested?

Existing parametrized coverage in `pyspark.pandas.tests.test_typedef` exercises `as_spark_type(NDArray[...])` and `pandas_on_spark_type(NDArray[...])` over numpy/Python scalar types; that is the regression test for this path.

The detection/extraction helper was additionally verified against numpy 2.3.5, numpy 2.4.6, and a simulated numpy-2.5 alias structure (where `__origin__` is a non-class generic alias): `NDArray[int]`/`NDArray[np.float64]` resolve to the correct scalar; `list[int]`, the bare `np.ndarray`, and plain `int` resolve to `None` (falling through to the existing branches). Validated on macOS-26 with numpy 2.5.0 via GitHub Actions on the fork (the `Build / Python-only (Python 3.12, MacOS26)` workflow).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
