### PR TITLE
[DO-NOT-MERGE][CONNECT][SS] Abort wedged foreachBatch worker read on query stop

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
@@ -19,6 +19,7 @@ package org.apache.spark.api.python
 
 import java.io.{BufferedInputStream, BufferedOutputStream, DataInputStream, DataOutputStream}
 import java.nio.channels.Channels
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.jdk.CollectionConverters._
 
@@ -30,6 +31,19 @@ import org.apache.spark.internal.config.Python.{PYTHON_AUTH_SOCKET_TIMEOUT, PYTH
 
 
 private[spark] object StreamingPythonRunner {
+  // Poll interval used by `readInterruptibly`'s watchdog to re-check the abort conditions (thread
+  // interrupted or the owning query stopping) while it waits for a worker response. Short enough
+  // that a streaming query stop() unblocks well within `spark.sql.streaming.stopTimeout`, long
+  // enough to add negligible overhead.
+  private val readWatchdogPollMillis = 500
+
+  // Grace period the watchdog allows after the abort condition first trips before it force-stops
+  // the worker. A responsive worker finishes the in-flight batch in well under this window, so a
+  // normal stop() lets the read complete cleanly (no spurious foreachBatch error); only a genuinely
+  // wedged worker is still blocked after the grace and gets killed. Kept comfortably below the
+  // default `spark.sql.streaming.stopTimeout` used by the tests (30s).
+  private val readAbortGraceMillis = 10000L
+
   def apply(
       func: PythonFunction,
       connectUrl: String,
@@ -55,6 +69,11 @@ private[spark] class StreamingPythonRunner(
   protected var pythonWorker: Option[PythonWorker] = None
   protected var pythonWorkerFactory: Option[PythonWorkerFactory] = None
   protected val pythonVer: String = func.pythonVer
+
+  // Predicate consulted by `readInterruptibly` to learn when a blocking worker read should be
+  // abandoned (e.g. the owning streaming query is being stopped). Defaults to never; callers that
+  // know the lifecycle (the Connect foreachBatch cleaner cache) install a real check.
+  @volatile private var shouldAbortRead: () => Boolean = () => false
 
   /**
    * Initializes the Python worker for streaming functions. Sets up Spark Connect session
@@ -179,6 +198,79 @@ private[spark] class StreamingPythonRunner(
       pythonWorker.map { worker =>
         factory.isWorkerStopped(worker)
       }
+    }
+  }
+
+  /**
+   * Installs a predicate telling [[readInterruptibly]] when an in-flight blocking worker read
+   * should be abandoned -- typically `() => !query.isActive`, so a streaming query stop() can
+   * promptly break a wedged read. Idempotent; the latest check wins.
+   */
+  def setReadAbortCheck(check: () => Boolean): Unit = {
+    shouldAbortRead = check
+  }
+
+  /**
+   * Reads a single Int from the Python worker in a way that is responsive to the owning streaming
+   * query being stopped.
+   *
+   * A streaming query `stop()` interrupts its micro-batch execution thread to unwind it, but the
+   * blocking socket read below honors neither `Thread.interrupt()` nor a socket read timeout: the
+   * worker channel is read via `Channels.newInputStream`, which is not closed by interrupting the
+   * reader thread, and `SO_TIMEOUT` has no effect on channel reads. So if a foreachBatch Python
+   * worker is wedged -- e.g. deadlocked on a re-entrant Spark Connect call -- a plain
+   * `dataIn.readInt()` keeps the stream thread blocked until `spark.sql.streaming.stopTimeout`
+   * elapses (and, with the default infinite timeout, forever), so the stop fails to take effect.
+   *
+   * To make the read abortable we guard it with a watchdog thread that watches for an abort
+   * condition -- the calling thread is interrupted, or the installed [[shouldAbortRead]] check
+   * trips (the query is being stopped). Once the condition has held for a short grace period (so a
+   * responsive worker can finish the in-flight batch and let the read complete cleanly), the
+   * watchdog stops the worker. `stop()` closes the worker channel, which unblocks the in-flight
+   * read with an `AsynchronousCloseException` so a genuinely wedged batch (and the query) can
+   * unwind promptly. When no abort is requested, or the read completes within the grace, the
+   * worker is left untouched, so neither a healthy stop nor a legitimately slow batch is disrupted.
+   */
+  def readInterruptibly(dataIn: DataInputStream): Int = {
+    val callerThread = Thread.currentThread()
+    val readDone = new AtomicBoolean(false)
+    val watchdogBody: Runnable = () => {
+      try {
+        var triggered = false
+        var abortSinceNanos = -1L
+        while (!triggered && !readDone.get()) {
+          if (callerThread.isInterrupted || shouldAbortRead()) {
+            if (abortSinceNanos < 0L) {
+              abortSinceNanos = System.nanoTime()
+            }
+            val elapsedMillis = (System.nanoTime() - abortSinceNanos) / 1000000L
+            if (elapsedMillis >= StreamingPythonRunner.readAbortGraceMillis) {
+              logWarning(
+                log"[session: ${MDC(SESSION_ID, sessionId)}] Python worker read still blocked " +
+                  log"after the query began stopping; stopping the worker to unblock it.")
+              stop()
+              triggered = true
+            } else {
+              Thread.sleep(StreamingPythonRunner.readWatchdogPollMillis)
+            }
+          } else {
+            // Not aborting (the common case): reset the grace timer and keep waiting.
+            abortSinceNanos = -1L
+            Thread.sleep(StreamingPythonRunner.readWatchdogPollMillis)
+          }
+        }
+      } catch {
+        case _: InterruptedException => // The read finished; readDone was set. Just exit.
+      }
+    }
+    val watchdog = new Thread(watchdogBody, s"streaming-python-runner-read-watchdog-$sessionId")
+    watchdog.setDaemon(true)
+    watchdog.start()
+    try {
+      dataIn.readInt()
+    } finally {
+      readDone.set(true)
+      watchdog.interrupt()
     }
   }
 }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
@@ -169,7 +169,10 @@ object StreamingForeachBatchHelper extends Logging {
       dataOut.flush()
 
       try {
-        dataIn.readInt() match {
+        // Use an interrupt-aware read so that stopping the streaming query (which interrupts the
+        // micro-batch execution thread running this function) can promptly unblock a wedged
+        // worker instead of hanging until spark.sql.streaming.stopTimeout. See SPARK-56586.
+        runner.readInterruptibly(dataIn) match {
           case 0 =>
             logInfo(
               log"[session: ${MDC(SESSION_ID, sessionHolder.sessionId)}] " +
@@ -264,6 +267,15 @@ object StreamingForeachBatchHelper extends Logging {
         case Some(_) =>
           throw IllegalStateErrors.cleanerAlreadySet(sessionHolder.key.toString, key.toString)
         case None => // Inserted. Normal.
+      }
+
+      // Let a wedged foreachBatch worker read be abandoned as soon as this query is being stopped.
+      // The micro-batch thread can block in StreamingPythonRunner reading the worker response, and
+      // that read is not broken by query.stop()'s thread interrupt; the runner's watchdog instead
+      // stops the worker (closing its socket) once the query is no longer active. See SPARK-56586.
+      cleaner match {
+        case RunnerCleaner(runner) => runner.setReadAbortCheck(() => !query.isActive)
+        case _ => // Non-Python cleaner; nothing to wire.
       }
 
       // Guard against the same shutdown race that SparkConnectStreamingQueryCache handles for


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes `StreamingPythonRunner`'s blocking read of the Python worker response interruptible when a Spark Connect `foreachBatch` query is being stopped.

`StreamingPythonRunner.readInterruptibly` guards the blocking `Channels.newInputStream(channel).readInt()` with a watchdog thread. The Connect `foreachBatch` cleaner cache installs an abort condition `() => !query.isActive` when it registers a query's cleaner. Once that abort condition has held for a short grace period (long enough for a responsive worker to finish the in-flight batch so a normal stop is undisturbed), the watchdog closes the worker channel, which unblocks a genuinely wedged read with an `AsynchronousCloseException` so the batch/query unwinds promptly. A legitimately slow batch (query still active) is never killed.

### Why are the changes needed?

`SparkConnectSessionHolderSuite` — `python foreachBatch process: process terminates after query is stopped` flakily fails (and previously hung for ~150 minutes) because `query.stop()` cannot terminate a wedged micro-batch thread.

The micro-batch execution thread runs the `foreachBatch` function, which blocks in `StreamingPythonRunner` reading the Python worker response. When the worker is wedged (e.g. deadlocked on a re-entrant Spark Connect call), that read is broken by neither `query.stop()`'s `Thread.interrupt()` (interrupting the reader does not close the channel, and the interrupt flag is never observed on the stream thread) nor a socket read timeout (`SO_TIMEOUT` has no effect on channel reads). So `stop()` blocks until `spark.sql.streaming.stopTimeout` elapses (default: infinite → hangs forever). The previous bound+retry only turned the hang into a failure; the retries deadlock identically.

This is one of the two remaining unmerged fixes keeping the apache/spark master matrix builds red — it fails the `connect` module on the scheduled Maven JDK 25 and JDK 21 (ARM) lanes.

### Does this PR introduce _any_ user-facing change?

No. The change only affects how a wedged Python worker read is aborted on query stop; a normal stop is undisturbed.

### How was this patch tested?

`connect` module tests on a fork, including the previously-flaky `SparkConnectSessionHolderSuite` foreachBatch termination test (also repeated x12 in a focused workflow to deflake).

- **Before (failing on apache/spark master):** `Build / Maven (Scala 2.13, JDK 25)` — `connect` module, `StreamingForeachBatchHelperSuite` foreachBatch termination test times out (`spark.sql.streaming.stopTimeout`): https://github.com/apache/spark/actions/runs/28179702547
- **After (passing on this branch):** `connect` module green on the fork — the formerly-hanging `python foreachBatch process: process terminates after query is stopped` now passes in ~5.5s (connect module: `Tests: succeeded 1612, failed 0`): https://github.com/HyukjinKwon/spark/actions/runs/28204993346/job/83555910566

### Was this patch authored or co-authored using generative AI tooling?

Yes.

This pull request and its description were written by Isaac.
