### PR TITLE
[SPARK-57650][YARN][TESTS][FOLLOW-UP] Reduce YarnClusterSuite flakiness from runner contention

### DIFF
--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
@@ -111,6 +111,14 @@ abstract class BaseYarnClusterSuite extends SparkFunSuite with Matchers {
     yarnConf.setFloat("yarn.scheduler.capacity.maximum-am-resource-percent", 1.0f)
     yarnConf.setFloat("yarn.scheduler.capacity.root.default.maximum-am-resource-percent", 1.0f)
 
+    // Give the single mini NodeManager generous memory. By default the mini cluster advertises
+    // only a small amount of memory, so once the AM (~1.4GB) is running there is barely enough
+    // headroom left for the executors these tests request. On a busy CI runner that makes
+    // executor allocation slow/racy and the YarnClusterSuite apps time out waiting to finish.
+    // The CI hosts have plenty of RAM, so let the NM offer enough for the AM plus a few executors.
+    yarnConf.setInt("yarn.nodemanager.resource.memory-mb", 8192)
+    yarnConf.setInt("yarn.scheduler.maximum-allocation-mb", 8192)
+
     // Support both IPv4 and IPv6
     yarnConf.set("yarn.resourcemanager.hostname", Utils.localHostNameForURI())
 
@@ -260,6 +268,15 @@ abstract class BaseYarnClusterSuite extends SparkFunSuite with Matchers {
       extraConf: Map[String, String] = Map()): String = {
     val props = new Properties()
     props.put(SPARK_JARS.key, "local:" + fakeSparkJar.getAbsolutePath())
+
+    // On a busy CI runner the in-JVM mini cluster, the driver and the container JVMs all compete
+    // for CPU, and the driver's RPC server occasionally cannot accept a connection in time. With
+    // the default of 3 retries an executor that loses this race gives up and exits, which leaves
+    // the application unable to finish and the suite times out. Give the executor->driver
+    // connection a larger retry budget so a transient stall does not permanently fail the app.
+    // These are defaults; individual tests can still override them via extraConf below.
+    props.setProperty("spark.rpc.io.maxRetries", "10")
+    props.setProperty("spark.rpc.io.retryWait", "2s")
 
     val testClasspath = new TestClasspathBuilder()
       .buildClassPath(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Two test-only mitigations in `BaseYarnClusterSuite` to reduce `YarnClusterSuite` flakiness on busy CI runners:

- Give the mini `NodeManager` 8GB (`yarn.nodemanager.resource.memory-mb`) and a matching `yarn.scheduler.maximum-allocation-mb`, so executor allocation is never starved once the ~1.4GB AM is running.
- Raise the executor→driver connection retry budget (`spark.rpc.io.maxRetries=10`, `spark.rpc.io.retryWait=2s`) so a transient accept stall does not permanently fail the executor. These are defaults; individual tests can still override them.

### Why are the changes needed?

This is a follow-up to SPARK-57650, which fixed the deterministic ACCEPTED-state hang (`maximum-am-resource-percent`). After that fix, the master `Build / Maven` `yarn` lanes still go red intermittently: `YarnClusterSuite` tests time out (`handle.getState().isFinal() was false`) because the AM/executor containers fail to connect to the driver's RPC server on localhost (Connection refused).

The in-JVM mini RM+NM, the driver subprocess, and the AM/executor JVMs all contend for CPU on a single CI runner, so the driver's accept loop occasionally stalls; an executor that loses the race exits after the default 3 connection retries, and the application can then never finish.

This is one of the two remaining unmerged fixes keeping the apache/spark master matrix builds red.

### Does this PR introduce _any_ user-facing change?

No. Test-only.

### How was this patch tested?

`resource-managers/yarn` module tests on a fork, repeated multiple times to confirm the flakiness is gone (the formerly-failing `YarnClusterSuite` tests pass consistently).

- **Before (still flaky on apache/spark master, after the SPARK-57650 base fix merged):** `Build / Maven (Scala 2.13, JDK 17)` — `resource-managers#yarn`, `YarnClusterSuite` times out (`handle.getState().isFinal() was false`, `BaseYarnClusterSuite.scala:220`): https://github.com/apache/spark/actions/runs/28174751831
- **After (passing on this branch):** `resource-managers/yarn` module green on the fork — https://github.com/HyukjinKwon/spark/actions/runs/28204995015/job/83556094951

### Was this patch authored or co-authored using generative AI tooling?

Yes.

This pull request and its description were written by Isaac.
