### PR TITLE
[DO-NOT-MERGE][SS][KAFKA] Work around JDK-8298446 C2 miscompilation causing IllegalMonitorStateException in Kafka tests on branch-4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,7 @@
       --sun-misc-unsafe-memory-access=allow
       --enable-native-access=ALL-UNNAMED
       -XX:+EnableDynamicAgentLoading
+      -XX:CompileCommand=exclude,org.apache.kafka.clients.producer.KafkaProducer::waitOnMetadata
     </extraJavaTestArgs>
     <mariadb.java.client.version>3.5.7</mariadb.java.client.version>
     <mysql.connector.version>9.6.0</mysql.connector.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a single JVM workaround flag to the test args in `pom.xml`:

```
-XX:CompileCommand=exclude,org.apache.kafka.clients.producer.KafkaProducer::waitOnMetadata
```

This excludes only `KafkaProducer.waitOnMetadata` from JIT compilation in the test JVM, so it runs in the interpreter. It is preceded in `extraJavaTestArgs` by the pre-existing `-XX:+IgnoreUnrecognizedVMOptions`, so it is a no-op on JDKs that do not understand or do not need it.

### Why are the changes needed?

The `branch-4.2` Maven (JDK 17) Kafka job fails ~227 tests, nearly the whole Kafka suite, with:

```
java.lang.IllegalMonitorStateException: current thread is not owner
  at java.base/java.lang.Object.wait(Native Method)
  at org.apache.kafka.common.utils.SystemTime.waitObject(SystemTime.java:60)
  at org.apache.kafka.clients.producer.internals.ProducerMetadata.awaitUpdate(ProducerMetadata.java:123)
  at org.apache.kafka.clients.producer.KafkaProducer.waitOnMetadata(KafkaProducer.java:1180)
  at org.apache.kafka.clients.producer.KafkaProducer.doSend(KafkaProducer.java:1027)
  ...
```

`SystemTime.waitObject` in kafka-clients 3.9.2 calls `obj.wait()` correctly inside `synchronized (obj)`. Verified from the actual jar bytecode: `monitorenter` -> `Object.wait` (line 60) -> `monitorexit`. A correct JVM cannot throw `IllegalMonitorStateException` here.

This is the HotSpot **C2 JIT bug [JDK-8298446](https://bugs.openjdk.org/browse/JDK-8298446)**: once C2 compiles `KafkaProducer.waitOnMetadata`, the monitor on the synchronized `obj.wait()` is dropped and every producer metadata wait throws "current thread is not owner". It is triggered nondeterministically by whether C2 compiles that hot method during the run, which is why the **identical** JDK (Zulu 17.0.19) and kafka-clients 3.9.2 pass on the master Maven Kafka job but wipe out the Kafka suite on the branch-4.2 run. Excluding that one method from JIT avoids the miscompilation.

### Does this PR introduce any user-facing change?

No. Test-only change.

### How was this patch tested?

Maven-on-fork (JDK 17) against `branch-4.2` with the fix, module matrix narrowed to the Kafka modules.

#### CI evidence
- Before (red): https://github.com/apache/spark/actions/runs/28182892330
- After (green): https://github.com/HyukjinKwon/spark/actions/runs/28205023510

### Was this patch authored or co-authored using generative AI tooling?

Yes, Generated-by: Isaac.
