### PR TITLE
[SPARK-57714][CORE] Add loser tree based k-way merger for UnsafeExternalSorter spill merge

### DIFF
--- a/core/benchmarks/SpillMergerBenchmark-results.txt
+++ b/core/benchmarks/SpillMergerBenchmark-results.txt
@@ -1,0 +1,110 @@
+================================================================================================
+Spill merger: PriorityQueue vs LoserTree
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.5
+Apple M4
+k-way merge scenario=low-prefix-collision runs=4 recordsPerRun=500000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+priority-queue                                                                    31             32           1         64.9          15.4       1.0X
+loser-tree                                                                        21             21           0         95.9          10.4       1.5X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.5
+Apple M4
+k-way merge scenario=low-prefix-collision runs=8 recordsPerRun=500000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+priority-queue                                                                   123            128           4         32.5          30.8       1.0X
+loser-tree                                                                        68             70           2         59.0          17.0       1.8X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.5
+Apple M4
+k-way merge scenario=low-prefix-collision runs=16 recordsPerRun=500000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------------------
+priority-queue                                                                    386            399          11         20.7          48.2       1.0X
+loser-tree                                                                        178            186          11         44.8          22.3       2.2X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.5
+Apple M4
+k-way merge scenario=low-prefix-collision runs=64 recordsPerRun=500000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------------------
+priority-queue                                                                   3175           3251         107         10.1          99.2       1.0X
+loser-tree                                                                       1111           1126          22         28.8          34.7       2.9X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.5
+Apple M4
+k-way merge scenario=low-prefix-collision runs=256 recordsPerRun=500000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+priority-queue                                                                   19406          20651        1761          6.6         151.6       1.0X
+loser-tree                                                                        7561           7568           9         16.9          59.1       2.6X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.5
+Apple M4
+k-way merge scenario=medium-prefix-collision runs=4 recordsPerRun=500000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+priority-queue                                                                       41             42           1         49.1          20.4       1.0X
+loser-tree                                                                           21             22           0         93.8          10.7       1.9X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.5
+Apple M4
+k-way merge scenario=medium-prefix-collision runs=8 recordsPerRun=500000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+priority-queue                                                                      135            138           4         29.5          33.8       1.0X
+loser-tree                                                                           60             60           0         66.9          14.9       2.3X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.5
+Apple M4
+k-way merge scenario=medium-prefix-collision runs=16 recordsPerRun=500000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+priority-queue                                                                       396            401           4         20.2          49.6       1.0X
+loser-tree                                                                           160            161           1         50.0          20.0       2.5X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.5
+Apple M4
+k-way merge scenario=medium-prefix-collision runs=64 recordsPerRun=500000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+priority-queue                                                                      2642           2681          56         12.1          82.6       1.0X
+loser-tree                                                                          1319           1321           2         24.3          41.2       2.0X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.5
+Apple M4
+k-way merge scenario=medium-prefix-collision runs=256 recordsPerRun=500000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+priority-queue                                                                      14540          14605          92          8.8         113.6       1.0X
+loser-tree                                                                           8228           8257          41         15.6          64.3       1.8X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.5
+Apple M4
+k-way merge scenario=high-prefix-collision runs=4 recordsPerRun=500000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------------------
+priority-queue                                                                     47             50           5         42.5          23.5       1.0X
+loser-tree                                                                         34             35           1         58.2          17.2       1.4X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.5
+Apple M4
+k-way merge scenario=high-prefix-collision runs=8 recordsPerRun=500000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------------------
+priority-queue                                                                    155            160           6         25.9          38.6       1.0X
+loser-tree                                                                         99            100           1         40.6          24.6       1.6X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.5
+Apple M4
+k-way merge scenario=high-prefix-collision runs=16 recordsPerRun=500000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+priority-queue                                                                     425            427           2         18.8          53.1       1.0X
+loser-tree                                                                         250            254           3         32.0          31.2       1.7X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.5
+Apple M4
+k-way merge scenario=high-prefix-collision runs=64 recordsPerRun=500000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+priority-queue                                                                    2421           2452          44         13.2          75.6       1.0X
+loser-tree                                                                        1342           1360          25         23.9          41.9       1.8X
+
+OpenJDK 64-Bit Server VM 17.0.16+8-LTS on Mac OS X 15.5
+Apple M4
+k-way merge scenario=high-prefix-collision runs=256 recordsPerRun=500000:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+priority-queue                                                                    13211          13214           5          9.7         103.2       1.0X
+loser-tree                                                                         7445           7456          16         17.2          58.2       1.8X
+
+

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
@@ -28,12 +28,14 @@ import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import org.apache.spark.SparkEnv;
 import org.apache.spark.TaskContext;
 import org.apache.spark.executor.ShuffleWriteMetrics;
 import org.apache.spark.internal.LogKeys;
 import org.apache.spark.internal.MDC;
 import org.apache.spark.internal.SparkLogger;
 import org.apache.spark.internal.SparkLoggerFactory;
+import org.apache.spark.internal.config.package$;
 import org.apache.spark.memory.MemoryConsumer;
 import org.apache.spark.memory.SparkOutOfMemoryError;
 import org.apache.spark.memory.TaskMemoryManager;
@@ -600,16 +602,31 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
       // Original single-round merge: open all spill readers at once
       logger.info("Merging {} spill files in single round",
           MDC.of(LogKeys.NUM_SPILL_WRITERS, spillWriters.size()));
-      final UnsafeSorterSpillMerger spillMerger = new UnsafeSorterSpillMerger(
-        recordComparatorSupplier.get(), prefixComparator, spillWriters.size());
-      for (UnsafeSorterSpillWriter spillWriter : spillWriters) {
-        spillMerger.addSpillIfNotEmpty(spillWriter.getReader(serializerManager));
+      final boolean useLoserTree = SparkEnv.get() != null && (boolean) SparkEnv.get().conf().get(
+          package$.MODULE$.UNSAFE_SORTER_SPILL_MERGER_USE_LOSER_TREE());
+      if (useLoserTree) {
+        final UnsafeLoserTreeSpillMerger spillMerger = new UnsafeLoserTreeSpillMerger(
+          recordComparatorSupplier.get(), prefixComparator, spillCount());
+        for (UnsafeSorterSpillWriter spillWriter : spillWriters) {
+          spillMerger.addSpillIfNotEmpty(spillWriter.getReader(serializerManager));
+        }
+        if (inMemSorter != null) {
+          readingIterator = new SpillableIterator(inMemSorter.getSortedIterator());
+          spillMerger.addSpillIfNotEmpty(readingIterator);
+        }
+        return spillMerger.getSortedIterator();
+      } else {
+        final UnsafeSorterSpillMerger spillMerger = new UnsafeSorterSpillMerger(
+          recordComparatorSupplier.get(), prefixComparator, spillWriters.size());
+        for (UnsafeSorterSpillWriter spillWriter : spillWriters) {
+          spillMerger.addSpillIfNotEmpty(spillWriter.getReader(serializerManager));
+        }
+        if (inMemSorter != null) {
+          readingIterator = new SpillableIterator(inMemSorter.getSortedIterator());
+          spillMerger.addSpillIfNotEmpty(readingIterator);
+        }
+        return spillMerger.getSortedIterator();
       }
-      if (inMemSorter != null) {
-        readingIterator = new SpillableIterator(inMemSorter.getSortedIterator());
-        spillMerger.addSpillIfNotEmpty(readingIterator);
-      }
-      return spillMerger.getSortedIterator();
     }
   }
 
@@ -665,6 +682,10 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
       inMemIter = readingIterator;
     }
     return new BoundedMergerContext(snapshot, inMemIter, merger);
+  }
+
+  private int spillCount() {
+    return spillWriters.size() + (inMemSorter != null ? 1 : 0);
   }
 
   @VisibleForTesting boolean hasSpaceForAnotherRecord() {

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeLoserTreeSpillMerger.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeLoserTreeSpillMerger.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.collection.unsafe.sort;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * A k-way merge implementation backed by a classic loser tree.
+ *
+ * Compared to a binary heap (sift-down), each replay along the path from a
+ * leaf to the root performs only a single comparison and a single loser read
+ * per level -- heap sift-down does two comparisons plus two child reads per
+ * level. For k-way merges, this approximately halves both the comparison
+ * count and the array touches per popped record.
+ *
+ * Layout:
+ *   loser[0]                        -- the overall winner (run id)
+ *   loser[1 .. treeSize-1]          -- the loser at each internal node
+ *   leaves are virtual; leaf i (for i in [0, capacity)) maps to run id i
+ */
+final class UnsafeLoserTreeSpillMerger {
+
+  private final RecordComparator recordComparator;
+  private final PrefixComparator prefixComparator;
+  private final UnsafeSorterIterator[] iterators;
+  // exhausted[capacity] is the always-empty sentinel slot.
+  private final boolean[] exhausted;
+  private final int[] loser;
+  private final int treeSize;
+  private final int sentinel;
+
+  private int numIterators = 0;
+  private int numRecords = 0;
+  private boolean treeBuilt = false;
+
+  UnsafeLoserTreeSpillMerger(
+      RecordComparator recordComparator,
+      PrefixComparator prefixComparator,
+      int numSpills) {
+    this.recordComparator = recordComparator;
+    this.prefixComparator = prefixComparator;
+    int capacity = Math.max(1, numSpills);
+    this.iterators = new UnsafeSorterIterator[capacity];
+    this.exhausted = new boolean[capacity + 1];
+    Arrays.fill(exhausted, true);
+    this.sentinel = capacity;
+    this.treeSize = nextPowerOfTwo(capacity);
+    this.loser = new int[treeSize];
+    Arrays.fill(loser, sentinel);
+  }
+
+  /**
+   * Add an UnsafeSorterIterator to this merger.
+   */
+  public void addSpillIfNotEmpty(UnsafeSorterIterator spillReader) throws IOException {
+    if (spillReader.hasNext()) {
+      spillReader.loadNext();
+      iterators[numIterators] = spillReader;
+      exhausted[numIterators] = false;
+      numIterators++;
+      numRecords += spillReader.getNumRecords();
+    }
+  }
+
+  public UnsafeSorterIterator getSortedIterator() {
+    buildTree();
+    return new MergedIterator();
+  }
+
+  private void buildTree() {
+    if (treeBuilt) {
+      return;
+    }
+    if (treeSize == 1) {
+      loser[0] = exhausted[0] ? sentinel : 0;
+    } else {
+      loser[0] = buildSubtree(1);
+    }
+    treeBuilt = true;
+  }
+
+  // Bottom-up build: returns the winner of the subtree rooted at `node` and
+  // stores the loser of that subtree at loser[node]. Virtual leaves beyond
+  // capacity collapse to the sentinel run id, which loses every comparison.
+  private int buildSubtree(int node) {
+    if (node >= treeSize) {
+      int runId = node - treeSize;
+      return Math.min(runId, sentinel);
+    }
+    int leftWinner = buildSubtree(node << 1);
+    int rightWinner = buildSubtree((node << 1) | 1);
+    if (isLess(leftWinner, rightWinner)) {
+      loser[node] = rightWinner;
+      return leftWinner;
+    } else {
+      loser[node] = leftWinner;
+      return rightWinner;
+    }
+  }
+
+  // Replay the path from `runId`'s leaf up to the root after that leaf's key
+  // changed. One comparison + one loser-slot read per level.
+  private void replay(int runId) {
+    int winner = runId;
+    int node = (treeSize + runId) >> 1;
+    while (node > 0) {
+      int other = loser[node];
+      if (isLess(other, winner)) {
+        loser[node] = winner;
+        winner = other;
+      }
+      node >>= 1;
+    }
+    loser[0] = winner;
+  }
+
+  private boolean isLess(int left, int right) {
+    boolean leftEmpty = exhausted[left];
+    boolean rightEmpty = exhausted[right];
+    if (leftEmpty) {
+      return false;
+    }
+    if (rightEmpty) {
+      return true;
+    }
+    UnsafeSorterIterator l = iterators[left];
+    UnsafeSorterIterator r = iterators[right];
+    int prefixCmp = prefixComparator.compare(l.getKeyPrefix(), r.getKeyPrefix());
+    if (prefixCmp != 0) {
+      return prefixCmp < 0;
+    }
+    int recCmp = recordComparator.compare(
+        l.getBaseObject(), l.getBaseOffset(), l.getRecordLength(),
+        r.getBaseObject(), r.getBaseOffset(), r.getRecordLength());
+    if (recCmp != 0) {
+      return recCmp < 0;
+    }
+    // Stable tie-break by run id (lower id wins). This differs from the
+    // original PriorityQueue which has no stable tie-break on equal keys.
+    return left < right;
+  }
+
+  private static int nextPowerOfTwo(int v) {
+    int s = 1;
+    while (s < v) {
+      s <<= 1;
+    }
+    return s;
+  }
+
+  private final class MergedIterator extends UnsafeSorterIterator {
+    private UnsafeSorterIterator currentReader;
+    private int currentWinner = -1;
+    private boolean hasNext;
+    private int exhaustedCount = 0;
+
+    MergedIterator() {
+      hasNext = (numIterators > 0);
+    }
+
+    @Override
+    public int getNumRecords() {
+      return numRecords;
+    }
+
+    @Override
+    public long getCurrentPageNumber() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return hasNext;
+    }
+
+    @Override
+    public void loadNext() throws IOException {
+      if (currentWinner != -1) {
+        UnsafeSorterIterator prev = iterators[currentWinner];
+        if (prev.hasNext()) {
+          prev.loadNext();
+        } else {
+          exhausted[currentWinner] = true;
+          exhaustedCount++;
+        }
+        replay(currentWinner);
+      }
+      currentWinner = loser[0];
+      currentReader = iterators[currentWinner];
+      // After this record, is there more?
+      // Yes if: current iterator has more records, or other iterators exist.
+      hasNext = iterators[currentWinner].hasNext()
+          || exhaustedCount < numIterators - 1;
+    }
+
+    @Override
+    public Object getBaseObject() { return currentReader.getBaseObject(); }
+
+    @Override
+    public long getBaseOffset() { return currentReader.getBaseOffset(); }
+
+    @Override
+    public int getRecordLength() { return currentReader.getRecordLength(); }
+
+    @Override
+    public long getKeyPrefix() { return currentReader.getKeyPrefix(); }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1965,6 +1965,18 @@ package object config {
         "The merge factor must be -1 (disabled) or at least 2.")
       .createWithDefault(-1)
 
+  private[spark] val UNSAFE_SORTER_SPILL_MERGER_USE_LOSER_TREE =
+    ConfigBuilder("spark.unsafe.sorter.spill.merger.useLoserTree")
+      .internal()
+      .doc("If true, use a loser tree based k-way merger when reading multiple spill files " +
+        "in UnsafeExternalSorter; otherwise use the original priority-queue based merger. " +
+        "Loser tree performs one comparison per replay versus two for heap sift-down, which " +
+        "can be faster when there are many spills.")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .version("4.3.0")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val DEFAULT_PLUGINS_LIST = "spark.plugins.defaultList"
 
   private[spark] val PLUGINS =

--- a/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
+++ b/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
@@ -33,6 +33,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import org.apache.spark.SparkConf;
+import org.apache.spark.SparkEnv;
 import org.apache.spark.TaskContext;
 import org.apache.spark.executor.ShuffleWriteMetrics;
 import org.apache.spark.executor.TaskMetrics;
@@ -968,5 +969,44 @@ public class UnsafeExternalSorterSuite {
 
     sorter.cleanupResources();
     assertSpillFilesWereCleanedUp();
+  }
+
+  @Test
+  public void testLoserTreeMergeWithSpillsAndInMemory() throws Exception {
+    SparkConf loserConf = new SparkConf()
+        .set(package$.MODULE$.UNSAFE_SORTER_SPILL_MERGER_USE_LOSER_TREE(), true);
+    SparkEnv env = mock(SparkEnv.class);
+    when(env.conf()).thenReturn(loserConf);
+    SparkEnv.set(env);
+    try {
+      final UnsafeExternalSorter sorter = newSorter();
+      // spill 1: {5, 8, 9}
+      insertNumber(sorter, 5);
+      insertNumber(sorter, 9);
+      insertNumber(sorter, 8);
+      sorter.spill();
+      // spill 2: {1, 3, 7}
+      insertNumber(sorter, 7);
+      insertNumber(sorter, 1);
+      insertNumber(sorter, 3);
+      sorter.spill();
+      // in-memory: {2, 4, 6}
+      insertNumber(sorter, 4);
+      insertNumber(sorter, 6);
+      insertNumber(sorter, 2);
+
+      UnsafeSorterIterator iter = sorter.getSortedIterator();
+      for (int i = 1; i <= 9; i++) {
+        iter.loadNext();
+        assertEquals(i, iter.getKeyPrefix());
+        assertEquals(i, Platform.getInt(iter.getBaseObject(), iter.getBaseOffset()));
+      }
+      assertFalse(iter.hasNext());
+
+      sorter.cleanupResources();
+      assertSpillFilesWereCleanedUp();
+    } finally {
+      SparkEnv.set(null);
+    }
   }
 }

--- a/core/src/test/scala/org/apache/spark/benchmark/SpillMergerBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/benchmark/SpillMergerBenchmark.scala
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.collection.unsafe.sort
+
+import java.io.IOException
+import java.util.Random
+
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+import org.apache.spark.unsafe.Platform
+
+/**
+ * Benchmark comparing UnsafeSorterSpillMerger (priority queue) vs
+ * UnsafeLoserTreeSpillMerger (loser tree) for k-way merge of spill iterators.
+ *
+ * To run:
+ * {{{
+ *   build/sbt "core/Test/runMain
+ *     org.apache.spark.util.collection.unsafe.sort.SpillMergerBenchmark"
+ * }}}
+ */
+object SpillMergerBenchmark extends BenchmarkBase {
+
+  private val prefixComparator: PrefixComparator = new PrefixComparator {
+    override def compare(a: Long, b: Long): Int = java.lang.Long.compare(a, b)
+  }
+
+  private val recordComparator: RecordComparator = new RecordComparator {
+    override def compare(
+        leftBase: Object, leftOff: Long, leftLen: Int,
+        rightBase: Object, rightOff: Long, rightLen: Int): Int = {
+      val l = Platform.getLong(leftBase, leftOff)
+      val r = Platform.getLong(rightBase, rightOff)
+      java.lang.Long.compare(l, r)
+    }
+  }
+
+  /**
+   * In-memory UnsafeSorterIterator backed by pre-built parallel arrays of (record, prefix).
+   * Each record holds a single long (8 bytes) so the record comparator has real work to do
+   * when prefixes tie.
+   */
+  private final class InMemoryRunIterator(records: Array[Long], prefixes: Array[Long])
+    extends UnsafeSorterIterator {
+
+    val sourceRecords: Array[Long] = records
+    val sourcePrefixes: Array[Long] = prefixes
+
+    private val total = records.length
+    private val recordLength = 8
+    private val buffer = new Array[Byte](recordLength)
+    private var index = -1
+
+    override def getNumRecords: Int = total
+
+    override def getCurrentPageNumber: Long =
+      throw new UnsupportedOperationException
+
+    override def hasNext: Boolean = index + 1 < total
+
+    @throws[IOException]
+    override def loadNext(): Unit = {
+      index += 1
+      Platform.putLong(buffer, Platform.BYTE_ARRAY_OFFSET, records(index))
+    }
+
+    override def getBaseObject: Object = buffer
+
+    override def getBaseOffset: Long = Platform.BYTE_ARRAY_OFFSET
+
+    override def getRecordLength: Int = recordLength
+
+    override def getKeyPrefix: Long = prefixes(index)
+  }
+
+  private final case class Scenario(
+      name: String,
+      prefixRepeat: Int,
+      duplicateFactor: Int)
+
+  private def buildRuns(
+      runCount: Int,
+      recordsPerRun: Int,
+      scenario: Scenario): Array[InMemoryRunIterator] = {
+    val random = new Random(42L)
+    Array.tabulate(runCount) { runId =>
+      val records = new Array[Long](recordsPerRun)
+      val prefixes = new Array[Long](recordsPerRun)
+      var suffix = runId.toLong
+      var i = 0
+      while (i < recordsPerRun) {
+        val prefix = (i / scenario.prefixRepeat).toLong
+        val suffixStep = if (i % scenario.duplicateFactor == 0) 1 else 0
+        suffix += suffixStep + random.nextInt(3)
+        prefixes(i) = prefix
+        records(i) = suffix
+        i += 1
+      }
+      new InMemoryRunIterator(records, prefixes)
+    }
+  }
+
+  private def cloneRuns(runs: Array[InMemoryRunIterator]): Array[InMemoryRunIterator] = {
+    runs.map(r => new InMemoryRunIterator(r.sourceRecords, r.sourcePrefixes))
+  }
+
+  private def consumePriorityQueue(runs: Array[InMemoryRunIterator]): Long = {
+    val merger = new UnsafeSorterSpillMerger(recordComparator, prefixComparator, runs.length)
+    runs.foreach(merger.addSpillIfNotEmpty)
+    drain(merger.getSortedIterator)
+  }
+
+  private def consumeLoserTree(runs: Array[InMemoryRunIterator]): Long = {
+    val merger = new UnsafeLoserTreeSpillMerger(recordComparator, prefixComparator, runs.length)
+    runs.foreach(merger.addSpillIfNotEmpty)
+    drain(merger.getSortedIterator)
+  }
+
+  private def drain(iter: UnsafeSorterIterator): Long = {
+    var checksum = 0L
+    while (iter.hasNext) {
+      iter.loadNext()
+      val v = Platform.getLong(iter.getBaseObject, iter.getBaseOffset)
+      checksum = checksum * 31 + v + java.lang.Long.rotateLeft(iter.getKeyPrefix, 17)
+    }
+    checksum
+  }
+
+  private def benchmarkCase(
+      runCount: Int,
+      recordsPerRun: Int,
+      scenario: Scenario): Unit = {
+    val runs = buildRuns(runCount, recordsPerRun, scenario)
+    val expected = consumePriorityQueue(cloneRuns(runs))
+    val actual = consumeLoserTree(cloneRuns(runs))
+    require(expected == actual, s"checksum mismatch: $expected != $actual")
+
+    val benchmark = new Benchmark(
+      s"k-way merge scenario=${scenario.name} runs=$runCount " +
+        s"recordsPerRun=$recordsPerRun",
+      runCount.toLong * recordsPerRun,
+      output = output)
+
+    benchmark.addCase("priority-queue") { _ =>
+      val checksum = consumePriorityQueue(cloneRuns(runs))
+      if (checksum != expected) {
+        throw new IllegalStateException(s"unexpected checksum $checksum")
+      }
+    }
+
+    benchmark.addCase("loser-tree") { _ =>
+      val checksum = consumeLoserTree(cloneRuns(runs))
+      if (checksum != expected) {
+        throw new IllegalStateException(s"unexpected checksum $checksum")
+      }
+    }
+
+    benchmark.run()
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val recordsPerRun = 500000
+    val runCounts = Seq(4, 8, 16, 64, 256)
+    val scenarios = Seq(
+      Scenario("low-prefix-collision", prefixRepeat = 1, duplicateFactor = 1),
+      Scenario("medium-prefix-collision", prefixRepeat = 64, duplicateFactor = 8),
+      Scenario("high-prefix-collision", prefixRepeat = 4096, duplicateFactor = 8))
+
+    runBenchmark("Spill merger: PriorityQueue vs LoserTree") {
+      scenarios.foreach { scenario =>
+        runCounts.foreach { runCount =>
+          benchmarkCase(runCount, recordsPerRun, scenario)
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/util/collection/unsafe/sort/UnsafeLoserTreeSpillMergerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/unsafe/sort/UnsafeLoserTreeSpillMergerSuite.scala
@@ -1,0 +1,349 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.collection.unsafe.sort
+
+import java.io.IOException
+import java.util.Random
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.unsafe.Platform
+
+class UnsafeLoserTreeSpillMergerSuite extends SparkFunSuite {
+
+  private val prefixComparator: PrefixComparator = new PrefixComparator {
+    override def compare(a: Long, b: Long): Int = java.lang.Long.compare(a, b)
+  }
+
+  private val recordComparator: RecordComparator = new RecordComparator {
+    override def compare(
+        leftBase: Object, leftOff: Long, leftLen: Int,
+        rightBase: Object, rightOff: Long, rightLen: Int): Int = {
+      val l = Platform.getLong(leftBase, leftOff)
+      val r = Platform.getLong(rightBase, rightOff)
+      java.lang.Long.compare(l, r)
+    }
+  }
+
+  private final class InMemoryRunIterator(records: Array[Long], prefixes: Array[Long])
+    extends UnsafeSorterIterator {
+
+    private val total = records.length
+    private val recordLength = 8
+    private val buffer = new Array[Byte](recordLength)
+    private var index = -1
+
+    override def getNumRecords: Int = total
+    override def getCurrentPageNumber: Long = throw new UnsupportedOperationException
+    override def hasNext: Boolean = index + 1 < total
+
+    @throws[IOException]
+    override def loadNext(): Unit = {
+      index += 1
+      Platform.putLong(buffer, Platform.BYTE_ARRAY_OFFSET, records(index))
+    }
+
+    override def getBaseObject: Object = buffer
+    override def getBaseOffset: Long = Platform.BYTE_ARRAY_OFFSET
+    override def getRecordLength: Int = recordLength
+    override def getKeyPrefix: Long = prefixes(index)
+  }
+
+  private def newRun(records: Seq[Long], prefixes: Seq[Long]): InMemoryRunIterator = {
+    require(records.length == prefixes.length)
+    new InMemoryRunIterator(records.toArray, prefixes.toArray)
+  }
+
+  /** Drain to a list of (prefix, record) pairs preserving order. */
+  private def drain(iter: UnsafeSorterIterator): Seq[(Long, Long)] = {
+    val out = scala.collection.mutable.ArrayBuffer.empty[(Long, Long)]
+    while (iter.hasNext) {
+      iter.loadNext()
+      val v = Platform.getLong(iter.getBaseObject, iter.getBaseOffset)
+      out += ((iter.getKeyPrefix, v))
+    }
+    out.toSeq
+  }
+
+  private def mergeWithPriorityQueue(
+      runs: Seq[InMemoryRunIterator]): Seq[(Long, Long)] = {
+    val merger = new UnsafeSorterSpillMerger(recordComparator, prefixComparator, runs.length)
+    runs.foreach(merger.addSpillIfNotEmpty)
+    drain(merger.getSortedIterator)
+  }
+
+  private def mergeWithLoserTree(
+      runs: Seq[InMemoryRunIterator]): Seq[(Long, Long)] = {
+    val merger = new UnsafeLoserTreeSpillMerger(recordComparator, prefixComparator, runs.length)
+    runs.foreach(merger.addSpillIfNotEmpty)
+    drain(merger.getSortedIterator)
+  }
+
+  /**
+   * Independent oracle: flatten all runs (with run id), sort lexicographically by
+   * (prefix, record, runId). Does NOT use either merger, so we can detect bugs even
+   * if both PriorityQueue and LoserTree happened to share the same defect.
+   */
+  private def oracleSort(
+      runs: Seq[(Seq[Long], Seq[Long])]): Seq[(Long, Long)] = {
+    val flat = runs.zipWithIndex.flatMap { case ((records, prefixes), runId) =>
+      records.zip(prefixes).map { case (rec, pre) => (pre, rec, runId) }
+    }
+    flat
+      .sortBy { case (pre, rec, runId) => (pre, rec, runId) }
+      .map { case (pre, rec, _) => (pre, rec) }
+  }
+
+
+  test("empty input produces empty output") {
+    val merger = new UnsafeLoserTreeSpillMerger(recordComparator, prefixComparator, 0)
+    val iter = merger.getSortedIterator
+    assert(!iter.hasNext)
+    assert(iter.getNumRecords === 0)
+  }
+
+  test("all input runs empty") {
+    val runs = Seq.fill(4)(newRun(Seq.empty, Seq.empty))
+    val merger = new UnsafeLoserTreeSpillMerger(recordComparator, prefixComparator, runs.length)
+    runs.foreach(merger.addSpillIfNotEmpty)
+    val iter = merger.getSortedIterator
+    assert(!iter.hasNext)
+    assert(iter.getNumRecords === 0)
+  }
+
+  test("single run passes through in order") {
+    val run = newRun(Seq(1L, 5L, 7L, 9L), Seq(1L, 5L, 7L, 9L))
+    val out = mergeWithLoserTree(Seq(run))
+    assert(out === Seq((1L, 1L), (5L, 5L), (7L, 7L), (9L, 9L)))
+  }
+
+  test("merging two simple runs preserves global order") {
+    val a = newRun(Seq(1L, 4L, 6L), Seq(1L, 4L, 6L))
+    val b = newRun(Seq(2L, 3L, 5L), Seq(2L, 3L, 5L))
+    val out = mergeWithLoserTree(Seq(a, b))
+    assert(out.map(_._1) === Seq(1L, 2L, 3L, 4L, 5L, 6L))
+  }
+
+  test("ties broken consistently with priority queue") {
+    // All prefixes equal; record ordering decides; equal records resolve by run id.
+    val runs = Seq(
+      newRun(Seq(10L, 20L, 30L), Seq(0L, 0L, 0L)),
+      newRun(Seq(10L, 20L, 30L), Seq(0L, 0L, 0L)),
+      newRun(Seq(15L, 25L), Seq(0L, 0L)))
+    val pq = mergeWithPriorityQueue(runs.map(reset))
+    val lt = mergeWithLoserTree(runs.map(reset))
+    assert(lt === pq)
+  }
+
+  test("randomized runs match priority queue output") {
+    val random = new Random(0xc0ffeeL)
+    Seq(1, 2, 3, 7, 16, 33, 64).foreach { runCount =>
+      Seq("low", "medium", "high").foreach { mode =>
+        val (prefixRepeat, recordsPerRun) = mode match {
+          case "low" => (1, 1024)
+          case "medium" => (32, 1024)
+          case "high" => (4096, 1024)
+        }
+        val runs = Array.tabulate(runCount) { runId =>
+          val records = new Array[Long](recordsPerRun)
+          val prefixes = new Array[Long](recordsPerRun)
+          var rec = runId.toLong
+          var i = 0
+          while (i < recordsPerRun) {
+            rec += random.nextInt(3).toLong
+            prefixes(i) = (i / prefixRepeat).toLong
+            records(i) = rec
+            i += 1
+          }
+          new InMemoryRunIterator(records, prefixes)
+        }.toSeq
+        // Build a separate set of run iterators (same data) for the second merger.
+        val twin = runs.map(reset)
+        val pq = mergeWithPriorityQueue(runs)
+        val lt = mergeWithLoserTree(twin)
+        assert(lt.length === pq.length,
+          s"length mismatch for runCount=$runCount mode=$mode")
+        assert(lt === pq, s"sequence mismatch for runCount=$runCount mode=$mode")
+        // Output must be globally non-decreasing on (prefix, record).
+        var i = 1
+        while (i < lt.length) {
+          val (p0, r0) = lt(i - 1)
+          val (p1, r1) = lt(i)
+          assert(p0 < p1 || (p0 == p1 && r0 <= r1),
+            s"out-of-order at index $i for runCount=$runCount mode=$mode")
+          i += 1
+        }
+      }
+    }
+  }
+
+  test("mix of empty and non-empty runs") {
+    val runs = Seq(
+      newRun(Seq.empty, Seq.empty),
+      newRun(Seq(2L, 4L), Seq(0L, 0L)),
+      newRun(Seq.empty, Seq.empty),
+      newRun(Seq(1L, 3L, 5L), Seq(0L, 0L, 0L)),
+      newRun(Seq.empty, Seq.empty))
+    val out = mergeWithLoserTree(runs)
+    assert(out.map(_._2) === Seq(1L, 2L, 3L, 4L, 5L))
+  }
+
+  test("non-power-of-two run counts") {
+    Seq(3, 5, 6, 9, 17).foreach { count =>
+      val runs = Array.tabulate(count) { i =>
+        val r = (0 until 8).map(j => (i + j * count).toLong).toArray
+        new InMemoryRunIterator(r, r.clone())
+      }.toSeq
+      val pq = mergeWithPriorityQueue(runs.map(reset))
+      val lt = mergeWithLoserTree(runs.map(reset))
+      assert(lt === pq, s"mismatch for runCount=$count")
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Independent oracle tests: compare LoserTree directly against a
+  // straight `sortBy` of the flattened input. These do NOT involve the
+  // PriorityQueue merger, so they catch defects shared by both mergers.
+  // -------------------------------------------------------------------------
+
+  test("oracle: hand-written corner cases") {
+    val cases: Seq[(String, Seq[(Seq[Long], Seq[Long])])] = Seq(
+      ("single run, single record", Seq((Seq(7L), Seq(3L)))),
+      ("single run, descending records but ascending prefixes",
+        Seq((Seq(9L, 1L, 0L), Seq(1L, 2L, 3L)))),
+      ("two runs, all same prefix and record (run-id breaks ties)",
+        Seq(
+          (Seq(5L, 5L, 5L), Seq(0L, 0L, 0L)),
+          (Seq(5L, 5L, 5L), Seq(0L, 0L, 0L)))),
+      ("interleaved prefix only",
+        Seq(
+          (Seq(0L, 0L, 0L), Seq(1L, 3L, 5L)),
+          (Seq(0L, 0L, 0L), Seq(2L, 4L, 6L)))),
+      ("Long.MinValue / Long.MaxValue prefixes",
+        Seq(
+          (Seq(0L, 0L, 0L),
+            Seq(Long.MinValue, 0L, Long.MaxValue)),
+          (Seq(1L, 2L),
+            Seq(Long.MinValue + 1L, Long.MaxValue - 1L)))),
+      ("run with one element, mixed with longer runs",
+        Seq(
+          (Seq(42L), Seq(10L)),
+          (Seq(1L, 2L, 3L, 4L), Seq(0L, 0L, 0L, 0L)),
+          (Seq(11L, 12L), Seq(20L, 20L)))),
+      ("many tiny runs, one record each",
+        (0 until 10).map(i => (Seq(i.toLong * 2), Seq(i.toLong)))),
+      ("17 runs (non-power-of-two), varying lengths",
+        (0 until 17).map { i =>
+          val len = (i % 4) + 1
+          val recs = (0 until len).map(_.toLong + i)
+          (recs, recs)
+        }))
+
+    cases.foreach { case (name, runData) =>
+      val runs = runData.map { case (recs, prefixes) =>
+        newRun(recs, prefixes)
+      }
+      val expected = oracleSort(runData)
+      val actual = mergeWithLoserTree(runs)
+      assert(actual === expected, s"oracle mismatch for case [$name]")
+      assert(actual.length === expected.length, s"length mismatch for case [$name]")
+    }
+  }
+
+  test("oracle: randomized fuzz against direct sort (no PQ involved)") {
+    val rng = new Random(0xdeadbeefL)
+    var iteration = 0
+    while (iteration < 200) {
+      val runCount = rng.nextInt(20) + 1 // 1..20 runs (covers 1, non-pow-2, pow-2)
+      val runData = (0 until runCount).map { _ =>
+        val len = rng.nextInt(50) // some runs may be empty
+        // Build a sorted run on (prefix, record).
+        val pairs = (0 until len).map { _ =>
+          val pre = rng.nextInt(8).toLong // small domain -> heavy ties
+          val rec = rng.nextInt(8).toLong
+          (pre, rec)
+        }.sortBy { case (p, r) => (p, r) }
+        (pairs.map(_._2), pairs.map(_._1))
+      }
+      val expected = oracleSort(runData)
+      val runs = runData.map { case (recs, pres) => newRun(recs, pres) }
+      val actual = mergeWithLoserTree(runs)
+      assert(actual.length === expected.length,
+        s"length mismatch on iteration=$iteration runCount=$runCount " +
+          s"expected=${expected.length} actual=${actual.length}")
+      assert(actual === expected,
+        s"sequence mismatch on iteration=$iteration runCount=$runCount")
+      iteration += 1
+    }
+  }
+
+  test("getNumRecords is exact and hasNext drains all and only those records") {
+    val runData = Seq(
+      (Seq(1L, 2L, 3L), Seq(0L, 0L, 0L)),
+      (Seq(4L, 5L), Seq(1L, 2L)),
+      (Seq.empty[Long], Seq.empty[Long]),
+      (Seq(6L), Seq(3L)))
+    val expectedTotal = runData.map(_._1.length).sum
+
+    val merger = new UnsafeLoserTreeSpillMerger(
+      recordComparator, prefixComparator, runData.length)
+    runData.foreach { case (recs, pres) => merger.addSpillIfNotEmpty(newRun(recs, pres)) }
+    val it = merger.getSortedIterator
+    assert(it.getNumRecords === expectedTotal)
+    var consumed = 0
+    while (it.hasNext) {
+      it.loadNext()
+      consumed += 1
+    }
+    assert(consumed === expectedTotal)
+    assert(!it.hasNext)
+  }
+
+  test("output is globally non-decreasing for randomized input (oracle-free invariant)") {
+    val rng = new Random(0x5eedL)
+    (0 until 50).foreach { _ =>
+      val runCount = rng.nextInt(16) + 1
+      val runs = (0 until runCount).map { _ =>
+        val len = rng.nextInt(40)
+        val pairs = (0 until len).map { _ =>
+          (rng.nextInt(6).toLong, rng.nextInt(6).toLong)
+        }.sortBy { case (p, r) => (p, r) }
+        newRun(pairs.map(_._2), pairs.map(_._1))
+      }
+      val merged = mergeWithLoserTree(runs)
+      var i = 1
+      while (i < merged.length) {
+        val (p0, r0) = merged(i - 1)
+        val (p1, r1) = merged(i)
+        assert(p0 < p1 || (p0 == p1 && r0 <= r1),
+          s"non-decreasing invariant violated at $i: ${(p0, r0)} > ${(p1, r1)}")
+        i += 1
+      }
+    }
+  }
+
+  /** Rebuild a fresh iterator from the same backing data so each merger gets a clean cursor. */
+  private def reset(it: InMemoryRunIterator): InMemoryRunIterator = {
+    val recordsField = classOf[InMemoryRunIterator].getDeclaredField("records")
+    recordsField.setAccessible(true)
+    val prefixesField = classOf[InMemoryRunIterator].getDeclaredField("prefixes")
+    prefixesField.setAccessible(true)
+    new InMemoryRunIterator(
+      recordsField.get(it).asInstanceOf[Array[Long]],
+      prefixesField.get(it).asInstanceOf[Array[Long]])
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a loser tree based k-way merger as an opt-in alternative to the
existing priority-queue (binary heap) based `UnsafeSorterSpillMerger`
used by `UnsafeExternalSorter` to merge spill files.

The new merger is gated behind config
`spark.unsafe.sorter.spill.merger.useLoserTree`, defaulting to `false`
so behavior is unchanged unless explicitly enabled.

### Why are the changes needed?

When `UnsafeExternalSorter` produces many spill files, the merge phase
is dominated by comparator cost. A loser tree performs one comparison
and one loser-slot read per level on each replay, versus two
comparisons plus two child reads for heap sift-down. For k-way merges
this roughly halves both the number of comparisons and the array
touches per popped record, improving end-to-end sort latency for
spill-heavy workloads.

Microbenchmark on Apple M4 / JDK 17 over 500K records per run shows
**1.4x to 2.9x speedup** across prefix-collision levels and run counts
from 4 to 256. Full results in `core/benchmarks/SpillMergerBenchmark-results.txt`.

| runs | low-collision | medium-collision | high-collision |
| ---: | :-----------: | :--------------: | :------------: |
|   4  |     1.5x      |       1.9x       |      1.4x      |
|   8  |     1.8x      |       2.3x       |      1.6x      |
|  16  |     2.2x      |       2.5x       |      1.7x      |
|  64  |     2.9x      |       2.0x       |      1.8x      |
| 256  |     2.6x      |       1.8x       |      1.8x      |

Concrete numbers at the most spill-heavy point (runs=256, 500K records/run, low collision):
- priority-queue: best 19406ms, avg 20651ms
- loser-tree:     best 7561ms,  avg 7568ms

### Does this PR introduce _any_ user-facing change?

No. The new behavior is gated behind an internal config defaulted to
`false`. Existing behavior is unchanged.

### How was this patch tested?

- New unit test suite `UnsafeLoserTreeSpillMergerSuite` (12 tests, all pass)
- Extended `UnsafeExternalSorterSuite` to cover the loser tree path
- New `SpillMergerBenchmark` for performance comparison; results
  committed under `core/benchmarks/`
- Ran `./dev/scalastyle` and `./dev/lint-java` locally — both pass

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude (Anthropic)
