### PR TITLE
[SPARK-57562][SQL] Add benchmarks for the TIME data type

### DIFF
--- a/sql/catalyst/benchmarks/HashBenchmark-jdk21-results.txt
+++ b/sql/catalyst/benchmarks/HashBenchmark-jdk21-results.txt
@@ -2,69 +2,69 @@
 single ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Hash For single ints:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                2095           2098           3        256.2           3.9       1.0X
-codegen version                                    3576           3595          26        150.1           6.7       0.6X
-codegen version 64-bit                             3128           3132           5        171.6           5.8       0.7X
-codegen HiveHash version                           2555           2557           2        210.1           4.8       0.8X
+interpreted version                                2101           2109          10        255.5           3.9       1.0X
+codegen version                                    3551           3553           3        151.2           6.6       0.6X
+codegen version 64-bit                             3138           3140           3        171.1           5.8       0.7X
+codegen HiveHash version                           2576           2577           2        208.4           4.8       0.8X
 
 
 ================================================================================================
 single longs
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Hash For single longs:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                2729           2731           3        196.7           5.1       1.0X
-codegen version                                    4544           4545           2        118.2           8.5       0.6X
-codegen version 64-bit                             3855           3856           1        139.3           7.2       0.7X
-codegen HiveHash version                           3157           3157           0        170.1           5.9       0.9X
+interpreted version                                2718           2720           3        197.6           5.1       1.0X
+codegen version                                    4545           4547           3        118.1           8.5       0.6X
+codegen version 64-bit                             3678           3679           1        146.0           6.9       0.7X
+codegen HiveHash version                           3153           3156           4        170.3           5.9       0.9X
 
 
 ================================================================================================
 normal
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Hash For normal:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                1353           1354           2          1.6         645.1       1.0X
-codegen version                                    1858           1858           0          1.1         886.1       0.7X
-codegen version 64-bit                              732            732           0          2.9         349.0       1.8X
-codegen HiveHash version                           3695           3695           0          0.6        1762.1       0.4X
+interpreted version                                1403           1405           3          1.5         668.8       1.0X
+codegen version                                    1967           1967           0          1.1         938.0       0.7X
+codegen version 64-bit                              756            758           2          2.8         360.6       1.9X
+codegen HiveHash version                           3815           3816           0          0.5        1819.3       0.4X
 
 
 ================================================================================================
 array
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Hash For array:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                1026           1030           5          0.1        7831.1       1.0X
-codegen version                                    3687           3698          15          0.0       28127.0       0.3X
-codegen version 64-bit                             2529           2533           6          0.1       19291.0       0.4X
-codegen HiveHash version                            740            740           0          0.2        5642.4       1.4X
+interpreted version                                1054           1054           0          0.1        8041.3       1.0X
+codegen version                                    3724           3725           1          0.0       28413.2       0.3X
+codegen version 64-bit                             2584           2584           0          0.1       19711.3       0.4X
+codegen HiveHash version                            731            734           6          0.2        5574.3       1.4X
 
 
 ================================================================================================
 map
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Hash For map:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                   0              0           0         96.5          10.4       1.0X
-codegen version                                     213            214           2          0.0       51915.6       0.0X
-codegen version 64-bit                              145            146           0          0.0       35490.6       0.0X
-codegen HiveHash version                             23             24           0          0.2        5712.0       0.0X
+interpreted version                                   0              0           0         87.9          11.4       1.0X
+codegen version                                     200            201           0          0.0       48911.9       0.0X
+codegen version 64-bit                              137            137           0          0.0       33445.0       0.0X
+codegen HiveHash version                             22             22           0          0.2        5405.3       0.0X
 
 

--- a/sql/catalyst/benchmarks/HashBenchmark-jdk25-results.txt
+++ b/sql/catalyst/benchmarks/HashBenchmark-jdk25-results.txt
@@ -2,69 +2,69 @@
 single ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Hash For single ints:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                2103           2104           0        255.2           3.9       1.0X
-codegen version                                    3186           3186           1        168.5           5.9       0.7X
-codegen version 64-bit                             3198           3206          12        167.9           6.0       0.7X
-codegen HiveHash version                           2550           2553           3        210.5           4.8       0.8X
+interpreted version                                1944           1954          15        276.2           3.6       1.0X
+codegen version                                    3501           3506           7        153.3           6.5       0.6X
+codegen version 64-bit                             3243           3250           9        165.5           6.0       0.6X
+codegen HiveHash version                           2441           2442           1        219.9           4.5       0.8X
 
 
 ================================================================================================
 single longs
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Hash For single longs:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                2893           2901          11        185.6           5.4       1.0X
-codegen version                                    4735           4741           8        113.4           8.8       0.6X
-codegen version 64-bit                             3788           3792           5        141.7           7.1       0.8X
-codegen HiveHash version                           3247           3250           3        165.3           6.0       0.9X
+interpreted version                                2461           2461           1        218.2           4.6       1.0X
+codegen version                                    4892           4900          12        109.7           9.1       0.5X
+codegen version 64-bit                             3837           3891          76        139.9           7.1       0.6X
+codegen HiveHash version                           3098           3113          20        173.3           5.8       0.8X
 
 
 ================================================================================================
 normal
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Hash For normal:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                1359           1362           5          1.5         647.8       1.0X
-codegen version                                    1734           1734           0          1.2         826.7       0.8X
-codegen version 64-bit                              722            723           3          2.9         344.1       1.9X
-codegen HiveHash version                           3686           3688           2          0.6        1757.8       0.4X
+interpreted version                                1346           1346           0          1.6         641.9       1.0X
+codegen version                                    1948           1953           7          1.1         929.0       0.7X
+codegen version 64-bit                              754            755           1          2.8         359.7       1.8X
+codegen HiveHash version                           4146           4147           0          0.5        1977.1       0.3X
 
 
 ================================================================================================
 array
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Hash For array:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                 998           1000           2          0.1        7616.1       1.0X
-codegen version                                    3592           3594           4          0.0       27402.0       0.3X
-codegen version 64-bit                             2445           2445           0          0.1       18650.8       0.4X
-codegen HiveHash version                            696            696           0          0.2        5308.3       1.4X
+interpreted version                                1128           1128           0          0.1        8603.7       1.0X
+codegen version                                    3677           3680           4          0.0       28051.8       0.3X
+codegen version 64-bit                             2643           2644           1          0.0       20165.2       0.4X
+codegen HiveHash version                            787            789           2          0.2        6007.0       1.4X
 
 
 ================================================================================================
 map
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Hash For map:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                   0              0           0         85.3          11.7       1.0X
-codegen version                                     232            232           0          0.0       56599.0       0.0X
-codegen version 64-bit                              155            155           0          0.0       37843.5       0.0X
-codegen HiveHash version                             25             25           0          0.2        6172.1       0.0X
+interpreted version                                   0              0           0         90.3          11.1       1.0X
+codegen version                                     184            185           1          0.0       45034.3       0.0X
+codegen version 64-bit                              150            150           0          0.0       36538.0       0.0X
+codegen HiveHash version                             15             15           0          0.3        3584.3       0.0X
 
 

--- a/sql/catalyst/benchmarks/HashBenchmark-results.txt
+++ b/sql/catalyst/benchmarks/HashBenchmark-results.txt
@@ -2,69 +2,69 @@
 single ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Hash For single ints:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                2035           2040           7        263.8           3.8       1.0X
-codegen version                                    3949           3952           3        135.9           7.4       0.5X
-codegen version 64-bit                             3419           3423           6        157.0           6.4       0.6X
-codegen HiveHash version                           2647           2663          23        202.8           4.9       0.8X
+interpreted version                                2044           2045           2        262.7           3.8       1.0X
+codegen version                                    3953           3956           4        135.8           7.4       0.5X
+codegen version 64-bit                             3439           3443           5        156.1           6.4       0.6X
+codegen HiveHash version                           2749           2750           2        195.3           5.1       0.7X
 
 
 ================================================================================================
 single longs
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Hash For single longs:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                2486           2492           8        215.9           4.6       1.0X
-codegen version                                    5601           5602           1         95.8          10.4       0.4X
-codegen version 64-bit                             4175           4183          11        128.6           7.8       0.6X
-codegen HiveHash version                           3263           3264           0        164.5           6.1       0.8X
+interpreted version                                2492           2493           2        215.5           4.6       1.0X
+codegen version                                    5630           5631           0         95.4          10.5       0.4X
+codegen version 64-bit                             4077           4078           1        131.7           7.6       0.6X
+codegen HiveHash version                           3146           3147           2        170.7           5.9       0.8X
 
 
 ================================================================================================
 normal
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Hash For normal:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                2734           2748          20          0.8        1303.7       1.0X
-codegen version                                    2511           2512           1          0.8        1197.4       1.1X
-codegen version 64-bit                              759            760           1          2.8         362.1       3.6X
-codegen HiveHash version                           4104           4105           1          0.5        1957.1       0.7X
+interpreted version                                2756           2758           2          0.8        1314.4       1.0X
+codegen version                                    2574           2574           0          0.8        1227.2       1.1X
+codegen version 64-bit                              766            774          12          2.7         365.5       3.6X
+codegen HiveHash version                           4182           4185           5          0.5        1994.1       0.7X
 
 
 ================================================================================================
 array
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Hash For array:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                1158           1158           0          0.1        8836.3       1.0X
-codegen version                                    3648           3654           9          0.0       27829.0       0.3X
-codegen version 64-bit                             2699           2700           1          0.0       20595.1       0.4X
-codegen HiveHash version                            889            889           1          0.1        6779.7       1.3X
+interpreted version                                1389           1391           3          0.1       10595.8       1.0X
+codegen version                                    3945           3945           0          0.0       30098.4       0.4X
+codegen version 64-bit                             2977           2977           0          0.0       22710.3       0.5X
+codegen HiveHash version                           1086           1088           2          0.1        8289.0       1.3X
 
 
 ================================================================================================
 map
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 9V74 80-Core Processor
 Hash For map:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                   0              0           0        101.5           9.9       1.0X
-codegen version                                     247            248           0          0.0       60408.3       0.0X
-codegen version 64-bit                              193            193           0          0.0       47021.2       0.0X
-codegen HiveHash version                             30             30           0          0.1        7362.8       0.0X
+interpreted version                                   0              0           0        102.5           9.8       1.0X
+codegen version                                     201            201           1          0.0       49039.1       0.0X
+codegen version 64-bit                              157            157           0          0.0       38253.6       0.0X
+codegen HiveHash version                             16             17           1          0.3        3958.7       0.0X
 
 

--- a/sql/catalyst/benchmarks/HashBenchmark-results.txt
+++ b/sql/catalyst/benchmarks/HashBenchmark-results.txt
@@ -2,69 +2,69 @@
 single ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 Hash For single ints:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                1216           1239          33        441.6           2.3       1.0X
-codegen version                                    2429           2434           6        221.0           4.5       0.5X
-codegen version 64-bit                             2336           2340           7        229.9           4.4       0.5X
-codegen HiveHash version                           1763           1778          20        304.5           3.3       0.7X
+interpreted version                                2035           2040           7        263.8           3.8       1.0X
+codegen version                                    3949           3952           3        135.9           7.4       0.5X
+codegen version 64-bit                             3419           3423           6        157.0           6.4       0.6X
+codegen HiveHash version                           2647           2663          23        202.8           4.9       0.8X
 
 
 ================================================================================================
 single longs
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 Hash For single longs:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                1870           1872           4        287.2           3.5       1.0X
-codegen version                                    3463           3475          17        155.0           6.5       0.5X
-codegen version 64-bit                             2954           2971          25        181.7           5.5       0.6X
-codegen HiveHash version                           1946           1965          27        275.9           3.6       1.0X
+interpreted version                                2486           2492           8        215.9           4.6       1.0X
+codegen version                                    5601           5602           1         95.8          10.4       0.4X
+codegen version 64-bit                             4175           4183          11        128.6           7.8       0.6X
+codegen HiveHash version                           3263           3264           0        164.5           6.1       0.8X
 
 
 ================================================================================================
 normal
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 Hash For normal:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                2301           2303           3          0.9        1097.0       1.0X
-codegen version                                    1794           1800           9          1.2         855.2       1.3X
-codegen version 64-bit                              479            482           3          4.4         228.2       4.8X
-codegen HiveHash version                           3906           3908           2          0.5        1862.5       0.6X
+interpreted version                                2734           2748          20          0.8        1303.7       1.0X
+codegen version                                    2511           2512           1          0.8        1197.4       1.1X
+codegen version 64-bit                              759            760           1          2.8         362.1       3.6X
+codegen HiveHash version                           4104           4105           1          0.5        1957.1       0.7X
 
 
 ================================================================================================
 array
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 Hash For array:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                1557           1596          55          0.1       11879.7       1.0X
-codegen version                                    2765           2766           2          0.0       21097.5       0.6X
-codegen version 64-bit                             2544           2643         139          0.1       19412.2       0.6X
-codegen HiveHash version                            647            698          64          0.2        4939.7       2.4X
+interpreted version                                1158           1158           0          0.1        8836.3       1.0X
+codegen version                                    3648           3654           9          0.0       27829.0       0.3X
+codegen version 64-bit                             2699           2700           1          0.0       20595.1       0.4X
+codegen HiveHash version                            889            889           1          0.1        6779.7       1.3X
 
 
 ================================================================================================
 map
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 Hash For map:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                   0              0           0        101.9           9.8       1.0X
-codegen version                                     194            197           4          0.0       47307.5       0.0X
-codegen version 64-bit                              183            184           3          0.0       44671.8       0.0X
-codegen HiveHash version                             16             17           1          0.3        3831.1       0.0X
+interpreted version                                   0              0           0        101.5           9.9       1.0X
+codegen version                                     247            248           0          0.0       60408.3       0.0X
+codegen version 64-bit                              193            193           0          0.0       47021.2       0.0X
+codegen HiveHash version                             30             30           0          0.1        7362.8       0.0X
 
 

--- a/sql/catalyst/benchmarks/HashBenchmark-results.txt
+++ b/sql/catalyst/benchmarks/HashBenchmark-results.txt
@@ -2,69 +2,69 @@
 single ints
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Hash For single ints:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                2035           2040           7        263.8           3.8       1.0X
-codegen version                                    3949           3952           3        135.9           7.4       0.5X
-codegen version 64-bit                             3419           3423           6        157.0           6.4       0.6X
-codegen HiveHash version                           2647           2663          23        202.8           4.9       0.8X
+interpreted version                                1216           1239          33        441.6           2.3       1.0X
+codegen version                                    2429           2434           6        221.0           4.5       0.5X
+codegen version 64-bit                             2336           2340           7        229.9           4.4       0.5X
+codegen HiveHash version                           1763           1778          20        304.5           3.3       0.7X
 
 
 ================================================================================================
 single longs
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Hash For single longs:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                2486           2492           8        215.9           4.6       1.0X
-codegen version                                    5601           5602           1         95.8          10.4       0.4X
-codegen version 64-bit                             4175           4183          11        128.6           7.8       0.6X
-codegen HiveHash version                           3263           3264           0        164.5           6.1       0.8X
+interpreted version                                1870           1872           4        287.2           3.5       1.0X
+codegen version                                    3463           3475          17        155.0           6.5       0.5X
+codegen version 64-bit                             2954           2971          25        181.7           5.5       0.6X
+codegen HiveHash version                           1946           1965          27        275.9           3.6       1.0X
 
 
 ================================================================================================
 normal
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Hash For normal:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                2734           2748          20          0.8        1303.7       1.0X
-codegen version                                    2511           2512           1          0.8        1197.4       1.1X
-codegen version 64-bit                              759            760           1          2.8         362.1       3.6X
-codegen HiveHash version                           4104           4105           1          0.5        1957.1       0.7X
+interpreted version                                2301           2303           3          0.9        1097.0       1.0X
+codegen version                                    1794           1800           9          1.2         855.2       1.3X
+codegen version 64-bit                              479            482           3          4.4         228.2       4.8X
+codegen HiveHash version                           3906           3908           2          0.5        1862.5       0.6X
 
 
 ================================================================================================
 array
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Hash For array:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                1158           1158           0          0.1        8836.3       1.0X
-codegen version                                    3648           3654           9          0.0       27829.0       0.3X
-codegen version 64-bit                             2699           2700           1          0.0       20595.1       0.4X
-codegen HiveHash version                            889            889           1          0.1        6779.7       1.3X
+interpreted version                                1557           1596          55          0.1       11879.7       1.0X
+codegen version                                    2765           2766           2          0.0       21097.5       0.6X
+codegen version 64-bit                             2544           2643         139          0.1       19412.2       0.6X
+codegen HiveHash version                            647            698          64          0.2        4939.7       2.4X
 
 
 ================================================================================================
 map
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Hash For map:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-interpreted version                                   0              0           0        101.5           9.9       1.0X
-codegen version                                     247            248           0          0.0       60408.3       0.0X
-codegen version 64-bit                              193            193           0          0.0       47021.2       0.0X
-codegen HiveHash version                             30             30           0          0.1        7362.8       0.0X
+interpreted version                                   0              0           0        101.9           9.8       1.0X
+codegen version                                     194            197           4          0.0       47307.5       0.0X
+codegen version 64-bit                              183            184           3          0.0       44671.8       0.0X
+codegen HiveHash version                             16             17           1          0.3        3831.1       0.0X
 
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/HashBenchmark.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/HashBenchmark.scala
@@ -125,6 +125,7 @@ object HashBenchmark extends BenchmarkBase {
       .add("binary", BinaryType)
       .add("date", DateType)
       .add("timestamp", TimestampType)
+      .add("time", TimeType())
     test("normal", normal, 1 << 10, 1 << 11)
 
     val arrayOfInt = ArrayType(IntegerType)

--- a/sql/core/benchmarks/CSVBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CSVBenchmark-jdk21-results.txt
@@ -2,76 +2,81 @@
 Benchmark to measure CSV read/write performance
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Parsing quoted values:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-One quoted string                                 23855          24079         214          0.0      477107.0       1.0X
+One quoted string                                 24108          24208         120          0.0      482158.6       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Wide rows with 1000 columns:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 1000 columns                               57781          58075         430          0.0       57780.6       1.0X
-Select 100 columns                                21035          21090          62          0.0       21035.2       2.7X
-Select one column                                 17302          17373          87          0.1       17301.6       3.3X
-count()                                            3712           3748          62          0.3        3711.8      15.6X
-Select 100 columns, one bad input field           25012          25037          31          0.0       25012.1       2.3X
-Select 100 columns, corrupt record field          28321          28454         195          0.0       28320.8       2.0X
+Select 1000 columns                               58682          59152         781          0.0       58682.0       1.0X
+Select 100 columns                                21338          21405          61          0.0       21337.7       2.8X
+Select one column                                 17634          17655          21          0.1       17633.7       3.3X
+count()                                            3693           3841         174          0.3        3692.6      15.9X
+Select 100 columns, one bad input field           25474          25528          74          0.0       25474.3       2.3X
+Select 100 columns, corrupt record field          28732          28839         132          0.0       28731.6       2.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Count a dataset with 10 columns:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns + count()                       10891          10912          32          0.9        1089.1       1.0X
-Select 1 column + count()                          7858           7860           2          1.3         785.8       1.4X
-count()                                            1675           1680           5          6.0         167.5       6.5X
+Select 10 columns + count()                       11065          11084          20          0.9        1106.5       1.0X
+Select 1 column + count()                          7672           7678           7          1.3         767.2       1.4X
+count()                                            1760           1771          15          5.7         176.0       6.3X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      844            851           8         11.9          84.4       1.0X
-to_csv(timestamp)                                  5614           5649          31          1.8         561.4       0.2X
-write timestamps to files                          6420           6451          29          1.6         642.0       0.1X
-Create a dataset of dates                           946            948           2         10.6          94.6       0.9X
-to_csv(date)                                       4207           4213           7          2.4         420.7       0.2X
-write dates to files                               4682           4691           9          2.1         468.2       0.2X
+Create a dataset of timestamps                      843            850           7         11.9          84.3       1.0X
+to_csv(timestamp)                                  5583           5679          85          1.8         558.3       0.2X
+write timestamps to files                          6100           6116          15          1.6         610.0       0.1X
+Create a dataset of dates                           936            949          15         10.7          93.6       0.9X
+to_csv(date)                                       3716           3721           5          2.7         371.6       0.2X
+write dates to files                               4143           4160          15          2.4         414.3       0.2X
+Create a dataset of times                           879            886           9         11.4          87.9       1.0X
+to_csv(time)                                       4755           4762           7          2.1         475.5       0.2X
+write times to files                               5146           5154           7          1.9         514.6       0.2X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Read dates and timestamps:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                                                  1152           1163          10          8.7         115.2       1.0X
-read timestamps from files                                                     10518          10575          49          1.0        1051.8       0.1X
-infer timestamps from files                                                    21286          21332          75          0.5        2128.6       0.1X
-read date text from files                                                       1061           1065           3          9.4         106.1       1.1X
-read date from files                                                            9268           9279           9          1.1         926.8       0.1X
-infer date from files                                                          19216          19277          69          0.5        1921.6       0.1X
-timestamp strings                                                               1321           1323           2          7.6         132.1       0.9X
-parse timestamps from Dataset[String]                                          12318          12342          24          0.8        1231.8       0.1X
-infer timestamps from Dataset[String]                                          22970          22992          20          0.4        2297.0       0.1X
-date strings                                                                    1770           1773           3          5.7         177.0       0.7X
-parse dates from Dataset[String]                                               11177          11186          10          0.9        1117.7       0.1X
-from_csv(timestamp)                                                            10259          10331          63          1.0        1025.9       0.1X
-from_csv(date)                                                                  9721           9743          37          1.0         972.1       0.1X
-infer error timestamps from Dataset[String] with default format                13166          13181          22          0.8        1316.6       0.1X
-infer error timestamps from Dataset[String] with user-provided format          13167          13196          32          0.8        1316.7       0.1X
-infer error timestamps from Dataset[String] with legacy format                 13172          13188          22          0.8        1317.2       0.1X
+read timestamp text from files                                                  1138           1168          43          8.8         113.8       1.0X
+read timestamps from files                                                     11005          11011           5          0.9        1100.5       0.1X
+infer timestamps from files                                                    21928          21949          20          0.5        2192.8       0.1X
+read date text from files                                                       1067           1080          24          9.4         106.7       1.1X
+read date from files                                                            9518           9547          27          1.1         951.8       0.1X
+infer date from files                                                          19662          19725          81          0.5        1966.2       0.1X
+timestamp strings                                                               1194           1197           3          8.4         119.4       1.0X
+parse timestamps from Dataset[String]                                          12861          12882          18          0.8        1286.1       0.1X
+infer timestamps from Dataset[String]                                          23859          23905          46          0.4        2385.9       0.0X
+date strings                                                                    1506           1510           3          6.6         150.6       0.8X
+parse dates from Dataset[String]                                               11569          11584          15          0.9        1156.9       0.1X
+from_csv(timestamp)                                                            10760          10803          38          0.9        1076.0       0.1X
+from_csv(date)                                                                  9984          10018          36          1.0         998.4       0.1X
+infer error timestamps from Dataset[String] with default format                13458          13485          44          0.7        1345.8       0.1X
+infer error timestamps from Dataset[String] with user-provided format          13426          13474          62          0.7        1342.6       0.1X
+infer error timestamps from Dataset[String] with legacy format                 13431          13466          56          0.7        1343.1       0.1X
+read time text from files                                                       1135           1156          19          8.8         113.5       1.0X
+read time from files                                                            9461           9484          21          1.1         946.1       0.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                        4087           4101          14          0.0       40874.4       1.0X
-pushdown disabled                                  4049           4058           9          0.0       40485.1       1.0X
-w/ filters                                          700            707           6          0.1        7001.4       5.8X
+w/o filters                                        4075           4123          44          0.0       40749.2       1.0X
+pushdown disabled                                  4113           4121          12          0.0       41130.1       1.0X
+w/ filters                                          766            773           7          0.1        7657.1       5.3X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Interval:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Read as Intervals                                   713            719           6          0.4        2376.0       1.0X
-Read Raw Strings                                    299            307           7          1.0         995.3       2.4X
+Read as Intervals                                   782            785           3          0.4        2607.0       1.0X
+Read Raw Strings                                    313            322          12          1.0        1042.8       2.5X
 
 

--- a/sql/core/benchmarks/CSVBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/CSVBenchmark-jdk25-results.txt
@@ -2,76 +2,81 @@
 Benchmark to measure CSV read/write performance
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Parsing quoted values:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-One quoted string                                 24142          24354         347          0.0      482846.0       1.0X
+One quoted string                                 26069          26269         191          0.0      521371.1       1.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Wide rows with 1000 columns:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 1000 columns                               54506          54865         537          0.0       54506.2       1.0X
-Select 100 columns                                20120          20224         127          0.0       20119.6       2.7X
-Select one column                                 16768          16835          65          0.1       16768.1       3.3X
-count()                                            3309           3350          63          0.3        3308.7      16.5X
-Select 100 columns, one bad input field           24294          24322          25          0.0       24294.1       2.2X
-Select 100 columns, corrupt record field          27414          27553         128          0.0       27414.5       2.0X
+Select 1000 columns                               55986          56459         812          0.0       55986.3       1.0X
+Select 100 columns                                20985          21247         342          0.0       20984.9       2.7X
+Select one column                                 17716          17881         189          0.1       17716.3       3.2X
+count()                                            3662           3716          75          0.3        3661.9      15.3X
+Select 100 columns, one bad input field           25177          25207          51          0.0       25177.5       2.2X
+Select 100 columns, corrupt record field          28367          28429          64          0.0       28366.9       2.0X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Count a dataset with 10 columns:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns + count()                       10745          10768          23          0.9        1074.5       1.0X
-Select 1 column + count()                          7639           7670          27          1.3         763.9       1.4X
-count()                                            1825           1833           9          5.5         182.5       5.9X
+Select 10 columns + count()                       10657          10678          33          0.9        1065.7       1.0X
+Select 1 column + count()                          7452           7471          20          1.3         745.2       1.4X
+count()                                            1635           1644           9          6.1         163.5       6.5X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      816            827          18         12.3          81.6       1.0X
-to_csv(timestamp)                                  5684           5774         116          1.8         568.4       0.1X
-write timestamps to files                          6362           6377          13          1.6         636.2       0.1X
-Create a dataset of dates                           918            929          13         10.9          91.8       0.9X
-to_csv(date)                                       4380           4393          12          2.3         438.0       0.2X
-write dates to files                               4561           4595          30          2.2         456.1       0.2X
+Create a dataset of timestamps                      841            867          33         11.9          84.1       1.0X
+to_csv(timestamp)                                  5517           5587          83          1.8         551.7       0.2X
+write timestamps to files                          5854           5870          21          1.7         585.4       0.1X
+Create a dataset of dates                           930            939          11         10.8          93.0       0.9X
+to_csv(date)                                       3911           3914           3          2.6         391.1       0.2X
+write dates to files                               4148           4151           4          2.4         414.8       0.2X
+Create a dataset of times                           883            906          21         11.3          88.3       1.0X
+to_csv(time)                                       4618           4631          11          2.2         461.8       0.2X
+write times to files                               4922           4938          20          2.0         492.2       0.2X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Read dates and timestamps:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                                                  1274           1277           3          7.8         127.4       1.0X
-read timestamps from files                                                     11382          11403          30          0.9        1138.2       0.1X
-infer timestamps from files                                                    22670          22804         131          0.4        2267.0       0.1X
-read date text from files                                                       1159           1173          13          8.6         115.9       1.1X
-read date from files                                                           11220          11232          10          0.9        1122.0       0.1X
-infer date from files                                                          22956          23076         108          0.4        2295.6       0.1X
-timestamp strings                                                               1114           1119           6          9.0         111.4       1.1X
-parse timestamps from Dataset[String]                                          12416          12434          17          0.8        1241.6       0.1X
-infer timestamps from Dataset[String]                                          23223          23341         102          0.4        2322.3       0.1X
-date strings                                                                    1527           1533           7          6.6         152.7       0.8X
-parse dates from Dataset[String]                                               12473          12490          15          0.8        1247.3       0.1X
-from_csv(timestamp)                                                            10490          10511          19          1.0        1049.0       0.1X
-from_csv(date)                                                                 11006          11026          30          0.9        1100.6       0.1X
-infer error timestamps from Dataset[String] with default format                14173          14258          74          0.7        1417.3       0.1X
-infer error timestamps from Dataset[String] with user-provided format          14214          14230          18          0.7        1421.4       0.1X
-infer error timestamps from Dataset[String] with legacy format                 14289          14317          26          0.7        1428.9       0.1X
+read timestamp text from files                                                  1133           1136           4          8.8         113.3       1.0X
+read timestamps from files                                                      9966           9987          29          1.0         996.6       0.1X
+infer timestamps from files                                                    20134          20188          56          0.5        2013.4       0.1X
+read date text from files                                                       1042           1046           3          9.6         104.2       1.1X
+read date from files                                                            9526           9549          23          1.0         952.6       0.1X
+infer date from files                                                          19605          19683         113          0.5        1960.5       0.1X
+timestamp strings                                                               1154           1175          32          8.7         115.4       1.0X
+parse timestamps from Dataset[String]                                          11837          11860          20          0.8        1183.7       0.1X
+infer timestamps from Dataset[String]                                          22006          22019          16          0.5        2200.6       0.1X
+date strings                                                                    1456           1462           6          6.9         145.6       0.8X
+parse dates from Dataset[String]                                               11330          11378          52          0.9        1133.0       0.1X
+from_csv(timestamp)                                                             9699           9710          11          1.0         969.9       0.1X
+from_csv(date)                                                                  9865           9882          19          1.0         986.5       0.1X
+infer error timestamps from Dataset[String] with default format                12822          12888          63          0.8        1282.2       0.1X
+infer error timestamps from Dataset[String] with user-provided format          12886          12902          20          0.8        1288.6       0.1X
+infer error timestamps from Dataset[String] with legacy format                 12903          12931          32          0.8        1290.3       0.1X
+read time text from files                                                       1149           1154           4          8.7         114.9       1.0X
+read time from files                                                            8988           9000          14          1.1         898.8       0.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                        3421           3431          10          0.0       34206.0       1.0X
-pushdown disabled                                  3360           3405          55          0.0       33598.8       1.0X
-w/ filters                                          774            778           5          0.1        7739.4       4.4X
+w/o filters                                        3833           3855          19          0.0       38331.6       1.0X
+pushdown disabled                                  3918           3940          22          0.0       39183.6       1.0X
+w/ filters                                          798            807           8          0.1        7978.1       4.8X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Interval:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Read as Intervals                                   722            725           3          0.4        2407.0       1.0X
-Read Raw Strings                                    329            332           4          0.9        1097.1       2.2X
+Read as Intervals                                   757            759           2          0.4        2524.8       1.0X
+Read Raw Strings                                    303            311          10          1.0        1010.7       2.5X
 
 

--- a/sql/core/benchmarks/CSVBenchmark-results.txt
+++ b/sql/core/benchmarks/CSVBenchmark-results.txt
@@ -2,81 +2,76 @@
 Benchmark to measure CSV read/write performance
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Parsing quoted values:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-One quoted string                                 10877          10913          57          0.0      217531.6       1.0X
+One quoted string                                 26170          26230          94          0.0      523394.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Wide rows with 1000 columns:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 1000 columns                               41330          42137         916          0.0       41330.3       1.0X
-Select 100 columns                                15231          15390         189          0.1       15231.0       2.7X
-Select one column                                 12603          12667          61          0.1       12603.2       3.3X
-count()                                            2610           2630          28          0.4        2610.3      15.8X
-Select 100 columns, one bad input field           17949          18138         202          0.1       17949.1       2.3X
-Select 100 columns, corrupt record field          20239          20372         126          0.0       20239.1       2.0X
+Select 1000 columns                               51860          52209         580          0.0       51859.6       1.0X
+Select 100 columns                                23745          23781          43          0.0       23745.3       2.2X
+Select one column                                 20220          20278          56          0.0       20219.6       2.6X
+count()                                            3218           3308         105          0.3        3218.2      16.1X
+Select 100 columns, one bad input field           28039          28266         212          0.0       28039.4       1.8X
+Select 100 columns, corrupt record field          31122          31132          17          0.0       31122.3       1.7X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Count a dataset with 10 columns:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns + count()                        6079           6168          80          1.6         607.9       1.0X
-Select 1 column + count()                          3674           3760         112          2.7         367.4       1.7X
-count()                                             870            882          17         11.5          87.0       7.0X
+Select 10 columns + count()                        9648           9682          35          1.0         964.8       1.0X
+Select 1 column + count()                          6694           6706          16          1.5         669.4       1.4X
+count()                                            1548           1560          19          6.5         154.8       6.2X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      712            755          38         14.0          71.2       1.0X
-to_csv(timestamp)                                  4106           4176          66          2.4         410.6       0.2X
-write timestamps to files                          4352           4365          13          2.3         435.2       0.2X
-Create a dataset of dates                           841            846           7         11.9          84.1       0.8X
-to_csv(date)                                       2660           2674          19          3.8         266.0       0.3X
-write dates to files                               2942           3003          80          3.4         294.2       0.2X
-Create a dataset of times                           771            789          28         13.0          77.1       0.9X
-to_csv(time)                                       3086           3130          47          3.2         308.6       0.2X
-write times to files                               3271           3390         119          3.1         327.1       0.2X
+Create a dataset of timestamps                      834            845          16         12.0          83.4       1.0X
+to_csv(timestamp)                                  5794           5808          21          1.7         579.4       0.1X
+write timestamps to files                          6073           6082          11          1.6         607.3       0.1X
+Create a dataset of dates                           959            968          12         10.4          95.9       0.9X
+to_csv(date)                                       3980           3987           6          2.5         398.0       0.2X
+write dates to files                               3894           3899           5          2.6         389.4       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Read dates and timestamps:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                                                   659            665           5         15.2          65.9       1.0X
-read timestamps from files                                                      7524           7566          66          1.3         752.4       0.1X
-infer timestamps from files                                                    14004          14125         123          0.7        1400.4       0.0X
-read date text from files                                                        551            554           2         18.1          55.1       1.2X
-read date from files                                                            5445           5496          47          1.8         544.5       0.1X
-infer date from files                                                          10910          10918           8          0.9        1091.0       0.1X
-timestamp strings                                                                762            775          18         13.1          76.2       0.9X
-parse timestamps from Dataset[String]                                           5936           6036          89          1.7         593.6       0.1X
-infer timestamps from Dataset[String]                                          10598          10664          67          0.9        1059.8       0.1X
-date strings                                                                    1205           1212           9          8.3         120.5       0.5X
-parse dates from Dataset[String]                                                6858           6911          49          1.5         685.8       0.1X
-from_csv(timestamp)                                                             4824           4859          33          2.1         482.4       0.1X
-from_csv(date)                                                                  6096           6101           7          1.6         609.6       0.1X
-infer error timestamps from Dataset[String] with default format                 7161           7167           7          1.4         716.1       0.1X
-infer error timestamps from Dataset[String] with user-provided format           7225           7311         136          1.4         722.5       0.1X
-infer error timestamps from Dataset[String] with legacy format                  7094           7244         131          1.4         709.4       0.1X
-read time text from files                                                        587            592           5         17.0          58.7       1.1X
-read time from files                                                            4141           4253         109          2.4         414.1       0.2X
+read timestamp text from files                                                  1180           1186           4          8.5         118.0       1.0X
+read timestamps from files                                                      9655           9670          19          1.0         965.5       0.1X
+infer timestamps from files                                                    19167          19244          68          0.5        1916.7       0.1X
+read date text from files                                                       1111           1129          22          9.0         111.1       1.1X
+read date from files                                                            9513           9521           7          1.1         951.3       0.1X
+infer date from files                                                          19126          19159          31          0.5        1912.6       0.1X
+timestamp strings                                                               1137           1144           7          8.8         113.7       1.0X
+parse timestamps from Dataset[String]                                          10759          10774          22          0.9        1075.9       0.1X
+infer timestamps from Dataset[String]                                          19823          19835          13          0.5        1982.3       0.1X
+date strings                                                                    1579           1583           5          6.3         157.9       0.7X
+parse dates from Dataset[String]                                               11033          11055          22          0.9        1103.3       0.1X
+from_csv(timestamp)                                                             8860           8864           6          1.1         886.0       0.1X
+from_csv(date)                                                                  9649           9670          27          1.0         964.9       0.1X
+infer error timestamps from Dataset[String] with default format                11156          11157           1          0.9        1115.6       0.1X
+infer error timestamps from Dataset[String] with user-provided format          11118          11147          26          0.9        1111.8       0.1X
+infer error timestamps from Dataset[String] with legacy format                 11140          11152          10          0.9        1114.0       0.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                        4222           4293          64          0.0       42222.8       1.0X
-pushdown disabled                                  4170           4176           9          0.0       41702.7       1.0X
-w/ filters                                          520            526           9          0.2        5198.6       8.1X
+w/o filters                                        4268           4277           9          0.0       42682.0       1.0X
+pushdown disabled                                  4250           4254           5          0.0       42501.3       1.0X
+w/ filters                                          863            869           5          0.1        8634.6       4.9X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Interval:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Read as Intervals                                   423            426           4          0.7        1408.4       1.0X
-Read Raw Strings                                    170            172           2          1.8         565.5       2.5X
+Read as Intervals                                   748            749           2          0.4        2493.1       1.0X
+Read Raw Strings                                    304            305           1          1.0        1014.7       2.5X
 
 

--- a/sql/core/benchmarks/CSVBenchmark-results.txt
+++ b/sql/core/benchmarks/CSVBenchmark-results.txt
@@ -2,76 +2,81 @@
 Benchmark to measure CSV read/write performance
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Parsing quoted values:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-One quoted string                                 26170          26230          94          0.0      523394.1       1.0X
+One quoted string                                 10877          10913          57          0.0      217531.6       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Wide rows with 1000 columns:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 1000 columns                               51860          52209         580          0.0       51859.6       1.0X
-Select 100 columns                                23745          23781          43          0.0       23745.3       2.2X
-Select one column                                 20220          20278          56          0.0       20219.6       2.6X
-count()                                            3218           3308         105          0.3        3218.2      16.1X
-Select 100 columns, one bad input field           28039          28266         212          0.0       28039.4       1.8X
-Select 100 columns, corrupt record field          31122          31132          17          0.0       31122.3       1.7X
+Select 1000 columns                               41330          42137         916          0.0       41330.3       1.0X
+Select 100 columns                                15231          15390         189          0.1       15231.0       2.7X
+Select one column                                 12603          12667          61          0.1       12603.2       3.3X
+count()                                            2610           2630          28          0.4        2610.3      15.8X
+Select 100 columns, one bad input field           17949          18138         202          0.1       17949.1       2.3X
+Select 100 columns, corrupt record field          20239          20372         126          0.0       20239.1       2.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Count a dataset with 10 columns:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns + count()                        9648           9682          35          1.0         964.8       1.0X
-Select 1 column + count()                          6694           6706          16          1.5         669.4       1.4X
-count()                                            1548           1560          19          6.5         154.8       6.2X
+Select 10 columns + count()                        6079           6168          80          1.6         607.9       1.0X
+Select 1 column + count()                          3674           3760         112          2.7         367.4       1.7X
+count()                                             870            882          17         11.5          87.0       7.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      834            845          16         12.0          83.4       1.0X
-to_csv(timestamp)                                  5794           5808          21          1.7         579.4       0.1X
-write timestamps to files                          6073           6082          11          1.6         607.3       0.1X
-Create a dataset of dates                           959            968          12         10.4          95.9       0.9X
-to_csv(date)                                       3980           3987           6          2.5         398.0       0.2X
-write dates to files                               3894           3899           5          2.6         389.4       0.2X
+Create a dataset of timestamps                      712            755          38         14.0          71.2       1.0X
+to_csv(timestamp)                                  4106           4176          66          2.4         410.6       0.2X
+write timestamps to files                          4352           4365          13          2.3         435.2       0.2X
+Create a dataset of dates                           841            846           7         11.9          84.1       0.8X
+to_csv(date)                                       2660           2674          19          3.8         266.0       0.3X
+write dates to files                               2942           3003          80          3.4         294.2       0.2X
+Create a dataset of times                           771            789          28         13.0          77.1       0.9X
+to_csv(time)                                       3086           3130          47          3.2         308.6       0.2X
+write times to files                               3271           3390         119          3.1         327.1       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Read dates and timestamps:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                                                  1180           1186           4          8.5         118.0       1.0X
-read timestamps from files                                                      9655           9670          19          1.0         965.5       0.1X
-infer timestamps from files                                                    19167          19244          68          0.5        1916.7       0.1X
-read date text from files                                                       1111           1129          22          9.0         111.1       1.1X
-read date from files                                                            9513           9521           7          1.1         951.3       0.1X
-infer date from files                                                          19126          19159          31          0.5        1912.6       0.1X
-timestamp strings                                                               1137           1144           7          8.8         113.7       1.0X
-parse timestamps from Dataset[String]                                          10759          10774          22          0.9        1075.9       0.1X
-infer timestamps from Dataset[String]                                          19823          19835          13          0.5        1982.3       0.1X
-date strings                                                                    1579           1583           5          6.3         157.9       0.7X
-parse dates from Dataset[String]                                               11033          11055          22          0.9        1103.3       0.1X
-from_csv(timestamp)                                                             8860           8864           6          1.1         886.0       0.1X
-from_csv(date)                                                                  9649           9670          27          1.0         964.9       0.1X
-infer error timestamps from Dataset[String] with default format                11156          11157           1          0.9        1115.6       0.1X
-infer error timestamps from Dataset[String] with user-provided format          11118          11147          26          0.9        1111.8       0.1X
-infer error timestamps from Dataset[String] with legacy format                 11140          11152          10          0.9        1114.0       0.1X
+read timestamp text from files                                                   659            665           5         15.2          65.9       1.0X
+read timestamps from files                                                      7524           7566          66          1.3         752.4       0.1X
+infer timestamps from files                                                    14004          14125         123          0.7        1400.4       0.0X
+read date text from files                                                        551            554           2         18.1          55.1       1.2X
+read date from files                                                            5445           5496          47          1.8         544.5       0.1X
+infer date from files                                                          10910          10918           8          0.9        1091.0       0.1X
+timestamp strings                                                                762            775          18         13.1          76.2       0.9X
+parse timestamps from Dataset[String]                                           5936           6036          89          1.7         593.6       0.1X
+infer timestamps from Dataset[String]                                          10598          10664          67          0.9        1059.8       0.1X
+date strings                                                                    1205           1212           9          8.3         120.5       0.5X
+parse dates from Dataset[String]                                                6858           6911          49          1.5         685.8       0.1X
+from_csv(timestamp)                                                             4824           4859          33          2.1         482.4       0.1X
+from_csv(date)                                                                  6096           6101           7          1.6         609.6       0.1X
+infer error timestamps from Dataset[String] with default format                 7161           7167           7          1.4         716.1       0.1X
+infer error timestamps from Dataset[String] with user-provided format           7225           7311         136          1.4         722.5       0.1X
+infer error timestamps from Dataset[String] with legacy format                  7094           7244         131          1.4         709.4       0.1X
+read time text from files                                                        587            592           5         17.0          58.7       1.1X
+read time from files                                                            4141           4253         109          2.4         414.1       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                        4268           4277           9          0.0       42682.0       1.0X
-pushdown disabled                                  4250           4254           5          0.0       42501.3       1.0X
-w/ filters                                          863            869           5          0.1        8634.6       4.9X
+w/o filters                                        4222           4293          64          0.0       42222.8       1.0X
+pushdown disabled                                  4170           4176           9          0.0       41702.7       1.0X
+w/ filters                                          520            526           9          0.2        5198.6       8.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Interval:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Read as Intervals                                   748            749           2          0.4        2493.1       1.0X
-Read Raw Strings                                    304            305           1          1.0        1014.7       2.5X
+Read as Intervals                                   423            426           4          0.7        1408.4       1.0X
+Read Raw Strings                                    170            172           2          1.8         565.5       2.5X
 
 

--- a/sql/core/benchmarks/CSVBenchmark-results.txt
+++ b/sql/core/benchmarks/CSVBenchmark-results.txt
@@ -2,76 +2,81 @@
 Benchmark to measure CSV read/write performance
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Parsing quoted values:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-One quoted string                                 26170          26230          94          0.0      523394.1       1.0X
+One quoted string                                 25478          25599         169          0.0      509568.3       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Wide rows with 1000 columns:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 1000 columns                               51860          52209         580          0.0       51859.6       1.0X
-Select 100 columns                                23745          23781          43          0.0       23745.3       2.2X
-Select one column                                 20220          20278          56          0.0       20219.6       2.6X
-count()                                            3218           3308         105          0.3        3218.2      16.1X
-Select 100 columns, one bad input field           28039          28266         212          0.0       28039.4       1.8X
-Select 100 columns, corrupt record field          31122          31132          17          0.0       31122.3       1.7X
+Select 1000 columns                               56126          56605         804          0.0       56125.6       1.0X
+Select 100 columns                                22091          22109          30          0.0       22090.8       2.5X
+Select one column                                 18548          18678         119          0.1       18547.7       3.0X
+count()                                            3389           3427          59          0.3        3388.7      16.6X
+Select 100 columns, one bad input field           27315          27333          24          0.0       27315.5       2.1X
+Select 100 columns, corrupt record field          30160          30250         136          0.0       30159.5       1.9X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Count a dataset with 10 columns:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns + count()                        9648           9682          35          1.0         964.8       1.0X
-Select 1 column + count()                          6694           6706          16          1.5         669.4       1.4X
-count()                                            1548           1560          19          6.5         154.8       6.2X
+Select 10 columns + count()                        9274           9317          71          1.1         927.4       1.0X
+Select 1 column + count()                          6631           6641          14          1.5         663.1       1.4X
+count()                                            1641           1645           5          6.1         164.1       5.7X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      834            845          16         12.0          83.4       1.0X
-to_csv(timestamp)                                  5794           5808          21          1.7         579.4       0.1X
-write timestamps to files                          6073           6082          11          1.6         607.3       0.1X
-Create a dataset of dates                           959            968          12         10.4          95.9       0.9X
-to_csv(date)                                       3980           3987           6          2.5         398.0       0.2X
-write dates to files                               3894           3899           5          2.6         389.4       0.2X
+Create a dataset of timestamps                      816            819           3         12.3          81.6       1.0X
+to_csv(timestamp)                                  5975           6013          33          1.7         597.5       0.1X
+write timestamps to files                          6295           6304           8          1.6         629.5       0.1X
+Create a dataset of dates                           930            933           2         10.7          93.0       0.9X
+to_csv(date)                                       4194           4194           1          2.4         419.4       0.2X
+write dates to files                               4235           4238           4          2.4         423.5       0.2X
+Create a dataset of times                           836            843          10         12.0          83.6       1.0X
+to_csv(time)                                       6053           6068          15          1.7         605.3       0.1X
+write times to files                               5988           5999           9          1.7         598.8       0.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Read dates and timestamps:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                                                  1180           1186           4          8.5         118.0       1.0X
-read timestamps from files                                                      9655           9670          19          1.0         965.5       0.1X
-infer timestamps from files                                                    19167          19244          68          0.5        1916.7       0.1X
-read date text from files                                                       1111           1129          22          9.0         111.1       1.1X
-read date from files                                                            9513           9521           7          1.1         951.3       0.1X
-infer date from files                                                          19126          19159          31          0.5        1912.6       0.1X
-timestamp strings                                                               1137           1144           7          8.8         113.7       1.0X
-parse timestamps from Dataset[String]                                          10759          10774          22          0.9        1075.9       0.1X
-infer timestamps from Dataset[String]                                          19823          19835          13          0.5        1982.3       0.1X
-date strings                                                                    1579           1583           5          6.3         157.9       0.7X
-parse dates from Dataset[String]                                               11033          11055          22          0.9        1103.3       0.1X
-from_csv(timestamp)                                                             8860           8864           6          1.1         886.0       0.1X
-from_csv(date)                                                                  9649           9670          27          1.0         964.9       0.1X
-infer error timestamps from Dataset[String] with default format                11156          11157           1          0.9        1115.6       0.1X
-infer error timestamps from Dataset[String] with user-provided format          11118          11147          26          0.9        1111.8       0.1X
-infer error timestamps from Dataset[String] with legacy format                 11140          11152          10          0.9        1114.0       0.1X
+read timestamp text from files                                                  1185           1200          12          8.4         118.5       1.0X
+read timestamps from files                                                      9670           9679           8          1.0         967.0       0.1X
+infer timestamps from files                                                    19643          19661          16          0.5        1964.3       0.1X
+read date text from files                                                       1091           1097           7          9.2         109.1       1.1X
+read date from files                                                            9817           9823           6          1.0         981.7       0.1X
+infer date from files                                                          19909          19928          22          0.5        1990.9       0.1X
+timestamp strings                                                               1198           1202           3          8.3         119.8       1.0X
+parse timestamps from Dataset[String]                                          11542          11566          31          0.9        1154.2       0.1X
+infer timestamps from Dataset[String]                                          21391          21431          46          0.5        2139.1       0.1X
+date strings                                                                    1622           1627           5          6.2         162.2       0.7X
+parse dates from Dataset[String]                                               11779          11802          21          0.8        1177.9       0.1X
+from_csv(timestamp)                                                             9606           9630          31          1.0         960.6       0.1X
+from_csv(date)                                                                 10052          10073          20          1.0        1005.2       0.1X
+infer error timestamps from Dataset[String] with default format                12378          12405          42          0.8        1237.8       0.1X
+infer error timestamps from Dataset[String] with user-provided format          12342          12413          67          0.8        1234.2       0.1X
+infer error timestamps from Dataset[String] with legacy format                 12373          12394          31          0.8        1237.3       0.1X
+read time text from files                                                       1159           1165           6          8.6         115.9       1.0X
+read time from files                                                            8704           8723          17          1.1         870.4       0.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                        4268           4277           9          0.0       42682.0       1.0X
-pushdown disabled                                  4250           4254           5          0.0       42501.3       1.0X
-w/ filters                                          863            869           5          0.1        8634.6       4.9X
+w/o filters                                        4080           4097          21          0.0       40801.3       1.0X
+pushdown disabled                                  3576           3581           5          0.0       35763.5       1.1X
+w/ filters                                          761            765           5          0.1        7607.7       5.4X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Interval:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Read as Intervals                                   748            749           2          0.4        2493.1       1.0X
-Read Raw Strings                                    304            305           1          1.0        1014.7       2.5X
+Read as Intervals                                   696            699           3          0.4        2319.4       1.0X
+Read Raw Strings                                    299            302           3          1.0         998.2       2.3X
 
 

--- a/sql/core/benchmarks/ExtractBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-jdk21-results.txt
@@ -1,104 +1,122 @@
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Invoke extract for timestamp:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   207            230          30         48.4          20.7       1.0X
-YEAR of timestamp                                   599            603           4         16.7          59.9       0.3X
-YEAROFWEEK of timestamp                             561            586          32         17.8          56.1       0.4X
-QUARTER of timestamp                                542            545           3         18.4          54.2       0.4X
-MONTH of timestamp                                  475            480           6         21.1          47.5       0.4X
-WEEK of timestamp                                   780            784           4         12.8          78.0       0.3X
-DAY of timestamp                                    487            490           3         20.6          48.7       0.4X
-DAYOFWEEK of timestamp                              670            672           2         14.9          67.0       0.3X
-DOW of timestamp                                    666            670           4         15.0          66.6       0.3X
-DOW_ISO of timestamp                                604            607           2         16.6          60.4       0.3X
-DAYOFWEEK_ISO of timestamp                          603            607           6         16.6          60.3       0.3X
-DOY of timestamp                                    519            523           4         19.3          51.9       0.4X
-HOUR of timestamp                                   407            409           2         24.6          40.7       0.5X
-MINUTE of timestamp                                 407            410           2         24.5          40.7       0.5X
-SECOND of timestamp                                 464            466           2         21.6          46.4       0.4X
+cast to timestamp                                   268            292          23         37.4          26.8       1.0X
+YEAR of timestamp                                   710            717          10         14.1          71.0       0.4X
+YEAROFWEEK of timestamp                             665            675          10         15.0          66.5       0.4X
+QUARTER of timestamp                                697            704           6         14.3          69.7       0.4X
+MONTH of timestamp                                  573            583          11         17.4          57.3       0.5X
+WEEK of timestamp                                   905            912           7         11.1          90.5       0.3X
+DAY of timestamp                                    572            585          11         17.5          57.2       0.5X
+DAYOFWEEK of timestamp                              764            777          16         13.1          76.4       0.4X
+DOW of timestamp                                    759            771          12         13.2          75.9       0.4X
+DOW_ISO of timestamp                                716            724           8         14.0          71.6       0.4X
+DAYOFWEEK_ISO of timestamp                          717            731          17         13.9          71.7       0.4X
+DOY of timestamp                                    620            632          10         16.1          62.0       0.4X
+HOUR of timestamp                                   498            500           2         20.1          49.8       0.5X
+MINUTE of timestamp                                 493            498           5         20.3          49.3       0.5X
+SECOND of timestamp                                 565            566           1         17.7          56.5       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Invoke date_part for timestamp:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   186            189           3         53.9          18.6       1.0X
-YEAR of timestamp                                   464            467           3         21.5          46.4       0.4X
-YEAROFWEEK of timestamp                             537            544           9         18.6          53.7       0.3X
-QUARTER of timestamp                                533            535           4         18.8          53.3       0.3X
-MONTH of timestamp                                  465            490          38         21.5          46.5       0.4X
-WEEK of timestamp                                   765            767           2         13.1          76.5       0.2X
-DAY of timestamp                                    482            483           1         20.8          48.2       0.4X
-DAYOFWEEK of timestamp                              657            660           5         15.2          65.7       0.3X
-DOW of timestamp                                    660            663           2         15.1          66.0       0.3X
-DOW_ISO of timestamp                                601            602           1         16.6          60.1       0.3X
-DAYOFWEEK_ISO of timestamp                          603            604           1         16.6          60.3       0.3X
-DOY of timestamp                                    513            515           3         19.5          51.3       0.4X
-HOUR of timestamp                                   405            407           2         24.7          40.5       0.5X
-MINUTE of timestamp                                 405            407           2         24.7          40.5       0.5X
-SECOND of timestamp                                 468            469           1         21.4          46.8       0.4X
+cast to timestamp                                   237            241           6         42.1          23.7       1.0X
+YEAR of timestamp                                   574            576           2         17.4          57.4       0.4X
+YEAROFWEEK of timestamp                             628            629           1         15.9          62.8       0.4X
+QUARTER of timestamp                                728            729           1         13.7          72.8       0.3X
+MONTH of timestamp                                  559            560           1         17.9          55.9       0.4X
+WEEK of timestamp                                   885            887           2         11.3          88.5       0.3X
+DAY of timestamp                                    561            562           2         17.8          56.1       0.4X
+DAYOFWEEK of timestamp                              752            753           1         13.3          75.2       0.3X
+DOW of timestamp                                    750            758           8         13.3          75.0       0.3X
+DOW_ISO of timestamp                                701            704           2         14.3          70.1       0.3X
+DAYOFWEEK_ISO of timestamp                          701            705           6         14.3          70.1       0.3X
+DOY of timestamp                                    611            616           8         16.4          61.1       0.4X
+HOUR of timestamp                                   489            490           2         20.5          48.9       0.5X
+MINUTE of timestamp                                 485            487           4         20.6          48.5       0.5X
+SECOND of timestamp                                 566            568           3         17.7          56.6       0.4X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Invoke extract for date:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        442            443           1         22.6          44.2       1.0X
-YEAR of date                                        463            465           3         21.6          46.3       1.0X
-YEAROFWEEK of date                                  536            538           3         18.6          53.6       0.8X
-QUARTER of date                                     530            536           8         18.9          53.0       0.8X
-MONTH of date                                       466            472           5         21.4          46.6       0.9X
-WEEK of date                                        770            778           7         13.0          77.0       0.6X
-DAY of date                                         480            482           1         20.8          48.0       0.9X
-DAYOFWEEK of date                                   658            661           3         15.2          65.8       0.7X
-DOW of date                                         657            658           1         15.2          65.7       0.7X
-DOW_ISO of date                                     599            600           2         16.7          59.9       0.7X
-DAYOFWEEK_ISO of date                               600            604           5         16.7          60.0       0.7X
-DOY of date                                         513            513           1         19.5          51.3       0.9X
-HOUR of date                                        892            905          21         11.2          89.2       0.5X
-MINUTE of date                                      889            893           4         11.3          88.9       0.5X
-SECOND of date                                      990            995           6         10.1          99.0       0.4X
+cast to date                                        653            655           4         15.3          65.3       1.0X
+YEAR of date                                        567            571           4         17.6          56.7       1.2X
+YEAROFWEEK of date                                  623            626           2         16.0          62.3       1.0X
+QUARTER of date                                     727            731           6         13.8          72.7       0.9X
+MONTH of date                                       551            554           2         18.1          55.1       1.2X
+WEEK of date                                        882            884           1         11.3          88.2       0.7X
+DAY of date                                         556            564          10         18.0          55.6       1.2X
+DAYOFWEEK of date                                   751            751           0         13.3          75.1       0.9X
+DOW of date                                         753            756           2         13.3          75.3       0.9X
+DOW_ISO of date                                     701            705           6         14.3          70.1       0.9X
+DAYOFWEEK_ISO of date                               698            701           2         14.3          69.8       0.9X
+DOY of date                                         610            611           1         16.4          61.0       1.1X
+HOUR of date                                       1043           1047           4          9.6         104.3       0.6X
+MINUTE of date                                     1043           1044           1          9.6         104.3       0.6X
+SECOND of date                                     1138           1145          10          8.8         113.8       0.6X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Invoke date_part for date:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        444            461          21         22.5          44.4       1.0X
-YEAR of date                                        461            462           1         21.7          46.1       1.0X
-YEAROFWEEK of date                                  538            540           2         18.6          53.8       0.8X
-QUARTER of date                                     531            534           3         18.8          53.1       0.8X
-MONTH of date                                       467            474          11         21.4          46.7       1.0X
-WEEK of date                                        768            775          10         13.0          76.8       0.6X
-DAY of date                                         476            480           4         21.0          47.6       0.9X
-DAYOFWEEK of date                                   655            657           2         15.3          65.5       0.7X
-DOW of date                                         658            661           3         15.2          65.8       0.7X
-DOW_ISO of date                                     599            600           1         16.7          59.9       0.7X
-DAYOFWEEK_ISO of date                               600            602           1         16.7          60.0       0.7X
-DOY of date                                         511            513           2         19.6          51.1       0.9X
-HOUR of date                                        888            892           4         11.3          88.8       0.5X
-MINUTE of date                                      891            895           5         11.2          89.1       0.5X
-SECOND of date                                      990            990           1         10.1          99.0       0.4X
+cast to date                                        652            654           4         15.3          65.2       1.0X
+YEAR of date                                        564            568           3         17.7          56.4       1.2X
+YEAROFWEEK of date                                  625            626           1         16.0          62.5       1.0X
+QUARTER of date                                     731            732           2         13.7          73.1       0.9X
+MONTH of date                                       553            554           1         18.1          55.3       1.2X
+WEEK of date                                        883            886           4         11.3          88.3       0.7X
+DAY of date                                         558            561           3         17.9          55.8       1.2X
+DAYOFWEEK of date                                   750            753           2         13.3          75.0       0.9X
+DOW of date                                         751            753           2         13.3          75.1       0.9X
+DOW_ISO of date                                     701            704           5         14.3          70.1       0.9X
+DAYOFWEEK_ISO of date                               701            702           1         14.3          70.1       0.9X
+DOY of date                                         606            609           3         16.5          60.6       1.1X
+HOUR of date                                       1040           1041           1          9.6         104.0       0.6X
+MINUTE of date                                     1040           1042           2          9.6         104.0       0.6X
+SECOND of date                                     1145           1147           2          8.7         114.5       0.6X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+Invoke extract for time:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+cast to time                                        508            514           6         19.7          50.8       1.0X
+HOUR of time                                        604            605           1         16.5          60.4       0.8X
+MINUTE of time                                      603            604           1         16.6          60.3       0.8X
+SECOND of time                                     1832           1839          12          5.5         183.2       0.3X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+Invoke date_part for time:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+cast to time                                        510            511           1         19.6          51.0       1.0X
+HOUR of time                                        599            601           2         16.7          59.9       0.9X
+MINUTE of time                                      600            601           2         16.7          60.0       0.9X
+SECOND of time                                     1834           1838           4          5.5         183.4       0.3X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Invoke extract for interval:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                    662            671          12         15.1          66.2       1.0X
-YEAR of interval                                    639            641           1         15.6          63.9       1.0X
-MONTH of interval                                   651            663          18         15.4          65.1       1.0X
-DAY of interval                                     643            644           0         15.5          64.3       1.0X
-HOUR of interval                                    652            654           1         15.3          65.2       1.0X
-MINUTE of interval                                  655            657           2         15.3          65.5       1.0X
-SECOND of interval                                  698            703           5         14.3          69.8       0.9X
+cast to interval                                    768            772           4         13.0          76.8       1.0X
+YEAR of interval                                    834            834           0         12.0          83.4       0.9X
+MONTH of interval                                   839            840           1         11.9          83.9       0.9X
+DAY of interval                                     755            759           3         13.2          75.5       1.0X
+HOUR of interval                                    755            758           2         13.2          75.5       1.0X
+MINUTE of interval                                  849            854           8         11.8          84.9       0.9X
+SECOND of interval                                  800            803           2         12.5          80.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Invoke date_part for interval:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                    658            660           2         15.2          65.8       1.0X
-YEAR of interval                                    641            642           1         15.6          64.1       1.0X
-MONTH of interval                                   649            659          13         15.4          64.9       1.0X
-DAY of interval                                     642            643           1         15.6          64.2       1.0X
-HOUR of interval                                    652            653           1         15.3          65.2       1.0X
-MINUTE of interval                                  654            660           8         15.3          65.4       1.0X
-SECOND of interval                                  700            700           1         14.3          70.0       0.9X
+cast to interval                                    767            770           2         13.0          76.7       1.0X
+YEAR of interval                                    837            838           1         11.9          83.7       0.9X
+MONTH of interval                                   843            845           2         11.9          84.3       0.9X
+DAY of interval                                     797            797           0         12.5          79.7       1.0X
+HOUR of interval                                    754            756           3         13.3          75.4       1.0X
+MINUTE of interval                                  856            858           3         11.7          85.6       0.9X
+SECOND of interval                                  796            799           4         12.6          79.6       1.0X
 

--- a/sql/core/benchmarks/ExtractBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-jdk25-results.txt
@@ -1,104 +1,122 @@
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Invoke extract for timestamp:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   257            279          19         38.9          25.7       1.0X
-YEAR of timestamp                                   562            581          23         17.8          56.2       0.5X
-YEAROFWEEK of timestamp                             630            657          34         15.9          63.0       0.4X
-QUARTER of timestamp                                651            669          20         15.4          65.1       0.4X
-MONTH of timestamp                                  570            593          36         17.6          57.0       0.5X
-WEEK of timestamp                                   895            910          16         11.2          89.5       0.3X
-DAY of timestamp                                    574            588          17         17.4          57.4       0.4X
-DAYOFWEEK of timestamp                              733            748          18         13.6          73.3       0.4X
-DOW of timestamp                                    737            748           9         13.6          73.7       0.3X
-DOW_ISO of timestamp                                687            708          28         14.6          68.7       0.4X
-DAYOFWEEK_ISO of timestamp                          685            712          30         14.6          68.5       0.4X
-DOY of timestamp                                    611            623          15         16.4          61.1       0.4X
-HOUR of timestamp                                   441            452          17         22.7          44.1       0.6X
-MINUTE of timestamp                                 439            449          11         22.8          43.9       0.6X
-SECOND of timestamp                                 555            560           7         18.0          55.5       0.5X
+cast to timestamp                                   275            285           9         36.3          27.5       1.0X
+YEAR of timestamp                                   666            673           7         15.0          66.6       0.4X
+YEAROFWEEK of timestamp                             635            649          19         15.7          63.5       0.4X
+QUARTER of timestamp                                677            704          37         14.8          67.7       0.4X
+MONTH of timestamp                                  566            571           5         17.7          56.6       0.5X
+WEEK of timestamp                                   902            906           4         11.1          90.2       0.3X
+DAY of timestamp                                    576            585          11         17.4          57.6       0.5X
+DAYOFWEEK of timestamp                              741            749          12         13.5          74.1       0.4X
+DOW of timestamp                                    740            745           5         13.5          74.0       0.4X
+DOW_ISO of timestamp                                680            681           1         14.7          68.0       0.4X
+DAYOFWEEK_ISO of timestamp                          680            684           5         14.7          68.0       0.4X
+DOY of timestamp                                    604            611          11         16.6          60.4       0.5X
+HOUR of timestamp                                   429            433           4         23.3          42.9       0.6X
+MINUTE of timestamp                                 431            435           4         23.2          43.1       0.6X
+SECOND of timestamp                                 522            533          13         19.1          52.2       0.5X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Invoke date_part for timestamp:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   247            261          17         40.6          24.7       1.0X
-YEAR of timestamp                                   562            575          16         17.8          56.2       0.4X
-YEAROFWEEK of timestamp                             626            645          19         16.0          62.6       0.4X
-QUARTER of timestamp                                647            655          12         15.4          64.7       0.4X
-MONTH of timestamp                                  568            578          12         17.6          56.8       0.4X
-WEEK of timestamp                                   881            886           4         11.3          88.1       0.3X
-DAY of timestamp                                    573            583          11         17.5          57.3       0.4X
-DAYOFWEEK of timestamp                              731            738           6         13.7          73.1       0.3X
-DOW of timestamp                                    733            748          18         13.6          73.3       0.3X
-DOW_ISO of timestamp                                686            692           6         14.6          68.6       0.4X
-DAYOFWEEK_ISO of timestamp                          688            700          14         14.5          68.8       0.4X
-DOY of timestamp                                    607            611           5         16.5          60.7       0.4X
-HOUR of timestamp                                   451            452           1         22.2          45.1       0.5X
-MINUTE of timestamp                                 436            445          15         23.0          43.6       0.6X
-SECOND of timestamp                                 529            536          10         18.9          52.9       0.5X
+cast to timestamp                                   247            252           4         40.5          24.7       1.0X
+YEAR of timestamp                                   539            541           2         18.6          53.9       0.5X
+YEAROFWEEK of timestamp                             624            625           0         16.0          62.4       0.4X
+QUARTER of timestamp                                733            736           5         13.6          73.3       0.3X
+MONTH of timestamp                                  557            558           2         18.0          55.7       0.4X
+WEEK of timestamp                                   898            899           2         11.1          89.8       0.3X
+DAY of timestamp                                    566            571           5         17.7          56.6       0.4X
+DAYOFWEEK of timestamp                              737            741           5         13.6          73.7       0.3X
+DOW of timestamp                                    733            737           4         13.6          73.3       0.3X
+DOW_ISO of timestamp                                689            691           2         14.5          68.9       0.4X
+DAYOFWEEK_ISO of timestamp                          668            670           3         15.0          66.8       0.4X
+DOY of timestamp                                    600            602           1         16.7          60.0       0.4X
+HOUR of timestamp                                   426            428           2         23.5          42.6       0.6X
+MINUTE of timestamp                                 431            438          14         23.2          43.1       0.6X
+SECOND of timestamp                                 521            522           1         19.2          52.1       0.5X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Invoke extract for date:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        529            533           5         18.9          52.9       1.0X
-YEAR of date                                        557            560           3         18.0          55.7       1.0X
-YEAROFWEEK of date                                  629            631           4         15.9          62.9       0.8X
-QUARTER of date                                     640            645           5         15.6          64.0       0.8X
-MONTH of date                                       567            581          22         17.6          56.7       0.9X
-WEEK of date                                        882            890          10         11.3          88.2       0.6X
-DAY of date                                         567            574           7         17.6          56.7       0.9X
-DAYOFWEEK of date                                   730            734           3         13.7          73.0       0.7X
-DOW of date                                         730            730           1         13.7          73.0       0.7X
-DOW_ISO of date                                     684            694          15         14.6          68.4       0.8X
-DAYOFWEEK_ISO of date                               683            686           2         14.6          68.3       0.8X
-DOY of date                                         608            610           3         16.4          60.8       0.9X
-HOUR of date                                        969            980          17         10.3          96.9       0.5X
-MINUTE of date                                      972            980          10         10.3          97.2       0.5X
-SECOND of date                                     1063           1064           2          9.4         106.3       0.5X
+cast to date                                        510            515           7         19.6          51.0       1.0X
+YEAR of date                                        540            543           3         18.5          54.0       0.9X
+YEAROFWEEK of date                                  616            618           2         16.2          61.6       0.8X
+QUARTER of date                                     736            738           2         13.6          73.6       0.7X
+MONTH of date                                       554            558           6         18.0          55.4       0.9X
+WEEK of date                                        893            897           3         11.2          89.3       0.6X
+DAY of date                                         569            570           1         17.6          56.9       0.9X
+DAYOFWEEK of date                                   730            736           5         13.7          73.0       0.7X
+DOW of date                                         734            736           3         13.6          73.4       0.7X
+DOW_ISO of date                                     665            673          10         15.0          66.5       0.8X
+DAYOFWEEK_ISO of date                               667            675          11         15.0          66.7       0.8X
+DOY of date                                         595            601           6         16.8          59.5       0.9X
+HOUR of date                                        958            966          11         10.4          95.8       0.5X
+MINUTE of date                                      959            960           1         10.4          95.9       0.5X
+SECOND of date                                     1034           1041           7          9.7         103.4       0.5X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Invoke date_part for date:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        530            531           1         18.9          53.0       1.0X
-YEAR of date                                        557            559           2         17.9          55.7       1.0X
-YEAROFWEEK of date                                  633            648          13         15.8          63.3       0.8X
-QUARTER of date                                     640            641           2         15.6          64.0       0.8X
-MONTH of date                                       563            566           2         17.8          56.3       0.9X
-WEEK of date                                        883            885           3         11.3          88.3       0.6X
-DAY of date                                         571            573           2         17.5          57.1       0.9X
-DAYOFWEEK of date                                   731            731           0         13.7          73.1       0.7X
-DOW of date                                         730            733           4         13.7          73.0       0.7X
-DOW_ISO of date                                     686            688           2         14.6          68.6       0.8X
-DAYOFWEEK_ISO of date                               687            688           2         14.6          68.7       0.8X
-DOY of date                                         608            609           1         16.5          60.8       0.9X
-HOUR of date                                        969            972           3         10.3          96.9       0.5X
-MINUTE of date                                      976            979           4         10.2          97.6       0.5X
-SECOND of date                                     1063           1064           2          9.4         106.3       0.5X
+cast to date                                        504            507           2         19.8          50.4       1.0X
+YEAR of date                                        538            545          10         18.6          53.8       0.9X
+YEAROFWEEK of date                                  612            618           5         16.3          61.2       0.8X
+QUARTER of date                                     734            736           3         13.6          73.4       0.7X
+MONTH of date                                       550            553           3         18.2          55.0       0.9X
+WEEK of date                                        893            895           2         11.2          89.3       0.6X
+DAY of date                                         565            566           1         17.7          56.5       0.9X
+DAYOFWEEK of date                                   732            733           1         13.7          73.2       0.7X
+DOW of date                                         732            739           7         13.7          73.2       0.7X
+DOW_ISO of date                                     667            669           1         15.0          66.7       0.8X
+DAYOFWEEK_ISO of date                               668            671           3         15.0          66.8       0.8X
+DOY of date                                         595            603          11         16.8          59.5       0.8X
+HOUR of date                                        954            955           1         10.5          95.4       0.5X
+MINUTE of date                                      955            956           1         10.5          95.5       0.5X
+SECOND of date                                     1034           1037           2          9.7         103.4       0.5X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+Invoke extract for time:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+cast to time                                        477            480           3         21.0          47.7       1.0X
+HOUR of time                                        515            518           3         19.4          51.5       0.9X
+MINUTE of time                                      510            511           1         19.6          51.0       0.9X
+SECOND of time                                     1858           1861           2          5.4         185.8       0.3X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+Invoke date_part for time:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+cast to time                                        473            475           2         21.1          47.3       1.0X
+HOUR of time                                        515            516           1         19.4          51.5       0.9X
+MINUTE of time                                      509            512           3         19.7          50.9       0.9X
+SECOND of time                                     1864           1870           9          5.4         186.4       0.3X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Invoke extract for interval:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                    743            745           3         13.5          74.3       1.0X
-YEAR of interval                                    726            732          10         13.8          72.6       1.0X
-MONTH of interval                                   729            738           9         13.7          72.9       1.0X
-DAY of interval                                     722            746          40         13.9          72.2       1.0X
-HOUR of interval                                    726            727           2         13.8          72.6       1.0X
-MINUTE of interval                                  734            737           4         13.6          73.4       1.0X
-SECOND of interval                                  780            781           1         12.8          78.0       1.0X
+cast to interval                                    723            728           4         13.8          72.3       1.0X
+YEAR of interval                                    707            709           3         14.1          70.7       1.0X
+MONTH of interval                                   711            715           5         14.1          71.1       1.0X
+DAY of interval                                     705            708           6         14.2          70.5       1.0X
+HOUR of interval                                    716            719           3         14.0          71.6       1.0X
+MINUTE of interval                                  717            725          15         14.0          71.7       1.0X
+SECOND of interval                                  767            771           3         13.0          76.7       0.9X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 Invoke date_part for interval:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                    744            748           6         13.4          74.4       1.0X
-YEAR of interval                                    725            735          17         13.8          72.5       1.0X
-MONTH of interval                                   725            729           3         13.8          72.5       1.0X
-DAY of interval                                     719            721           3         13.9          71.9       1.0X
-HOUR of interval                                    724            726           2         13.8          72.4       1.0X
-MINUTE of interval                                  732            734           2         13.7          73.2       1.0X
-SECOND of interval                                  778            781           4         12.9          77.8       1.0X
+cast to interval                                    720            724           4         13.9          72.0       1.0X
+YEAR of interval                                    704            707           2         14.2          70.4       1.0X
+MONTH of interval                                   712            715           2         14.0          71.2       1.0X
+DAY of interval                                     702            705           3         14.2          70.2       1.0X
+HOUR of interval                                    719            724           6         13.9          71.9       1.0X
+MINUTE of interval                                  716            725          12         14.0          71.6       1.0X
+SECOND of interval                                  767            769           2         13.0          76.7       0.9X
 

--- a/sql/core/benchmarks/ExtractBenchmark-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-results.txt
@@ -1,122 +1,104 @@
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Invoke extract for timestamp:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   191            200           8         52.3          19.1       1.0X
-YEAR of timestamp                                   772            785          18         13.0          77.2       0.2X
-YEAROFWEEK of timestamp                             887            899          18         11.3          88.7       0.2X
-QUARTER of timestamp                                782            794          15         12.8          78.2       0.2X
-MONTH of timestamp                                  773            804          46         12.9          77.3       0.2X
-WEEK of timestamp                                  1072           1090          26          9.3         107.2       0.2X
-DAY of timestamp                                    781            786           5         12.8          78.1       0.2X
-DAYOFWEEK of timestamp                              973            979           8         10.3          97.3       0.2X
-DOW of timestamp                                    970            979           8         10.3          97.0       0.2X
-DOW_ISO of timestamp                                887            894           9         11.3          88.7       0.2X
-DAYOFWEEK_ISO of timestamp                          876            887          18         11.4          87.6       0.2X
-DOY of timestamp                                    842            854          10         11.9          84.2       0.2X
-HOUR of timestamp                                   613            615           2         16.3          61.3       0.3X
-MINUTE of timestamp                                 628            634           6         15.9          62.8       0.3X
-SECOND of timestamp                                 686            692          10         14.6          68.6       0.3X
+cast to timestamp                                   257            270          18         39.0          25.7       1.0X
+YEAR of timestamp                                   684            690           5         14.6          68.4       0.4X
+YEAROFWEEK of timestamp                             752            776          39         13.3          75.2       0.3X
+QUARTER of timestamp                                711            726          21         14.1          71.1       0.4X
+MONTH of timestamp                                  699            706           8         14.3          69.9       0.4X
+WEEK of timestamp                                   958            965           8         10.4          95.8       0.3X
+DAY of timestamp                                    696            709          15         14.4          69.6       0.4X
+DAYOFWEEK of timestamp                              836            840           5         12.0          83.6       0.3X
+DOW of timestamp                                    836            844          12         12.0          83.6       0.3X
+DOW_ISO of timestamp                                814            815           1         12.3          81.4       0.3X
+DAYOFWEEK_ISO of timestamp                          812            816           3         12.3          81.2       0.3X
+DOY of timestamp                                    710            712           2         14.1          71.0       0.4X
+HOUR of timestamp                                   577            587          14         17.3          57.7       0.4X
+MINUTE of timestamp                                 582            584           3         17.2          58.2       0.4X
+SECOND of timestamp                                 681            683           2         14.7          68.1       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Invoke date_part for timestamp:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   156            157           1         64.1          15.6       1.0X
-YEAR of timestamp                                   770            797          31         13.0          77.0       0.2X
-YEAROFWEEK of timestamp                             921            943          37         10.9          92.1       0.2X
-QUARTER of timestamp                                778            788          15         12.9          77.8       0.2X
-MONTH of timestamp                                  752            760          11         13.3          75.2       0.2X
-WEEK of timestamp                                  1133           1159          25          8.8         113.3       0.1X
-DAY of timestamp                                    769            773           7         13.0          76.9       0.2X
-DAYOFWEEK of timestamp                             1005           1016          12         10.0         100.5       0.2X
-DOW of timestamp                                   1015           1075          54          9.9         101.5       0.2X
-DOW_ISO of timestamp                                923            932           7         10.8          92.3       0.2X
-DAYOFWEEK_ISO of timestamp                          921            923           1         10.9          92.1       0.2X
-DOY of timestamp                                    885            906          27         11.3          88.5       0.2X
-HOUR of timestamp                                   620            626           9         16.1          62.0       0.3X
-MINUTE of timestamp                                 632            638           9         15.8          63.2       0.2X
-SECOND of timestamp                                 713            715           2         14.0          71.3       0.2X
+cast to timestamp                                   233            236           3         42.9          23.3       1.0X
+YEAR of timestamp                                   686            693           8         14.6          68.6       0.3X
+YEAROFWEEK of timestamp                             741            744           3         13.5          74.1       0.3X
+QUARTER of timestamp                                708            713           4         14.1          70.8       0.3X
+MONTH of timestamp                                  693            704          14         14.4          69.3       0.3X
+WEEK of timestamp                                   956            960           4         10.5          95.6       0.2X
+DAY of timestamp                                    691            696           5         14.5          69.1       0.3X
+DAYOFWEEK of timestamp                              830            837           8         12.0          83.0       0.3X
+DOW of timestamp                                    830            831           0         12.0          83.0       0.3X
+DOW_ISO of timestamp                                803            809          11         12.5          80.3       0.3X
+DAYOFWEEK_ISO of timestamp                          803            808           8         12.5          80.3       0.3X
+DOY of timestamp                                    707            714           9         14.1          70.7       0.3X
+HOUR of timestamp                                   573            575           2         17.5          57.3       0.4X
+MINUTE of timestamp                                 570            575           5         17.5          57.0       0.4X
+SECOND of timestamp                                 683            686           2         14.6          68.3       0.3X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Invoke extract for date:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        692            692           1         14.5          69.2       1.0X
-YEAR of date                                        771            776           6         13.0          77.1       0.9X
-YEAROFWEEK of date                                  940            946           6         10.6          94.0       0.7X
-QUARTER of date                                     788            810          36         12.7          78.8       0.9X
-MONTH of date                                       765            770           6         13.1          76.5       0.9X
-WEEK of date                                       1186           1194           9          8.4         118.6       0.6X
-DAY of date                                         774            786          11         12.9          77.4       0.9X
-DAYOFWEEK of date                                  1018           1023           4          9.8         101.8       0.7X
-DOW of date                                        1015           1031          25          9.9         101.5       0.7X
-DOW_ISO of date                                     937            962          25         10.7          93.7       0.7X
-DAYOFWEEK_ISO of date                               924            933          10         10.8          92.4       0.7X
-DOY of date                                         885            913          26         11.3          88.5       0.8X
-HOUR of date                                       2092           2099           7          4.8         209.2       0.3X
-MINUTE of date                                     1904           1927          23          5.3         190.4       0.4X
-SECOND of date                                     2224           2242          22          4.5         222.4       0.3X
+cast to date                                        565            569           5         17.7          56.5       1.0X
+YEAR of date                                        690            691           2         14.5          69.0       0.8X
+YEAROFWEEK of date                                  734            736           2         13.6          73.4       0.8X
+QUARTER of date                                     702            704           3         14.2          70.2       0.8X
+MONTH of date                                       689            693           4         14.5          68.9       0.8X
+WEEK of date                                        946            954           6         10.6          94.6       0.6X
+DAY of date                                         684            689           6         14.6          68.4       0.8X
+DAYOFWEEK of date                                   828            831           4         12.1          82.8       0.7X
+DOW of date                                         826            827           1         12.1          82.6       0.7X
+DOW_ISO of date                                     796            805          11         12.6          79.6       0.7X
+DAYOFWEEK_ISO of date                               798            801           3         12.5          79.8       0.7X
+DOY of date                                         710            712           4         14.1          71.0       0.8X
+HOUR of date                                       1177           1186          13          8.5         117.7       0.5X
+MINUTE of date                                     1173           1175           2          8.5         117.3       0.5X
+SECOND of date                                     1265           1272          11          7.9         126.5       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Invoke date_part for date:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        692            702          10         14.5          69.2       1.0X
-YEAR of date                                        779            782           5         12.8          77.9       0.9X
-YEAROFWEEK of date                                  949            960          13         10.5          94.9       0.7X
-QUARTER of date                                     777            785           7         12.9          77.7       0.9X
-MONTH of date                                       764            768           4         13.1          76.4       0.9X
-WEEK of date                                       1212           1223          12          8.2         121.2       0.6X
-DAY of date                                         783            819          56         12.8          78.3       0.9X
-DAYOFWEEK of date                                  1033           1038           6          9.7         103.3       0.7X
-DOW of date                                        1031           1053          35          9.7         103.1       0.7X
-DOW_ISO of date                                     923            942          22         10.8          92.3       0.7X
-DAYOFWEEK_ISO of date                               935            939           3         10.7          93.5       0.7X
-DOY of date                                         879            893          12         11.4          87.9       0.8X
-HOUR of date                                       2101           2121          27          4.8         210.1       0.3X
-MINUTE of date                                     1927           1933           7          5.2         192.7       0.4X
-SECOND of date                                     2251           2261          16          4.4         225.1       0.3X
+cast to date                                        559            565           8         17.9          55.9       1.0X
+YEAR of date                                        688            691           3         14.5          68.8       0.8X
+YEAROFWEEK of date                                  737            741           5         13.6          73.7       0.8X
+QUARTER of date                                     700            703           5         14.3          70.0       0.8X
+MONTH of date                                       686            690           7         14.6          68.6       0.8X
+WEEK of date                                        947            948           1         10.6          94.7       0.6X
+DAY of date                                         683            685           2         14.6          68.3       0.8X
+DAYOFWEEK of date                                   825            826           1         12.1          82.5       0.7X
+DOW of date                                         822            826           4         12.2          82.2       0.7X
+DOW_ISO of date                                     797            801           4         12.5          79.7       0.7X
+DAYOFWEEK_ISO of date                               797            802           4         12.5          79.7       0.7X
+DOY of date                                         706            706           1         14.2          70.6       0.8X
+HOUR of date                                       1174           1180           6          8.5         117.4       0.5X
+MINUTE of date                                     1169           1171           2          8.6         116.9       0.5X
+SECOND of date                                     1265           1268           3          7.9         126.5       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
-Invoke extract for time:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-cast to time                                        349            352           3         28.7          34.9       1.0X
-HOUR of time                                        380            404          35         26.3          38.0       0.9X
-MINUTE of time                                      380            381           1         26.3          38.0       0.9X
-SECOND of time                                     2053           2058           4          4.9         205.3       0.2X
-
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
-Invoke date_part for time:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-cast to time                                        345            346           1         28.9          34.5       1.0X
-HOUR of time                                        382            382           1         26.2          38.2       0.9X
-MINUTE of time                                      381            383           2         26.2          38.1       0.9X
-SECOND of time                                     2062           2066           7          4.8         206.2       0.2X
-
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Invoke extract for interval:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                    916            923           9         10.9          91.6       1.0X
-YEAR of interval                                    937            947           9         10.7          93.7       1.0X
-MONTH of interval                                   935            941           8         10.7          93.5       1.0X
-DAY of interval                                     893            912          23         11.2          89.3       1.0X
-HOUR of interval                                    941            954          17         10.6          94.1       1.0X
-MINUTE of interval                                  980            988           8         10.2          98.0       0.9X
-SECOND of interval                                  868            871           5         11.5          86.8       1.1X
+cast to interval                                    859            862           4         11.6          85.9       1.0X
+YEAR of interval                                    828            828           1         12.1          82.8       1.0X
+MONTH of interval                                   842            854          20         11.9          84.2       1.0X
+DAY of interval                                     827            832           7         12.1          82.7       1.0X
+HOUR of interval                                    848            850           2         11.8          84.8       1.0X
+MINUTE of interval                                  852            860          14         11.7          85.2       1.0X
+SECOND of interval                                  941            943           2         10.6          94.1       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Invoke date_part for interval:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                    909            920          18         11.0          90.9       1.0X
-YEAR of interval                                    939            949          10         10.7          93.9       1.0X
-MONTH of interval                                   921            932          11         10.9          92.1       1.0X
-DAY of interval                                     924            931          10         10.8          92.4       1.0X
-HOUR of interval                                    942            945           3         10.6          94.2       1.0X
-MINUTE of interval                                  998           1007           9         10.0          99.8       0.9X
-SECOND of interval                                  880            889          15         11.4          88.0       1.0X
+cast to interval                                    851            852           0         11.7          85.1       1.0X
+YEAR of interval                                    823            825           3         12.1          82.3       1.0X
+MONTH of interval                                   833            838           4         12.0          83.3       1.0X
+DAY of interval                                     835            836           2         12.0          83.5       1.0X
+HOUR of interval                                    846            851           6         11.8          84.6       1.0X
+MINUTE of interval                                  857            859           2         11.7          85.7       1.0X
+SECOND of interval                                  942            949          10         10.6          94.2       0.9X
 

--- a/sql/core/benchmarks/ExtractBenchmark-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-results.txt
@@ -1,104 +1,122 @@
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Invoke extract for timestamp:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   257            270          18         39.0          25.7       1.0X
-YEAR of timestamp                                   684            690           5         14.6          68.4       0.4X
-YEAROFWEEK of timestamp                             752            776          39         13.3          75.2       0.3X
-QUARTER of timestamp                                711            726          21         14.1          71.1       0.4X
-MONTH of timestamp                                  699            706           8         14.3          69.9       0.4X
-WEEK of timestamp                                   958            965           8         10.4          95.8       0.3X
-DAY of timestamp                                    696            709          15         14.4          69.6       0.4X
-DAYOFWEEK of timestamp                              836            840           5         12.0          83.6       0.3X
-DOW of timestamp                                    836            844          12         12.0          83.6       0.3X
-DOW_ISO of timestamp                                814            815           1         12.3          81.4       0.3X
-DAYOFWEEK_ISO of timestamp                          812            816           3         12.3          81.2       0.3X
-DOY of timestamp                                    710            712           2         14.1          71.0       0.4X
-HOUR of timestamp                                   577            587          14         17.3          57.7       0.4X
-MINUTE of timestamp                                 582            584           3         17.2          58.2       0.4X
-SECOND of timestamp                                 681            683           2         14.7          68.1       0.4X
+cast to timestamp                                   191            200           8         52.3          19.1       1.0X
+YEAR of timestamp                                   772            785          18         13.0          77.2       0.2X
+YEAROFWEEK of timestamp                             887            899          18         11.3          88.7       0.2X
+QUARTER of timestamp                                782            794          15         12.8          78.2       0.2X
+MONTH of timestamp                                  773            804          46         12.9          77.3       0.2X
+WEEK of timestamp                                  1072           1090          26          9.3         107.2       0.2X
+DAY of timestamp                                    781            786           5         12.8          78.1       0.2X
+DAYOFWEEK of timestamp                              973            979           8         10.3          97.3       0.2X
+DOW of timestamp                                    970            979           8         10.3          97.0       0.2X
+DOW_ISO of timestamp                                887            894           9         11.3          88.7       0.2X
+DAYOFWEEK_ISO of timestamp                          876            887          18         11.4          87.6       0.2X
+DOY of timestamp                                    842            854          10         11.9          84.2       0.2X
+HOUR of timestamp                                   613            615           2         16.3          61.3       0.3X
+MINUTE of timestamp                                 628            634           6         15.9          62.8       0.3X
+SECOND of timestamp                                 686            692          10         14.6          68.6       0.3X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Invoke date_part for timestamp:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   233            236           3         42.9          23.3       1.0X
-YEAR of timestamp                                   686            693           8         14.6          68.6       0.3X
-YEAROFWEEK of timestamp                             741            744           3         13.5          74.1       0.3X
-QUARTER of timestamp                                708            713           4         14.1          70.8       0.3X
-MONTH of timestamp                                  693            704          14         14.4          69.3       0.3X
-WEEK of timestamp                                   956            960           4         10.5          95.6       0.2X
-DAY of timestamp                                    691            696           5         14.5          69.1       0.3X
-DAYOFWEEK of timestamp                              830            837           8         12.0          83.0       0.3X
-DOW of timestamp                                    830            831           0         12.0          83.0       0.3X
-DOW_ISO of timestamp                                803            809          11         12.5          80.3       0.3X
-DAYOFWEEK_ISO of timestamp                          803            808           8         12.5          80.3       0.3X
-DOY of timestamp                                    707            714           9         14.1          70.7       0.3X
-HOUR of timestamp                                   573            575           2         17.5          57.3       0.4X
-MINUTE of timestamp                                 570            575           5         17.5          57.0       0.4X
-SECOND of timestamp                                 683            686           2         14.6          68.3       0.3X
+cast to timestamp                                   156            157           1         64.1          15.6       1.0X
+YEAR of timestamp                                   770            797          31         13.0          77.0       0.2X
+YEAROFWEEK of timestamp                             921            943          37         10.9          92.1       0.2X
+QUARTER of timestamp                                778            788          15         12.9          77.8       0.2X
+MONTH of timestamp                                  752            760          11         13.3          75.2       0.2X
+WEEK of timestamp                                  1133           1159          25          8.8         113.3       0.1X
+DAY of timestamp                                    769            773           7         13.0          76.9       0.2X
+DAYOFWEEK of timestamp                             1005           1016          12         10.0         100.5       0.2X
+DOW of timestamp                                   1015           1075          54          9.9         101.5       0.2X
+DOW_ISO of timestamp                                923            932           7         10.8          92.3       0.2X
+DAYOFWEEK_ISO of timestamp                          921            923           1         10.9          92.1       0.2X
+DOY of timestamp                                    885            906          27         11.3          88.5       0.2X
+HOUR of timestamp                                   620            626           9         16.1          62.0       0.3X
+MINUTE of timestamp                                 632            638           9         15.8          63.2       0.2X
+SECOND of timestamp                                 713            715           2         14.0          71.3       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Invoke extract for date:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        565            569           5         17.7          56.5       1.0X
-YEAR of date                                        690            691           2         14.5          69.0       0.8X
-YEAROFWEEK of date                                  734            736           2         13.6          73.4       0.8X
-QUARTER of date                                     702            704           3         14.2          70.2       0.8X
-MONTH of date                                       689            693           4         14.5          68.9       0.8X
-WEEK of date                                        946            954           6         10.6          94.6       0.6X
-DAY of date                                         684            689           6         14.6          68.4       0.8X
-DAYOFWEEK of date                                   828            831           4         12.1          82.8       0.7X
-DOW of date                                         826            827           1         12.1          82.6       0.7X
-DOW_ISO of date                                     796            805          11         12.6          79.6       0.7X
-DAYOFWEEK_ISO of date                               798            801           3         12.5          79.8       0.7X
-DOY of date                                         710            712           4         14.1          71.0       0.8X
-HOUR of date                                       1177           1186          13          8.5         117.7       0.5X
-MINUTE of date                                     1173           1175           2          8.5         117.3       0.5X
-SECOND of date                                     1265           1272          11          7.9         126.5       0.4X
+cast to date                                        692            692           1         14.5          69.2       1.0X
+YEAR of date                                        771            776           6         13.0          77.1       0.9X
+YEAROFWEEK of date                                  940            946           6         10.6          94.0       0.7X
+QUARTER of date                                     788            810          36         12.7          78.8       0.9X
+MONTH of date                                       765            770           6         13.1          76.5       0.9X
+WEEK of date                                       1186           1194           9          8.4         118.6       0.6X
+DAY of date                                         774            786          11         12.9          77.4       0.9X
+DAYOFWEEK of date                                  1018           1023           4          9.8         101.8       0.7X
+DOW of date                                        1015           1031          25          9.9         101.5       0.7X
+DOW_ISO of date                                     937            962          25         10.7          93.7       0.7X
+DAYOFWEEK_ISO of date                               924            933          10         10.8          92.4       0.7X
+DOY of date                                         885            913          26         11.3          88.5       0.8X
+HOUR of date                                       2092           2099           7          4.8         209.2       0.3X
+MINUTE of date                                     1904           1927          23          5.3         190.4       0.4X
+SECOND of date                                     2224           2242          22          4.5         222.4       0.3X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Invoke date_part for date:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        559            565           8         17.9          55.9       1.0X
-YEAR of date                                        688            691           3         14.5          68.8       0.8X
-YEAROFWEEK of date                                  737            741           5         13.6          73.7       0.8X
-QUARTER of date                                     700            703           5         14.3          70.0       0.8X
-MONTH of date                                       686            690           7         14.6          68.6       0.8X
-WEEK of date                                        947            948           1         10.6          94.7       0.6X
-DAY of date                                         683            685           2         14.6          68.3       0.8X
-DAYOFWEEK of date                                   825            826           1         12.1          82.5       0.7X
-DOW of date                                         822            826           4         12.2          82.2       0.7X
-DOW_ISO of date                                     797            801           4         12.5          79.7       0.7X
-DAYOFWEEK_ISO of date                               797            802           4         12.5          79.7       0.7X
-DOY of date                                         706            706           1         14.2          70.6       0.8X
-HOUR of date                                       1174           1180           6          8.5         117.4       0.5X
-MINUTE of date                                     1169           1171           2          8.6         116.9       0.5X
-SECOND of date                                     1265           1268           3          7.9         126.5       0.4X
+cast to date                                        692            702          10         14.5          69.2       1.0X
+YEAR of date                                        779            782           5         12.8          77.9       0.9X
+YEAROFWEEK of date                                  949            960          13         10.5          94.9       0.7X
+QUARTER of date                                     777            785           7         12.9          77.7       0.9X
+MONTH of date                                       764            768           4         13.1          76.4       0.9X
+WEEK of date                                       1212           1223          12          8.2         121.2       0.6X
+DAY of date                                         783            819          56         12.8          78.3       0.9X
+DAYOFWEEK of date                                  1033           1038           6          9.7         103.3       0.7X
+DOW of date                                        1031           1053          35          9.7         103.1       0.7X
+DOW_ISO of date                                     923            942          22         10.8          92.3       0.7X
+DAYOFWEEK_ISO of date                               935            939           3         10.7          93.5       0.7X
+DOY of date                                         879            893          12         11.4          87.9       0.8X
+HOUR of date                                       2101           2121          27          4.8         210.1       0.3X
+MINUTE of date                                     1927           1933           7          5.2         192.7       0.4X
+SECOND of date                                     2251           2261          16          4.4         225.1       0.3X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
+Invoke extract for time:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+cast to time                                        349            352           3         28.7          34.9       1.0X
+HOUR of time                                        380            404          35         26.3          38.0       0.9X
+MINUTE of time                                      380            381           1         26.3          38.0       0.9X
+SECOND of time                                     2053           2058           4          4.9         205.3       0.2X
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
+Invoke date_part for time:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+cast to time                                        345            346           1         28.9          34.5       1.0X
+HOUR of time                                        382            382           1         26.2          38.2       0.9X
+MINUTE of time                                      381            383           2         26.2          38.1       0.9X
+SECOND of time                                     2062           2066           7          4.8         206.2       0.2X
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Invoke extract for interval:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                    859            862           4         11.6          85.9       1.0X
-YEAR of interval                                    828            828           1         12.1          82.8       1.0X
-MONTH of interval                                   842            854          20         11.9          84.2       1.0X
-DAY of interval                                     827            832           7         12.1          82.7       1.0X
-HOUR of interval                                    848            850           2         11.8          84.8       1.0X
-MINUTE of interval                                  852            860          14         11.7          85.2       1.0X
-SECOND of interval                                  941            943           2         10.6          94.1       0.9X
+cast to interval                                    916            923           9         10.9          91.6       1.0X
+YEAR of interval                                    937            947           9         10.7          93.7       1.0X
+MONTH of interval                                   935            941           8         10.7          93.5       1.0X
+DAY of interval                                     893            912          23         11.2          89.3       1.0X
+HOUR of interval                                    941            954          17         10.6          94.1       1.0X
+MINUTE of interval                                  980            988           8         10.2          98.0       0.9X
+SECOND of interval                                  868            871           5         11.5          86.8       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Invoke date_part for interval:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                    851            852           0         11.7          85.1       1.0X
-YEAR of interval                                    823            825           3         12.1          82.3       1.0X
-MONTH of interval                                   833            838           4         12.0          83.3       1.0X
-DAY of interval                                     835            836           2         12.0          83.5       1.0X
-HOUR of interval                                    846            851           6         11.8          84.6       1.0X
-MINUTE of interval                                  857            859           2         11.7          85.7       1.0X
-SECOND of interval                                  942            949          10         10.6          94.2       0.9X
+cast to interval                                    909            920          18         11.0          90.9       1.0X
+YEAR of interval                                    939            949          10         10.7          93.9       1.0X
+MONTH of interval                                   921            932          11         10.9          92.1       1.0X
+DAY of interval                                     924            931          10         10.8          92.4       1.0X
+HOUR of interval                                    942            945           3         10.6          94.2       1.0X
+MINUTE of interval                                  998           1007           9         10.0          99.8       0.9X
+SECOND of interval                                  880            889          15         11.4          88.0       1.0X
 

--- a/sql/core/benchmarks/ExtractBenchmark-results.txt
+++ b/sql/core/benchmarks/ExtractBenchmark-results.txt
@@ -1,104 +1,122 @@
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Invoke extract for timestamp:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   257            270          18         39.0          25.7       1.0X
-YEAR of timestamp                                   684            690           5         14.6          68.4       0.4X
-YEAROFWEEK of timestamp                             752            776          39         13.3          75.2       0.3X
-QUARTER of timestamp                                711            726          21         14.1          71.1       0.4X
-MONTH of timestamp                                  699            706           8         14.3          69.9       0.4X
-WEEK of timestamp                                   958            965           8         10.4          95.8       0.3X
-DAY of timestamp                                    696            709          15         14.4          69.6       0.4X
-DAYOFWEEK of timestamp                              836            840           5         12.0          83.6       0.3X
-DOW of timestamp                                    836            844          12         12.0          83.6       0.3X
-DOW_ISO of timestamp                                814            815           1         12.3          81.4       0.3X
-DAYOFWEEK_ISO of timestamp                          812            816           3         12.3          81.2       0.3X
-DOY of timestamp                                    710            712           2         14.1          71.0       0.4X
-HOUR of timestamp                                   577            587          14         17.3          57.7       0.4X
-MINUTE of timestamp                                 582            584           3         17.2          58.2       0.4X
-SECOND of timestamp                                 681            683           2         14.7          68.1       0.4X
+cast to timestamp                                   269            286          30         37.2          26.9       1.0X
+YEAR of timestamp                                   707            721          13         14.1          70.7       0.4X
+YEAROFWEEK of timestamp                             767            774           6         13.0          76.7       0.4X
+QUARTER of timestamp                                725            727           3         13.8          72.5       0.4X
+MONTH of timestamp                                  703            712          14         14.2          70.3       0.4X
+WEEK of timestamp                                   987            990           5         10.1          98.7       0.3X
+DAY of timestamp                                    704            709           4         14.2          70.4       0.4X
+DAYOFWEEK of timestamp                              844            851          11         11.8          84.4       0.3X
+DOW of timestamp                                    843            844           1         11.9          84.3       0.3X
+DOW_ISO of timestamp                                800            810          17         12.5          80.0       0.3X
+DAYOFWEEK_ISO of timestamp                          801            802           1         12.5          80.1       0.3X
+DOY of timestamp                                    733            736           5         13.6          73.3       0.4X
+HOUR of timestamp                                   539            547          12         18.5          53.9       0.5X
+MINUTE of timestamp                                 534            536           2         18.7          53.4       0.5X
+SECOND of timestamp                                 626            628           3         16.0          62.6       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Invoke date_part for timestamp:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to timestamp                                   233            236           3         42.9          23.3       1.0X
-YEAR of timestamp                                   686            693           8         14.6          68.6       0.3X
-YEAROFWEEK of timestamp                             741            744           3         13.5          74.1       0.3X
-QUARTER of timestamp                                708            713           4         14.1          70.8       0.3X
-MONTH of timestamp                                  693            704          14         14.4          69.3       0.3X
-WEEK of timestamp                                   956            960           4         10.5          95.6       0.2X
-DAY of timestamp                                    691            696           5         14.5          69.1       0.3X
-DAYOFWEEK of timestamp                              830            837           8         12.0          83.0       0.3X
-DOW of timestamp                                    830            831           0         12.0          83.0       0.3X
-DOW_ISO of timestamp                                803            809          11         12.5          80.3       0.3X
-DAYOFWEEK_ISO of timestamp                          803            808           8         12.5          80.3       0.3X
-DOY of timestamp                                    707            714           9         14.1          70.7       0.3X
-HOUR of timestamp                                   573            575           2         17.5          57.3       0.4X
-MINUTE of timestamp                                 570            575           5         17.5          57.0       0.4X
-SECOND of timestamp                                 683            686           2         14.6          68.3       0.3X
+cast to timestamp                                   235            236           1         42.5          23.5       1.0X
+YEAR of timestamp                                   668            670           2         15.0          66.8       0.4X
+YEAROFWEEK of timestamp                             713            714           1         14.0          71.3       0.3X
+QUARTER of timestamp                                691            693           2         14.5          69.1       0.3X
+MONTH of timestamp                                  669            671           3         15.0          66.9       0.4X
+WEEK of timestamp                                   963            964           1         10.4          96.3       0.2X
+DAY of timestamp                                    671            677          10         14.9          67.1       0.4X
+DAYOFWEEK of timestamp                              809            811           4         12.4          80.9       0.3X
+DOW of timestamp                                    809            810           1         12.4          80.9       0.3X
+DOW_ISO of timestamp                                767            776          10         13.0          76.7       0.3X
+DAYOFWEEK_ISO of timestamp                          767            770           4         13.0          76.7       0.3X
+DOY of timestamp                                    699            700           1         14.3          69.9       0.3X
+HOUR of timestamp                                   503            505           2         19.9          50.3       0.5X
+MINUTE of timestamp                                 506            508           2         19.8          50.6       0.5X
+SECOND of timestamp                                 591            596           5         16.9          59.1       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Invoke extract for date:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        565            569           5         17.7          56.5       1.0X
-YEAR of date                                        690            691           2         14.5          69.0       0.8X
-YEAROFWEEK of date                                  734            736           2         13.6          73.4       0.8X
-QUARTER of date                                     702            704           3         14.2          70.2       0.8X
-MONTH of date                                       689            693           4         14.5          68.9       0.8X
-WEEK of date                                        946            954           6         10.6          94.6       0.6X
-DAY of date                                         684            689           6         14.6          68.4       0.8X
-DAYOFWEEK of date                                   828            831           4         12.1          82.8       0.7X
-DOW of date                                         826            827           1         12.1          82.6       0.7X
-DOW_ISO of date                                     796            805          11         12.6          79.6       0.7X
-DAYOFWEEK_ISO of date                               798            801           3         12.5          79.8       0.7X
-DOY of date                                         710            712           4         14.1          71.0       0.8X
-HOUR of date                                       1177           1186          13          8.5         117.7       0.5X
-MINUTE of date                                     1173           1175           2          8.5         117.3       0.5X
-SECOND of date                                     1265           1272          11          7.9         126.5       0.4X
+cast to date                                        574            575           1         17.4          57.4       1.0X
+YEAR of date                                        667            672           4         15.0          66.7       0.9X
+YEAROFWEEK of date                                  712            715           4         14.0          71.2       0.8X
+QUARTER of date                                     691            694           3         14.5          69.1       0.8X
+MONTH of date                                       666            667           1         15.0          66.6       0.9X
+WEEK of date                                        964            964           0         10.4          96.4       0.6X
+DAY of date                                         665            665           1         15.0          66.5       0.9X
+DAYOFWEEK of date                                   809            811           3         12.4          80.9       0.7X
+DOW of date                                         806            809           3         12.4          80.6       0.7X
+DOW_ISO of date                                     766            767           0         13.0          76.6       0.7X
+DAYOFWEEK_ISO of date                               768            770           2         13.0          76.8       0.7X
+DOY of date                                         698            699           2         14.3          69.8       0.8X
+HOUR of date                                       1124           1127           3          8.9         112.4       0.5X
+MINUTE of date                                     1127           1139          17          8.9         112.7       0.5X
+SECOND of date                                     1276           1277           2          7.8         127.6       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Invoke date_part for date:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to date                                        559            565           8         17.9          55.9       1.0X
-YEAR of date                                        688            691           3         14.5          68.8       0.8X
-YEAROFWEEK of date                                  737            741           5         13.6          73.7       0.8X
-QUARTER of date                                     700            703           5         14.3          70.0       0.8X
-MONTH of date                                       686            690           7         14.6          68.6       0.8X
-WEEK of date                                        947            948           1         10.6          94.7       0.6X
-DAY of date                                         683            685           2         14.6          68.3       0.8X
-DAYOFWEEK of date                                   825            826           1         12.1          82.5       0.7X
-DOW of date                                         822            826           4         12.2          82.2       0.7X
-DOW_ISO of date                                     797            801           4         12.5          79.7       0.7X
-DAYOFWEEK_ISO of date                               797            802           4         12.5          79.7       0.7X
-DOY of date                                         706            706           1         14.2          70.6       0.8X
-HOUR of date                                       1174           1180           6          8.5         117.4       0.5X
-MINUTE of date                                     1169           1171           2          8.6         116.9       0.5X
-SECOND of date                                     1265           1268           3          7.9         126.5       0.4X
+cast to date                                        569            586          23         17.6          56.9       1.0X
+YEAR of date                                        665            667           3         15.0          66.5       0.9X
+YEAROFWEEK of date                                  709            731          20         14.1          70.9       0.8X
+QUARTER of date                                     689            693           4         14.5          68.9       0.8X
+MONTH of date                                       666            668           2         15.0          66.6       0.9X
+WEEK of date                                        959            961           2         10.4          95.9       0.6X
+DAY of date                                         666            670           4         15.0          66.6       0.9X
+DAYOFWEEK of date                                   807            809           2         12.4          80.7       0.7X
+DOW of date                                         808            810           1         12.4          80.8       0.7X
+DOW_ISO of date                                     762            765           4         13.1          76.2       0.7X
+DAYOFWEEK_ISO of date                               763            765           3         13.1          76.3       0.7X
+DOY of date                                         696            704           8         14.4          69.6       0.8X
+HOUR of date                                       1121           1126           7          8.9         112.1       0.5X
+MINUTE of date                                     1121           1121           0          8.9         112.1       0.5X
+SECOND of date                                     1270           1277           9          7.9         127.0       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+Invoke extract for time:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+cast to time                                        461            462           1         21.7          46.1       1.0X
+HOUR of time                                        528            531           3         18.9          52.8       0.9X
+MINUTE of time                                      535            540           8         18.7          53.5       0.9X
+SECOND of time                                     1487           1492           6          6.7         148.7       0.3X
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+Invoke date_part for time:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+cast to time                                        465            469           4         21.5          46.5       1.0X
+HOUR of time                                        534            538           4         18.7          53.4       0.9X
+MINUTE of time                                      535            540           6         18.7          53.5       0.9X
+SECOND of time                                     1489           1490           1          6.7         148.9       0.3X
+
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Invoke extract for interval:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                    859            862           4         11.6          85.9       1.0X
-YEAR of interval                                    828            828           1         12.1          82.8       1.0X
-MONTH of interval                                   842            854          20         11.9          84.2       1.0X
-DAY of interval                                     827            832           7         12.1          82.7       1.0X
-HOUR of interval                                    848            850           2         11.8          84.8       1.0X
-MINUTE of interval                                  852            860          14         11.7          85.2       1.0X
-SECOND of interval                                  941            943           2         10.6          94.1       0.9X
+cast to interval                                    816            818           3         12.3          81.6       1.0X
+YEAR of interval                                    791            799          11         12.6          79.1       1.0X
+MONTH of interval                                   802            811           8         12.5          80.2       1.0X
+DAY of interval                                     805            808           5         12.4          80.5       1.0X
+HOUR of interval                                    804            806           2         12.4          80.4       1.0X
+MINUTE of interval                                  808            809           1         12.4          80.8       1.0X
+SECOND of interval                                  849            851           2         11.8          84.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 Invoke date_part for interval:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-cast to interval                                    851            852           0         11.7          85.1       1.0X
-YEAR of interval                                    823            825           3         12.1          82.3       1.0X
-MONTH of interval                                   833            838           4         12.0          83.3       1.0X
-DAY of interval                                     835            836           2         12.0          83.5       1.0X
-HOUR of interval                                    846            851           6         11.8          84.6       1.0X
-MINUTE of interval                                  857            859           2         11.7          85.7       1.0X
-SECOND of interval                                  942            949          10         10.6          94.2       0.9X
+cast to interval                                    814            817           4         12.3          81.4       1.0X
+YEAR of interval                                    789            791           4         12.7          78.9       1.0X
+MONTH of interval                                   805            806           1         12.4          80.5       1.0X
+DAY of interval                                     805            811           7         12.4          80.5       1.0X
+HOUR of interval                                    804            805           0         12.4          80.4       1.0X
+MINUTE of interval                                  805            809           4         12.4          80.5       1.0X
+SECOND of interval                                  850            852           2         11.8          85.0       1.0X
 

--- a/sql/core/benchmarks/JsonBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/JsonBenchmark-jdk21-results.txt
@@ -3,128 +3,133 @@ Benchmark for performance of JSON parsing
 ================================================================================================
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 JSON schema inferring:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        2505           2612          96          2.0         501.0       1.0X
-UTF-8 is set                                       5362           5380          16          0.9        1072.3       0.5X
+No encoding                                        2115           2163          70          2.4         423.1       1.0X
+UTF-8 is set                                       4788           4813          42          1.0         957.6       0.4X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 count a short column:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        1952           1958           5          2.6         390.4       1.0X
-UTF-8 is set                                       4416           4420           5          1.1         883.3       0.4X
+No encoding                                        1686           1739          71          3.0         337.1       1.0X
+UTF-8 is set                                       4169           4173           4          1.2         833.7       0.4X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 count a wide column:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        4546           4551           5          0.2        4545.6       1.0X
-UTF-8 is set                                       4369           4375          10          0.2        4369.2       1.0X
+No encoding                                        4835           4847          13          0.2        4834.8       1.0X
+UTF-8 is set                                       4548           4582          33          0.2        4547.7       1.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 select wide row:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                       10036          10149         153          0.0      200713.2       1.0X
-UTF-8 is set                                      10794          10832          34          0.0      215870.3       0.9X
+No encoding                                        9960          10029          62          0.0      199193.2       1.0X
+UTF-8 is set                                      10698          10718          19          0.0      213963.4       0.9X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Select a subset of 10 columns:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns                                  1664           1665           1          0.6        1663.8       1.0X
-Select 1 column                                    1123           1125           3          0.9        1123.1       1.5X
+Select 10 columns                                  1602           1610           7          0.6        1602.3       1.0X
+Select 1 column                                    1035           1038           3          1.0        1034.9       1.5X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 creation of JSON parser per line:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Short column without encoding                       583            586           3          1.7         583.3       1.0X
-Short column with UTF-8                            1118           1124           7          0.9        1118.2       0.5X
-Wide column without encoding                       5316           5335          18          0.2        5316.3       0.1X
-Wide column with UTF-8                             8905           8913           7          0.1        8904.8       0.1X
+Short column without encoding                       509            543          55          2.0         509.4       1.0X
+Short column with UTF-8                            1107           1109           3          0.9        1107.0       0.5X
+Wide column without encoding                       5136           5147           9          0.2        5135.6       0.1X
+Wide column with UTF-8                             9648           9679          39          0.1        9647.8       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 JSON functions:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                            68             70           2         14.6          68.3       1.0X
-from_json                                          1085           1089           5          0.9        1084.6       0.1X
-json_tuple                                         1060           1061           1          0.9        1059.6       0.1X
-get_json_object wholestage off                     1070           1071           2          0.9        1070.1       0.1X
-get_json_object wholestage on                       990            994           4          1.0         989.6       0.1X
+Text read                                            69             72           3         14.4          69.5       1.0X
+from_json                                          1007           1021          13          1.0        1007.1       0.1X
+json_tuple                                          963            978          13          1.0         963.4       0.1X
+get_json_object wholestage off                      985            992           8          1.0         985.4       0.1X
+get_json_object wholestage on                       891            892           1          1.1         890.8       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Dataset of json strings:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           240            241           1         20.8          48.1       1.0X
-schema inferring                                   1831           1836           4          2.7         366.2       0.1X
-parsing                                            2510           2518          11          2.0         502.1       0.1X
+Text read                                           255            255           1         19.6          51.0       1.0X
+schema inferring                                   1494           1500           6          3.3         298.8       0.2X
+parsing                                            2147           2161          14          2.3         429.4       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Json files in the per-line mode:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           618            623           5          8.1         123.5       1.0X
-Schema inferring                                   2382           2384           2          2.1         476.5       0.3X
-Parsing without charset                            2665           2670           5          1.9         533.0       0.2X
-Parsing with UTF-8                                 5166           5180          12          1.0        1033.2       0.1X
+Text read                                           611            621          10          8.2         122.1       1.0X
+Schema inferring                                   1893           1899           9          2.6         378.5       0.3X
+Parsing without charset                            2418           2425           7          2.1         483.5       0.3X
+Parsing with UTF-8                                 5038           5057          26          1.0        1007.6       0.1X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      105            108           3          9.5         105.5       1.0X
-to_json(timestamp)                                  555            557           2          1.8         555.1       0.2X
-write timestamps to files                           618            626          12          1.6         617.8       0.2X
-Create a dataset of dates                           112            117           4          8.9         112.2       0.9X
-to_json(date)                                       420            420           0          2.4         420.3       0.3X
-write dates to files                                401            403           2          2.5         401.4       0.3X
+Create a dataset of timestamps                      112            113           2          9.0         111.6       1.0X
+to_json(timestamp)                                  518            522           5          1.9         518.5       0.2X
+write timestamps to files                           547            551           6          1.8         547.1       0.2X
+Create a dataset of dates                           124            129           5          8.1         123.8       0.9X
+to_json(date)                                       386            389           3          2.6         386.1       0.3X
+write dates to files                                381            384           3          2.6         380.7       0.3X
+Create a dataset of times                           118            119           2          8.5         118.0       0.9X
+to_json(time)                                       428            431           2          2.3         428.2       0.3X
+write times to files                                507            513           5          2.0         506.8       0.2X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Read dates and timestamps:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                                                   149            153           7          6.7         148.5       1.0X
-read timestamps from files                                                      1052           1059           7          1.0        1051.7       0.1X
-infer timestamps from files                                                     1976           1980           4          0.5        1976.4       0.1X
-read date text from files                                                        154            157           3          6.5         153.5       1.0X
-read date from files                                                             647            655           6          1.5         647.4       0.2X
-timestamp strings                                                                146            147           0          6.8         146.5       1.0X
-parse timestamps from Dataset[String]                                           1226           1228           2          0.8        1226.2       0.1X
-infer timestamps from Dataset[String]                                           2150           2159          12          0.5        2149.5       0.1X
-date strings                                                                     198            200           2          5.0         198.3       0.7X
-parse dates from Dataset[String]                                                 920            923           3          1.1         920.4       0.2X
-from_json(timestamp)                                                            1749           1751           4          0.6        1748.6       0.1X
-from_json(date)                                                                 1464           1468           4          0.7        1464.3       0.1X
-infer error timestamps from Dataset[String] with default format                 1358           1362           3          0.7        1358.0       0.1X
-infer error timestamps from Dataset[String] with user-provided format           1357           1360           3          0.7        1356.8       0.1X
-infer error timestamps from Dataset[String] with legacy format                  1384           1389           5          0.7        1383.5       0.1X
+read timestamp text from files                                                   161            166           7          6.2         161.5       1.0X
+read timestamps from files                                                      1094           1101           9          0.9        1094.5       0.1X
+infer timestamps from files                                                    12942          12994          76          0.1       12942.0       0.0X
+read date text from files                                                        158            159           2          6.3         157.7       1.0X
+read date from files                                                             621            623           3          1.6         621.3       0.3X
+timestamp strings                                                                148            149           2          6.8         147.5       1.1X
+parse timestamps from Dataset[String]                                           1291           1292           1          0.8        1290.5       0.1X
+infer timestamps from Dataset[String]                                          13104          13144          35          0.1       13103.8       0.0X
+date strings                                                                     201            202           1          5.0         201.4       0.8X
+parse dates from Dataset[String]                                                 948            961          21          1.1         947.6       0.2X
+from_json(timestamp)                                                            1826           1829           5          0.5        1825.6       0.1X
+from_json(date)                                                                 1476           1480           3          0.7        1476.0       0.1X
+infer error timestamps from Dataset[String] with default format                11843          11879          33          0.1       11843.1       0.0X
+infer error timestamps from Dataset[String] with user-provided format          11822          11857          31          0.1       11821.6       0.0X
+infer error timestamps from Dataset[String] with legacy format                 11887          11903          26          0.1       11886.6       0.0X
+read time text from files                                                        162            168           9          6.2         162.2       1.0X
+read time from files                                                             818            823           6          1.2         818.0       0.2X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                        6285           6289           4          0.0       62852.4       1.0X
-pushdown disabled                                  6190           6193           5          0.0       61896.8       1.0X
-w/ filters                                          599            602           6          0.2        5989.5      10.5X
+w/o filters                                        5205           5225          20          0.0       52054.7       1.0X
+pushdown disabled                                  5023           5041          24          0.0       50233.9       1.0X
+w/ filters                                          655            657           4          0.2        6553.9       7.9X
 
-OpenJDK 64-Bit Server VM 21.0.10+7-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Partial JSON results:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-parse invalid JSON                                 2393           2422          43          0.0      239282.1       1.0X
+parse invalid JSON                                 2373           2393          20          0.0      237324.2       1.0X
 
 

--- a/sql/core/benchmarks/JsonBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/JsonBenchmark-jdk25-results.txt
@@ -3,128 +3,133 @@ Benchmark for performance of JSON parsing
 ================================================================================================
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 JSON schema inferring:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        2323           2386          96          2.2         464.5       1.0X
-UTF-8 is set                                       4970           4983          18          1.0         993.9       0.5X
+No encoding                                        1990           2113         143          2.5         397.9       1.0X
+UTF-8 is set                                       4454           4478          24          1.1         890.8       0.4X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 count a short column:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        2147           2199          67          2.3         429.4       1.0X
-UTF-8 is set                                       4826           4846          23          1.0         965.1       0.4X
+No encoding                                        1670           1704          40          3.0         334.0       1.0X
+UTF-8 is set                                       3889           3901          10          1.3         777.9       0.4X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 count a wide column:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        4544           4564          22          0.2        4544.2       1.0X
-UTF-8 is set                                       4411           4424          17          0.2        4411.0       1.0X
+No encoding                                        4779           4787           8          0.2        4778.7       1.0X
+UTF-8 is set                                       4464           4464           0          0.2        4463.7       1.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 select wide row:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        9487           9565          91          0.0      189740.3       1.0X
-UTF-8 is set                                      10224          10258          42          0.0      204476.7       0.9X
+No encoding                                       10133          10193          53          0.0      202653.6       1.0X
+UTF-8 is set                                      10704          10764          67          0.0      214080.8       0.9X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Select a subset of 10 columns:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns                                  1678           1682           6          0.6        1677.6       1.0X
-Select 1 column                                    1198           1200           3          0.8        1197.5       1.4X
+Select 10 columns                                  1606           1612           6          0.6        1605.9       1.0X
+Select 1 column                                    1171           1172           1          0.9        1171.2       1.4X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 creation of JSON parser per line:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Short column without encoding                       621            627           5          1.6         621.4       1.0X
-Short column with UTF-8                            1178           1184          11          0.8        1177.8       0.5X
-Wide column without encoding                       4988           5023          31          0.2        4987.6       0.1X
-Wide column with UTF-8                             6444           6510          61          0.2        6443.6       0.1X
+Short column without encoding                       488            492           4          2.0         488.2       1.0X
+Short column with UTF-8                            1006           1020          24          1.0        1005.6       0.5X
+Wide column without encoding                       5486           5513          24          0.2        5485.8       0.1X
+Wide column with UTF-8                             9427           9444          16          0.1        9426.6       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 JSON functions:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                            50             51           2         19.9          50.2       1.0X
-from_json                                          1046           1048           2          1.0        1045.9       0.0X
-json_tuple                                          931            958          23          1.1         931.4       0.1X
-get_json_object wholestage off                      998           1001           3          1.0         998.2       0.1X
-get_json_object wholestage on                       913            915           4          1.1         912.5       0.1X
+Text read                                            56             57           1         17.7          56.5       1.0X
+from_json                                           916            927          17          1.1         916.4       0.1X
+json_tuple                                          895            898           3          1.1         895.2       0.1X
+get_json_object wholestage off                      920            929           8          1.1         919.8       0.1X
+get_json_object wholestage on                       827            837          16          1.2         827.5       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Dataset of json strings:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           210            211           1         23.8          42.0       1.0X
-schema inferring                                   1780           1785           7          2.8         356.0       0.1X
-parsing                                            2586           2592           9          1.9         517.3       0.1X
+Text read                                           229            232           4         21.8          45.8       1.0X
+schema inferring                                   1420           1422           2          3.5         284.0       0.2X
+parsing                                            2174           2183           8          2.3         434.8       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Json files in the per-line mode:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           574            577           4          8.7         114.8       1.0X
-Schema inferring                                   2344           2347           2          2.1         468.9       0.2X
-Parsing without charset                            2927           2935           7          1.7         585.3       0.2X
-Parsing with UTF-8                                 5678           5682           4          0.9        1135.5       0.1X
+Text read                                           572            577           5          8.7         114.5       1.0X
+Schema inferring                                   2005           2018          22          2.5         401.0       0.3X
+Parsing without charset                            2343           2351           7          2.1         468.5       0.2X
+Parsing with UTF-8                                 4674           4688          15          1.1         934.9       0.1X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                       99            103           4         10.1          99.0       1.0X
-to_json(timestamp)                                  533            535           3          1.9         532.7       0.2X
-write timestamps to files                           589            594           4          1.7         589.2       0.2X
-Create a dataset of dates                           105            107           2          9.5         104.8       0.9X
-to_json(date)                                       398            402           3          2.5         398.3       0.2X
-write dates to files                                398            407          12          2.5         397.8       0.2X
+Create a dataset of timestamps                      109            110           1          9.2         108.8       1.0X
+to_json(timestamp)                                  474            476           1          2.1         474.2       0.2X
+write timestamps to files                           515            521           9          1.9         515.3       0.2X
+Create a dataset of dates                           118            121           3          8.4         118.4       0.9X
+to_json(date)                                       354            365          10          2.8         354.0       0.3X
+write dates to files                                356            358           3          2.8         356.4       0.3X
+Create a dataset of times                           109            111           2          9.1         109.4       1.0X
+to_json(time)                                       420            420           1          2.4         419.7       0.3X
+write times to files                                420            423           4          2.4         420.2       0.3X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Read dates and timestamps:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                                                   143            144           2          7.0         142.6       1.0X
-read timestamps from files                                                      1006           1009           3          1.0        1005.7       0.1X
-infer timestamps from files                                                     1849           1849           0          0.5        1849.1       0.1X
-read date text from files                                                        140            140           0          7.1         140.0       1.0X
-read date from files                                                             681            684           5          1.5         680.5       0.2X
-timestamp strings                                                                132            134           2          7.6         131.8       1.1X
-parse timestamps from Dataset[String]                                           1134           1136           2          0.9        1134.1       0.1X
-infer timestamps from Dataset[String]                                           1935           1938           3          0.5        1934.7       0.1X
-date strings                                                                     194            198           4          5.1         194.3       0.7X
-parse dates from Dataset[String]                                                 935            936           1          1.1         935.1       0.2X
-from_json(timestamp)                                                            1563           1569           6          0.6        1562.8       0.1X
-from_json(date)                                                                 1372           1398          35          0.7        1371.8       0.1X
-infer error timestamps from Dataset[String] with default format                 1335           1338           3          0.7        1335.2       0.1X
-infer error timestamps from Dataset[String] with user-provided format           1318           1332          16          0.8        1317.6       0.1X
-infer error timestamps from Dataset[String] with legacy format                  1354           1356           1          0.7        1354.1       0.1X
+read timestamp text from files                                                   152            155           6          6.6         151.7       1.0X
+read timestamps from files                                                       912            915           4          1.1         912.4       0.2X
+infer timestamps from files                                                    11750          11753           3          0.1       11749.6       0.0X
+read date text from files                                                        138            139           2          7.3         137.5       1.1X
+read date from files                                                             579            581           2          1.7         579.3       0.3X
+timestamp strings                                                                140            142           3          7.1         140.5       1.1X
+parse timestamps from Dataset[String]                                           1071           1075           4          0.9        1070.9       0.1X
+infer timestamps from Dataset[String]                                          11867          11883          20          0.1       11866.7       0.0X
+date strings                                                                     194            196           2          5.2         193.8       0.8X
+parse dates from Dataset[String]                                                 849            853           4          1.2         849.3       0.2X
+from_json(timestamp)                                                            1546           1565          23          0.6        1546.3       0.1X
+from_json(date)                                                                 1304           1307           3          0.8        1303.9       0.1X
+infer error timestamps from Dataset[String] with default format                10789          10802          11          0.1       10789.4       0.0X
+infer error timestamps from Dataset[String] with user-provided format          10734          10783          43          0.1       10733.7       0.0X
+infer error timestamps from Dataset[String] with legacy format                 10787          10828          35          0.1       10786.8       0.0X
+read time text from files                                                        152            155           5          6.6         151.7       1.0X
+read time from files                                                             788            790           2          1.3         787.9       0.2X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                        5454           5462          11          0.0       54538.3       1.0X
-pushdown disabled                                  5418           5427          11          0.0       54175.8       1.0X
-w/ filters                                          584            591           6          0.2        5838.7       9.3X
+w/o filters                                        4594           4603          12          0.0       45937.4       1.0X
+pushdown disabled                                  4435           4446          17          0.0       44353.9       1.0X
+w/ filters                                          709            711           2          0.1        7086.2       6.5X
 
-OpenJDK 64-Bit Server VM 25.0.2+10-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 9V74 80-Core Processor
 Partial JSON results:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-parse invalid JSON                                 2244           2247           4          0.0      224391.1       1.0X
+parse invalid JSON                                 2357           2360           3          0.0      235736.6       1.0X
 
 

--- a/sql/core/benchmarks/JsonBenchmark-results.txt
+++ b/sql/core/benchmarks/JsonBenchmark-results.txt
@@ -3,128 +3,133 @@ Benchmark for performance of JSON parsing
 ================================================================================================
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 JSON schema inferring:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        1899           1983          91          2.6         379.7       1.0X
-UTF-8 is set                                       5121           5134          13          1.0        1024.2       0.4X
+No encoding                                        1069           1158         154          4.7         213.8       1.0X
+UTF-8 is set                                       2298           2361         101          2.2         459.5       0.5X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 count a short column:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        1927           1963          55          2.6         385.5       1.0X
-UTF-8 is set                                       4451           4462          10          1.1         890.2       0.4X
+No encoding                                         978           1033          86          5.1         195.6       1.0X
+UTF-8 is set                                       2095           2180         101          2.4         419.0       0.5X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 count a wide column:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        5230           5246          16          0.2        5230.0       1.0X
-UTF-8 is set                                       4768           4856          88          0.2        4767.9       1.1X
+No encoding                                        2349           2441          84          0.4        2348.5       1.0X
+UTF-8 is set                                       3257           3305          58          0.3        3256.8       0.7X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 select wide row:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        8996           9163         215          0.0      179920.8       1.0X
-UTF-8 is set                                       9757           9790          31          0.0      195143.4       0.9X
+No encoding                                        5388           5520         177          0.0      107761.9       1.0X
+UTF-8 is set                                       5643           5692          43          0.0      112869.1       1.0X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Select a subset of 10 columns:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns                                  1557           1560           3          0.6        1557.2       1.0X
-Select 1 column                                    1184           1196          20          0.8        1183.7       1.3X
+Select 10 columns                                   755            762          11          1.3         754.9       1.0X
+Select 1 column                                     516            525           8          1.9         516.4       1.5X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 creation of JSON parser per line:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Short column without encoding                       561            563           3          1.8         561.5       1.0X
-Short column with UTF-8                            1140           1146           8          0.9        1139.9       0.5X
-Wide column without encoding                       5163           5179          23          0.2        5163.2       0.1X
-Wide column with UTF-8                             9810           9833          22          0.1        9810.2       0.1X
+Short column without encoding                       277            283           8          3.6         276.9       1.0X
+Short column with UTF-8                             485            486           1          2.1         484.5       0.6X
+Wide column without encoding                       4075           4126          77          0.2        4075.3       0.1X
+Wide column with UTF-8                             4631           4678          52          0.2        4630.9       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 JSON functions:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                            62             66           4         16.2          61.7       1.0X
-from_json                                           969            979           9          1.0         968.7       0.1X
-json_tuple                                          905            908           4          1.1         905.1       0.1X
-get_json_object wholestage off                      938            942           4          1.1         938.3       0.1X
-get_json_object wholestage on                       835            847          18          1.2         835.0       0.1X
+Text read                                            41             42           1         24.3          41.2       1.0X
+from_json                                           591            600           9          1.7         590.8       0.1X
+json_tuple                                          577            587           8          1.7         577.2       0.1X
+get_json_object wholestage off                      555            574          24          1.8         554.5       0.1X
+get_json_object wholestage on                       534            546          10          1.9         533.6       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Dataset of json strings:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           254            256           3         19.7          50.7       1.0X
-schema inferring                                   1504           1524          26          3.3         300.8       0.2X
-parsing                                            2391           2421          27          2.1         478.2       0.1X
+Text read                                           172            173           1         29.0          34.5       1.0X
+schema inferring                                    746            748           1          6.7         149.2       0.2X
+parsing                                            1153           1165          13          4.3         230.7       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Json files in the per-line mode:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           624            652          30          8.0         124.8       1.0X
-Schema inferring                                   2032           2036           5          2.5         406.5       0.3X
-Parsing without charset                            2527           2529           3          2.0         505.4       0.2X
-Parsing with UTF-8                                 5453           5470          27          0.9        1090.6       0.1X
+Text read                                           303            307           4         16.5          60.5       1.0X
+Schema inferring                                    998           1012          18          5.0         199.6       0.3X
+Parsing without charset                            1119           1140          21          4.5         223.7       0.3X
+Parsing with UTF-8                                 2281           2318          62          2.2         456.1       0.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      107            110           4          9.4         106.5       1.0X
-to_json(timestamp)                                  576            582           9          1.7         576.3       0.2X
-write timestamps to files                           623            626           4          1.6         623.2       0.2X
-Create a dataset of dates                           120            123           3          8.3         120.1       0.9X
-to_json(date)                                       391            398           7          2.6         391.0       0.3X
-write dates to files                                415            418           5          2.4         415.3       0.3X
+Create a dataset of timestamps                       55             58           3         18.3          54.7       1.0X
+to_json(timestamp)                                  472            479           6          2.1         472.2       0.1X
+write timestamps to files                           617            625           8          1.6         617.4       0.1X
+Create a dataset of dates                            85             87           2         11.8          84.9       0.6X
+to_json(date)                                       243            250           8          4.1         242.7       0.2X
+write dates to files                                464            481          18          2.2         464.4       0.1X
+Create a dataset of times                            80             84           4         12.5          79.9       0.7X
+to_json(time)                                       279            288          13          3.6         278.9       0.2X
+write times to files                                481            488          10          2.1         480.8       0.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Read dates and timestamps:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                                                   163            165           4          6.1         162.8       1.0X
-read timestamps from files                                                       987            997          12          1.0         987.2       0.2X
-infer timestamps from files                                                     1835           1847          20          0.5        1835.4       0.1X
-read date text from files                                                        150            153           3          6.7         149.8       1.1X
-read date from files                                                             621            623           2          1.6         621.4       0.3X
-timestamp strings                                                                145            146           1          6.9         145.2       1.1X
-parse timestamps from Dataset[String]                                           1171           1185          21          0.9        1170.6       0.1X
-infer timestamps from Dataset[String]                                           2012           2015           5          0.5        2011.7       0.1X
-date strings                                                                     215            217           2          4.6         215.2       0.8X
-parse dates from Dataset[String]                                                 927            931           5          1.1         927.4       0.2X
-from_json(timestamp)                                                            1635           1639           6          0.6        1635.3       0.1X
-from_json(date)                                                                 1405           1412           6          0.7        1405.0       0.1X
-infer error timestamps from Dataset[String] with default format                 1273           1276           5          0.8        1273.4       0.1X
-infer error timestamps from Dataset[String] with user-provided format           1257           1260           3          0.8        1256.7       0.1X
-infer error timestamps from Dataset[String] with legacy format                  1258           1260           3          0.8        1258.0       0.1X
+read timestamp text from files                                                    90             91           1         11.1          90.1       1.0X
+read timestamps from files                                                       583            591           7          1.7         583.3       0.2X
+infer timestamps from files                                                     6711           6806         110          0.1        6711.1       0.0X
+read date text from files                                                         81             83           3         12.4          80.9       1.1X
+read date from files                                                             287            287           1          3.5         286.9       0.3X
+timestamp strings                                                                 82             83           1         12.1          82.4       1.1X
+parse timestamps from Dataset[String]                                            503            504           2          2.0         502.6       0.2X
+infer timestamps from Dataset[String]                                           6086           6107          23          0.2        6086.3       0.0X
+date strings                                                                     135            145          11          7.4         135.5       0.7X
+parse dates from Dataset[String]                                                 410            417           9          2.4         410.4       0.2X
+from_json(timestamp)                                                             880            895          13          1.1         880.1       0.1X
+from_json(date)                                                                  756            760           4          1.3         756.0       0.1X
+infer error timestamps from Dataset[String] with default format                 5478           5559          81          0.2        5477.5       0.0X
+infer error timestamps from Dataset[String] with user-provided format           5470           5569         134          0.2        5470.4       0.0X
+infer error timestamps from Dataset[String] with legacy format                  5585           5590           8          0.2        5585.4       0.0X
+read time text from files                                                         81             82           1         12.4          80.8       1.1X
+read time from files                                                             358            419          96          2.8         358.3       0.3X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                        4817           4833          15          0.0       48167.4       1.0X
-pushdown disabled                                  4772           4776           5          0.0       47721.9       1.0X
-w/ filters                                          695            710          16          0.1        6949.2       6.9X
+w/o filters                                        4669           4841         296          0.0       46694.5       1.0X
+pushdown disabled                                  4625           4725         117          0.0       46247.7       1.0X
+w/ filters                                          411            430          17          0.2        4106.4      11.4X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
 Partial JSON results:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-parse invalid JSON                                 2386           2451         111          0.0      238564.1       1.0X
+parse invalid JSON                                 1257           1292          37          0.0      125652.2       1.0X
 
 

--- a/sql/core/benchmarks/JsonBenchmark-results.txt
+++ b/sql/core/benchmarks/JsonBenchmark-results.txt
@@ -3,133 +3,128 @@ Benchmark for performance of JSON parsing
 ================================================================================================
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 JSON schema inferring:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        1069           1158         154          4.7         213.8       1.0X
-UTF-8 is set                                       2298           2361         101          2.2         459.5       0.5X
+No encoding                                        1899           1983          91          2.6         379.7       1.0X
+UTF-8 is set                                       5121           5134          13          1.0        1024.2       0.4X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 count a short column:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                         978           1033          86          5.1         195.6       1.0X
-UTF-8 is set                                       2095           2180         101          2.4         419.0       0.5X
+No encoding                                        1927           1963          55          2.6         385.5       1.0X
+UTF-8 is set                                       4451           4462          10          1.1         890.2       0.4X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 count a wide column:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        2349           2441          84          0.4        2348.5       1.0X
-UTF-8 is set                                       3257           3305          58          0.3        3256.8       0.7X
+No encoding                                        5230           5246          16          0.2        5230.0       1.0X
+UTF-8 is set                                       4768           4856          88          0.2        4767.9       1.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 select wide row:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        5388           5520         177          0.0      107761.9       1.0X
-UTF-8 is set                                       5643           5692          43          0.0      112869.1       1.0X
+No encoding                                        8996           9163         215          0.0      179920.8       1.0X
+UTF-8 is set                                       9757           9790          31          0.0      195143.4       0.9X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 Select a subset of 10 columns:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns                                   755            762          11          1.3         754.9       1.0X
-Select 1 column                                     516            525           8          1.9         516.4       1.5X
+Select 10 columns                                  1557           1560           3          0.6        1557.2       1.0X
+Select 1 column                                    1184           1196          20          0.8        1183.7       1.3X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 creation of JSON parser per line:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Short column without encoding                       277            283           8          3.6         276.9       1.0X
-Short column with UTF-8                             485            486           1          2.1         484.5       0.6X
-Wide column without encoding                       4075           4126          77          0.2        4075.3       0.1X
-Wide column with UTF-8                             4631           4678          52          0.2        4630.9       0.1X
+Short column without encoding                       561            563           3          1.8         561.5       1.0X
+Short column with UTF-8                            1140           1146           8          0.9        1139.9       0.5X
+Wide column without encoding                       5163           5179          23          0.2        5163.2       0.1X
+Wide column with UTF-8                             9810           9833          22          0.1        9810.2       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 JSON functions:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                            41             42           1         24.3          41.2       1.0X
-from_json                                           591            600           9          1.7         590.8       0.1X
-json_tuple                                          577            587           8          1.7         577.2       0.1X
-get_json_object wholestage off                      555            574          24          1.8         554.5       0.1X
-get_json_object wholestage on                       534            546          10          1.9         533.6       0.1X
+Text read                                            62             66           4         16.2          61.7       1.0X
+from_json                                           969            979           9          1.0         968.7       0.1X
+json_tuple                                          905            908           4          1.1         905.1       0.1X
+get_json_object wholestage off                      938            942           4          1.1         938.3       0.1X
+get_json_object wholestage on                       835            847          18          1.2         835.0       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 Dataset of json strings:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           172            173           1         29.0          34.5       1.0X
-schema inferring                                    746            748           1          6.7         149.2       0.2X
-parsing                                            1153           1165          13          4.3         230.7       0.1X
+Text read                                           254            256           3         19.7          50.7       1.0X
+schema inferring                                   1504           1524          26          3.3         300.8       0.2X
+parsing                                            2391           2421          27          2.1         478.2       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 Json files in the per-line mode:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           303            307           4         16.5          60.5       1.0X
-Schema inferring                                    998           1012          18          5.0         199.6       0.3X
-Parsing without charset                            1119           1140          21          4.5         223.7       0.3X
-Parsing with UTF-8                                 2281           2318          62          2.2         456.1       0.1X
+Text read                                           624            652          30          8.0         124.8       1.0X
+Schema inferring                                   2032           2036           5          2.5         406.5       0.3X
+Parsing without charset                            2527           2529           3          2.0         505.4       0.2X
+Parsing with UTF-8                                 5453           5470          27          0.9        1090.6       0.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                       55             58           3         18.3          54.7       1.0X
-to_json(timestamp)                                  472            479           6          2.1         472.2       0.1X
-write timestamps to files                           617            625           8          1.6         617.4       0.1X
-Create a dataset of dates                            85             87           2         11.8          84.9       0.6X
-to_json(date)                                       243            250           8          4.1         242.7       0.2X
-write dates to files                                464            481          18          2.2         464.4       0.1X
-Create a dataset of times                            80             84           4         12.5          79.9       0.7X
-to_json(time)                                       279            288          13          3.6         278.9       0.2X
-write times to files                                481            488          10          2.1         480.8       0.1X
+Create a dataset of timestamps                      107            110           4          9.4         106.5       1.0X
+to_json(timestamp)                                  576            582           9          1.7         576.3       0.2X
+write timestamps to files                           623            626           4          1.6         623.2       0.2X
+Create a dataset of dates                           120            123           3          8.3         120.1       0.9X
+to_json(date)                                       391            398           7          2.6         391.0       0.3X
+write dates to files                                415            418           5          2.4         415.3       0.3X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 Read dates and timestamps:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                                                    90             91           1         11.1          90.1       1.0X
-read timestamps from files                                                       583            591           7          1.7         583.3       0.2X
-infer timestamps from files                                                     6711           6806         110          0.1        6711.1       0.0X
-read date text from files                                                         81             83           3         12.4          80.9       1.1X
-read date from files                                                             287            287           1          3.5         286.9       0.3X
-timestamp strings                                                                 82             83           1         12.1          82.4       1.1X
-parse timestamps from Dataset[String]                                            503            504           2          2.0         502.6       0.2X
-infer timestamps from Dataset[String]                                           6086           6107          23          0.2        6086.3       0.0X
-date strings                                                                     135            145          11          7.4         135.5       0.7X
-parse dates from Dataset[String]                                                 410            417           9          2.4         410.4       0.2X
-from_json(timestamp)                                                             880            895          13          1.1         880.1       0.1X
-from_json(date)                                                                  756            760           4          1.3         756.0       0.1X
-infer error timestamps from Dataset[String] with default format                 5478           5559          81          0.2        5477.5       0.0X
-infer error timestamps from Dataset[String] with user-provided format           5470           5569         134          0.2        5470.4       0.0X
-infer error timestamps from Dataset[String] with legacy format                  5585           5590           8          0.2        5585.4       0.0X
-read time text from files                                                         81             82           1         12.4          80.8       1.1X
-read time from files                                                             358            419          96          2.8         358.3       0.3X
+read timestamp text from files                                                   163            165           4          6.1         162.8       1.0X
+read timestamps from files                                                       987            997          12          1.0         987.2       0.2X
+infer timestamps from files                                                     1835           1847          20          0.5        1835.4       0.1X
+read date text from files                                                        150            153           3          6.7         149.8       1.1X
+read date from files                                                             621            623           2          1.6         621.4       0.3X
+timestamp strings                                                                145            146           1          6.9         145.2       1.1X
+parse timestamps from Dataset[String]                                           1171           1185          21          0.9        1170.6       0.1X
+infer timestamps from Dataset[String]                                           2012           2015           5          0.5        2011.7       0.1X
+date strings                                                                     215            217           2          4.6         215.2       0.8X
+parse dates from Dataset[String]                                                 927            931           5          1.1         927.4       0.2X
+from_json(timestamp)                                                            1635           1639           6          0.6        1635.3       0.1X
+from_json(date)                                                                 1405           1412           6          0.7        1405.0       0.1X
+infer error timestamps from Dataset[String] with default format                 1273           1276           5          0.8        1273.4       0.1X
+infer error timestamps from Dataset[String] with user-provided format           1257           1260           3          0.8        1256.7       0.1X
+infer error timestamps from Dataset[String] with legacy format                  1258           1260           3          0.8        1258.0       0.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                        4669           4841         296          0.0       46694.5       1.0X
-pushdown disabled                                  4625           4725         117          0.0       46247.7       1.0X
-w/ filters                                          411            430          17          0.2        4106.4      11.4X
+w/o filters                                        4817           4833          15          0.0       48167.4       1.0X
+pushdown disabled                                  4772           4776           5          0.0       47721.9       1.0X
+w/ filters                                          695            710          16          0.1        6949.2       6.9X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
+AMD EPYC 9V74 80-Core Processor
 Partial JSON results:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-parse invalid JSON                                 1257           1292          37          0.0      125652.2       1.0X
+parse invalid JSON                                 2386           2451         111          0.0      238564.1       1.0X
 
 

--- a/sql/core/benchmarks/JsonBenchmark-results.txt
+++ b/sql/core/benchmarks/JsonBenchmark-results.txt
@@ -3,128 +3,133 @@ Benchmark for performance of JSON parsing
 ================================================================================================
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 JSON schema inferring:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        1899           1983          91          2.6         379.7       1.0X
-UTF-8 is set                                       5121           5134          13          1.0        1024.2       0.4X
+No encoding                                        2596           2685         103          1.9         519.2       1.0X
+UTF-8 is set                                       5809           5825          26          0.9        1161.8       0.4X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 count a short column:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        1927           1963          55          2.6         385.5       1.0X
-UTF-8 is set                                       4451           4462          10          1.1         890.2       0.4X
+No encoding                                        2402           2459          50          2.1         480.4       1.0X
+UTF-8 is set                                       5429           5456          23          0.9        1085.9       0.4X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 count a wide column:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        5230           5246          16          0.2        5230.0       1.0X
-UTF-8 is set                                       4768           4856          88          0.2        4767.9       1.1X
+No encoding                                        5003           5033          27          0.2        5003.3       1.0X
+UTF-8 is set                                       4741           4749          11          0.2        4741.4       1.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 select wide row:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        8996           9163         215          0.0      179920.8       1.0X
-UTF-8 is set                                       9757           9790          31          0.0      195143.4       0.9X
+No encoding                                        8420           8445          30          0.0      168391.8       1.0X
+UTF-8 is set                                       8926           8973          41          0.0      178526.8       0.9X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select a subset of 10 columns:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns                                  1557           1560           3          0.6        1557.2       1.0X
-Select 1 column                                    1184           1196          20          0.8        1183.7       1.3X
+Select 10 columns                                  1766           1771           5          0.6        1765.5       1.0X
+Select 1 column                                    1312           1323           9          0.8        1312.5       1.3X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 creation of JSON parser per line:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Short column without encoding                       561            563           3          1.8         561.5       1.0X
-Short column with UTF-8                            1140           1146           8          0.9        1139.9       0.5X
-Wide column without encoding                       5163           5179          23          0.2        5163.2       0.1X
-Wide column with UTF-8                             9810           9833          22          0.1        9810.2       0.1X
+Short column without encoding                       685            689           4          1.5         685.0       1.0X
+Short column with UTF-8                            1259           1260           1          0.8        1259.2       0.5X
+Wide column without encoding                       5335           5347          13          0.2        5335.4       0.1X
+Wide column with UTF-8                            10189          10243          52          0.1       10188.8       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 JSON functions:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                            62             66           4         16.2          61.7       1.0X
-from_json                                           969            979           9          1.0         968.7       0.1X
-json_tuple                                          905            908           4          1.1         905.1       0.1X
-get_json_object wholestage off                      938            942           4          1.1         938.3       0.1X
-get_json_object wholestage on                       835            847          18          1.2         835.0       0.1X
+Text read                                            61             64           2         16.3          61.4       1.0X
+from_json                                          1472           1473           1          0.7        1472.4       0.0X
+json_tuple                                         1468           1477           9          0.7        1468.3       0.0X
+get_json_object wholestage off                     1493           1498           5          0.7        1492.7       0.0X
+get_json_object wholestage on                      1408           1418           9          0.7        1408.2       0.0X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Dataset of json strings:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           254            256           3         19.7          50.7       1.0X
-schema inferring                                   1504           1524          26          3.3         300.8       0.2X
-parsing                                            2391           2421          27          2.1         478.2       0.1X
+Text read                                           231            232           1         21.7          46.2       1.0X
+schema inferring                                   1816           1821           9          2.8         363.1       0.1X
+parsing                                            2626           2628           3          1.9         525.2       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Json files in the per-line mode:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           624            652          30          8.0         124.8       1.0X
-Schema inferring                                   2032           2036           5          2.5         406.5       0.3X
-Parsing without charset                            2527           2529           3          2.0         505.4       0.2X
-Parsing with UTF-8                                 5453           5470          27          0.9        1090.6       0.1X
+Text read                                           584            589           4          8.6         116.7       1.0X
+Schema inferring                                   2511           2535          33          2.0         502.1       0.2X
+Parsing without charset                            2968           2976           8          1.7         593.5       0.2X
+Parsing with UTF-8                                 5937           5960          40          0.8        1187.3       0.1X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      107            110           4          9.4         106.5       1.0X
-to_json(timestamp)                                  576            582           9          1.7         576.3       0.2X
-write timestamps to files                           623            626           4          1.6         623.2       0.2X
-Create a dataset of dates                           120            123           3          8.3         120.1       0.9X
-to_json(date)                                       391            398           7          2.6         391.0       0.3X
-write dates to files                                415            418           5          2.4         415.3       0.3X
+Create a dataset of timestamps                      104            108           4          9.6         103.9       1.0X
+to_json(timestamp)                                  602            603           1          1.7         602.2       0.2X
+write timestamps to files                           645            646           0          1.5         645.4       0.2X
+Create a dataset of dates                           118            121           3          8.5         118.2       0.9X
+to_json(date)                                       431            435           4          2.3         430.8       0.2X
+write dates to files                                415            418           4          2.4         415.3       0.3X
+Create a dataset of times                           105            107           2          9.5         105.4       1.0X
+to_json(time)                                       599            602           3          1.7         598.7       0.2X
+write times to files                                604            608           4          1.7         604.3       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Read dates and timestamps:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                                                   163            165           4          6.1         162.8       1.0X
-read timestamps from files                                                       987            997          12          1.0         987.2       0.2X
-infer timestamps from files                                                     1835           1847          20          0.5        1835.4       0.1X
-read date text from files                                                        150            153           3          6.7         149.8       1.1X
-read date from files                                                             621            623           2          1.6         621.4       0.3X
-timestamp strings                                                                145            146           1          6.9         145.2       1.1X
-parse timestamps from Dataset[String]                                           1171           1185          21          0.9        1170.6       0.1X
-infer timestamps from Dataset[String]                                           2012           2015           5          0.5        2011.7       0.1X
-date strings                                                                     215            217           2          4.6         215.2       0.8X
-parse dates from Dataset[String]                                                 927            931           5          1.1         927.4       0.2X
-from_json(timestamp)                                                            1635           1639           6          0.6        1635.3       0.1X
-from_json(date)                                                                 1405           1412           6          0.7        1405.0       0.1X
-infer error timestamps from Dataset[String] with default format                 1273           1276           5          0.8        1273.4       0.1X
-infer error timestamps from Dataset[String] with user-provided format           1257           1260           3          0.8        1256.7       0.1X
-infer error timestamps from Dataset[String] with legacy format                  1258           1260           3          0.8        1258.0       0.1X
+read timestamp text from files                                                   149            153           6          6.7         149.3       1.0X
+read timestamps from files                                                      1131           1156          25          0.9        1130.6       0.1X
+infer timestamps from files                                                    11851          11867          20          0.1       11851.3       0.0X
+read date text from files                                                        140            143           5          7.2         139.8       1.1X
+read date from files                                                             777            789          20          1.3         776.7       0.2X
+timestamp strings                                                                138            139           1          7.2         138.5       1.1X
+parse timestamps from Dataset[String]                                           1244           1246           2          0.8        1244.2       0.1X
+infer timestamps from Dataset[String]                                          11836          11838           2          0.1       11836.2       0.0X
+date strings                                                                     193            194           0          5.2         193.2       0.8X
+parse dates from Dataset[String]                                                 896            897           1          1.1         896.1       0.2X
+from_json(timestamp)                                                            2038           2048           9          0.5        2038.5       0.1X
+from_json(date)                                                                 1782           1784           1          0.6        1782.3       0.1X
+infer error timestamps from Dataset[String] with default format                10711          10735          35          0.1       10711.0       0.0X
+infer error timestamps from Dataset[String] with user-provided format          10642          10647           7          0.1       10641.6       0.0X
+infer error timestamps from Dataset[String] with legacy format                 10419          10579         142          0.1       10419.3       0.0X
+read time text from files                                                        145            149           4          6.9         144.8       1.0X
+read time from files                                                             918            933          14          1.1         917.9       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                        4817           4833          15          0.0       48167.4       1.0X
-pushdown disabled                                  4772           4776           5          0.0       47721.9       1.0X
-w/ filters                                          695            710          16          0.1        6949.2       6.9X
+w/o filters                                        6663           6698          31          0.0       66628.4       1.0X
+pushdown disabled                                  6764           6791          44          0.0       67644.7       1.0X
+w/ filters                                          565            569           4          0.2        5654.5      11.8X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Linux 6.14.0-1017-azure
-AMD EPYC 9V74 80-Core Processor
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Partial JSON results:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-parse invalid JSON                                 2386           2451         111          0.0      238564.1       1.0X
+parse invalid JSON                                 2197           2299         160          0.0      219679.8       1.0X
 
 

--- a/sql/core/benchmarks/TimeBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/TimeBenchmark-jdk21-results.txt
@@ -1,0 +1,126 @@
+================================================================================================
+Current time
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+current_time:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+current_time wholestage off                         227            228           2         44.1          22.7       1.0X
+current_time wholestage on                          236            253          23         42.3          23.6       1.0X
+
+
+================================================================================================
+make_time
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+make_time:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+make_time wholestage off                            481            522          58         20.8          48.1       1.0X
+make_time wholestage on                             453            463          10         22.1          45.3       1.1X
+
+
+================================================================================================
+Parsing time
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+to_time:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+to_time wholestage off                             5579           5600          29          1.8         557.9       1.0X
+to_time wholestage on                              5443           5464          20          1.8         544.3       1.0X
+
+
+================================================================================================
+Extract components from TIME
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+hour of time:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+hour of time wholestage off                         540            544           5         18.5          54.0       1.0X
+hour of time wholestage on                          539            547           6         18.5          53.9       1.0X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+minute of time:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+minute of time wholestage off                       544            545           1         18.4          54.4       1.0X
+minute of time wholestage on                        541            547           4         18.5          54.1       1.0X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+second of time:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+second of time wholestage off                       530            531           2         18.9          53.0       1.0X
+second of time wholestage on                        536            543           4         18.6          53.6       1.0X
+
+
+================================================================================================
+time_trunc
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+time_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+time_trunc HOUR wholestage off                      898            904           8         11.1          89.8       1.0X
+time_trunc HOUR wholestage on                       885            891           4         11.3          88.5       1.0X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+time_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+time_trunc MINUTE wholestage off                   1127           1131           6          8.9         112.7       1.0X
+time_trunc MINUTE wholestage on                     917            925           7         10.9          91.7       1.2X
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+time_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+time_trunc SECOND wholestage off                   1158           1159           2          8.6         115.8       1.0X
+time_trunc SECOND wholestage on                     944            952           8         10.6          94.4       1.2X
+
+
+================================================================================================
+time_diff
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+time_diff:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+time_diff wholestage off                           1030           1034           5          9.7         103.0       1.0X
+time_diff wholestage on                            1075           1077           2          9.3         107.5       1.0X
+
+
+================================================================================================
+TIME +/- interval
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+TIME +/- interval:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+time + interval hour                                477            482           4         20.9          47.7       1.0X
+time + interval minute                              484            489           5         20.7          48.4       1.0X
+time + interval second                              479            484           4         20.9          47.9       1.0X
+time - interval hour                                488            496           6         20.5          48.8       1.0X
+
+
+================================================================================================
+Conversion from/to external types
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.11+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+To/from java.time.LocalTime:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+From java.time.LocalTime                            179            184           5         27.9          35.8       1.0X
+Collect java.time.LocalTime                        1074           1154          70          4.7         214.9       0.2X
+
+

--- a/sql/core/benchmarks/TimeBenchmark-jdk25-results.txt
+++ b/sql/core/benchmarks/TimeBenchmark-jdk25-results.txt
@@ -1,0 +1,126 @@
+================================================================================================
+Current time
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+current_time:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+current_time wholestage off                         224            230           9         44.6          22.4       1.0X
+current_time wholestage on                          251            257          10         39.8          25.1       0.9X
+
+
+================================================================================================
+make_time
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+make_time:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+make_time wholestage off                            504            505           1         19.8          50.4       1.0X
+make_time wholestage on                             446            453           4         22.4          44.6       1.1X
+
+
+================================================================================================
+Parsing time
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+to_time:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+to_time wholestage off                             5026           5029           4          2.0         502.6       1.0X
+to_time wholestage on                              5097           5101           6          2.0         509.7       1.0X
+
+
+================================================================================================
+Extract components from TIME
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+hour of time:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+hour of time wholestage off                         495            501           8         20.2          49.5       1.0X
+hour of time wholestage on                          476            484           5         21.0          47.6       1.0X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+minute of time:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+minute of time wholestage off                       491            495           6         20.4          49.1       1.0X
+minute of time wholestage on                        475            486          13         21.1          47.5       1.0X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+second of time:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+second of time wholestage off                       487            490           4         20.5          48.7       1.0X
+second of time wholestage on                        473            477           7         21.1          47.3       1.0X
+
+
+================================================================================================
+time_trunc
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+time_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+time_trunc HOUR wholestage off                      871            874           3         11.5          87.1       1.0X
+time_trunc HOUR wholestage on                       867            869           2         11.5          86.7       1.0X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+time_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+time_trunc MINUTE wholestage off                    885            886           2         11.3          88.5       1.0X
+time_trunc MINUTE wholestage on                     858            867           7         11.7          85.8       1.0X
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+time_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+time_trunc SECOND wholestage off                    906            911           7         11.0          90.6       1.0X
+time_trunc SECOND wholestage on                     886            896          12         11.3          88.6       1.0X
+
+
+================================================================================================
+time_diff
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+time_diff:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+time_diff wholestage off                           1115           1116           2          9.0         111.5       1.0X
+time_diff wholestage on                             926            930           3         10.8          92.6       1.2X
+
+
+================================================================================================
+TIME +/- interval
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+TIME +/- interval:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+time + interval hour                                452            458           4         22.1          45.2       1.0X
+time + interval minute                              451            455           4         22.2          45.1       1.0X
+time + interval second                              449            457          14         22.3          44.9       1.0X
+time - interval hour                                456            457           1         21.9          45.6       1.0X
+
+
+================================================================================================
+Conversion from/to external types
+================================================================================================
+
+OpenJDK 64-Bit Server VM 25.0.3+9-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
+To/from java.time.LocalTime:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+From java.time.LocalTime                            187            189           2         26.8          37.3       1.0X
+Collect java.time.LocalTime                        1046           1230         160          4.8         209.2       0.2X
+
+

--- a/sql/core/benchmarks/TimeBenchmark-results.txt
+++ b/sql/core/benchmarks/TimeBenchmark-results.txt
@@ -1,0 +1,126 @@
+================================================================================================
+Current time
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
+current_time:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+current_time wholestage off                         144            145           2         69.4          14.4       1.0X
+current_time wholestage on                          147            187          45         67.9          14.7       1.0X
+
+
+================================================================================================
+make_time
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
+make_time:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+make_time wholestage off                            322            323           1         31.0          32.2       1.0X
+make_time wholestage on                             308            310           2         32.5          30.8       1.0X
+
+
+================================================================================================
+Parsing time
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
+to_time:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+to_time wholestage off                             5902           5970          97          1.7         590.2       1.0X
+to_time wholestage on                              5824           5959          99          1.7         582.4       1.0X
+
+
+================================================================================================
+Extract components from TIME
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
+hour of time:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+hour of time wholestage off                         365            365           1         27.4          36.5       1.0X
+hour of time wholestage on                          354            356           2         28.2          35.4       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
+minute of time:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+minute of time wholestage off                       349            351           2         28.6          34.9       1.0X
+minute of time wholestage on                        353            356           2         28.4          35.3       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
+second of time:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+second of time wholestage off                       347            348           1         28.8          34.7       1.0X
+second of time wholestage on                        350            352           2         28.6          35.0       1.0X
+
+
+================================================================================================
+time_trunc
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
+time_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+time_trunc HOUR wholestage off                      709            714           7         14.1          70.9       1.0X
+time_trunc HOUR wholestage on                       687            706          29         14.6          68.7       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
+time_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+time_trunc MINUTE wholestage off                    689            693           6         14.5          68.9       1.0X
+time_trunc MINUTE wholestage on                     692            696           5         14.5          69.2       1.0X
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
+time_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+time_trunc SECOND wholestage off                    685            686           2         14.6          68.5       1.0X
+time_trunc SECOND wholestage on                     719            728           5         13.9          71.9       1.0X
+
+
+================================================================================================
+time_diff
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
+time_diff:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+time_diff wholestage off                            999           1011          17         10.0          99.9       1.0X
+time_diff wholestage on                             708            712           7         14.1          70.8       1.4X
+
+
+================================================================================================
+TIME +/- interval
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
+TIME +/- interval:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+time + interval hour                                330            331           1         30.3          33.0       1.0X
+time + interval minute                              327            331           3         30.6          32.7       1.0X
+time + interval second                              328            334           4         30.5          32.8       1.0X
+time - interval hour                                335            339           5         29.8          33.5       1.0X
+
+
+================================================================================================
+Conversion from/to external types
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
+Apple M3 Pro
+To/from java.time.LocalTime:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+From java.time.LocalTime                            133            135           2         37.6          26.6       1.0X
+Collect java.time.LocalTime                         606            634          27          8.2         121.2       0.2X
+
+

--- a/sql/core/benchmarks/TimeBenchmark-results.txt
+++ b/sql/core/benchmarks/TimeBenchmark-results.txt
@@ -2,125 +2,125 @@
 Current time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 current_time:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-current_time wholestage off                         144            145           2         69.4          14.4       1.0X
-current_time wholestage on                          147            187          45         67.9          14.7       1.0X
+current_time wholestage off                         225            234          14         44.5          22.5       1.0X
+current_time wholestage on                          250            274          30         40.1          25.0       0.9X
 
 
 ================================================================================================
 make_time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 make_time:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-make_time wholestage off                            322            323           1         31.0          32.2       1.0X
-make_time wholestage on                             308            310           2         32.5          30.8       1.0X
+make_time wholestage off                            476            534          82         21.0          47.6       1.0X
+make_time wholestage on                             465            474           9         21.5          46.5       1.0X
 
 
 ================================================================================================
 Parsing time
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 to_time:                                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-to_time wholestage off                             5902           5970          97          1.7         590.2       1.0X
-to_time wholestage on                              5824           5959          99          1.7         582.4       1.0X
+to_time wholestage off                             5782           5804          30          1.7         578.2       1.0X
+to_time wholestage on                              5782           5799          14          1.7         578.2       1.0X
 
 
 ================================================================================================
 Extract components from TIME
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 hour of time:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hour of time wholestage off                         365            365           1         27.4          36.5       1.0X
-hour of time wholestage on                          354            356           2         28.2          35.4       1.0X
+hour of time wholestage off                         541            542           2         18.5          54.1       1.0X
+hour of time wholestage on                          528            534           5         18.9          52.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 minute of time:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-minute of time wholestage off                       349            351           2         28.6          34.9       1.0X
-minute of time wholestage on                        353            356           2         28.4          35.3       1.0X
+minute of time wholestage off                       532            536           6         18.8          53.2       1.0X
+minute of time wholestage on                        527            533           5         19.0          52.7       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 second of time:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-second of time wholestage off                       347            348           1         28.8          34.7       1.0X
-second of time wholestage on                        350            352           2         28.6          35.0       1.0X
+second of time wholestage off                       529            532           5         18.9          52.9       1.0X
+second of time wholestage on                        525            527           2         19.0          52.5       1.0X
 
 
 ================================================================================================
 time_trunc
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 time_trunc HOUR:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-time_trunc HOUR wholestage off                      709            714           7         14.1          70.9       1.0X
-time_trunc HOUR wholestage on                       687            706          29         14.6          68.7       1.0X
+time_trunc HOUR wholestage off                      897            901           5         11.1          89.7       1.0X
+time_trunc HOUR wholestage on                       911            916           4         11.0          91.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 time_trunc MINUTE:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-time_trunc MINUTE wholestage off                    689            693           6         14.5          68.9       1.0X
-time_trunc MINUTE wholestage on                     692            696           5         14.5          69.2       1.0X
+time_trunc MINUTE wholestage off                    985            985           1         10.2          98.5       1.0X
+time_trunc MINUTE wholestage on                     965            971           6         10.4          96.5       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 time_trunc SECOND:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-time_trunc SECOND wholestage off                    685            686           2         14.6          68.5       1.0X
-time_trunc SECOND wholestage on                     719            728           5         13.9          71.9       1.0X
+time_trunc SECOND wholestage off                   1005           1010           7          9.9         100.5       1.0X
+time_trunc SECOND wholestage on                     987            992           6         10.1          98.7       1.0X
 
 
 ================================================================================================
 time_diff
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 time_diff:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-time_diff wholestage off                            999           1011          17         10.0          99.9       1.0X
-time_diff wholestage on                             708            712           7         14.1          70.8       1.4X
+time_diff wholestage off                           1075           1082          10          9.3         107.5       1.0X
+time_diff wholestage on                            1034           1044           9          9.7         103.4       1.0X
 
 
 ================================================================================================
 TIME +/- interval
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 TIME +/- interval:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-time + interval hour                                330            331           1         30.3          33.0       1.0X
-time + interval minute                              327            331           3         30.6          32.7       1.0X
-time + interval second                              328            334           4         30.5          32.8       1.0X
-time - interval hour                                335            339           5         29.8          33.5       1.0X
+time + interval hour                                481            484           3         20.8          48.1       1.0X
+time + interval minute                              477            489          16         21.0          47.7       1.0X
+time + interval second                              479            482           3         20.9          47.9       1.0X
+time - interval hour                                481            488          12         20.8          48.1       1.0X
 
 
 ================================================================================================
 Conversion from/to external types
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.18+8-LTS on Mac OS X 26.5
-Apple M3 Pro
+OpenJDK 64-Bit Server VM 17.0.19+10-LTS on Linux 6.17.0-1018-azure
+AMD EPYC 7763 64-Core Processor
 To/from java.time.LocalTime:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-From java.time.LocalTime                            133            135           2         37.6          26.6       1.0X
-Collect java.time.LocalTime                         606            634          27          8.2         121.2       0.2X
+From java.time.LocalTime                            181            188           6         27.6          36.2       1.0X
+Collect java.time.LocalTime                         930           1084         173          5.4         186.0       0.2X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
@@ -69,7 +69,8 @@ object ExtractBenchmark extends SqlBasedBenchmark {
     case "interval" => "(cast(timestamp_seconds(id) as date) - date'0001-01-01') + " +
       "(timestamp_seconds(id) - timestamp'1000-01-01 01:02:03.123456')"
     case other => throw new IllegalArgumentException(
-      s"Unsupported column type $other. Valid column types are 'timestamp' and 'date'")
+      s"Unsupported column type $other. Valid column types are " +
+        "'timestamp', 'date', 'time', and 'interval'")
   }
 
   private def run(
@@ -90,6 +91,7 @@ object ExtractBenchmark extends SqlBasedBenchmark {
   }
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    spark.conf.set(SQLConf.TIME_TYPE_ENABLED.key, "true")
     val N = 10000000L
     val datetimeFields = Seq("YEAR", "YEAROFWEEK", "QUARTER", "MONTH", "WEEK", "DAY", "DAYOFWEEK",
       "DOW", "DOW_ISO", "DAYOFWEEK_ISO", "DOY", "HOUR", "MINUTE", "SECOND")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ExtractBenchmark.scala
@@ -64,6 +64,8 @@ object ExtractBenchmark extends SqlBasedBenchmark {
   private def castExpr(from: String): String = from match {
     case "timestamp" => "timestamp_seconds(id)"
     case "date" => "cast(timestamp_seconds(id) as date)"
+    case "time" => "make_time(cast(mod(id, 24) as int), cast(mod(id, 60) as int), " +
+      "cast(mod(id, 60) as decimal(8,6)))"
     case "interval" => "(cast(timestamp_seconds(id) as date) - date'0001-01-01') + " +
       "(timestamp_seconds(id) - timestamp'1000-01-01 01:02:03.123456')"
     case other => throw new IllegalArgumentException(
@@ -92,9 +94,11 @@ object ExtractBenchmark extends SqlBasedBenchmark {
     val datetimeFields = Seq("YEAR", "YEAROFWEEK", "QUARTER", "MONTH", "WEEK", "DAY", "DAYOFWEEK",
       "DOW", "DOW_ISO", "DAYOFWEEK_ISO", "DOY", "HOUR", "MINUTE", "SECOND")
     val intervalFields = Seq("YEAR", "MONTH", "DAY", "HOUR", "MINUTE", "SECOND")
+    val timeFields = Seq("HOUR", "MINUTE", "SECOND")
     val settings = Map(
       "timestamp" -> datetimeFields,
       "date" -> datetimeFields,
+      "time" -> timeFields,
       "interval" -> intervalFields)
 
     for {(dataType, fields) <- settings; func <- Seq("extract", "date_part")} {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TimeBenchmark.scala
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import java.time.LocalTime
+
+import org.apache.spark.benchmark.Benchmark
+
+/**
+ * Synthetic benchmark for TIME data type functions.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class>
+ *        --jars <spark core test jar>,<spark catalyst test jar> <sql core test jar>
+ *   2. build/sbt "sql/Test/runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results will be written to "benchmarks/TimeBenchmark-results.txt".
+ * }}}
+ */
+object TimeBenchmark extends SqlBasedBenchmark {
+  private def doBenchmark(cardinality: Int, exprs: String*): Unit = {
+    spark.range(cardinality)
+      .selectExpr(exprs: _*)
+      .noop()
+  }
+
+  private def run(cardinality: Int, name: String, exprs: String*): Unit = {
+    codegenBenchmark(name, cardinality) {
+      doBenchmark(cardinality, exprs: _*)
+    }
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val N = 10000000
+    // Generate TIME values using make_time(hour, minute, decimal_seconds)
+    val timeExpr = "make_time(cast(mod(id, 24) as int), cast(mod(id, 60) as int), " +
+      "cast(mod(id, 60) as decimal(8,6)))"
+
+    runBenchmark("Current time") {
+      run(N, "current_time", "current_time()")
+    }
+
+    runBenchmark("make_time") {
+      run(N, "make_time", timeExpr)
+    }
+
+    runBenchmark("Parsing time") {
+      val timeStrExpr = "concat(lpad(cast(mod(id, 24) as string), 2, '0'), ':', " +
+        "lpad(cast(mod(id, 60) as string), 2, '0'), ':', " +
+        "lpad(cast(mod(id, 60) as string), 2, '0'))"
+      run(N, "to_time", s"to_time($timeStrExpr, 'HH:mm:ss')")
+    }
+
+    runBenchmark("Extract components from TIME") {
+      run(N, "hour of time", s"hour($timeExpr)")
+      run(N, "minute of time", s"minute($timeExpr)")
+      run(N, "second of time", s"second($timeExpr)")
+    }
+
+    runBenchmark("time_trunc") {
+      Seq("HOUR", "MINUTE", "SECOND").foreach { level =>
+        run(N, s"time_trunc $level", s"time_trunc('$level', $timeExpr)")
+      }
+    }
+
+    runBenchmark("time_diff") {
+      val timeExpr2 = "make_time(cast(mod(id + 1, 24) as int), cast(mod(id + 2, 60) as int), " +
+        "cast(mod(id + 3, 60) as decimal(8,6)))"
+      run(N, "time_diff", s"time_diff('SECOND', $timeExpr, $timeExpr2)")
+    }
+
+    runBenchmark("TIME +/- interval") {
+      // Use make_time with hour < 22 to avoid overflow when adding intervals
+      val safeTimeExpr = "make_time(cast(mod(id, 20) as int), cast(mod(id, 60) as int), " +
+        "cast(mod(id, 60) as decimal(8,6)))"
+      val benchmark = new Benchmark("TIME +/- interval", N, output = output)
+      benchmark.addCase("time + interval hour") { _ =>
+        doBenchmark(N, s"$safeTimeExpr + interval 1 hour")
+      }
+      benchmark.addCase("time + interval minute") { _ =>
+        doBenchmark(N, s"$safeTimeExpr + interval 30 minute")
+      }
+      benchmark.addCase("time + interval second") { _ =>
+        doBenchmark(N, s"$safeTimeExpr + interval 45 second")
+      }
+      benchmark.addCase("time - interval hour") { _ =>
+        // Use hours >= 1 to avoid underflow
+        val subTimeExpr = "make_time(cast(mod(id, 20) + 2 as int), cast(mod(id, 60) as int), " +
+          "cast(mod(id, 60) as decimal(8,6)))"
+        doBenchmark(N, s"$subTimeExpr - interval 1 hour")
+      }
+      benchmark.run()
+    }
+
+    runBenchmark("Conversion from/to external types") {
+      import spark.implicits._
+      val rowsNum = 5000000
+      val numIters = 3
+      val benchmark = new Benchmark("To/from java.time.LocalTime", rowsNum, output = output)
+      benchmark.addCase("From java.time.LocalTime", numIters) { _ =>
+        spark.range(rowsNum)
+          .map(nanos => LocalTime.ofNanoOfDay(nanos % 86400000000000L))
+          .noop()
+      }
+      def localTimes = {
+        spark.range(0, rowsNum, 1, 1)
+          .map(nanos => LocalTime.ofNanoOfDay(nanos % 86400000000000L))
+      }
+      benchmark.addCase("Collect java.time.LocalTime", numIters) { _ =>
+        localTimes.collect()
+      }
+      benchmark.run()
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TimeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TimeBenchmark.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.benchmark
 import java.time.LocalTime
 
 import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.internal.SQLConf
 
 /**
  * Synthetic benchmark for TIME data type functions.
@@ -48,6 +49,7 @@ object TimeBenchmark extends SqlBasedBenchmark {
   }
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    spark.conf.set(SQLConf.TIME_TYPE_ENABLED.key, "true")
     val N = 10000000
     // Generate TIME values using make_time(hour, minute, decimal_seconds)
     val timeExpr = "make_time(cast(mod(id, 24) as int), cast(mod(id, 60) as int), " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVBenchmark.scala
@@ -148,6 +148,7 @@ object CSVBenchmark extends SqlBasedBenchmark {
   }
 
   private def datetimeBenchmark(rowsNum: Int, numIters: Int): Unit = {
+    spark.conf.set(SQLConf.TIME_TYPE_ENABLED.key, "true")
     def timestamps = {
       spark.range(0, rowsNum, 1, 1).mapPartitions { iter =>
         iter.map(Instant.ofEpochSecond(_))
@@ -194,7 +195,7 @@ object CSVBenchmark extends SqlBasedBenchmark {
 
       def times = {
         spark.range(0, rowsNum, 1, 1).mapPartitions { iter =>
-          iter.map(t => LocalTime.ofNanoOfDay((t % 86400000000L) * 1000000L))
+          iter.map(t => LocalTime.ofNanoOfDay(t % 86400000000000L))
         }.select($"value".as("time"))
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVBenchmark.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution.datasources.csv
 
 import java.io.File
-import java.time.{Instant, LocalDate}
+import java.time.{Instant, LocalDate, LocalTime}
 
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.{Column, Dataset, Row}
@@ -190,6 +190,26 @@ object CSVBenchmark extends SqlBasedBenchmark {
         dates.write.option("header", true).mode("overwrite").csv(dateDir)
       }
 
+      val timeDir = new File(path, "time").getAbsolutePath
+
+      def times = {
+        spark.range(0, rowsNum, 1, 1).mapPartitions { iter =>
+          iter.map(t => LocalTime.ofNanoOfDay((t % 86400000000L) * 1000000L))
+        }.select($"value".as("time"))
+      }
+
+      writeBench.addCase("Create a dataset of times", numIters) { _ =>
+        times.noop()
+      }
+
+      writeBench.addCase("to_csv(time)", numIters) { _ =>
+        times.select(to_csv(struct($"time"))).noop()
+      }
+
+      writeBench.addCase("write times to files", numIters) { _ =>
+        times.write.option("header", true).mode("overwrite").csv(timeDir)
+      }
+
       writeBench.run()
 
       val readBench = new Benchmark("Read dates and timestamps", rowsNum, output = output)
@@ -321,6 +341,20 @@ object CSVBenchmark extends SqlBasedBenchmark {
           spark.read.option("header", false)
             .option("inferSchema", true).csv(errorTimestampStr).noop()
         }
+      }
+
+      val timeSchema = new StructType().add("time", TimeType())
+
+      readBench.addCase("read time text from files", numIters) { _ =>
+        spark.read.text(timeDir).noop()
+      }
+
+      readBench.addCase("read time from files", numIters) { _ =>
+        val ds = spark.read
+          .option("header", true)
+          .schema(timeSchema)
+          .csv(timeDir)
+        ds.noop()
       }
 
       readBench.run()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonBenchmark.scala
@@ -365,6 +365,7 @@ object JsonBenchmark extends SqlBasedBenchmark {
   }
 
   private def datetimeBenchmark(rowsNum: Int, numIters: Int): Unit = {
+    spark.conf.set(SQLConf.TIME_TYPE_ENABLED.key, "true")
     def timestamps = {
       spark.range(0, rowsNum, 1, 1).mapPartitions { iter =>
         iter.map(Instant.ofEpochSecond(_))
@@ -411,7 +412,7 @@ object JsonBenchmark extends SqlBasedBenchmark {
 
       def times = {
         spark.range(0, rowsNum, 1, 1).mapPartitions { iter =>
-          iter.map(t => LocalTime.ofNanoOfDay((t % 86400000000L) * 1000000L))
+          iter.map(t => LocalTime.ofNanoOfDay(t % 86400000000000L))
         }.select($"value".as("time"))
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonBenchmark.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution.datasources.json
 
 import java.io.File
-import java.time.{Instant, LocalDate}
+import java.time.{Instant, LocalDate, LocalTime}
 
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.{Column, Dataset, Row}
@@ -407,6 +407,26 @@ object JsonBenchmark extends SqlBasedBenchmark {
         dates.write.option("header", true).mode("overwrite").json(dateDir)
       }
 
+      val timeDir = new File(path, "time").getAbsolutePath
+
+      def times = {
+        spark.range(0, rowsNum, 1, 1).mapPartitions { iter =>
+          iter.map(t => LocalTime.ofNanoOfDay((t % 86400000000L) * 1000000L))
+        }.select($"value".as("time"))
+      }
+
+      writeBench.addCase("Create a dataset of times", numIters) { _ =>
+        times.noop()
+      }
+
+      writeBench.addCase("to_json(time)", numIters) { _ =>
+        times.select(to_json(struct($"time"))).noop()
+      }
+
+      writeBench.addCase("write times to files", numIters) { _ =>
+        times.write.option("header", true).mode("overwrite").json(timeDir)
+      }
+
       writeBench.run()
 
       val readBench = new Benchmark("Read dates and timestamps", rowsNum, output = output)
@@ -506,6 +526,16 @@ object JsonBenchmark extends SqlBasedBenchmark {
         withSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key -> "LEGACY") {
           spark.read.option("inferTimestamp", true).json(errorTimestampStr).noop()
         }
+      }
+
+      val timeSchema = new StructType().add("time", TimeType())
+
+      readBench.addCase("read time text from files", numIters) { _ =>
+        spark.read.text(timeDir).noop()
+      }
+
+      readBench.addCase("read time from files", numIters) { _ =>
+        spark.read.schema(timeSchema).json(timeDir).noop()
       }
 
       readBench.run()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add TIME data type benchmarks:
- New `TimeBenchmark` covering current_time, make_time, to_time, hour/minute/second extraction, time_trunc, time_diff, TIME +/- interval, and LocalTime conversion/collection
- `ExtractBenchmark`: add TIME cases (HOUR, MINUTE, SECOND)
- `JsonBenchmark`: add TIME write/read cases
- `CSVBenchmark`: add TIME write/read cases
- `HashBenchmark`: add TIME column to normal schema
    
Add `TimeBenchmark` covering TIME data type functions: `current_time`, `make_time`, `to_time`, hour / minute / second extraction, `time_trunc`, `time_diff`, TIME + / - interval, and `LocalTime` conversion / collection.
    
### Why are the changes needed?
    
The SPIP (SPARK-51162, Q6) flagged performance regressions as the main risk. There was no TIME-specific benchmark until now.
    
### Does this PR introduce _any_ user-facing change?
    
No. Benchmark only.
    
### How was this patch tested?
    
All five benchmarks run successfully. Results generated via GitHub Actions Benchmarks workflow on Linux CI (AMD EPYC 7763 / OpenJDK 17.0.19).
    
### Was this patch authored or co-authored using generative AI tooling?
    
Co-Authored using Claude Opus 4.6