### PR TITLE
[SPARK-57719][SQL][TESTS] Move `IdentifierClauseParserSuite` to the catalyst parser package

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/IdentifierClauseParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/IdentifierClauseParserSuite.scala
@@ -15,12 +15,11 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql
+package org.apache.spark.sql.catalyst.parser
 
 import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, ExpressionWithUnresolvedIdentifier, UnresolvedAttribute, UnresolvedExtractValue, UnresolvedFunction, UnresolvedInlineTable, UnresolvedStar}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Cast, LambdaFunction, Literal, UnresolvedNamedLambdaVariable}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parsePlan
-import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoStatement, OneRowRelation, Pivot, Project, SubqueryAlias, Unpivot}
 import org.apache.spark.sql.catalyst.util.EvaluateUnresolvedInlineTable
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR moves `IdentifierClauseParserSuite` to `org.apache.spark.sql.catalyst.parser` (`sql/catalyst`) so its directory and package match.

### Why are the changes needed?

This file was introduced at Spark 4.1.1 by the following.
- https://github.com/apache/spark/pull/53407

https://github.com/apache/spark/blob/688064e691a63a44075dee769eb07ceed19068f6/sql/core/src/test/scala/org/apache/spark/sql/execution/command/IdentifierClauseParserSuite.scala#L18-L18

The suite is a Catalyst-level parser test (extends `AnalysisTest`, uses `CatalystSqlParser`) with no `sql/core` dependency, but it was placed under `execution/command` while declaring the top-level `org.apache.spark.sql` package. It's weird. Moving it next to the sibling parser suites fixes the directory/package mismatch.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8