### PR TITLE
[SPARK-57717][SQL] Pin BIN_BY_ENABLED explicitly in BIN BY tests

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveBinBySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveBinBySuite.scala
@@ -31,8 +31,7 @@ import org.apache.spark.sql.types._
 
 class ResolveBinBySuite extends AnalysisTest {
 
-  // Run the resolution tests with the operator enabled. The dedicated gate test below uses
-  // `super.test` to escape this wrapper and pins the flag off.
+  // Enable the operator for all tests here (the gate test opts out via `super.test`).
   override protected def test(testName: String, testTags: Tag*)(testFun: => Any)
                              (implicit pos: Position): Unit = {
     super.test(testName, testTags: _*) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveBinBySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveBinBySuite.scala
@@ -31,8 +31,8 @@ import org.apache.spark.sql.types._
 
 class ResolveBinBySuite extends AnalysisTest {
 
-  // BIN BY is gated off by default; run the resolution tests with it enabled. The dedicated
-  // gate test below uses `super.test` to observe the default-off behavior.
+  // Run the resolution tests with the operator enabled. The dedicated gate test below uses
+  // `super.test` to escape this wrapper and pins the flag off.
   override protected def test(testName: String, testTags: Tag*)(testFun: => Any)
                              (implicit pos: Position): Unit = {
     super.test(testName, testTags: _*) {
@@ -336,9 +336,10 @@ class ResolveBinBySuite extends AnalysisTest {
       "appended BinBy attributes must have distinct exprIds across the two join sides")
   }
 
-  // `super.test` escapes the suite-wide flag-on wrapper so this runs with the default (off).
-  super.test("BIN BY is gated off by default") {
-    assert(!SQLConf.get.getConf(SQLConf.BIN_BY_ENABLED))
-    expectError(unresolved(), "UNSUPPORTED_FEATURE.BIN_BY")
+  // `super.test` escapes the suite-wide flag-on wrapper; pin the flag off explicitly.
+  super.test("BIN BY is rejected when the operator is disabled") {
+    withSQLConf(SQLConf.BIN_BY_ENABLED.key -> "false") {
+      expectError(unresolved(), "UNSUPPORTED_FEATURE.BIN_BY")
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/BinBySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/BinBySuite.scala
@@ -58,17 +58,19 @@ class BinBySuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("BIN BY is gated off by default") {
-    withTempView("metrics") {
-      createMetricsView()
-      // Gated off, the operator is rejected at analysis with the same UNSUPPORTED_FEATURE.BIN_BY
-      // condition the execution stub raises when enabled.
-      checkError(
-        exception = intercept[SparkThrowable] {
-          spark.sql(binByQuery).queryExecution.assertAnalyzed()
-        },
-        condition = "UNSUPPORTED_FEATURE.BIN_BY",
-        parameters = Map.empty[String, String])
+  test("BIN BY is rejected when the operator is disabled") {
+    withSQLConf(SQLConf.BIN_BY_ENABLED.key -> "false") {
+      withTempView("metrics") {
+        createMetricsView()
+        // Disabled, the operator is rejected at analysis with the same UNSUPPORTED_FEATURE.BIN_BY
+        // condition the execution stub raises when enabled.
+        checkError(
+          exception = intercept[SparkThrowable] {
+            spark.sql(binByQuery).queryExecution.assertAnalyzed()
+          },
+          condition = "UNSUPPORTED_FEATURE.BIN_BY",
+          parameters = Map.empty[String, String])
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

The two BIN BY tests that assert the operator is rejected now pin `spark.sql.binByRelationOperator.enabled` explicitly (`= false`) via `withSQLConf`, instead of relying on the config's default:

- `BinBySuite` and `ResolveBinBySuite`: the "BIN BY is gated off by default" cases are renamed to "BIN BY is rejected when the operator is disabled" and wrap the query in `withSQLConf(BIN_BY_ENABLED.key -> "false")`.
- `ResolveBinBySuite` also drops the `assert(!SQLConf.get.getConf(BIN_BY_ENABLED))` check, which asserted the default value directly.

No production code changes; the config default stays `false`.

### Why are the changes needed?

Tests should not depend on a config's default value. A case that runs without pinning the flag fails in any environment that flips the config on (for example a config-flip CI lane), even though the behavior under test is unchanged. Pinning the flag explicitly keeps the suites self-contained and stable across those lanes.

### Does this PR introduce _any_ user-facing change?

No. Test-only change; the `spark.sql.binByRelationOperator.enabled` default is unchanged.

### How was this patch tested?

Ran the updated suites locally:

- `build/sbt 'catalyst/testOnly *ResolveBinBySuite'` (17 tests, all pass)
- `build/sbt 'sql/testOnly *BinBySuite'` (3 tests, all pass)

scalastyle is clean for both modules.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
