### PR TITLE
[SPARK-57560][SQL][TESTS] Add tests for TRY eval mode of TIME datetime arithmetic

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryEval.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryEval.scala
@@ -70,6 +70,10 @@ case class TryEval(child: Expression) extends UnaryExpression {
        2022-01-01
       > SELECT _FUNC_(timestamp'2021-01-01 00:00:00', interval 1 day);
        2021-01-02 00:00:00
+      > SELECT _FUNC_(time'09:00:00', interval 1 hour);
+       10:00:00
+      > SELECT _FUNC_(time'23:00:00', interval 2 hour);
+       NULL
       > SELECT _FUNC_(interval 1 year, interval 2 year);
        3-0
   """,
@@ -185,6 +189,10 @@ case class TryMod(left: Expression, right: Expression, replacement: Expression)
        2020-01-01
       > SELECT _FUNC_(timestamp'2021-01-02 00:00:00', interval 1 day);
        2021-01-01 00:00:00
+      > SELECT _FUNC_(time'09:00:00', interval 1 hour);
+       08:00:00
+      > SELECT _FUNC_(time'00:30:00', interval 1 hour);
+       NULL
       > SELECT _FUNC_(interval 2 year, interval 1 year);
        1-0
   """,

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/nonansi/try_arithmetic.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/nonansi/try_arithmetic.sql.out
@@ -139,6 +139,48 @@ Project [try_add(INTERVAL '02' SECOND, 2021-01-01 00:00:00) AS try_add(INTERVAL 
 
 
 -- !query
+SELECT try_add(time'08:00:00', interval 1 hour)
+-- !query analysis
+Project [try_add(08:00:00, INTERVAL '01' HOUR) AS try_add(TIME '08:00:00', INTERVAL '01' HOUR)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_add(interval 1 hour, time'08:00:00')
+-- !query analysis
+Project [try_add(INTERVAL '01' HOUR, 08:00:00) AS try_add(INTERVAL '01' HOUR, TIME '08:00:00')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_add(time'23:59:59.999999', interval 1 hour)
+-- !query analysis
+Project [try_add(23:59:59.999999, INTERVAL '01' HOUR) AS try_add(TIME '23:59:59.999999', INTERVAL '01' HOUR)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_add(time'00:00:00', interval -1 second)
+-- !query analysis
+Project [try_add(00:00:00, INTERVAL '-01' SECOND) AS try_add(TIME '00:00:00', INTERVAL '-01' SECOND)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_add(time'08:30:00', null)
+-- !query analysis
+Project [try_add(08:30:00, null) AS try_add(TIME '08:30:00', NULL)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_add(null, interval 1 hour)
+-- !query analysis
+Project [try_add(null, INTERVAL '01' HOUR) AS try_add(NULL, INTERVAL '01' HOUR)#x]
++- OneRowRelation
+
+
+-- !query
 SELECT try_add(interval 2 year, interval 2 year)
 -- !query analysis
 Project [try_add(INTERVAL '2' YEAR, INTERVAL '2' YEAR) AS try_add(INTERVAL '2' YEAR, INTERVAL '2' YEAR)#x]
@@ -397,6 +439,55 @@ Project [try_subtract(INTERVAL '2147483647' MONTH, INTERVAL '-2' MONTH) AS try_s
 SELECT try_subtract(interval 106751991 day, interval -3 day)
 -- !query analysis
 Project [try_subtract(INTERVAL '106751991' DAY, INTERVAL '-3' DAY) AS try_subtract(INTERVAL '106751991' DAY, INTERVAL '-3' DAY)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_subtract(time'10:00:00', interval 1 hour)
+-- !query analysis
+Project [try_subtract(10:00:00, INTERVAL '01' HOUR) AS try_subtract(TIME '10:00:00', INTERVAL '01' HOUR)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_subtract(time'00:30:00', interval 1 hour)
+-- !query analysis
+Project [try_subtract(00:30:00, INTERVAL '01' HOUR) AS try_subtract(TIME '00:30:00', INTERVAL '01' HOUR)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_subtract(time'00:00:00', interval 1 second)
+-- !query analysis
+Project [try_subtract(00:00:00, INTERVAL '01' SECOND) AS try_subtract(TIME '00:00:00', INTERVAL '01' SECOND)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_subtract(time'10:00:00', null)
+-- !query analysis
+Project [try_subtract(10:00:00, null) AS try_subtract(TIME '10:00:00', NULL)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_subtract(time'10:00:00', time'08:00:00')
+-- !query analysis
+Project [try_subtract(10:00:00, 08:00:00) AS try_subtract(TIME '10:00:00', TIME '08:00:00')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_subtract(time'08:00:00.123456', time'10:00:00')
+-- !query analysis
+Project [try_subtract(08:00:00.123456, 10:00:00) AS try_subtract(TIME '08:00:00.123456', TIME '10:00:00')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_subtract(null, time'08:00:00')
+-- !query analysis
+Project [try_subtract(null, 08:00:00) AS try_subtract(NULL, TIME '08:00:00')#x]
 +- OneRowRelation
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/try_arithmetic.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/try_arithmetic.sql.out
@@ -139,6 +139,48 @@ Project [try_add(INTERVAL '02' SECOND, 2021-01-01 00:00:00) AS try_add(INTERVAL 
 
 
 -- !query
+SELECT try_add(time'08:00:00', interval 1 hour)
+-- !query analysis
+Project [try_add(08:00:00, INTERVAL '01' HOUR) AS try_add(TIME '08:00:00', INTERVAL '01' HOUR)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_add(interval 1 hour, time'08:00:00')
+-- !query analysis
+Project [try_add(INTERVAL '01' HOUR, 08:00:00) AS try_add(INTERVAL '01' HOUR, TIME '08:00:00')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_add(time'23:59:59.999999', interval 1 hour)
+-- !query analysis
+Project [try_add(23:59:59.999999, INTERVAL '01' HOUR) AS try_add(TIME '23:59:59.999999', INTERVAL '01' HOUR)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_add(time'00:00:00', interval -1 second)
+-- !query analysis
+Project [try_add(00:00:00, INTERVAL '-01' SECOND) AS try_add(TIME '00:00:00', INTERVAL '-01' SECOND)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_add(time'08:30:00', null)
+-- !query analysis
+Project [try_add(08:30:00, null) AS try_add(TIME '08:30:00', NULL)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_add(null, interval 1 hour)
+-- !query analysis
+Project [try_add(null, INTERVAL '01' HOUR) AS try_add(NULL, INTERVAL '01' HOUR)#x]
++- OneRowRelation
+
+
+-- !query
 SELECT try_add(interval 2 year, interval 2 year)
 -- !query analysis
 Project [try_add(INTERVAL '2' YEAR, INTERVAL '2' YEAR) AS try_add(INTERVAL '2' YEAR, INTERVAL '2' YEAR)#x]
@@ -397,6 +439,55 @@ Project [try_subtract(INTERVAL '2147483647' MONTH, INTERVAL '-2' MONTH) AS try_s
 SELECT try_subtract(interval 106751991 day, interval -3 day)
 -- !query analysis
 Project [try_subtract(INTERVAL '106751991' DAY, INTERVAL '-3' DAY) AS try_subtract(INTERVAL '106751991' DAY, INTERVAL '-3' DAY)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_subtract(time'10:00:00', interval 1 hour)
+-- !query analysis
+Project [try_subtract(10:00:00, INTERVAL '01' HOUR) AS try_subtract(TIME '10:00:00', INTERVAL '01' HOUR)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_subtract(time'00:30:00', interval 1 hour)
+-- !query analysis
+Project [try_subtract(00:30:00, INTERVAL '01' HOUR) AS try_subtract(TIME '00:30:00', INTERVAL '01' HOUR)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_subtract(time'00:00:00', interval 1 second)
+-- !query analysis
+Project [try_subtract(00:00:00, INTERVAL '01' SECOND) AS try_subtract(TIME '00:00:00', INTERVAL '01' SECOND)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_subtract(time'10:00:00', null)
+-- !query analysis
+Project [try_subtract(10:00:00, null) AS try_subtract(TIME '10:00:00', NULL)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_subtract(time'10:00:00', time'08:00:00')
+-- !query analysis
+Project [try_subtract(10:00:00, 08:00:00) AS try_subtract(TIME '10:00:00', TIME '08:00:00')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_subtract(time'08:00:00.123456', time'10:00:00')
+-- !query analysis
+Project [try_subtract(08:00:00.123456, 10:00:00) AS try_subtract(TIME '08:00:00.123456', TIME '10:00:00')#x]
++- OneRowRelation
+
+
+-- !query
+SELECT try_subtract(null, time'08:00:00')
+-- !query analysis
+Project [try_subtract(null, 08:00:00) AS try_subtract(NULL, TIME '08:00:00')#x]
 +- OneRowRelation
 
 

--- a/sql/core/src/test/resources/sql-tests/inputs/try_arithmetic.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/try_arithmetic.sql
@@ -27,6 +27,14 @@ SELECT try_add(timestamp_ntz'2021-01-01 00:00:00', interval 2 second);
 SELECT try_add(interval 2 year, timestamp_ltz'2021-01-01 00:00:00');
 SELECT try_add(interval 2 second, timestamp_ntz'2021-01-01 00:00:00');
 
+-- Time + Interval
+SELECT try_add(time'08:00:00', interval 1 hour);
+SELECT try_add(interval 1 hour, time'08:00:00');
+SELECT try_add(time'23:59:59.999999', interval 1 hour);
+SELECT try_add(time'00:00:00', interval -1 second);
+SELECT try_add(time'08:30:00', null);
+SELECT try_add(null, interval 1 hour);
+
 -- Interval + Interval
 SELECT try_add(interval 2 year, interval 2 year);
 SELECT try_add(interval 2 second, interval 2 second);
@@ -71,6 +79,17 @@ SELECT try_subtract(interval 2 year, interval 3 year);
 SELECT try_subtract(interval 3 second, interval 2 second);
 SELECT try_subtract(interval 2147483647 month, interval -2 month);
 SELECT try_subtract(interval 106751991 day, interval -3 day);
+
+-- Time - Interval
+SELECT try_subtract(time'10:00:00', interval 1 hour);
+SELECT try_subtract(time'00:30:00', interval 1 hour);
+SELECT try_subtract(time'00:00:00', interval 1 second);
+SELECT try_subtract(time'10:00:00', null);
+
+-- Time - Time
+SELECT try_subtract(time'10:00:00', time'08:00:00');
+SELECT try_subtract(time'08:00:00.123456', time'10:00:00');
+SELECT try_subtract(null, time'08:00:00');
 
 -- Numeric * Numeric
 SELECT try_multiply(2, 3);

--- a/sql/core/src/test/resources/sql-tests/results/nonansi/try_arithmetic.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/nonansi/try_arithmetic.sql.out
@@ -168,6 +168,54 @@ struct<try_add(INTERVAL '02' SECOND, TIMESTAMP_NTZ '2021-01-01 00:00:00'):timest
 
 
 -- !query
+SELECT try_add(time'08:00:00', interval 1 hour)
+-- !query schema
+struct<try_add(TIME '08:00:00', INTERVAL '01' HOUR):time(6)>
+-- !query output
+09:00:00
+
+
+-- !query
+SELECT try_add(interval 1 hour, time'08:00:00')
+-- !query schema
+struct<try_add(INTERVAL '01' HOUR, TIME '08:00:00'):time(6)>
+-- !query output
+09:00:00
+
+
+-- !query
+SELECT try_add(time'23:59:59.999999', interval 1 hour)
+-- !query schema
+struct<try_add(TIME '23:59:59.999999', INTERVAL '01' HOUR):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_add(time'00:00:00', interval -1 second)
+-- !query schema
+struct<try_add(TIME '00:00:00', INTERVAL '-01' SECOND):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_add(time'08:30:00', null)
+-- !query schema
+struct<try_add(TIME '08:30:00', NULL):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_add(null, interval 1 hour)
+-- !query schema
+struct<try_add(NULL, INTERVAL '01' HOUR):interval hour>
+-- !query output
+NULL
+
+
+-- !query
 SELECT try_add(interval 2 year, interval 2 year)
 -- !query schema
 struct<try_add(INTERVAL '2' YEAR, INTERVAL '2' YEAR):interval year>
@@ -461,6 +509,62 @@ NULL
 SELECT try_subtract(interval 106751991 day, interval -3 day)
 -- !query schema
 struct<try_subtract(INTERVAL '106751991' DAY, INTERVAL '-3' DAY):interval day>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_subtract(time'10:00:00', interval 1 hour)
+-- !query schema
+struct<try_subtract(TIME '10:00:00', INTERVAL '01' HOUR):time(6)>
+-- !query output
+09:00:00
+
+
+-- !query
+SELECT try_subtract(time'00:30:00', interval 1 hour)
+-- !query schema
+struct<try_subtract(TIME '00:30:00', INTERVAL '01' HOUR):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_subtract(time'00:00:00', interval 1 second)
+-- !query schema
+struct<try_subtract(TIME '00:00:00', INTERVAL '01' SECOND):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_subtract(time'10:00:00', null)
+-- !query schema
+struct<try_subtract(TIME '10:00:00', NULL):interval hour to second>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_subtract(time'10:00:00', time'08:00:00')
+-- !query schema
+struct<try_subtract(TIME '10:00:00', TIME '08:00:00'):interval hour to second>
+-- !query output
+0 02:00:00.000000000
+
+
+-- !query
+SELECT try_subtract(time'08:00:00.123456', time'10:00:00')
+-- !query schema
+struct<try_subtract(TIME '08:00:00.123456', TIME '10:00:00'):interval hour to second>
+-- !query output
+-0 01:59:59.876544000
+
+
+-- !query
+SELECT try_subtract(null, time'08:00:00')
+-- !query schema
+struct<try_subtract(NULL, TIME '08:00:00'):interval hour to second>
 -- !query output
 NULL
 

--- a/sql/core/src/test/resources/sql-tests/results/try_arithmetic.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/try_arithmetic.sql.out
@@ -214,6 +214,54 @@ struct<try_add(INTERVAL '02' SECOND, TIMESTAMP_NTZ '2021-01-01 00:00:00'):timest
 
 
 -- !query
+SELECT try_add(time'08:00:00', interval 1 hour)
+-- !query schema
+struct<try_add(TIME '08:00:00', INTERVAL '01' HOUR):time(6)>
+-- !query output
+09:00:00
+
+
+-- !query
+SELECT try_add(interval 1 hour, time'08:00:00')
+-- !query schema
+struct<try_add(INTERVAL '01' HOUR, TIME '08:00:00'):time(6)>
+-- !query output
+09:00:00
+
+
+-- !query
+SELECT try_add(time'23:59:59.999999', interval 1 hour)
+-- !query schema
+struct<try_add(TIME '23:59:59.999999', INTERVAL '01' HOUR):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_add(time'00:00:00', interval -1 second)
+-- !query schema
+struct<try_add(TIME '00:00:00', INTERVAL '-01' SECOND):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_add(time'08:30:00', null)
+-- !query schema
+struct<try_add(TIME '08:30:00', NULL):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_add(null, interval 1 hour)
+-- !query schema
+struct<try_add(NULL, INTERVAL '01' HOUR):interval hour>
+-- !query output
+NULL
+
+
+-- !query
 SELECT try_add(interval 2 year, interval 2 year)
 -- !query schema
 struct<try_add(INTERVAL '2' YEAR, INTERVAL '2' YEAR):interval year>
@@ -599,6 +647,62 @@ NULL
 SELECT try_subtract(interval 106751991 day, interval -3 day)
 -- !query schema
 struct<try_subtract(INTERVAL '106751991' DAY, INTERVAL '-3' DAY):interval day>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_subtract(time'10:00:00', interval 1 hour)
+-- !query schema
+struct<try_subtract(TIME '10:00:00', INTERVAL '01' HOUR):time(6)>
+-- !query output
+09:00:00
+
+
+-- !query
+SELECT try_subtract(time'00:30:00', interval 1 hour)
+-- !query schema
+struct<try_subtract(TIME '00:30:00', INTERVAL '01' HOUR):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_subtract(time'00:00:00', interval 1 second)
+-- !query schema
+struct<try_subtract(TIME '00:00:00', INTERVAL '01' SECOND):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_subtract(time'10:00:00', null)
+-- !query schema
+struct<try_subtract(TIME '10:00:00', NULL):interval hour to second>
+-- !query output
+NULL
+
+
+-- !query
+SELECT try_subtract(time'10:00:00', time'08:00:00')
+-- !query schema
+struct<try_subtract(TIME '10:00:00', TIME '08:00:00'):interval hour to second>
+-- !query output
+0 02:00:00.000000000
+
+
+-- !query
+SELECT try_subtract(time'08:00:00.123456', time'10:00:00')
+-- !query schema
+struct<try_subtract(TIME '08:00:00.123456', TIME '10:00:00'):interval hour to second>
+-- !query output
+-0 01:59:59.876544000
+
+
+-- !query
+SELECT try_subtract(null, time'08:00:00')
+-- !query schema
+struct<try_subtract(NULL, TIME '08:00:00'):interval hour to second>
 -- !query output
 NULL
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Today `try_add`/`try_subtract` already work over TIME values, but that path was never covered by tests. This PR adds that coverage and documents it, so that TIME arithmetic in TRY mode is guaranteed to return `NULL` instead of failing when the result falls outside the valid time range `[00:00, 24:00)`.

For example, adding an hour that pushes a time past midnight, or subtracting below `00:00`, now reliably yields `NULL`:

```sql
-- overflow past 24:00 -> NULL instead of an error
SELECT try_add(TIME'23:00:00', INTERVAL 2 HOUR);
 NULL

-- underflow below 00:00 -> NULL
SELECT try_subtract(TIME'00:30:00', INTERVAL 1 HOUR);
 NULL

-- in-range arithmetic keeps working as usual
SELECT try_add(TIME'08:00:00', INTERVAL 1 HOUR);
 09:00:00

SELECT try_subtract(TIME'10:00:00', INTERVAL 1 HOUR);
 09:00:00

-- TIME - TIME returns a day-time interval (never overflows)
SELECT try_subtract(TIME'10:00:00', TIME'08:00:00');
 0 02:00:00.000000000
```

Under the hood no new behavior is needed: `try_add`/`try_subtract` over TIME go through the existing generic `TryEval(Add/Subtract(..., EvalMode.ANSI))` fallback in `TryEval`. Since `InheritAnalysisRules` exposes the replacement as a child, `BinaryArithmeticWithDatetimeResolver` resolves the inner `Add`/`Subtract` to `TimeAddInterval`/`SubtractTimes`, and `TryEval` suppresses the resulting `DATETIME_OVERFLOW` error to `NULL` -- exactly how `TIMESTAMP`/`DATE` try arithmetic already behaves.

Concretely, this PR:
- Adds `try_add`/`try_subtract` TIME cases to `try_arithmetic.sql` (in-range results, overflow/underflow to NULL, NULL propagation, and `TIME - TIME` returning a day-time interval) and regenerates the golden files (including the `nonansi` and `analyzer-results` variants).
- Adds TIME examples to the `try_add`/`try_subtract` `@ExpressionDescription`.

### Why are the changes needed?
`TryEval` carried a TODO to support TRY eval mode on datetime arithmetic expressions. TIME arithmetic (`TimeAddInterval`, `SubtractTimes`) is in this family; without explicit coverage, `try_*` usage over TIME was untested. This guarantees that TRY-mode TIME arithmetic returns NULL (not an error) on out-of-range results, consistent with the other datetime types.

### Does this PR introduce _any_ user-facing change?
No behavior change. It adds tests and documentation examples for `try_add`/`try_subtract` over TIME.

### How was this patch tested?
- Added cases to `try_arithmetic.sql` and regenerated golden files.
- `build/sbt 'sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z try_arithmetic'`
- `build/sbt 'sql/testOnly org.apache.spark.sql.expressions.ExpressionInfoSuite -- -z "check outputs of expression examples"'`

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Cursor