### PR TITLE
[SPARK-57571][SQL] Support TIME predicate pushdown to ORC

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilters.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.orc
 
-import java.time.{Duration, Instant, LocalDate, LocalDateTime, Period}
+import java.time.{Duration, Instant, LocalDate, LocalDateTime, LocalTime, Period}
 
 import org.apache.hadoop.hive.common.`type`.HiveDecimal
 import org.apache.hadoop.hive.ql.io.sarg.{PredicateLeaf, SearchArgument}
@@ -25,7 +25,7 @@ import org.apache.hadoop.hive.ql.io.sarg.SearchArgument.Builder
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory.newBuilder
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable
 
-import org.apache.spark.sql.catalyst.util.DateTimeUtils.{instantToMicros, localDateTimeToMicros, localDateToDays, toJavaDate, toJavaTimestamp}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.{instantToMicros, localDateTimeToMicros, localDateToDays, localTimeToNanos, toJavaDate, toJavaTimestamp}
 import org.apache.spark.sql.catalyst.util.IntervalUtils
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
@@ -142,7 +142,7 @@ private[sql] object OrcFilters extends OrcFiltersBase {
   def getPredicateLeafType(dataType: DataType): PredicateLeaf.Type = dataType match {
     case BooleanType => PredicateLeaf.Type.BOOLEAN
     case ByteType | ShortType | IntegerType | LongType |
-         _: AnsiIntervalType | TimestampNTZType => PredicateLeaf.Type.LONG
+         _: AnsiIntervalType | TimestampNTZType | _: TimeType => PredicateLeaf.Type.LONG
     case FloatType | DoubleType => PredicateLeaf.Type.FLOAT
     case StringType => PredicateLeaf.Type.STRING
     case DateType => PredicateLeaf.Type.DATE
@@ -170,6 +170,8 @@ private[sql] object OrcFilters extends OrcFiltersBase {
       toJavaTimestamp(instantToMicros(value.asInstanceOf[Instant]))
     case _: TimestampNTZType if value.isInstanceOf[LocalDateTime] =>
       localDateTimeToMicros(value.asInstanceOf[LocalDateTime])
+    case _: TimeType if value.isInstanceOf[LocalTime] =>
+      localTimeToNanos(value.asInstanceOf[LocalTime])
     case _: YearMonthIntervalType =>
       IntervalUtils.periodToMonths(value.asInstanceOf[Period]).longValue()
     case _: DayTimeIntervalType =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources.orc
 import java.math.MathContext
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
-import java.time.{Duration, LocalDateTime, Period}
+import java.time.{Duration, LocalDateTime, LocalTime, Period}
 
 import scala.jdk.CollectionConverters._
 
@@ -361,6 +361,39 @@ class OrcFilterSuite extends OrcTest with SharedSparkSession {
           Literal(localDateTimes(0)) >= $"_1",
           PredicateLeaf.Operator.LESS_THAN_EQUALS)
         checkFilterPredicate(Literal(localDateTimes(3)) <= $"_1", PredicateLeaf.Operator.LESS_THAN)
+      }
+    }
+  }
+
+  test("SPARK-57571: filter pushdown - time") {
+    val times = Seq(
+      LocalTime.of(1, 2, 3),
+      LocalTime.of(8, 11, 22),
+      LocalTime.of(14, 30, 0),
+      LocalTime.of(23, 59, 59))
+    withOrcFile(times.map(Tuple1(_))) { path =>
+      readFile(path) { implicit df =>
+        checkFilterPredicate($"_1".isNull, PredicateLeaf.Operator.IS_NULL)
+
+        checkFilterPredicate($"_1" === times(0), PredicateLeaf.Operator.EQUALS)
+        checkFilterPredicate($"_1" <=> times(0), PredicateLeaf.Operator.NULL_SAFE_EQUALS)
+
+        checkFilterPredicate($"_1" < times(1), PredicateLeaf.Operator.LESS_THAN)
+        checkFilterPredicate($"_1" > times(2), PredicateLeaf.Operator.LESS_THAN_EQUALS)
+        checkFilterPredicate($"_1" <= times(0), PredicateLeaf.Operator.LESS_THAN_EQUALS)
+        checkFilterPredicate($"_1" >= times(3), PredicateLeaf.Operator.LESS_THAN)
+
+        checkFilterPredicate(Literal(times(0)) === $"_1", PredicateLeaf.Operator.EQUALS)
+        checkFilterPredicate(
+          Literal(times(0)) <=> $"_1", PredicateLeaf.Operator.NULL_SAFE_EQUALS)
+        checkFilterPredicate(Literal(times(1)) > $"_1", PredicateLeaf.Operator.LESS_THAN)
+        checkFilterPredicate(
+          Literal(times(2)) < $"_1",
+          PredicateLeaf.Operator.LESS_THAN_EQUALS)
+        checkFilterPredicate(
+          Literal(times(0)) >= $"_1",
+          PredicateLeaf.Operator.LESS_THAN_EQUALS)
+        checkFilterPredicate(Literal(times(3)) <= $"_1", PredicateLeaf.Operator.LESS_THAN)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds TIME type predicate pushdown support to the ORC reader in `OrcFilters.scala`. Two methods are extended:

- `getPredicateLeafType`: adds a `TimeType` case that maps to `PredicateLeaf.Type.LONG`, grouped with the existing `TimestampNTZType`/`AnsiIntervalType` LONG cases.
- `castLiteralValue`: adds a `TimeType` case that converts a `java.time.LocalTime` literal to its nanos-of-day representation via `DateTimeUtils.localTimeToNanos`.

Two imports are added: `java.time.LocalTime` and `DateTimeUtils.localTimeToNanos`.

The leaf-builder (`buildLeafSearchArgument`) is type-agnostic. It calls `getPredicateLeafType` and `castLiteralValue` generically for all comparison operators. Once both helpers handle `TimeType`, all supported comparisons (EqualTo, EqualNullSafe, LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual, In, IsNull, IsNotNull) push down automatically with no operator-specific code and no SARG-tree changes.

A correctness note on the value unit: the literal is converted to **nanos-of-day**, not micros-of-day. The already-merged Parquet TIME pushdown (SPARK-51687) uses micros because Parquet's logical TIME type is defined in microseconds. ORC differs. The native ORC TIME read/write path (SPARK-54472) persists Spark's internal long representation, which stores nanos-of-day. The pushed-down literal must use nanos to match what is stored in the ORC file. Using micros here would produce a silent correctness bug where predicates filter against the wrong scale.

### Why are the changes needed?

`OrcFilters` handled Date, Timestamp, and TimestampNTZ predicate pushdown but had no `TimeType` case. Without this change, any predicate on a TIME column over ORC is never pushed to the reader. The engine performs a full stripe/row-group scan and evaluates the filter only after reading all rows into memory.

This is a sub-task of SPARK-57550 (extend TIME type support across Spark). The TIME data type was added by SPIP SPARK-51162 and shipped in Spark 4.1.0. Native ORC read/write for TIME landed in SPARK-54472. Predicate pushdown is the remaining gap for ORC to treat TIME on par with other temporal types.

### Does this PR introduce _any_ user-facing change?

No change to query results. Queries that filter on a TIME column stored in ORC format now push the predicate to the ORC reader, reducing the number of rows and stripes read during a scan.

### How was this patch tested?

A new test was added to `OrcFilterSuite` named `"SPARK-57571: filter pushdown - time"`, modeled on the existing `timestamp_ntz` sibling test. The test writes `LocalTime` values to an ORC file and asserts the correct SARG operator for IsNull, EqualTo, null-safe-equals, LessThan, LessThanOrEqual, GreaterThan, and GreaterThanOrEqual pushdown in both column-op-literal and literal-op-column forms.

The test suite was not run locally (the dev desktop cannot complete a full Spark build without OOM). Verification relies on GitHub Actions CI on the fork.

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated using Kiro (Claude Opus 4.8)