### PR TITLE
[SPARK-57724][SQL] Add missing error class MISSING_CLAUSES_FOR_OPERATION

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5542,6 +5542,12 @@
     },
     "sqlState" : "0A000"
   },
+  "MISSING_CLAUSES_FOR_OPERATION" : {
+    "message" : [
+      "Missing required clause(s) <clauses> for operation <operation>."
+    ],
+    "sqlState" : "42601"
+  },
   "MISSING_DATABASE_FOR_V1_SESSION_CATALOG" : {
     "message" : [
       "Database name is not specified in the v1 session catalog. Please ensure to provide a valid database name when interacting with the v1 catalog."

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -788,4 +788,48 @@ class QueryParsingErrorsSuite extends SharedSparkSession {
         start = 33,
         stop = 41))
   }
+
+  test("MISSING_CLAUSES_FOR_OPERATION: metric view creation without WITH METRICS") {
+    val query =
+      """CREATE VIEW mv
+        |LANGUAGE YAML
+        |AS
+        |$$
+        |version: 0.1
+        |$$""".stripMargin
+
+    checkError(
+      exception = parseException(query),
+      condition = "MISSING_CLAUSES_FOR_OPERATION",
+      sqlState = "42601",
+      parameters = Map(
+        "clauses" -> "WITH METRICS",
+        "operation" -> "METRIC VIEW CREATION"),
+      context = ExpectedContext(
+        fragment = query,
+        start = 0,
+        stop = query.length - 1))
+  }
+
+  test("MISSING_CLAUSES_FOR_OPERATION: metric view creation without LANGUAGE") {
+    val query =
+      """CREATE VIEW mv
+        |WITH METRICS
+        |AS
+        |$$
+        |version: 0.1
+        |$$""".stripMargin
+
+    checkError(
+      exception = parseException(query),
+      condition = "MISSING_CLAUSES_FOR_OPERATION",
+      sqlState = "42601",
+      parameters = Map(
+        "clauses" -> "LANGUAGE",
+        "operation" -> "METRIC VIEW CREATION"),
+      context = ExpectedContext(
+        fragment = query,
+        start = 0,
+        stop = query.length - 1))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

SPARK-54405 (METRIC VIEW) introduced error handling that throws the `MISSING_CLAUSES_FOR_OPERATION` error class from `QueryParsingErrors.missingClausesForOperation`, but never registered it in `error-conditions.json`. Register the error condition so the error class resolves correctly through the error-handling framework.

### Why are the changes needed?
This error class was used but not declared. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No tests

Generated-by: Opus 4.8
