### PR TITLE
[SPARK-57590][SQL] Read and infer Parquet schema from tar and zip archives

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
@@ -186,20 +186,9 @@ abstract class ArchiveReader(path: Path) {
   }
 
   /**
-   * Materializes each archive entry to a file under `localDir` and yields `(entryName, localFile)`
-   * for every entry kept by `entryFilter`. This is the counterpart to [[readEntries]] for formats
-   * that cannot be parsed from a streaming `InputStream` and instead need random access to a
-   * complete file (e.g. Parquet/ORC, which read a trailing footer). Entries are materialized one at
-   * a time as the returned iterator advances, so a caller that consumes sequentially and deletes
-   * each file after use keeps at most one entry in `localDir` at a time. The caller owns the
-   * lifetime of the produced files and of `localDir`.
-   *
-   * @param conf Hadoop conf used to open and decompress the archive.
-   * @param localDir an existing local directory the entries are written into.
-   * @param entryFilter keeps only entries whose name satisfies it; entries that fail it are skipped
-   *                    without being written to disk. Defaults to keeping every entry that
-   *                    [[readEntries]] surfaces (i.e. non-directory, non-dotfile entries).
-   * @return an iterator of `(entry name, local file)`; each file lives until the caller deletes it.
+   * Materializes each kept entry to a file under `localDir` as `(entryName, localFile)`, lazily one
+   * at a time -- the [[readEntries]] counterpart for random-access formats (Parquet/ORC footers).
+   * The caller owns the produced files and `localDir`.
    */
   final def localizeEntries(
       conf: Configuration,
@@ -291,16 +280,9 @@ object ArchiveReader extends Logging {
   }
 
   /**
-   * Copies one archive entry's bytes to a fresh file under `localDir`, used by
-   * [[ArchiveReader.localizeEntries]] to localize entries for random-access formats. The entry
-   * stream is not closed here (the reader owns the underlying archive stream); the output file is.
-   * Uniqueness comes from [[File.createTempFile]], so entries that share a basename across archive
-   * subdirectories never collide; the sanitized basename is kept only as a readable suffix.
-   *
-   * @param in bytes of one archive entry.
-   * @param localDir an existing local directory the file is created in.
-   * @param entryName the entry's name within the archive, used only to derive a readable file name.
-   * @return the local file the entry was written to.
+   * Copies one entry's bytes to a fresh, uniquely-named file under `localDir` (entries sharing a
+   * basename across archive subdirs won't collide). The entry stream is left open (the reader owns
+   * it); the output file is closed.
    */
   private def copyEntryToLocalFile(in: InputStream, localDir: File, entryName: String): File = {
     val rawBasename = entryName.substring(entryName.lastIndexOf('/') + 1)
@@ -312,13 +294,9 @@ object ArchiveReader extends Logging {
   }
 
   /**
-   * Reads an archive of random-access files: each kept entry is unpacked to a temp file under a
-   * fresh local dir and read with `readOne`. The counterpart to [[readEntries]] for formats that
-   * need a complete file (Parquet/ORC footers, Excel). Entries are unpacked one at a time, each
-   * reader and temp file released before the next opens; the temp dir, current reader, and archive
-   * stream are released on task completion, so an abandoned read (e.g. a `LIMIT`) does not leak.
-   * The per-entry [[PartitionedFile]] points at the temp file but keeps the archive's path and
-   * modification time, so `input_file_name()` / `_metadata` still report the archive.
+   * Reads an archive of random-access files -- the [[readEntries]] counterpart for formats needing
+   * a complete file (Parquet/ORC footers, Excel). The per-entry [[PartitionedFile]] keeps the
+   * archive's path, so `input_file_name()`/`_metadata` report it.
    */
   def readLocalizedEntries(
       file: PartitionedFile,
@@ -447,8 +425,8 @@ object ArchiveReader extends Logging {
 
   /**
    * Driver-side schema inference for random-access archive formats: `looseInfer` seeds from loose
-   * files, then each archive folds into the seed via `foldEntries`, one entry on disk at a time
-   * (missing/corrupt skipped per the ignore flags). `mergeSchema` off samples one schema.
+   * files; each archive's entries fold in one at a time -- `inferOne` reads one unpacked entry,
+   * `mergeSchemas` combines it -- deleting each before the next. `mergeSchema` off samples one.
    */
   def inferArchiveSchema(
       files: Seq[FileStatus],
@@ -458,15 +436,22 @@ object ArchiveReader extends Logging {
       ignoreMissingFiles: Boolean,
       ignoreCorruptFiles: Boolean,
       mergeSchema: Boolean,
-      looseInfer: Seq[FileStatus] => Option[StructType])(
-      foldEntries: (Option[StructType], Iterator[(String, File)]) => Option[StructType])
-      : Option[StructType] = {
+      looseInfer: Seq[FileStatus] => Option[StructType],
+      inferOne: File => Option[StructType],
+      mergeSchemas: (StructType, StructType) => StructType): Option[StructType] = {
     val (archives, nonArchives) = files.partition(f => isArchivePath(f.getPath))
     val tempDir = Utils.createTempDir(namePrefix = tempPrefix)
     def foldArchive(archive: FileStatus, seed: Option[StructType], limit: Int): Option[StructType] =
       withLocalizedArchive(
         archive, conf, tempDir, entryFilter, ignoreMissingFiles, ignoreCorruptFiles,
-        onSkip = seed)(entries => foldEntries(seed, entries.take(limit)))
+        onSkip = seed) { entries =>
+        var merged = seed
+        entries.take(limit).foreach { case (_, file) =>
+          try inferOne(file).foreach(s => merged = Some(merged.fold(s)(mergeSchemas(_, s))))
+          finally file.delete()
+        }
+        merged
+      }
     try {
       val looseSchema = if (nonArchives.nonEmpty) looseInfer(nonArchives) else None
       if (mergeSchema) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
@@ -107,6 +107,12 @@ abstract class ArchiveReader(path: Path) {
    * Entry skipping mirrors Spark's file listing: `ignoredPathSegmentRegex` is the effective filter
    * (the `ignoredPathSegmentRegex` data source option), so callers reading with a custom filter
    * must pass its compiled form here for archive entries to be filtered like loose files.
+   *
+   * @param conf Hadoop configuration used to open the archive stream.
+   * @param ignoredPathSegmentRegex the effective path-segment filter (the `ignoredPathSegmentRegex`
+   *                                data source option); entries matching it are skipped.
+   * @param parseEntry turns one entry's `(name, stream)` into an iterator of results.
+   * @return an iterator over the concatenated per-entry results; also [[Closeable]].
    */
   def readEntries[T](
       conf: Configuration,
@@ -187,9 +193,14 @@ abstract class ArchiveReader(path: Path) {
 
   /**
    * Materializes each kept entry to a file under `localDir` as `(entryName, localFile)`, lazily one
-   * at a time -- the [[readEntries]] counterpart for random-access formats (Parquet/ORC footers).
+   * at a time -- for random-access formats (Parquet/ORC footers).
+   *
+   * @param conf Hadoop configuration used to open the archive stream.
+   * @param localDir directory the entry files are written under.
+   * @param entryFilter keeps only entries whose name satisfies it; others are skipped.
+   * @return an iterator yielding each kept entry's `(name, localFile)`.
    */
-  final def localizeEntries(
+  private def localizeEntries(
       conf: Configuration,
       localDir: File,
       entryFilter: String => Boolean = _ => true): Iterator[(String, File)] =
@@ -291,16 +302,24 @@ object ArchiveReader extends Logging {
   }
 
   /**
-   * Reads an archive of random-access files -- the [[readEntries]] counterpart for formats needing
-   * a complete file (Parquet/ORC, Excel). The per-entry [[PartitionedFile]] keeps the
-   * archive's path, so `input_file_name()`/`_metadata` report it.
+   * Reads an archive of random-access files for formats needing a complete file (Parquet/ORC,
+   * Excel): each kept entry is unpacked to a local temp file and `readEntry` is applied to it, and
+   * the per-entry results are concatenated. The per-entry [[PartitionedFile]] keeps the archive's
+   * path, so `input_file_name()`/`_metadata` report it.
+   *
+   * @param file the archive [[PartitionedFile]].
+   * @param conf Hadoop configuration used to open the archive stream.
+   * @param entryFilter keeps only entries whose name satisfies it; others are skipped.
+   * @param tempPrefix name prefix for the temp dir the entries are unpacked into.
+   * @param readEntry reads one unpacked entry (as a [[PartitionedFile]]) into rows.
+   * @return an iterator over the concatenated per-entry rows; also [[Closeable]].
    */
   def readLocalizedEntries(
       file: PartitionedFile,
       conf: Configuration,
       entryFilter: String => Boolean,
       tempPrefix: String)(
-      readOne: PartitionedFile => Iterator[InternalRow]): Iterator[InternalRow] = {
+      readEntry: PartitionedFile => Iterator[InternalRow]): Iterator[InternalRow] = {
     val tempDir = Utils.createTempDir(Utils.getLocalDir(SparkEnv.get.conf), tempPrefix)
     val entries = ArchiveReader(file.toPath).localizeEntries(conf, tempDir, entryFilter)
 
@@ -332,7 +351,7 @@ object ArchiveReader extends Logging {
           if (entries.hasNext) {
             val (_, entryFile) = entries.next()
             currentFile = entryFile
-            current = readOne(file.copy(
+            current = readEntry(file.copy(
               filePath = SparkPath.fromUri(entryFile.toURI),
               start = 0L,
               length = entryFile.length(),
@@ -376,6 +395,16 @@ object ArchiveReader extends Logging {
   /**
    * Localizes one archive's kept entries and applies `use`. The entries iterator is closed before
    * returning (the driver has no TaskContext), so `use` must consume what it needs first.
+   *
+   * @param archive the archive [[FileStatus]].
+   * @param conf Hadoop configuration used to open the archive stream.
+   * @param tempDir directory the entries are unpacked into.
+   * @param entryFilter keeps only entries whose name satisfies it; others are skipped.
+   * @param ignoreMissingFiles when true, a missing archive is skipped (yields `onSkip`).
+   * @param ignoreCorruptFiles when true, a corrupt archive is skipped (yields `onSkip`).
+   * @param onSkip value returned when the archive is skipped.
+   * @param use consumes the localized entries; must read what it needs before returning.
+   * @return `use`'s result, or `onSkip` when the archive is skipped.
    */
   private[datasources] def withLocalizedArchive[T](
       archive: FileStatus,
@@ -418,8 +447,20 @@ object ArchiveReader extends Logging {
 
   /**
    * Driver-side schema inference for random-access archive formats: `looseInfer` seeds from loose
-   * files; each archive's entries fold in one at a time -- `inferOne` reads one unpacked entry,
+   * files; each archive's entries fold in one at a time -- `inferEntry` reads one unpacked entry,
    * `mergeSchemas` combines it -- deleting each before the next. `mergeSchema` off samples one.
+   *
+   * @param files loose files and archives to infer from.
+   * @param conf Hadoop configuration used to open the archive streams.
+   * @param tempPrefix name prefix for the temp dir entries are unpacked into.
+   * @param entryFilter keeps only entries whose name satisfies it; others are skipped.
+   * @param ignoreMissingFiles when true, a missing archive is skipped.
+   * @param ignoreCorruptFiles when true, a corrupt archive is skipped.
+   * @param mergeSchema when true, merge schemas across all entries; when false, sample one.
+   * @param looseInfer infers the schema of the loose (non-archive) files.
+   * @param inferEntry infers the schema of one unpacked entry.
+   * @param mergeSchemas combines two inferred schemas.
+   * @return the merged schema, or `None` if nothing could be inferred.
    */
   def inferArchiveSchema(
       files: Seq[FileStatus],
@@ -430,7 +471,7 @@ object ArchiveReader extends Logging {
       ignoreCorruptFiles: Boolean,
       mergeSchema: Boolean,
       looseInfer: Seq[FileStatus] => Option[StructType],
-      inferOne: File => Option[StructType],
+      inferEntry: File => Option[StructType],
       mergeSchemas: (StructType, StructType) => StructType): Option[StructType] = {
     val (archives, nonArchives) = files.partition(f => isArchivePath(f.getPath))
     val tempDir = Utils.createTempDir(namePrefix = tempPrefix)
@@ -440,7 +481,7 @@ object ArchiveReader extends Logging {
         onSkip = seed) { entries =>
         var merged = seed
         entries.take(limit).foreach { case (_, file) =>
-          try inferOne(file).foreach(s => merged = Some(merged.fold(s)(mergeSchemas(_, s))))
+          try inferEntry(file).foreach(s => merged = Some(merged.fold(s)(mergeSchemas(_, s))))
           finally file.delete()
         }
         merged

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
@@ -188,7 +188,6 @@ abstract class ArchiveReader(path: Path) {
   /**
    * Materializes each kept entry to a file under `localDir` as `(entryName, localFile)`, lazily one
    * at a time -- the [[readEntries]] counterpart for random-access formats (Parquet/ORC footers).
-   * The caller owns the produced files and `localDir`.
    */
   final def localizeEntries(
       conf: Configuration,
@@ -206,8 +205,7 @@ abstract class ArchiveReader(path: Path) {
 object ArchiveReader extends Logging {
 
   /**
-   * Whether `path` names an archive this reader can stream. Dispatched purely on the file
-   * extension -- `.tar`, `.tar.gz`, `.tgz`, or `.zip` -- since the bytes are not inspected here.
+   * Whether `path` names an archive this reader can stream.
    */
   def isArchivePath(path: Path): Boolean = {
     val name = path.getName.toLowerCase(Locale.ROOT)
@@ -280,9 +278,8 @@ object ArchiveReader extends Logging {
   }
 
   /**
-   * Copies one entry's bytes to a fresh, uniquely-named file under `localDir` (entries sharing a
-   * basename across archive subdirs won't collide). The entry stream is left open (the reader owns
-   * it); the output file is closed.
+   * Copies one entry's bytes to a unique file under `localDir`.
+   * The entry stream is left open (the reader owns it); the output file is closed.
    */
   private def copyEntryToLocalFile(in: InputStream, localDir: File, entryName: String): File = {
     val rawBasename = entryName.substring(entryName.lastIndexOf('/') + 1)
@@ -295,7 +292,7 @@ object ArchiveReader extends Logging {
 
   /**
    * Reads an archive of random-access files -- the [[readEntries]] counterpart for formats needing
-   * a complete file (Parquet/ORC footers, Excel). The per-entry [[PartitionedFile]] keeps the
+   * a complete file (Parquet/ORC, Excel). The per-entry [[PartitionedFile]] keeps the
    * archive's path, so `input_file_name()`/`_metadata` report it.
    */
   def readLocalizedEntries(
@@ -308,7 +305,7 @@ object ArchiveReader extends Logging {
     val entries = ArchiveReader(file.toPath).localizeEntries(conf, tempDir, entryFilter)
 
     // Element type is `Object`, not `InternalRow`: a batch scan yields `ColumnarBatch`, so
-    // per-element casts would fail; the whole iterator is cast once at the end.
+    // per-element casts would fail;
     val rows = new Iterator[Object] with Closeable {
       private var current: Iterator[Object] = Iterator.empty
       private var currentFile: File = _
@@ -366,13 +363,9 @@ object ArchiveReader extends Logging {
       }
     }
 
-    // Only delete the temp dir here; do NOT close `rows`. `rows` is Closeable and becomes
-    // FileScanRDD's `currentIterator`, which its own (early-registered) task-completion listener
-    // closes -- after downstream exec nodes' listeners, per reverse-order execution. Closing the
-    // per-entry reader from this listener (registered during iteration, so it would run first)
-    // would free the vectorized reader's off-heap column vectors while downstream operators may
-    // still reference them, re-introducing the SPARK-37089 use-after-free. FileScanRDD's close of
-    // `rows` still releases the current reader and the archive stream, so nothing leaks.
+    // Delete only the temp dir here; FileScanRDD closes `rows`. Closing the per-entry reader from
+    // this listener (it runs before FileScanRDD's) would free the vectorized reader's off-heap
+    // vectors while downstream operators still read them.
     Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit] { _ =>
       Utils.deleteRecursively(tempDir)
     })
@@ -380,8 +373,7 @@ object ArchiveReader extends Logging {
   }
 
   /**
-   * Localizes one archive's kept entries and applies `use`, returning `onSkip` when the archive is
-   * missing/corrupt and the matching ignore flag is set. The entries iterator is closed before
+   * Localizes one archive's kept entries and applies `use`. The entries iterator is closed before
    * returning (the driver has no TaskContext), so `use` must consume what it needs first.
    */
   private[datasources] def withLocalizedArchive[T](
@@ -405,7 +397,7 @@ object ArchiveReader extends Logging {
         onSkip
       case NonFatal(e) =>
         Utils.getRootCause(e) match {
-          // A missing archive is a FileNotFoundException (a subtype of IOException); govern it by
+          // A missing archive is a FileNotFoundException; govern it by
           // ignoreMissingFiles (handled above), not by ignoreCorruptFiles -- matching FileScanRDD,
           // which rethrows missing-file errors regardless of ignoreCorruptFiles.
           case _: FileNotFoundException => throw e

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
@@ -305,7 +305,8 @@ object ArchiveReader extends Logging {
     val entries = ArchiveReader(file.toPath).localizeEntries(conf, tempDir, entryFilter)
 
     // Element type is `Object`, not `InternalRow`: a batch scan yields `ColumnarBatch`, so
-    // per-element casts would fail;
+    // per-element casts would fail. The whole iterator is cast back to `Iterator[InternalRow]`
+    // at the end, matching how the plain reader's columnar output is typed.
     val rows = new Iterator[Object] with Closeable {
       private var current: Iterator[Object] = Iterator.empty
       private var currentFile: File = _

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
@@ -36,7 +36,7 @@ import org.apache.hadoop.io.Text
 import org.apache.hadoop.util.LineReader
 
 import org.apache.spark.{SparkEnv, TaskContext}
-import org.apache.spark.internal.{Logging, LogKeys, MDC}
+import org.apache.spark.internal.{Logging, LogKeys}
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types.StructType

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import java.io.{Closeable, File, FileOutputStream, InputStream}
+import java.io.{Closeable, File, FileNotFoundException, FileOutputStream, InputStream, IOException}
 import java.util.Locale
 import java.util.regex.Pattern
 import java.util.zip.GZIPInputStream
@@ -29,14 +29,17 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream
 import org.apache.commons.io.ByteOrderMark
 import org.apache.commons.io.input.{BOMInputStream, CloseShieldInputStream}
+import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.util.LineReader
 
 import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.internal.{Logging, LogKeys, MDC}
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.{HadoopFSUtils, Utils}
 
 /**
@@ -211,7 +214,7 @@ abstract class ArchiveReader(path: Path) {
     }
 }
 
-object ArchiveReader {
+object ArchiveReader extends Logging {
 
   /**
    * Whether `path` names an archive this reader can stream. Dispatched purely on the file
@@ -396,6 +399,86 @@ object ArchiveReader {
       Utils.deleteRecursively(tempDir)
     })
     rows.asInstanceOf[Iterator[InternalRow]]
+  }
+
+  /**
+   * Localizes one archive's kept entries and applies `use`, returning `onSkip` when the archive is
+   * missing/corrupt and the matching ignore flag is set. The entries iterator is closed before
+   * returning (the driver has no TaskContext), so `use` must consume what it needs first.
+   */
+  private[datasources] def withLocalizedArchive[T](
+      archive: FileStatus,
+      conf: Configuration,
+      tempDir: File,
+      entryFilter: String => Boolean,
+      ignoreMissingFiles: Boolean,
+      ignoreCorruptFiles: Boolean,
+      onSkip: => T)(
+      use: Iterator[(String, File)] => T): T = {
+    var entries: Iterator[(String, File)] = null
+    try {
+      entries = ArchiveReader(archive.getPath).localizeEntries(conf, tempDir, entryFilter)
+      use(entries)
+    } catch {
+      case e: Exception if ignoreMissingFiles &&
+          ExceptionUtils.getThrowables(e).exists(_.isInstanceOf[FileNotFoundException]) =>
+        logWarning(log"Skipping missing archive during inference: " +
+          log"${MDC(LogKeys.PATH, archive.getPath.toString)}", e)
+        onSkip
+      case NonFatal(e) =>
+        Utils.getRootCause(e) match {
+          // A missing archive is a FileNotFoundException (a subtype of IOException); govern it by
+          // ignoreMissingFiles (handled above), not by ignoreCorruptFiles -- matching FileScanRDD,
+          // which rethrows missing-file errors regardless of ignoreCorruptFiles.
+          case _: FileNotFoundException => throw e
+          case _: RuntimeException | _: IOException if ignoreCorruptFiles =>
+            logWarning(log"Skipping corrupt archive during inference: " +
+              log"${MDC(LogKeys.PATH, archive.getPath.toString)}", e)
+            onSkip
+          case _ => throw e
+        }
+    } finally {
+      entries match {
+        case c: Closeable => c.close()
+        case _ =>
+      }
+    }
+  }
+
+  /**
+   * Driver-side schema inference for random-access archive formats: `looseInfer` seeds from loose
+   * files, then each archive folds into the seed via `foldEntries`, one entry on disk at a time
+   * (missing/corrupt skipped per the ignore flags). `mergeSchema` off samples one schema.
+   */
+  def inferArchiveSchema(
+      files: Seq[FileStatus],
+      conf: Configuration,
+      tempPrefix: String,
+      entryFilter: String => Boolean,
+      ignoreMissingFiles: Boolean,
+      ignoreCorruptFiles: Boolean,
+      mergeSchema: Boolean,
+      looseInfer: Seq[FileStatus] => Option[StructType])(
+      foldEntries: (Option[StructType], Iterator[(String, File)]) => Option[StructType])
+      : Option[StructType] = {
+    val (archives, nonArchives) = files.partition(f => isArchivePath(f.getPath))
+    val tempDir = Utils.createTempDir(namePrefix = tempPrefix)
+    def foldArchive(archive: FileStatus, seed: Option[StructType], limit: Int): Option[StructType] =
+      withLocalizedArchive(
+        archive, conf, tempDir, entryFilter, ignoreMissingFiles, ignoreCorruptFiles,
+        onSkip = seed)(entries => foldEntries(seed, entries.take(limit)))
+    try {
+      val looseSchema = if (nonArchives.nonEmpty) looseInfer(nonArchives) else None
+      if (mergeSchema) {
+        archives.foldLeft(looseSchema)((acc, a) => foldArchive(a, acc, Int.MaxValue))
+      } else if (looseSchema.isDefined) {
+        looseSchema
+      } else {
+        archives.iterator.map(foldArchive(_, None, 1)).find(_.isDefined).flatten
+      }
+    } finally {
+      Utils.deleteRecursively(tempDir)
+    }
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ArchiveReader.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import java.io.{Closeable, InputStream}
+import java.io.{Closeable, File, FileOutputStream, InputStream}
 import java.util.Locale
 import java.util.regex.Pattern
 import java.util.zip.GZIPInputStream
@@ -34,8 +34,10 @@ import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.util.LineReader
 
-import org.apache.spark.TaskContext
-import org.apache.spark.util.HadoopFSUtils
+import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.paths.SparkPath
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.util.{HadoopFSUtils, Utils}
 
 /**
  * Streaming reader for a single archive file. The archive is opened once and decompressed/unpacked
@@ -179,6 +181,34 @@ abstract class ArchiveReader(path: Path) {
     }
     entries
   }
+
+  /**
+   * Materializes each archive entry to a file under `localDir` and yields `(entryName, localFile)`
+   * for every entry kept by `entryFilter`. This is the counterpart to [[readEntries]] for formats
+   * that cannot be parsed from a streaming `InputStream` and instead need random access to a
+   * complete file (e.g. Parquet/ORC, which read a trailing footer). Entries are materialized one at
+   * a time as the returned iterator advances, so a caller that consumes sequentially and deletes
+   * each file after use keeps at most one entry in `localDir` at a time. The caller owns the
+   * lifetime of the produced files and of `localDir`.
+   *
+   * @param conf Hadoop conf used to open and decompress the archive.
+   * @param localDir an existing local directory the entries are written into.
+   * @param entryFilter keeps only entries whose name satisfies it; entries that fail it are skipped
+   *                    without being written to disk. Defaults to keeping every entry that
+   *                    [[readEntries]] surfaces (i.e. non-directory, non-dotfile entries).
+   * @return an iterator of `(entry name, local file)`; each file lives until the caller deletes it.
+   */
+  final def localizeEntries(
+      conf: Configuration,
+      localDir: File,
+      entryFilter: String => Boolean = _ => true): Iterator[(String, File)] =
+    readEntries(conf) { (name, in) =>
+      if (entryFilter(name)) {
+        Iterator.single((name, ArchiveReader.copyEntryToLocalFile(in, localDir, name)))
+      } else {
+        Iterator.empty
+      }
+    }
 }
 
 object ArchiveReader {
@@ -255,6 +285,117 @@ object ArchiveReader {
         text
       }
     }
+  }
+
+  /**
+   * Copies one archive entry's bytes to a fresh file under `localDir`, used by
+   * [[ArchiveReader.localizeEntries]] to localize entries for random-access formats. The entry
+   * stream is not closed here (the reader owns the underlying archive stream); the output file is.
+   * Uniqueness comes from [[File.createTempFile]], so entries that share a basename across archive
+   * subdirectories never collide; the sanitized basename is kept only as a readable suffix.
+   *
+   * @param in bytes of one archive entry.
+   * @param localDir an existing local directory the file is created in.
+   * @param entryName the entry's name within the archive, used only to derive a readable file name.
+   * @return the local file the entry was written to.
+   */
+  private def copyEntryToLocalFile(in: InputStream, localDir: File, entryName: String): File = {
+    val rawBasename = entryName.substring(entryName.lastIndexOf('/') + 1)
+    val basename = rawBasename.replaceAll("[^A-Za-z0-9._-]", "_")
+    val local = File.createTempFile("archive-entry-", "-" + basename, localDir)
+    val out = new FileOutputStream(local)
+    try Utils.copyStream(in, out) finally out.close()
+    local
+  }
+
+  /**
+   * Reads an archive of random-access files: each kept entry is unpacked to a temp file under a
+   * fresh local dir and read with `readOne`. The counterpart to [[readEntries]] for formats that
+   * need a complete file (Parquet/ORC footers, Excel). Entries are unpacked one at a time, each
+   * reader and temp file released before the next opens; the temp dir, current reader, and archive
+   * stream are released on task completion, so an abandoned read (e.g. a `LIMIT`) does not leak.
+   * The per-entry [[PartitionedFile]] points at the temp file but keeps the archive's path and
+   * modification time, so `input_file_name()` / `_metadata` still report the archive.
+   */
+  def readLocalizedEntries(
+      file: PartitionedFile,
+      conf: Configuration,
+      entryFilter: String => Boolean,
+      tempPrefix: String)(
+      readOne: PartitionedFile => Iterator[InternalRow]): Iterator[InternalRow] = {
+    val tempDir = Utils.createTempDir(Utils.getLocalDir(SparkEnv.get.conf), tempPrefix)
+    val entries = ArchiveReader(file.toPath).localizeEntries(conf, tempDir, entryFilter)
+
+    // Element type is `Object`, not `InternalRow`: a batch scan yields `ColumnarBatch`, so
+    // per-element casts would fail; the whole iterator is cast once at the end.
+    val rows = new Iterator[Object] with Closeable {
+      private var current: Iterator[Object] = Iterator.empty
+      private var currentFile: File = _
+      private var done = false
+
+      private def releaseCurrent(): Unit = {
+        current match {
+          case c: Closeable => try c.close() catch { case NonFatal(_) => }
+          case _ =>
+        }
+        current = Iterator.empty
+        if (currentFile != null) {
+          currentFile.delete()
+          currentFile = null
+        }
+      }
+
+      // Advance on `hasNext`, not in `next`, so a reader reusing a mutable batch is not probed for
+      // the next entry before the current batch is consumed.
+      private def advance(): Unit = {
+        while (!done && !current.hasNext) {
+          releaseCurrent()
+          if (entries.hasNext) {
+            val (_, entryFile) = entries.next()
+            currentFile = entryFile
+            current = readOne(file.copy(
+              filePath = SparkPath.fromUri(entryFile.toURI),
+              start = 0L,
+              length = entryFile.length(),
+              fileSize = entryFile.length(),
+              modificationTime = file.modificationTime)).asInstanceOf[Iterator[Object]]
+          } else {
+            done = true
+          }
+        }
+      }
+
+      override def hasNext: Boolean = {
+        advance()
+        !done && current.hasNext
+      }
+
+      override def next(): Object = {
+        if (!hasNext) throw new NoSuchElementException
+        current.next()
+      }
+
+      override def close(): Unit = {
+        done = true
+        releaseCurrent()
+        entries match {
+          case c: Closeable => try c.close() catch { case NonFatal(_) => }
+          case _ =>
+        }
+      }
+    }
+
+    // Only delete the temp dir here; do NOT close `rows`. `rows` is Closeable and becomes
+    // FileScanRDD's `currentIterator`, which its own (early-registered) task-completion listener
+    // closes -- after downstream exec nodes' listeners, per reverse-order execution. Closing the
+    // per-entry reader from this listener (registered during iteration, so it would run first)
+    // would free the vectorized reader's off-heap column vectors while downstream operators may
+    // still reference them, re-introducing the SPARK-37089 use-after-free. FileScanRDD's close of
+    // `rows` still releases the current reader and the archive stream, so nothing leaks.
+    Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit] { _ =>
+      Utils.deleteRecursively(tempDir)
+    })
+    rows.asInstanceOf[Iterator[InternalRow]]
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -17,13 +17,15 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import java.io.{Closeable, FileNotFoundException}
+import java.io.{Closeable, File, FileNotFoundException, IOException}
 import java.time.ZoneId
+import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Try}
+import scala.util.control.NonFatal
 
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.conf.Configuration
@@ -41,12 +43,13 @@ import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{PATH, SCHEMA}
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.FileSourceOptions
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.catalyst.parser.LegacyTypeStringParser
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
-import org.apache.spark.sql.catalyst.util.{DateTimeUtils, RebaseDateTime}
+import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils, RebaseDateTime}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.types.ops.ParquetTypeOps
@@ -86,7 +89,84 @@ class ParquetFileFormat
       sparkSession: SparkSession,
       parameters: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
+    val parquetOptions = new ParquetOptions(parameters, getSqlConf(sparkSession))
+    if (parquetOptions.archiveFormatEnabled &&
+        files.exists(f => ArchiveReader.isArchivePath(f.getPath))) {
+      return inferArchiveSchema(sparkSession, parameters, files, parquetOptions.mergeSchema,
+        parquetOptions.ignoreCorruptFiles, parquetOptions.ignoreMissingFiles)
+    }
     ParquetUtils.inferSchema(sparkSession, parameters, files)
+  }
+
+  /**
+   * Schema inference when the inputs include archives. Loose files use the standard
+   * [[ParquetUtils.inferSchema]] path and seed the merge; each archive's entries fold in one at a
+   * time via [[ParquetFileFormat.mergeArchiveEntrySchemas]], bounding disk to one entry.
+   * `mergeSchema = false` samples a single schema. A corrupt/missing archive is skipped under the
+   * matching `ignore*` flag.
+   */
+  private def inferArchiveSchema(
+      sparkSession: SparkSession,
+      parameters: Map[String, String],
+      files: Seq[FileStatus],
+      mergeSchema: Boolean,
+      ignoreCorruptFiles: Boolean,
+      ignoreMissingFiles: Boolean): Option[StructType] = {
+    val conf = sparkSession.sessionState.newHadoopConfWithOptions(parameters)
+    val (archives, nonArchives) = files.partition(f => ArchiveReader.isArchivePath(f.getPath))
+    val tempDir = Utils.createTempDir(namePrefix = "parquet-archive-infer")
+
+    // Folds one archive's entries (at most `limit`) into `seed`, always closing the archive stream
+    // (the driver has no TaskContext to do it); skips the archive under the matching ignore flag.
+    def foldArchive(
+        archive: FileStatus, seed: Option[StructType], limit: Int): Option[StructType] = {
+      try {
+        val entries = ArchiveReader(archive.getPath)
+          .localizeEntries(conf, tempDir, ParquetFileFormat.isParquetArchiveEntry)
+        try ParquetFileFormat.mergeArchiveEntrySchemas(
+          sparkSession, parameters, entries.take(limit), seed)
+        finally entries match {
+          case c: Closeable => c.close()
+          case _ =>
+        }
+      } catch {
+        case e: Exception if ignoreMissingFiles &&
+            ExceptionUtils.getThrowables(e).exists(_.isInstanceOf[FileNotFoundException]) =>
+          logWarning(log"Skipping missing archive during inference: " +
+            log"${MDC(PATH, archive.getPath.toString)}", e)
+          seed
+        case NonFatal(e) =>
+          Utils.getRootCause(e) match {
+            // A missing archive is a FileNotFoundException (a subtype of IOException); it must be
+            // governed by ignoreMissingFiles (handled above), not silently dropped as corrupt under
+            // ignoreCorruptFiles -- matching FileScanRDD, which rethrows missing-file errors
+            // regardless of ignoreCorruptFiles.
+            case _: FileNotFoundException => throw e
+            case _: RuntimeException | _: IOException if ignoreCorruptFiles =>
+              logWarning(log"Skipping corrupt archive during inference: " +
+                log"${MDC(PATH, archive.getPath.toString)}", e)
+              seed
+            case _ => throw e
+          }
+      }
+    }
+
+    try {
+      val looseSchema =
+        if (nonArchives.nonEmpty) ParquetUtils.inferSchema(sparkSession, parameters, nonArchives)
+        else None
+      if (mergeSchema) {
+        archives.foldLeft(looseSchema)((acc, a) => foldArchive(a, acc, Int.MaxValue))
+      } else if (looseSchema.isDefined) {
+        // Not merging: the loose schema already samples one, so leave the archives unopened.
+        looseSchema
+      } else {
+        // Sample the first archive entry that yields a schema.
+        archives.iterator.map(foldArchive(_, None, 1)).find(_.isDefined).flatten
+      }
+    } finally {
+      Utils.deleteRecursively(tempDir)
+    }
   }
 
   /**
@@ -113,6 +193,12 @@ class ParquetFileFormat
       sparkSession: SparkSession,
       options: Map[String, String],
       path: Path): Boolean = {
+    // An archive is read by unpacking its entries, so the archive itself is a single split
+    // rather than carved into byte ranges.
+    val parquetOptions = new ParquetOptions(options, getSqlConf(sparkSession))
+    if (parquetOptions.archiveFormatEnabled && ArchiveReader.isArchivePath(path)) {
+      return false
+    }
     true
   }
 
@@ -204,6 +290,7 @@ class ParquetFileFormat
     val parquetOptions = new ParquetOptions(options, sqlConf)
     val datetimeRebaseModeInRead = parquetOptions.datetimeRebaseModeInRead
     val int96RebaseModeInRead = parquetOptions.int96RebaseModeInRead
+    val archiveFormatEnabled = parquetOptions.archiveFormatEnabled
 
     // Should always be set by FileSourceScanExec creating this.
     // Check conf before checking option, to allow working around an issue by changing conf.
@@ -219,7 +306,7 @@ class ParquetFileFormat
       assert(supportBatch(sparkSession, resultSchema))
     }
 
-    (file: PartitionedFile) => {
+    val readSingleFile: PartitionedFile => Iterator[InternalRow] = (file: PartitionedFile) => {
       assert(file.partitionValues.numFields == partitionSchema.size)
 
       val split = new FileSplit(file.toPath, file.start, file.length, Array.empty[String])
@@ -306,6 +393,25 @@ class ParquetFileFormat
         if (shouldCloseInputStream.get) {
           openedFooter.inputStreamOpt.ifPresent(Utils.closeQuietly)
         }
+      }
+    }
+
+    // An archive is read by unpacking each Parquet entry to a local temp file and reading it with
+    // the plain JVM reader -- Parquet needs random access to its footer, so it cannot be streamed.
+    // ArchiveReader.readLocalizedEntries owns the unpack/iterate/cleanup; the per-entry read reuses
+    // readSingleFile, which keeps `input_file_name()` / `_metadata` pointing at the archive path.
+    def readArchiveFile(file: PartitionedFile): Iterator[InternalRow] =
+      ArchiveReader.readLocalizedEntries(
+        file, broadcastedHadoopConf.value.value,
+        ParquetFileFormat.isParquetArchiveEntry, "parquet-archive") {
+        entryFile => readSingleFile(entryFile)
+      }
+
+    (file: PartitionedFile) => {
+      if (archiveFormatEnabled && ArchiveReader.isArchivePath(file.toPath)) {
+        readArchiveFile(file)
+      } else {
+        readSingleFile(file)
       }
     }
   }
@@ -445,6 +551,16 @@ class ParquetFileFormat
 }
 
 object ParquetFileFormat extends Logging {
+
+  /**
+   * Whether an archive entry is a Parquet data file. Skips non-Parquet sidecars an archive may
+   * contain (e.g. `_SUCCESS`, `_committed_*`, `_common_metadata`) so an archive reads like a
+   * directory of Parquet part-files. The read path and schema inference must use the same
+   * predicate, or the inferred schema would not match the data that is read.
+   */
+  private[parquet] def isParquetArchiveEntry(name: String): Boolean =
+    name.toLowerCase(Locale.ROOT).endsWith(".parquet")
+
   val ROW_INDEX = "row_index"
 
   // A name for a temporary column that holds row indexes computed by the file format reader
@@ -567,6 +683,19 @@ object ParquetFileFormat extends Logging {
       parameters: Map[String, String],
       filesToTouch: Seq[FileStatus],
       sparkSession: SparkSession): Option[StructType] = {
+    val reader = buildSchemaReader(sparkSession)
+    SchemaMergeUtils.mergeSchemasInParallel(sparkSession, parameters, filesToTouch, reader)
+  }
+
+  /**
+   * Builds the Parquet footer-reading function, shared by the distributed merge
+   * ([[mergeSchemasInParallel]]) and the sequential archive-entry merge
+   * ([[mergeArchiveEntrySchemas]]). `SQLConf` is read here so the returned closure stays
+   * serializable.
+   */
+  private[parquet] def buildSchemaReader(
+      sparkSession: SparkSession)
+      : (Seq[FileStatus], Configuration, Boolean, Boolean) => Seq[StructType] = {
     val sqlConf = SessionStateHelper.getSqlConf(sparkSession)
     val assumeBinaryIsString = sqlConf.isParquetBinaryAsString
     val assumeInt96IsTimestamp = sqlConf.isParquetINT96AsTimestamp
@@ -576,7 +705,7 @@ object ParquetFileFormat extends Logging {
     val respectUnknownTypeAnnotation =
       sqlConf.parquetReaderRespectUnknownTypeAnnotation
 
-    val reader = (files: Seq[FileStatus], conf: Configuration, ignoreCorruptFiles: Boolean,
+    (files: Seq[FileStatus], conf: Configuration, ignoreCorruptFiles: Boolean,
         ignoreMissingFiles: Boolean) => {
       // Converter used to convert Parquet `MessageType` to Spark SQL `StructType`
       val converter = new ParquetToSparkSchemaConverter(
@@ -590,8 +719,46 @@ object ParquetFileFormat extends Logging {
       readParquetFootersInParallel(conf, files, ignoreCorruptFiles, ignoreMissingFiles)
         .map(ParquetFileFormat.readSchemaFromFooter(_, converter))
     }
+  }
 
-    SchemaMergeUtils.mergeSchemasInParallel(sparkSession, parameters, filesToTouch, reader)
+  /**
+   * Driver-side, sequential analog of [[mergeSchemasInParallel]] for archive entries: they unpack
+   * to a driver-local temp dir that executors can't read, so the schemas can't be merged in a
+   * distributed job. Reads each lazily-unpacked entry's footer and deletes it before pulling the
+   * next, so disk holds one entry at a time; `seed` is the starting schema (loose files). The
+   * caller owns closing `entries`.
+   */
+  private[sql] def mergeArchiveEntrySchemas(
+      sparkSession: SparkSession,
+      parameters: Map[String, String],
+      entries: Iterator[(String, File)],
+      seed: Option[StructType]): Option[StructType] = {
+    val caseSensitive = SessionStateHelper.getSqlConf(sparkSession).caseSensitiveAnalysis
+    val fileSourceOptions = new FileSourceOptions(CaseInsensitiveMap(parameters))
+    val conf = sparkSession.sessionState.newHadoopConfWithOptions(parameters)
+    val reader = buildSchemaReader(sparkSession)
+
+    var merged = seed
+    entries.foreach { case (_, file) =>
+      try {
+        // The footer reader needs only a path and length (cf. mergeSchemasInParallel).
+        val status = new FileStatus(
+          file.length(), false, 0, 0, file.lastModified(), 0, null, null, null,
+          new Path(file.toURI))
+        reader(Seq(status), conf, fileSourceOptions.ignoreCorruptFiles,
+            fileSourceOptions.ignoreMissingFiles).foreach { schema =>
+          merged = Some(merged.fold(schema) { acc =>
+            try acc.merge(schema, caseSensitive) catch {
+              case e: Throwable =>
+                throw QueryExecutionErrors.failedToMergeIncompatibleSchemasError(acc, schema, e)
+            }
+          })
+        }
+      } finally {
+        file.delete()
+      }
+    }
+    merged
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import java.io.{Closeable, File, FileNotFoundException, IOException}
+import java.io.{Closeable, FileNotFoundException, IOException}
 import java.time.ZoneId
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
@@ -42,13 +42,12 @@ import org.apache.spark.{SparkException, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{PATH, SCHEMA}
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.FileSourceOptions
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.catalyst.parser.LegacyTypeStringParser
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
-import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils, RebaseDateTime}
+import org.apache.spark.sql.catalyst.util.{DateTimeUtils, RebaseDateTime}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.types.ops.ParquetTypeOps
@@ -99,9 +98,8 @@ class ParquetFileFormat
 
   /**
    * Schema inference for inputs including archives: loose files seed via
-   * [[ParquetUtils.inferSchema]], each archive's entries fold in via
-   * [[ParquetFileFormat.mergeArchiveEntrySchemas]] (one footer at a time).
-   * [[ArchiveReader.inferArchiveSchema]] owns partition/unpack/policy/cleanup.
+   * [[ParquetUtils.inferSchema]], then each archive's entries fold in one footer at a time.
+   * [[ArchiveReader.inferArchiveSchema]] owns the orchestration; this supplies the footer reader.
    */
   private def inferArchiveSchema(
       sparkSession: SparkSession,
@@ -111,12 +109,23 @@ class ParquetFileFormat
       ignoreCorruptFiles: Boolean,
       ignoreMissingFiles: Boolean): Option[StructType] = {
     val conf = sparkSession.sessionState.newHadoopConfWithOptions(parameters)
+    val caseSensitive = SessionStateHelper.getSqlConf(sparkSession).caseSensitiveAnalysis
+    val reader = ParquetFileFormat.buildSchemaReader(sparkSession)
     ArchiveReader.inferArchiveSchema(
       files, conf, "parquet-archive-infer", ParquetFileFormat.isParquetArchiveEntry,
       ignoreMissingFiles, ignoreCorruptFiles, mergeSchema,
-      fs => ParquetUtils.inferSchema(sparkSession, parameters, fs)) { (seed, entries) =>
-      ParquetFileFormat.mergeArchiveEntrySchemas(sparkSession, parameters, entries, seed)
-    }
+      fs => ParquetUtils.inferSchema(sparkSession, parameters, fs),
+      file => {
+        // The footer reader needs only a path and length (cf. mergeSchemasInParallel).
+        val status = new FileStatus(file.length(), false, 0, 0, file.lastModified(), 0, null, null,
+          null, new Path(file.toURI))
+        reader(Seq(status), conf, ignoreCorruptFiles, ignoreMissingFiles).headOption
+      },
+      (acc, schema) =>
+        try acc.merge(schema, caseSensitive) catch {
+          case cause: SparkException =>
+            throw QueryExecutionErrors.failedMergingSchemaError(acc, schema, cause)
+        })
   }
 
   /**
@@ -669,44 +678,6 @@ object ParquetFileFormat extends Logging {
       readParquetFootersInParallel(conf, files, ignoreCorruptFiles, ignoreMissingFiles)
         .map(ParquetFileFormat.readSchemaFromFooter(_, converter))
     }
-  }
-
-  /**
-   * Driver-side analog of [[mergeSchemasInParallel]] for archive entries (they unpack to a
-   * driver-local temp dir executors can't read): reads each entry's footer into `seed`, deleting it
-   * before the next so disk holds one entry. The caller owns closing `entries`.
-   */
-  private[sql] def mergeArchiveEntrySchemas(
-      sparkSession: SparkSession,
-      parameters: Map[String, String],
-      entries: Iterator[(String, File)],
-      seed: Option[StructType]): Option[StructType] = {
-    val caseSensitive = SessionStateHelper.getSqlConf(sparkSession).caseSensitiveAnalysis
-    val fileSourceOptions = new FileSourceOptions(CaseInsensitiveMap(parameters))
-    val conf = sparkSession.sessionState.newHadoopConfWithOptions(parameters)
-    val reader = buildSchemaReader(sparkSession)
-
-    var merged = seed
-    entries.foreach { case (_, file) =>
-      try {
-        // The footer reader needs only a path and length (cf. mergeSchemasInParallel).
-        val status = new FileStatus(
-          file.length(), false, 0, 0, file.lastModified(), 0, null, null, null,
-          new Path(file.toURI))
-        reader(Seq(status), conf, fileSourceOptions.ignoreCorruptFiles,
-            fileSourceOptions.ignoreMissingFiles).foreach { schema =>
-          merged = Some(merged.fold(schema) { acc =>
-            try acc.merge(schema, caseSensitive) catch {
-              case cause: SparkException =>
-                throw QueryExecutionErrors.failedMergingSchemaError(acc, schema, cause)
-            }
-          })
-        }
-      } finally {
-        file.delete()
-      }
-    }
-    merged
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import java.io.{Closeable, FileNotFoundException, IOException}
+import java.io.{Closeable, FileNotFoundException}
 import java.time.ZoneId
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -39,7 +39,7 @@ import org.apache.parquet.format.converter.ParquetMetadataConverter.SKIP_ROW_GRO
 import org.apache.parquet.hadoop._
 import org.apache.parquet.hadoop.util.HadoopInputFile
 
-import org.apache.spark.TaskContext
+import org.apache.spark.{SparkException, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.{PATH, SCHEMA}
 import org.apache.spark.sql.SparkSession
@@ -749,8 +749,8 @@ object ParquetFileFormat extends Logging {
             fileSourceOptions.ignoreMissingFiles).foreach { schema =>
           merged = Some(merged.fold(schema) { acc =>
             try acc.merge(schema, caseSensitive) catch {
-              case e: Throwable =>
-                throw QueryExecutionErrors.failedToMergeIncompatibleSchemasError(acc, schema, e)
+              case cause: SparkException =>
+                throw QueryExecutionErrors.failedMergingSchemaError(acc, schema, cause)
             }
           })
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -642,7 +642,7 @@ object ParquetFileFormat extends Logging {
   /**
    * Builds the Parquet footer-reading function, shared by the distributed merge
    * ([[mergeSchemasInParallel]]) and the sequential archive-entry merge
-   * ([[mergeArchiveEntrySchemas]]). `SQLConf` is read here so the returned closure stays
+   * ([[ArchiveReader.inferArchiveSchema]]). `SQLConf` is read here so the returned closure stays
    * serializable.
    */
   private[parquet] def buildSchemaReader(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -356,9 +356,8 @@ class ParquetFileFormat
     }
 
     // An archive is read by unpacking each Parquet entry to a local temp file and reading it with
-    // the plain JVM reader -- Parquet needs random access to its footer, so it cannot be streamed.
-    // ArchiveReader.readLocalizedEntries owns the unpack/iterate/cleanup; the per-entry read reuses
-    // readSingleFile, which keeps `input_file_name()` / `_metadata` pointing at the archive path.
+    // the plain JVM reader (readSingleFile); ArchiveReader.readLocalizedEntries owns the
+    // unpack/iterate/cleanup.
     def readArchiveFile(file: PartitionedFile): Iterator[InternalRow] =
       ArchiveReader.readLocalizedEntries(
         file, broadcastedHadoopConf.value.value,
@@ -511,12 +510,6 @@ class ParquetFileFormat
 
 object ParquetFileFormat extends Logging {
 
-  /**
-   * Whether an archive entry is a Parquet data file. Skips non-Parquet sidecars an archive may
-   * contain (e.g. `_SUCCESS`, `_committed_*`, `_common_metadata`) so an archive reads like a
-   * directory of Parquet part-files. The read path and schema inference must use the same
-   * predicate, or the inferred schema would not match the data that is read.
-   */
   private[parquet] def isParquetArchiveEntry(name: String): Boolean =
     name.toLowerCase(Locale.ROOT).endsWith(".parquet")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Try}
-import scala.util.control.NonFatal
 
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.conf.Configuration
@@ -99,11 +98,10 @@ class ParquetFileFormat
   }
 
   /**
-   * Schema inference when the inputs include archives. Loose files use the standard
-   * [[ParquetUtils.inferSchema]] path and seed the merge; each archive's entries fold in one at a
-   * time via [[ParquetFileFormat.mergeArchiveEntrySchemas]], bounding disk to one entry.
-   * `mergeSchema = false` samples a single schema. A corrupt/missing archive is skipped under the
-   * matching `ignore*` flag.
+   * Schema inference for inputs including archives: loose files seed via
+   * [[ParquetUtils.inferSchema]], each archive's entries fold in via
+   * [[ParquetFileFormat.mergeArchiveEntrySchemas]] (one footer at a time).
+   * [[ArchiveReader.inferArchiveSchema]] owns partition/unpack/policy/cleanup.
    */
   private def inferArchiveSchema(
       sparkSession: SparkSession,
@@ -113,59 +111,11 @@ class ParquetFileFormat
       ignoreCorruptFiles: Boolean,
       ignoreMissingFiles: Boolean): Option[StructType] = {
     val conf = sparkSession.sessionState.newHadoopConfWithOptions(parameters)
-    val (archives, nonArchives) = files.partition(f => ArchiveReader.isArchivePath(f.getPath))
-    val tempDir = Utils.createTempDir(namePrefix = "parquet-archive-infer")
-
-    // Folds one archive's entries (at most `limit`) into `seed`, always closing the archive stream
-    // (the driver has no TaskContext to do it); skips the archive under the matching ignore flag.
-    def foldArchive(
-        archive: FileStatus, seed: Option[StructType], limit: Int): Option[StructType] = {
-      try {
-        val entries = ArchiveReader(archive.getPath)
-          .localizeEntries(conf, tempDir, ParquetFileFormat.isParquetArchiveEntry)
-        try ParquetFileFormat.mergeArchiveEntrySchemas(
-          sparkSession, parameters, entries.take(limit), seed)
-        finally entries match {
-          case c: Closeable => c.close()
-          case _ =>
-        }
-      } catch {
-        case e: Exception if ignoreMissingFiles &&
-            ExceptionUtils.getThrowables(e).exists(_.isInstanceOf[FileNotFoundException]) =>
-          logWarning(log"Skipping missing archive during inference: " +
-            log"${MDC(PATH, archive.getPath.toString)}", e)
-          seed
-        case NonFatal(e) =>
-          Utils.getRootCause(e) match {
-            // A missing archive is a FileNotFoundException (a subtype of IOException); it must be
-            // governed by ignoreMissingFiles (handled above), not silently dropped as corrupt under
-            // ignoreCorruptFiles -- matching FileScanRDD, which rethrows missing-file errors
-            // regardless of ignoreCorruptFiles.
-            case _: FileNotFoundException => throw e
-            case _: RuntimeException | _: IOException if ignoreCorruptFiles =>
-              logWarning(log"Skipping corrupt archive during inference: " +
-                log"${MDC(PATH, archive.getPath.toString)}", e)
-              seed
-            case _ => throw e
-          }
-      }
-    }
-
-    try {
-      val looseSchema =
-        if (nonArchives.nonEmpty) ParquetUtils.inferSchema(sparkSession, parameters, nonArchives)
-        else None
-      if (mergeSchema) {
-        archives.foldLeft(looseSchema)((acc, a) => foldArchive(a, acc, Int.MaxValue))
-      } else if (looseSchema.isDefined) {
-        // Not merging: the loose schema already samples one, so leave the archives unopened.
-        looseSchema
-      } else {
-        // Sample the first archive entry that yields a schema.
-        archives.iterator.map(foldArchive(_, None, 1)).find(_.isDefined).flatten
-      }
-    } finally {
-      Utils.deleteRecursively(tempDir)
+    ArchiveReader.inferArchiveSchema(
+      files, conf, "parquet-archive-infer", ParquetFileFormat.isParquetArchiveEntry,
+      ignoreMissingFiles, ignoreCorruptFiles, mergeSchema,
+      fs => ParquetUtils.inferSchema(sparkSession, parameters, fs)) { (seed, entries) =>
+      ParquetFileFormat.mergeArchiveEntrySchemas(sparkSession, parameters, entries, seed)
     }
   }
 
@@ -722,11 +672,9 @@ object ParquetFileFormat extends Logging {
   }
 
   /**
-   * Driver-side, sequential analog of [[mergeSchemasInParallel]] for archive entries: they unpack
-   * to a driver-local temp dir that executors can't read, so the schemas can't be merged in a
-   * distributed job. Reads each lazily-unpacked entry's footer and deletes it before pulling the
-   * next, so disk holds one entry at a time; `seed` is the starting schema (loose files). The
-   * caller owns closing `entries`.
+   * Driver-side analog of [[mergeSchemasInParallel]] for archive entries (they unpack to a
+   * driver-local temp dir executors can't read): reads each entry's footer into `seed`, deleting it
+   * before the next so disk holds one entry. The caller owns closing `entries`.
    */
   private[sql] def mergeArchiveEntrySchemas(
       sparkSession: SparkSession,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -119,7 +119,10 @@ class ParquetFileFormat
         // The footer reader needs only a path and length (cf. mergeSchemasInParallel).
         val status = new FileStatus(file.length(), false, 0, 0, file.lastModified(), 0, null, null,
           null, new Path(file.toURI))
-        reader(Seq(status), conf, ignoreCorruptFiles, ignoreMissingFiles).headOption
+        // Force the ignore flags off per entry (positional: reader is a function value): a corrupt
+        // entry must throw so inferArchiveSchema skips the whole archive (a corrupt entry condemns
+        // the archive). The archive-granular skip is governed by the real flags passed above.
+        reader(Seq(status), conf, false, false).headOption
       },
       (acc, schema) =>
         try acc.merge(schema, caseSensitive) catch {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ArchiveReadSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ArchiveReadSuiteBase.scala
@@ -343,19 +343,6 @@ trait ArchiveReadSuiteBase extends QueryTest with SharedSparkSession {
       }
     }
 
-    test("archive inference widens a column's type across entries like a directory") {
-      // The column is integral in the first entry and string in the second; inference over all
-      // entries widens the merged type to string, exactly as a directory read would.
-      withArchiveFile() { archive =>
-        writeArchive(archive, Seq(
-          entryName(0) -> encodeFile(Seq(1, 2).toDF("c")),
-          entryName(1) -> encodeFile(Seq("x").toDF("c"))))
-        val schema = inferredSchema(Seq(archive.getCanonicalPath))
-        assert(schema.length == 1 && schema.head.dataType == StringType,
-          s"expected the column widened to string across entries, got $schema")
-      }
-    }
-
     test("inference merges archive entries with loose files in the same directory") {
       // An archive entry and a loose file with the same schema infer one combined schema, matching
       // a directory read of the same files.
@@ -379,6 +366,22 @@ trait ArchiveReadSuiteBase extends QueryTest with SharedSparkSession {
   // ----- shared schema-merge tests (run when `supportsSchemaMerge`) ----------
 
   if (supportsSchemaMerge) {
+    test("archive inference widens a column's type across entries like a directory") {
+      // The column is integral in the first entry and string in the second; inference over all
+      // entries widens the merged type to string, exactly as a directory read would. This is a
+      // schema-merge behavior (cross-entry type reconciliation), so it is gated by
+      // `supportsSchemaMerge` rather than `supportsSchemaInference`: a format can infer a single
+      // file's schema without reconciling differing types across files (e.g. Parquet).
+      withArchiveFile() { archive =>
+        writeArchive(archive, Seq(
+          entryName(0) -> encodeFile(Seq(1, 2).toDF("c")),
+          entryName(1) -> encodeFile(Seq("x").toDF("c"))))
+        val schema = inferredSchema(Seq(archive.getCanonicalPath))
+        assert(schema.length == 1 && schema.head.dataType == StringType,
+          s"expected the column widened to string across entries, got $schema")
+      }
+    }
+
     test("archive entries with differing fields read like a directory") {
       // One entry carries an extra field the other lacks; read under a schema covering both, the
       // missing field reads back null -- exactly as a directory read of the same files does.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ParquetArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ParquetArchiveReadBase.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import java.nio.file.Files
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.util.Utils
+
+/**
+ * Binds [[ArchiveReadSuiteBase]]'s file-format hooks to Parquet. Unlike the streaming formats,
+ * Parquet entries are unpacked to a local file before reading (Parquet needs random access to its
+ * footer), but the read/inference parity contract the base verifies is identical. Parquet is
+ * self-describing, so [[inferenceOptions]] stays empty and the base's schema-inference tests run as
+ * well. There is no header concept, so (unlike CSV) there is a single base rather than header and
+ * headerless variants.
+ */
+trait ParquetArchiveReadBase extends ArchiveReadSuiteBase {
+
+  override protected def format: String = "parquet"
+
+  override protected def fileExtension: String = "parquet"
+
+  override protected def readOptions: Map[String, String] = Map.empty
+
+  override protected def readSchema: String = "id INT, name STRING"
+
+  // Parquet has an authoritative per-file schema and only unions differing fields across files when
+  // `mergeSchema` is set, so it does not union by name during default inference the way the
+  // schema-on-read formats do. The differing-fields *read* (missing column -> null) is still
+  // supported and is covered by a Parquet-specific test in ParquetTarArchiveReadSuite.
+  override protected def supportsSchemaMerge: Boolean = false
+
+  override protected def encodeFile(
+      df: DataFrame,
+      writeOptions: Map[String, String]): Array[Byte] = {
+    val dir = Utils.createTempDir(namePrefix = "archive-test-encode")
+    try {
+      df.coalesce(1).write.format("parquet")
+        .options(writeOptions).mode("overwrite").save(dir.getCanonicalPath)
+      val parts = dir.listFiles().filter { f =>
+        f.isFile && !f.getName.startsWith("_") && !f.getName.startsWith(".") &&
+          !f.getName.endsWith(".crc")
+      }
+      assert(parts.length == 1,
+        s"expected exactly one data file, got: ${parts.map(_.getName).toList}")
+      Files.readAllBytes(parts.head.toPath)
+    } finally Utils.deleteRecursively(dir)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ParquetArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ParquetArchiveReadBase.scala
@@ -17,9 +17,12 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import java.io.File
 import java.nio.file.Files
 
 import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions.input_file_name
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.Utils
 
 /**
@@ -32,6 +35,8 @@ import org.apache.spark.util.Utils
  */
 trait ParquetArchiveReadBase extends ArchiveReadSuiteBase {
 
+  import testImplicits._
+
   override protected def format: String = "parquet"
 
   override protected def fileExtension: String = "parquet"
@@ -43,7 +48,7 @@ trait ParquetArchiveReadBase extends ArchiveReadSuiteBase {
   // Parquet has an authoritative per-file schema and only unions differing fields across files when
   // `mergeSchema` is set, so it does not union by name during default inference the way the
   // schema-on-read formats do. The differing-fields *read* (missing column -> null) is still
-  // supported and is covered by a Parquet-specific test in ParquetTarArchiveReadSuite.
+  // supported and is covered by a Parquet-specific test below.
   override protected def supportsSchemaMerge: Boolean = false
 
   override protected def encodeFile(
@@ -61,5 +66,69 @@ trait ParquetArchiveReadBase extends ArchiveReadSuiteBase {
         s"expected exactly one data file, got: ${parts.map(_.getName).toList}")
       Files.readAllBytes(parts.head.toPath)
     } finally Utils.deleteRecursively(dir)
+  }
+
+  for (vectorized <- Seq(true, false)) {
+    test(s"archive reads return the same rows with vectorized reader = $vectorized") {
+      // Parquet entries are read with the vectorized (columnar) reader or the row-based reader
+      // depending on this flag; both must read archive entries identically to a directory read.
+      withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> vectorized.toString) {
+        assertArchiveMatchesDir(
+          Seq(entryName(0) -> encodeFile(sampleDf((1, "Alice"), (2, "Bob")))))
+      }
+    }
+  }
+
+  test("input_file_name reports the archive path, not the unpacked temp file") {
+    withArchiveFile() { archive =>
+      writeArchive(archive, Seq(entryName(0) -> encodeFile(sampleDf((1, "Alice"), (2, "Bob")))))
+      val paths = read(archive.getCanonicalPath)
+        .select(input_file_name()).distinct().collect().map(_.getString(0))
+      assert(paths.forall(_.contains(archive.getName)),
+        s"expected the archive path, got: ${paths.toList}")
+      assert(paths.forall(p => !p.contains("parquet-archive")),
+        s"the unpacked temp path leaked into input_file_name: ${paths.toList}")
+    }
+  }
+
+  test("an abandoned read (LIMIT) over an archive returns partial rows and cleans up") {
+    withArchiveFile() { archive =>
+      val parts = (0 until 4).map(i => entryName(i) -> encodeFile(sampleDf((i, s"v$i"))))
+      writeArchive(archive, parts)
+      // LIMIT stops iteration before later entries are reached; the task-completion listener
+      // removes the temp dir. Assert the query runs and returns exactly the requested rows.
+      assert(read(archive.getCanonicalPath).limit(2).collect().length == 2)
+    }
+  }
+
+  test("archive entries with differing fields read like a directory") {
+    // Parquet does not union schemas during inference (supportsSchemaMerge = false), but reading
+    // entries with differing fields under a covering schema still fills the missing column with
+    // null, exactly as a directory read of the same files does.
+    val withName = sampleDf((1, "Alice"), (2, "Bob"))
+    val idOnly = Seq(3).toDF("id")
+    assertArchiveMatchesDir(
+      Seq(entryName(0) -> encodeFile(withName), entryName(1) -> encodeFile(idOnly)))
+  }
+
+  test("archive inference unions differing fields across entries with mergeSchema=true") {
+    // Parquet does not union schemas during default inference, but `mergeSchema=true` folds every
+    // entry's schema; over an archive that folds each unpacked entry one at a time. The unioned
+    // schema must match a directory read of the same files under the same option.
+    val withName = sampleDf((1, "Alice"), (2, "Bob"))
+    val idExtra = Seq((3, 30)).toDF("id", "extra")
+    val entries = Seq(entryName(0) -> encodeFile(withName), entryName(1) -> encodeFile(idExtra))
+    val merge = Map("mergeSchema" -> "true")
+    withArchiveFile() { archive =>
+      writeArchive(archive, entries)
+      val archiveSchema = inferredSchema(Seq(archive.getCanonicalPath), merge)
+      withTempDir { dir =>
+        entries.foreach { case (n, b) => Files.write(new File(dir, n).toPath, b) }
+        assert(archiveSchema.fieldNames.toSet == Set("id", "name", "extra"),
+          s"expected the union of entry fields, got $archiveSchema")
+        assert(archiveSchema == inferredSchema(Seq(dir.getCanonicalPath), merge),
+          s"archive mergeSchema inference diverged from a directory read; got $archiveSchema")
+      }
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ParquetArchiveReadBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ParquetArchiveReadBase.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.datasources
 import java.io.File
 import java.nio.file.Files
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.input_file_name
 import org.apache.spark.sql.internal.SQLConf
@@ -128,6 +129,54 @@ trait ParquetArchiveReadBase extends ArchiveReadSuiteBase {
           s"expected the union of entry fields, got $archiveSchema")
         assert(archiveSchema == inferredSchema(Seq(dir.getCanonicalPath), merge),
           s"archive mergeSchema inference diverged from a directory read; got $archiveSchema")
+      }
+    }
+  }
+
+  Seq(true, false).foreach { ignoreCorrupt =>
+    test(s"ignoreCorruptFiles=$ignoreCorrupt: inference skips a corrupt entry's whole archive") {
+      // A corrupt entry condemns its whole archive during inference (no partial ingestion), so the
+      // `extra` column carried by the bad archive's valid sibling entry must not surface. A good
+      // archive is unaffected. mergeSchema=true folds every entry's footer.
+      val merge = Map("mergeSchema" -> "true")
+      val sibling = Seq((3, "Carol", "x")).toDF("id", "name", "extra")
+      withTempDir { dir =>
+        writeArchive(new File(dir, s"good.${archiveExtensions.head}"),
+          Seq(entryName(0) -> encodeFile(sampleDf((1, "Alice"), (2, "Bob")))))
+        writeArchive(new File(dir, s"bad.${archiveExtensions.head}"), Seq(
+          entryName(0) -> encodeFile(sibling),
+          entryName(1) -> "This is not a valid Parquet file".getBytes("UTF-8")))
+        withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> ignoreCorrupt.toString) {
+          if (ignoreCorrupt) {
+            assert(inferredSchema(Seq(dir.getCanonicalPath), merge).fieldNames.toSet ==
+              Set("id", "name"),
+              "the whole corrupt archive, including its valid sibling entry, should be skipped")
+          } else {
+            intercept[Exception](inferredSchema(Seq(dir.getCanonicalPath), merge))
+          }
+        }
+      }
+    }
+
+    test(s"ignoreCorruptFiles=$ignoreCorrupt: read skips the rest of an archive at a bad entry") {
+      // The streaming read matches the other formats: entries before the corrupt one are ingested,
+      // then the rest of that archive is skipped (not whole-archive atomic like inference). A
+      // separate good archive is read in full.
+      val alive = sampleDf((1, "Alice"), (2, "Bob"))
+      val beforeCorrupt = sampleDf((3, "Carol"))
+      withTempDir { dir =>
+        writeArchive(new File(dir, s"good.${archiveExtensions.head}"),
+          Seq(entryName(0) -> encodeFile(alive)))
+        writeArchive(new File(dir, s"bad.${archiveExtensions.head}"), Seq(
+          entryName(0) -> encodeFile(beforeCorrupt),
+          entryName(1) -> "This is not a valid Parquet file".getBytes("UTF-8")))
+        withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> ignoreCorrupt.toString) {
+          if (ignoreCorrupt) {
+            checkAnswer(read(dir.getCanonicalPath), alive.union(beforeCorrupt))
+          } else {
+            intercept[SparkException](read(dir.getCanonicalPath).collect())
+          }
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ParquetTarArchiveReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ParquetTarArchiveReadSuite.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import java.io.File
+import java.nio.file.Files
+
 import org.apache.spark.sql.functions.input_file_name
 import org.apache.spark.sql.internal.SQLConf
 
@@ -74,5 +77,26 @@ class ParquetTarArchiveReadSuite
     val idOnly = Seq(3).toDF("id")
     assertArchiveMatchesDir(
       Seq(entryName(0) -> encodeFile(withName), entryName(1) -> encodeFile(idOnly)))
+  }
+
+  test("archive inference unions differing fields across entries with mergeSchema=true") {
+    // Parquet does not union schemas during default inference, but `mergeSchema=true` folds every
+    // entry's schema; over an archive that folds each unpacked entry one at a time. The unioned
+    // schema must match a directory read of the same files under the same option.
+    val withName = sampleDf((1, "Alice"), (2, "Bob"))
+    val idExtra = Seq((3, 30)).toDF("id", "extra")
+    val entries = Seq(entryName(0) -> encodeFile(withName), entryName(1) -> encodeFile(idExtra))
+    val merge = Map("mergeSchema" -> "true")
+    withArchiveFile() { archive =>
+      writeArchive(archive, entries)
+      val archiveSchema = inferredSchema(Seq(archive.getCanonicalPath), merge)
+      withTempDir { dir =>
+        entries.foreach { case (n, b) => Files.write(new File(dir, n).toPath, b) }
+        assert(archiveSchema.fieldNames.toSet == Set("id", "name", "extra"),
+          s"expected the union of entry fields, got $archiveSchema")
+        assert(archiveSchema == inferredSchema(Seq(dir.getCanonicalPath), merge),
+          s"archive mergeSchema inference diverged from a directory read; got $archiveSchema")
+      }
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ParquetTarArchiveReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ParquetTarArchiveReadSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.sql.functions.input_file_name
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Reads of Parquet files packed in tar archives (`.tar`/`.tar.gz`/`.tgz`): the shared archive
+ * read/inference parity tests from [[ArchiveReadSuiteBase]] (bound to Parquet by
+ * [[ParquetArchiveReadBase]] over tar containers via [[TarArchiveReadBase]]), plus Parquet-specific
+ * tests for the unpack-to-disk read path.
+ */
+class ParquetTarArchiveReadSuite
+  extends ArchiveReadSuiteBase
+  with ParquetArchiveReadBase
+  with TarArchiveReadBase {
+
+  import testImplicits._
+
+  for (vectorized <- Seq(true, false)) {
+    test(s"archive reads return the same rows with vectorized reader = $vectorized") {
+      // Parquet entries are read with the vectorized (columnar) reader or the row-based reader
+      // depending on this flag; both must read archive entries identically to a directory read.
+      withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> vectorized.toString) {
+        assertArchiveMatchesDir(
+          Seq(entryName(0) -> encodeFile(sampleDf((1, "Alice"), (2, "Bob")))))
+      }
+    }
+  }
+
+  test("input_file_name reports the archive path, not the unpacked temp file") {
+    withArchiveFile() { archive =>
+      writeArchive(archive, Seq(entryName(0) -> encodeFile(sampleDf((1, "Alice"), (2, "Bob")))))
+      val paths = read(archive.getCanonicalPath)
+        .select(input_file_name()).distinct().collect().map(_.getString(0))
+      assert(paths.forall(_.contains("archive.tar")),
+        s"expected the archive path, got: ${paths.toList}")
+      assert(paths.forall(p => !p.contains("parquet-archive")),
+        s"the unpacked temp path leaked into input_file_name: ${paths.toList}")
+    }
+  }
+
+  test("an abandoned read (LIMIT) over an archive returns partial rows and cleans up") {
+    withArchiveFile() { archive =>
+      val parts = (0 until 4).map(i => entryName(i) -> encodeFile(sampleDf((i, s"v$i"))))
+      writeArchive(archive, parts)
+      // LIMIT stops iteration before later entries are reached; the task-completion listener
+      // removes the temp dir. Assert the query runs and returns exactly the requested rows.
+      assert(read(archive.getCanonicalPath).limit(2).collect().length == 2)
+    }
+  }
+
+  test("archive entries with differing fields read like a directory") {
+    // Parquet does not union schemas during inference (supportsSchemaMerge = false), but reading
+    // entries with differing fields under a covering schema still fills the missing column with
+    // null, exactly as a directory read of the same files does.
+    val withName = sampleDf((1, "Alice"), (2, "Bob"))
+    val idOnly = Seq(3).toDF("id")
+    assertArchiveMatchesDir(
+      Seq(entryName(0) -> encodeFile(withName), entryName(1) -> encodeFile(idOnly)))
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ParquetZipArchiveReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ParquetZipArchiveReadSuite.scala
@@ -18,11 +18,11 @@
 package org.apache.spark.sql.execution.datasources
 
 /**
- * Reads of Parquet files packed in tar archives (`.tar`/`.tar.gz`/`.tgz`): the shared archive
- * read/inference parity tests from [[ArchiveReadSuiteBase]] plus the Parquet-specific tests from
- * [[ParquetArchiveReadBase]], over tar containers via [[TarArchiveReadBase]].
+ * Reads of Parquet files packed in zip archives (`.zip`): the shared archive read/inference parity
+ * tests from [[ArchiveReadSuiteBase]] plus the Parquet-specific tests from
+ * [[ParquetArchiveReadBase]], over zip containers via [[ZipArchiveReadBase]].
  */
-class ParquetTarArchiveReadSuite
+class ParquetZipArchiveReadSuite
   extends ArchiveReadSuiteBase
   with ParquetArchiveReadBase
-  with TarArchiveReadBase
+  with ZipArchiveReadBase


### PR DESCRIPTION
### What changes were proposed in this pull request?

Extends the archive-read feature (gated by `spark.sql.files.archive.reader.enabled`, default off) to Parquet, for both tar (`.tar` / `.tar.gz` / `.tgz`) and `.zip` archives. The earlier formats — CSV (SPARK-57135, SPARK-57321), JSON (SPARK-57419), text (SPARK-57478), XML (SPARK-57479), Avro (SPARK-57481), and the zip container (SPARK-57705) — stream each entry through `ArchiveReader`. Parquet can't: it needs random access to its footer, so an entry must be a complete, seekable file.

This unpacks entries to local temp files, one at a time:

- `ArchiveReader` gains `localizeEntries` / `readLocalizedEntries` — the random-access counterpart to `readEntries`: unpack a kept entry to a temp file, read it, and release the reader and file before the next entry opens. The temp dir is removed on task completion, and `FileScanRDD` closes the entry iterator, so an abandoned read (e.g. a `LIMIT`) doesn't leak.
- `ParquetFileFormat`: `isSplitable` is false for archives (one split each); the per-file read is factored into `readSingleFile` and reused per entry; `input_file_name()` / `_metadata.file_path` stay the archive path, not the temp file. Schema inference reads entry footers driver-side, folding one at a time (only the first when `mergeSchema=false`). A corrupt archive is skipped under `ignoreCorruptFiles`, a missing one under `ignoreMissingFiles`.

Reading works for tar and zip with no container-specific code — dispatch goes through `ArchiveReader`. V2 sources are untouched; archive dispatch is V1-only.

### Why are the changes needed?

Parquet is the most common columnar format, and packing many small part-files into one archive is a natural way to ship them. This completes the archive-read series for Parquet, with the same gated, per-entry semantics as the other formats.

### Does this PR introduce _any_ user-facing change?

Yes, gated by `spark.sql.files.archive.reader.enabled` (default false). When enabled, Parquet files in tar or zip archives can be read and their schema inferred; with the flag off there is no change.

### How was this patch tested?

`ParquetArchiveReadBase` holds the Parquet-specific tests (read parity across the vectorized and row-based readers, `input_file_name`, an abandoned `LIMIT`, differing fields, and `mergeSchema` union). `ParquetTarArchiveReadSuite` and `ParquetZipArchiveReadSuite` each run those plus the shared `ArchiveReadSuiteBase` parity/inference tests, over tar and zip respectively.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code
