### PR TITLE
[SPARK-57711][SQL][TEST][FOLLOWUP] Fix linter failure

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
@@ -1126,10 +1126,10 @@ class SQLAppStatusListenerMemoryLeakSuite extends SparkFunSuite {
         // DAGScheduler notifies the job waiter -- unblocking the failing action on this thread --
         // *before* it posts SparkListenerJobEnd to the listener bus (see
         // DAGScheduler.failJobAndIndependentStages). That trailing JobEnd can therefore still be in
-        // flight when this thread calls waitUntilEmpty() above; if it is enqueued just after the bus
-        // is drained, the failed execution never reaches the cleanup threshold and lingers in
-        // liveExecutions. Poll with eventually() so the trailing end event is delivered and the live
-        // entries drain, rather than asserting once immediately.
+        // flight when this thread calls waitUntilEmpty() above; if it is enqueued just after the
+        // bus is drained, the failed execution never reaches the cleanup threshold and lingers in
+        // liveExecutions. Poll with eventually() so the trailing end event is delivered and the
+        // live entries drain, rather than asserting once immediately.
         eventually(timeout(5.seconds), interval(10.milliseconds)) {
           assert(statusStore.listener.get.noLiveData())
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes a liter failure which is introduced by #56790.
https://github.com/HyukjinKwon/spark/actions/runs/28169229008/job/83432207959
```
Had test failures in pyspark.sql.tests.connect.test_parity_python_streaming_datasource with python3.12; see logs.
Error:  running /__w/spark/spark/python/run-tests --modules=pyspark-streaming,pyspark-structured-streaming,pyspark-structured-streaming-connect --parallelism=1 --python-executables=python3.12 ; received return code 255
Error: Process completed with exit code 19.
```

### Why are the changes needed?
To recover CI.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
GA.

### Was this patch authored or co-authored using generative AI tooling?
No.