### PR TITLE
[SPARK-57728][SQL][TESTS] Make SQL tests independent of the `ignoreDataLocality` default

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileIndexSuite.scala
@@ -209,6 +209,7 @@ class FileIndexSuite extends SharedSparkSession {
         s"parDiscoveryThreshold=$parDiscoveryThreshold, sqlConf=$sqlConf, options=$options"
       ) {
         withSQLConf(
+          SQLConf.IGNORE_DATA_LOCALITY.key -> "false",
           SQLConf.IGNORE_MISSING_FILES.key -> sqlConf,
           SQLConf.PARALLEL_PARTITION_DISCOVERY_THRESHOLD.key -> parDiscoveryThreshold.toString,
           "fs.mockFs.impl" -> raceCondition.getName,
@@ -485,7 +486,9 @@ class FileIndexSuite extends SharedSparkSession {
 
   test("SPARK-25062 - InMemoryFileIndex stores BlockLocation objects no matter what subclass " +
     "the FS returns") {
-    withSQLConf("fs.file.impl" -> classOf[SpecialBlockLocationFileSystem].getName) {
+    withSQLConf(
+        SQLConf.IGNORE_DATA_LOCALITY.key -> "false",
+        "fs.file.impl" -> classOf[SpecialBlockLocationFileSystem].getName) {
       withTempDir { dir =>
         val file = new File(dir, "text.txt")
         stringToFile(file, "text")
@@ -544,8 +547,10 @@ class FileIndexSuite extends SharedSparkSession {
       override def hasNext: Boolean = iter.hasNext
       override def next(): LocatedFileStatus = iter.next()
     })
-    val fileIndex = new TestInMemoryFileIndex(spark, path)
-    assert(fileIndex.leafFileStatuses.toSeq == statuses)
+    withSQLConf(SQLConf.IGNORE_DATA_LOCALITY.key -> "false") {
+      val fileIndex = new TestInMemoryFileIndex(spark, path)
+      assert(fileIndex.leafFileStatuses.toSeq == statuses)
+    }
   }
 
   test("SPARK-48649: Ignore invalid partitions") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -307,6 +307,7 @@ class FileSourceStrategySuite extends SharedSparkSession {
   test("Locality support for FileScanRDD - one file per partition") {
     withSQLConf(
         SQLConf.FILES_MAX_PARTITION_BYTES.key -> "10",
+        SQLConf.IGNORE_DATA_LOCALITY.key -> "false",
         "fs.file.impl" -> classOf[LocalityTestFileSystem].getName,
         "fs.file.impl.disable.cache" -> "true") {
       val table =
@@ -332,6 +333,7 @@ class FileSourceStrategySuite extends SharedSparkSession {
     withSQLConf(
         SQLConf.FILES_MAX_PARTITION_BYTES.key -> "10",
         SQLConf.FILES_OPEN_COST_IN_BYTES.key -> "0",
+        SQLConf.IGNORE_DATA_LOCALITY.key -> "false",
         "fs.file.impl" -> classOf[LocalityTestFileSystem].getName,
         "fs.file.impl.disable.cache" -> "true") {
       val table =

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/HadoopFsRelationTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/HadoopFsRelationTest.scala
@@ -855,7 +855,9 @@ abstract class HadoopFsRelationTest extends QueryTest with TestHiveSingleton {
         assert(preferredLocations.distinct.length == 2)
       }
 
-      withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> dataSourceName) {
+      withSQLConf(
+          SQLConf.USE_V1_SOURCE_LIST.key -> dataSourceName,
+          SQLConf.IGNORE_DATA_LOCALITY.key -> "false") {
         checkLocality()
 
         withSQLConf(SQLConf.PARALLEL_PARTITION_DISCOVERY_THRESHOLD.key -> "0") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR pins `spark.sql.sources.ignoreDataLocality` to `false` in 
- `FileIndexSuite`
- `FileSourceStrategySuite`
- `HadoopFsRelationTest`

### Why are the changes needed?

Pinning `spark.sql.sources.ignoreDataLocality` keeps the test independent of the default value.

https://github.com/apache/spark/blob/225975d809a8a7c9f08a60e36576c391b82a2306/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L2435-L2445

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CI.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8