### PR TITLE
[SPARK-57730][SQL][TESTS] Mark `HiveClientUserNameSuite` as `SlowHiveTest`

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientUserNameSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientUserNameSuite.scala
@@ -22,8 +22,10 @@ import java.security.PrivilegedExceptionAction
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.security.UserGroupInformation
 
+import org.apache.spark.tags.SlowHiveTest
 import org.apache.spark.util.Utils
 
+@SlowHiveTest
 class HiveClientUserNameSuite(version: String) extends HiveVersionSuite(version) {
 
   test("username of HiveClient - no UGI") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
@@ -34,10 +34,8 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{BooleanType, DateType, IntegerType, LongType, StringType, StructType, TimestampType}
-import org.apache.spark.tags.SlowHiveTest
 import org.apache.spark.util.Utils
 
-@SlowHiveTest
 class HivePartitionFilteringSuite(version: String)
     extends HiveVersionSuite(version) with SQLHelper {
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
@@ -34,8 +34,10 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{BooleanType, DateType, IntegerType, LongType, StringType, StructType, TimestampType}
+import org.apache.spark.tags.SlowHiveTest
 import org.apache.spark.util.Utils
 
+@SlowHiveTest
 class HivePartitionFilteringSuite(version: String)
     extends HiveVersionSuite(version) with SQLHelper {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR annotates `HiveClientUserNameSuite` with `SlowHiveTest`.

### Why are the changes needed?

To rebalance Hive test CIs.

- https://github.com/apache/spark/actions/runs/28305120380

<img width="637" height="100" alt="Screenshot 2026-06-27 at 19 35 47" src="https://github.com/user-attachments/assets/cc156ac0-c25d-4948-8397-da895ebf9b82" />

### Does this PR introduce _any_ user-facing change?

No. This is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8